### PR TITLE
[Feat] 실제 인증과 사용자-계좌 매핑 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/exception/AccountAccessDeniedException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/AccountAccessDeniedException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.exception;
+
+/** user-account membership에 없는 계좌 접근을 막는 예외 */
+public class AccountAccessDeniedException extends RuntimeException {
+
+  public AccountAccessDeniedException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/exception/InvalidCredentialsException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/InvalidCredentialsException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.exception;
+
+/** 로그인 자격 증명 검증 실패를 나타내는 예외 */
+public class InvalidCredentialsException extends RuntimeException {
+
+  public InvalidCredentialsException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AccountAccessScope.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AccountAccessScope.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.auth.model;
+
+/** 요청 경로별로 필요한 최소 계좌 권한 수준 */
+public enum AccountAccessScope {
+  READ,
+  TRANSFER
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/LoginCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/LoginCommand.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** 로그인 자격 증명 입력 */
+public record LoginCommand(String loginId, String password) {
+
+  public LoginCommand {
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (password == null || password.isBlank()) {
+      throw new IllegalArgumentException("password is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/LoginResult.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/LoginResult.java
@@ -1,0 +1,22 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 로그인 성공 후 반환하는 bearer token 결과 */
+public record LoginResult(String accessToken, String tokenType, Instant expiresAt, long userId) {
+
+  public LoginResult {
+    if (accessToken == null || accessToken.isBlank()) {
+      throw new IllegalArgumentException("accessToken is required");
+    }
+    if (tokenType == null || tokenType.isBlank()) {
+      throw new IllegalArgumentException("tokenType is required");
+    }
+    if (expiresAt == null) {
+      throw new IllegalArgumentException("expiresAt is required");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/LoginUser.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/LoginUser.java
@@ -1,0 +1,20 @@
+package com.aquilabank.domain.auth.model;
+
+/** 로그인 검증에 필요한 최소 사용자/credential 조회 모델 */
+public record LoginUser(long userId, String loginId, String passwordHash, UserStatus status) {
+
+  public LoginUser {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (passwordHash == null || passwordHash.isBlank()) {
+      throw new IllegalArgumentException("passwordHash is required");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/MembershipRole.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/MembershipRole.java
@@ -1,0 +1,15 @@
+package com.aquilabank.domain.auth.model;
+
+/** 조회/송금 허용 범위를 role로 단순화해 membership 정책을 고정합니다. */
+public enum MembershipRole {
+  OWNER,
+  MEMBER,
+  VIEWER;
+
+  public boolean allows(AccountAccessScope scope) {
+    return switch (scope) {
+      case READ -> true;
+      case TRANSFER -> this == OWNER || this == MEMBER;
+    };
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/MembershipStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/MembershipStatus.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.auth.model;
+
+/** revoked membership는 남겨도 접근 계산에서는 제외합니다. */
+public enum MembershipStatus {
+  ACTIVE,
+  REVOKED
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembership.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembership.java
@@ -1,0 +1,21 @@
+package com.aquilabank.domain.auth.model;
+
+/** user와 account를 연결하는 단건 membership 조회 모델 */
+public record UserAccountMembership(
+    long userId, long accountId, MembershipRole role, MembershipStatus status) {
+
+  public UserAccountMembership {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (role == null) {
+      throw new IllegalArgumentException("role is required");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserStatus.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.model;
+
+/** 계정 상태가 ACTIVE가 아니면 로그인 발급을 막습니다. */
+public enum UserStatus {
+  ACTIVE,
+  LOCKED,
+  DISABLED
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AccountAccessPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AccountAccessPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import java.util.Optional;
+
+/** user-account membership을 조회해 계좌 접근 가능 여부를 계산하는 port */
+public interface AccountAccessPort {
+
+  Optional<UserAccountMembership> findMembership(long userId, long accountId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AuthTokenIssuePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AuthTokenIssuePort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.LoginResult;
+
+/** 인증 완료 user 정보로 access token을 발급하는 port */
+public interface AuthTokenIssuePort {
+
+  LoginResult issue(long userId, String subject);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/PasswordHashPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/PasswordHashPort.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.auth.port;
+
+/** password hash 알고리즘을 domain 밖으로 분리하는 port */
+public interface PasswordHashPort {
+
+  boolean matches(String rawPassword, String passwordHash);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserCredentialLoadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserCredentialLoadPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.LoginUser;
+import java.util.Optional;
+
+/** loginId 기준 credential 조회 port */
+public interface UserCredentialLoadPort {
+
+  Optional<LoginUser> findByLoginId(String loginId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessService.java
@@ -1,0 +1,40 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
+import com.aquilabank.domain.auth.model.AccountAccessScope;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.port.AccountAccessPort;
+
+/** user-account membership 한 건 조회로 계좌 접근 권한을 판단합니다. */
+public final class AccountAccessService implements AccountAccessUseCase {
+
+  private final AccountAccessPort accountAccessPort;
+
+  public AccountAccessService(AccountAccessPort accountAccessPort) {
+    this.accountAccessPort = accountAccessPort;
+  }
+
+  @Override
+  public long verify(long userId, long accountId, AccountAccessScope scope) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (scope == null) {
+      throw new IllegalArgumentException("scope is required");
+    }
+
+    UserAccountMembership membership =
+        accountAccessPort
+            .findMembership(userId, accountId)
+            .orElseThrow(() -> new AccountAccessDeniedException("account access is denied"));
+
+    if (membership.status() != MembershipStatus.ACTIVE || !membership.role().allows(scope)) {
+      throw new AccountAccessDeniedException("account access is denied");
+    }
+    return accountId;
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AccountAccessScope;
+
+/** user가 특정 account에 필요한 권한을 가졌는지 확인하는 진입점 */
+public interface AccountAccessUseCase {
+
+  long verify(long userId, long accountId, AccountAccessScope scope);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/LoginService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/LoginService.java
@@ -1,0 +1,42 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.LoginCommand;
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+
+/** loginId/password 검증 후 JWT 발급 port로 위임합니다. */
+public final class LoginService implements LoginUseCase {
+
+  private final UserCredentialLoadPort userCredentialLoadPort;
+  private final PasswordHashPort passwordHashPort;
+  private final AuthTokenIssuePort authTokenIssuePort;
+
+  public LoginService(
+      UserCredentialLoadPort userCredentialLoadPort,
+      PasswordHashPort passwordHashPort,
+      AuthTokenIssuePort authTokenIssuePort) {
+    this.userCredentialLoadPort = userCredentialLoadPort;
+    this.passwordHashPort = passwordHashPort;
+    this.authTokenIssuePort = authTokenIssuePort;
+  }
+
+  @Override
+  public LoginResult login(LoginCommand command) {
+    LoginUser user =
+        userCredentialLoadPort
+            .findByLoginId(command.loginId())
+            .orElseThrow(() -> new InvalidCredentialsException("login failed"));
+
+    if (user.status() != UserStatus.ACTIVE
+        || !passwordHashPort.matches(command.password(), user.passwordHash())) {
+      throw new InvalidCredentialsException("login failed");
+    }
+
+    return authTokenIssuePort.issue(user.userId(), user.loginId());
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/LoginUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/LoginUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.LoginCommand;
+import com.aquilabank.domain.auth.model.LoginResult;
+
+/** 사용자 로그인과 bearer token 발급 진입점 */
+public interface LoginUseCase {
+
+  LoginResult login(LoginCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -1,0 +1,30 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.usecase.AccountAccessService;
+import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
+import com.aquilabank.domain.auth.usecase.LoginService;
+import com.aquilabank.domain.auth.usecase.LoginUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** auth use case와 persistence/security adapter를 조립 */
+@Configuration
+public class AuthConfiguration {
+
+  @Bean
+  LoginUseCase loginUseCase(
+      UserCredentialLoadPort userCredentialLoadPort,
+      PasswordHashPort passwordHashPort,
+      AuthTokenIssuePort authTokenIssuePort) {
+    return new LoginService(userCredentialLoadPort, passwordHashPort, authTokenIssuePort);
+  }
+
+  @Bean
+  AccountAccessUseCase accountAccessUseCase(AccountAccessPort accountAccessPort) {
+    return new AccountAccessService(accountAccessPort);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -1,0 +1,73 @@
+package com.aquilabank.global.persistence.auth;
+
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.MembershipRole;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** loginId lookup과 user-account membership lookup을 한 adapter로 묶습니다. */
+@Repository
+public class JdbcAuthRepository implements UserCredentialLoadPort, AccountAccessPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcAuthRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public Optional<LoginUser> findByLoginId(String loginId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT id, login_id, password_hash, user_status
+            FROM bank_user
+            WHERE login_id = :loginId
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            (rs, rowNum) -> mapLoginUser(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<UserAccountMembership> findMembership(long userId, long accountId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT user_id, account_id, membership_role, membership_status
+            FROM user_account_membership
+            WHERE user_id = :userId
+              AND account_id = :accountId
+            """,
+            new MapSqlParameterSource().addValue("userId", userId).addValue("accountId", accountId),
+            (rs, rowNum) -> mapMembership(rs))
+        .stream()
+        .findFirst();
+  }
+
+  private LoginUser mapLoginUser(ResultSet rs) throws SQLException {
+    return new LoginUser(
+        rs.getLong("id"),
+        rs.getString("login_id"),
+        rs.getString("password_hash"),
+        UserStatus.valueOf(rs.getString("user_status")));
+  }
+
+  private UserAccountMembership mapMembership(ResultSet rs) throws SQLException {
+    return new UserAccountMembership(
+        rs.getLong("user_id"),
+        rs.getLong("account_id"),
+        MembershipRole.valueOf(rs.getString("membership_role")),
+        MembershipStatus.valueOf(rs.getString("membership_status")));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferWriteRepository.java
@@ -7,6 +7,7 @@ import com.aquilabank.domain.ledger.exception.SnapshotNotFoundException;
 import com.aquilabank.domain.ledger.model.TransferCommand;
 import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.port.TransferWritePort;
+import com.aquilabank.global.web.RequestTraceContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.ResultSet;
@@ -255,6 +256,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
       String currencyCode,
       String summary,
       Instant bookedAt) {
+    String traceId = RequestTraceContext.currentRequestId().orElse(null);
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("accountId", accountId)
@@ -264,6 +266,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
             .addValue("amountMinor", amountMinor)
             .addValue("currencyCode", currencyCode)
             .addValue("summary", summary)
+            .addValue("traceId", traceId)
             .addValue("bookedAt", Timestamp.from(bookedAt));
 
     Long id =
@@ -279,6 +282,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
                 currency_code,
                 booked_at,
                 description,
+                trace_id,
                 occurred_at,
                 created_at,
                 updated_at
@@ -293,6 +297,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
                 :currencyCode,
                 :bookedAt,
                 :summary,
+                :traceId,
                 :bookedAt,
                 :bookedAt,
                 :bookedAt

--- a/back/src/main/java/com/aquilabank/global/security/AuthenticatedAccountPrincipal.java
+++ b/back/src/main/java/com/aquilabank/global/security/AuthenticatedAccountPrincipal.java
@@ -1,4 +1,15 @@
 package com.aquilabank.global.security;
 
-/** JWT auth와 bootstrap header auth가 함께 쓰는 account principal */
-public record AuthenticatedAccountPrincipal(long accountId, String subject) {}
+/** dev/test bootstrap header auth가 쓰는 account 고정 principal */
+public record AuthenticatedAccountPrincipal(long accountId, String subject)
+    implements AuthenticatedRequestPrincipal {
+
+  public AuthenticatedAccountPrincipal {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (subject == null || subject.isBlank()) {
+      throw new IllegalArgumentException("subject is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/AuthenticatedRequestPrincipal.java
+++ b/back/src/main/java/com/aquilabank/global/security/AuthenticatedRequestPrincipal.java
@@ -1,0 +1,8 @@
+package com.aquilabank.global.security;
+
+/** JWT user principal과 bootstrap account principal을 함께 다루는 공통 타입 */
+public sealed interface AuthenticatedRequestPrincipal
+    permits AuthenticatedAccountPrincipal, AuthenticatedUserPrincipal {
+
+  String subject();
+}

--- a/back/src/main/java/com/aquilabank/global/security/AuthenticatedUserPrincipal.java
+++ b/back/src/main/java/com/aquilabank/global/security/AuthenticatedUserPrincipal.java
@@ -1,0 +1,15 @@
+package com.aquilabank.global.security;
+
+/** 실제 bearer JWT가 해석한 user 중심 principal */
+public record AuthenticatedUserPrincipal(long userId, String subject)
+    implements AuthenticatedRequestPrincipal {
+
+  public AuthenticatedUserPrincipal {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (subject == null || subject.isBlank()) {
+      throw new IllegalArgumentException("subject is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/HmacAccessTokenIssuer.java
+++ b/back/src/main/java/com/aquilabank/global/security/HmacAccessTokenIssuer.java
@@ -1,0 +1,56 @@
+package com.aquilabank.global.security;
+
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.time.Instant;
+import java.util.Date;
+import javax.crypto.spec.SecretKeySpec;
+
+/** resource server 검증과 같은 shared secret으로 access token을 발급합니다. */
+public class HmacAccessTokenIssuer implements AuthTokenIssuePort {
+
+  private final SecretKeySpec secretKeySpec;
+  private final String issuer;
+  private final long accessTokenTtlSeconds;
+
+  public HmacAccessTokenIssuer(
+      SecretKeySpec secretKeySpec, String issuer, long accessTokenTtlSeconds) {
+    this.secretKeySpec = secretKeySpec;
+    this.issuer = issuer;
+    this.accessTokenTtlSeconds = accessTokenTtlSeconds;
+  }
+
+  @Override
+  public LoginResult issue(long userId, String subject) {
+    Instant now = Instant.now();
+    Instant expiresAt = now.plusSeconds(accessTokenTtlSeconds);
+
+    JWTClaimsSet.Builder claims =
+        new JWTClaimsSet.Builder()
+            .subject(subject)
+            .issueTime(Date.from(now))
+            .expirationTime(Date.from(expiresAt))
+            .claim("user_id", userId);
+    if (issuer != null && !issuer.isBlank()) {
+      claims.issuer(issuer);
+    }
+
+    SignedJWT signedJwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(),
+            claims.build());
+    try {
+      signedJwt.sign(new MACSigner(secretKeySpec.getEncoded()));
+    } catch (JOSEException ex) {
+      throw new IllegalStateException("access token signing failed", ex);
+    }
+    return new LoginResult(signedJwt.serialize(), "Bearer", expiresAt, userId);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/JwtUserAuthenticationConverter.java
+++ b/back/src/main/java/com/aquilabank/global/security/JwtUserAuthenticationConverter.java
@@ -9,21 +9,20 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
-/** 검증 완료된 JWT를 account-aware principal로 바꾸는 converter */
-public class JwtAccountAuthenticationConverter
-    implements Converter<Jwt, AbstractAuthenticationToken> {
+/** 검증 완료된 JWT를 user 중심 principal로 변환합니다. */
+public class JwtUserAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
-  private static final String ACCOUNT_ID_CLAIM = "account_id";
+  private static final String USER_ID_CLAIM = "user_id";
 
   @Override
   public AbstractAuthenticationToken convert(Jwt jwt) {
-    Number accountId = jwt.getClaim(ACCOUNT_ID_CLAIM);
-    if (accountId == null || accountId.longValue() <= 0) {
-      throw new IllegalArgumentException("account_id claim must be a positive number");
+    Number userId = jwt.getClaim(USER_ID_CLAIM);
+    if (userId == null || userId.longValue() <= 0) {
+      throw new IllegalArgumentException("user_id claim must be a positive number");
     }
     Collection<GrantedAuthority> authorities = extractAuthorities(jwt);
-    AuthenticatedAccountPrincipal principal =
-        new AuthenticatedAccountPrincipal(accountId.longValue(), jwt.getSubject());
+    AuthenticatedUserPrincipal principal =
+        new AuthenticatedUserPrincipal(userId.longValue(), jwt.getSubject());
     return new JwtAuthenticationToken(jwt, authorities, jwt.getSubject()) {
       @Override
       public Object getPrincipal() {
@@ -35,7 +34,6 @@ public class JwtAccountAuthenticationConverter
   private Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
     Object rawScope = jwt.getClaims().get("scope");
     if (rawScope instanceof String scope && !scope.isBlank()) {
-      // scope claim을 SCOPE_* authority로 정규화
       return Arrays.stream(scope.split(" "))
           .filter(token -> !token.isBlank())
           .map(token -> (GrantedAuthority) () -> "SCOPE_" + token)

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -1,15 +1,21 @@
 package com.aquilabank.global.security;
 
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.global.web.RequestIdFilter;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -32,6 +38,7 @@ public class SecurityConfiguration {
   @Bean
   SecurityFilterChain securityFilterChain(
       HttpSecurity http,
+      RequestIdFilter requestIdFilter,
       ObjectProvider<BootstrapHeaderAuthenticationFilter> bootstrapHeaderAuthenticationFilter,
       JwtDecoder jwtDecoder)
       throws Exception {
@@ -47,6 +54,8 @@ public class SecurityConfiguration {
             auth ->
                 auth.requestMatchers("/actuator/health", "/actuator/info")
                     .permitAll()
+                    .requestMatchers("/api/v1/auth/login")
+                    .permitAll()
                     // 내부 bootstrap API는 계좌 principal 대신 별도 token으로 보호합니다.
                     .requestMatchers("/internal/api/v1/accounts/bootstrap")
                     .permitAll()
@@ -57,22 +66,30 @@ public class SecurityConfiguration {
                 oauth2.jwt(
                     jwt ->
                         jwt.decoder(jwtDecoder)
-                            .jwtAuthenticationConverter(new JwtAccountAuthenticationConverter())))
+                            .jwtAuthenticationConverter(new JwtUserAuthenticationConverter())))
         .exceptionHandling(
             exception ->
                 exception.authenticationEntryPoint(
                     new HttpStatusEntryPoint(org.springframework.http.HttpStatus.UNAUTHORIZED)));
 
+    http.addFilterBefore(requestIdFilter, AnonymousAuthenticationFilter.class);
+
     BootstrapHeaderAuthenticationFilter filter =
         bootstrapHeaderAuthenticationFilter.getIfAvailable();
     if (filter != null) {
-      // bootstrap header filter 선행 등록
-      http.addFilterBefore(filter, AnonymousAuthenticationFilter.class);
+      // request-id를 먼저 심고 그 다음에 bootstrap auth를 해석합니다.
+      http.addFilterAfter(filter, RequestIdFilter.class);
     }
     return http.build();
   }
 
   @Bean
+  RequestIdFilter requestIdFilter() {
+    return new RequestIdFilter();
+  }
+
+  @Bean
+  @Profile({"dev", "test"})
   @ConditionalOnProperty(name = "security.bootstrap-header-auth.enabled", havingValue = "true")
   BootstrapHeaderAuthenticationFilter bootstrapHeaderAuthenticationFilter(
       BootstrapHeaderAuthProperties bootstrapHeaderAuthProperties) {
@@ -83,10 +100,7 @@ public class SecurityConfiguration {
 
   @Bean
   JwtDecoder jwtDecoder(SecurityJwtProperties securityJwtProperties) {
-    SecretKeySpec secretKeySpec =
-        new SecretKeySpec(
-            securityJwtProperties.secret().getBytes(java.nio.charset.StandardCharsets.UTF_8),
-            "HmacSHA256");
+    SecretKeySpec secretKeySpec = secretKeySpec(securityJwtProperties);
     NimbusJwtDecoder decoder =
         NimbusJwtDecoder.withSecretKey(secretKeySpec).macAlgorithm(MacAlgorithm.HS256).build();
 
@@ -97,5 +111,29 @@ public class SecurityConfiguration {
             : JwtValidators.createDefaultWithIssuer(securityJwtProperties.issuer());
     decoder.setJwtValidator(validator);
     return decoder;
+  }
+
+  @Bean
+  PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  PasswordHashPort passwordHashPort(PasswordEncoder passwordEncoder) {
+    return passwordEncoder::matches;
+  }
+
+  @Bean
+  AuthTokenIssuePort authTokenIssuePort(SecurityJwtProperties securityJwtProperties) {
+    return new HmacAccessTokenIssuer(
+        secretKeySpec(securityJwtProperties),
+        securityJwtProperties.issuer(),
+        securityJwtProperties.accessTokenTtlSeconds());
+  }
+
+  private SecretKeySpec secretKeySpec(SecurityJwtProperties securityJwtProperties) {
+    return new SecretKeySpec(
+        securityJwtProperties.secret().getBytes(java.nio.charset.StandardCharsets.UTF_8),
+        "HmacSHA256");
   }
 }

--- a/back/src/main/java/com/aquilabank/global/security/SecurityJwtProperties.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityJwtProperties.java
@@ -4,4 +4,4 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** 로컬 bootstrap과 배포 resource server 검증이 함께 쓰는 JWT 설정 */
 @ConfigurationProperties(prefix = "security.jwt")
-public record SecurityJwtProperties(String secret, String issuer) {}
+public record SecurityJwtProperties(String secret, String issuer, long accessTokenTtlSeconds) {}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.aquilabank.global.web;
 
+import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
 import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
@@ -46,6 +48,18 @@ public class ApiExceptionHandler {
   ResponseEntity<ApiErrorResponse> handleBootstrapUnauthorized(
       BootstrapApiAccessDeniedException ex, HttpServletRequest request) {
     return response(HttpStatus.UNAUTHORIZED, ex.getMessage(), request.getRequestURI());
+  }
+
+  @ExceptionHandler(InvalidCredentialsException.class)
+  ResponseEntity<ApiErrorResponse> handleUnauthorized(
+      InvalidCredentialsException ex, HttpServletRequest request) {
+    return response(HttpStatus.UNAUTHORIZED, ex.getMessage(), request.getRequestURI());
+  }
+
+  @ExceptionHandler(AccountAccessDeniedException.class)
+  ResponseEntity<ApiErrorResponse> handleForbidden(
+      AccountAccessDeniedException ex, HttpServletRequest request) {
+    return response(HttpStatus.FORBIDDEN, ex.getMessage(), request.getRequestURI());
   }
 
   @ExceptionHandler(SnapshotNotFoundException.class)

--- a/back/src/main/java/com/aquilabank/global/web/RequestIdFilter.java
+++ b/back/src/main/java/com/aquilabank/global/web/RequestIdFilter.java
@@ -1,0 +1,35 @@
+package com.aquilabank.global.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/** 모든 요청에 request-id를 부여해 로그와 ledger trace를 같은 키로 묶습니다. */
+public class RequestIdFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    String requestId = resolveRequestId(request);
+    RequestTraceContext.set(requestId);
+    response.setHeader(RequestTraceContext.REQUEST_ID_HEADER, requestId);
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      RequestTraceContext.clear();
+    }
+  }
+
+  private String resolveRequestId(HttpServletRequest request) {
+    String requestId = request.getHeader(RequestTraceContext.REQUEST_ID_HEADER);
+    if (requestId == null || requestId.isBlank()) {
+      return UUID.randomUUID().toString();
+    }
+    return requestId;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/RequestTraceContext.java
+++ b/back/src/main/java/com/aquilabank/global/web/RequestTraceContext.java
@@ -1,0 +1,25 @@
+package com.aquilabank.global.web;
+
+import java.util.Optional;
+import org.slf4j.MDC;
+
+/** request-id를 로그와 persistence adapter가 함께 참조하는 최소 컨텍스트 */
+public final class RequestTraceContext {
+
+  public static final String REQUEST_ID_HEADER = "X-Request-Id";
+  public static final String REQUEST_ID_KEY = "requestId";
+
+  private RequestTraceContext() {}
+
+  public static void set(String requestId) {
+    MDC.put(REQUEST_ID_KEY, requestId);
+  }
+
+  public static Optional<String> currentRequestId() {
+    return Optional.ofNullable(MDC.get(REQUEST_ID_KEY));
+  }
+
+  public static void clear() {
+    MDC.remove(REQUEST_ID_KEY);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -1,0 +1,48 @@
+package com.aquilabank.global.web.auth;
+
+import com.aquilabank.domain.auth.model.LoginCommand;
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.usecase.LoginUseCase;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 최소 login API로 실제 bearer JWT 발급 경로를 노출합니다. */
+@Validated
+@RestController
+@RequestMapping("/api/v1/auth")
+public class LoginController {
+
+  private final LoginUseCase loginUseCase;
+
+  public LoginController(LoginUseCase loginUseCase) {
+    this.loginUseCase = loginUseCase;
+  }
+
+  @PostMapping("/login")
+  public LoginResponse login(@Valid @RequestBody LoginRequest request) {
+    LoginResult result =
+        loginUseCase.login(new LoginCommand(request.loginId(), request.password()));
+    return LoginResponse.from(result);
+  }
+
+  /** 로그인 요청 body */
+  public record LoginRequest(
+      @NotBlank(message = "loginId is required") @Size(max = 80, message = "loginId must be 80 characters or less") String loginId,
+      @NotBlank(message = "password is required") @Size(max = 120, message = "password must be 120 characters or less") String password) {}
+
+  /** access token 발급 응답 */
+  public record LoginResponse(
+      String accessToken, String tokenType, java.time.Instant expiresAt, long userId) {
+
+    private static LoginResponse from(LoginResult result) {
+      return new LoginResponse(
+          result.accessToken(), result.tokenType(), result.expiresAt(), result.userId());
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
@@ -3,7 +3,9 @@ package com.aquilabank.global.web.ledger;
 import com.aquilabank.domain.ledger.model.TransferCommand;
 import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
-import com.aquilabank.global.web.security.CurrentAccountId;
+import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -23,17 +25,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class TransferCommandController {
 
   private final TransferCommandUseCase transferCommandUseCase;
+  private final RequestAccountAuthorizationService requestAccountAuthorizationService;
 
-  public TransferCommandController(TransferCommandUseCase transferCommandUseCase) {
+  public TransferCommandController(
+      TransferCommandUseCase transferCommandUseCase,
+      RequestAccountAuthorizationService requestAccountAuthorizationService) {
     this.transferCommandUseCase = transferCommandUseCase;
+    this.requestAccountAuthorizationService = requestAccountAuthorizationService;
   }
 
   @PostMapping
   public TransferResponse transfer(
-      @CurrentAccountId long sourceAccountId,
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
       @RequestHeader("Idempotency-Key") String idempotencyKey,
       @Valid @RequestBody TransferRequest request) {
-    // 인증 principal과 HTTP body/header를 domain command로 조립
+    long sourceAccountId =
+        requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            principal, request.sourceAccountId());
     TransferResult result =
         transferCommandUseCase.transfer(
             new TransferCommand(
@@ -48,6 +56,7 @@ public class TransferCommandController {
 
   /** 송금 요청 body */
   public record TransferRequest(
+      @Positive(message = "sourceAccountId must be positive") long sourceAccountId,
       @Positive(message = "targetAccountId must be positive") long targetAccountId,
       @Positive(message = "amountMinor must be positive") long amountMinor,
       @NotBlank(message = "currencyCode is required") @Pattern(

--- a/back/src/main/java/com/aquilabank/global/web/security/CurrentAuthenticatedPrincipal.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/CurrentAuthenticatedPrincipal.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** 인증된 account id 주입용 controller parameter marker */
+/** 현재 인증 principal을 controller argument로 주입합니다. */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CurrentAccountId {}
+public @interface CurrentAuthenticatedPrincipal {}

--- a/back/src/main/java/com/aquilabank/global/web/security/CurrentAuthenticatedPrincipalArgumentResolver.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/CurrentAuthenticatedPrincipalArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.aquilabank.global.web.security;
 
-import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
+import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -11,15 +11,15 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.server.ResponseStatusException;
 
-/** SecurityContext principal에서 {@link CurrentAccountId}를 해석하는 resolver */
+/** SecurityContext principal을 controller에서 직접 탐색하지 않게 감쌉니다. */
 @Component
-public class CurrentAccountIdArgumentResolver implements HandlerMethodArgumentResolver {
+public class CurrentAuthenticatedPrincipalArgumentResolver
+    implements HandlerMethodArgumentResolver {
 
   @Override
   public boolean supportsParameter(MethodParameter parameter) {
-    return parameter.hasParameterAnnotation(CurrentAccountId.class)
-        && (parameter.getParameterType().equals(long.class)
-            || parameter.getParameterType().equals(Long.class));
+    return parameter.hasParameterAnnotation(CurrentAuthenticatedPrincipal.class)
+        && AuthenticatedRequestPrincipal.class.isAssignableFrom(parameter.getParameterType());
   }
 
   @Override
@@ -28,14 +28,14 @@ public class CurrentAccountIdArgumentResolver implements HandlerMethodArgumentRe
       ModelAndViewContainer mavContainer,
       NativeWebRequest webRequest,
       WebDataBinderFactory binderFactory) {
-    // controller에서 SecurityContext 직접 탐색 제거
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     if (authentication == null || !authentication.isAuthenticated()) {
       throw unauthorized();
     }
+
     Object principal = authentication.getPrincipal();
-    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
-      return accountPrincipal.accountId();
+    if (principal instanceof AuthenticatedRequestPrincipal requestPrincipal) {
+      return requestPrincipal;
     }
     throw unauthorized();
   }

--- a/back/src/main/java/com/aquilabank/global/web/security/RequestAccountAuthorizationService.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/RequestAccountAuthorizationService.java
@@ -1,0 +1,62 @@
+package com.aquilabank.global.web.security;
+
+import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
+import com.aquilabank.domain.auth.model.AccountAccessScope;
+import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
+import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
+import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import com.aquilabank.global.web.RequestTraceContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** 요청에 담긴 accountId를 principal 기준으로 검증해 controller 중복을 줄입니다. */
+@Component
+public class RequestAccountAuthorizationService {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(RequestAccountAuthorizationService.class);
+
+  private final AccountAccessUseCase accountAccessUseCase;
+
+  public RequestAccountAuthorizationService(AccountAccessUseCase accountAccessUseCase) {
+    this.accountAccessUseCase = accountAccessUseCase;
+  }
+
+  public long resolveReadableAccountId(
+      AuthenticatedRequestPrincipal principal, long requestedAccountId) {
+    return resolve(principal, requestedAccountId, AccountAccessScope.READ);
+  }
+
+  public long resolveTransferSourceAccountId(
+      AuthenticatedRequestPrincipal principal, long requestedAccountId) {
+    return resolve(principal, requestedAccountId, AccountAccessScope.TRANSFER);
+  }
+
+  private long resolve(
+      AuthenticatedRequestPrincipal principal, long requestedAccountId, AccountAccessScope scope) {
+    if (requestedAccountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      return accountAccessUseCase.verify(userPrincipal.userId(), requestedAccountId, scope);
+    }
+
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      if (accountPrincipal.accountId() != requestedAccountId) {
+        log.warn(
+            "bootstrap account mismatch requestId={} subject={} bootstrapAccountId={} requestedAccountId={}",
+            RequestTraceContext.currentRequestId().orElse("-"),
+            accountPrincipal.subject(),
+            accountPrincipal.accountId(),
+            requestedAccountId);
+        throw new AccountAccessDeniedException("account access is denied");
+      }
+      return requestedAccountId;
+    }
+
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
@@ -9,15 +9,17 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebMvcSecurityConfiguration implements WebMvcConfigurer {
 
-  private final CurrentAccountIdArgumentResolver currentAccountIdArgumentResolver;
+  private final CurrentAuthenticatedPrincipalArgumentResolver
+      currentAuthenticatedPrincipalArgumentResolver;
 
   public WebMvcSecurityConfiguration(
-      CurrentAccountIdArgumentResolver currentAccountIdArgumentResolver) {
-    this.currentAccountIdArgumentResolver = currentAccountIdArgumentResolver;
+      CurrentAuthenticatedPrincipalArgumentResolver currentAuthenticatedPrincipalArgumentResolver) {
+    this.currentAuthenticatedPrincipalArgumentResolver =
+        currentAuthenticatedPrincipalArgumentResolver;
   }
 
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-    resolvers.add(currentAccountIdArgumentResolver);
+    resolvers.add(currentAuthenticatedPrincipalArgumentResolver);
   }
 }

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
@@ -4,10 +4,14 @@ import com.aquilabank.domain.transaction.model.TransactionCursor;
 import com.aquilabank.domain.transaction.model.TransactionQuery;
 import com.aquilabank.domain.transaction.model.TransactionStatus;
 import com.aquilabank.domain.transaction.usecase.TransactionQueryUseCase;
-import com.aquilabank.global.web.security.CurrentAccountId;
+import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import jakarta.validation.constraints.Positive;
 import java.time.OffsetDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,19 +19,25 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 /** transaction timeline read use case를 노출하는 HTTP adapter */
+@Validated
 @RestController
 @RequestMapping("/api/v1/transactions")
 public class TransactionQueryController {
 
   private final TransactionQueryUseCase transactionQueryUseCase;
+  private final RequestAccountAuthorizationService requestAccountAuthorizationService;
 
-  public TransactionQueryController(TransactionQueryUseCase transactionQueryUseCase) {
+  public TransactionQueryController(
+      TransactionQueryUseCase transactionQueryUseCase,
+      RequestAccountAuthorizationService requestAccountAuthorizationService) {
     this.transactionQueryUseCase = transactionQueryUseCase;
+    this.requestAccountAuthorizationService = requestAccountAuthorizationService;
   }
 
   @GetMapping
   public TransactionQueryResponse getTransactions(
-      @CurrentAccountId long accountId,
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @RequestParam @Positive(message = "accountId must be positive") long accountId,
       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
       @RequestParam(defaultValue = "20") int limit,
@@ -37,9 +47,11 @@ public class TransactionQueryController {
       // 첫 page와 후속 page를 같은 endpoint로 통일
       TransactionCursor decodedCursor =
           cursor == null || cursor.isBlank() ? null : TransactionCursorCodec.decode(cursor);
+      long resolvedAccountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(principal, accountId);
       TransactionQuery query =
           new TransactionQuery(
-              accountId, from.toInstant(), to.toInstant(), limit, decodedCursor, status);
+              resolvedAccountId, from.toInstant(), to.toInstant(), limit, decodedCursor, status);
       return TransactionQueryResponse.from(transactionQueryUseCase.getTransactions(query));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -60,6 +60,8 @@ management:
       show-details: never
 
 logging:
+  pattern:
+    level: '%5p [requestId:%X{requestId:-}]'
   level:
     root: INFO
 
@@ -76,6 +78,7 @@ security:
   jwt:
     secret: ${SECURITY_JWT_SECRET}
     issuer: ${SECURITY_JWT_ISSUER:}
+    access-token-ttl-seconds: ${SECURITY_JWT_ACCESS_TOKEN_TTL_SECONDS:900}
   bootstrap-header-auth:
     enabled: ${SECURITY_BOOTSTRAP_HEADER_AUTH_ENABLED:false}
     account-id-header: ${SECURITY_BOOTSTRAP_ACCOUNT_ID_HEADER:X-Account-Id}

--- a/back/src/main/resources/db/migration/V4__add_auth_user_membership.sql
+++ b/back/src/main/resources/db/migration/V4__add_auth_user_membership.sql
@@ -1,0 +1,27 @@
+CREATE TABLE bank_user (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    login_id VARCHAR(80) NOT NULL,
+    password_hash VARCHAR(120) NOT NULL,
+    display_name VARCHAR(80) NOT NULL,
+    user_status VARCHAR(16) NOT NULL CHECK (user_status IN ('ACTIVE', 'LOCKED', 'DISABLED')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_bank_user_login_id UNIQUE (login_id)
+);
+
+CREATE TABLE user_account_membership (
+    user_id BIGINT NOT NULL,
+    account_id BIGINT NOT NULL,
+    membership_role VARCHAR(16) NOT NULL CHECK (membership_role IN ('OWNER', 'MEMBER', 'VIEWER')),
+    membership_status VARCHAR(16) NOT NULL CHECK (membership_status IN ('ACTIVE', 'REVOKED')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, account_id),
+    CONSTRAINT fk_user_account_membership_user
+        FOREIGN KEY (user_id) REFERENCES bank_user (id),
+    CONSTRAINT fk_user_account_membership_account
+        FOREIGN KEY (account_id) REFERENCES bank_account (id)
+);
+
+CREATE INDEX idx_user_account_membership_account_user
+    ON user_account_membership (account_id, user_id);

--- a/back/src/test/java/com/aquilabank/global/security/BootstrapHeaderSecurityProfileTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/BootstrapHeaderSecurityProfileTest.java
@@ -1,0 +1,33 @@
+package com.aquilabank.global.security;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("prod")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      "spring.flyway.enabled=false",
+      "management.health.db.enabled=false",
+      "spring.datasource.url=jdbc:postgresql://localhost:5432/aquila_bank_test",
+      "spring.datasource.username=postgres",
+      "spring.datasource.password=postgres",
+      "spring.datasource.hikari.initialization-fail-timeout=0",
+      "security.bootstrap-header-auth.enabled=true",
+      "security.jwt.secret=test-local-jwt-secret-test-local-jwt-secret",
+      "security.jwt.access-token-ttl-seconds=300"
+    })
+class BootstrapHeaderSecurityProfileTest {
+
+  @Autowired private ObjectProvider<BootstrapHeaderAuthenticationFilter> filterProvider;
+
+  @Test
+  void doesNotRegisterBootstrapHeaderFilterOutsideDevAndTest() {
+    assertNull(filterProvider.getIfAvailable());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/security/JwtUserAuthenticationConverterTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/JwtUserAuthenticationConverterTest.java
@@ -9,41 +9,40 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
-class JwtAccountAuthenticationConverterTest {
+class JwtUserAuthenticationConverterTest {
 
-  private final JwtAccountAuthenticationConverter converter =
-      new JwtAccountAuthenticationConverter();
+  private final JwtUserAuthenticationConverter converter = new JwtUserAuthenticationConverter();
 
   @Test
-  void convertsJwtToAuthenticatedAccountPrincipal() {
+  void convertsJwtToAuthenticatedUserPrincipal() {
     Jwt jwt =
         new Jwt(
             "token",
             Instant.now(),
             Instant.now().plusSeconds(300),
             Map.of("alg", "HS256"),
-            Map.of("sub", "user-1", "account_id", 123L, "scope", "transactions:read"));
+            Map.of("sub", "alice", "user_id", 123L, "scope", "transactions:read"));
 
     JwtAuthenticationToken authentication = (JwtAuthenticationToken) converter.convert(jwt);
-    AuthenticatedAccountPrincipal principal =
-        (AuthenticatedAccountPrincipal) authentication.getPrincipal();
+    AuthenticatedUserPrincipal principal =
+        (AuthenticatedUserPrincipal) authentication.getPrincipal();
 
-    assertEquals(123L, principal.accountId());
-    assertEquals("user-1", principal.subject());
+    assertEquals(123L, principal.userId());
+    assertEquals("alice", principal.subject());
     assertEquals(
         "SCOPE_transactions:read",
         authentication.getAuthorities().iterator().next().getAuthority());
   }
 
   @Test
-  void rejectsMissingAccountIdClaim() {
+  void rejectsMissingUserIdClaim() {
     Jwt jwt =
         new Jwt(
             "token",
             Instant.now(),
             Instant.now().plusSeconds(300),
             Map.of("alg", "HS256"),
-            Map.of("sub", "user-1"));
+            Map.of("sub", "alice"));
 
     assertThrows(IllegalArgumentException.class, () -> converter.convert(jwt));
   }

--- a/back/src/test/java/com/aquilabank/global/security/TransactionJwtSecurityIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/TransactionJwtSecurityIntegrationTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.aquilabank.domain.auth.model.AccountAccessScope;
+import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
 import com.aquilabank.domain.transaction.model.TransactionDirection;
 import com.aquilabank.domain.transaction.model.TransactionSlice;
 import com.aquilabank.domain.transaction.model.TransactionStatus;
@@ -45,6 +47,8 @@ class TransactionJwtSecurityIntegrationTest {
 
   @Autowired private JwtDecoder jwtDecoder;
 
+  @MockitoBean private AccountAccessUseCase accountAccessUseCase;
+
   @MockitoBean private TransactionReadPort transactionReadPort;
 
   private MockMvc mockMvc;
@@ -55,7 +59,7 @@ class TransactionJwtSecurityIntegrationTest {
   }
 
   @Test
-  void acceptsBearerJwtAndResolvesAccountId() throws Exception {
+  void acceptsBearerJwtAndResolvesUserAccountAccess() throws Exception {
     when(transactionReadPort.fetch(argThat(query -> query.accountId() == 555L)))
         .thenReturn(
             new TransactionSlice(
@@ -75,11 +79,13 @@ class TransactionJwtSecurityIntegrationTest {
                 null,
                 false,
                 20));
+    when(accountAccessUseCase.verify(55L, 555L, AccountAccessScope.READ)).thenReturn(555L);
 
     mockMvc
         .perform(
             get("/api/v1/transactions")
-                .header("Authorization", "Bearer " + issueToken("user-555", 555L))
+                .header("Authorization", "Bearer " + issueToken("user-555", 55L))
+                .param("accountId", "555")
                 .param("from", "2026-04-01T00:00:00Z")
                 .param("to", "2026-04-17T00:00:00Z"))
         .andExpect(status().isOk())
@@ -91,6 +97,7 @@ class TransactionJwtSecurityIntegrationTest {
     mockMvc
         .perform(
             get("/api/v1/transactions")
+                .param("accountId", "555")
                 .param("from", "2026-04-01T00:00:00Z")
                 .param("to", "2026-04-17T00:00:00Z"))
         .andExpect(status().isUnauthorized());
@@ -99,22 +106,20 @@ class TransactionJwtSecurityIntegrationTest {
   @Test
   void decoderReadsSignedToken() throws Exception {
     String token = issueToken("user-777", 777L);
-    AuthenticatedAccountPrincipal principal =
-        (AuthenticatedAccountPrincipal)
-            new JwtAccountAuthenticationConverter()
-                .convert(jwtDecoder.decode(token))
-                .getPrincipal();
-    assertEquals(777L, principal.accountId());
+    AuthenticatedUserPrincipal principal =
+        (AuthenticatedUserPrincipal)
+            new JwtUserAuthenticationConverter().convert(jwtDecoder.decode(token)).getPrincipal();
+    assertEquals(777L, principal.userId());
   }
 
-  private String issueToken(String subject, long accountId) throws JOSEException {
+  private String issueToken(String subject, long userId) throws JOSEException {
     Instant now = Instant.now();
     JWTClaimsSet claimsSet =
         new JWTClaimsSet.Builder()
             .subject(subject)
             .issueTime(Date.from(now))
             .expirationTime(Date.from(now.plusSeconds(300)))
-            .claim("account_id", accountId)
+            .claim("user_id", userId)
             .build();
 
     SignedJWT signedJwt =

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -1,0 +1,267 @@
+package com.aquilabank.global.web.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  private MockMvc mockMvc;
+  private long allowedSourceAccountId;
+  private long targetAccountId;
+  private long deniedAccountId;
+
+  @BeforeEach
+  void setUpDatabase() throws Exception {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    resetBankingTables(jdbcTemplate);
+
+    allowedSourceAccountId = bootstrapAccount("allowed source", 10_000L);
+    targetAccountId = bootstrapAccount("allowed target", 0L);
+    deniedAccountId = bootstrapAccount("denied source", 5_000L);
+
+    long[] userIdHolder = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          userIdHolder[0] = insertUser("alice", "Alice", "password123!");
+          insertMembership(userIdHolder[0], allowedSourceAccountId, "OWNER");
+        });
+  }
+
+  @Test
+  void loginIssuesJwtAndAllowsMappedAccountFlow() throws Exception {
+    String token = login("alice", "password123!");
+
+    MvcResult transferResult =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers")
+                    .header("Authorization", "Bearer " + token)
+                    .header("X-Request-Id", "jwt-transfer-request")
+                    .header("Idempotency-Key", "jwt-transfer-001")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "targetAccountId": %d,
+                          "amountMinor": 1500,
+                          "currencyCode": "KRW",
+                          "summary": "rent"
+                        }
+                        """
+                            .formatted(allowedSourceAccountId, targetAccountId)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.sourceAccountId").value(allowedSourceAccountId))
+            .andReturn();
+
+    assertEquals("jwt-transfer-request", transferResult.getResponse().getHeader("X-Request-Id"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId))
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId))
+        .andExpect(jsonPath("$.items[0].transactionReference").isString());
+  }
+
+  @Test
+  void rejectsUnmappedAccountAccess() throws Exception {
+    String token = login("alice", "password123!");
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(deniedAccountId))
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Authorization", "Bearer " + token)
+                .header("Idempotency-Key", "jwt-transfer-403")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": 500,
+                      "currencyCode": "KRW",
+                      "summary": "blocked"
+                    }
+                    """
+                        .formatted(deniedAccountId, targetAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
+  @Test
+  void rejectsInvalidLoginCredentials() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "loginId": "alice",
+                      "password": "wrong-password"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("login failed"));
+  }
+
+  private String login(String loginId, String password) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "loginId": "%s",
+                          "password": "%s"
+                        }
+                        """
+                            .formatted(loginId, password)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    JsonNode body = objectMapper.readTree(result.getResponse().getContentAsByteArray());
+    assertEquals("Bearer", body.get("tokenType").asText());
+    assertNotNull(body.get("expiresAt"));
+    return body.get("accessToken").asText();
+  }
+
+  private long bootstrapAccount(String displayName, long initialBalanceMinor) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/internal/api/v1/accounts/bootstrap")
+                    .header("X-Bootstrap-Token", "test-bootstrap-api-token")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "displayName": "%s",
+                          "currencyCode": "KRW",
+                          "initialBalanceMinor": %d
+                        }
+                        """
+                            .formatted(displayName, initialBalanceMinor)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    return objectMapper
+        .readTree(result.getResponse().getContentAsByteArray())
+        .get("accountId")
+        .asLong();
+  }
+
+  private long insertUser(String loginId, String displayName, String password) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                :passwordHash,
+                :displayName,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("loginId", loginId)
+                .addValue("passwordHash", passwordEncoder.encode(password))
+                .addValue("displayName", displayName),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("user insert did not return id");
+    }
+    return userId;
+  }
+
+  private void insertMembership(long userId, long accountId, String membershipRole) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO user_account_membership (
+            user_id,
+            account_id,
+            membership_role,
+            membership_status,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :accountId,
+            :membershipRole,
+            'ACTIVE',
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("accountId", accountId)
+            .addValue("membershipRole", membershipRole));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
@@ -60,10 +60,12 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
     assertEquals(sourceAccountId, response.sourceAccountId());
     assertEquals(targetAccountId, response.targetAccountId());
     assertEquals(8_500L, response.availableBalanceAfterMinor());
+    assertEquals("transfer-001-request", response.requestId());
     assertEquals(2L, countRows("ledger_entry", response.transactionReference()));
     assertEquals(2L, countRows("transaction_read_model", response.transactionReference()));
     assertEquals(8_500L, balanceOf(sourceAccountId));
     assertEquals(1_500L, balanceOf(targetAccountId));
+    assertEquals(2L, countTraceRows(response.requestId()));
 
     Map<String, Object> commandState = idempotencyState("transfer-001");
     assertEquals("COMPLETED", commandState.get("processing_status"));
@@ -99,18 +101,20 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
             .perform(
                 post("/api/v1/transfers")
                     .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", "transfer-003-request")
                     .header("Idempotency-Key", "transfer-003")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         """
                     {
+                      "sourceAccountId": %d,
                       "targetAccountId": %d,
                       "amountMinor": 1500,
                       "currencyCode": "KRW",
                       "summary": "rent"
                     }
                     """
-                            .formatted(targetAccountId)))
+                            .formatted(sourceAccountId, targetAccountId)))
             .andReturn();
 
     assertEquals(409, result.getResponse().getStatus(), result.getResponse().getContentAsString());
@@ -135,6 +139,7 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
         mockMvc
             .perform(
                 post("/internal/api/v1/accounts/bootstrap")
+                    .header("X-Request-Id", "bootstrap-%s".formatted(displayName.replace(" ", "-")))
                     .header("X-Bootstrap-Token", "test-bootstrap-api-token")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
@@ -157,29 +162,34 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
   private TransferResponseView invokeTransfer(
       String idempotencyKey, long targetAccountId, long amountMinor, String summary)
       throws Exception {
+    String requestId = idempotencyKey + "-request";
     MvcResult result =
         mockMvc
             .perform(
                 post("/api/v1/transfers")
                     .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", requestId)
                     .header("Idempotency-Key", idempotencyKey)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         """
                         {
+                          "sourceAccountId": %d,
                           "targetAccountId": %d,
                           "amountMinor": %d,
                           "currencyCode": "KRW",
                           "summary": "%s"
                         }
                         """
-                            .formatted(targetAccountId, amountMinor, summary)))
+                            .formatted(sourceAccountId, targetAccountId, amountMinor, summary)))
             .andReturn();
 
     assertEquals(200, result.getResponse().getStatus(), result.getResponse().getContentAsString());
 
-    return objectMapper.readValue(
-        result.getResponse().getContentAsByteArray(), TransferResponseView.class);
+    return new TransferResponseView(
+        objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(), TransferResponseBody.class),
+        result.getResponse().getHeader("X-Request-Id"));
   }
 
   private void updateBalance(long accountId, long availableBalanceMinor) {
@@ -241,6 +251,17 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
         Long.class);
   }
 
+  private long countTraceRows(String requestId) {
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT COUNT(*)
+        FROM ledger_entry
+        WHERE trace_id = :requestId
+        """,
+        new MapSqlParameterSource().addValue("requestId", requestId),
+        Long.class);
+  }
+
   private Map<String, Object> idempotencyState(String idempotencyKey) {
     return jdbcTemplate.queryForMap(
         """
@@ -264,7 +285,26 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
         new MapSqlParameterSource().addValue("transactionReference", transactionReference));
   }
 
-  private record TransferResponseView(
+  private record TransferResponseView(TransferResponseBody body, String requestId) {
+
+    private String transactionReference() {
+      return body.transactionReference();
+    }
+
+    private long sourceAccountId() {
+      return body.sourceAccountId();
+    }
+
+    private long targetAccountId() {
+      return body.targetAccountId();
+    }
+
+    private long availableBalanceAfterMinor() {
+      return body.availableBalanceAfterMinor();
+    }
+  }
+
+  private record TransferResponseBody(
       String transactionReference,
       long sourceAccountId,
       long targetAccountId,

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -12,7 +12,8 @@ import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
-import com.aquilabank.global.web.security.CurrentAccountIdArgumentResolver;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -22,15 +23,19 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class TransferCommandControllerTest {
 
   private TransferCommandUseCase transferCommandUseCase;
+  private RequestAccountAuthorizationService requestAccountAuthorizationService;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
     transferCommandUseCase = mock(TransferCommandUseCase.class);
+    requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
     mockMvc =
-        MockMvcBuilders.standaloneSetup(new TransferCommandController(transferCommandUseCase))
+        MockMvcBuilders.standaloneSetup(
+                new TransferCommandController(
+                    transferCommandUseCase, requestAccountAuthorizationService))
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
-            .setCustomArgumentResolvers(new CurrentAccountIdArgumentResolver())
+            .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .setControllerAdvice(new ApiExceptionHandler())
             .build();
   }
@@ -48,6 +53,9 @@ class TransferCommandControllerTest {
                 8500L,
                 java.time.Instant.parse("2026-04-16T10:00:00Z"),
                 "BOOKED"));
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
 
     mockMvc
         .perform(
@@ -58,6 +66,7 @@ class TransferCommandControllerTest {
                 .content(
                     """
                     {
+                      "sourceAccountId": 101,
                       "targetAccountId": 202,
                       "amountMinor": 1500,
                       "currencyCode": "KRW",
@@ -83,6 +92,7 @@ class TransferCommandControllerTest {
                 .content(
                     """
                     {
+                      "sourceAccountId": 101,
                       "targetAccountId": 202,
                       "amountMinor": 1500,
                       "currencyCode": "KRW",
@@ -103,6 +113,7 @@ class TransferCommandControllerTest {
                 .content(
                     """
                     {
+                      "sourceAccountId": 0,
                       "targetAccountId": 101,
                       "amountMinor": 0,
                       "currencyCode": "krw",

--- a/back/src/test/java/com/aquilabank/global/web/security/CurrentAuthenticatedPrincipalArgumentResolverTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/security/CurrentAuthenticatedPrincipalArgumentResolverTest.java
@@ -3,7 +3,7 @@ package com.aquilabank.global.web.security;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -14,9 +14,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.server.ResponseStatusException;
 
-class CurrentAccountIdArgumentResolverTest {
+class CurrentAuthenticatedPrincipalArgumentResolverTest {
 
-  private final CurrentAccountIdArgumentResolver resolver = new CurrentAccountIdArgumentResolver();
+  private final CurrentAuthenticatedPrincipalArgumentResolver resolver =
+      new CurrentAuthenticatedPrincipalArgumentResolver();
 
   @AfterEach
   void tearDown() {
@@ -24,17 +25,18 @@ class CurrentAccountIdArgumentResolverTest {
   }
 
   @Test
-  void resolvesAccountIdFromPrincipal() throws Exception {
+  void resolvesPrincipalFromSecurityContext() throws Exception {
+    AuthenticatedUserPrincipal principal = new AuthenticatedUserPrincipal(321L, "tester");
     SecurityContextHolder.getContext()
         .setAuthentication(
             UsernamePasswordAuthenticationToken.authenticated(
-                new AuthenticatedAccountPrincipal(321L, "tester"), null, java.util.List.of()));
+                principal, null, java.util.List.of()));
 
     Object resolved =
         resolver.resolveArgument(
             parameter(), null, new ServletWebRequest(new MockHttpServletRequest()), null);
 
-    assertEquals(321L, resolved);
+    assertEquals(principal, resolved);
   }
 
   @Test
@@ -47,12 +49,16 @@ class CurrentAccountIdArgumentResolverTest {
   }
 
   private MethodParameter parameter() throws NoSuchMethodException {
-    Method method = Fixture.class.getDeclaredMethod("handle", long.class);
+    Method method =
+        Fixture.class.getDeclaredMethod(
+            "handle", com.aquilabank.global.security.AuthenticatedRequestPrincipal.class);
     return new MethodParameter(method, 0);
   }
 
   private static final class Fixture {
 
-    void handle(@CurrentAccountId long accountId) {}
+    void handle(
+        @CurrentAuthenticatedPrincipal
+            com.aquilabank.global.security.AuthenticatedRequestPrincipal principal) {}
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
@@ -15,7 +15,8 @@ import com.aquilabank.domain.transaction.model.TransactionStatus;
 import com.aquilabank.domain.transaction.model.TransactionSummary;
 import com.aquilabank.domain.transaction.usecase.TransactionQueryUseCase;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
-import com.aquilabank.global.web.security.CurrentAccountIdArgumentResolver;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,15 +27,19 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class TransactionQueryControllerTest {
 
   private TransactionQueryUseCase transactionQueryUseCase;
+  private RequestAccountAuthorizationService requestAccountAuthorizationService;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
     transactionQueryUseCase = mock(TransactionQueryUseCase.class);
+    requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
     mockMvc =
-        MockMvcBuilders.standaloneSetup(new TransactionQueryController(transactionQueryUseCase))
+        MockMvcBuilders.standaloneSetup(
+                new TransactionQueryController(
+                    transactionQueryUseCase, requestAccountAuthorizationService))
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
-            .setCustomArgumentResolvers(new CurrentAccountIdArgumentResolver())
+            .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .build();
   }
 
@@ -61,11 +66,15 @@ class TransactionQueryControllerTest {
                 nextCursor,
                 true,
                 20));
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
 
     mockMvc
         .perform(
             get("/api/v1/transactions")
                 .header("X-Account-Id", "101")
+                .param("accountId", "101")
                 .param("from", "2026-04-01T00:00:00Z")
                 .param("to", "2026-04-17T00:00:00Z")
                 .param("limit", "20"))
@@ -78,10 +87,14 @@ class TransactionQueryControllerTest {
 
   @Test
   void rejectsTooLargeDateRange() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
     mockMvc
         .perform(
             get("/api/v1/transactions")
                 .header("X-Account-Id", "101")
+                .param("accountId", "101")
                 .param("from", "2026-01-01T00:00:00Z")
                 .param("to", "2026-03-10T00:00:00Z")
                 .param("limit", "20"))
@@ -94,11 +107,15 @@ class TransactionQueryControllerTest {
     String encoded = TransactionCursorCodec.encode(cursor);
     when(transactionQueryUseCase.getTransactions(argThat(query -> cursor.equals(query.cursor()))))
         .thenReturn(new TransactionSlice(List.of(), null, false, 20));
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
 
     mockMvc
         .perform(
             get("/api/v1/transactions")
                 .header("X-Account-Id", "101")
+                .param("accountId", "101")
                 .param("from", "2026-04-01T00:00:00Z")
                 .param("to", "2026-04-17T00:00:00Z")
                 .param("limit", "20")
@@ -114,6 +131,7 @@ class TransactionQueryControllerTest {
     mockMvc
         .perform(
             get("/api/v1/transactions")
+                .param("accountId", "101")
                 .param("from", "2026-04-01T00:00:00Z")
                 .param("to", "2026-04-17T00:00:00Z")
                 .param("limit", "20"))

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -2,6 +2,7 @@ package com.aquilabank.support;
 
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -37,17 +38,30 @@ public abstract class PostgresContainerTestSupport {
     jdbcTemplate
         .getJdbcTemplate()
         .execute(
-            """
-            TRUNCATE TABLE
-                transaction_read_model,
-                ledger_entry,
-                command_idempotency,
-                outbox_event,
-                account_balance_snapshot,
-                bank_account
-            RESTART IDENTITY CASCADE
-            """);
-    jdbcTemplate.getJdbcTemplate().execute("ALTER SEQUENCE bank_account_number_seq RESTART WITH 1");
+            (ConnectionCallback<Void>)
+                connection -> {
+                  try (java.sql.Statement statement = connection.createStatement()) {
+                    statement.execute(
+                        """
+                        TRUNCATE TABLE
+                            transaction_read_model,
+                            ledger_entry,
+                            command_idempotency,
+                            outbox_event,
+                            account_balance_snapshot,
+                            user_account_membership,
+                            bank_user,
+                            bank_account
+                        RESTART IDENTITY CASCADE
+                        """);
+                    statement.execute("ALTER SEQUENCE bank_account_number_seq RESTART WITH 1");
+                    connection.commit();
+                    return null;
+                  } catch (Exception ex) {
+                    connection.rollback();
+                    throw ex;
+                  }
+                });
   }
 
   protected void commit(PlatformTransactionManager transactionManager, Runnable callback) {


### PR DESCRIPTION
## 🔗 Related Issue
- close #5

## 📝 Summary
- `user_id` 중심 login/JWT 발급과 `user_account_membership` 기반 계좌 접근 검증을 추가했습니다.
- 거래 조회/송금이 explicit account selection과 access check 경로로 전환됐습니다.
- dev/test 전용 bootstrap header auth 격리와 request-id/trace_id 연계를 함께 정리했습니다.

## 🛠 Changes
- `bank_user`, `user_account_membership` migration과 auth domain/JDBC adapter/login API를 추가했습니다.
- JWT principal을 `user_id` 기반으로 전환하고 transaction/transfer account access resolver를 추가했습니다.
- request-id filter, ledger `trace_id` 기록, 통합 테스트와 prod profile 격리 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- `./back/gradlew -p back test --tests 'com.aquilabank.global.web.ledger.TransferCommandApiIntegrationTest.createsTransferAndPersistsLedgerReadModelOutboxAndIdempotency' --tests 'com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest' --tests 'com.aquilabank.global.security.BootstrapHeaderSecurityProfileTest'`
- login -> JWT -> 허용/비허용 계좌 접근과 request-id/trace_id 연계를 확인했습니다.

## 📸 Screenshot / API Example
- `POST /api/v1/auth/login`
- `GET /api/v1/transactions?accountId={id}&from=...&to=...`
- `POST /api/v1/transfers` body에 `sourceAccountId`를 추가했습니다.

## ⚠️ Risk & Rollback
- 예상 리스크:
  - 기존 `account_id` claim JWT와 `@CurrentAccountId` 기반 호출은 더 이상 동작하지 않습니다.
  - `user_account_membership` 데이터가 없으면 거래 조회/송금이 403으로 거부됩니다.
- 롤백 방법:
  - 이 PR revert 후 기존 `account_id` claim 기반 JWT와 bootstrap account principal 경로로 되돌립니다.
  - 필요 시 V4 migration 이후 생성된 `bank_user`, `user_account_membership` 데이터는 별도 정리합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.