### PR TITLE
[Feat] 내부 사용자와 계좌 멤버십 bootstrap 경로 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/exception/DuplicateLoginIdException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/DuplicateLoginIdException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.exception;
+
+/** 같은 loginId 재사용을 막아 내부 bootstrap 중복 생성을 방지합니다. */
+public class DuplicateLoginIdException extends RuntimeException {
+
+  public DuplicateLoginIdException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipUpsertCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipUpsertCommand.java
@@ -1,0 +1,21 @@
+package com.aquilabank.domain.auth.model;
+
+/** 내부 bootstrap에서 user-account membership을 생성/갱신할 때 쓰는 명령입니다. */
+public record UserAccountMembershipUpsertCommand(
+    long userId, long accountId, MembershipRole role, MembershipStatus status) {
+
+  public UserAccountMembershipUpsertCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (role == null) {
+      throw new IllegalArgumentException("role is required");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserBootstrapCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserBootstrapCommand.java
@@ -1,0 +1,17 @@
+package com.aquilabank.domain.auth.model;
+
+/** 내부 bootstrap에서 새 사용자를 만들 때 받는 최소 입력입니다. */
+public record UserBootstrapCommand(String loginId, String password, String displayName) {
+
+  public UserBootstrapCommand {
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (password == null || password.isBlank()) {
+      throw new IllegalArgumentException("password is required");
+    }
+    if (displayName == null || displayName.isBlank()) {
+      throw new IllegalArgumentException("displayName is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserBootstrapResult.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserBootstrapResult.java
@@ -1,0 +1,26 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 내부 bootstrap 이후 login과 membership 부여에 재사용하는 사용자 식별 결과입니다. */
+public record UserBootstrapResult(
+    long userId, String loginId, String displayName, UserStatus status, Instant createdAt) {
+
+  public UserBootstrapResult {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (displayName == null || displayName.isBlank()) {
+      throw new IllegalArgumentException("displayName is required");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserBootstrapWriteCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserBootstrapWriteCommand.java
@@ -1,0 +1,21 @@
+package com.aquilabank.domain.auth.model;
+
+/** hash 완료된 사용자 credential을 저장소 계층으로 넘기는 write 명령입니다. */
+public record UserBootstrapWriteCommand(
+    String loginId, String passwordHash, String displayName, UserStatus status) {
+
+  public UserBootstrapWriteCommand {
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (passwordHash == null || passwordHash.isBlank()) {
+      throw new IllegalArgumentException("passwordHash is required");
+    }
+    if (displayName == null || displayName.isBlank()) {
+      throw new IllegalArgumentException("displayName is required");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/PasswordHashPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/PasswordHashPort.java
@@ -3,5 +3,7 @@ package com.aquilabank.domain.auth.port;
 /** password hash 알고리즘을 domain 밖으로 분리하는 port */
 public interface PasswordHashPort {
 
+  String encode(String rawPassword);
+
   boolean matches(String rawPassword, String passwordHash);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserAccountMembershipUpsertPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserAccountMembershipUpsertPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserAccountMembershipUpsertCommand;
+
+/** user-account membership 생성/갱신을 저장소 계층으로 위임합니다. */
+public interface UserAccountMembershipUpsertPort {
+
+  UserAccountMembership upsert(UserAccountMembershipUpsertCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserBootstrapPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserBootstrapPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.UserBootstrapResult;
+import com.aquilabank.domain.auth.model.UserBootstrapWriteCommand;
+
+/** hash 완료된 사용자 정보를 저장해 login 대상 user를 생성합니다. */
+public interface UserBootstrapPort {
+
+  UserBootstrapResult bootstrap(UserBootstrapWriteCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipUpsertService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipUpsertService.java
@@ -1,0 +1,25 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserAccountMembershipUpsertCommand;
+import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
+
+/** membership upsert를 한 경로로 고정해 bootstrap과 운영 도구의 write 규칙을 맞춥니다. */
+public final class UserAccountMembershipUpsertService
+    implements UserAccountMembershipUpsertUseCase {
+
+  private final UserAccountMembershipUpsertPort userAccountMembershipUpsertPort;
+
+  public UserAccountMembershipUpsertService(
+      UserAccountMembershipUpsertPort userAccountMembershipUpsertPort) {
+    this.userAccountMembershipUpsertPort = userAccountMembershipUpsertPort;
+  }
+
+  @Override
+  public UserAccountMembership upsert(UserAccountMembershipUpsertCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+    return userAccountMembershipUpsertPort.upsert(command);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipUpsertUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipUpsertUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserAccountMembershipUpsertCommand;
+
+public interface UserAccountMembershipUpsertUseCase {
+
+  UserAccountMembership upsert(UserAccountMembershipUpsertCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserBootstrapService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserBootstrapService.java
@@ -1,0 +1,35 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.UserBootstrapCommand;
+import com.aquilabank.domain.auth.model.UserBootstrapResult;
+import com.aquilabank.domain.auth.model.UserBootstrapWriteCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.UserBootstrapPort;
+
+/** 내부 bootstrap 입력을 hash 처리 후 저장소 write 명령으로 변환합니다. */
+public final class UserBootstrapService implements UserBootstrapUseCase {
+
+  private final UserBootstrapPort userBootstrapPort;
+  private final PasswordHashPort passwordHashPort;
+
+  public UserBootstrapService(
+      UserBootstrapPort userBootstrapPort, PasswordHashPort passwordHashPort) {
+    this.userBootstrapPort = userBootstrapPort;
+    this.passwordHashPort = passwordHashPort;
+  }
+
+  @Override
+  public UserBootstrapResult bootstrap(UserBootstrapCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+
+    return userBootstrapPort.bootstrap(
+        new UserBootstrapWriteCommand(
+            command.loginId(),
+            passwordHashPort.encode(command.password()),
+            command.displayName(),
+            UserStatus.ACTIVE));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserBootstrapUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserBootstrapUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.UserBootstrapCommand;
+import com.aquilabank.domain.auth.model.UserBootstrapResult;
+
+public interface UserBootstrapUseCase {
+
+  UserBootstrapResult bootstrap(UserBootstrapCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -3,11 +3,17 @@ package com.aquilabank.global.config;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
+import com.aquilabank.domain.auth.port.UserBootstrapPort;
 import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
 import com.aquilabank.domain.auth.usecase.AccountAccessService;
 import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
 import com.aquilabank.domain.auth.usecase.LoginService;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipUpsertService;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipUpsertUseCase;
+import com.aquilabank.domain.auth.usecase.UserBootstrapService;
+import com.aquilabank.domain.auth.usecase.UserBootstrapUseCase;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -26,5 +32,17 @@ public class AuthConfiguration {
   @Bean
   AccountAccessUseCase accountAccessUseCase(AccountAccessPort accountAccessPort) {
     return new AccountAccessService(accountAccessPort);
+  }
+
+  @Bean
+  UserBootstrapUseCase userBootstrapUseCase(
+      UserBootstrapPort userBootstrapPort, PasswordHashPort passwordHashPort) {
+    return new UserBootstrapService(userBootstrapPort, passwordHashPort);
+  }
+
+  @Bean
+  UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase(
+      UserAccountMembershipUpsertPort userAccountMembershipUpsertPort) {
+    return new UserAccountMembershipUpsertService(userAccountMembershipUpsertPort);
   }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -1,0 +1,151 @@
+package com.aquilabank.global.persistence.auth;
+
+import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserAccountMembershipUpsertCommand;
+import com.aquilabank.domain.auth.model.UserBootstrapResult;
+import com.aquilabank.domain.auth.model.UserBootstrapWriteCommand;
+import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
+import com.aquilabank.domain.auth.port.UserBootstrapPort;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** auth bootstrap 쓰기 경로를 JDBC로 고정해 테스트와 운영 도구가 같은 저장 경로를 탑니다. */
+@Repository
+public class JdbcAuthWriteRepository implements UserBootstrapPort, UserAccountMembershipUpsertPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcAuthWriteRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional
+  public UserBootstrapResult bootstrap(UserBootstrapWriteCommand command) {
+    Instant now = Instant.now();
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("loginId", command.loginId())
+            .addValue("passwordHash", command.passwordHash())
+            .addValue("displayName", command.displayName())
+            .addValue("userStatus", command.status().name())
+            .addValue("now", Timestamp.from(now));
+
+    try {
+      Long userId =
+          jdbcTemplate.queryForObject(
+              """
+              INSERT INTO bank_user (
+                  login_id,
+                  password_hash,
+                  display_name,
+                  user_status,
+                  created_at,
+                  updated_at
+              )
+              VALUES (
+                  :loginId,
+                  :passwordHash,
+                  :displayName,
+                  :userStatus,
+                  :now,
+                  :now
+              )
+              RETURNING id
+              """,
+              params,
+              Long.class);
+
+      if (userId == null) {
+        throw new IllegalStateException("bank_user insert did not return an id");
+      }
+
+      return new UserBootstrapResult(
+          userId, command.loginId(), command.displayName(), command.status(), now);
+    } catch (DuplicateKeyException ex) {
+      throw new DuplicateLoginIdException("loginId is already used");
+    }
+  }
+
+  @Override
+  @Transactional
+  public UserAccountMembership upsert(UserAccountMembershipUpsertCommand command) {
+    assertUserExists(command.userId());
+    assertAccountExists(command.accountId());
+
+    Instant now = Instant.now();
+    jdbcTemplate.update(
+        """
+        INSERT INTO user_account_membership (
+            user_id,
+            account_id,
+            membership_role,
+            membership_status,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :accountId,
+            :membershipRole,
+            :membershipStatus,
+            :now,
+            :now
+        )
+        ON CONFLICT (user_id, account_id)
+        DO UPDATE
+        SET membership_role = EXCLUDED.membership_role,
+            membership_status = EXCLUDED.membership_status,
+            updated_at = EXCLUDED.updated_at
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", command.userId())
+            .addValue("accountId", command.accountId())
+            .addValue("membershipRole", command.role().name())
+            .addValue("membershipStatus", command.status().name())
+            .addValue("now", Timestamp.from(now)));
+
+    return new UserAccountMembership(
+        command.userId(), command.accountId(), command.role(), command.status());
+  }
+
+  private void assertUserExists(long userId) {
+    Boolean exists =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM bank_user
+                WHERE id = :userId
+            )
+            """,
+            new MapSqlParameterSource().addValue("userId", userId),
+            Boolean.class);
+    if (!Boolean.TRUE.equals(exists)) {
+      throw new IllegalArgumentException("userId is invalid");
+    }
+  }
+
+  private void assertAccountExists(long accountId) {
+    Boolean exists =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM bank_account
+                WHERE id = :accountId
+            )
+            """,
+            new MapSqlParameterSource().addValue("accountId", accountId),
+            Boolean.class);
+    if (!Boolean.TRUE.equals(exists)) {
+      throw new IllegalArgumentException("accountId is invalid");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/AuthBootstrapApiProperties.java
+++ b/back/src/main/java/com/aquilabank/global/security/AuthBootstrapApiProperties.java
@@ -1,0 +1,19 @@
+package com.aquilabank.global.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** 내부 사용자/bootstrap API의 token 보호 설정입니다. */
+@ConfigurationProperties(prefix = "security.auth-bootstrap-api")
+public record AuthBootstrapApiProperties(boolean enabled, String tokenHeader, String token) {
+
+  public AuthBootstrapApiProperties {
+    if (tokenHeader == null || tokenHeader.isBlank()) {
+      throw new IllegalArgumentException(
+          "security.auth-bootstrap-api.token-header must not be blank");
+    }
+    if (enabled && (token == null || token.isBlank())) {
+      throw new IllegalArgumentException(
+          "security.auth-bootstrap-api.token must not be blank when enabled");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -31,7 +31,8 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 @EnableConfigurationProperties({
   SecurityJwtProperties.class,
   BootstrapHeaderAuthProperties.class,
-  AccountBootstrapApiProperties.class
+  AccountBootstrapApiProperties.class,
+  AuthBootstrapApiProperties.class
 })
 public class SecurityConfiguration {
 
@@ -56,8 +57,10 @@ public class SecurityConfiguration {
                     .permitAll()
                     .requestMatchers("/api/v1/auth/login")
                     .permitAll()
-                    // 내부 bootstrap API는 계좌 principal 대신 별도 token으로 보호합니다.
+                    // 내부 bootstrap API는 JWT 대신 별도 shared token으로 보호합니다.
                     .requestMatchers("/internal/api/v1/accounts/bootstrap")
+                    .permitAll()
+                    .requestMatchers("/internal/api/v1/auth/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())
@@ -120,7 +123,17 @@ public class SecurityConfiguration {
 
   @Bean
   PasswordHashPort passwordHashPort(PasswordEncoder passwordEncoder) {
-    return passwordEncoder::matches;
+    return new PasswordHashPort() {
+      @Override
+      public String encode(String rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+      }
+
+      @Override
+      public boolean matches(String rawPassword, String passwordHash) {
+        return passwordEncoder.matches(rawPassword, passwordHash);
+      }
+    };
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.web;
 
 import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
+import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
 import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
@@ -69,6 +70,7 @@ public class ApiExceptionHandler {
   }
 
   @ExceptionHandler({
+    DuplicateLoginIdException.class,
     CommandConflictException.class,
     CurrencyMismatchException.class,
     InsufficientBalanceException.class

--- a/back/src/main/java/com/aquilabank/global/web/auth/AuthBootstrapController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/AuthBootstrapController.java
@@ -1,0 +1,126 @@
+package com.aquilabank.global.web.auth;
+
+import com.aquilabank.domain.auth.model.MembershipRole;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserAccountMembershipUpsertCommand;
+import com.aquilabank.domain.auth.model.UserBootstrapCommand;
+import com.aquilabank.domain.auth.model.UserBootstrapResult;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipUpsertUseCase;
+import com.aquilabank.domain.auth.usecase.UserBootstrapUseCase;
+import com.aquilabank.global.security.AuthBootstrapApiProperties;
+import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 내부 운영/테스트가 user bootstrap과 membership upsert를 같은 경로 규칙으로 호출합니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/auth")
+@ConditionalOnProperty(name = "security.auth-bootstrap-api.enabled", havingValue = "true")
+public class AuthBootstrapController {
+
+  private final UserBootstrapUseCase userBootstrapUseCase;
+  private final UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase;
+  private final AuthBootstrapApiProperties authBootstrapApiProperties;
+
+  public AuthBootstrapController(
+      UserBootstrapUseCase userBootstrapUseCase,
+      UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase,
+      AuthBootstrapApiProperties authBootstrapApiProperties) {
+    this.userBootstrapUseCase = userBootstrapUseCase;
+    this.userAccountMembershipUpsertUseCase = userAccountMembershipUpsertUseCase;
+    this.authBootstrapApiProperties = authBootstrapApiProperties;
+  }
+
+  @PostMapping("/users/bootstrap")
+  public UserBootstrapResponse bootstrapUser(
+      HttpServletRequest httpServletRequest, @Valid @RequestBody UserBootstrapRequest request) {
+    validateBootstrapToken(httpServletRequest);
+
+    UserBootstrapResult result =
+        userBootstrapUseCase.bootstrap(
+            new UserBootstrapCommand(request.loginId(), request.password(), request.displayName()));
+    return UserBootstrapResponse.from(result);
+  }
+
+  @PutMapping("/users/{userId}/memberships/{accountId}")
+  public UserAccountMembershipResponse upsertMembership(
+      HttpServletRequest httpServletRequest,
+      @PathVariable @Positive(message = "userId must be positive") long userId,
+      @PathVariable @Positive(message = "accountId must be positive") long accountId,
+      @Valid @RequestBody UserAccountMembershipRequest request) {
+    validateBootstrapToken(httpServletRequest);
+
+    UserAccountMembership membership =
+        userAccountMembershipUpsertUseCase.upsert(
+            new UserAccountMembershipUpsertCommand(
+                userId, accountId, request.membershipRole(), request.membershipStatus()));
+    return UserAccountMembershipResponse.from(membership);
+  }
+
+  private void validateBootstrapToken(HttpServletRequest httpServletRequest) {
+    String bootstrapToken = httpServletRequest.getHeader(authBootstrapApiProperties.tokenHeader());
+
+    // permitAll endpoint라도 shared token 검증이 없으면 내부 bootstrap이 외부 요청에 그대로 열립니다.
+    if (bootstrapToken == null
+        || bootstrapToken.isBlank()
+        || !authBootstrapApiProperties.token().equals(bootstrapToken)) {
+      throw new BootstrapApiAccessDeniedException("bootstrap token is invalid");
+    }
+  }
+
+  /** 내부 사용자 bootstrap 요청 body */
+  public record UserBootstrapRequest(
+      @NotBlank(message = "loginId is required") @Size(max = 80, message = "loginId must be 80 characters or less") String loginId,
+      @NotBlank(message = "password is required") @Size(max = 120, message = "password must be 120 characters or less") String password,
+      @NotBlank(message = "displayName is required") @Size(max = 80, message = "displayName must be 80 characters or less") String displayName) {}
+
+  /** 내부 membership upsert 요청 body */
+  public record UserAccountMembershipRequest(
+      @NotNull(message = "membershipRole is required") MembershipRole membershipRole,
+      @NotNull(message = "membershipStatus is required") MembershipStatus membershipStatus) {}
+
+  /** 내부 사용자 bootstrap 완료 응답 */
+  public record UserBootstrapResponse(
+      long userId,
+      String loginId,
+      String displayName,
+      String userStatus,
+      java.time.Instant createdAt) {
+
+    static UserBootstrapResponse from(UserBootstrapResult result) {
+      return new UserBootstrapResponse(
+          result.userId(),
+          result.loginId(),
+          result.displayName(),
+          result.status().name(),
+          result.createdAt());
+    }
+  }
+
+  /** 내부 membership upsert 완료 응답 */
+  public record UserAccountMembershipResponse(
+      long userId, long accountId, String membershipRole, String membershipStatus) {
+
+    static UserAccountMembershipResponse from(UserAccountMembership membership) {
+      return new UserAccountMembershipResponse(
+          membership.userId(),
+          membership.accountId(),
+          membership.role().name(),
+          membership.status().name());
+    }
+  }
+}

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -20,3 +20,6 @@ security:
   account-bootstrap-api:
     enabled: ${SECURITY_ACCOUNT_BOOTSTRAP_API_ENABLED:true}
     token: ${SECURITY_ACCOUNT_BOOTSTRAP_API_TOKEN:dev-bootstrap-api-token}
+  auth-bootstrap-api:
+    enabled: ${SECURITY_AUTH_BOOTSTRAP_API_ENABLED:true}
+    token: ${SECURITY_AUTH_BOOTSTRAP_API_TOKEN:dev-auth-bootstrap-api-token}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -87,3 +87,7 @@ security:
     enabled: ${SECURITY_ACCOUNT_BOOTSTRAP_API_ENABLED:false}
     token-header: ${SECURITY_ACCOUNT_BOOTSTRAP_API_TOKEN_HEADER:X-Bootstrap-Token}
     token: ${SECURITY_ACCOUNT_BOOTSTRAP_API_TOKEN:}
+  auth-bootstrap-api:
+    enabled: ${SECURITY_AUTH_BOOTSTRAP_API_ENABLED:false}
+    token-header: ${SECURITY_AUTH_BOOTSTRAP_API_TOKEN_HEADER:X-Auth-Bootstrap-Token}
+    token: ${SECURITY_AUTH_BOOTSTRAP_API_TOKEN:}

--- a/back/src/test/java/com/aquilabank/global/web/auth/AuthBootstrapControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/AuthBootstrapControllerTest.java
@@ -1,0 +1,124 @@
+package com.aquilabank.global.web.auth;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.auth.model.MembershipRole;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserBootstrapResult;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipUpsertUseCase;
+import com.aquilabank.domain.auth.usecase.UserBootstrapUseCase;
+import com.aquilabank.global.security.AuthBootstrapApiProperties;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AuthBootstrapControllerTest {
+
+  private static final String TOKEN_HEADER = "X-Auth-Bootstrap-Token";
+  private static final String TOKEN = "test-auth-bootstrap-api-token";
+
+  private UserBootstrapUseCase userBootstrapUseCase;
+  private UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    userBootstrapUseCase = mock(UserBootstrapUseCase.class);
+    userAccountMembershipUpsertUseCase = mock(UserAccountMembershipUpsertUseCase.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new AuthBootstrapController(
+                    userBootstrapUseCase,
+                    userAccountMembershipUpsertUseCase,
+                    new AuthBootstrapApiProperties(true, TOKEN_HEADER, TOKEN)))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void bootstrapsUserWithSharedToken() throws Exception {
+    when(userBootstrapUseCase.bootstrap(argThat(command -> "alice".equals(command.loginId()))))
+        .thenReturn(
+            new UserBootstrapResult(
+                21L, "alice", "Alice", UserStatus.ACTIVE, Instant.parse("2026-04-16T10:30:00Z")));
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/auth/users/bootstrap")
+                .header(TOKEN_HEADER, TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "loginId": "alice",
+                      "password": "password123!",
+                      "displayName": "Alice"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(21))
+        .andExpect(jsonPath("$.loginId").value("alice"))
+        .andExpect(jsonPath("$.userStatus").value("ACTIVE"));
+
+    verify(userBootstrapUseCase)
+        .bootstrap(argThat(command -> "password123!".equals(command.password())));
+  }
+
+  @Test
+  void upsertsMembershipWithSharedToken() throws Exception {
+    when(userAccountMembershipUpsertUseCase.upsert(argThat(command -> command.accountId() == 101L)))
+        .thenReturn(
+            new UserAccountMembership(21L, 101L, MembershipRole.OWNER, MembershipStatus.ACTIVE));
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/21/memberships/101")
+                .header(TOKEN_HEADER, TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "membershipRole": "OWNER",
+                      "membershipStatus": "ACTIVE"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(21))
+        .andExpect(jsonPath("$.accountId").value(101))
+        .andExpect(jsonPath("$.membershipRole").value("OWNER"));
+
+    verify(userAccountMembershipUpsertUseCase)
+        .upsert(argThat(command -> command.role() == MembershipRole.OWNER));
+  }
+
+  @Test
+  void rejectsMissingOrInvalidBootstrapToken() throws Exception {
+    mockMvc
+        .perform(
+            post("/internal/api/v1/auth/users/bootstrap")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "loginId": "alice",
+                      "password": "password123!",
+                      "displayName": "Alice"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("bootstrap token is invalid"));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/AuthBootstrapSecurityProfileTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/AuthBootstrapSecurityProfileTest.java
@@ -1,0 +1,32 @@
+package com.aquilabank.global.web.auth;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("prod")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      "spring.flyway.enabled=false",
+      "management.health.db.enabled=false",
+      "spring.datasource.url=jdbc:postgresql://localhost:5432/aquila_bank_test",
+      "spring.datasource.username=postgres",
+      "spring.datasource.password=postgres",
+      "spring.datasource.hikari.initialization-fail-timeout=0",
+      "security.jwt.secret=test-local-jwt-secret-test-local-jwt-secret",
+      "security.jwt.access-token-ttl-seconds=300"
+    })
+class AuthBootstrapSecurityProfileTest {
+
+  @Autowired private ObjectProvider<AuthBootstrapController> authBootstrapControllerProvider;
+
+  @Test
+  void doesNotRegisterAuthBootstrapControllerInProdByDefault() {
+    assertNull(authBootstrapControllerProvider.getIfAvailable());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -16,14 +17,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.context.WebApplicationContext;
 
 @ActiveProfiles("test")
@@ -32,17 +30,17 @@ import org.springframework.web.context.WebApplicationContext;
     properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
 class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSupport {
 
+  private static final String ACCOUNT_BOOTSTRAP_TOKEN = "test-bootstrap-api-token";
+  private static final String AUTH_BOOTSTRAP_TOKEN = "test-auth-bootstrap-api-token";
+
   @Autowired private WebApplicationContext context;
 
   @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
 
   @Autowired private ObjectMapper objectMapper;
 
-  @Autowired private PasswordEncoder passwordEncoder;
-
-  @Autowired private PlatformTransactionManager transactionManager;
-
   private MockMvc mockMvc;
+  private long userId;
   private long allowedSourceAccountId;
   private long targetAccountId;
   private long deniedAccountId;
@@ -56,13 +54,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
     targetAccountId = bootstrapAccount("allowed target", 0L);
     deniedAccountId = bootstrapAccount("denied source", 5_000L);
 
-    long[] userIdHolder = new long[1];
-    commit(
-        transactionManager,
-        () -> {
-          userIdHolder[0] = insertUser("alice", "Alice", "password123!");
-          insertMembership(userIdHolder[0], allowedSourceAccountId, "OWNER");
-        });
+    userId = bootstrapUser("alice", "Alice", "password123!");
+    upsertMembership(userId, allowedSourceAccountId, "OWNER", "ACTIVE");
   }
 
   @Test
@@ -142,6 +135,42 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void membershipUpsertUpdatesTransferPermission() throws Exception {
+    upsertMembership(userId, allowedSourceAccountId, "VIEWER", "ACTIVE");
+    String token = login("alice", "password123!");
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId))
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Authorization", "Bearer " + token)
+                .header("Idempotency-Key", "jwt-transfer-viewer-403")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": 500,
+                      "currencyCode": "KRW",
+                      "summary": "viewer-blocked"
+                    }
+                    """
+                        .formatted(allowedSourceAccountId, targetAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
+  @Test
   void rejectsInvalidLoginCredentials() throws Exception {
     mockMvc
         .perform(
@@ -186,7 +215,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         mockMvc
             .perform(
                 post("/internal/api/v1/accounts/bootstrap")
-                    .header("X-Bootstrap-Token", "test-bootstrap-api-token")
+                    .header("X-Bootstrap-Token", ACCOUNT_BOOTSTRAP_TOKEN)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         """
@@ -206,62 +235,51 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .asLong();
   }
 
-  private long insertUser(String loginId, String displayName, String password) {
-    Long userId =
-        jdbcTemplate.queryForObject(
-            """
-            INSERT INTO bank_user (
-                login_id,
-                password_hash,
-                display_name,
-                user_status,
-                created_at,
-                updated_at
-            )
-            VALUES (
-                :loginId,
-                :passwordHash,
-                :displayName,
-                'ACTIVE',
-                CURRENT_TIMESTAMP,
-                CURRENT_TIMESTAMP
-            )
-            RETURNING id
-            """,
-            new MapSqlParameterSource()
-                .addValue("loginId", loginId)
-                .addValue("passwordHash", passwordEncoder.encode(password))
-                .addValue("displayName", displayName),
-            Long.class);
-    if (userId == null) {
-      throw new IllegalStateException("user insert did not return id");
-    }
-    return userId;
+  private long bootstrapUser(String loginId, String displayName, String password) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/internal/api/v1/auth/users/bootstrap")
+                    .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "loginId": "%s",
+                          "password": "%s",
+                          "displayName": "%s"
+                        }
+                        """
+                            .formatted(loginId, password, displayName)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    return objectMapper
+        .readTree(result.getResponse().getContentAsByteArray())
+        .get("userId")
+        .asLong();
   }
 
-  private void insertMembership(long userId, long accountId, String membershipRole) {
-    jdbcTemplate.update(
-        """
-        INSERT INTO user_account_membership (
-            user_id,
-            account_id,
-            membership_role,
-            membership_status,
-            created_at,
-            updated_at
-        )
-        VALUES (
-            :userId,
-            :accountId,
-            :membershipRole,
-            'ACTIVE',
-            CURRENT_TIMESTAMP,
-            CURRENT_TIMESTAMP
-        )
-        """,
-        new MapSqlParameterSource()
-            .addValue("userId", userId)
-            .addValue("accountId", accountId)
-            .addValue("membershipRole", membershipRole));
+  private void upsertMembership(
+      long userId, long accountId, String membershipRole, String membershipStatus)
+      throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/%d/memberships/%d".formatted(userId, accountId))
+                .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "membershipRole": "%s",
+                      "membershipStatus": "%s"
+                    }
+                    """
+                        .formatted(membershipRole, membershipStatus)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(userId))
+        .andExpect(jsonPath("$.accountId").value(accountId))
+        .andExpect(jsonPath("$.membershipRole").value(membershipRole))
+        .andExpect(jsonPath("$.membershipStatus").value(membershipStatus));
   }
 }

--- a/back/src/test/resources/application-test.yml
+++ b/back/src/test/resources/application-test.yml
@@ -28,3 +28,6 @@ security:
   account-bootstrap-api:
     enabled: true
     token: test-bootstrap-api-token
+  auth-bootstrap-api:
+    enabled: true
+    token: test-auth-bootstrap-api-token


### PR DESCRIPTION
## 🔗 Related Issue
- close #7

## 📝 Summary
- 내부 전용 auth bootstrap API로 `bank_user` 생성, password hash 저장, `user_account_membership` upsert 경로를 추가했습니다.
- dev/test/prod에서 auth bootstrap 경로의 활성화와 token 보호를 분리하고, login -> JWT -> account access 흐름을 실제 bootstrap API 기준으로 검증하도록 통합 테스트를 교체했습니다.

## 🛠 Changes
- auth domain에 user bootstrap/membership upsert command, use case, write port와 JDBC adapter를 추가했습니다.
- `/internal/api/v1/auth/users/bootstrap`, `/internal/api/v1/auth/users/{userId}/memberships/{accountId}` 내부 API와 token property를 추가했습니다.
- auth bootstrap controller/security profile/unit/integration 테스트를 추가하고 기존 직접 SQL 시딩 테스트를 API 기반으로 바꿨습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth ./back/gradlew -p back test --tests com.aquilabank.global.web.auth.AuthBootstrapControllerTest --tests com.aquilabank.global.web.auth.AuthBootstrapSecurityProfileTest --tests com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 내부 bootstrap token/property 설정이 누락되면 dev/test에서 bootstrap API를 기대한 대로 호출하지 못할 수 있습니다.
- 롤백 방법: PR revert 후 기존 직접 SQL 기반 테스트/운영 경로로 되돌리고, `security.auth-bootstrap-api.*` 설정을 제거합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [ ] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.