### PR TITLE
[Feat] 내부 사용자/계좌 권한 조회·회수 경로 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/exception/AuthUserNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/AuthUserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.exception;
+
+/** 내부 auth 관리 경로에서 찾을 수 없는 user 조회/갱신을 구분합니다. */
+public class AuthUserNotFoundException extends RuntimeException {
+
+  public AuthUserNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/exception/UserAccountMembershipNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/UserAccountMembershipNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.exception;
+
+/** 내부 auth 관리 경로에서 찾을 수 없는 membership 조회/갱신을 구분합니다. */
+public class UserAccountMembershipNotFoundException extends RuntimeException {
+
+  public UserAccountMembershipNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AccountAccessMembership.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AccountAccessMembership.java
@@ -1,0 +1,28 @@
+package com.aquilabank.domain.auth.model;
+
+/** access 검증이 membership 상태와 user 상태를 한 번에 판단하도록 묶은 조회 모델입니다. */
+public record AccountAccessMembership(
+    long userId,
+    long accountId,
+    MembershipRole role,
+    MembershipStatus membershipStatus,
+    UserStatus userStatus) {
+
+  public AccountAccessMembership {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (role == null) {
+      throw new IllegalArgumentException("role is required");
+    }
+    if (membershipStatus == null) {
+      throw new IllegalArgumentException("membershipStatus is required");
+    }
+    if (userStatus == null) {
+      throw new IllegalArgumentException("userStatus is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthUserSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthUserSummary.java
@@ -1,0 +1,34 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 내부 auth 관리 조회가 password hash 없이 재사용하는 사용자 요약 모델입니다. */
+public record AuthUserSummary(
+    long userId,
+    String loginId,
+    String displayName,
+    UserStatus status,
+    Instant createdAt,
+    Instant updatedAt) {
+
+  public AuthUserSummary {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (displayName == null || displayName.isBlank()) {
+      throw new IllegalArgumentException("displayName is required");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+    if (updatedAt == null) {
+      throw new IllegalArgumentException("updatedAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipStatusUpdateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipStatusUpdateCommand.java
@@ -1,0 +1,18 @@
+package com.aquilabank.domain.auth.model;
+
+/** 내부 auth 관리 경로가 membership 상태를 변경할 때 쓰는 명령입니다. */
+public record UserAccountMembershipStatusUpdateCommand(
+    long userId, long accountId, MembershipStatus status) {
+
+  public UserAccountMembershipStatusUpdateCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipSummary.java
@@ -1,0 +1,34 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 내부 auth 관리 조회가 membership 상태와 갱신 시각을 확인할 때 쓰는 요약 모델입니다. */
+public record UserAccountMembershipSummary(
+    long userId,
+    long accountId,
+    MembershipRole role,
+    MembershipStatus status,
+    Instant createdAt,
+    Instant updatedAt) {
+
+  public UserAccountMembershipSummary {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (role == null) {
+      throw new IllegalArgumentException("role is required");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+    if (updatedAt == null) {
+      throw new IllegalArgumentException("updatedAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserStatusUpdateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserStatusUpdateCommand.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** 내부 auth 관리 경로가 user 상태를 변경할 때 쓰는 명령입니다. */
+public record UserStatusUpdateCommand(long userId, UserStatus status) {
+
+  public UserStatusUpdateCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AccountAccessPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AccountAccessPort.java
@@ -1,5 +1,6 @@
 package com.aquilabank.domain.auth.port;
 
+import com.aquilabank.domain.auth.model.AccountAccessMembership;
 import com.aquilabank.domain.auth.model.UserAccountMembership;
 import java.util.Optional;
 
@@ -7,4 +8,16 @@ import java.util.Optional;
 public interface AccountAccessPort {
 
   Optional<UserAccountMembership> findMembership(long userId, long accountId);
+
+  default Optional<AccountAccessMembership> findAccessMembership(long userId, long accountId) {
+    return findMembership(userId, accountId)
+        .map(
+            membership ->
+                new AccountAccessMembership(
+                    membership.userId(),
+                    membership.accountId(),
+                    membership.role(),
+                    membership.status(),
+                    com.aquilabank.domain.auth.model.UserStatus.ACTIVE));
+  }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserAccountMembershipQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserAccountMembershipQueryPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
+import java.util.Optional;
+
+/** 내부 auth 관리 exact lookup을 위한 membership 조회 port입니다. */
+public interface UserAccountMembershipQueryPort {
+
+  Optional<UserAccountMembershipSummary> findByUserIdAndAccountId(long userId, long accountId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserAccountMembershipStatusUpdatePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserAccountMembershipStatusUpdatePort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
+
+/** 내부 auth 관리 경로의 membership status update를 저장소 계층으로 위임합니다. */
+public interface UserAccountMembershipStatusUpdatePort {
+
+  UserAccountMembershipSummary updateStatus(UserAccountMembershipStatusUpdateCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserQueryPort.java
@@ -1,0 +1,12 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+import java.util.Optional;
+
+/** 내부 auth 관리 exact lookup을 위한 user 조회 port입니다. */
+public interface UserQueryPort {
+
+  Optional<AuthUserSummary> findByUserId(long userId);
+
+  Optional<AuthUserSummary> findByLoginId(String loginId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserQueryPort.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 /** 내부 auth 관리 exact lookup을 위한 user 조회 port입니다. */
 public interface UserQueryPort {
 
-  Optional<AuthUserSummary> findByUserId(long userId);
+  Optional<AuthUserSummary> findSummaryByUserId(long userId);
 
-  Optional<AuthUserSummary> findByLoginId(String loginId);
+  Optional<AuthUserSummary> findSummaryByLoginId(String loginId);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserStatusUpdatePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserStatusUpdatePort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
+
+/** 내부 auth 관리 경로의 user status update를 저장소 계층으로 위임합니다. */
+public interface UserStatusUpdatePort {
+
+  AuthUserSummary updateStatus(UserStatusUpdateCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessService.java
@@ -1,9 +1,10 @@
 package com.aquilabank.domain.auth.usecase;
 
 import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
+import com.aquilabank.domain.auth.model.AccountAccessMembership;
 import com.aquilabank.domain.auth.model.AccountAccessScope;
 import com.aquilabank.domain.auth.model.MembershipStatus;
-import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
 
 /** user-account membership 한 건 조회로 계좌 접근 권한을 판단합니다. */
@@ -27,12 +28,14 @@ public final class AccountAccessService implements AccountAccessUseCase {
       throw new IllegalArgumentException("scope is required");
     }
 
-    UserAccountMembership membership =
+    AccountAccessMembership membership =
         accountAccessPort
-            .findMembership(userId, accountId)
+            .findAccessMembership(userId, accountId)
             .orElseThrow(() -> new AccountAccessDeniedException("account access is denied"));
 
-    if (membership.status() != MembershipStatus.ACTIVE || !membership.role().allows(scope)) {
+    if (membership.userStatus() != UserStatus.ACTIVE
+        || membership.membershipStatus() != MembershipStatus.ACTIVE
+        || !membership.role().allows(scope)) {
       throw new AccountAccessDeniedException("account access is denied");
     }
     return accountId;

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthUserQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthUserQueryService.java
@@ -1,0 +1,35 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.port.UserQueryPort;
+
+/** 내부 auth 관리 exact lookup을 domain 예외와 함께 묶습니다. */
+public final class AuthUserQueryService implements AuthUserQueryUseCase {
+
+  private final UserQueryPort userQueryPort;
+
+  public AuthUserQueryService(UserQueryPort userQueryPort) {
+    this.userQueryPort = userQueryPort;
+  }
+
+  @Override
+  public AuthUserSummary getByUserId(long userId) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    return userQueryPort
+        .findByUserId(userId)
+        .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
+  }
+
+  @Override
+  public AuthUserSummary getByLoginId(String loginId) {
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    return userQueryPort
+        .findByLoginId(loginId)
+        .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthUserQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthUserQueryService.java
@@ -19,7 +19,7 @@ public final class AuthUserQueryService implements AuthUserQueryUseCase {
       throw new IllegalArgumentException("userId must be positive");
     }
     return userQueryPort
-        .findByUserId(userId)
+        .findSummaryByUserId(userId)
         .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
   }
 
@@ -29,7 +29,7 @@ public final class AuthUserQueryService implements AuthUserQueryUseCase {
       throw new IllegalArgumentException("loginId is required");
     }
     return userQueryPort
-        .findByLoginId(loginId)
+        .findSummaryByLoginId(loginId)
         .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthUserQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthUserQueryUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+
+public interface AuthUserQueryUseCase {
+
+  AuthUserSummary getByUserId(long userId);
+
+  AuthUserSummary getByLoginId(String loginId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipQueryService.java
@@ -1,0 +1,29 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
+import com.aquilabank.domain.auth.port.UserAccountMembershipQueryPort;
+
+/** 내부 auth 관리 exact lookup을 membership not found 예외와 함께 묶습니다. */
+public final class UserAccountMembershipQueryService implements UserAccountMembershipQueryUseCase {
+
+  private final UserAccountMembershipQueryPort userAccountMembershipQueryPort;
+
+  public UserAccountMembershipQueryService(
+      UserAccountMembershipQueryPort userAccountMembershipQueryPort) {
+    this.userAccountMembershipQueryPort = userAccountMembershipQueryPort;
+  }
+
+  @Override
+  public UserAccountMembershipSummary getByUserIdAndAccountId(long userId, long accountId) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    return userAccountMembershipQueryPort
+        .findByUserIdAndAccountId(userId, accountId)
+        .orElseThrow(() -> new UserAccountMembershipNotFoundException("membership is not found"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipQueryUseCase.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
+
+public interface UserAccountMembershipQueryUseCase {
+
+  UserAccountMembershipSummary getByUserIdAndAccountId(long userId, long accountId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipStatusUpdateService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipStatusUpdateService.java
@@ -1,0 +1,25 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
+import com.aquilabank.domain.auth.port.UserAccountMembershipStatusUpdatePort;
+
+/** 내부 auth 관리가 membership 상태를 명시적으로 갱신하는 경로입니다. */
+public final class UserAccountMembershipStatusUpdateService
+    implements UserAccountMembershipStatusUpdateUseCase {
+
+  private final UserAccountMembershipStatusUpdatePort userAccountMembershipStatusUpdatePort;
+
+  public UserAccountMembershipStatusUpdateService(
+      UserAccountMembershipStatusUpdatePort userAccountMembershipStatusUpdatePort) {
+    this.userAccountMembershipStatusUpdatePort = userAccountMembershipStatusUpdatePort;
+  }
+
+  @Override
+  public UserAccountMembershipSummary update(UserAccountMembershipStatusUpdateCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+    return userAccountMembershipStatusUpdatePort.updateStatus(command);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipStatusUpdateUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserAccountMembershipStatusUpdateUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
+
+public interface UserAccountMembershipStatusUpdateUseCase {
+
+  UserAccountMembershipSummary update(UserAccountMembershipStatusUpdateCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserStatusUpdateService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserStatusUpdateService.java
@@ -1,0 +1,23 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
+import com.aquilabank.domain.auth.port.UserStatusUpdatePort;
+
+/** 내부 auth 관리가 user 상태를 명시적으로 갱신하는 경로입니다. */
+public final class UserStatusUpdateService implements UserStatusUpdateUseCase {
+
+  private final UserStatusUpdatePort userStatusUpdatePort;
+
+  public UserStatusUpdateService(UserStatusUpdatePort userStatusUpdatePort) {
+    this.userStatusUpdatePort = userStatusUpdatePort;
+  }
+
+  @Override
+  public AuthUserSummary update(UserStatusUpdateCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+    return userStatusUpdatePort.updateStatus(command);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/UserStatusUpdateUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/UserStatusUpdateUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
+
+public interface UserStatusUpdateUseCase {
+
+  AuthUserSummary update(UserStatusUpdateCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -3,17 +3,29 @@ package com.aquilabank.global.config;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.UserAccountMembershipQueryPort;
+import com.aquilabank.domain.auth.port.UserAccountMembershipStatusUpdatePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
 import com.aquilabank.domain.auth.port.UserBootstrapPort;
 import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.port.UserQueryPort;
+import com.aquilabank.domain.auth.port.UserStatusUpdatePort;
 import com.aquilabank.domain.auth.usecase.AccountAccessService;
 import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
+import com.aquilabank.domain.auth.usecase.AuthUserQueryService;
+import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
 import com.aquilabank.domain.auth.usecase.LoginService;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryService;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateService;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipUpsertService;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipUpsertUseCase;
 import com.aquilabank.domain.auth.usecase.UserBootstrapService;
 import com.aquilabank.domain.auth.usecase.UserBootstrapUseCase;
+import com.aquilabank.domain.auth.usecase.UserStatusUpdateService;
+import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -44,5 +56,27 @@ public class AuthConfiguration {
   UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase(
       UserAccountMembershipUpsertPort userAccountMembershipUpsertPort) {
     return new UserAccountMembershipUpsertService(userAccountMembershipUpsertPort);
+  }
+
+  @Bean
+  AuthUserQueryUseCase authUserQueryUseCase(UserQueryPort userQueryPort) {
+    return new AuthUserQueryService(userQueryPort);
+  }
+
+  @Bean
+  UserStatusUpdateUseCase userStatusUpdateUseCase(UserStatusUpdatePort userStatusUpdatePort) {
+    return new UserStatusUpdateService(userStatusUpdatePort);
+  }
+
+  @Bean
+  UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase(
+      UserAccountMembershipQueryPort userAccountMembershipQueryPort) {
+    return new UserAccountMembershipQueryService(userAccountMembershipQueryPort);
+  }
+
+  @Bean
+  UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase(
+      UserAccountMembershipStatusUpdatePort userAccountMembershipStatusUpdatePort) {
+    return new UserAccountMembershipStatusUpdateService(userAccountMembershipStatusUpdatePort);
   }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -1,22 +1,33 @@
 package com.aquilabank.global.persistence.auth;
 
+import com.aquilabank.domain.auth.model.AccountAccessMembership;
+import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.LoginUser;
 import com.aquilabank.domain.auth.model.MembershipRole;
 import com.aquilabank.domain.auth.model.MembershipStatus;
 import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.UserAccountMembershipQueryPort;
 import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.port.UserQueryPort;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-/** loginId lookup과 user-account membership lookup을 한 adapter로 묶습니다. */
+/** login/access exact lookup을 한 adapter로 묶어 auth read 경로를 단순화합니다. */
 @Repository
-public class JdbcAuthRepository implements UserCredentialLoadPort, AccountAccessPort {
+public class JdbcAuthRepository
+    implements UserCredentialLoadPort,
+        AccountAccessPort,
+        UserQueryPort,
+        UserAccountMembershipQueryPort {
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -40,6 +51,36 @@ public class JdbcAuthRepository implements UserCredentialLoadPort, AccountAccess
   }
 
   @Override
+  public Optional<AuthUserSummary> findSummaryByUserId(long userId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT id, login_id, display_name, user_status, created_at, updated_at
+            FROM bank_user
+            WHERE id = :userId
+            """,
+            new MapSqlParameterSource().addValue("userId", userId),
+            (rs, rowNum) -> mapUserSummary(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<AuthUserSummary> findSummaryByLoginId(String loginId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT id, login_id, display_name, user_status, created_at, updated_at
+            FROM bank_user
+            WHERE login_id = :loginId
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            (rs, rowNum) -> mapUserSummary(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
   public Optional<UserAccountMembership> findMembership(long userId, long accountId) {
     return jdbcTemplate
         .query(
@@ -51,6 +92,45 @@ public class JdbcAuthRepository implements UserCredentialLoadPort, AccountAccess
             """,
             new MapSqlParameterSource().addValue("userId", userId).addValue("accountId", accountId),
             (rs, rowNum) -> mapMembership(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<AccountAccessMembership> findAccessMembership(long userId, long accountId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT m.user_id,
+                   m.account_id,
+                   m.membership_role,
+                   m.membership_status,
+                   u.user_status
+            FROM user_account_membership m
+            JOIN bank_user u
+              ON u.id = m.user_id
+            WHERE m.user_id = :userId
+              AND m.account_id = :accountId
+            """,
+            new MapSqlParameterSource().addValue("userId", userId).addValue("accountId", accountId),
+            (rs, rowNum) -> mapAccessMembership(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<UserAccountMembershipSummary> findByUserIdAndAccountId(
+      long userId, long accountId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT user_id, account_id, membership_role, membership_status, created_at, updated_at
+            FROM user_account_membership
+            WHERE user_id = :userId
+              AND account_id = :accountId
+            """,
+            new MapSqlParameterSource().addValue("userId", userId).addValue("accountId", accountId),
+            (rs, rowNum) -> mapMembershipSummary(rs))
         .stream()
         .findFirst();
   }
@@ -69,5 +149,41 @@ public class JdbcAuthRepository implements UserCredentialLoadPort, AccountAccess
         rs.getLong("account_id"),
         MembershipRole.valueOf(rs.getString("membership_role")),
         MembershipStatus.valueOf(rs.getString("membership_status")));
+  }
+
+  private AccountAccessMembership mapAccessMembership(ResultSet rs) throws SQLException {
+    return new AccountAccessMembership(
+        rs.getLong("user_id"),
+        rs.getLong("account_id"),
+        MembershipRole.valueOf(rs.getString("membership_role")),
+        MembershipStatus.valueOf(rs.getString("membership_status")),
+        UserStatus.valueOf(rs.getString("user_status")));
+  }
+
+  private AuthUserSummary mapUserSummary(ResultSet rs) throws SQLException {
+    return new AuthUserSummary(
+        rs.getLong("id"),
+        rs.getString("login_id"),
+        rs.getString("display_name"),
+        UserStatus.valueOf(rs.getString("user_status")),
+        toInstant(rs.getTimestamp("created_at")),
+        toInstant(rs.getTimestamp("updated_at")));
+  }
+
+  private UserAccountMembershipSummary mapMembershipSummary(ResultSet rs) throws SQLException {
+    return new UserAccountMembershipSummary(
+        rs.getLong("user_id"),
+        rs.getLong("account_id"),
+        MembershipRole.valueOf(rs.getString("membership_role")),
+        MembershipStatus.valueOf(rs.getString("membership_status")),
+        toInstant(rs.getTimestamp("created_at")),
+        toInstant(rs.getTimestamp("updated_at")));
+  }
+
+  private Instant toInstant(Timestamp timestamp) {
+    if (timestamp == null) {
+      throw new IllegalStateException("timestamp must not be null");
+    }
+    return timestamp.toInstant();
   }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -1,12 +1,23 @@
 package com.aquilabank.global.persistence.auth;
 
+import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
 import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
+import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
+import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserAccountMembershipUpsertCommand;
 import com.aquilabank.domain.auth.model.UserBootstrapResult;
 import com.aquilabank.domain.auth.model.UserBootstrapWriteCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
+import com.aquilabank.domain.auth.port.UserAccountMembershipStatusUpdatePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
 import com.aquilabank.domain.auth.port.UserBootstrapPort;
+import com.aquilabank.domain.auth.port.UserStatusUpdatePort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import org.springframework.dao.DuplicateKeyException;
@@ -17,7 +28,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** auth bootstrap 쓰기 경로를 JDBC로 고정해 테스트와 운영 도구가 같은 저장 경로를 탑니다. */
 @Repository
-public class JdbcAuthWriteRepository implements UserBootstrapPort, UserAccountMembershipUpsertPort {
+public class JdbcAuthWriteRepository
+    implements UserBootstrapPort,
+        UserAccountMembershipUpsertPort,
+        UserStatusUpdatePort,
+        UserAccountMembershipStatusUpdatePort {
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -115,6 +130,55 @@ public class JdbcAuthWriteRepository implements UserBootstrapPort, UserAccountMe
         command.userId(), command.accountId(), command.role(), command.status());
   }
 
+  @Override
+  @Transactional
+  public AuthUserSummary updateStatus(UserStatusUpdateCommand command) {
+    Instant now = Instant.now();
+    return jdbcTemplate
+        .query(
+            """
+            UPDATE bank_user
+            SET user_status = :userStatus,
+                updated_at = :now
+            WHERE id = :userId
+            RETURNING id, login_id, display_name, user_status, created_at, updated_at
+            """,
+            new MapSqlParameterSource()
+                .addValue("userId", command.userId())
+                .addValue("userStatus", command.status().name())
+                .addValue("now", Timestamp.from(now)),
+            (rs, rowNum) -> mapUserSummary(rs))
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
+  }
+
+  @Override
+  @Transactional
+  public UserAccountMembershipSummary updateStatus(
+      UserAccountMembershipStatusUpdateCommand command) {
+    Instant now = Instant.now();
+    return jdbcTemplate
+        .query(
+            """
+            UPDATE user_account_membership
+            SET membership_status = :membershipStatus,
+                updated_at = :now
+            WHERE user_id = :userId
+              AND account_id = :accountId
+            RETURNING user_id, account_id, membership_role, membership_status, created_at, updated_at
+            """,
+            new MapSqlParameterSource()
+                .addValue("userId", command.userId())
+                .addValue("accountId", command.accountId())
+                .addValue("membershipStatus", command.status().name())
+                .addValue("now", Timestamp.from(now)),
+            (rs, rowNum) -> mapMembershipSummary(rs))
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new UserAccountMembershipNotFoundException("membership is not found"));
+  }
+
   private void assertUserExists(long userId) {
     Boolean exists =
         jdbcTemplate.queryForObject(
@@ -147,5 +211,26 @@ public class JdbcAuthWriteRepository implements UserBootstrapPort, UserAccountMe
     if (!Boolean.TRUE.equals(exists)) {
       throw new IllegalArgumentException("accountId is invalid");
     }
+  }
+
+  private AuthUserSummary mapUserSummary(ResultSet rs) throws SQLException {
+    return new AuthUserSummary(
+        rs.getLong("id"),
+        rs.getString("login_id"),
+        rs.getString("display_name"),
+        UserStatus.valueOf(rs.getString("user_status")),
+        rs.getTimestamp("created_at").toInstant(),
+        rs.getTimestamp("updated_at").toInstant());
+  }
+
+  private UserAccountMembershipSummary mapMembershipSummary(ResultSet rs) throws SQLException {
+    return new UserAccountMembershipSummary(
+        rs.getLong("user_id"),
+        rs.getLong("account_id"),
+        com.aquilabank.domain.auth.model.MembershipRole.valueOf(rs.getString("membership_role")),
+        com.aquilabank.domain.auth.model.MembershipStatus.valueOf(
+            rs.getString("membership_status")),
+        rs.getTimestamp("created_at").toInstant(),
+        rs.getTimestamp("updated_at").toInstant());
   }
 }

--- a/back/src/main/java/com/aquilabank/global/security/InternalAuthTokenGuard.java
+++ b/back/src/main/java/com/aquilabank/global/security/InternalAuthTokenGuard.java
@@ -1,0 +1,26 @@
+package com.aquilabank.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+/** 내부 auth 관리 surface가 같은 shared token 검증 규칙을 재사용하도록 묶습니다. */
+@Component
+public class InternalAuthTokenGuard {
+
+  private final AuthBootstrapApiProperties authBootstrapApiProperties;
+
+  public InternalAuthTokenGuard(AuthBootstrapApiProperties authBootstrapApiProperties) {
+    this.authBootstrapApiProperties = authBootstrapApiProperties;
+  }
+
+  public void validate(HttpServletRequest httpServletRequest) {
+    String bootstrapToken = httpServletRequest.getHeader(authBootstrapApiProperties.tokenHeader());
+
+    // permitAll endpoint라도 shared token 검증이 없으면 내부 auth 관리 경로가 외부 요청에 그대로 열립니다.
+    if (bootstrapToken == null
+        || bootstrapToken.isBlank()
+        || !authBootstrapApiProperties.token().equals(bootstrapToken)) {
+      throw new BootstrapApiAccessDeniedException("bootstrap token is invalid");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.aquilabank.global.web;
 
 import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
+import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
 import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
 import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
@@ -63,9 +65,12 @@ public class ApiExceptionHandler {
     return response(HttpStatus.FORBIDDEN, ex.getMessage(), request.getRequestURI());
   }
 
-  @ExceptionHandler(SnapshotNotFoundException.class)
-  ResponseEntity<ApiErrorResponse> handleNotFound(
-      SnapshotNotFoundException ex, HttpServletRequest request) {
+  @ExceptionHandler({
+    SnapshotNotFoundException.class,
+    AuthUserNotFoundException.class,
+    UserAccountMembershipNotFoundException.class
+  })
+  ResponseEntity<ApiErrorResponse> handleNotFound(RuntimeException ex, HttpServletRequest request) {
     return response(HttpStatus.NOT_FOUND, ex.getMessage(), request.getRequestURI());
   }
 

--- a/back/src/main/java/com/aquilabank/global/web/auth/AuthBootstrapController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/AuthBootstrapController.java
@@ -9,13 +9,14 @@ import com.aquilabank.domain.auth.model.UserBootstrapResult;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipUpsertUseCase;
 import com.aquilabank.domain.auth.usecase.UserBootstrapUseCase;
 import com.aquilabank.global.security.AuthBootstrapApiProperties;
-import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
+import com.aquilabank.global.security.InternalAuthTokenGuard;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,21 +35,32 @@ public class AuthBootstrapController {
 
   private final UserBootstrapUseCase userBootstrapUseCase;
   private final UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase;
-  private final AuthBootstrapApiProperties authBootstrapApiProperties;
+  private final InternalAuthTokenGuard internalAuthTokenGuard;
 
+  @Autowired
   public AuthBootstrapController(
       UserBootstrapUseCase userBootstrapUseCase,
       UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase,
-      AuthBootstrapApiProperties authBootstrapApiProperties) {
+      InternalAuthTokenGuard internalAuthTokenGuard) {
     this.userBootstrapUseCase = userBootstrapUseCase;
     this.userAccountMembershipUpsertUseCase = userAccountMembershipUpsertUseCase;
-    this.authBootstrapApiProperties = authBootstrapApiProperties;
+    this.internalAuthTokenGuard = internalAuthTokenGuard;
+  }
+
+  AuthBootstrapController(
+      UserBootstrapUseCase userBootstrapUseCase,
+      UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase,
+      AuthBootstrapApiProperties authBootstrapApiProperties) {
+    this(
+        userBootstrapUseCase,
+        userAccountMembershipUpsertUseCase,
+        new InternalAuthTokenGuard(authBootstrapApiProperties));
   }
 
   @PostMapping("/users/bootstrap")
   public UserBootstrapResponse bootstrapUser(
       HttpServletRequest httpServletRequest, @Valid @RequestBody UserBootstrapRequest request) {
-    validateBootstrapToken(httpServletRequest);
+    internalAuthTokenGuard.validate(httpServletRequest);
 
     UserBootstrapResult result =
         userBootstrapUseCase.bootstrap(
@@ -62,24 +74,13 @@ public class AuthBootstrapController {
       @PathVariable @Positive(message = "userId must be positive") long userId,
       @PathVariable @Positive(message = "accountId must be positive") long accountId,
       @Valid @RequestBody UserAccountMembershipRequest request) {
-    validateBootstrapToken(httpServletRequest);
+    internalAuthTokenGuard.validate(httpServletRequest);
 
     UserAccountMembership membership =
         userAccountMembershipUpsertUseCase.upsert(
             new UserAccountMembershipUpsertCommand(
                 userId, accountId, request.membershipRole(), request.membershipStatus()));
     return UserAccountMembershipResponse.from(membership);
-  }
-
-  private void validateBootstrapToken(HttpServletRequest httpServletRequest) {
-    String bootstrapToken = httpServletRequest.getHeader(authBootstrapApiProperties.tokenHeader());
-
-    // permitAll endpoint라도 shared token 검증이 없으면 내부 bootstrap이 외부 요청에 그대로 열립니다.
-    if (bootstrapToken == null
-        || bootstrapToken.isBlank()
-        || !authBootstrapApiProperties.token().equals(bootstrapToken)) {
-      throw new BootstrapApiAccessDeniedException("bootstrap token is invalid");
-    }
   }
 
   /** 내부 사용자 bootstrap 요청 body */

--- a/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
@@ -1,0 +1,151 @@
+package com.aquilabank.global.web.auth;
+
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
+import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
+import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
+import com.aquilabank.global.security.InternalAuthTokenGuard;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.time.Instant;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 내부 auth 관리 exact lookup과 revoke/update를 bootstrap surface와 같은 보호 규칙으로 노출합니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/auth")
+@ConditionalOnProperty(name = "security.auth-bootstrap-api.enabled", havingValue = "true")
+public class InternalAuthAdminController {
+
+  private final AuthUserQueryUseCase authUserQueryUseCase;
+  private final UserStatusUpdateUseCase userStatusUpdateUseCase;
+  private final UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase;
+  private final UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase;
+  private final InternalAuthTokenGuard internalAuthTokenGuard;
+
+  public InternalAuthAdminController(
+      AuthUserQueryUseCase authUserQueryUseCase,
+      UserStatusUpdateUseCase userStatusUpdateUseCase,
+      UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase,
+      UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase,
+      InternalAuthTokenGuard internalAuthTokenGuard) {
+    this.authUserQueryUseCase = authUserQueryUseCase;
+    this.userStatusUpdateUseCase = userStatusUpdateUseCase;
+    this.userAccountMembershipQueryUseCase = userAccountMembershipQueryUseCase;
+    this.userAccountMembershipStatusUpdateUseCase = userAccountMembershipStatusUpdateUseCase;
+    this.internalAuthTokenGuard = internalAuthTokenGuard;
+  }
+
+  @GetMapping("/users/{userId}")
+  public AuthUserResponse getUser(
+      HttpServletRequest httpServletRequest,
+      @PathVariable @Positive(message = "userId must be positive") long userId) {
+    internalAuthTokenGuard.validate(httpServletRequest);
+    return AuthUserResponse.from(authUserQueryUseCase.getByUserId(userId));
+  }
+
+  @GetMapping("/users/by-login-id")
+  public AuthUserResponse getUserByLoginId(
+      HttpServletRequest httpServletRequest,
+      @RequestParam @NotBlank(message = "loginId is required") String loginId) {
+    internalAuthTokenGuard.validate(httpServletRequest);
+    return AuthUserResponse.from(authUserQueryUseCase.getByLoginId(loginId));
+  }
+
+  @GetMapping("/users/{userId}/memberships/{accountId}")
+  public UserAccountMembershipResponse getMembership(
+      HttpServletRequest httpServletRequest,
+      @PathVariable @Positive(message = "userId must be positive") long userId,
+      @PathVariable @Positive(message = "accountId must be positive") long accountId) {
+    internalAuthTokenGuard.validate(httpServletRequest);
+    return UserAccountMembershipResponse.from(
+        userAccountMembershipQueryUseCase.getByUserIdAndAccountId(userId, accountId));
+  }
+
+  @PutMapping("/users/{userId}/status")
+  public AuthUserResponse updateUserStatus(
+      HttpServletRequest httpServletRequest,
+      @PathVariable @Positive(message = "userId must be positive") long userId,
+      @Valid @RequestBody UserStatusRequest request) {
+    internalAuthTokenGuard.validate(httpServletRequest);
+    return AuthUserResponse.from(
+        userStatusUpdateUseCase.update(new UserStatusUpdateCommand(userId, request.userStatus())));
+  }
+
+  @PutMapping("/users/{userId}/memberships/{accountId}/status")
+  public UserAccountMembershipResponse updateMembershipStatus(
+      HttpServletRequest httpServletRequest,
+      @PathVariable @Positive(message = "userId must be positive") long userId,
+      @PathVariable @Positive(message = "accountId must be positive") long accountId,
+      @Valid @RequestBody UserAccountMembershipStatusRequest request) {
+    internalAuthTokenGuard.validate(httpServletRequest);
+    return UserAccountMembershipResponse.from(
+        userAccountMembershipStatusUpdateUseCase.update(
+            new UserAccountMembershipStatusUpdateCommand(
+                userId, accountId, request.membershipStatus())));
+  }
+
+  /** 내부 user status update 요청 body */
+  public record UserStatusRequest(
+      @NotNull(message = "userStatus is required") UserStatus userStatus) {}
+
+  /** 내부 membership status update 요청 body */
+  public record UserAccountMembershipStatusRequest(
+      @NotNull(message = "membershipStatus is required") com.aquilabank.domain.auth.model.MembershipStatus membershipStatus) {}
+
+  /** 내부 auth user exact lookup 응답 */
+  public record AuthUserResponse(
+      long userId,
+      String loginId,
+      String displayName,
+      String userStatus,
+      Instant createdAt,
+      Instant updatedAt) {
+
+    static AuthUserResponse from(AuthUserSummary summary) {
+      return new AuthUserResponse(
+          summary.userId(),
+          summary.loginId(),
+          summary.displayName(),
+          summary.status().name(),
+          summary.createdAt(),
+          summary.updatedAt());
+    }
+  }
+
+  /** 내부 auth membership exact lookup 응답 */
+  public record UserAccountMembershipResponse(
+      long userId,
+      long accountId,
+      String membershipRole,
+      String membershipStatus,
+      Instant createdAt,
+      Instant updatedAt) {
+
+    static UserAccountMembershipResponse from(UserAccountMembershipSummary summary) {
+      return new UserAccountMembershipResponse(
+          summary.userId(),
+          summary.accountId(),
+          summary.role().name(),
+          summary.status().name(),
+          summary.createdAt(),
+          summary.updatedAt());
+    }
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/AuthBootstrapSecurityProfileTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/AuthBootstrapSecurityProfileTest.java
@@ -25,8 +25,12 @@ class AuthBootstrapSecurityProfileTest {
 
   @Autowired private ObjectProvider<AuthBootstrapController> authBootstrapControllerProvider;
 
+  @Autowired
+  private ObjectProvider<InternalAuthAdminController> internalAuthAdminControllerProvider;
+
   @Test
-  void doesNotRegisterAuthBootstrapControllerInProdByDefault() {
+  void doesNotRegisterInternalAuthControllersInProdByDefault() {
     assertNull(authBootstrapControllerProvider.getIfAvailable());
+    assertNull(internalAuthAdminControllerProvider.getIfAvailable());
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -1,0 +1,174 @@
+package com.aquilabank.global.web.auth;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.MembershipRole;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
+import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
+import com.aquilabank.global.security.AuthBootstrapApiProperties;
+import com.aquilabank.global.security.InternalAuthTokenGuard;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class InternalAuthAdminControllerTest {
+
+  private static final String TOKEN_HEADER = "X-Auth-Bootstrap-Token";
+  private static final String TOKEN = "test-auth-bootstrap-api-token";
+
+  private AuthUserQueryUseCase authUserQueryUseCase;
+  private UserStatusUpdateUseCase userStatusUpdateUseCase;
+  private UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase;
+  private UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    authUserQueryUseCase = mock(AuthUserQueryUseCase.class);
+    userStatusUpdateUseCase = mock(UserStatusUpdateUseCase.class);
+    userAccountMembershipQueryUseCase = mock(UserAccountMembershipQueryUseCase.class);
+    userAccountMembershipStatusUpdateUseCase = mock(UserAccountMembershipStatusUpdateUseCase.class);
+
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new InternalAuthAdminController(
+                    authUserQueryUseCase,
+                    userStatusUpdateUseCase,
+                    userAccountMembershipQueryUseCase,
+                    userAccountMembershipStatusUpdateUseCase,
+                    new InternalAuthTokenGuard(
+                        new AuthBootstrapApiProperties(true, TOKEN_HEADER, TOKEN))))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void getsUserByUserIdAndLoginId() throws Exception {
+    AuthUserSummary summary =
+        new AuthUserSummary(
+            21L,
+            "alice",
+            "Alice",
+            UserStatus.ACTIVE,
+            Instant.parse("2026-04-16T11:00:00Z"),
+            Instant.parse("2026-04-16T11:05:00Z"));
+
+    when(authUserQueryUseCase.getByUserId(21L)).thenReturn(summary);
+    when(authUserQueryUseCase.getByLoginId("alice")).thenReturn(summary);
+
+    mockMvc
+        .perform(get("/internal/api/v1/auth/users/21").header(TOKEN_HEADER, TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(21))
+        .andExpect(jsonPath("$.loginId").value("alice"))
+        .andExpect(jsonPath("$.userStatus").value("ACTIVE"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/users/by-login-id")
+                .header(TOKEN_HEADER, TOKEN)
+                .param("loginId", "alice"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.displayName").value("Alice"));
+  }
+
+  @Test
+  void getsMembershipAndUpdatesStatuses() throws Exception {
+    UserAccountMembershipSummary membershipSummary =
+        new UserAccountMembershipSummary(
+            21L,
+            101L,
+            MembershipRole.OWNER,
+            MembershipStatus.ACTIVE,
+            Instant.parse("2026-04-16T11:00:00Z"),
+            Instant.parse("2026-04-16T11:05:00Z"));
+    AuthUserSummary disabledUser =
+        new AuthUserSummary(
+            21L,
+            "alice",
+            "Alice",
+            UserStatus.DISABLED,
+            Instant.parse("2026-04-16T11:00:00Z"),
+            Instant.parse("2026-04-16T11:06:00Z"));
+    UserAccountMembershipSummary revokedMembership =
+        new UserAccountMembershipSummary(
+            21L,
+            101L,
+            MembershipRole.OWNER,
+            MembershipStatus.REVOKED,
+            Instant.parse("2026-04-16T11:00:00Z"),
+            Instant.parse("2026-04-16T11:06:00Z"));
+
+    when(userAccountMembershipQueryUseCase.getByUserIdAndAccountId(21L, 101L))
+        .thenReturn(membershipSummary);
+    when(userStatusUpdateUseCase.update(argThat(command -> command.userId() == 21L)))
+        .thenReturn(disabledUser);
+    when(userAccountMembershipStatusUpdateUseCase.update(
+            argThat(command -> command.accountId() == 101L)))
+        .thenReturn(revokedMembership);
+
+    mockMvc
+        .perform(get("/internal/api/v1/auth/users/21/memberships/101").header(TOKEN_HEADER, TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.membershipRole").value("OWNER"))
+        .andExpect(jsonPath("$.membershipStatus").value("ACTIVE"));
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/21/status")
+                .header(TOKEN_HEADER, TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "userStatus": "DISABLED"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userStatus").value("DISABLED"));
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/21/memberships/101/status")
+                .header(TOKEN_HEADER, TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "membershipStatus": "REVOKED"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.membershipStatus").value("REVOKED"));
+
+    verify(userStatusUpdateUseCase)
+        .update(argThat(command -> command.status() == UserStatus.DISABLED));
+    verify(userAccountMembershipStatusUpdateUseCase)
+        .update(argThat(command -> command.status() == MembershipStatus.REVOKED));
+  }
+
+  @Test
+  void rejectsMissingOrInvalidBootstrapToken() throws Exception {
+    mockMvc
+        .perform(get("/internal/api/v1/auth/users/21"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("bootstrap token is invalid"));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -187,6 +187,122 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.message").value("login failed"));
   }
 
+  @Test
+  void internalAuthAdminLookupReturnsBootstrappedUserAndMembership() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/users/%d".formatted(userId))
+                .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(userId))
+        .andExpect(jsonPath("$.loginId").value("alice"))
+        .andExpect(jsonPath("$.userStatus").value("ACTIVE"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/users/by-login-id")
+                .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN)
+                .param("loginId", "alice"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.displayName").value("Alice"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/users/%d/memberships/%d"
+                    .formatted(userId, allowedSourceAccountId))
+                .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(userId))
+        .andExpect(jsonPath("$.accountId").value(allowedSourceAccountId))
+        .andExpect(jsonPath("$.membershipStatus").value("ACTIVE"));
+  }
+
+  @Test
+  void disabledUserCannotLoginOrUseExistingJwt() throws Exception {
+    String token = login("alice", "password123!");
+    updateUserStatus(userId, "DISABLED");
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "loginId": "alice",
+                      "password": "password123!"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("login failed"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId))
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Authorization", "Bearer " + token)
+                .header("Idempotency-Key", "jwt-transfer-disabled-403")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": 500,
+                      "currencyCode": "KRW",
+                      "summary": "disabled-blocked"
+                    }
+                    """
+                        .formatted(allowedSourceAccountId, targetAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
+  @Test
+  void revokedMembershipBlocksExistingJwtAccess() throws Exception {
+    String token = login("alice", "password123!");
+    updateMembershipStatus(userId, allowedSourceAccountId, "REVOKED");
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId))
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Authorization", "Bearer " + token)
+                .header("Idempotency-Key", "jwt-transfer-revoked-403")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": 500,
+                      "currencyCode": "KRW",
+                      "summary": "revoked-blocked"
+                    }
+                    """
+                        .formatted(allowedSourceAccountId, targetAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
   private String login(String loginId, String password) throws Exception {
     MvcResult result =
         mockMvc
@@ -280,6 +396,44 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.userId").value(userId))
         .andExpect(jsonPath("$.accountId").value(accountId))
         .andExpect(jsonPath("$.membershipRole").value(membershipRole))
+        .andExpect(jsonPath("$.membershipStatus").value(membershipStatus));
+  }
+
+  private void updateUserStatus(long userId, String userStatus) throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/%d/status".formatted(userId))
+                .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "userStatus": "%s"
+                    }
+                    """
+                        .formatted(userStatus)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(userId))
+        .andExpect(jsonPath("$.userStatus").value(userStatus));
+  }
+
+  private void updateMembershipStatus(long userId, long accountId, String membershipStatus)
+      throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/%d/memberships/%d/status".formatted(userId, accountId))
+                .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "membershipStatus": "%s"
+                    }
+                    """
+                        .formatted(membershipStatus)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(userId))
+        .andExpect(jsonPath("$.accountId").value(accountId))
         .andExpect(jsonPath("$.membershipStatus").value(membershipStatus));
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #9

## 📝 Summary
- 내부 auth 관리 경로에 사용자/membership exact lookup과 status 회수 API를 추가했습니다.
- `user DISABLED`와 `membership REVOKED`가 login 차단과 기존 JWT 계좌 접근 차단으로 이어지도록 access lookup을 보강했습니다.

## 🛠 Changes
- auth domain에 조회/회수용 모델, not-found 예외, status update/use case 계약을 추가했습니다.
- JDBC auth read/update adapter를 추가하고 account access 조회가 `user_status`와 `membership_status`를 함께 판단하도록 바꿨습니다.
- `/internal/api/v1/auth` 아래 user 조회, loginId 조회, membership 조회, user status update, membership status update API를 추가했습니다.
- revoke 후 login/access 차단과 prod 기본 비활성 시나리오를 테스트로 검증했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth ./back/gradlew -p back test --tests com.aquilabank.global.web.auth.AuthBootstrapControllerTest --tests com.aquilabank.global.web.auth.InternalAuthAdminControllerTest --tests com.aquilabank.global.web.auth.AuthBootstrapSecurityProfileTest --tests com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest`
- 각 커밋 pre-commit hook에서 `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: internal auth 관리 경로가 늘어나면서 token 설정 누락 시 dev/test 운영 도구 호출이 실패할 수 있습니다.
- 롤백 방법: PR revert 후 `/internal/api/v1/auth` 조회/회수 API와 access lookup join 변경을 제거합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [ ] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.