### PR TITLE
[Feat] 내부 auth 조회·회수 감사 경로 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditEntry.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditEntry.java
@@ -1,0 +1,50 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 내부 auth 상태 변경 성공 이력을 저장소 adapter에 넘길 때 쓰는 감사 모델입니다. */
+public record AuthStatusChangeAuditEntry(
+    AuthStatusChangeType changeType,
+    String requestId,
+    String actorSubject,
+    long targetUserId,
+    Long targetAccountId,
+    String beforeStatus,
+    String afterStatus,
+    String reason,
+    AuthStatusChangeOutcome outcome,
+    Instant createdAt) {
+
+  public AuthStatusChangeAuditEntry {
+    if (changeType == null) {
+      throw new IllegalArgumentException("changeType is required");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (targetUserId <= 0) {
+      throw new IllegalArgumentException("targetUserId must be positive");
+    }
+    if (targetAccountId != null && targetAccountId <= 0) {
+      throw new IllegalArgumentException("targetAccountId must be positive when present");
+    }
+    if (beforeStatus == null || beforeStatus.isBlank()) {
+      throw new IllegalArgumentException("beforeStatus is required");
+    }
+    if (afterStatus == null || afterStatus.isBlank()) {
+      throw new IllegalArgumentException("afterStatus is required");
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new IllegalArgumentException("reason is required");
+    }
+    if (outcome == null) {
+      throw new IllegalArgumentException("outcome is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeOutcome.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeOutcome.java
@@ -1,0 +1,6 @@
+package com.aquilabank.domain.auth.model;
+
+/** 내부 auth 상태 변경 감사 outcome 값입니다. */
+public enum AuthStatusChangeOutcome {
+  SUCCESS
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeType.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeType.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.auth.model;
+
+/** 내부 auth 상태 변경 종류를 user/membership 단위로 구분합니다. */
+public enum AuthStatusChangeType {
+  USER_STATUS,
+  MEMBERSHIP_STATUS
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipStatusUpdateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipStatusUpdateCommand.java
@@ -2,7 +2,12 @@ package com.aquilabank.domain.auth.model;
 
 /** 내부 auth 관리 경로가 membership 상태를 변경할 때 쓰는 명령입니다. */
 public record UserAccountMembershipStatusUpdateCommand(
-    long userId, long accountId, MembershipStatus status) {
+    long userId,
+    long accountId,
+    MembershipStatus status,
+    String reason,
+    String actorSubject,
+    String requestId) {
 
   public UserAccountMembershipStatusUpdateCommand {
     if (userId <= 0) {
@@ -13,6 +18,15 @@ public record UserAccountMembershipStatusUpdateCommand(
     }
     if (status == null) {
       throw new IllegalArgumentException("status is required");
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new IllegalArgumentException("reason is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserStatusUpdateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserStatusUpdateCommand.java
@@ -1,7 +1,8 @@
 package com.aquilabank.domain.auth.model;
 
 /** 내부 auth 관리 경로가 user 상태를 변경할 때 쓰는 명령입니다. */
-public record UserStatusUpdateCommand(long userId, UserStatus status) {
+public record UserStatusUpdateCommand(
+    long userId, UserStatus status, String reason, String actorSubject, String requestId) {
 
   public UserStatusUpdateCommand {
     if (userId <= 0) {
@@ -9,6 +10,15 @@ public record UserStatusUpdateCommand(long userId, UserStatus status) {
     }
     if (status == null) {
       throw new IllegalArgumentException("status is required");
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new IllegalArgumentException("reason is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -3,6 +3,9 @@ package com.aquilabank.global.persistence.auth;
 import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
 import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
 import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditEntry;
+import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.UserAccountMembership;
 import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
@@ -134,23 +137,38 @@ public class JdbcAuthWriteRepository
   @Transactional
   public AuthUserSummary updateStatus(UserStatusUpdateCommand command) {
     Instant now = Instant.now();
-    return jdbcTemplate
-        .query(
-            """
+    UserStatus beforeStatus = loadCurrentUserStatusForUpdate(command.userId());
+    AuthUserSummary summary =
+        jdbcTemplate
+            .query(
+                """
             UPDATE bank_user
             SET user_status = :userStatus,
                 updated_at = :now
             WHERE id = :userId
             RETURNING id, login_id, display_name, user_status, created_at, updated_at
             """,
-            new MapSqlParameterSource()
-                .addValue("userId", command.userId())
-                .addValue("userStatus", command.status().name())
-                .addValue("now", Timestamp.from(now)),
-            (rs, rowNum) -> mapUserSummary(rs))
-        .stream()
-        .findFirst()
-        .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
+                new MapSqlParameterSource()
+                    .addValue("userId", command.userId())
+                    .addValue("userStatus", command.status().name())
+                    .addValue("now", Timestamp.from(now)),
+                (rs, rowNum) -> mapUserSummary(rs))
+            .stream()
+            .findFirst()
+            .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
+    insertStatusChangeAudit(
+        new AuthStatusChangeAuditEntry(
+            AuthStatusChangeType.USER_STATUS,
+            command.requestId(),
+            command.actorSubject(),
+            command.userId(),
+            null,
+            beforeStatus.name(),
+            summary.status().name(),
+            command.reason(),
+            AuthStatusChangeOutcome.SUCCESS,
+            now));
+    return summary;
   }
 
   @Override
@@ -158,9 +176,12 @@ public class JdbcAuthWriteRepository
   public UserAccountMembershipSummary updateStatus(
       UserAccountMembershipStatusUpdateCommand command) {
     Instant now = Instant.now();
-    return jdbcTemplate
-        .query(
-            """
+    com.aquilabank.domain.auth.model.MembershipStatus beforeStatus =
+        loadCurrentMembershipStatusForUpdate(command.userId(), command.accountId());
+    UserAccountMembershipSummary summary =
+        jdbcTemplate
+            .query(
+                """
             UPDATE user_account_membership
             SET membership_status = :membershipStatus,
                 updated_at = :now
@@ -168,15 +189,107 @@ public class JdbcAuthWriteRepository
               AND account_id = :accountId
             RETURNING user_id, account_id, membership_role, membership_status, created_at, updated_at
             """,
-            new MapSqlParameterSource()
-                .addValue("userId", command.userId())
-                .addValue("accountId", command.accountId())
-                .addValue("membershipStatus", command.status().name())
-                .addValue("now", Timestamp.from(now)),
-            (rs, rowNum) -> mapMembershipSummary(rs))
+                new MapSqlParameterSource()
+                    .addValue("userId", command.userId())
+                    .addValue("accountId", command.accountId())
+                    .addValue("membershipStatus", command.status().name())
+                    .addValue("now", Timestamp.from(now)),
+                (rs, rowNum) -> mapMembershipSummary(rs))
+            .stream()
+            .findFirst()
+            .orElseThrow(
+                () -> new UserAccountMembershipNotFoundException("membership is not found"));
+    insertStatusChangeAudit(
+        new AuthStatusChangeAuditEntry(
+            AuthStatusChangeType.MEMBERSHIP_STATUS,
+            command.requestId(),
+            command.actorSubject(),
+            command.userId(),
+            command.accountId(),
+            beforeStatus.name(),
+            summary.status().name(),
+            command.reason(),
+            AuthStatusChangeOutcome.SUCCESS,
+            now));
+    return summary;
+  }
+
+  private UserStatus loadCurrentUserStatusForUpdate(long userId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT user_status
+            FROM bank_user
+            WHERE id = :userId
+            FOR UPDATE
+            """,
+            new MapSqlParameterSource().addValue("userId", userId),
+            (rs, rowNum) -> UserStatus.valueOf(rs.getString("user_status")))
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
+  }
+
+  private com.aquilabank.domain.auth.model.MembershipStatus loadCurrentMembershipStatusForUpdate(
+      long userId, long accountId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT membership_status
+            FROM user_account_membership
+            WHERE user_id = :userId
+              AND account_id = :accountId
+            FOR UPDATE
+            """,
+            new MapSqlParameterSource().addValue("userId", userId).addValue("accountId", accountId),
+            (rs, rowNum) ->
+                com.aquilabank.domain.auth.model.MembershipStatus.valueOf(
+                    rs.getString("membership_status")))
         .stream()
         .findFirst()
         .orElseThrow(() -> new UserAccountMembershipNotFoundException("membership is not found"));
+  }
+
+  private void insertStatusChangeAudit(AuthStatusChangeAuditEntry entry) {
+    // status update와 감사 row를 같은 transaction에 묶어 운영 흔적이 빠지지 않게 합니다.
+    jdbcTemplate.update(
+        """
+        INSERT INTO auth_status_change_audit (
+            request_id,
+            actor_subject,
+            change_type,
+            target_user_id,
+            target_account_id,
+            before_status,
+            after_status,
+            reason,
+            outcome,
+            created_at
+        )
+        VALUES (
+            :requestId,
+            :actorSubject,
+            :changeType,
+            :targetUserId,
+            :targetAccountId,
+            :beforeStatus,
+            :afterStatus,
+            :reason,
+            :outcome,
+            :createdAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("requestId", entry.requestId())
+            .addValue("actorSubject", entry.actorSubject())
+            .addValue("changeType", entry.changeType().name())
+            .addValue("targetUserId", entry.targetUserId())
+            .addValue("targetAccountId", entry.targetAccountId())
+            .addValue("beforeStatus", entry.beforeStatus())
+            .addValue("afterStatus", entry.afterStatus())
+            .addValue("reason", entry.reason())
+            .addValue("outcome", entry.outcome().name())
+            .addValue("createdAt", Timestamp.from(entry.createdAt())));
   }
 
   private void assertUserExists(long userId) {

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -2,6 +2,7 @@ package com.aquilabank.global.security;
 
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.global.web.InternalAuthStatusAuditRequestCachingFilter;
 import com.aquilabank.global.web.RequestIdFilter;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.ObjectProvider;
@@ -40,6 +41,7 @@ public class SecurityConfiguration {
   SecurityFilterChain securityFilterChain(
       HttpSecurity http,
       RequestIdFilter requestIdFilter,
+      InternalAuthStatusAuditRequestCachingFilter internalAuthStatusAuditRequestCachingFilter,
       ObjectProvider<BootstrapHeaderAuthenticationFilter> bootstrapHeaderAuthenticationFilter,
       JwtDecoder jwtDecoder)
       throws Exception {
@@ -76,6 +78,7 @@ public class SecurityConfiguration {
                     new HttpStatusEntryPoint(org.springframework.http.HttpStatus.UNAUTHORIZED)));
 
     http.addFilterBefore(requestIdFilter, AnonymousAuthenticationFilter.class);
+    http.addFilterAfter(internalAuthStatusAuditRequestCachingFilter, RequestIdFilter.class);
 
     BootstrapHeaderAuthenticationFilter filter =
         bootstrapHeaderAuthenticationFilter.getIfAvailable();
@@ -89,6 +92,11 @@ public class SecurityConfiguration {
   @Bean
   RequestIdFilter requestIdFilter() {
     return new RequestIdFilter();
+  }
+
+  @Bean
+  InternalAuthStatusAuditRequestCachingFilter internalAuthStatusAuditRequestCachingFilter() {
+    return new InternalAuthStatusAuditRequestCachingFilter();
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -10,19 +10,44 @@ import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
 import com.aquilabank.domain.ledger.exception.SnapshotNotFoundException;
 import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
+import com.aquilabank.global.security.BootstrapHeaderAuthProperties;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 /** domain/web 예외를 공통 API error response로 바꾸는 handler */
 @RestControllerAdvice
 public class ApiExceptionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(ApiExceptionHandler.class);
+  private static final String DEFAULT_ACTOR_SUBJECT_HEADER = "X-Subject";
+  private static final Pattern USER_STATUS_PATH_PATTERN =
+      Pattern.compile("^/internal/api/v1/auth/users/(\\d+)/status$");
+  private static final Pattern MEMBERSHIP_STATUS_PATH_PATTERN =
+      Pattern.compile("^/internal/api/v1/auth/users/(\\d+)/memberships/(\\d+)/status$");
+  private final String actorSubjectHeader;
+
+  public ApiExceptionHandler() {
+    this.actorSubjectHeader = DEFAULT_ACTOR_SUBJECT_HEADER;
+  }
+
+  @Autowired
+  public ApiExceptionHandler(BootstrapHeaderAuthProperties bootstrapHeaderAuthProperties) {
+    this.actorSubjectHeader = bootstrapHeaderAuthProperties.subjectHeader();
+  }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   ResponseEntity<ApiErrorResponse> handleValidation(
@@ -32,37 +57,37 @@ public class ApiExceptionHandler {
             .findFirst()
             .map(FieldError::getDefaultMessage)
             .orElse("validation failed");
-    return response(HttpStatus.BAD_REQUEST, message, request.getRequestURI());
+    return response(HttpStatus.BAD_REQUEST, message, request);
   }
 
   @ExceptionHandler(ConstraintViolationException.class)
   ResponseEntity<ApiErrorResponse> handleConstraint(
       ConstraintViolationException ex, HttpServletRequest request) {
-    return response(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
+    return response(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
   ResponseEntity<ApiErrorResponse> handleIllegalArgument(
       IllegalArgumentException ex, HttpServletRequest request) {
-    return response(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
+    return response(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
   }
 
   @ExceptionHandler(BootstrapApiAccessDeniedException.class)
   ResponseEntity<ApiErrorResponse> handleBootstrapUnauthorized(
       BootstrapApiAccessDeniedException ex, HttpServletRequest request) {
-    return response(HttpStatus.UNAUTHORIZED, ex.getMessage(), request.getRequestURI());
+    return response(HttpStatus.UNAUTHORIZED, ex.getMessage(), request);
   }
 
   @ExceptionHandler(InvalidCredentialsException.class)
   ResponseEntity<ApiErrorResponse> handleUnauthorized(
       InvalidCredentialsException ex, HttpServletRequest request) {
-    return response(HttpStatus.UNAUTHORIZED, ex.getMessage(), request.getRequestURI());
+    return response(HttpStatus.UNAUTHORIZED, ex.getMessage(), request);
   }
 
   @ExceptionHandler(AccountAccessDeniedException.class)
   ResponseEntity<ApiErrorResponse> handleForbidden(
       AccountAccessDeniedException ex, HttpServletRequest request) {
-    return response(HttpStatus.FORBIDDEN, ex.getMessage(), request.getRequestURI());
+    return response(HttpStatus.FORBIDDEN, ex.getMessage(), request);
   }
 
   @ExceptionHandler({
@@ -71,7 +96,7 @@ public class ApiExceptionHandler {
     UserAccountMembershipNotFoundException.class
   })
   ResponseEntity<ApiErrorResponse> handleNotFound(RuntimeException ex, HttpServletRequest request) {
-    return response(HttpStatus.NOT_FOUND, ex.getMessage(), request.getRequestURI());
+    return response(HttpStatus.NOT_FOUND, ex.getMessage(), request);
   }
 
   @ExceptionHandler({
@@ -81,21 +106,109 @@ public class ApiExceptionHandler {
     InsufficientBalanceException.class
   })
   ResponseEntity<ApiErrorResponse> handleConflict(RuntimeException ex, HttpServletRequest request) {
-    return response(HttpStatus.CONFLICT, ex.getMessage(), request.getRequestURI());
+    return response(HttpStatus.CONFLICT, ex.getMessage(), request);
   }
 
   @ExceptionHandler(IllegalStateException.class)
   ResponseEntity<ApiErrorResponse> handleIllegalState(
       IllegalStateException ex, HttpServletRequest request) {
-    return response(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), request.getRequestURI());
+    return response(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), request);
   }
 
   private ResponseEntity<ApiErrorResponse> response(
-      HttpStatus status, String message, String path) {
+      HttpStatus status, String message, HttpServletRequest request) {
+    logInternalAuthStatusFailure(request, message);
     return ResponseEntity.status(status)
         .body(
             new ApiErrorResponse(
-                Instant.now(), status.value(), status.getReasonPhrase(), message, path));
+                Instant.now(),
+                status.value(),
+                status.getReasonPhrase(),
+                message,
+                request.getRequestURI()));
+  }
+
+  private void logInternalAuthStatusFailure(HttpServletRequest request, String error) {
+    AuditFailureContext context = extractAuditFailureContext(request);
+    if (context == null) {
+      return;
+    }
+    log.warn(
+        "internal auth status update failed requestId={} actorSubject={} targetUserId={} targetAccountId={} requestedStatus={} reason={} path={} error={}",
+        RequestTraceContext.currentRequestId().orElse("-"),
+        context.actorSubject(),
+        context.targetUserId(),
+        context.targetAccountId() == null ? "-" : context.targetAccountId(),
+        context.requestedStatus(),
+        context.reason(),
+        request.getRequestURI(),
+        error);
+  }
+
+  private AuditFailureContext extractAuditFailureContext(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    Matcher membershipMatcher = MEMBERSHIP_STATUS_PATH_PATTERN.matcher(path);
+    if (membershipMatcher.matches()) {
+      return new AuditFailureContext(
+          request.getHeader(actorSubjectHeader),
+          parseLong(membershipMatcher.group(1)),
+          parseLong(membershipMatcher.group(2)),
+          extractJsonField(request, "membershipStatus"),
+          extractJsonField(request, "reason"));
+    }
+
+    Matcher userMatcher = USER_STATUS_PATH_PATTERN.matcher(path);
+    if (userMatcher.matches()) {
+      return new AuditFailureContext(
+          request.getHeader(actorSubjectHeader),
+          parseLong(userMatcher.group(1)),
+          null,
+          extractJsonField(request, "userStatus"),
+          extractJsonField(request, "reason"));
+    }
+    return null;
+  }
+
+  private Long parseLong(String value) {
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException ex) {
+      return null;
+    }
+  }
+
+  private String extractJsonField(HttpServletRequest request, String fieldName) {
+    if (!(request instanceof ContentCachingRequestWrapper wrapper)) {
+      return "-";
+    }
+    byte[] content = wrapper.getContentAsByteArray();
+    if (content.length == 0) {
+      return "-";
+    }
+    String body = new String(content, StandardCharsets.UTF_8);
+    Pattern fieldPattern =
+        Pattern.compile("\"" + Pattern.quote(fieldName) + "\"\\s*:\\s*\"([^\"]*)\"");
+    Matcher matcher = fieldPattern.matcher(body);
+    if (!matcher.find()) {
+      return "-";
+    }
+    String value = matcher.group(1);
+    return value == null || value.isBlank() ? "-" : value;
+  }
+
+  private record AuditFailureContext(
+      String actorSubject,
+      Long targetUserId,
+      Long targetAccountId,
+      String requestedStatus,
+      String reason) {
+
+    private AuditFailureContext {
+      actorSubject = actorSubject == null || actorSubject.isBlank() ? "-" : actorSubject;
+      requestedStatus =
+          requestedStatus == null || requestedStatus.isBlank() ? "-" : requestedStatus;
+      reason = reason == null || reason.isBlank() ? "-" : reason;
+    }
   }
 
   /** 모든 API가 공유하는 기본 error body */

--- a/back/src/main/java/com/aquilabank/global/web/InternalAuthStatusAuditRequestCachingFilter.java
+++ b/back/src/main/java/com/aquilabank/global/web/InternalAuthStatusAuditRequestCachingFilter.java
@@ -1,0 +1,47 @@
+package com.aquilabank.global.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+/** 내부 auth 상태 변경 실패 로그도 request body를 읽을 수 있게 request를 감쌉니다. */
+public class InternalAuthStatusAuditRequestCachingFilter extends OncePerRequestFilter {
+
+  private static final int REQUEST_CACHE_LIMIT = 2048;
+  private static final String USER_PATH_PREFIX = "/internal/api/v1/auth/users/";
+  private static final String MEMBERSHIP_SEGMENT = "/memberships/";
+  private static final String STATUS_SUFFIX = "/status";
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    return !isUserStatusPath(path) && !isMembershipStatusPath(path);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (request instanceof ContentCachingRequestWrapper) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    filterChain.doFilter(new ContentCachingRequestWrapper(request, REQUEST_CACHE_LIMIT), response);
+  }
+
+  private boolean isUserStatusPath(String path) {
+    return path.startsWith(USER_PATH_PREFIX)
+        && path.endsWith(STATUS_SUFFIX)
+        && !path.contains(MEMBERSHIP_SEGMENT);
+  }
+
+  private boolean isMembershipStatusPath(String path) {
+    return path.startsWith(USER_PATH_PREFIX)
+        && path.contains(MEMBERSHIP_SEGMENT)
+        && path.endsWith(STATUS_SUFFIX);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
@@ -9,12 +9,15 @@ import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
 import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
+import com.aquilabank.global.security.BootstrapHeaderAuthProperties;
 import com.aquilabank.global.security.InternalAuthTokenGuard;
+import com.aquilabank.global.web.RequestTraceContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import java.time.Instant;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.validation.annotation.Validated;
@@ -38,18 +41,21 @@ public class InternalAuthAdminController {
   private final UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase;
   private final UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase;
   private final InternalAuthTokenGuard internalAuthTokenGuard;
+  private final String actorSubjectHeader;
 
   public InternalAuthAdminController(
       AuthUserQueryUseCase authUserQueryUseCase,
       UserStatusUpdateUseCase userStatusUpdateUseCase,
       UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase,
       UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase,
-      InternalAuthTokenGuard internalAuthTokenGuard) {
+      InternalAuthTokenGuard internalAuthTokenGuard,
+      BootstrapHeaderAuthProperties bootstrapHeaderAuthProperties) {
     this.authUserQueryUseCase = authUserQueryUseCase;
     this.userStatusUpdateUseCase = userStatusUpdateUseCase;
     this.userAccountMembershipQueryUseCase = userAccountMembershipQueryUseCase;
     this.userAccountMembershipStatusUpdateUseCase = userAccountMembershipStatusUpdateUseCase;
     this.internalAuthTokenGuard = internalAuthTokenGuard;
+    this.actorSubjectHeader = bootstrapHeaderAuthProperties.subjectHeader();
   }
 
   @GetMapping("/users/{userId}")
@@ -85,7 +91,13 @@ public class InternalAuthAdminController {
       @Valid @RequestBody UserStatusRequest request) {
     internalAuthTokenGuard.validate(httpServletRequest);
     return AuthUserResponse.from(
-        userStatusUpdateUseCase.update(new UserStatusUpdateCommand(userId, request.userStatus())));
+        userStatusUpdateUseCase.update(
+            new UserStatusUpdateCommand(
+                userId,
+                request.userStatus(),
+                request.reason(),
+                resolveActorSubject(httpServletRequest),
+                resolveRequestId(httpServletRequest))));
   }
 
   @PutMapping("/users/{userId}/memberships/{accountId}/status")
@@ -98,16 +110,44 @@ public class InternalAuthAdminController {
     return UserAccountMembershipResponse.from(
         userAccountMembershipStatusUpdateUseCase.update(
             new UserAccountMembershipStatusUpdateCommand(
-                userId, accountId, request.membershipStatus())));
+                userId,
+                accountId,
+                request.membershipStatus(),
+                request.reason(),
+                resolveActorSubject(httpServletRequest),
+                resolveRequestId(httpServletRequest))));
   }
 
   /** 내부 user status update 요청 body */
   public record UserStatusRequest(
-      @NotNull(message = "userStatus is required") UserStatus userStatus) {}
+      @NotNull(message = "userStatus is required") UserStatus userStatus,
+      @NotBlank(message = "reason is required") @Size(max = 200, message = "reason must be 200 characters or less") String reason) {}
 
   /** 내부 membership status update 요청 body */
   public record UserAccountMembershipStatusRequest(
-      @NotNull(message = "membershipStatus is required") com.aquilabank.domain.auth.model.MembershipStatus membershipStatus) {}
+      @NotNull(message = "membershipStatus is required") com.aquilabank.domain.auth.model.MembershipStatus membershipStatus,
+      @NotBlank(message = "reason is required") @Size(max = 200, message = "reason must be 200 characters or less") String reason) {}
+
+  private String resolveActorSubject(HttpServletRequest httpServletRequest) {
+    String actorSubject = httpServletRequest.getHeader(actorSubjectHeader);
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject header is required");
+    }
+    return actorSubject;
+  }
+
+  private String resolveRequestId(HttpServletRequest httpServletRequest) {
+    return RequestTraceContext.currentRequestId()
+        .orElseGet(
+            () -> {
+              String requestId =
+                  httpServletRequest.getHeader(RequestTraceContext.REQUEST_ID_HEADER);
+              if (requestId == null || requestId.isBlank()) {
+                throw new IllegalStateException("requestId is not initialized");
+              }
+              return requestId;
+            });
+  }
 
   /** 내부 auth user exact lookup 응답 */
   public record AuthUserResponse(

--- a/back/src/main/resources/db/migration/V5__add_auth_status_change_audit.sql
+++ b/back/src/main/resources/db/migration/V5__add_auth_status_change_audit.sql
@@ -1,0 +1,21 @@
+CREATE TABLE auth_status_change_audit (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    request_id VARCHAR(64) NOT NULL,
+    actor_subject VARCHAR(120) NOT NULL,
+    change_type VARCHAR(32) NOT NULL
+        CHECK (change_type IN ('USER_STATUS', 'MEMBERSHIP_STATUS')),
+    target_user_id BIGINT NOT NULL,
+    target_account_id BIGINT,
+    before_status VARCHAR(16) NOT NULL,
+    after_status VARCHAR(16) NOT NULL,
+    reason VARCHAR(200) NOT NULL,
+    outcome VARCHAR(16) NOT NULL CHECK (outcome IN ('SUCCESS')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_auth_status_change_audit_user
+        FOREIGN KEY (target_user_id) REFERENCES bank_user (id),
+    CONSTRAINT fk_auth_status_change_audit_account
+        FOREIGN KEY (target_account_id) REFERENCES bank_account (id)
+);
+
+CREATE INDEX idx_auth_status_change_audit_request_id
+    ON auth_status_change_audit (request_id);

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -19,6 +19,7 @@ import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
 import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
 import com.aquilabank.global.security.AuthBootstrapApiProperties;
+import com.aquilabank.global.security.BootstrapHeaderAuthProperties;
 import com.aquilabank.global.security.InternalAuthTokenGuard;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import java.time.Instant;
@@ -32,6 +33,9 @@ class InternalAuthAdminControllerTest {
 
   private static final String TOKEN_HEADER = "X-Auth-Bootstrap-Token";
   private static final String TOKEN = "test-auth-bootstrap-api-token";
+  private static final String SUBJECT_HEADER = "X-Subject";
+  private static final String SUBJECT = "ops-admin";
+  private static final String REQUEST_ID_HEADER = "X-Request-Id";
 
   private AuthUserQueryUseCase authUserQueryUseCase;
   private UserStatusUpdateUseCase userStatusUpdateUseCase;
@@ -54,7 +58,8 @@ class InternalAuthAdminControllerTest {
                     userAccountMembershipQueryUseCase,
                     userAccountMembershipStatusUpdateUseCase,
                     new InternalAuthTokenGuard(
-                        new AuthBootstrapApiProperties(true, TOKEN_HEADER, TOKEN))))
+                        new AuthBootstrapApiProperties(true, TOKEN_HEADER, TOKEN)),
+                    new BootstrapHeaderAuthProperties(false, "X-Account-Id", SUBJECT_HEADER)))
             .setControllerAdvice(new ApiExceptionHandler())
             .build();
   }
@@ -134,11 +139,14 @@ class InternalAuthAdminControllerTest {
         .perform(
             put("/internal/api/v1/auth/users/21/status")
                 .header(TOKEN_HEADER, TOKEN)
+                .header(SUBJECT_HEADER, SUBJECT)
+                .header(REQUEST_ID_HEADER, "user-status-request")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
                     {
-                      "userStatus": "DISABLED"
+                      "userStatus": "DISABLED",
+                      "reason": "fraud-review"
                     }
                     """))
         .andExpect(status().isOk())
@@ -148,20 +156,69 @@ class InternalAuthAdminControllerTest {
         .perform(
             put("/internal/api/v1/auth/users/21/memberships/101/status")
                 .header(TOKEN_HEADER, TOKEN)
+                .header(SUBJECT_HEADER, SUBJECT)
+                .header(REQUEST_ID_HEADER, "membership-status-request")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
                     {
-                      "membershipStatus": "REVOKED"
+                      "membershipStatus": "REVOKED",
+                      "reason": "manual-revoke"
                     }
                     """))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.membershipStatus").value("REVOKED"));
 
     verify(userStatusUpdateUseCase)
-        .update(argThat(command -> command.status() == UserStatus.DISABLED));
+        .update(
+            argThat(
+                command ->
+                    command.status() == UserStatus.DISABLED
+                        && command.reason().equals("fraud-review")
+                        && command.actorSubject().equals(SUBJECT)
+                        && command.requestId().equals("user-status-request")));
     verify(userAccountMembershipStatusUpdateUseCase)
-        .update(argThat(command -> command.status() == MembershipStatus.REVOKED));
+        .update(
+            argThat(
+                command ->
+                    command.status() == MembershipStatus.REVOKED
+                        && command.reason().equals("manual-revoke")
+                        && command.actorSubject().equals(SUBJECT)
+                        && command.requestId().equals("membership-status-request")));
+  }
+
+  @Test
+  void rejectsMissingReasonOrActorSubject() throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/21/status")
+                .header(TOKEN_HEADER, TOKEN)
+                .header(REQUEST_ID_HEADER, "missing-reason-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "userStatus": "DISABLED"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("reason is required"));
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/21/memberships/101/status")
+                .header(TOKEN_HEADER, TOKEN)
+                .header(REQUEST_ID_HEADER, "missing-subject-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "membershipStatus": "REVOKED",
+                      "reason": "manual-revoke"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("actorSubject header is required"));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -32,6 +32,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
 
   private static final String ACCOUNT_BOOTSTRAP_TOKEN = "test-bootstrap-api-token";
   private static final String AUTH_BOOTSTRAP_TOKEN = "test-auth-bootstrap-api-token";
+  private static final String AUTH_ADMIN_SUBJECT = "ops-admin";
 
   @Autowired private WebApplicationContext context;
 
@@ -220,7 +221,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   @Test
   void disabledUserCannotLoginOrUseExistingJwt() throws Exception {
     String token = login("alice", "password123!");
-    updateUserStatus(userId, "DISABLED");
+    updateUserStatus(userId, "DISABLED", "fraud-review", "user-disabled-request");
 
     mockMvc
         .perform(
@@ -270,7 +271,21 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   @Test
   void revokedMembershipBlocksExistingJwtAccess() throws Exception {
     String token = login("alice", "password123!");
-    updateMembershipStatus(userId, allowedSourceAccountId, "REVOKED");
+    updateMembershipStatus(
+        userId, allowedSourceAccountId, "REVOKED", "manual-revoke", "membership-revoked-request");
+
+    AuthStatusChangeAuditView audit =
+        loadAuditByRequestId("membership-revoked-request")
+            .orElseThrow(() -> new AssertionError("audit row is not created"));
+    assertEquals("membership-revoked-request", audit.requestId());
+    assertEquals(AUTH_ADMIN_SUBJECT, audit.actorSubject());
+    assertEquals("MEMBERSHIP_STATUS", audit.changeType());
+    assertEquals(userId, audit.targetUserId());
+    assertEquals(allowedSourceAccountId, audit.targetAccountId());
+    assertEquals("ACTIVE", audit.beforeStatus());
+    assertEquals("REVOKED", audit.afterStatus());
+    assertEquals("manual-revoke", audit.reason());
+    assertEquals("SUCCESS", audit.outcome());
 
     mockMvc
         .perform(
@@ -399,41 +414,97 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.membershipStatus").value(membershipStatus));
   }
 
-  private void updateUserStatus(long userId, String userStatus) throws Exception {
+  private void updateUserStatus(long userId, String userStatus, String reason, String requestId)
+      throws Exception {
     mockMvc
         .perform(
             put("/internal/api/v1/auth/users/%d/status".formatted(userId))
                 .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN)
+                .header("X-Subject", AUTH_ADMIN_SUBJECT)
+                .header("X-Request-Id", requestId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
                     {
-                      "userStatus": "%s"
+                      "userStatus": "%s",
+                      "reason": "%s"
                     }
                     """
-                        .formatted(userStatus)))
+                        .formatted(userStatus, reason)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.userId").value(userId))
         .andExpect(jsonPath("$.userStatus").value(userStatus));
   }
 
-  private void updateMembershipStatus(long userId, long accountId, String membershipStatus)
+  private void updateMembershipStatus(
+      long userId, long accountId, String membershipStatus, String reason, String requestId)
       throws Exception {
     mockMvc
         .perform(
             put("/internal/api/v1/auth/users/%d/memberships/%d/status".formatted(userId, accountId))
                 .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN)
+                .header("X-Subject", AUTH_ADMIN_SUBJECT)
+                .header("X-Request-Id", requestId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
                     {
-                      "membershipStatus": "%s"
+                      "membershipStatus": "%s",
+                      "reason": "%s"
                     }
                     """
-                        .formatted(membershipStatus)))
+                        .formatted(membershipStatus, reason)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.userId").value(userId))
         .andExpect(jsonPath("$.accountId").value(accountId))
         .andExpect(jsonPath("$.membershipStatus").value(membershipStatus));
   }
+
+  private java.util.Optional<AuthStatusChangeAuditView> loadAuditByRequestId(String requestId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT request_id,
+                   actor_subject,
+                   change_type,
+                   target_user_id,
+                   target_account_id,
+                   before_status,
+                   after_status,
+                   reason,
+                   outcome
+            FROM auth_status_change_audit
+            WHERE request_id = :requestId
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
+                .addValue("requestId", requestId),
+            (rs, rowNum) -> {
+              Long targetAccountId = rs.getObject("target_account_id", Long.class);
+              return new AuthStatusChangeAuditView(
+                  rs.getString("request_id"),
+                  rs.getString("actor_subject"),
+                  rs.getString("change_type"),
+                  rs.getLong("target_user_id"),
+                  targetAccountId,
+                  rs.getString("before_status"),
+                  rs.getString("after_status"),
+                  rs.getString("reason"),
+                  rs.getString("outcome"));
+            })
+        .stream()
+        .findFirst();
+  }
+
+  private record AuthStatusChangeAuditView(
+      String requestId,
+      String actorSubject,
+      String changeType,
+      long targetUserId,
+      Long targetAccountId,
+      String beforeStatus,
+      String afterStatus,
+      String reason,
+      String outcome) {}
 }

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -44,6 +44,7 @@ public abstract class PostgresContainerTestSupport {
                     statement.execute(
                         """
                         TRUNCATE TABLE
+                            auth_status_change_audit,
                             transaction_read_model,
                             ledger_entry,
                             command_idempotency,


### PR DESCRIPTION
## 🔗 Related Issue
- close #11

## 📝 Summary
- 내부 auth 관리 경로에 user/membership exact lookup과 status update surface를 정리하고, 회수 시 login/access 차단까지 연결했습니다.
- 추가로 status update 요청에 `reason`을 필수화하고, 성공 감사 row와 실패 structured audit log를 남기도록 보강했습니다.
- 현재 diff에는 `develop`에 아직 없는 내부 auth 조회·회수 선행 커밋도 함께 포함됩니다.

## 🛠 Changes
- 내부 auth admin user/membership 조회 및 `user_status`/`membership_status` update 경로 추가
- status update 요청에 `reason`, `actorSubject(X-Subject)`, `requestId` 반영
- `auth_status_change_audit` 테이블 추가와 성공 감사 저장, 실패 structured audit log 추가
- revoke 후 login/access 차단 및 감사 기록 생성 통합 테스트 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit hook에서 `./back/gradlew -p back check`
- `membership REVOKED` 호출 후 감사 row 생성 통합 테스트 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - 내부 auth status update가 이제 `X-Subject`와 `reason`을 요구하므로 운영 호출 스크립트가 같이 갱신되어야 합니다.
  - `auth_status_change_audit` migration이 추가되어 배포 순서와 rollback 경로를 함께 봐야 합니다.
- 롤백 방법:
  - 애플리케이션은 PR revert로 되돌릴 수 있습니다.
  - migration 적용 후에도 테이블은 감사 이력 보존을 위해 남기고, 코드만 이전 버전으로 되돌리는 경로를 우선 사용합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.