### PR TITLE
[Feat] 내부 auth 감사 기록 requestId exact lookup API 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/exception/AuthStatusChangeAuditNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/AuthStatusChangeAuditNotFoundException.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.exception;
+
+public class AuthStatusChangeAuditNotFoundException extends RuntimeException {
+
+  public AuthStatusChangeAuditNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditSummary.java
@@ -1,0 +1,16 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 내부 운영이 requestId 하나로 exact lookup 할 감사 row 표현입니다. */
+public record AuthStatusChangeAuditSummary(
+    String requestId,
+    String actorSubject,
+    AuthStatusChangeType changeType,
+    long targetUserId,
+    Long targetAccountId,
+    String beforeStatus,
+    String afterStatus,
+    String reason,
+    AuthStatusChangeOutcome outcome,
+    Instant createdAt) {}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AuthStatusChangeAuditQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AuthStatusChangeAuditQueryPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
+import java.util.Optional;
+
+/** 내부 auth 감사 exact lookup read path입니다. */
+public interface AuthStatusChangeAuditQueryPort {
+
+  Optional<AuthStatusChangeAuditSummary> findByRequestId(String requestId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryService.java
@@ -1,0 +1,26 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
+import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
+
+/** requestId exact lookup 결과를 domain 예외와 함께 고정합니다. */
+public final class AuthStatusChangeAuditQueryService implements AuthStatusChangeAuditQueryUseCase {
+
+  private final AuthStatusChangeAuditQueryPort authStatusChangeAuditQueryPort;
+
+  public AuthStatusChangeAuditQueryService(
+      AuthStatusChangeAuditQueryPort authStatusChangeAuditQueryPort) {
+    this.authStatusChangeAuditQueryPort = authStatusChangeAuditQueryPort;
+  }
+
+  @Override
+  public AuthStatusChangeAuditSummary getByRequestId(String requestId) {
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    return authStatusChangeAuditQueryPort
+        .findByRequestId(requestId)
+        .orElseThrow(() -> new AuthStatusChangeAuditNotFoundException("audit record is not found"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryUseCase.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
+
+public interface AuthStatusChangeAuditQueryUseCase {
+
+  AuthStatusChangeAuditSummary getByRequestId(String requestId);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.config;
 
 import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipQueryPort;
@@ -12,6 +13,8 @@ import com.aquilabank.domain.auth.port.UserQueryPort;
 import com.aquilabank.domain.auth.port.UserStatusUpdatePort;
 import com.aquilabank.domain.auth.usecase.AccountAccessService;
 import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
+import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryService;
+import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryUseCase;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryService;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
 import com.aquilabank.domain.auth.usecase.LoginService;
@@ -72,6 +75,12 @@ public class AuthConfiguration {
   UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase(
       UserAccountMembershipQueryPort userAccountMembershipQueryPort) {
     return new UserAccountMembershipQueryService(userAccountMembershipQueryPort);
+  }
+
+  @Bean
+  AuthStatusChangeAuditQueryUseCase authStatusChangeAuditQueryUseCase(
+      AuthStatusChangeAuditQueryPort authStatusChangeAuditQueryPort) {
+    return new AuthStatusChangeAuditQueryService(authStatusChangeAuditQueryPort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -1,6 +1,9 @@
 package com.aquilabank.global.persistence.auth;
 
 import com.aquilabank.domain.auth.model.AccountAccessMembership;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
+import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.LoginUser;
 import com.aquilabank.domain.auth.model.MembershipRole;
@@ -9,6 +12,7 @@ import com.aquilabank.domain.auth.model.UserAccountMembership;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipQueryPort;
 import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
 import com.aquilabank.domain.auth.port.UserQueryPort;
@@ -27,7 +31,8 @@ public class JdbcAuthRepository
     implements UserCredentialLoadPort,
         AccountAccessPort,
         UserQueryPort,
-        UserAccountMembershipQueryPort {
+        UserAccountMembershipQueryPort,
+        AuthStatusChangeAuditQueryPort {
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -135,6 +140,33 @@ public class JdbcAuthRepository
         .findFirst();
   }
 
+  @Override
+  public Optional<AuthStatusChangeAuditSummary> findByRequestId(String requestId) {
+    // requestId exact match만 허용해 idx_auth_status_change_audit_request_id 경로를 그대로 사용합니다.
+    return jdbcTemplate
+        .query(
+            """
+            SELECT request_id,
+                   actor_subject,
+                   change_type,
+                   target_user_id,
+                   target_account_id,
+                   before_status,
+                   after_status,
+                   reason,
+                   outcome,
+                   created_at
+            FROM auth_status_change_audit
+            WHERE request_id = :requestId
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            new MapSqlParameterSource().addValue("requestId", requestId),
+            (rs, rowNum) -> mapStatusChangeAuditSummary(rs))
+        .stream()
+        .findFirst();
+  }
+
   private LoginUser mapLoginUser(ResultSet rs) throws SQLException {
     return new LoginUser(
         rs.getLong("id"),
@@ -178,6 +210,22 @@ public class JdbcAuthRepository
         MembershipStatus.valueOf(rs.getString("membership_status")),
         toInstant(rs.getTimestamp("created_at")),
         toInstant(rs.getTimestamp("updated_at")));
+  }
+
+  private AuthStatusChangeAuditSummary mapStatusChangeAuditSummary(ResultSet rs)
+      throws SQLException {
+    Long targetAccountId = rs.getObject("target_account_id", Long.class);
+    return new AuthStatusChangeAuditSummary(
+        rs.getString("request_id"),
+        rs.getString("actor_subject"),
+        AuthStatusChangeType.valueOf(rs.getString("change_type")),
+        rs.getLong("target_user_id"),
+        targetAccountId,
+        rs.getString("before_status"),
+        rs.getString("after_status"),
+        rs.getString("reason"),
+        AuthStatusChangeOutcome.valueOf(rs.getString("outcome")),
+        toInstant(rs.getTimestamp("created_at")));
   }
 
   private Instant toInstant(Timestamp timestamp) {

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.web;
 
 import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
+import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
 import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
 import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
@@ -92,6 +93,7 @@ public class ApiExceptionHandler {
 
   @ExceptionHandler({
     SnapshotNotFoundException.class,
+    AuthStatusChangeAuditNotFoundException.class,
     AuthUserNotFoundException.class,
     UserAccountMembershipNotFoundException.class
   })

--- a/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditController.java
@@ -1,0 +1,69 @@
+package com.aquilabank.global.web.auth;
+
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
+import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryUseCase;
+import com.aquilabank.global.security.InternalAuthTokenGuard;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 내부 auth 감사 requestId exact lookup만 분리해 운영 조회 경계를 고정합니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/auth/status-change-audits")
+@ConditionalOnProperty(name = "security.auth-bootstrap-api.enabled", havingValue = "true")
+public class InternalAuthStatusChangeAuditController {
+
+  private final AuthStatusChangeAuditQueryUseCase authStatusChangeAuditQueryUseCase;
+  private final InternalAuthTokenGuard internalAuthTokenGuard;
+
+  public InternalAuthStatusChangeAuditController(
+      AuthStatusChangeAuditQueryUseCase authStatusChangeAuditQueryUseCase,
+      InternalAuthTokenGuard internalAuthTokenGuard) {
+    this.authStatusChangeAuditQueryUseCase = authStatusChangeAuditQueryUseCase;
+    this.internalAuthTokenGuard = internalAuthTokenGuard;
+  }
+
+  @GetMapping("/by-request-id")
+  public AuthStatusChangeAuditResponse getByRequestId(
+      HttpServletRequest httpServletRequest,
+      @RequestParam @NotBlank(message = "requestId is required") String requestId) {
+    internalAuthTokenGuard.validate(httpServletRequest);
+    return AuthStatusChangeAuditResponse.from(
+        authStatusChangeAuditQueryUseCase.getByRequestId(requestId));
+  }
+
+  /** 내부 auth status change audit exact lookup 응답 */
+  public record AuthStatusChangeAuditResponse(
+      String requestId,
+      String actorSubject,
+      long targetUserId,
+      Long targetAccountId,
+      String changeType,
+      String beforeStatus,
+      String afterStatus,
+      String reason,
+      String outcome,
+      Instant createdAt) {
+
+    static AuthStatusChangeAuditResponse from(AuthStatusChangeAuditSummary summary) {
+      return new AuthStatusChangeAuditResponse(
+          summary.requestId(),
+          summary.actorSubject(),
+          summary.targetUserId(),
+          summary.targetAccountId(),
+          summary.changeType().name(),
+          summary.beforeStatus(),
+          summary.afterStatus(),
+          summary.reason(),
+          summary.outcome().name(),
+          summary.createdAt());
+    }
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditControllerTest.java
@@ -1,0 +1,101 @@
+package com.aquilabank.global.web.auth;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
+import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeType;
+import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryUseCase;
+import com.aquilabank.global.security.AuthBootstrapApiProperties;
+import com.aquilabank.global.security.InternalAuthTokenGuard;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class InternalAuthStatusChangeAuditControllerTest {
+
+  private static final String TOKEN_HEADER = "X-Auth-Bootstrap-Token";
+  private static final String TOKEN = "test-auth-bootstrap-api-token";
+
+  private AuthStatusChangeAuditQueryUseCase authStatusChangeAuditQueryUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    authStatusChangeAuditQueryUseCase = mock(AuthStatusChangeAuditQueryUseCase.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new InternalAuthStatusChangeAuditController(
+                    authStatusChangeAuditQueryUseCase,
+                    new InternalAuthTokenGuard(
+                        new AuthBootstrapApiProperties(true, TOKEN_HEADER, TOKEN))))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void getsAuditByRequestId() throws Exception {
+    when(authStatusChangeAuditQueryUseCase.getByRequestId("membership-revoked-request"))
+        .thenReturn(
+            new AuthStatusChangeAuditSummary(
+                "membership-revoked-request",
+                "ops-admin",
+                AuthStatusChangeType.MEMBERSHIP_STATUS,
+                21L,
+                101L,
+                "ACTIVE",
+                "REVOKED",
+                "manual-revoke",
+                AuthStatusChangeOutcome.SUCCESS,
+                Instant.parse("2026-04-16T11:06:00Z")));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/status-change-audits/by-request-id")
+                .header(TOKEN_HEADER, TOKEN)
+                .param("requestId", "membership-revoked-request"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.requestId").value("membership-revoked-request"))
+        .andExpect(jsonPath("$.actorSubject").value("ops-admin"))
+        .andExpect(jsonPath("$.targetUserId").value(21))
+        .andExpect(jsonPath("$.targetAccountId").value(101))
+        .andExpect(jsonPath("$.changeType").value("MEMBERSHIP_STATUS"))
+        .andExpect(jsonPath("$.beforeStatus").value("ACTIVE"))
+        .andExpect(jsonPath("$.afterStatus").value("REVOKED"))
+        .andExpect(jsonPath("$.reason").value("manual-revoke"))
+        .andExpect(jsonPath("$.outcome").value("SUCCESS"))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-16T11:06:00Z"));
+  }
+
+  @Test
+  void returnsNotFoundWhenRequestIdDoesNotExist() throws Exception {
+    when(authStatusChangeAuditQueryUseCase.getByRequestId("missing-request"))
+        .thenThrow(new AuthStatusChangeAuditNotFoundException("audit record is not found"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/status-change-audits/by-request-id")
+                .header(TOKEN_HEADER, TOKEN)
+                .param("requestId", "missing-request"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("audit record is not found"));
+  }
+
+  @Test
+  void rejectsMissingOrInvalidBootstrapToken() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/status-change-audits/by-request-id")
+                .param("requestId", "membership-revoked-request"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("bootstrap token is invalid"));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -318,6 +318,33 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.message").value("account access is denied"));
   }
 
+  @Test
+  void internalAuthAuditLookupReturnsStoredAuditByRequestId() throws Exception {
+    updateMembershipStatus(
+        userId, allowedSourceAccountId, "REVOKED", "manual-revoke", "membership-revoked-request");
+
+    AuthStatusChangeAuditView audit =
+        loadAuditByRequestId("membership-revoked-request")
+            .orElseThrow(() -> new AssertionError("audit row is not created"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/status-change-audits/by-request-id")
+                .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN)
+                .param("requestId", "membership-revoked-request"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.requestId").value(audit.requestId()))
+        .andExpect(jsonPath("$.actorSubject").value(audit.actorSubject()))
+        .andExpect(jsonPath("$.targetUserId").value(audit.targetUserId()))
+        .andExpect(jsonPath("$.targetAccountId").value(audit.targetAccountId()))
+        .andExpect(jsonPath("$.changeType").value(audit.changeType()))
+        .andExpect(jsonPath("$.beforeStatus").value(audit.beforeStatus()))
+        .andExpect(jsonPath("$.afterStatus").value(audit.afterStatus()))
+        .andExpect(jsonPath("$.reason").value(audit.reason()))
+        .andExpect(jsonPath("$.outcome").value(audit.outcome()))
+        .andExpect(jsonPath("$.createdAt").value(audit.createdAt().toString()));
+  }
+
   private String login(String loginId, String password) throws Exception {
     MvcResult result =
         mockMvc
@@ -472,7 +499,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                    before_status,
                    after_status,
                    reason,
-                   outcome
+                   outcome,
+                   created_at
             FROM auth_status_change_audit
             WHERE request_id = :requestId
             ORDER BY id DESC
@@ -491,7 +519,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                   rs.getString("before_status"),
                   rs.getString("after_status"),
                   rs.getString("reason"),
-                  rs.getString("outcome"));
+                  rs.getString("outcome"),
+                  rs.getTimestamp("created_at").toInstant());
             })
         .stream()
         .findFirst();
@@ -506,5 +535,6 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
       String beforeStatus,
       String afterStatus,
       String reason,
-      String outcome) {}
+      String outcome,
+      java.time.Instant createdAt) {}
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #16

## 📝 Summary
- 내부 auth status change audit를 `requestId` 기준으로 exact lookup 하는 내부 전용 API를 추가했습니다.
- 기존 bootstrap token 보호 규칙을 그대로 재사용하고, 없는 `requestId`는 404로 응답하도록 맞췄습니다.

## 🛠 Changes
- `AuthStatusChangeAuditQueryUseCase`와 JDBC exact lookup read path를 추가했습니다.
- `GET /internal/api/v1/auth/status-change-audits/by-request-id?requestId=...` endpoint를 추가했습니다.
- unit/integration test에서 200/404/401과 revoke 직후 lookup 성공을 검증했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- `GET /internal/api/v1/auth/status-change-audits/by-request-id?requestId=membership-revoked-request`
- Header: `X-Auth-Bootstrap-Token: <token>`

## ⚠️ Risk & Rollback
- 예상 리스크: 내부 운영 도구가 새 경로를 사용하기 전까지는 requestId 조회 기능이 문서 없이 숨겨질 수 있습니다.
- 롤백 방법: `InternalAuthStatusChangeAuditController`, audit query usecase/adapter wiring을 되돌리면 됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [ ] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.