### PR TITLE
[Feat] 내부 auth 회수 사유 코드 표준화

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditEntry.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditEntry.java
@@ -11,9 +11,33 @@ public record AuthStatusChangeAuditEntry(
     Long targetAccountId,
     String beforeStatus,
     String afterStatus,
-    String reason,
+    AuthStatusChangeReason normalizedReason,
     AuthStatusChangeOutcome outcome,
     Instant createdAt) {
+
+  public AuthStatusChangeAuditEntry(
+      AuthStatusChangeType changeType,
+      String requestId,
+      String actorSubject,
+      long targetUserId,
+      Long targetAccountId,
+      String beforeStatus,
+      String afterStatus,
+      String reason,
+      AuthStatusChangeOutcome outcome,
+      Instant createdAt) {
+    this(
+        changeType,
+        requestId,
+        actorSubject,
+        targetUserId,
+        targetAccountId,
+        beforeStatus,
+        afterStatus,
+        new AuthStatusChangeReason(AuthStatusChangeReasonCode.LEGACY_FREE_TEXT, reason),
+        outcome,
+        createdAt);
+  }
 
   public AuthStatusChangeAuditEntry {
     if (changeType == null) {
@@ -37,7 +61,7 @@ public record AuthStatusChangeAuditEntry(
     if (afterStatus == null || afterStatus.isBlank()) {
       throw new IllegalArgumentException("afterStatus is required");
     }
-    if (reason == null || reason.isBlank()) {
+    if (normalizedReason == null) {
       throw new IllegalArgumentException("reason is required");
     }
     if (outcome == null) {
@@ -46,5 +70,17 @@ public record AuthStatusChangeAuditEntry(
     if (createdAt == null) {
       throw new IllegalArgumentException("createdAt is required");
     }
+  }
+
+  public AuthStatusChangeReasonCode reasonCode() {
+    return normalizedReason.reasonCode();
+  }
+
+  public String reasonDetail() {
+    return normalizedReason.reasonDetail();
+  }
+
+  public String reason() {
+    return normalizedReason.reasonDetail();
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditSummary.java
@@ -11,6 +11,43 @@ public record AuthStatusChangeAuditSummary(
     Long targetAccountId,
     String beforeStatus,
     String afterStatus,
-    String reason,
+    AuthStatusChangeReason normalizedReason,
     AuthStatusChangeOutcome outcome,
-    Instant createdAt) {}
+    Instant createdAt) {
+
+  public AuthStatusChangeAuditSummary(
+      String requestId,
+      String actorSubject,
+      AuthStatusChangeType changeType,
+      long targetUserId,
+      Long targetAccountId,
+      String beforeStatus,
+      String afterStatus,
+      String reason,
+      AuthStatusChangeOutcome outcome,
+      Instant createdAt) {
+    this(
+        requestId,
+        actorSubject,
+        changeType,
+        targetUserId,
+        targetAccountId,
+        beforeStatus,
+        afterStatus,
+        new AuthStatusChangeReason(AuthStatusChangeReasonCode.LEGACY_FREE_TEXT, reason),
+        outcome,
+        createdAt);
+  }
+
+  public AuthStatusChangeReasonCode reasonCode() {
+    return normalizedReason.reasonCode();
+  }
+
+  public String reasonDetail() {
+    return normalizedReason.reasonDetail();
+  }
+
+  public String reason() {
+    return normalizedReason.reasonDetail();
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeReason.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeReason.java
@@ -1,0 +1,19 @@
+package com.aquilabank.domain.auth.model;
+
+/** 사유 코드는 분류용, detail은 운영 문맥 보존용으로 분리합니다. */
+public record AuthStatusChangeReason(AuthStatusChangeReasonCode reasonCode, String reasonDetail) {
+
+  public static final int MAX_REASON_DETAIL_LENGTH = 200;
+
+  public AuthStatusChangeReason {
+    if (reasonCode == null) {
+      throw new IllegalArgumentException("reasonCode is required");
+    }
+    if (reasonDetail == null || reasonDetail.isBlank()) {
+      throw new IllegalArgumentException("reasonDetail is required");
+    }
+    if (reasonDetail.length() > MAX_REASON_DETAIL_LENGTH) {
+      throw new IllegalArgumentException("reasonDetail must be 200 characters or less");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeReasonCode.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeReasonCode.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.model;
+
+/** 내부 auth 상태 변경 사유 코드를 고정해 운영 분류를 흔들리지 않게 유지합니다. */
+public enum AuthStatusChangeReasonCode {
+  FRAUD_REVIEW,
+  USER_REQUEST,
+  OPS_MANUAL,
+  ACCOUNT_CLOSURE,
+  LEGACY_FREE_TEXT
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeReasonNormalizer.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeReasonNormalizer.java
@@ -1,0 +1,29 @@
+package com.aquilabank.domain.auth.model;
+
+/** legacy reason 입력을 한시 호환하면서 내부 command는 단일 reason 구조로 정규화합니다. */
+public final class AuthStatusChangeReasonNormalizer {
+
+  private AuthStatusChangeReasonNormalizer() {}
+
+  public static AuthStatusChangeReason normalize(
+      AuthStatusChangeReasonCode reasonCode, String reasonDetail, String legacyReason) {
+    boolean hasLegacyReason = hasText(legacyReason);
+    boolean hasReasonDetail = hasText(reasonDetail);
+
+    if (hasLegacyReason && (reasonCode != null || hasReasonDetail)) {
+      throw new IllegalArgumentException(
+          "reason and reasonCode/reasonDetail cannot be used together");
+    }
+    if (hasLegacyReason) {
+      return new AuthStatusChangeReason(AuthStatusChangeReasonCode.LEGACY_FREE_TEXT, legacyReason);
+    }
+    if (reasonCode == null) {
+      throw new IllegalArgumentException("reasonCode is required");
+    }
+    return new AuthStatusChangeReason(reasonCode, reasonDetail);
+  }
+
+  private static boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipStatusUpdateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserAccountMembershipStatusUpdateCommand.java
@@ -5,7 +5,7 @@ public record UserAccountMembershipStatusUpdateCommand(
     long userId,
     long accountId,
     MembershipStatus status,
-    String reason,
+    AuthStatusChangeReason normalizedReason,
     String actorSubject,
     String requestId) {
 
@@ -19,7 +19,7 @@ public record UserAccountMembershipStatusUpdateCommand(
     if (status == null) {
       throw new IllegalArgumentException("status is required");
     }
-    if (reason == null || reason.isBlank()) {
+    if (normalizedReason == null) {
       throw new IllegalArgumentException("reason is required");
     }
     if (actorSubject == null || actorSubject.isBlank()) {
@@ -28,5 +28,17 @@ public record UserAccountMembershipStatusUpdateCommand(
     if (requestId == null || requestId.isBlank()) {
       throw new IllegalArgumentException("requestId is required");
     }
+  }
+
+  public AuthStatusChangeReasonCode reasonCode() {
+    return normalizedReason.reasonCode();
+  }
+
+  public String reasonDetail() {
+    return normalizedReason.reasonDetail();
+  }
+
+  public String reason() {
+    return normalizedReason.reasonDetail();
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/model/UserStatusUpdateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/UserStatusUpdateCommand.java
@@ -2,7 +2,11 @@ package com.aquilabank.domain.auth.model;
 
 /** 내부 auth 관리 경로가 user 상태를 변경할 때 쓰는 명령입니다. */
 public record UserStatusUpdateCommand(
-    long userId, UserStatus status, String reason, String actorSubject, String requestId) {
+    long userId,
+    UserStatus status,
+    AuthStatusChangeReason normalizedReason,
+    String actorSubject,
+    String requestId) {
 
   public UserStatusUpdateCommand {
     if (userId <= 0) {
@@ -11,7 +15,7 @@ public record UserStatusUpdateCommand(
     if (status == null) {
       throw new IllegalArgumentException("status is required");
     }
-    if (reason == null || reason.isBlank()) {
+    if (normalizedReason == null) {
       throw new IllegalArgumentException("reason is required");
     }
     if (actorSubject == null || actorSubject.isBlank()) {
@@ -20,5 +24,17 @@ public record UserStatusUpdateCommand(
     if (requestId == null || requestId.isBlank()) {
       throw new IllegalArgumentException("requestId is required");
     }
+  }
+
+  public AuthStatusChangeReasonCode reasonCode() {
+    return normalizedReason.reasonCode();
+  }
+
+  public String reasonDetail() {
+    return normalizedReason.reasonDetail();
+  }
+
+  public String reason() {
+    return normalizedReason.reasonDetail();
   }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -1,10 +1,10 @@
 package com.aquilabank.global.persistence.auth;
 
 import com.aquilabank.domain.auth.model.AccountAccessMembership;
-import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
-import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.LoginUser;

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -1,6 +1,8 @@
 package com.aquilabank.global.persistence.auth;
 
 import com.aquilabank.domain.auth.model.AccountAccessMembership;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
 import com.aquilabank.domain.auth.model.AuthStatusChangeType;
@@ -153,6 +155,7 @@ public class JdbcAuthRepository
                    target_account_id,
                    before_status,
                    after_status,
+                   reason_code,
                    reason,
                    outcome,
                    created_at
@@ -223,7 +226,9 @@ public class JdbcAuthRepository
         targetAccountId,
         rs.getString("before_status"),
         rs.getString("after_status"),
-        rs.getString("reason"),
+        new AuthStatusChangeReason(
+            AuthStatusChangeReasonCode.valueOf(rs.getString("reason_code")),
+            rs.getString("reason")),
         AuthStatusChangeOutcome.valueOf(rs.getString("outcome")),
         toInstant(rs.getTimestamp("created_at")));
   }

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -165,7 +165,7 @@ public class JdbcAuthWriteRepository
             null,
             beforeStatus.name(),
             summary.status().name(),
-            command.reason(),
+            command.normalizedReason(),
             AuthStatusChangeOutcome.SUCCESS,
             now));
     return summary;
@@ -208,7 +208,7 @@ public class JdbcAuthWriteRepository
             command.accountId(),
             beforeStatus.name(),
             summary.status().name(),
-            command.reason(),
+            command.normalizedReason(),
             AuthStatusChangeOutcome.SUCCESS,
             now));
     return summary;
@@ -262,6 +262,7 @@ public class JdbcAuthWriteRepository
             target_account_id,
             before_status,
             after_status,
+            reason_code,
             reason,
             outcome,
             created_at
@@ -274,6 +275,7 @@ public class JdbcAuthWriteRepository
             :targetAccountId,
             :beforeStatus,
             :afterStatus,
+            :reasonCode,
             :reason,
             :outcome,
             :createdAt
@@ -287,7 +289,8 @@ public class JdbcAuthWriteRepository
             .addValue("targetAccountId", entry.targetAccountId())
             .addValue("beforeStatus", entry.beforeStatus())
             .addValue("afterStatus", entry.afterStatus())
-            .addValue("reason", entry.reason())
+            .addValue("reasonCode", entry.reasonCode().name())
+            .addValue("reason", entry.reasonDetail())
             .addValue("outcome", entry.outcome().name())
             .addValue("createdAt", Timestamp.from(entry.createdAt())));
   }

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -6,6 +6,7 @@ import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
 import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
 import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
@@ -136,13 +137,14 @@ public class ApiExceptionHandler {
       return;
     }
     log.warn(
-        "internal auth status update failed requestId={} actorSubject={} targetUserId={} targetAccountId={} requestedStatus={} reason={} path={} error={}",
+        "internal auth status update failed requestId={} actorSubject={} targetUserId={} targetAccountId={} requestedStatus={} reasonCode={} reasonDetail={} path={} error={}",
         RequestTraceContext.currentRequestId().orElse("-"),
         context.actorSubject(),
         context.targetUserId(),
         context.targetAccountId() == null ? "-" : context.targetAccountId(),
         context.requestedStatus(),
-        context.reason(),
+        context.reasonCode(),
+        context.reasonDetail(),
         request.getRequestURI(),
         error);
   }
@@ -156,7 +158,8 @@ public class ApiExceptionHandler {
           parseLong(membershipMatcher.group(1)),
           parseLong(membershipMatcher.group(2)),
           extractJsonField(request, "membershipStatus"),
-          extractJsonField(request, "reason"));
+          extractReasonCode(request),
+          extractReasonDetail(request));
     }
 
     Matcher userMatcher = USER_STATUS_PATH_PATTERN.matcher(path);
@@ -166,7 +169,8 @@ public class ApiExceptionHandler {
           parseLong(userMatcher.group(1)),
           null,
           extractJsonField(request, "userStatus"),
-          extractJsonField(request, "reason"));
+          extractReasonCode(request),
+          extractReasonDetail(request));
     }
     return null;
   }
@@ -198,18 +202,40 @@ public class ApiExceptionHandler {
     return value == null || value.isBlank() ? "-" : value;
   }
 
+  private String extractReasonCode(HttpServletRequest request) {
+    String reasonCode = extractJsonField(request, "reasonCode");
+    if (!"-".equals(reasonCode)) {
+      return reasonCode;
+    }
+    String legacyReason = extractJsonField(request, "reason");
+    if ("-".equals(legacyReason)) {
+      return "-";
+    }
+    return AuthStatusChangeReasonCode.LEGACY_FREE_TEXT.name();
+  }
+
+  private String extractReasonDetail(HttpServletRequest request) {
+    String reasonDetail = extractJsonField(request, "reasonDetail");
+    if (!"-".equals(reasonDetail)) {
+      return reasonDetail;
+    }
+    return extractJsonField(request, "reason");
+  }
+
   private record AuditFailureContext(
       String actorSubject,
       Long targetUserId,
       Long targetAccountId,
       String requestedStatus,
-      String reason) {
+      String reasonCode,
+      String reasonDetail) {
 
     private AuditFailureContext {
       actorSubject = actorSubject == null || actorSubject.isBlank() ? "-" : actorSubject;
       requestedStatus =
           requestedStatus == null || requestedStatus.isBlank() ? "-" : requestedStatus;
-      reason = reason == null || reason.isBlank() ? "-" : reason;
+      reasonCode = reasonCode == null || reasonCode.isBlank() ? "-" : reasonCode;
+      reasonDetail = reasonDetail == null || reasonDetail.isBlank() ? "-" : reasonDetail;
     }
   }
 

--- a/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
@@ -1,5 +1,8 @@
 package com.aquilabank.global.web.auth;
 
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonNormalizer;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
@@ -95,7 +98,7 @@ public class InternalAuthAdminController {
             new UserStatusUpdateCommand(
                 userId,
                 request.userStatus(),
-                request.reason(),
+                resolveReason(request.reasonCode(), request.reasonDetail(), request.reason()),
                 resolveActorSubject(httpServletRequest),
                 resolveRequestId(httpServletRequest))));
   }
@@ -113,7 +116,7 @@ public class InternalAuthAdminController {
                 userId,
                 accountId,
                 request.membershipStatus(),
-                request.reason(),
+                resolveReason(request.reasonCode(), request.reasonDetail(), request.reason()),
                 resolveActorSubject(httpServletRequest),
                 resolveRequestId(httpServletRequest))));
   }
@@ -121,12 +124,28 @@ public class InternalAuthAdminController {
   /** 내부 user status update 요청 body */
   public record UserStatusRequest(
       @NotNull(message = "userStatus is required") UserStatus userStatus,
-      @NotBlank(message = "reason is required") @Size(max = 200, message = "reason must be 200 characters or less") String reason) {}
+      AuthStatusChangeReasonCode reasonCode,
+      @Size(
+              max = AuthStatusChangeReason.MAX_REASON_DETAIL_LENGTH,
+              message = "reasonDetail must be 200 characters or less")
+          String reasonDetail,
+      @Size(
+              max = AuthStatusChangeReason.MAX_REASON_DETAIL_LENGTH,
+              message = "reason must be 200 characters or less")
+          String reason) {}
 
   /** 내부 membership status update 요청 body */
   public record UserAccountMembershipStatusRequest(
       @NotNull(message = "membershipStatus is required") com.aquilabank.domain.auth.model.MembershipStatus membershipStatus,
-      @NotBlank(message = "reason is required") @Size(max = 200, message = "reason must be 200 characters or less") String reason) {}
+      AuthStatusChangeReasonCode reasonCode,
+      @Size(
+              max = AuthStatusChangeReason.MAX_REASON_DETAIL_LENGTH,
+              message = "reasonDetail must be 200 characters or less")
+          String reasonDetail,
+      @Size(
+              max = AuthStatusChangeReason.MAX_REASON_DETAIL_LENGTH,
+              message = "reason must be 200 characters or less")
+          String reason) {}
 
   private String resolveActorSubject(HttpServletRequest httpServletRequest) {
     String actorSubject = httpServletRequest.getHeader(actorSubjectHeader);
@@ -147,6 +166,11 @@ public class InternalAuthAdminController {
               }
               return requestId;
             });
+  }
+
+  private AuthStatusChangeReason resolveReason(
+      AuthStatusChangeReasonCode reasonCode, String reasonDetail, String reason) {
+    return AuthStatusChangeReasonNormalizer.normalize(reasonCode, reasonDetail, reason);
   }
 
   /** 내부 auth user exact lookup 응답 */

--- a/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditController.java
@@ -48,6 +48,8 @@ public class InternalAuthStatusChangeAuditController {
       String changeType,
       String beforeStatus,
       String afterStatus,
+      String reasonCode,
+      String reasonDetail,
       String reason,
       String outcome,
       Instant createdAt) {
@@ -61,6 +63,8 @@ public class InternalAuthStatusChangeAuditController {
           summary.changeType().name(),
           summary.beforeStatus(),
           summary.afterStatus(),
+          summary.reasonCode().name(),
+          summary.reasonDetail(),
           summary.reason(),
           summary.outcome().name(),
           summary.createdAt());

--- a/back/src/main/resources/db/migration/V6__standardize_auth_status_change_reason_code.sql
+++ b/back/src/main/resources/db/migration/V6__standardize_auth_status_change_reason_code.sql
@@ -1,0 +1,19 @@
+ALTER TABLE auth_status_change_audit
+    ADD COLUMN reason_code VARCHAR(32);
+
+UPDATE auth_status_change_audit
+SET reason_code = 'LEGACY_FREE_TEXT'
+WHERE reason_code IS NULL;
+
+ALTER TABLE auth_status_change_audit
+    ALTER COLUMN reason_code SET NOT NULL;
+
+ALTER TABLE auth_status_change_audit
+    ADD CONSTRAINT chk_auth_status_change_audit_reason_code
+        CHECK (reason_code IN (
+            'FRAUD_REVIEW',
+            'USER_REQUEST',
+            'OPS_MANUAL',
+            'ACCOUNT_CLOSURE',
+            'LEGACY_FREE_TEXT'
+        ));

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -202,7 +202,7 @@ class InternalAuthAdminControllerTest {
                     }
                     """))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value("reason is required"));
+        .andExpect(jsonPath("$.message").value("reasonCode is required"));
 
     mockMvc
         .perform(

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -146,7 +146,8 @@ class InternalAuthAdminControllerTest {
                     """
                     {
                       "userStatus": "DISABLED",
-                      "reason": "fraud-review"
+                      "reasonCode": "FRAUD_REVIEW",
+                      "reasonDetail": "fraud-review"
                     }
                     """))
         .andExpect(status().isOk())
@@ -174,6 +175,8 @@ class InternalAuthAdminControllerTest {
             argThat(
                 command ->
                     command.status() == UserStatus.DISABLED
+                        && command.reasonCode().name().equals("FRAUD_REVIEW")
+                        && command.reasonDetail().equals("fraud-review")
                         && command.reason().equals("fraud-review")
                         && command.actorSubject().equals(SUBJECT)
                         && command.requestId().equals("user-status-request")));
@@ -182,6 +185,8 @@ class InternalAuthAdminControllerTest {
             argThat(
                 command ->
                     command.status() == MembershipStatus.REVOKED
+                        && command.reasonCode().name().equals("LEGACY_FREE_TEXT")
+                        && command.reasonDetail().equals("manual-revoke")
                         && command.reason().equals("manual-revoke")
                         && command.actorSubject().equals(SUBJECT)
                         && command.requestId().equals("membership-status-request")));
@@ -214,11 +219,52 @@ class InternalAuthAdminControllerTest {
                     """
                     {
                       "membershipStatus": "REVOKED",
-                      "reason": "manual-revoke"
+                      "reasonCode": "OPS_MANUAL"
                     }
                     """))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value("actorSubject header is required"));
+        .andExpect(jsonPath("$.message").value("reasonDetail is required"));
+  }
+
+  @Test
+  void acceptsLegacyReasonAsFallbackCode() throws Exception {
+    AuthUserSummary disabledUser =
+        new AuthUserSummary(
+            21L,
+            "alice",
+            "Alice",
+            UserStatus.DISABLED,
+            Instant.parse("2026-04-16T11:00:00Z"),
+            Instant.parse("2026-04-16T11:06:00Z"));
+
+    when(userStatusUpdateUseCase.update(argThat(command -> command.userId() == 21L)))
+        .thenReturn(disabledUser);
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/21/status")
+                .header(TOKEN_HEADER, TOKEN)
+                .header(SUBJECT_HEADER, SUBJECT)
+                .header(REQUEST_ID_HEADER, "legacy-reason-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "userStatus": "DISABLED",
+                      "reason": "legacy-free-text"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userStatus").value("DISABLED"));
+
+    verify(userStatusUpdateUseCase)
+        .update(
+            argThat(
+                command ->
+                    command.status() == UserStatus.DISABLED
+                        && command.reasonCode().name().equals("LEGACY_FREE_TEXT")
+                        && command.reasonDetail().equals("legacy-free-text")
+                        && command.requestId().equals("legacy-reason-request")));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditControllerTest.java
@@ -7,6 +7,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
 import com.aquilabank.domain.auth.model.AuthStatusChangeType;
@@ -53,7 +55,7 @@ class InternalAuthStatusChangeAuditControllerTest {
                 101L,
                 "ACTIVE",
                 "REVOKED",
-                "manual-revoke",
+                new AuthStatusChangeReason(AuthStatusChangeReasonCode.OPS_MANUAL, "manual-revoke"),
                 AuthStatusChangeOutcome.SUCCESS,
                 Instant.parse("2026-04-16T11:06:00Z")));
 
@@ -70,6 +72,8 @@ class InternalAuthStatusChangeAuditControllerTest {
         .andExpect(jsonPath("$.changeType").value("MEMBERSHIP_STATUS"))
         .andExpect(jsonPath("$.beforeStatus").value("ACTIVE"))
         .andExpect(jsonPath("$.afterStatus").value("REVOKED"))
+        .andExpect(jsonPath("$.reasonCode").value("OPS_MANUAL"))
+        .andExpect(jsonPath("$.reasonDetail").value("manual-revoke"))
         .andExpect(jsonPath("$.reason").value("manual-revoke"))
         .andExpect(jsonPath("$.outcome").value("SUCCESS"))
         .andExpect(jsonPath("$.createdAt").value("2026-04-16T11:06:00Z"));

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditControllerTest.java
@@ -7,10 +7,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
-import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
-import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryUseCase;
 import com.aquilabank.global.security.AuthBootstrapApiProperties;

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -467,8 +467,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   private void updateLegacyUserStatus(
-      long userId, String userStatus, String reason, String requestId)
-      throws Exception {
+      long userId, String userStatus, String reason, String requestId) throws Exception {
     mockMvc
         .perform(
             put("/internal/api/v1/auth/users/%d/status".formatted(userId))

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -221,7 +221,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   @Test
   void disabledUserCannotLoginOrUseExistingJwt() throws Exception {
     String token = login("alice", "password123!");
-    updateUserStatus(userId, "DISABLED", "fraud-review", "user-disabled-request");
+    updateLegacyUserStatus(userId, "DISABLED", "fraud-review", "user-disabled-request");
 
     mockMvc
         .perform(
@@ -272,7 +272,12 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   void revokedMembershipBlocksExistingJwtAccess() throws Exception {
     String token = login("alice", "password123!");
     updateMembershipStatus(
-        userId, allowedSourceAccountId, "REVOKED", "manual-revoke", "membership-revoked-request");
+        userId,
+        allowedSourceAccountId,
+        "REVOKED",
+        "OPS_MANUAL",
+        "manual-revoke",
+        "membership-revoked-request");
 
     AuthStatusChangeAuditView audit =
         loadAuditByRequestId("membership-revoked-request")
@@ -284,7 +289,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
     assertEquals(allowedSourceAccountId, audit.targetAccountId());
     assertEquals("ACTIVE", audit.beforeStatus());
     assertEquals("REVOKED", audit.afterStatus());
-    assertEquals("manual-revoke", audit.reason());
+    assertEquals("OPS_MANUAL", audit.reasonCode());
+    assertEquals("manual-revoke", audit.reasonDetail());
     assertEquals("SUCCESS", audit.outcome());
 
     mockMvc
@@ -321,7 +327,12 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   @Test
   void internalAuthAuditLookupReturnsStoredAuditByRequestId() throws Exception {
     updateMembershipStatus(
-        userId, allowedSourceAccountId, "REVOKED", "manual-revoke", "membership-revoked-request");
+        userId,
+        allowedSourceAccountId,
+        "REVOKED",
+        "OPS_MANUAL",
+        "manual-revoke",
+        "membership-revoked-request");
 
     AuthStatusChangeAuditView audit =
         loadAuditByRequestId("membership-revoked-request")
@@ -340,9 +351,23 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.changeType").value(audit.changeType()))
         .andExpect(jsonPath("$.beforeStatus").value(audit.beforeStatus()))
         .andExpect(jsonPath("$.afterStatus").value(audit.afterStatus()))
-        .andExpect(jsonPath("$.reason").value(audit.reason()))
+        .andExpect(jsonPath("$.reasonCode").value(audit.reasonCode()))
+        .andExpect(jsonPath("$.reasonDetail").value(audit.reasonDetail()))
+        .andExpect(jsonPath("$.reason").value(audit.reasonDetail()))
         .andExpect(jsonPath("$.outcome").value(audit.outcome()))
         .andExpect(jsonPath("$.createdAt").value(audit.createdAt().toString()));
+  }
+
+  @Test
+  void legacyReasonRequestFallsBackToLegacyFreeTextCode() throws Exception {
+    updateLegacyUserStatus(userId, "DISABLED", "fraud-review", "legacy-reason-request");
+
+    AuthStatusChangeAuditView audit =
+        loadAuditByRequestId("legacy-reason-request")
+            .orElseThrow(() -> new AssertionError("audit row is not created"));
+
+    assertEquals("LEGACY_FREE_TEXT", audit.reasonCode());
+    assertEquals("fraud-review", audit.reasonDetail());
   }
 
   private String login(String loginId, String password) throws Exception {
@@ -441,7 +466,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.membershipStatus").value(membershipStatus));
   }
 
-  private void updateUserStatus(long userId, String userStatus, String reason, String requestId)
+  private void updateLegacyUserStatus(
+      long userId, String userStatus, String reason, String requestId)
       throws Exception {
     mockMvc
         .perform(
@@ -464,7 +490,12 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   private void updateMembershipStatus(
-      long userId, long accountId, String membershipStatus, String reason, String requestId)
+      long userId,
+      long accountId,
+      String membershipStatus,
+      String reasonCode,
+      String reasonDetail,
+      String requestId)
       throws Exception {
     mockMvc
         .perform(
@@ -477,10 +508,11 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """
                     {
                       "membershipStatus": "%s",
-                      "reason": "%s"
+                      "reasonCode": "%s",
+                      "reasonDetail": "%s"
                     }
                     """
-                        .formatted(membershipStatus, reason)))
+                        .formatted(membershipStatus, reasonCode, reasonDetail)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.userId").value(userId))
         .andExpect(jsonPath("$.accountId").value(accountId))
@@ -498,6 +530,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                    target_account_id,
                    before_status,
                    after_status,
+                   reason_code,
                    reason,
                    outcome,
                    created_at
@@ -518,6 +551,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                   targetAccountId,
                   rs.getString("before_status"),
                   rs.getString("after_status"),
+                  rs.getString("reason_code"),
                   rs.getString("reason"),
                   rs.getString("outcome"),
                   rs.getTimestamp("created_at").toInstant());
@@ -534,7 +568,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
       Long targetAccountId,
       String beforeStatus,
       String afterStatus,
-      String reason,
+      String reasonCode,
+      String reasonDetail,
       String outcome,
       java.time.Instant createdAt) {}
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #18

## 📝 Summary
- 내부 auth status update 요청을 `reasonCode` + `reasonDetail` 구조로 표준화했습니다.
- 기존 free-text `reason` 요청은 `LEGACY_FREE_TEXT`로 한시 정규화해 기존 운영 호출체가 즉시 깨지지 않도록 맞췄습니다.
- 감사 저장, requestId lookup 응답, failure structured log가 같은 reason 구조를 사용하도록 정렬했습니다.

## 🛠 Changes
- `AuthStatusChangeReasonCode`, `AuthStatusChangeReason`, normalizer를 추가하고 internal status update request를 새 구조로 받도록 변경했습니다.
- `V6__standardize_auth_status_change_reason_code.sql`로 `auth_status_change_audit.reason_code`를 추가하고 기존 row를 `LEGACY_FREE_TEXT`로 backfill 했습니다.
- audit write/read path, lookup response, failure log, unit/integration test를 `reasonCode` + `reasonDetail` 기준으로 갱신했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 상태 변경 요청 예시
```json
{
  "membershipStatus": "REVOKED",
  "reasonCode": "OPS_MANUAL",
  "reasonDetail": "manual-revoke"
}
```
- lookup 응답 예시 필드: `reasonCode`, `reasonDetail`, `reason`

## ⚠️ Risk & Rollback
- 예상 리스크: 내부 호출체가 새 구조로 넘어가기 전까지는 legacy `reason` fallback에 의존할 수 있습니다.
- 롤백 방법: `V6__standardize_auth_status_change_reason_code.sql`과 reason normalization/controller changes를 함께 되돌립니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [ ] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.