### PR TITLE
[Test] 내부 auth 운영 예시 스크립트 smoke 검증 추가

### DIFF
--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeSupport.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeSupport.java
@@ -157,8 +157,8 @@ final class InternalAuthOpsScriptSmokeSupport {
     if (raw.isEmpty()) {
       return List.of();
     }
-    String[] parts = raw.split("\u0000", -1);
-    int size = raw.endsWith("\u0000") ? parts.length - 1 : parts.length;
+    String[] parts = raw.split("\n", -1);
+    int size = raw.endsWith("\n") ? parts.length - 1 : parts.length;
     return List.of(parts).subList(0, size);
   }
 
@@ -170,7 +170,7 @@ final class InternalAuthOpsScriptSmokeSupport {
         : "${FAKE_CURL_ARGS_FILE:?}"
         : > "${FAKE_CURL_ARGS_FILE}"
         for arg in "$@"; do
-          printf '%s\0' "$arg" >> "${FAKE_CURL_ARGS_FILE}"
+          printf '%s\n' "$arg" >> "${FAKE_CURL_ARGS_FILE}"
         done
         exit 0
         """;

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeSupport.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeSupport.java
@@ -1,0 +1,223 @@
+package com.aquilabank.global.web.auth;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/** fake curl로 실제 네트워크 없이 script argv/body만 캡처합니다. */
+final class InternalAuthOpsScriptSmokeSupport {
+
+  static final ScriptSpec USER_STATUS_SPEC =
+      new ScriptSpec(
+          "user-status",
+          repoRoot().resolve("tools/ops/internal-auth-update-user-status.sh"),
+          "usage: tools/ops/internal-auth-update-user-status.sh",
+          List.of(
+              "http://localhost:8080",
+              "test-auth-bootstrap-api-token",
+              "ops-admin",
+              "auth-user-disable-20260416-001",
+              "21",
+              "DISABLED",
+              "FRAUD_REVIEW",
+              "fraud-review"),
+          List.of(
+              "--fail-with-body",
+              "--silent",
+              "--show-error",
+              "--request",
+              "PUT",
+              "--header",
+              "Content-Type: application/json",
+              "--header",
+              "X-Auth-Bootstrap-Token: test-auth-bootstrap-api-token",
+              "--header",
+              "X-Subject: ops-admin",
+              "--header",
+              "X-Request-Id: auth-user-disable-20260416-001",
+              "--data",
+              "{\"userStatus\":\"DISABLED\",\"reasonCode\":\"FRAUD_REVIEW\",\"reasonDetail\":\"fraud-review\"}",
+              "http://localhost:8080/internal/api/v1/auth/users/21/status"),
+          List.of(
+              "tools/ops/internal-auth-update-user-status.sh \\",
+              "http://localhost:8080 \\",
+              "\"$SECURITY_AUTH_BOOTSTRAP_API_TOKEN\" \\",
+              "auth-user-disable-20260416-001 \\",
+              "DISABLED \\",
+              "FRAUD_REVIEW \\",
+              "fraud-review",
+              "\"X-Auth-Bootstrap-Token: ${SECURITY_AUTH_BOOTSTRAP_API_TOKEN}\"",
+              "\"X-Subject: ops-admin\"",
+              "\"X-Request-Id: auth-user-disable-20260416-001\"",
+              "\"reasonCode\":\"FRAUD_REVIEW\"",
+              "\"reasonDetail\":\"fraud-review\"",
+              "\"http://localhost:8080/internal/api/v1/auth/users/21/status\""));
+
+  static final ScriptSpec MEMBERSHIP_STATUS_SPEC =
+      new ScriptSpec(
+          "membership-status",
+          repoRoot().resolve("tools/ops/internal-auth-update-membership-status.sh"),
+          "usage: tools/ops/internal-auth-update-membership-status.sh",
+          List.of(
+              "http://localhost:8080",
+              "test-auth-bootstrap-api-token",
+              "ops-admin",
+              "auth-membership-revoke-20260416-001",
+              "21",
+              "1001",
+              "REVOKED",
+              "OPS_MANUAL",
+              "manual-revoke"),
+          List.of(
+              "--fail-with-body",
+              "--silent",
+              "--show-error",
+              "--request",
+              "PUT",
+              "--header",
+              "Content-Type: application/json",
+              "--header",
+              "X-Auth-Bootstrap-Token: test-auth-bootstrap-api-token",
+              "--header",
+              "X-Subject: ops-admin",
+              "--header",
+              "X-Request-Id: auth-membership-revoke-20260416-001",
+              "--data",
+              "{\"membershipStatus\":\"REVOKED\",\"reasonCode\":\"OPS_MANUAL\",\"reasonDetail\":\"manual-revoke\"}",
+              "http://localhost:8080/internal/api/v1/auth/users/21/memberships/1001/status"),
+          List.of(
+              "tools/ops/internal-auth-update-membership-status.sh \\",
+              "http://localhost:8080 \\",
+              "\"$SECURITY_AUTH_BOOTSTRAP_API_TOKEN\" \\",
+              "auth-membership-revoke-20260416-001 \\",
+              "1001 \\",
+              "REVOKED \\",
+              "OPS_MANUAL \\",
+              "manual-revoke",
+              "\"X-Auth-Bootstrap-Token: ${SECURITY_AUTH_BOOTSTRAP_API_TOKEN}\"",
+              "\"X-Subject: ops-admin\"",
+              "\"X-Request-Id: auth-membership-revoke-20260416-001\"",
+              "\"reasonCode\":\"OPS_MANUAL\"",
+              "\"reasonDetail\":\"manual-revoke\"",
+              "\"http://localhost:8080/internal/api/v1/auth/users/21/memberships/1001/status\""));
+
+  private static final Duration SCRIPT_TIMEOUT = Duration.ofSeconds(5);
+
+  private InternalAuthOpsScriptSmokeSupport() {}
+
+  static ScriptResult run(Path tempDir, ScriptSpec spec, List<String> args)
+      throws IOException, InterruptedException {
+    Path fakeCurlDir = Files.createDirectories(tempDir.resolve("fake-bin"));
+    Path fakeCurlArgsFile = tempDir.resolve(spec.name() + "-curl-args.bin");
+    writeFakeCurl(fakeCurlDir.resolve("curl"), fakeCurlArgsFile);
+
+    ProcessBuilder processBuilder =
+        new ProcessBuilder(buildCommand(spec.scriptPath().toString(), args));
+    processBuilder.directory(repoRoot().toFile());
+    processBuilder.environment().put("PATH", fakeCurlDir + pathSeparator() + currentPath());
+    processBuilder.environment().put("FAKE_CURL_ARGS_FILE", fakeCurlArgsFile.toString());
+
+    Process process = processBuilder.start();
+    boolean finished = process.waitFor(SCRIPT_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+    if (!finished) {
+      process.destroyForcibly();
+      throw new IllegalStateException("script execution timed out: " + spec.name());
+    }
+
+    return new ScriptResult(
+        process.exitValue(),
+        new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8),
+        new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8),
+        readCapturedArgs(fakeCurlArgsFile));
+  }
+
+  static String readReadme() throws IOException {
+    return Files.readString(repoRoot().resolve("back/README.md"), StandardCharsets.UTF_8);
+  }
+
+  private static List<String> buildCommand(String scriptPath, List<String> args) {
+    List<String> command = new java.util.ArrayList<>();
+    command.add("bash");
+    command.add(scriptPath);
+    command.addAll(args);
+    return command;
+  }
+
+  private static List<String> readCapturedArgs(Path fakeCurlArgsFile) throws IOException {
+    if (!Files.exists(fakeCurlArgsFile)) {
+      return List.of();
+    }
+    String raw = Files.readString(fakeCurlArgsFile, StandardCharsets.UTF_8);
+    if (raw.isEmpty()) {
+      return List.of();
+    }
+    String[] parts = raw.split("\u0000", -1);
+    int size = raw.endsWith("\u0000") ? parts.length - 1 : parts.length;
+    return List.of(parts).subList(0, size);
+  }
+
+  private static void writeFakeCurl(Path fakeCurlPath, Path fakeCurlArgsFile) throws IOException {
+    String script =
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        : "${FAKE_CURL_ARGS_FILE:?}"
+        : > "${FAKE_CURL_ARGS_FILE}"
+        for arg in "$@"; do
+          printf '%s\0' "$arg" >> "${FAKE_CURL_ARGS_FILE}"
+        done
+        exit 0
+        """;
+    Files.writeString(fakeCurlPath, script, StandardCharsets.UTF_8);
+    try {
+      Files.setPosixFilePermissions(
+          fakeCurlPath,
+          Set.of(
+              PosixFilePermission.OWNER_READ,
+              PosixFilePermission.OWNER_WRITE,
+              PosixFilePermission.OWNER_EXECUTE));
+    } catch (UnsupportedOperationException ignored) {
+      fakeCurlPath.toFile().setExecutable(true);
+    }
+    if (Files.notExists(fakeCurlArgsFile)) {
+      Files.createFile(fakeCurlArgsFile);
+    }
+  }
+
+  private static Path repoRoot() {
+    Path current = Path.of("").toAbsolutePath().normalize();
+    if (Files.exists(current.resolve("back/README.md"))) {
+      return current;
+    }
+    Path parent = current.getParent();
+    if (parent != null && Files.exists(parent.resolve("back/README.md"))) {
+      return parent;
+    }
+    throw new IllegalStateException("repo root is not found from " + current);
+  }
+
+  private static String currentPath() {
+    String path = System.getenv("PATH");
+    return path == null ? "" : path;
+  }
+
+  private static String pathSeparator() {
+    return System.getProperty("path.separator");
+  }
+
+  record ScriptSpec(
+      String name,
+      Path scriptPath,
+      String usagePrefix,
+      List<String> args,
+      List<String> expectedCurlArgs,
+      List<String> requiredReadmeSnippets) {}
+
+  record ScriptResult(int exitCode, String stdout, String stderr, List<String> curlArgs) {}
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeTest.java
@@ -69,4 +69,22 @@ class InternalAuthOpsScriptSmokeTest {
         .containsExactlyElementsOf(
             InternalAuthOpsScriptSmokeSupport.MEMBERSHIP_STATUS_SPEC.expectedCurlArgs());
   }
+
+  @Test
+  void readmeUserStatusExamplesMatchSmokeSpec() throws Exception {
+    assertReadmeContains(InternalAuthOpsScriptSmokeSupport.USER_STATUS_SPEC);
+  }
+
+  @Test
+  void readmeMembershipStatusExamplesMatchSmokeSpec() throws Exception {
+    assertReadmeContains(InternalAuthOpsScriptSmokeSupport.MEMBERSHIP_STATUS_SPEC);
+  }
+
+  private void assertReadmeContains(InternalAuthOpsScriptSmokeSupport.ScriptSpec spec)
+      throws Exception {
+    String readme = InternalAuthOpsScriptSmokeSupport.readReadme();
+    for (String snippet : spec.requiredReadmeSnippets()) {
+      assertThat(readme).contains(snippet);
+    }
+  }
 }

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeTest.java
@@ -1,0 +1,72 @@
+package com.aquilabank.global.web.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InternalAuthOpsScriptSmokeTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void userStatusScriptRejectsMissingArgs() throws Exception {
+    InternalAuthOpsScriptSmokeSupport.ScriptResult result =
+        InternalAuthOpsScriptSmokeSupport.run(
+            tempDir,
+            InternalAuthOpsScriptSmokeSupport.USER_STATUS_SPEC,
+            InternalAuthOpsScriptSmokeSupport.USER_STATUS_SPEC.args().subList(0, 7));
+
+    assertThat(result.exitCode()).isEqualTo(1);
+    assertThat(result.stderr())
+        .contains(InternalAuthOpsScriptSmokeSupport.USER_STATUS_SPEC.usagePrefix());
+    assertThat(result.curlArgs()).isEmpty();
+  }
+
+  @Test
+  void membershipStatusScriptRejectsMissingArgs() throws Exception {
+    InternalAuthOpsScriptSmokeSupport.ScriptResult result =
+        InternalAuthOpsScriptSmokeSupport.run(
+            tempDir,
+            InternalAuthOpsScriptSmokeSupport.MEMBERSHIP_STATUS_SPEC,
+            InternalAuthOpsScriptSmokeSupport.MEMBERSHIP_STATUS_SPEC.args().subList(0, 8));
+
+    assertThat(result.exitCode()).isEqualTo(1);
+    assertThat(result.stderr())
+        .contains(InternalAuthOpsScriptSmokeSupport.MEMBERSHIP_STATUS_SPEC.usagePrefix());
+    assertThat(result.curlArgs()).isEmpty();
+  }
+
+  @Test
+  void userStatusScriptBuildsExpectedCurlRequest() throws Exception {
+    InternalAuthOpsScriptSmokeSupport.ScriptResult result =
+        InternalAuthOpsScriptSmokeSupport.run(
+            tempDir,
+            InternalAuthOpsScriptSmokeSupport.USER_STATUS_SPEC,
+            InternalAuthOpsScriptSmokeSupport.USER_STATUS_SPEC.args());
+
+    assertThat(result.exitCode()).isZero();
+    assertThat(result.stderr()).isEmpty();
+    assertThat(result.stdout()).isEmpty();
+    assertThat(result.curlArgs())
+        .containsExactlyElementsOf(
+            InternalAuthOpsScriptSmokeSupport.USER_STATUS_SPEC.expectedCurlArgs());
+  }
+
+  @Test
+  void membershipStatusScriptBuildsExpectedCurlRequest() throws Exception {
+    InternalAuthOpsScriptSmokeSupport.ScriptResult result =
+        InternalAuthOpsScriptSmokeSupport.run(
+            tempDir,
+            InternalAuthOpsScriptSmokeSupport.MEMBERSHIP_STATUS_SPEC,
+            InternalAuthOpsScriptSmokeSupport.MEMBERSHIP_STATUS_SPEC.args());
+
+    assertThat(result.exitCode()).isZero();
+    assertThat(result.stderr()).isEmpty();
+    assertThat(result.stdout()).isEmpty();
+    assertThat(result.curlArgs())
+        .containsExactlyElementsOf(
+            InternalAuthOpsScriptSmokeSupport.MEMBERSHIP_STATUS_SPEC.expectedCurlArgs());
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #22

## 📝 Summary
- 내부 auth 운영 예시 스크립트를 실제 서버 호출 없이 smoke 검증하는 테스트를 추가했습니다.
- user/membership 스크립트의 인자 개수, endpoint, 필수 헤더, payload 형식을 검증하고 README runbook 예시와 drift 나면 실패하게 만들었습니다.

## 🛠 Changes
- fake `curl` 주입과 argv 캡처를 담당하는 `InternalAuthOpsScriptSmokeSupport` 추가
- `InternalAuthOpsScriptSmokeTest`에서 user/membership 스크립트 usage 실패와 정상 요청 문자열 smoke 검증 추가
- `back/README.md` internal auth runbook 예시와 테스트 스펙 drift 검증 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back compileTestJava`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*InternalAuthOpsScriptSmokeTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- UI 변경 없음
- 실제 운영 서버 호출 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - README 예시 표현을 크게 바꾸면 smoke test 스니펫도 함께 갱신해야 합니다.
  - shell quoting 규칙을 바꾸면 fake `curl` 캡처 기대값도 같이 조정해야 합니다.
- 롤백 방법:
  - `InternalAuthOpsScriptSmokeSupport`, `InternalAuthOpsScriptSmokeTest`를 제거하고 관련 테스트 변경만 되돌리면 됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.