### PR TITLE
[Chore] 내부 auth requestId exact lookup 운영 스크립트 및 smoke 검증 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -237,12 +237,14 @@ requestId drill-down:
 success audit exact lookup 예시:
 
 ```bash
-curl --fail-with-body --silent --show-error \
-  --header "X-Auth-Bootstrap-Token: ${SECURITY_AUTH_BOOTSTRAP_API_TOKEN}" \
-  "http://localhost:8080/internal/api/v1/auth/status-change-audits/by-request-id?requestId=auth-user-disable-20260416-001"
+tools/ops/internal-auth-find-status-change-audit.sh \
+  http://localhost:8080 \
+  "$SECURITY_AUTH_BOOTSTRAP_API_TOKEN" \
+  auth-user-disable-20260416-001
 ```
 
 - exact lookup은 성공 변경 row만 반환합니다.
+- wrapper script 내부에서 exact lookup endpoint, `X-Auth-Bootstrap-Token`, `requestId` query를 고정합니다.
 - failure 원본은 structured log이므로 incident 시작점은 항상 로그 검색입니다.
 
 ## Test

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeSupport.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeSupport.java
@@ -13,6 +13,32 @@ import java.util.concurrent.TimeUnit;
 /** fake curl로 실제 네트워크 없이 script argv/body만 캡처합니다. */
 final class InternalAuthOpsScriptSmokeSupport {
 
+  static final ScriptSpec STATUS_CHANGE_AUDIT_LOOKUP_SPEC =
+      new ScriptSpec(
+          "status-change-audit-lookup",
+          repoRoot().resolve("tools/ops/internal-auth-find-status-change-audit.sh"),
+          "usage: tools/ops/internal-auth-find-status-change-audit.sh",
+          List.of(
+              "http://localhost:8080",
+              "test-auth-bootstrap-api-token",
+              "auth-user-disable-20260416-001"),
+          List.of(
+              "--fail-with-body",
+              "--silent",
+              "--show-error",
+              "--get",
+              "--header",
+              "X-Auth-Bootstrap-Token: test-auth-bootstrap-api-token",
+              "--data-urlencode",
+              "requestId=auth-user-disable-20260416-001",
+              "http://localhost:8080/internal/api/v1/auth/status-change-audits/by-request-id"),
+          List.of(
+              "tools/ops/internal-auth-find-status-change-audit.sh \\",
+              "http://localhost:8080 \\",
+              "\"$SECURITY_AUTH_BOOTSTRAP_API_TOKEN\" \\",
+              "auth-user-disable-20260416-001",
+              "- exact lookup은 성공 변경 row만 반환합니다."));
+
   static final ScriptSpec USER_STATUS_SPEC =
       new ScriptSpec(
           "user-status",

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthOpsScriptSmokeTest.java
@@ -11,6 +11,20 @@ class InternalAuthOpsScriptSmokeTest {
   @TempDir Path tempDir;
 
   @Test
+  void statusChangeAuditLookupScriptRejectsMissingArgs() throws Exception {
+    InternalAuthOpsScriptSmokeSupport.ScriptResult result =
+        InternalAuthOpsScriptSmokeSupport.run(
+            tempDir,
+            InternalAuthOpsScriptSmokeSupport.STATUS_CHANGE_AUDIT_LOOKUP_SPEC,
+            InternalAuthOpsScriptSmokeSupport.STATUS_CHANGE_AUDIT_LOOKUP_SPEC.args().subList(0, 2));
+
+    assertThat(result.exitCode()).isEqualTo(1);
+    assertThat(result.stderr())
+        .contains(InternalAuthOpsScriptSmokeSupport.STATUS_CHANGE_AUDIT_LOOKUP_SPEC.usagePrefix());
+    assertThat(result.curlArgs()).isEmpty();
+  }
+
+  @Test
   void userStatusScriptRejectsMissingArgs() throws Exception {
     InternalAuthOpsScriptSmokeSupport.ScriptResult result =
         InternalAuthOpsScriptSmokeSupport.run(
@@ -71,6 +85,22 @@ class InternalAuthOpsScriptSmokeTest {
   }
 
   @Test
+  void statusChangeAuditLookupScriptBuildsExpectedCurlRequest() throws Exception {
+    InternalAuthOpsScriptSmokeSupport.ScriptResult result =
+        InternalAuthOpsScriptSmokeSupport.run(
+            tempDir,
+            InternalAuthOpsScriptSmokeSupport.STATUS_CHANGE_AUDIT_LOOKUP_SPEC,
+            InternalAuthOpsScriptSmokeSupport.STATUS_CHANGE_AUDIT_LOOKUP_SPEC.args());
+
+    assertThat(result.exitCode()).isZero();
+    assertThat(result.stderr()).isEmpty();
+    assertThat(result.stdout()).isEmpty();
+    assertThat(result.curlArgs())
+        .containsExactlyElementsOf(
+            InternalAuthOpsScriptSmokeSupport.STATUS_CHANGE_AUDIT_LOOKUP_SPEC.expectedCurlArgs());
+  }
+
+  @Test
   void readmeUserStatusExamplesMatchSmokeSpec() throws Exception {
     assertReadmeContains(InternalAuthOpsScriptSmokeSupport.USER_STATUS_SPEC);
   }
@@ -78,6 +108,11 @@ class InternalAuthOpsScriptSmokeTest {
   @Test
   void readmeMembershipStatusExamplesMatchSmokeSpec() throws Exception {
     assertReadmeContains(InternalAuthOpsScriptSmokeSupport.MEMBERSHIP_STATUS_SPEC);
+  }
+
+  @Test
+  void readmeStatusChangeAuditLookupExamplesMatchSmokeSpec() throws Exception {
+    assertReadmeContains(InternalAuthOpsScriptSmokeSupport.STATUS_CHANGE_AUDIT_LOOKUP_SPEC);
   }
 
   private void assertReadmeContains(InternalAuthOpsScriptSmokeSupport.ScriptSpec spec)

--- a/tools/ops/internal-auth-find-status-change-audit.sh
+++ b/tools/ops/internal-auth-find-status-change-audit.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  cat <<'USAGE' >&2
+usage: tools/ops/internal-auth-find-status-change-audit.sh <base_url> <bootstrap_token> <request_id>
+
+example:
+  tools/ops/internal-auth-find-status-change-audit.sh \
+    http://localhost:8080 \
+    "$SECURITY_AUTH_BOOTSTRAP_API_TOKEN" \
+    auth-user-disable-20260416-001
+USAGE
+  exit 1
+fi
+
+base_url="$1"
+bootstrap_token="$2"
+request_id="$3"
+
+# requestId exact lookup은 query로 고정해 운영자가 같은 incident key를 그대로 재현하게 합니다.
+curl --fail-with-body --silent --show-error \
+  --get \
+  --header "X-Auth-Bootstrap-Token: ${bootstrap_token}" \
+  --data-urlencode "requestId=${request_id}" \
+  "${base_url%/}/internal/api/v1/auth/status-change-audits/by-request-id"


### PR DESCRIPTION
## 🔗 Related Issue
- close #24

## 📝 Summary
- internal auth success audit exact lookup을 `requestId` 하나로 재현하는 운영 래퍼 스크립트를 추가했습니다.
- fake `curl` smoke에 exact lookup 케이스를 편입해 endpoint, bootstrap token header, `requestId` query drift를 고정했습니다.
- `back/README.md` exact lookup 예시를 새 래퍼 스크립트 기준으로 정리했습니다.

## 🛠 Changes
- `tools/ops/internal-auth-find-status-change-audit.sh` 추가
- `InternalAuthOpsScriptSmokeSupport` / `InternalAuthOpsScriptSmokeTest`에 exact lookup spec, missing args, curl argv, README drift 검증 추가
- `back/README.md` exact lookup 예시를 wrapper script 호출로 갱신

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash -n tools/ops/internal-auth-find-status-change-audit.sh`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*InternalAuthOpsScriptSmokeTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- `tools/ops/internal-auth-find-status-change-audit.sh http://localhost:8080 "$SECURITY_AUTH_BOOTSTRAP_API_TOKEN" auth-user-disable-20260416-001`

## ⚠️ Risk & Rollback
- 예상 리스크: 향후 README 예시를 raw `curl`로 다시 바꾸거나 wrapper 인자를 확장할 때 smoke spec을 같이 갱신하지 않으면 drift가 다시 생길 수 있습니다.
- 롤백 방법: `ca3f8ce`, `98db732`, `85e7c9a` 세 커밋을 순서대로 revert 하면 wrapper, smoke, README 변경이 함께 제거됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.