### PR TITLE
[Test] 내부 auth legacy reason 호환 경계 검증 추가

### DIFF
--- a/back/src/test/java/com/aquilabank/domain/auth/model/AuthStatusChangeReasonNormalizerTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/model/AuthStatusChangeReasonNormalizerTest.java
@@ -1,0 +1,38 @@
+package com.aquilabank.domain.auth.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class AuthStatusChangeReasonNormalizerTest {
+
+  @Test
+  void legacyReasonOnlyFallsBackToLegacyFreeTextCode() {
+    AuthStatusChangeReason result =
+        AuthStatusChangeReasonNormalizer.normalize(null, null, "legacy-free-text");
+
+    assertThat(result.reasonCode()).isEqualTo(AuthStatusChangeReasonCode.LEGACY_FREE_TEXT);
+    assertThat(result.reasonDetail()).isEqualTo("legacy-free-text");
+  }
+
+  @Test
+  void rejectsLegacyReasonMixedWithReasonCode() {
+    assertThatThrownBy(
+            () ->
+                AuthStatusChangeReasonNormalizer.normalize(
+                    AuthStatusChangeReasonCode.OPS_MANUAL, null, "legacy-free-text"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("reason and reasonCode/reasonDetail cannot be used together");
+  }
+
+  @Test
+  void rejectsLegacyReasonMixedWithReasonDetail() {
+    assertThatThrownBy(
+            () ->
+                AuthStatusChangeReasonNormalizer.normalize(
+                    null, "manual-revoke", "legacy-free-text"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("reason and reasonCode/reasonDetail cannot be used together");
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.web.auth;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -265,6 +266,100 @@ class InternalAuthAdminControllerTest {
                         && command.reasonCode().name().equals("LEGACY_FREE_TEXT")
                         && command.reasonDetail().equals("legacy-free-text")
                         && command.requestId().equals("legacy-reason-request")));
+  }
+
+  @Test
+  void acceptsLegacyReasonForMembershipStatusAsFallbackCode() throws Exception {
+    UserAccountMembershipSummary revokedMembership =
+        new UserAccountMembershipSummary(
+            21L,
+            101L,
+            MembershipRole.OWNER,
+            MembershipStatus.REVOKED,
+            Instant.parse("2026-04-16T11:00:00Z"),
+            Instant.parse("2026-04-16T11:06:00Z"));
+
+    when(userAccountMembershipStatusUpdateUseCase.update(
+            argThat(command -> command.accountId() == 101L)))
+        .thenReturn(revokedMembership);
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/21/memberships/101/status")
+                .header(TOKEN_HEADER, TOKEN)
+                .header(SUBJECT_HEADER, SUBJECT)
+                .header(REQUEST_ID_HEADER, "membership-legacy-reason-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "membershipStatus": "REVOKED",
+                      "reason": "manual-revoke"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.membershipStatus").value("REVOKED"));
+
+    verify(userAccountMembershipStatusUpdateUseCase)
+        .update(
+            argThat(
+                command ->
+                    command.status() == MembershipStatus.REVOKED
+                        && command.reasonCode().name().equals("LEGACY_FREE_TEXT")
+                        && command.reasonDetail().equals("manual-revoke")
+                        && command.reason().equals("manual-revoke")
+                        && command.actorSubject().equals(SUBJECT)
+                        && command.requestId().equals("membership-legacy-reason-request")));
+  }
+
+  @Test
+  void rejectsMixedReasonAndReasonCodeForUserStatusUpdate() throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/21/status")
+                .header(TOKEN_HEADER, TOKEN)
+                .header(SUBJECT_HEADER, SUBJECT)
+                .header(REQUEST_ID_HEADER, "user-mixed-reason-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "userStatus": "DISABLED",
+                      "reasonCode": "FRAUD_REVIEW",
+                      "reason": "legacy-free-text"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            jsonPath("$.message")
+                .value("reason and reasonCode/reasonDetail cannot be used together"));
+
+    verifyNoInteractions(userStatusUpdateUseCase);
+  }
+
+  @Test
+  void rejectsMixedReasonAndReasonDetailForMembershipStatusUpdate() throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/21/memberships/101/status")
+                .header(TOKEN_HEADER, TOKEN)
+                .header(SUBJECT_HEADER, SUBJECT)
+                .header(REQUEST_ID_HEADER, "membership-mixed-reason-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "membershipStatus": "REVOKED",
+                      "reasonDetail": "manual-revoke",
+                      "reason": "legacy-free-text"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            jsonPath("$.message")
+                .value("reason and reasonCode/reasonDetail cannot be used together"));
+
+    verifyNoInteractions(userAccountMembershipStatusUpdateUseCase);
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -370,6 +370,25 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
     assertEquals("fraud-review", audit.reasonDetail());
   }
 
+  @Test
+  void legacyMembershipReasonRequestFallsBackToLegacyFreeTextCode() throws Exception {
+    updateLegacyMembershipStatus(
+        userId,
+        allowedSourceAccountId,
+        "REVOKED",
+        "manual-revoke",
+        "membership-legacy-reason-request");
+
+    AuthStatusChangeAuditView audit =
+        loadAuditByRequestId("membership-legacy-reason-request")
+            .orElseThrow(() -> new AssertionError("audit row is not created"));
+
+    assertEquals("membership-legacy-reason-request", audit.requestId());
+    assertEquals("LEGACY_FREE_TEXT", audit.reasonCode());
+    assertEquals("manual-revoke", audit.reasonDetail());
+    assertEquals("SUCCESS", audit.outcome());
+  }
+
   private String login(String loginId, String password) throws Exception {
     MvcResult result =
         mockMvc
@@ -512,6 +531,30 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     }
                     """
                         .formatted(membershipStatus, reasonCode, reasonDetail)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(userId))
+        .andExpect(jsonPath("$.accountId").value(accountId))
+        .andExpect(jsonPath("$.membershipStatus").value(membershipStatus));
+  }
+
+  private void updateLegacyMembershipStatus(
+      long userId, long accountId, String membershipStatus, String reason, String requestId)
+      throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/auth/users/%d/memberships/%d/status".formatted(userId, accountId))
+                .header("X-Auth-Bootstrap-Token", AUTH_BOOTSTRAP_TOKEN)
+                .header("X-Subject", AUTH_ADMIN_SUBJECT)
+                .header("X-Request-Id", requestId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "membershipStatus": "%s",
+                      "reason": "%s"
+                    }
+                    """
+                        .formatted(membershipStatus, reason)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.userId").value(userId))
         .andExpect(jsonPath("$.accountId").value(accountId))


### PR DESCRIPTION
## 🔗 Related Issue
- close #26

## 📝 Summary
- internal auth legacy `reason` 한시 호환 경계를 production 변경 없이 테스트로 고정했습니다.
- user/membership 두 경로에서 legacy-only 허용과 mixed input `400`을 명시적으로 검증하도록 보강했습니다.
- audit row가 legacy 입력을 `LEGACY_FREE_TEXT`로 정규화하는지 user/membership 양쪽 integration에서 확인합니다.

## 🛠 Changes
- `AuthStatusChangeReasonNormalizerTest` 추가로 legacy-only, `reason + reasonCode`, `reason + reasonDetail` 경계 unit test 고정
- `InternalAuthAdminControllerTest` 보강으로 membership legacy fallback, user/membership mixed input `400` 검증 추가
- `LoginAndAccountAccessApiIntegrationTest` 보강으로 membership legacy 입력의 audit `reasonCode`/`reasonDetail` 정규화 검증 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*AuthStatusChangeReasonNormalizerTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*InternalAuthAdminControllerTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- `PUT /internal/api/v1/auth/users/{userId}/status` body `{"userStatus":"DISABLED","reason":"legacy-free-text"}` -> audit `reasonCode=LEGACY_FREE_TEXT`
- `PUT /internal/api/v1/auth/users/{userId}/memberships/{accountId}/status` body `{"membershipStatus":"REVOKED","reason":"manual-revoke"}` -> audit `reasonCode=LEGACY_FREE_TEXT`

## ⚠️ Risk & Rollback
- 예상 리스크: legacy compatibility 제거 또는 validation message 변경 시 이번 테스트들이 먼저 깨집니다. 의도된 contract 변경이면 테스트 expectation을 함께 갱신해야 합니다.
- 롤백 방법: `6cc0cfb`, `67cd5f5`, `40f8564` 세 커밋을 순서대로 revert 하면 test-only 변경이 제거됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.