### PR TITLE
[Docs] 내부 auth 실패 alert 후속 범위 404/409/500 운영 기준 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -227,6 +227,68 @@ requestId drill-down:
 - `actorSubject=-`인 `400`은 헤더 누락 성격이므로 운영 스크립트 drift 또는 수동 호출 오류로 분류합니다.
 - `404`, `409`, `500`은 이번 최소 범위에서 제외하고 후속 이슈로 분리합니다.
 
+### 404/409/500 후속 수집 패턴
+
+#### 404 운영 기준
+
+- 대표 원인:
+  - `user is not found`
+  - `membership is not found`
+- 수집 패턴:
+
+```text
+404 후보:
+  "internal auth status update failed" AND "httpStatus=404"
+
+같은 actor의 404 반복:
+  "internal auth status update failed" AND "httpStatus=404" AND "actorSubject=<actor-subject>" AND "path=<endpoint>"
+```
+
+- 운영 의미:
+  - stale `userId`/`accountId` 재사용
+  - 수동 호출 대상 오입력
+  - 배치가 이미 정리된 대상을 늦게 호출한 경우
+
+#### 409 운영 기준
+
+- 현재 known 상태:
+  - 내부 auth status update 경로에서 `409` 대표 error 문구는 아직 고정돼 있지 않습니다.
+  - 현재 runbook에서는 `httpStatus=409`와 같은 `actorSubject`/`path` 반복 패턴을 먼저 수집하고, 세부 error 분류는 후속 구현 이슈로 남깁니다.
+- 수집 패턴:
+
+```text
+409 후보:
+  "internal auth status update failed" AND "httpStatus=409"
+
+같은 actor의 409 반복:
+  "internal auth status update failed" AND "httpStatus=409" AND "actorSubject=<actor-subject>" AND "path=<endpoint>"
+```
+
+- 운영 의미:
+  - 같은 대상에 대한 중복 상태 변경 시도
+  - caller 재시도 정책 또는 수동 재실행 충돌
+  - 상태 전이 전후 확인이 필요한 경쟁 조건 후보
+
+#### 500 운영 기준
+
+- 대표 원인:
+  - `requestId is not initialized` 같은 서버 상태 불일치
+  - persistence/runtime 예외로 인한 internal error
+- 수집 패턴:
+
+```text
+500 후보:
+  "internal auth status update failed" AND "httpStatus=500"
+
+requestId 우선 drill-down:
+  "internal auth status update failed" AND "httpStatus=500" AND "requestId=<request-id>"
+```
+
+- 운영 의미:
+  - 운영 입력 오류보다 서버 측 장애 후보 우선
+  - 같은 시간대 `actorSubject`/`path` 확산 여부 확인 필요
+  - success audit exact lookup 부재만으로 종료하지 말고 로그 타임라인 재확인이 필요
+
 ### requestId 장애 추적 절차
 
 1. alert 또는 문의에서 `requestId`를 확보합니다. alert payload에 `requestId`가 없으면 같은 시간대 `actorSubject + path + error`로 실패 로그를 먼저 좁힙니다.

--- a/back/README.md
+++ b/back/README.md
@@ -225,7 +225,7 @@ requestId drill-down:
 - `401 Unauthorized`: `5분 내 3회 이상`이면 warning, 같은 window에서 `10회 이상`이면 critical 후보로 봅니다.
 - `400 Bad Request`: 같은 `actorSubject`에서 연속 `2회 이상`이면 warning, `5회 이상`이면 critical 후보로 봅니다.
 - `actorSubject=-`인 `400`은 헤더 누락 성격이므로 운영 스크립트 drift 또는 수동 호출 오류로 분류합니다.
-- `404`, `409`, `500`은 이번 최소 범위에서 제외하고 후속 이슈로 분리합니다.
+- `404`, `409`, `500`은 최소 alert 기본값에서는 제외하고, 아래 후속 운영 기준으로 별도 판단합니다.
 
 ### 404/409/500 후속 수집 패턴
 
@@ -288,6 +288,46 @@ requestId 우선 drill-down:
   - 운영 입력 오류보다 서버 측 장애 후보 우선
   - 같은 시간대 `actorSubject`/`path` 확산 여부 확인 필요
   - success audit exact lookup 부재만으로 종료하지 말고 로그 타임라인 재확인이 필요
+
+### 404/409/500 제외/승격 조건
+
+#### 404 운영 기준
+
+- 제외 조건:
+  - 단발 `404`이고 같은 actor가 직후 대상 식별자를 수정해 성공 호출로 전환한 경우
+  - 수동 점검 과정에서 잘못된 `userId`/`accountId`를 한 번 입력한 경우
+- 승격 조건:
+  - 같은 `actorSubject + path`에서 동일 target miss가 `10분 내 3회 이상` 반복되면 warning 후보
+  - 같은 배치 또는 actor가 여러 target에서 `404`를 확산시키면 critical 후보
+
+#### 409 운영 기준
+
+- 제외 조건:
+  - 같은 actor의 단발 중복 호출이고, 인접 시간대에 성공 감사 row가 확인되는 경우
+  - 수동 재실행이나 caller retry가 이미 적용된 상태로 보이는 경우
+- 승격 조건:
+  - 같은 `actorSubject + path + requestedStatus` 조합의 `409`가 `10분 내 3회 이상` 반복되고 success audit row가 확인되지 않으면 warning 후보
+  - 서로 다른 actor가 같은 target에 충돌하는 정황이 보이면 critical 후보
+
+#### 500 운영 기준
+
+- 제외 조건:
+  - 기본적으로 제외하지 않습니다.
+- 승격 조건:
+  - `500` 한 건만으로도 incident 후보로 triage 합니다.
+  - 같은 시간대에 `500`이 2회 이상 반복되거나 여러 actor/path로 확산되면 critical 후보로 봅니다.
+
+### 404/409/500 requestId 추적 차이
+
+- `404`:
+  - `requestId`로 실패 로그 한 줄을 찾은 뒤, 같은 `targetUserId`/`targetAccountId`가 실제로 존재했는지 먼저 확인합니다.
+  - success audit row가 없더라도 바로 장애로 보지 않고, stale target 또는 수동 오입력 가능성을 먼저 분리합니다.
+- `409`:
+  - `requestId`로 실패 시점을 찾은 뒤, 같은 `actorSubject + path + requestedStatus` 조합의 직전/직후 호출을 같이 봅니다.
+  - 다른 `requestId`의 success audit row가 근접 시간대에 있으면 중복 호출 또는 재시도 충돌 가능성을 우선 봅니다.
+- `500`:
+  - `requestId`를 가장 먼저 확보하고, 같은 시간대 `actorSubject + path + error` 확산 여부를 바로 확인합니다.
+  - success audit row가 없고 같은 오류가 반복되면 caller 오입력보다 서버 장애 후보로 바로 승격합니다.
 
 ### requestId 장애 추적 절차
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #28

## 📝 Summary
- 내부 auth 실패 alert runbook에 `404`/`409`/`500` 후속 운영 기준을 추가했습니다.
- 수집 패턴, 제외/승격 조건, `requestId` 추적 차이를 문서화해 `401`/`400` 기준과 분리된 운영 판단 기준을 정리했습니다.

## 🛠 Changes
- `back/README.md`에 `404`/`409`/`500`별 대표 원인, known 상태, 수집 패턴 추가
- `back/README.md`에 `404`/`409`/`500`별 제외 조건과 승격 조건 추가
- `back/README.md`에 `404`/`409`/`500`별 `requestId` 추적 차이와 success audit exact lookup 해석 차이 보강

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `rg -n "401|400|404|409|500|requestId|status update failed|exact lookup" back/README.md docs`
- README에서 `404`/`409`/`500` 각각에 대해 수집 패턴, 제외/승격 조건, 추적 절차가 모두 보이는지 수동 확인
- 기존 `401`/`400` 기준과 새 섹션이 충돌하지 않는지 수동 확인

## 📸 Screenshot / API Example
- `back/README.md` internal auth failure alert 구간에 `404 운영 기준`, `409 운영 기준`, `500 운영 기준`, `404/409/500 requestId 추적 차이` 섹션 추가

## ⚠️ Risk & Rollback
- 예상 리스크: `409` 대표 error 문구는 아직 고정되지 않아 후속 구현 전까지는 `httpStatus`, `actorSubject`, `path` 반복 패턴 중심으로 운영 판단해야 합니다.
- 롤백 방법: `d156925`, `99d7187` 두 커밋을 순서대로 revert 하면 runbook 보강이 제거됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.