### PR TITLE
[Feat] 계좌 요약 조회 API 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/account/exception/AccountSummaryNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/account/exception/AccountSummaryNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.account.exception;
+
+/** 계좌 요약 조회 결과 부재 예외 */
+public class AccountSummaryNotFoundException extends RuntimeException {
+
+  public AccountSummaryNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/model/AccountSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/account/model/AccountSummary.java
@@ -1,0 +1,46 @@
+package com.aquilabank.domain.account.model;
+
+import java.time.Instant;
+
+/** 고객 계좌 단건 조회에 필요한 최소 요약 모델 */
+public record AccountSummary(
+    long accountId,
+    String accountNumber,
+    String displayName,
+    String accountStatus,
+    String currencyCode,
+    long availableBalanceMinor,
+    long pendingBalanceMinor,
+    Instant createdAt,
+    Instant balanceUpdatedAt) {
+
+  public AccountSummary {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (accountNumber == null || accountNumber.isBlank() || accountNumber.length() > 20) {
+      throw new IllegalArgumentException("accountNumber must be between 1 and 20 characters");
+    }
+    if (displayName == null || displayName.isBlank()) {
+      throw new IllegalArgumentException("displayName is required");
+    }
+    if (accountStatus == null || accountStatus.isBlank()) {
+      throw new IllegalArgumentException("accountStatus is required");
+    }
+    if (currencyCode == null || !currencyCode.matches("^[A-Z]{3}$")) {
+      throw new IllegalArgumentException("currencyCode must be a 3-letter uppercase code");
+    }
+    if (availableBalanceMinor < 0) {
+      throw new IllegalArgumentException("availableBalanceMinor must be zero or positive");
+    }
+    if (pendingBalanceMinor < 0) {
+      throw new IllegalArgumentException("pendingBalanceMinor must be zero or positive");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt must not be null");
+    }
+    if (balanceUpdatedAt == null) {
+      throw new IllegalArgumentException("balanceUpdatedAt must not be null");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/port/AccountSummaryReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/account/port/AccountSummaryReadPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.account.port;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import java.util.Optional;
+
+/** 고객 계좌 단건 exact lookup 조회를 저장소 계층으로 위임합니다. */
+public interface AccountSummaryReadPort {
+
+  Optional<AccountSummary> findByAccountId(long accountId);
+}

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryService.java
@@ -1,0 +1,25 @@
+package com.aquilabank.domain.account.usecase;
+
+import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.port.AccountSummaryReadPort;
+
+/** 계좌 요약 exact lookup을 not found 예외와 함께 묶습니다. */
+public final class AccountSummaryQueryService implements AccountSummaryQueryUseCase {
+
+  private final AccountSummaryReadPort accountSummaryReadPort;
+
+  public AccountSummaryQueryService(AccountSummaryReadPort accountSummaryReadPort) {
+    this.accountSummaryReadPort = accountSummaryReadPort;
+  }
+
+  @Override
+  public AccountSummary getByAccountId(long accountId) {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    return accountSummaryReadPort
+        .findByAccountId(accountId)
+        .orElseThrow(() -> new AccountSummaryNotFoundException("account summary is not found"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.account.usecase;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+
+/** 고객 계좌 단건 조회 진입점 */
+public interface AccountSummaryQueryUseCase {
+
+  AccountSummary getByAccountId(long accountId);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AccountSummaryConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AccountSummaryConfiguration.java
@@ -1,0 +1,18 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.account.port.AccountSummaryReadPort;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryService;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** account summary use case와 JDBC adapter를 조립 */
+@Configuration
+public class AccountSummaryConfiguration {
+
+  @Bean
+  AccountSummaryQueryUseCase accountSummaryQueryUseCase(
+      AccountSummaryReadPort accountSummaryReadPort) {
+    return new AccountSummaryQueryService(accountSummaryReadPort);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountSummaryRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountSummaryRepository.java
@@ -1,0 +1,78 @@
+package com.aquilabank.global.persistence.account;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.port.AccountSummaryReadPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 고객 계좌 단건 조회를 bank_account + snapshot exact lookup으로 읽어옵니다. */
+@Repository
+public class JdbcAccountSummaryRepository implements AccountSummaryReadPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcAccountSummaryRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<AccountSummary> findByAccountId(long accountId) {
+    // account_id PK exact lookup이라 account 원본과 snapshot을 한 번만 join 합니다.
+    return jdbcTemplate
+        .query(
+            """
+            SELECT account.id,
+                   account.account_number,
+                   account.display_name,
+                   account.account_status,
+                   account.currency_code AS account_currency_code,
+                   snapshot.available_balance_minor,
+                   snapshot.pending_balance_minor,
+                   snapshot.currency_code AS snapshot_currency_code,
+                   account.created_at,
+                   snapshot.updated_at
+            FROM bank_account account
+            JOIN account_balance_snapshot snapshot
+              ON snapshot.account_id = account.id
+            WHERE account.id = :accountId
+            """,
+            new MapSqlParameterSource().addValue("accountId", accountId),
+            (rs, rowNum) -> mapAccountSummary(rs))
+        .stream()
+        .findFirst();
+  }
+
+  private AccountSummary mapAccountSummary(ResultSet rs) throws SQLException {
+    String accountCurrencyCode = rs.getString("account_currency_code");
+    String snapshotCurrencyCode = rs.getString("snapshot_currency_code");
+    if (!accountCurrencyCode.equals(snapshotCurrencyCode)) {
+      throw new IllegalStateException("account snapshot currency does not match");
+    }
+
+    return new AccountSummary(
+        rs.getLong("id"),
+        rs.getString("account_number"),
+        rs.getString("display_name"),
+        rs.getString("account_status"),
+        accountCurrencyCode,
+        rs.getLong("available_balance_minor"),
+        rs.getLong("pending_balance_minor"),
+        toInstant(rs.getTimestamp("created_at")),
+        toInstant(rs.getTimestamp("updated_at")));
+  }
+
+  private Instant toInstant(Timestamp timestamp) {
+    if (timestamp == null) {
+      throw new IllegalStateException("timestamp must not be null");
+    }
+    return timestamp.toInstant();
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.aquilabank.global.web;
 
+import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
 import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
 import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
 import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
@@ -93,6 +94,7 @@ public class ApiExceptionHandler {
   }
 
   @ExceptionHandler({
+    AccountSummaryNotFoundException.class,
     SnapshotNotFoundException.class,
     AuthStatusChangeAuditNotFoundException.class,
     AuthUserNotFoundException.class,

--- a/back/src/main/java/com/aquilabank/global/web/account/AccountSummaryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/account/AccountSummaryController.java
@@ -1,0 +1,73 @@
+package com.aquilabank.global.web.account;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/** 고객 계좌 요약 단건 조회를 노출하는 HTTP adapter */
+@Validated
+@RestController
+@RequestMapping("/api/v1/accounts")
+public class AccountSummaryController {
+
+  private final AccountSummaryQueryUseCase accountSummaryQueryUseCase;
+  private final RequestAccountAuthorizationService requestAccountAuthorizationService;
+
+  public AccountSummaryController(
+      AccountSummaryQueryUseCase accountSummaryQueryUseCase,
+      RequestAccountAuthorizationService requestAccountAuthorizationService) {
+    this.accountSummaryQueryUseCase = accountSummaryQueryUseCase;
+    this.requestAccountAuthorizationService = requestAccountAuthorizationService;
+  }
+
+  @GetMapping("/{accountId}")
+  public AccountSummaryResponse getAccount(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @PathVariable @Positive(message = "accountId must be positive") long accountId) {
+    try {
+      // 권한 실패를 먼저 끊어 타 계좌 존재 여부를 요약 조회 응답으로 노출하지 않습니다.
+      long resolvedAccountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(principal, accountId);
+      return AccountSummaryResponse.from(
+          accountSummaryQueryUseCase.getByAccountId(resolvedAccountId));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+
+  /** 고객 계좌 요약 응답 */
+  public record AccountSummaryResponse(
+      long accountId,
+      String accountNumber,
+      String displayName,
+      String accountStatus,
+      String currencyCode,
+      long availableBalanceMinor,
+      long pendingBalanceMinor,
+      java.time.Instant createdAt,
+      java.time.Instant balanceUpdatedAt) {
+
+    static AccountSummaryResponse from(AccountSummary summary) {
+      return new AccountSummaryResponse(
+          summary.accountId(),
+          summary.accountNumber(),
+          summary.displayName(),
+          summary.accountStatus(),
+          summary.currencyCode(),
+          summary.availableBalanceMinor(),
+          summary.pendingBalanceMinor(),
+          summary.createdAt(),
+          summary.balanceUpdatedAt());
+    }
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/security/AccountSummaryJwtSecurityIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/AccountSummaryJwtSecurityIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.aquilabank.global.security;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.port.AccountSummaryReadPort;
+import com.aquilabank.domain.auth.model.AccountAccessScope;
+import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class AccountSummaryJwtSecurityIntegrationTest {
+
+  private static final String TEST_SECRET = "test-local-jwt-secret-test-local-jwt-secret";
+
+  @Autowired private WebApplicationContext context;
+
+  @MockitoBean private AccountAccessUseCase accountAccessUseCase;
+
+  @MockitoBean private AccountSummaryReadPort accountSummaryReadPort;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUpMockMvc() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void acceptsBearerJwtAndReturnsMappedAccountSummary() throws Exception {
+    when(accountAccessUseCase.verify(55L, 555L, AccountAccessScope.READ)).thenReturn(555L);
+    when(accountSummaryReadPort.findByAccountId(555L))
+        .thenReturn(
+            Optional.of(
+                new AccountSummary(
+                    555L,
+                    "100000000000001",
+                    "salary account",
+                    "ACTIVE",
+                    "KRW",
+                    15000L,
+                    0L,
+                    Instant.parse("2026-04-16T09:00:00Z"),
+                    Instant.parse("2026-04-16T09:05:00Z"))));
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts/555")
+                .header("Authorization", "Bearer " + issueToken("user-555", 55L)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountId").value(555L))
+        .andExpect(jsonPath("$.availableBalanceMinor").value(15000L))
+        .andExpect(jsonPath("$.accountStatus").value("ACTIVE"));
+  }
+
+  @Test
+  void rejectsRequestWithoutJwtOrBootstrapHeader() throws Exception {
+    mockMvc.perform(get("/api/v1/accounts/555")).andExpect(status().isUnauthorized());
+  }
+
+  private String issueToken(String subject, long userId) throws JOSEException {
+    Instant now = Instant.now();
+    JWTClaimsSet claimsSet =
+        new JWTClaimsSet.Builder()
+            .subject(subject)
+            .issueTime(Date.from(now))
+            .expirationTime(Date.from(now.plusSeconds(300)))
+            .claim("user_id", userId)
+            .build();
+
+    SignedJWT signedJwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(), claimsSet);
+    signedJwt.sign(new MACSigner(TEST_SECRET.getBytes(StandardCharsets.UTF_8)));
+    return signedJwt.serialize();
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/account/AccountSummaryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/account/AccountSummaryControllerTest.java
@@ -1,0 +1,87 @@
+package com.aquilabank.global.web.account;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AccountSummaryControllerTest {
+
+  private AccountSummaryQueryUseCase accountSummaryQueryUseCase;
+  private RequestAccountAuthorizationService requestAccountAuthorizationService;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    accountSummaryQueryUseCase = mock(AccountSummaryQueryUseCase.class);
+    requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new AccountSummaryController(
+                    accountSummaryQueryUseCase, requestAccountAuthorizationService))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
+            .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
+            .build();
+  }
+
+  @Test
+  void returnsAccountSummary() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(any(), eq(101L)))
+        .thenReturn(101L);
+    when(accountSummaryQueryUseCase.getByAccountId(101L))
+        .thenReturn(
+            new AccountSummary(
+                101L,
+                "100000000000001",
+                "daily account",
+                "ACTIVE",
+                "KRW",
+                8000L,
+                0L,
+                Instant.parse("2026-04-16T09:00:00Z"),
+                Instant.parse("2026-04-16T09:05:00Z")));
+
+    mockMvc
+        .perform(get("/api/v1/accounts/101").header("X-Account-Id", "101"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountId").value(101L))
+        .andExpect(jsonPath("$.accountNumber").value("100000000000001"))
+        .andExpect(jsonPath("$.availableBalanceMinor").value(8000L))
+        .andExpect(jsonPath("$.pendingBalanceMinor").value(0L));
+  }
+
+  @Test
+  void returnsNotFoundWhenAccountSummaryIsMissing() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(any(), eq(101L)))
+        .thenReturn(101L);
+    when(accountSummaryQueryUseCase.getByAccountId(101L))
+        .thenThrow(new AccountSummaryNotFoundException("account summary is not found"));
+
+    mockMvc
+        .perform(get("/api/v1/accounts/101").header("X-Account-Id", "101"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("account summary is not found"));
+  }
+
+  @Test
+  void rejectsMissingAuthenticationHeader() throws Exception {
+    mockMvc.perform(get("/api/v1/accounts/101")).andExpect(status().isUnauthorized());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -98,11 +98,28 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId))
         .andExpect(jsonPath("$.items[0].transactionReference").isString());
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts/%d".formatted(allowedSourceAccountId))
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountId").value(allowedSourceAccountId))
+        .andExpect(jsonPath("$.currencyCode").value("KRW"))
+        .andExpect(jsonPath("$.availableBalanceMinor").value(8500L))
+        .andExpect(jsonPath("$.pendingBalanceMinor").value(0));
   }
 
   @Test
   void rejectsUnmappedAccountAccess() throws Exception {
     String token = login("alice", "password123!");
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts/%d".formatted(deniedAccountId))
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
 
     mockMvc
         .perform(


### PR DESCRIPTION
## 🔗 Related Issue
- close #30

## 📝 Summary
- 고객이 접근 가능한 계좌의 기본 정보와 snapshot 잔액을 단건 조회할 수 있도록 `GET /api/v1/accounts/{accountId}` 를 추가했습니다.
- 조회는 `bank_account` + `account_balance_snapshot` exact lookup 으로 처리하고, 기존 `RequestAccountAuthorizationService` 로 READ 권한을 먼저 검증합니다.

## 🛠 Changes
- domain 계층에 `AccountSummary` 조회 모델, read port, use case, not found 예외를 추가했습니다.
- global 계층에 read-only JDBC adapter와 account summary controller를 추가했습니다.
- API error handler에 account summary not found 매핑을 추가했습니다.
- controller/JWT security/Postgres integration 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back check`
- pre-commit hook 기준 backend check 통과

## 📸 Screenshot / API Example
- 응답 예시:
```json
{
  "accountId": 101,
  "accountNumber": "100000000000001",
  "displayName": "daily account",
  "accountStatus": "ACTIVE",
  "currencyCode": "KRW",
  "availableBalanceMinor": 8500,
  "pendingBalanceMinor": 0,
  "createdAt": "2026-04-16T09:00:00Z",
  "balanceUpdatedAt": "2026-04-16T09:05:00Z"
}
```

## ⚠️ Risk & Rollback
- 예상 리스크:
  - account summary 조회가 snapshot row에 의존하므로 비정상 데이터에서는 `404` 또는 서버 오류가 바로 드러납니다.
  - 권한 검사를 먼저 수행하므로 기존 `account access is denied` 계약이 유지되는지 리뷰가 필요합니다.
- 롤백 방법:
  - PR revert 시 account summary endpoint와 관련 wiring/test가 함께 제거되어 기존 로그인/거래/이체 경로로 복귀합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.