### PR TITLE
[Perf] 거래 조회 기준선과 인덱스 검증 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepository.java
@@ -9,12 +9,10 @@ import com.aquilabank.domain.transaction.model.TransactionSummary;
 import com.aquilabank.domain.transaction.port.TransactionReadPort;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,62 +32,9 @@ public class JdbcTransactionReadRepository implements TransactionReadPort {
   @Override
   @Transactional(readOnly = true)
   public TransactionSlice fetch(TransactionQuery query) {
-    MapSqlParameterSource params =
-        new MapSqlParameterSource()
-            .addValue("accountId", query.accountId())
-            .addValue("from", Timestamp.from(query.from()))
-            .addValue("to", Timestamp.from(query.to()))
-            // 다음 page 존재 여부 판단용 sentinel row 한 건 추가 조회
-            .addValue("fetchLimit", query.limit() + 1);
-
-    StringBuilder sql =
-        new StringBuilder(
-            """
-            SELECT id,
-                   account_id,
-                   transaction_reference,
-                   direction,
-                   transaction_status,
-                   amount_minor,
-                   balance_after_minor,
-                   currency_code,
-                   summary,
-                   counterparty_masked_name,
-                   booked_at
-            FROM transaction_read_model
-            WHERE account_id = :accountId
-              AND booked_at >= :from
-              AND booked_at < :to
-            """);
-
-    if (query.status() != null) {
-      sql.append("\n  AND transaction_status = :status");
-      params.addValue("status", query.status().name());
-    }
-
-    if (query.cursor() != null) {
-      // keyset pagination은 같은 ORDER BY 컬럼을 재사용해 깊은 OFFSET scan 회피
-      sql.append(
-          """
-
-              AND (
-                    booked_at < :cursorBookedAt
-                 OR (booked_at = :cursorBookedAt AND id < :cursorId)
-              )
-          """);
-      params
-          .addValue("cursorBookedAt", Timestamp.from(query.cursor().bookedAt()))
-          .addValue("cursorId", query.cursor().id());
-    }
-
-    sql.append(
-        """
-
-            ORDER BY booked_at DESC, id DESC
-            LIMIT :fetchLimit
-        """);
-
-    List<TransactionSummary> rows = jdbcTemplate.query(sql.toString(), params, ROW_MAPPER);
+    TransactionReadQueryStatement statement = TransactionReadQueryStatement.from(query);
+    List<TransactionSummary> rows =
+        jdbcTemplate.query(statement.sql(), statement.params(), ROW_MAPPER);
     boolean hasNext = rows.size() > query.limit();
     // hasNext 판단에만 쓴 sentinel row는 응답 전에 제거
     List<TransactionSummary> items =

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionReadQueryStatement.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionReadQueryStatement.java
@@ -1,0 +1,76 @@
+package com.aquilabank.global.persistence.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import java.sql.Timestamp;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+/** 거래 조회 SQL과 bind 파라미터를 한 곳에 모아 운영 경로와 EXPLAIN 기준선을 맞춥니다. */
+final class TransactionReadQueryStatement {
+
+  private final String sql;
+  private final MapSqlParameterSource params;
+
+  private TransactionReadQueryStatement(String sql, MapSqlParameterSource params) {
+    this.sql = sql;
+    this.params = params;
+  }
+
+  static TransactionReadQueryStatement from(TransactionQuery query) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("accountId", query.accountId())
+            .addValue("from", Timestamp.from(query.from()))
+            .addValue("to", Timestamp.from(query.to()))
+            // 다음 page 존재 여부 판단용 sentinel row 한 건 추가 조회
+            .addValue("fetchLimit", query.limit() + 1);
+
+    StringBuilder sql =
+        new StringBuilder(
+            """
+            SELECT id,
+                   account_id,
+                   transaction_reference,
+                   direction,
+                   transaction_status,
+                   amount_minor,
+                   balance_after_minor,
+                   currency_code,
+                   summary,
+                   counterparty_masked_name,
+                   booked_at
+            FROM transaction_read_model
+            WHERE account_id = :accountId
+              AND booked_at >= :from
+              AND booked_at < :to
+            """);
+
+    if (query.status() != null) {
+      sql.append("\n  AND transaction_status = :status");
+      params.addValue("status", query.status().name());
+    }
+
+    if (query.cursor() != null) {
+      // keyset cursor와 ORDER BY tuple을 같게 두어 composite index range scan으로 이어지게 합니다.
+      sql.append("\n  AND (booked_at, id) < (:cursorBookedAt, :cursorId)");
+      params
+          .addValue("cursorBookedAt", Timestamp.from(query.cursor().bookedAt()))
+          .addValue("cursorId", query.cursor().id());
+    }
+
+    sql.append(
+        """
+
+            ORDER BY booked_at DESC, id DESC
+            LIMIT :fetchLimit
+        """);
+    return new TransactionReadQueryStatement(sql.toString(), params);
+  }
+
+  String sql() {
+    return sql;
+  }
+
+  MapSqlParameterSource params() {
+    return params;
+  }
+}

--- a/back/src/main/resources/db/migration/V7__document_transaction_query_index_intent.sql
+++ b/back/src/main/resources/db/migration/V7__document_transaction_query_index_intent.sql
@@ -1,0 +1,5 @@
+COMMENT ON INDEX idx_transaction_read_model_account_cursor IS
+    'GET /api/v1/transactions 첫 page/후속 cursor page용. account_id filter 뒤 booked_at DESC, id DESC keyset 정렬 유지';
+
+COMMENT ON INDEX idx_transaction_read_model_account_status_cursor IS
+    'GET /api/v1/transactions status filter page용. status filter 뒤에도 booked_at DESC, id DESC keyset 정렬 유지';

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
@@ -1,0 +1,146 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.aquilabank.support.TransactionExplainPlan;
+import com.aquilabank.support.TransactionReadModelBaselineFixture;
+import com.aquilabank.support.TransactionReadModelBaselineFixture.BaselineWindow;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcTransactionReadRepositoryBaselineIntegrationTest extends PostgresContainerTestSupport {
+
+  private final TransactionReadModelBaselineFixture fixture =
+      new TransactionReadModelBaselineFixture();
+
+  @Autowired private JdbcTransactionReadRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  private BaselineWindow baselineWindow;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+    commit(transactionManager, () -> baselineWindow = fixture.seed(jdbcTemplate));
+  }
+
+  @Test
+  void firstPageUsesAccountCursorIndexWithoutSeqScanOrSort() {
+    TransactionQuery query =
+        new TransactionQuery(
+            baselineWindow.hotAccountId(),
+            baselineWindow.from(),
+            baselineWindow.to(),
+            50,
+            null,
+            null);
+
+    TransactionSlice slice = repository.fetch(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(50);
+    assertThat(slice.hasNext()).isTrue();
+    assertThat(plan.rootNodeType()).isEqualTo("Limit");
+    assertThat(plan.actualRows()).isEqualTo(51.0d);
+    assertThat(plan.usesIndex("idx_transaction_read_model_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void cursorPageKeepsSameAccountCursorIndex() {
+    TransactionQuery firstPageQuery =
+        new TransactionQuery(
+            baselineWindow.hotAccountId(),
+            baselineWindow.from(),
+            baselineWindow.to(),
+            50,
+            null,
+            null);
+    TransactionSlice firstSlice = repository.fetch(firstPageQuery);
+
+    TransactionQuery nextPageQuery =
+        new TransactionQuery(
+            baselineWindow.hotAccountId(),
+            baselineWindow.from(),
+            baselineWindow.to(),
+            50,
+            firstSlice.nextCursor(),
+            null);
+
+    TransactionSlice nextSlice = repository.fetch(nextPageQuery);
+    TransactionExplainPlan plan = explain(nextPageQuery);
+
+    assertThat(firstSlice.nextCursor()).isNotNull();
+    assertThat(nextSlice.items()).hasSize(50);
+    assertThat(nextSlice.items().getFirst().bookedAt())
+        .isBeforeOrEqualTo(firstSlice.items().getLast().bookedAt());
+    assertThat(plan.usesIndex("idx_transaction_read_model_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void statusFilteredCursorPageUsesStatusCursorIndex() {
+    TransactionQuery firstPageQuery =
+        new TransactionQuery(
+            baselineWindow.hotAccountId(),
+            baselineWindow.from(),
+            baselineWindow.to(),
+            50,
+            null,
+            TransactionStatus.BOOKED);
+    TransactionSlice firstSlice = repository.fetch(firstPageQuery);
+
+    TransactionQuery nextPageQuery =
+        new TransactionQuery(
+            baselineWindow.hotAccountId(),
+            baselineWindow.from(),
+            baselineWindow.to(),
+            50,
+            firstSlice.nextCursor(),
+            TransactionStatus.BOOKED);
+
+    TransactionSlice nextSlice = repository.fetch(nextPageQuery);
+    TransactionExplainPlan plan = explain(nextPageQuery);
+
+    assertThat(firstSlice.nextCursor()).isNotNull();
+    assertThat(nextSlice.items()).hasSize(50);
+    assertThat(nextSlice.items()).allMatch(item -> item.status() == TransactionStatus.BOOKED);
+    assertThat(plan.usesIndex("idx_transaction_read_model_account_status_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  private TransactionExplainPlan explain(TransactionQuery query) {
+    TransactionReadQueryStatement statement = TransactionReadQueryStatement.from(query);
+    String explainJson =
+        jdbcTemplate.queryForObject(
+            "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)\n" + statement.sql(),
+            statement.params(),
+            (rs, rowNum) -> rs.getString(1));
+    if (explainJson == null) {
+      throw new IllegalStateException("EXPLAIN did not return JSON");
+    }
+    return TransactionExplainPlan.fromJson(objectMapper, explainJson);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
@@ -35,12 +35,25 @@ class JdbcTransactionReadRepositoryBaselineIntegrationTest extends PostgresConta
 
   @Autowired private PlatformTransactionManager transactionManager;
 
+  private static final Object SEED_LOCK = new Object();
+  private static BaselineWindow sharedBaselineWindow;
+
   private BaselineWindow baselineWindow;
 
   @BeforeEach
   void setUpDatabase() {
-    resetBankingTables(jdbcTemplate);
-    commit(transactionManager, () -> baselineWindow = fixture.seed(jdbcTemplate));
+    if (sharedBaselineWindow != null) {
+      baselineWindow = sharedBaselineWindow;
+      return;
+    }
+
+    synchronized (SEED_LOCK) {
+      if (sharedBaselineWindow == null) {
+        resetBankingTables(jdbcTemplate);
+        commit(transactionManager, () -> sharedBaselineWindow = fixture.seed(jdbcTemplate));
+      }
+      baselineWindow = sharedBaselineWindow;
+    }
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
@@ -50,7 +50,8 @@ class JdbcTransactionReadRepositoryBaselineIntegrationTest extends PostgresConta
     synchronized (SEED_LOCK) {
       if (sharedBaselineWindow == null) {
         resetBankingTables(jdbcTemplate);
-        commit(transactionManager, () -> sharedBaselineWindow = fixture.seed(jdbcTemplate));
+        // baseline seed는 조회 성능 검증용 setup이라 기본 5초 transaction timeout보다 넉넉히 둡니다.
+        commit(transactionManager, 30, () -> sharedBaselineWindow = fixture.seed(jdbcTemplate));
       }
       baselineWindow = sharedBaselineWindow;
     }

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/TransactionDatasourceStatementTimeoutIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/TransactionDatasourceStatementTimeoutIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      "spring.flyway.enabled=true",
+      "management.health.db.enabled=true",
+      "DB_STATEMENT_TIMEOUT_MS=1000",
+      "spring.jdbc.template.query-timeout=10"
+    })
+class TransactionDatasourceStatementTimeoutIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @Test
+  void datasourceStatementTimeoutCancelsSlowQueryBeforeJdbcTimeout() {
+    long startedAt = System.nanoTime();
+    Throwable thrown = catchThrowable(() -> executeSlowQuery(4.0d));
+    Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
+
+    assertThat(thrown).isInstanceOf(QueryTimeoutException.class);
+    assertThat(rootCauseMessage(thrown)).contains("statement timeout");
+    assertThat(elapsed).isLessThan(Duration.ofSeconds(3));
+  }
+
+  private void executeSlowQuery(double sleepSeconds) {
+    PreparedStatementCreator statementCreator =
+        connection -> {
+          var statement = connection.prepareStatement("SELECT pg_sleep(?)");
+          statement.setDouble(1, sleepSeconds);
+          return statement;
+        };
+    jdbcTemplate.execute(
+        statementCreator,
+        preparedStatement -> {
+          preparedStatement.execute();
+          return null;
+        });
+  }
+
+  private String rootCauseMessage(Throwable thrown) {
+    Throwable rootCause = thrown;
+    while (rootCause.getCause() != null) {
+      rootCause = rootCause.getCause();
+    }
+    return rootCause.getMessage();
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/TransactionJdbcQueryTimeoutIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/TransactionJdbcQueryTimeoutIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      "spring.flyway.enabled=true",
+      "management.health.db.enabled=true",
+      "DB_STATEMENT_TIMEOUT_MS=10000",
+      "spring.jdbc.template.query-timeout=1"
+    })
+class TransactionJdbcQueryTimeoutIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @Test
+  void jdbcQueryTimeoutCancelsSlowQueryBeforeDatasourceStatementTimeout() {
+    long startedAt = System.nanoTime();
+    Throwable thrown = catchThrowable(() -> executeSlowQuery(4.0d));
+    Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
+
+    assertThat(thrown).isInstanceOf(QueryTimeoutException.class);
+    assertThat(elapsed).isLessThan(Duration.ofSeconds(3));
+    assertThat(rootCauseMessage(thrown)).doesNotContain("statement timeout");
+  }
+
+  private void executeSlowQuery(double sleepSeconds) {
+    PreparedStatementCreator statementCreator =
+        connection -> {
+          var statement = connection.prepareStatement("SELECT pg_sleep(?)");
+          statement.setDouble(1, sleepSeconds);
+          return statement;
+        };
+    jdbcTemplate.execute(
+        statementCreator,
+        preparedStatement -> {
+          preparedStatement.execute();
+          return null;
+        });
+  }
+
+  private String rootCauseMessage(Throwable thrown) {
+    Throwable rootCause = thrown;
+    while (rootCause.getCause() != null) {
+      rootCause = rootCause.getCause();
+    }
+    return rootCause.getMessage();
+  }
+}

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -66,7 +66,16 @@ public abstract class PostgresContainerTestSupport {
   }
 
   protected void commit(PlatformTransactionManager transactionManager, Runnable callback) {
-    new TransactionTemplate(transactionManager).executeWithoutResult(status -> callback.run());
+    commit(transactionManager, null, callback);
+  }
+
+  protected void commit(
+      PlatformTransactionManager transactionManager, Integer timeoutSeconds, Runnable callback) {
+    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+    if (timeoutSeconds != null) {
+      transactionTemplate.setTimeout(timeoutSeconds);
+    }
+    transactionTemplate.executeWithoutResult(status -> callback.run());
   }
 
   private void migrateSchema(DataSource dataSource) {

--- a/back/src/test/java/com/aquilabank/support/TransactionExplainPlan.java
+++ b/back/src/test/java/com/aquilabank/support/TransactionExplainPlan.java
@@ -1,0 +1,65 @@
+package com.aquilabank.support;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/** PostgreSQL EXPLAIN JSON에서 baseline 비교용 핵심 정보만 추립니다. */
+public record TransactionExplainPlan(
+    String rootNodeType,
+    double actualRows,
+    long sharedHitBlocks,
+    long sharedReadBlocks,
+    Set<String> nodeTypes,
+    Set<String> indexNames) {
+
+  public static TransactionExplainPlan fromJson(ObjectMapper objectMapper, String planJson) {
+    try {
+      JsonNode rootArray = objectMapper.readTree(planJson);
+      JsonNode rootPlan = rootArray.path(0).path("Plan");
+      if (rootPlan.isMissingNode()) {
+        throw new IllegalArgumentException("EXPLAIN JSON root plan is missing");
+      }
+
+      LinkedHashSet<String> nodeTypes = new LinkedHashSet<>();
+      LinkedHashSet<String> indexNames = new LinkedHashSet<>();
+      collect(rootPlan, nodeTypes, indexNames);
+
+      return new TransactionExplainPlan(
+          rootPlan.path("Node Type").asText(),
+          rootPlan.path("Actual Rows").asDouble(),
+          rootPlan.path("Shared Hit Blocks").asLong(),
+          rootPlan.path("Shared Read Blocks").asLong(),
+          nodeTypes,
+          indexNames);
+    } catch (IOException ex) {
+      throw new IllegalArgumentException("EXPLAIN JSON parse failed", ex);
+    }
+  }
+
+  public boolean hasNodeType(String nodeType) {
+    return nodeTypes.contains(nodeType);
+  }
+
+  public boolean usesIndex(String indexName) {
+    return indexNames.contains(indexName);
+  }
+
+  private static void collect(JsonNode node, Set<String> nodeTypes, Set<String> indexNames) {
+    String nodeType = node.path("Node Type").asText(null);
+    if (nodeType != null) {
+      nodeTypes.add(nodeType);
+    }
+
+    String indexName = node.path("Index Name").asText(null);
+    if (indexName != null) {
+      indexNames.add(indexName);
+    }
+
+    for (JsonNode child : node.path("Plans")) {
+      collect(child, nodeTypes, indexNames);
+    }
+  }
+}

--- a/back/src/test/java/com/aquilabank/support/TransactionReadModelBaselineFixture.java
+++ b/back/src/test/java/com/aquilabank/support/TransactionReadModelBaselineFixture.java
@@ -1,0 +1,204 @@
+package com.aquilabank.support;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/** 거래 조회 baseline 테스트에서 같은 데이터 분포를 반복 재현하는 fixture */
+public final class TransactionReadModelBaselineFixture {
+
+  private static final String ACTIVE = "ACTIVE";
+  private static final String CURRENCY_CODE = "KRW";
+  private static final Instant WINDOW_START = Instant.parse("2026-04-01T00:00:00Z");
+  private static final Instant WINDOW_END = Instant.parse("2026-05-01T00:00:00Z");
+  private static final int HOT_ACCOUNT_ROW_COUNT = 80_000;
+  private static final int HOT_ACCOUNT_STEP_SECONDS = 30;
+  private static final int NOISE_ACCOUNT_COUNT = 6;
+  private static final int NOISE_ACCOUNT_ROW_COUNT = 4_000;
+  private static final int NOISE_ACCOUNT_STEP_SECONDS = 360;
+
+  public BaselineWindow seed(NamedParameterJdbcTemplate jdbcTemplate) {
+    long hotAccountId = insertAccount(jdbcTemplate, "baseline-hot-account", WINDOW_START);
+    insertTimelineRows(
+        jdbcTemplate, hotAccountId, HOT_ACCOUNT_ROW_COUNT, HOT_ACCOUNT_STEP_SECONDS, "hot-account");
+
+    List<Long> noiseAccountIds = new ArrayList<>();
+    for (int index = 1; index <= NOISE_ACCOUNT_COUNT; index++) {
+      long accountId = insertAccount(jdbcTemplate, "baseline-noise-account-" + index, WINDOW_START);
+      insertTimelineRows(
+          jdbcTemplate,
+          accountId,
+          NOISE_ACCOUNT_ROW_COUNT,
+          NOISE_ACCOUNT_STEP_SECONDS,
+          "noise-account-" + index);
+      noiseAccountIds.add(accountId);
+    }
+
+    analyzeTables(jdbcTemplate);
+    return new BaselineWindow(hotAccountId, noiseAccountIds, WINDOW_START, WINDOW_END);
+  }
+
+  private long insertAccount(
+      NamedParameterJdbcTemplate jdbcTemplate, String displayName, Instant createdAt) {
+    String accountNumber =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0')
+            """,
+            new MapSqlParameterSource(),
+            String.class);
+    if (accountNumber == null) {
+      throw new IllegalStateException("baseline account number is not generated");
+    }
+
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountNumber,
+                :displayName,
+                :accountStatus,
+                :currencyCode,
+                :createdAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountNumber", accountNumber)
+                .addValue("displayName", displayName)
+                .addValue("accountStatus", ACTIVE)
+                .addValue("currencyCode", CURRENCY_CODE)
+                .addValue("createdAt", Timestamp.from(createdAt)),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("baseline account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertTimelineRows(
+      NamedParameterJdbcTemplate jdbcTemplate,
+      long accountId,
+      int rowCount,
+      int stepSeconds,
+      String referencePrefix) {
+    jdbcTemplate.update(
+        """
+        WITH generated AS (
+            SELECT
+                :accountId AS account_id,
+                series AS seq,
+                CAST(:windowStart AS timestamptz)
+                    + make_interval(secs => ((series - 1) * :stepSeconds)::integer) AS booked_at,
+                CASE WHEN mod(series, 7) = 0 THEN 'DEBIT' ELSE 'CREDIT' END AS direction,
+                CASE
+                    WHEN mod(series, 53) = 0 THEN 'REVERSED'
+                    WHEN mod(series, 5) = 0 THEN 'PENDING'
+                    ELSE 'BOOKED'
+                END AS transaction_status,
+                CASE WHEN mod(series, 7) = 0 THEN 1300 ELSE 1700 END AS amount_minor,
+                1000000
+                    + SUM(
+                        CASE WHEN mod(series, 7) = 0 THEN -1300 ELSE 1700 END
+                    ) OVER (ORDER BY series) AS balance_after_minor,
+                :referencePrefix || '-trx-' || series AS transaction_reference,
+                :referencePrefix || '-entry-' || series AS entry_reference,
+                'seed-' || :referencePrefix || '-' || series AS summary,
+                CASE WHEN mod(series, 3) = 0 THEN 'MERCHANT' ELSE 'ATM' END
+                    AS counterparty_masked_name
+            FROM generate_series(1, :rowCount) AS series
+        ),
+        inserted_ledger AS (
+            INSERT INTO ledger_entry (
+                account_id,
+                transaction_reference,
+                entry_reference,
+                direction,
+                entry_status,
+                amount_minor,
+                currency_code,
+                booked_at,
+                occurred_at,
+                description,
+                metadata,
+                created_at,
+                updated_at
+            )
+            SELECT
+                account_id,
+                transaction_reference,
+                entry_reference,
+                direction,
+                transaction_status,
+                amount_minor,
+                :currencyCode,
+                booked_at,
+                booked_at,
+                summary,
+                '{}'::jsonb,
+                booked_at,
+                booked_at
+            FROM generated
+            RETURNING id, entry_reference
+        )
+        INSERT INTO transaction_read_model (
+            ledger_entry_id,
+            account_id,
+            transaction_reference,
+            direction,
+            transaction_status,
+            amount_minor,
+            balance_after_minor,
+            currency_code,
+            summary,
+            counterparty_masked_name,
+            booked_at,
+            created_at
+        )
+        SELECT
+            inserted_ledger.id,
+            generated.account_id,
+            generated.transaction_reference,
+            generated.direction,
+            generated.transaction_status,
+            generated.amount_minor,
+            generated.balance_after_minor,
+            :currencyCode,
+            generated.summary,
+            generated.counterparty_masked_name,
+            generated.booked_at,
+            generated.booked_at
+        FROM generated
+        JOIN inserted_ledger
+          ON inserted_ledger.entry_reference = generated.entry_reference
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("currencyCode", CURRENCY_CODE)
+            .addValue("referencePrefix", referencePrefix)
+            .addValue("rowCount", rowCount)
+            .addValue("stepSeconds", stepSeconds)
+            .addValue("windowStart", Timestamp.from(WINDOW_START)));
+  }
+
+  private void analyzeTables(NamedParameterJdbcTemplate jdbcTemplate) {
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE bank_account");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE ledger_entry");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE transaction_read_model");
+  }
+
+  public record BaselineWindow(
+      long hotAccountId, List<Long> noiseAccountIds, Instant from, Instant to) {}
+}

--- a/back/src/test/java/com/aquilabank/support/TransactionReadModelBaselineFixture.java
+++ b/back/src/test/java/com/aquilabank/support/TransactionReadModelBaselineFixture.java
@@ -14,11 +14,13 @@ public final class TransactionReadModelBaselineFixture {
   private static final String CURRENCY_CODE = "KRW";
   private static final Instant WINDOW_START = Instant.parse("2026-04-01T00:00:00Z");
   private static final Instant WINDOW_END = Instant.parse("2026-05-01T00:00:00Z");
+  private static final long OPENING_BALANCE_MINOR = 1_000_000L;
   private static final int HOT_ACCOUNT_ROW_COUNT = 80_000;
   private static final int HOT_ACCOUNT_STEP_SECONDS = 30;
   private static final int NOISE_ACCOUNT_COUNT = 6;
   private static final int NOISE_ACCOUNT_ROW_COUNT = 4_000;
   private static final int NOISE_ACCOUNT_STEP_SECONDS = 360;
+  private static final int INSERT_BATCH_SIZE = 5_000;
 
   public BaselineWindow seed(NamedParameterJdbcTemplate jdbcTemplate) {
     long hotAccountId = insertAccount(jdbcTemplate, "baseline-hot-account", WINDOW_START);
@@ -94,103 +96,107 @@ public final class TransactionReadModelBaselineFixture {
       int rowCount,
       int stepSeconds,
       String referencePrefix) {
-    jdbcTemplate.update(
-        """
-        WITH generated AS (
-            SELECT
-                :accountId AS account_id,
-                series AS seq,
-                CAST(:windowStart AS timestamptz)
-                    + make_interval(secs => ((series - 1) * :stepSeconds)::integer) AS booked_at,
-                CASE WHEN mod(series, 7) = 0 THEN 'DEBIT' ELSE 'CREDIT' END AS direction,
-                CASE
-                    WHEN mod(series, 53) = 0 THEN 'REVERSED'
-                    WHEN mod(series, 5) = 0 THEN 'PENDING'
-                    ELSE 'BOOKED'
-                END AS transaction_status,
-                CASE WHEN mod(series, 7) = 0 THEN 1300 ELSE 1700 END AS amount_minor,
-                1000000
-                    + SUM(
-                        CASE WHEN mod(series, 7) = 0 THEN -1300 ELSE 1700 END
-                    ) OVER (ORDER BY series) AS balance_after_minor,
-                :referencePrefix || '-trx-' || series AS transaction_reference,
-                :referencePrefix || '-entry-' || series AS entry_reference,
-                'seed-' || :referencePrefix || '-' || series AS summary,
-                CASE WHEN mod(series, 3) = 0 THEN 'MERCHANT' ELSE 'ATM' END
-                    AS counterparty_masked_name
-            FROM generate_series(1, :rowCount) AS series
-        ),
-        inserted_ledger AS (
-            INSERT INTO ledger_entry (
-                account_id,
-                transaction_reference,
-                entry_reference,
-                direction,
-                entry_status,
-                amount_minor,
-                currency_code,
-                booked_at,
-                occurred_at,
-                description,
-                metadata,
-                created_at,
-                updated_at
-            )
-            SELECT
-                account_id,
-                transaction_reference,
-                entry_reference,
-                direction,
-                transaction_status,
-                amount_minor,
-                :currencyCode,
-                booked_at,
-                booked_at,
-                summary,
-                '{}'::jsonb,
-                booked_at,
-                booked_at
-            FROM generated
-            RETURNING id, entry_reference
-        )
-        INSERT INTO transaction_read_model (
-            ledger_entry_id,
-            account_id,
-            transaction_reference,
-            direction,
-            transaction_status,
-            amount_minor,
-            balance_after_minor,
-            currency_code,
-            summary,
-            counterparty_masked_name,
-            booked_at,
-            created_at
-        )
-        SELECT
-            inserted_ledger.id,
-            generated.account_id,
-            generated.transaction_reference,
-            generated.direction,
-            generated.transaction_status,
-            generated.amount_minor,
-            generated.balance_after_minor,
-            :currencyCode,
-            generated.summary,
-            generated.counterparty_masked_name,
-            generated.booked_at,
-            generated.booked_at
-        FROM generated
-        JOIN inserted_ledger
-          ON inserted_ledger.entry_reference = generated.entry_reference
-        """,
-        new MapSqlParameterSource()
-            .addValue("accountId", accountId)
-            .addValue("currencyCode", CURRENCY_CODE)
-            .addValue("referencePrefix", referencePrefix)
-            .addValue("rowCount", rowCount)
-            .addValue("stepSeconds", stepSeconds)
-            .addValue("windowStart", Timestamp.from(WINDOW_START)));
+    for (int startSeq = 1; startSeq <= rowCount; startSeq += INSERT_BATCH_SIZE) {
+      int endSeq = Math.min(startSeq + INSERT_BATCH_SIZE - 1, rowCount);
+      jdbcTemplate.update(
+          """
+          WITH generated AS (
+              SELECT
+                  :accountId AS account_id,
+                  series AS seq,
+                  CAST(:windowStart AS timestamptz)
+                      + make_interval(secs => ((series - 1) * :stepSeconds)::integer) AS booked_at,
+                  CASE WHEN mod(series, 7) = 0 THEN 'DEBIT' ELSE 'CREDIT' END AS direction,
+                  CASE
+                      WHEN mod(series, 53) = 0 THEN 'REVERSED'
+                      WHEN mod(series, 5) = 0 THEN 'PENDING'
+                      ELSE 'BOOKED'
+                  END AS transaction_status,
+                  CASE WHEN mod(series, 7) = 0 THEN 1300 ELSE 1700 END AS amount_minor,
+                  :openingBalanceMinor
+                      + ((series - (series / 7)) * 1700)
+                      - ((series / 7) * 1300) AS balance_after_minor,
+                  :referencePrefix || '-trx-' || series AS transaction_reference,
+                  :referencePrefix || '-entry-' || series AS entry_reference,
+                  'seed-' || :referencePrefix || '-' || series AS summary,
+                  CASE WHEN mod(series, 3) = 0 THEN 'MERCHANT' ELSE 'ATM' END
+                      AS counterparty_masked_name
+              FROM generate_series(:startSeq, :endSeq) AS series
+          ),
+          inserted_ledger AS (
+              INSERT INTO ledger_entry (
+                  account_id,
+                  transaction_reference,
+                  entry_reference,
+                  direction,
+                  entry_status,
+                  amount_minor,
+                  currency_code,
+                  booked_at,
+                  occurred_at,
+                  description,
+                  metadata,
+                  created_at,
+                  updated_at
+              )
+              SELECT
+                  account_id,
+                  transaction_reference,
+                  entry_reference,
+                  direction,
+                  transaction_status,
+                  amount_minor,
+                  :currencyCode,
+                  booked_at,
+                  booked_at,
+                  summary,
+                  '{}'::jsonb,
+                  booked_at,
+                  booked_at
+              FROM generated
+              RETURNING id, entry_reference
+          )
+          INSERT INTO transaction_read_model (
+              ledger_entry_id,
+              account_id,
+              transaction_reference,
+              direction,
+              transaction_status,
+              amount_minor,
+              balance_after_minor,
+              currency_code,
+              summary,
+              counterparty_masked_name,
+              booked_at,
+              created_at
+          )
+          SELECT
+              inserted_ledger.id,
+              generated.account_id,
+              generated.transaction_reference,
+              generated.direction,
+              generated.transaction_status,
+              generated.amount_minor,
+              generated.balance_after_minor,
+              :currencyCode,
+              generated.summary,
+              generated.counterparty_masked_name,
+              generated.booked_at,
+              generated.booked_at
+          FROM generated
+          JOIN inserted_ledger
+            ON inserted_ledger.entry_reference = generated.entry_reference
+          """,
+          new MapSqlParameterSource()
+              .addValue("accountId", accountId)
+              .addValue("currencyCode", CURRENCY_CODE)
+              .addValue("referencePrefix", referencePrefix)
+              .addValue("openingBalanceMinor", OPENING_BALANCE_MINOR)
+              .addValue("startSeq", startSeq)
+              .addValue("endSeq", endSeq)
+              .addValue("stepSeconds", stepSeconds)
+              .addValue("windowStart", Timestamp.from(WINDOW_START)));
+    }
   }
 
   private void analyzeTables(NamedParameterJdbcTemplate jdbcTemplate) {

--- a/tools/test/run-transaction-query-baseline.sh
+++ b/tools/test/run-transaction-query-baseline.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+./back/gradlew -p back test \
+  --tests '*JdbcTransactionReadRepositoryBaselineIntegrationTest' \
+  --tests '*TransactionDatasourceStatementTimeoutIntegrationTest' \
+  --tests '*TransactionJdbcQueryTimeoutIntegrationTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #32

## 📝 Summary
- `GET /api/v1/transactions` 기준으로 대량 샘플 데이터, EXPLAIN baseline, timeout 가드 검증 경로를 추가했습니다.
- 운영 조회 SQL과 baseline 검증이 같은 query shape를 보도록 keyset statement를 분리했고, 현재 두 인덱스의 책임을 migration comment로 고정했습니다.
- 재현용 스크립트를 추가해 같은 baseline 검증을 다시 실행할 수 있게 했습니다.

## 🛠 Changes
- 거래 조회 baseline fixture와 EXPLAIN JSON 파서를 추가했습니다.
- `JdbcTransactionReadRepository` SQL을 `TransactionReadQueryStatement`로 분리하고 tuple cursor 비교 기반 baseline integration test를 추가했습니다.
- datasource `statement_timeout` / Spring JDBC `query-timeout` 가드 테스트와 baseline 실행 스크립트를 추가했습니다.
- `idx_transaction_read_model_account_cursor`, `idx_transaction_read_model_account_status_cursor` 의도를 Flyway migration comment로 기록했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-transaction-baseline tools/test/run-transaction-query-baseline.sh`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- baseline fixture 적재 후 대표 조회 3종이 `Seq Scan` / `Sort` 없이 기존 거래 조회 인덱스를 타는지 integration test로 확인
- timeout 검증에서 datasource `statement_timeout`과 Spring JDBC `query-timeout`이 동기식 거래 조회보다 먼저 차단하는지 integration test로 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - baseline fixture 크기를 더 키우면 local Docker/PostgreSQL 자원 사용량이 증가할 수 있습니다.
  - tuple cursor 비교와 EXPLAIN assertion이 PostgreSQL planner 변화에 민감할 수 있습니다.
- 롤백 방법:
  - `TransactionReadQueryStatement` 분리와 baseline/timeout 테스트를 되돌립니다.
  - `V7__document_transaction_query_index_intent.sql` migration을 revert 하거나 follow-up migration으로 comment를 제거합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [ ] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.