### PR TITLE
[Feat] outbox Kafka producer 어댑터 추가

### DIFF
--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
+    implementation("org.springframework.kafka:spring-kafka")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/back/src/main/java/com/aquilabank/global/config/OutboxConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/OutboxConfiguration.java
@@ -4,17 +4,35 @@ import com.aquilabank.domain.notification.port.OutboxEventPublishPort;
 import com.aquilabank.domain.notification.port.OutboxEventStore;
 import com.aquilabank.domain.notification.usecase.OutboxDispatchService;
 import com.aquilabank.domain.notification.usecase.OutboxDispatchUseCase;
+import com.aquilabank.global.notification.KafkaOutboxEventPublisher;
+import com.aquilabank.global.notification.LoggingOutboxEventPublisher;
+import com.aquilabank.global.notification.OutboxTopicResolver;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.util.ClassUtils;
 
 /** Spring adapter와 scheduler를 domain outbox use case에 연결 */
 @Configuration
 @EnableScheduling
-@EnableConfigurationProperties(OutboxProperties.class)
+@EnableConfigurationProperties({OutboxProperties.class, OutboxKafkaProperties.class})
 public class OutboxConfiguration {
+
+  private static final Logger log = LoggerFactory.getLogger(OutboxConfiguration.class);
 
   @Bean
   OutboxDispatchUseCase outboxDispatchUseCase(
@@ -28,5 +46,100 @@ public class OutboxConfiguration {
         outboxProperties.batchSize(),
         Duration.ofSeconds(outboxProperties.staleAfterSeconds()),
         Duration.ofSeconds(outboxProperties.maxRetryDelaySeconds()));
+  }
+
+  @Bean
+  LoggingOutboxEventPublisher loggingOutboxEventPublisher() {
+    return new LoggingOutboxEventPublisher();
+  }
+
+  @Bean
+  OutboxTopicResolver outboxTopicResolver(OutboxKafkaProperties outboxKafkaProperties) {
+    return new OutboxTopicResolver(outboxKafkaProperties.topic());
+  }
+
+  @Bean
+  @Conditional(OutboxKafkaPublisherCondition.class)
+  ProducerFactory<String, String> outboxKafkaProducerFactory(
+      OutboxKafkaProperties outboxKafkaProperties) {
+    return new DefaultKafkaProducerFactory<>(kafkaProducerConfig(outboxKafkaProperties));
+  }
+
+  @Bean
+  @ConditionalOnBean(name = "outboxKafkaProducerFactory")
+  KafkaTemplate<String, String> outboxKafkaTemplate(
+      ProducerFactory<String, String> outboxKafkaProducerFactory) {
+    return new KafkaTemplate<>(outboxKafkaProducerFactory);
+  }
+
+  @Bean
+  @ConditionalOnBean(name = "outboxKafkaTemplate")
+  KafkaOutboxEventPublisher kafkaOutboxEventPublisher(
+      KafkaTemplate<String, String> outboxKafkaTemplate,
+      OutboxTopicResolver outboxTopicResolver,
+      OutboxKafkaProperties outboxKafkaProperties) {
+    return new KafkaOutboxEventPublisher(
+        outboxKafkaTemplate,
+        outboxTopicResolver,
+        Duration.ofMillis(outboxKafkaProperties.sendTimeoutMs()));
+  }
+
+  @Bean
+  OutboxEventPublishPort outboxEventPublishPort(
+      LoggingOutboxEventPublisher loggingOutboxEventPublisher,
+      OutboxKafkaProperties outboxKafkaProperties,
+      ObjectProvider<KafkaOutboxEventPublisher> kafkaOutboxEventPublisherProvider) {
+    KafkaOutboxEventPublisher kafkaOutboxEventPublisher =
+        kafkaOutboxEventPublisherProvider.getIfAvailable();
+    if (kafkaOutboxEventPublisher != null) {
+      log.info(
+          "outbox Kafka publisher enabled. defaultTopic={}, bootstrapServers={}",
+          outboxKafkaProperties.topic().defaultName(),
+          outboxKafkaProperties.bootstrapServers());
+      return kafkaOutboxEventPublisher;
+    }
+    log.info(
+        "outbox Kafka publisher unavailable. using logging fallback. reason={}",
+        outboxKafkaProperties.disabledReason());
+    return loggingOutboxEventPublisher;
+  }
+
+  private Map<String, Object> kafkaProducerConfig(OutboxKafkaProperties outboxKafkaProperties) {
+    Map<String, Object> config = new HashMap<>();
+    config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, outboxKafkaProperties.bootstrapServers());
+    config.put(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+        resolveSerializerClass(outboxKafkaProperties.serializer().keyClass()));
+    config.put(
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        resolveSerializerClass(outboxKafkaProperties.serializer().valueClass()));
+    config.put(ProducerConfig.CLIENT_ID_CONFIG, outboxKafkaProperties.producer().clientId());
+    config.put(ProducerConfig.ACKS_CONFIG, outboxKafkaProperties.producer().acks());
+    config.put(
+        ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG,
+        outboxKafkaProperties.producer().enableIdempotence());
+    config.put(
+        ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION,
+        outboxKafkaProperties.producer().maxInFlightRequestsPerConnection());
+    config.put(ProducerConfig.RETRIES_CONFIG, outboxKafkaProperties.retry().retries());
+    config.put(
+        ProducerConfig.RETRY_BACKOFF_MS_CONFIG, outboxKafkaProperties.retry().retryBackoffMs());
+    config.put(
+        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG,
+        outboxKafkaProperties.retry().deliveryTimeoutMs());
+    config.put(
+        ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, outboxKafkaProperties.retry().requestTimeoutMs());
+    return config;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Class<? extends Serializer<?>> resolveSerializerClass(String className) {
+    Class<?> serializerClass =
+        ClassUtils.resolveClassName(className, OutboxConfiguration.class.getClassLoader());
+    if (!Serializer.class.isAssignableFrom(serializerClass)) {
+      throw new IllegalArgumentException(
+          "serializer must implement Kafka Serializer: " + className);
+    }
+    return (Class<? extends Serializer<?>>) serializerClass;
   }
 }

--- a/back/src/main/java/com/aquilabank/global/config/OutboxKafkaProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/OutboxKafkaProperties.java
@@ -1,0 +1,68 @@
+package com.aquilabank.global.config;
+
+import java.util.Map;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/** Kafka producer 전용 설정을 poller 설정과 분리해 운영 경계를 명확히 둡니다. */
+@ConfigurationProperties(prefix = "outbox.kafka")
+public record OutboxKafkaProperties(
+    boolean enabled,
+    String bootstrapServers,
+    long sendTimeoutMs,
+    TopicProperties topic,
+    SerializerProperties serializer,
+    RetryProperties retry,
+    ProducerProperties producer) {
+
+  public OutboxKafkaProperties {
+    sendTimeoutMs = sendTimeoutMs > 0 ? sendTimeoutMs : 5000;
+    topic = topic == null ? new TopicProperties(null, Map.of()) : topic;
+    serializer =
+        serializer == null
+            ? new SerializerProperties(
+                StringSerializer.class.getName(), StringSerializer.class.getName())
+            : serializer;
+    retry = retry == null ? new RetryProperties(3, 1000, 30000, 3000) : retry;
+    producer =
+        producer == null
+            ? new ProducerProperties("aquila-bank-outbox-producer", "all", true, 1)
+            : producer;
+  }
+
+  public String disabledReason() {
+    if (!enabled) {
+      return "outbox.kafka.enabled=false";
+    }
+    if (!StringUtils.hasText(bootstrapServers)) {
+      return "outbox.kafka.bootstrap-servers is blank";
+    }
+    if (!topic.hasDefaultTopic()) {
+      return "outbox.kafka.topic.default-name is blank";
+    }
+    return "ready";
+  }
+
+  public record TopicProperties(String defaultName, Map<String, String> eventTypeOverrides) {
+
+    public TopicProperties {
+      eventTypeOverrides = eventTypeOverrides == null ? Map.of() : Map.copyOf(eventTypeOverrides);
+    }
+
+    boolean hasDefaultTopic() {
+      return StringUtils.hasText(defaultName);
+    }
+  }
+
+  public record SerializerProperties(String keyClass, String valueClass) {}
+
+  public record RetryProperties(
+      int retries, long retryBackoffMs, long deliveryTimeoutMs, long requestTimeoutMs) {}
+
+  public record ProducerProperties(
+      String clientId,
+      String acks,
+      boolean enableIdempotence,
+      int maxInFlightRequestsPerConnection) {}
+}

--- a/back/src/main/java/com/aquilabank/global/config/OutboxKafkaPublisherCondition.java
+++ b/back/src/main/java/com/aquilabank/global/config/OutboxKafkaPublisherCondition.java
@@ -1,0 +1,19 @@
+package com.aquilabank.global.config;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+/** 필수 Kafka 설정이 모두 있을 때만 producer bean 을 올려 fallback 선택을 단순화합니다. */
+final class OutboxKafkaPublisherCondition implements Condition {
+
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    return context.getEnvironment().getProperty("outbox.kafka.enabled", Boolean.class, false)
+        && StringUtils.hasText(
+            context.getEnvironment().getProperty("outbox.kafka.bootstrap-servers"))
+        && StringUtils.hasText(
+            context.getEnvironment().getProperty("outbox.kafka.topic.default-name"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/KafkaOutboxEventPublisher.java
+++ b/back/src/main/java/com/aquilabank/global/notification/KafkaOutboxEventPublisher.java
@@ -1,0 +1,49 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.OutboxEvent;
+import com.aquilabank.domain.notification.port.OutboxEventPublishPort;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.springframework.kafka.core.KafkaTemplate;
+
+/** broker ack 까지 기다려야 outbox row 상태 전이를 현재 계약대로 유지할 수 있습니다. */
+public final class KafkaOutboxEventPublisher implements OutboxEventPublishPort {
+
+  private final KafkaTemplate<String, String> kafkaTemplate;
+  private final OutboxTopicResolver outboxTopicResolver;
+  private final Duration sendTimeout;
+
+  public KafkaOutboxEventPublisher(
+      KafkaTemplate<String, String> kafkaTemplate,
+      OutboxTopicResolver outboxTopicResolver,
+      Duration sendTimeout) {
+    this.kafkaTemplate = kafkaTemplate;
+    this.outboxTopicResolver = outboxTopicResolver;
+    this.sendTimeout = sendTimeout;
+  }
+
+  @Override
+  public void publish(OutboxEvent event) {
+    String topic = outboxTopicResolver.resolve(event);
+    try {
+      kafkaTemplate
+          .send(topic, event.eventKey(), event.payload())
+          .get(sendTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("kafka publish interrupted", ex);
+    } catch (ExecutionException ex) {
+      Throwable cause = ex.getCause();
+      if (cause instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      throw new IllegalStateException(
+          cause == null || cause.getMessage() == null ? "kafka publish failed" : cause.getMessage(),
+          cause == null ? ex : cause);
+    } catch (TimeoutException ex) {
+      throw new IllegalStateException("kafka publish timed out", ex);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/LoggingOutboxEventPublisher.java
+++ b/back/src/main/java/com/aquilabank/global/notification/LoggingOutboxEventPublisher.java
@@ -4,10 +4,8 @@ import com.aquilabank.domain.notification.model.OutboxEvent;
 import com.aquilabank.domain.notification.port.OutboxEventPublishPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
 /** 실제 broker/websocket/push adapter 도입 전까지 쓰는 bootstrap publisher */
-@Component
 public class LoggingOutboxEventPublisher implements OutboxEventPublishPort {
 
   private static final Logger log = LoggerFactory.getLogger(LoggingOutboxEventPublisher.class);

--- a/back/src/main/java/com/aquilabank/global/notification/OutboxTopicResolver.java
+++ b/back/src/main/java/com/aquilabank/global/notification/OutboxTopicResolver.java
@@ -1,0 +1,30 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.OutboxEvent;
+import com.aquilabank.global.config.OutboxKafkaProperties;
+import java.util.Map;
+import org.springframework.util.StringUtils;
+
+/** 기본 topic + event type override 만 허용해 운영 topic 관리 복잡도를 낮춥니다. */
+public final class OutboxTopicResolver {
+
+  private final String defaultTopic;
+  private final Map<String, String> eventTypeOverrides;
+
+  public OutboxTopicResolver(OutboxKafkaProperties.TopicProperties topicProperties) {
+    this.defaultTopic = topicProperties.defaultName();
+    this.eventTypeOverrides = topicProperties.eventTypeOverrides();
+  }
+
+  public String resolve(OutboxEvent event) {
+    String topic = eventTypeOverrides.get(event.eventType());
+    if (StringUtils.hasText(topic)) {
+      return topic;
+    }
+    if (StringUtils.hasText(defaultTopic)) {
+      return defaultTopic;
+    }
+    throw new IllegalStateException(
+        "outbox Kafka topic is missing for eventType=" + event.eventType());
+  }
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -73,6 +73,27 @@ outbox:
     batch-size: ${OUTBOX_POLLER_BATCH_SIZE:20}
     stale-after-seconds: ${OUTBOX_POLLER_STALE_AFTER_SECONDS:30}
     max-retry-delay-seconds: ${OUTBOX_POLLER_MAX_RETRY_DELAY_SECONDS:60}
+  kafka:
+    enabled: ${OUTBOX_KAFKA_ENABLED:false}
+    bootstrap-servers: ${OUTBOX_KAFKA_BOOTSTRAP_SERVERS:}
+    send-timeout-ms: ${OUTBOX_KAFKA_SEND_TIMEOUT_MS:5000}
+    topic:
+      default-name: ${OUTBOX_KAFKA_TOPIC_DEFAULT:}
+      event-type-overrides:
+        TransferBooked: ${OUTBOX_KAFKA_TOPIC_TRANSFER_BOOKED:}
+    serializer:
+      key-class: ${OUTBOX_KAFKA_KEY_SERIALIZER:org.apache.kafka.common.serialization.StringSerializer}
+      value-class: ${OUTBOX_KAFKA_VALUE_SERIALIZER:org.apache.kafka.common.serialization.StringSerializer}
+    retry:
+      retries: ${OUTBOX_KAFKA_PRODUCER_RETRIES:3}
+      retry-backoff-ms: ${OUTBOX_KAFKA_PRODUCER_RETRY_BACKOFF_MS:1000}
+      delivery-timeout-ms: ${OUTBOX_KAFKA_PRODUCER_DELIVERY_TIMEOUT_MS:30000}
+      request-timeout-ms: ${OUTBOX_KAFKA_PRODUCER_REQUEST_TIMEOUT_MS:3000}
+    producer:
+      client-id: ${OUTBOX_KAFKA_PRODUCER_CLIENT_ID:aquila-bank-outbox-producer}
+      acks: ${OUTBOX_KAFKA_PRODUCER_ACKS:all}
+      enable-idempotence: ${OUTBOX_KAFKA_PRODUCER_ENABLE_IDEMPOTENCE:true}
+      max-in-flight-requests-per-connection: ${OUTBOX_KAFKA_PRODUCER_MAX_IN_FLIGHT:1}
 
 security:
   jwt:

--- a/back/src/test/java/com/aquilabank/global/config/OutboxConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/OutboxConfigurationTest.java
@@ -1,0 +1,62 @@
+package com.aquilabank.global.config;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+
+import com.aquilabank.domain.notification.port.OutboxEventPublishPort;
+import com.aquilabank.domain.notification.port.OutboxEventStore;
+import com.aquilabank.global.notification.KafkaOutboxEventPublisher;
+import com.aquilabank.global.notification.LoggingOutboxEventPublisher;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class OutboxConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(OutboxConfiguration.class)
+          .withBean(OutboxEventStore.class, () -> mock(OutboxEventStore.class))
+          .withPropertyValues(
+              "outbox.poller.enabled=false",
+              "outbox.poller.fixed-delay-ms=1000",
+              "outbox.poller.initial-delay-ms=3000",
+              "outbox.poller.batch-size=20",
+              "outbox.poller.stale-after-seconds=30",
+              "outbox.poller.max-retry-delay-seconds=60");
+
+  @Test
+  void usesLoggingFallbackWhenKafkaIsDisabled() {
+    contextRunner
+        .withPropertyValues("outbox.kafka.enabled=false")
+        .run(
+            context ->
+                assertInstanceOf(
+                    LoggingOutboxEventPublisher.class,
+                    context.getBean("outboxEventPublishPort", OutboxEventPublishPort.class)));
+  }
+
+  @Test
+  void usesKafkaPublisherWhenRequiredKafkaPropertiesArePresent() {
+    contextRunner
+        .withPropertyValues(
+            "outbox.kafka.enabled=true",
+            "outbox.kafka.bootstrap-servers=localhost:9092",
+            "outbox.kafka.topic.default-name=bank.notification.outbox.v1")
+        .run(
+            context ->
+                assertInstanceOf(
+                    KafkaOutboxEventPublisher.class,
+                    context.getBean("outboxEventPublishPort", OutboxEventPublishPort.class)));
+  }
+
+  @Test
+  void usesLoggingFallbackWhenKafkaIsEnabledButRequiredValuesAreMissing() {
+    contextRunner
+        .withPropertyValues("outbox.kafka.enabled=true")
+        .run(
+            context ->
+                assertInstanceOf(
+                    LoggingOutboxEventPublisher.class,
+                    context.getBean("outboxEventPublishPort", OutboxEventPublishPort.class)));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/notification/KafkaOutboxEventPublisherTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/KafkaOutboxEventPublisherTest.java
@@ -1,0 +1,84 @@
+package com.aquilabank.global.notification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.notification.model.OutboxEvent;
+import com.aquilabank.global.config.OutboxKafkaProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+class KafkaOutboxEventPublisherTest {
+
+  private KafkaTemplate<String, String> kafkaTemplate;
+  private KafkaOutboxEventPublisher kafkaOutboxEventPublisher;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    kafkaTemplate = org.mockito.Mockito.mock(KafkaTemplate.class);
+    OutboxTopicResolver outboxTopicResolver =
+        new OutboxTopicResolver(
+            new OutboxKafkaProperties.TopicProperties(
+                "bank.notification.outbox.v1",
+                Map.of("TransferBooked", "bank.transfer.booked.v1")));
+    kafkaOutboxEventPublisher =
+        new KafkaOutboxEventPublisher(kafkaTemplate, outboxTopicResolver, Duration.ofSeconds(1));
+  }
+
+  @Test
+  void publishesUsingEventTypeOverrideTopicAndEventKey() {
+    OutboxEvent event =
+        new OutboxEvent(
+            1L,
+            "TRANSFER",
+            "TRX-100",
+            "TransferBooked",
+            "transfer-booked:TRX-100",
+            "{\"transactionReference\":\"TRX-100\"}",
+            0,
+            Instant.now(),
+            Instant.now());
+    when(kafkaTemplate.send(
+            eq("bank.transfer.booked.v1"), eq(event.eventKey()), eq(event.payload())))
+        .thenReturn(CompletableFuture.<SendResult<String, String>>completedFuture(null));
+
+    kafkaOutboxEventPublisher.publish(event);
+
+    verify(kafkaTemplate).send("bank.transfer.booked.v1", event.eventKey(), event.payload());
+  }
+
+  @Test
+  void rethrowsRuntimeFailureFromKafkaSend() {
+    OutboxEvent event =
+        new OutboxEvent(
+            2L,
+            "TRANSFER",
+            "TRX-101",
+            "TransferBooked",
+            "transfer-booked:TRX-101",
+            "{\"transactionReference\":\"TRX-101\"}",
+            0,
+            Instant.now(),
+            Instant.now());
+    CompletableFuture<SendResult<String, String>> failedFuture = new CompletableFuture<>();
+    failedFuture.completeExceptionally(new IllegalStateException("broker down"));
+    when(kafkaTemplate.send(
+            eq("bank.transfer.booked.v1"), eq(event.eventKey()), eq(event.payload())))
+        .thenReturn(failedFuture);
+
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> kafkaOutboxEventPublisher.publish(event));
+
+    assertEquals("broker down", exception.getMessage());
+  }
+}

--- a/back/src/test/resources/application-test.yml
+++ b/back/src/test/resources/application-test.yml
@@ -19,6 +19,8 @@ outbox:
   poller:
     # scheduled dispatch는 끄고 테스트가 retry 타이밍을 직접 제어하게 합니다.
     enabled: false
+  kafka:
+    enabled: false
 
 security:
   jwt:


### PR DESCRIPTION
## 🔗 Related Issue
- close #36

## 📝 Summary
- `LoggingOutboxEventPublisher` 단일 경로를 조건부 Kafka producer + logging fallback 구조로 분리했습니다.
- `outbox.kafka.*` 설정을 추가해 topic, serializer, producer retry를 poller 설정과 독립적으로 제어할 수 있게 했습니다.
- broker ack 기준으로 outbox 상태 전이를 유지하도록 Kafka publish 경로와 selection 테스트를 보강했습니다.

## 🛠 Changes
- `spring-kafka` 의존성과 `OutboxKafkaProperties`, `OutboxKafkaPublisherCondition` 추가
- `KafkaOutboxEventPublisher`, `OutboxTopicResolver`, `OutboxConfiguration` wiring 추가
- Kafka enabled/disabled/fallback selection 테스트와 publisher 단위 테스트 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-outbox ./back/gradlew -p back test --tests '*Outbox*'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
- Kafka enable 시 `OUTBOX_KAFKA_BOOTSTRAP_SERVERS`, `OUTBOX_KAFKA_TOPIC_DEFAULT` 누락 상태면 logging fallback 이 유지되므로 운영 env 주입 확인이 필요합니다.
- serializer class 오설정 시 producer 생성 또는 publish 시점 실패가 발생할 수 있습니다.
- 롤백 방법:
- PR revert 시 기존 logging publisher 단일 경로로 복귀합니다.
- 운영 중 긴급 차단은 `OUTBOX_KAFKA_ENABLED=false` 로 fallback 전환 가능합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.