### PR TITLE
[Feat] 거래 단건 상세 조회 API 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/transaction/exception/TransactionDetailNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/exception/TransactionDetailNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.transaction.exception;
+
+/** 거래 상세 exact lookup 결과 부재 예외 */
+public class TransactionDetailNotFoundException extends RuntimeException {
+
+  public TransactionDetailNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionDetail.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionDetail.java
@@ -1,0 +1,20 @@
+package com.aquilabank.domain.transaction.model;
+
+import java.time.Instant;
+
+/** 거래 상세 drill-down 응답용 domain projection */
+public record TransactionDetail(
+    long accountId,
+    String transactionReference,
+    TransactionDirection direction,
+    TransactionStatus transactionStatus,
+    long amountMinor,
+    long balanceAfterMinor,
+    String currencyCode,
+    String summary,
+    String counterpartyMaskedName,
+    Instant bookedAt,
+    String entryReference,
+    TransactionStatus entryStatus,
+    Instant occurredAt,
+    String description) {}

--- a/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionDetailQuery.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionDetailQuery.java
@@ -1,0 +1,17 @@
+package com.aquilabank.domain.transaction.model;
+
+/** source/target row 혼선을 막기 위한 account scope 포함 exact lookup 조건 */
+public record TransactionDetailQuery(long accountId, String transactionReference) {
+
+  public TransactionDetailQuery {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (transactionReference == null || transactionReference.isBlank()) {
+      throw new IllegalArgumentException("transactionReference must not be blank");
+    }
+    if (transactionReference.length() > 64) {
+      throw new IllegalArgumentException("transactionReference must be 64 characters or less");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/transaction/port/TransactionDetailReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/port/TransactionDetailReadPort.java
@@ -1,0 +1,11 @@
+package com.aquilabank.domain.transaction.port;
+
+import com.aquilabank.domain.transaction.model.TransactionDetail;
+import com.aquilabank.domain.transaction.model.TransactionDetailQuery;
+import java.util.Optional;
+
+/** 거래 상세 exact lookup 조회를 저장소 계층으로 위임합니다. */
+public interface TransactionDetailReadPort {
+
+  Optional<TransactionDetail> find(TransactionDetailQuery query);
+}

--- a/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionDetailQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionDetailQueryService.java
@@ -1,0 +1,24 @@
+package com.aquilabank.domain.transaction.usecase;
+
+import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
+import com.aquilabank.domain.transaction.model.TransactionDetail;
+import com.aquilabank.domain.transaction.model.TransactionDetailQuery;
+import com.aquilabank.domain.transaction.port.TransactionDetailReadPort;
+
+/** 거래 상세 exact lookup을 not found 예외와 함께 묶습니다. */
+public final class TransactionDetailQueryService implements TransactionDetailQueryUseCase {
+
+  private final TransactionDetailReadPort transactionDetailReadPort;
+
+  public TransactionDetailQueryService(TransactionDetailReadPort transactionDetailReadPort) {
+    this.transactionDetailReadPort = transactionDetailReadPort;
+  }
+
+  @Override
+  public TransactionDetail getTransactionDetail(TransactionDetailQuery query) {
+    return transactionDetailReadPort
+        .find(query)
+        .orElseThrow(
+            () -> new TransactionDetailNotFoundException("transaction detail is not found"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionDetailQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionDetailQueryUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.transaction.usecase;
+
+import com.aquilabank.domain.transaction.model.TransactionDetail;
+import com.aquilabank.domain.transaction.model.TransactionDetailQuery;
+
+/** 거래 상세 단건 조회 진입점 */
+public interface TransactionDetailQueryUseCase {
+
+  TransactionDetail getTransactionDetail(TransactionDetailQuery query);
+}

--- a/back/src/main/java/com/aquilabank/global/config/TransactionDetailConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/TransactionDetailConfiguration.java
@@ -1,0 +1,19 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.transaction.port.TransactionDetailReadPort;
+import com.aquilabank.domain.transaction.usecase.TransactionDetailQueryService;
+import com.aquilabank.domain.transaction.usecase.TransactionDetailQueryUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** 거래 상세 exact lookup use case와 read port를 연결 */
+@Configuration
+public class TransactionDetailConfiguration {
+
+  @Bean
+  TransactionDetailQueryUseCase transactionDetailQueryUseCase(
+      TransactionDetailReadPort transactionDetailReadPort) {
+    // 상세 drill-down도 domain use case를 통해 JDBC adapter와 분리합니다.
+    return new TransactionDetailQueryService(transactionDetailReadPort);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionDetailRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionDetailRepository.java
@@ -1,0 +1,69 @@
+package com.aquilabank.global.persistence.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionDetail;
+import com.aquilabank.domain.transaction.model.TransactionDetailQuery;
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.port.TransactionDetailReadPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 거래 상세 exact lookup을 transaction_read_model + ledger_entry join으로 읽어옵니다. */
+@Repository
+public class JdbcTransactionDetailRepository implements TransactionDetailReadPort {
+
+  private static final RowMapper<TransactionDetail> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcTransactionDetailRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<TransactionDetail> find(TransactionDetailQuery query) {
+    TransactionDetailQueryStatement statement = TransactionDetailQueryStatement.from(query);
+    List<TransactionDetail> rows =
+        jdbcTemplate.query(statement.sql(), statement.params(), ROW_MAPPER);
+    if (rows.size() > 1) {
+      throw new IllegalStateException(
+          "transaction detail query returned multiple rows for accountId=%d transactionReference=%s"
+              .formatted(query.accountId(), query.transactionReference()));
+    }
+    return rows.stream().findFirst();
+  }
+
+  private static TransactionDetail mapRow(ResultSet rs) throws SQLException {
+    return new TransactionDetail(
+        rs.getLong("account_id"),
+        rs.getString("transaction_reference"),
+        TransactionDirection.valueOf(rs.getString("direction")),
+        TransactionStatus.valueOf(rs.getString("transaction_status")),
+        rs.getLong("amount_minor"),
+        rs.getLong("balance_after_minor"),
+        rs.getString("currency_code"),
+        rs.getString("summary"),
+        rs.getString("counterparty_masked_name"),
+        toInstant(rs.getTimestamp("booked_at"), "booked_at"),
+        rs.getString("entry_reference"),
+        TransactionStatus.valueOf(rs.getString("entry_status")),
+        toInstant(rs.getTimestamp("occurred_at"), "occurred_at"),
+        rs.getString("description"));
+  }
+
+  private static Instant toInstant(Timestamp timestamp, String columnName) {
+    if (timestamp == null) {
+      throw new IllegalStateException(columnName + " must not be null");
+    }
+    return timestamp.toInstant();
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionDetailQueryStatement.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionDetailQueryStatement.java
@@ -1,0 +1,62 @@
+package com.aquilabank.global.persistence.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionDetailQuery;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+/** 거래 상세 SQL과 bind 파라미터를 묶어 exact lookup query shape를 고정합니다. */
+final class TransactionDetailQueryStatement {
+
+  private final String sql;
+  private final MapSqlParameterSource params;
+
+  private TransactionDetailQueryStatement(String sql, MapSqlParameterSource params) {
+    this.sql = sql;
+    this.params = params;
+  }
+
+  static TransactionDetailQueryStatement from(TransactionDetailQuery query) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("accountId", query.accountId())
+            .addValue("transactionReference", query.transactionReference())
+            // 두 건 이상이면 정합성 이상으로 처리하기 위해 최대 두 건까지만 읽습니다.
+            .addValue("rowLimit", 2);
+
+    return new TransactionDetailQueryStatement(
+        """
+        SELECT trm.account_id,
+               trm.transaction_reference,
+               trm.direction,
+               trm.transaction_status,
+               trm.amount_minor,
+               trm.balance_after_minor,
+               trm.currency_code,
+               trm.summary,
+               trm.counterparty_masked_name,
+               trm.booked_at,
+               le.entry_reference,
+               le.entry_status,
+               le.occurred_at,
+               le.description
+        FROM ledger_entry le
+        JOIN transaction_read_model trm
+          ON trm.ledger_entry_id = le.id
+        WHERE le.transaction_reference = :transactionReference
+          AND le.account_id = :accountId
+          -- source/target row가 같은 transactionReference를 공유하므로 account scope를 양쪽 테이블에 고정합니다.
+          AND trm.account_id = :accountId
+          AND trm.transaction_reference = :transactionReference
+        ORDER BY le.id DESC
+        LIMIT :rowLimit
+        """,
+        params);
+  }
+
+  String sql() {
+    return sql;
+  }
+
+  MapSqlParameterSource params() {
+    return params;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -12,6 +12,7 @@ import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
 import com.aquilabank.domain.ledger.exception.SnapshotNotFoundException;
+import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
 import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
 import com.aquilabank.global.security.BootstrapHeaderAuthProperties;
 import jakarta.servlet.http.HttpServletRequest;
@@ -98,7 +99,8 @@ public class ApiExceptionHandler {
     SnapshotNotFoundException.class,
     AuthStatusChangeAuditNotFoundException.class,
     AuthUserNotFoundException.class,
-    UserAccountMembershipNotFoundException.class
+    UserAccountMembershipNotFoundException.class,
+    TransactionDetailNotFoundException.class
   })
   ResponseEntity<ApiErrorResponse> handleNotFound(RuntimeException ex, HttpServletRequest request) {
     return response(HttpStatus.NOT_FOUND, ex.getMessage(), request);

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionDetailController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionDetailController.java
@@ -1,0 +1,50 @@
+package com.aquilabank.global.web.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionDetailQuery;
+import com.aquilabank.domain.transaction.usecase.TransactionDetailQueryUseCase;
+import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/** 거래 상세 drill-down exact lookup을 노출하는 HTTP adapter */
+@Validated
+@RestController
+@RequestMapping("/api/v1/transactions")
+public class TransactionDetailController {
+
+  private final TransactionDetailQueryUseCase transactionDetailQueryUseCase;
+  private final RequestAccountAuthorizationService requestAccountAuthorizationService;
+
+  public TransactionDetailController(
+      TransactionDetailQueryUseCase transactionDetailQueryUseCase,
+      RequestAccountAuthorizationService requestAccountAuthorizationService) {
+    this.transactionDetailQueryUseCase = transactionDetailQueryUseCase;
+    this.requestAccountAuthorizationService = requestAccountAuthorizationService;
+  }
+
+  @GetMapping("/{transactionReference}")
+  public TransactionDetailResponse getTransactionDetail(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @PathVariable String transactionReference,
+      @RequestParam @Positive(message = "accountId must be positive") long accountId) {
+    try {
+      // 권한 실패를 먼저 끊어 타 계좌 거래 존재 여부를 상세 응답으로 노출하지 않습니다.
+      long resolvedAccountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(principal, accountId);
+      return TransactionDetailResponse.from(
+          transactionDetailQueryUseCase.getTransactionDetail(
+              new TransactionDetailQuery(resolvedAccountId, transactionReference)));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionDetailResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionDetailResponse.java
@@ -1,0 +1,40 @@
+package com.aquilabank.global.web.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionDetail;
+import java.time.Instant;
+
+/** 거래 상세 endpoint 응답 모델 */
+public record TransactionDetailResponse(
+    long accountId,
+    String transactionReference,
+    String direction,
+    String transactionStatus,
+    long amountMinor,
+    long balanceAfterMinor,
+    String currencyCode,
+    String summary,
+    String counterpartyMaskedName,
+    Instant bookedAt,
+    String entryReference,
+    String entryStatus,
+    Instant occurredAt,
+    String description) {
+
+  static TransactionDetailResponse from(TransactionDetail item) {
+    return new TransactionDetailResponse(
+        item.accountId(),
+        item.transactionReference(),
+        item.direction().name(),
+        item.transactionStatus().name(),
+        item.amountMinor(),
+        item.balanceAfterMinor(),
+        item.currencyCode(),
+        item.summary(),
+        item.counterpartyMaskedName(),
+        item.bookedAt(),
+        item.entryReference(),
+        item.entryStatus().name(),
+        item.occurredAt(),
+        item.description());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionDetailRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionDetailRepositoryIntegrationTest.java
@@ -1,0 +1,271 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.aquilabank.domain.transaction.model.TransactionDetailQuery;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcTransactionDetailRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcTransactionDetailRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void findsTransactionDetailByAccountScopedReference() {
+    Instant bookedAt = Instant.parse("2026-04-16T09:00:00Z");
+    Instant occurredAt = Instant.parse("2026-04-16T09:00:01Z");
+    long[] accountIds = new long[2];
+    commit(
+        transactionManager,
+        () -> {
+          accountIds[0] = insertBankAccount("source account");
+          accountIds[1] = insertBankAccount("target account");
+          long sourceLedgerEntryId =
+              insertLedgerEntry(
+                  accountIds[0], "TRX-1", "ENT-1", "DEBIT", bookedAt, occurredAt, "rent");
+          insertReadModel(
+              sourceLedgerEntryId,
+              accountIds[0],
+              "TRX-1",
+              "DEBIT",
+              1500L,
+              8500L,
+              "rent",
+              "TARGET",
+              bookedAt);
+          long targetLedgerEntryId =
+              insertLedgerEntry(
+                  accountIds[1], "TRX-1", "ENT-2", "CREDIT", bookedAt, occurredAt, "rent");
+          insertReadModel(
+              targetLedgerEntryId,
+              accountIds[1],
+              "TRX-1",
+              "CREDIT",
+              1500L,
+              1500L,
+              "rent",
+              "SOURCE",
+              bookedAt);
+        });
+
+    Optional<com.aquilabank.domain.transaction.model.TransactionDetail> result =
+        repository.find(new TransactionDetailQuery(accountIds[0], "TRX-1"));
+
+    assertThat(result).isPresent();
+    assertThat(result.orElseThrow().accountId()).isEqualTo(accountIds[0]);
+    assertThat(result.orElseThrow().direction()).hasToString("DEBIT");
+    assertThat(result.orElseThrow().entryReference()).isEqualTo("ENT-1");
+    assertThat(result.orElseThrow().counterpartyMaskedName()).isEqualTo("TARGET");
+  }
+
+  @Test
+  void throwsWhenSameAccountReferenceReturnsMultipleRows() {
+    Instant bookedAt = Instant.parse("2026-04-16T09:00:00Z");
+    Instant occurredAt = Instant.parse("2026-04-16T09:00:01Z");
+    long[] accountId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          accountId[0] = insertBankAccount("duplicate account");
+          long firstLedgerEntryId =
+              insertLedgerEntry(
+                  accountId[0], "TRX-DUP", "ENT-DUP-1", "DEBIT", bookedAt, occurredAt, "dup");
+          insertReadModel(
+              firstLedgerEntryId,
+              accountId[0],
+              "TRX-DUP",
+              "DEBIT",
+              100L,
+              900L,
+              "dup",
+              "TARGET",
+              bookedAt);
+          long secondLedgerEntryId =
+              insertLedgerEntry(
+                  accountId[0],
+                  "TRX-DUP",
+                  "ENT-DUP-2",
+                  "DEBIT",
+                  bookedAt.plusSeconds(1),
+                  occurredAt.plusSeconds(1),
+                  "dup");
+          insertReadModel(
+              secondLedgerEntryId,
+              accountId[0],
+              "TRX-DUP",
+              "DEBIT",
+              100L,
+              800L,
+              "dup",
+              "TARGET",
+              bookedAt.plusSeconds(1));
+        });
+
+    assertThatThrownBy(() -> repository.find(new TransactionDetailQuery(accountId[0], "TRX-DUP")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("multiple rows");
+  }
+
+  private long insertBankAccount(String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private long insertLedgerEntry(
+      long accountId,
+      String transactionReference,
+      String entryReference,
+      String direction,
+      Instant bookedAt,
+      Instant occurredAt,
+      String description) {
+    Long ledgerEntryId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO ledger_entry (
+                account_id,
+                transaction_reference,
+                entry_reference,
+                direction,
+                entry_status,
+                amount_minor,
+                currency_code,
+                booked_at,
+                occurred_at,
+                description,
+                metadata,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountId,
+                :transactionReference,
+                :entryReference,
+                :direction,
+                'BOOKED',
+                1500,
+                'KRW',
+                :bookedAt,
+                :occurredAt,
+                :description,
+                '{}'::jsonb,
+                :bookedAt,
+                :bookedAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("transactionReference", transactionReference)
+                .addValue("entryReference", entryReference)
+                .addValue("direction", direction)
+                .addValue("bookedAt", Timestamp.from(bookedAt))
+                .addValue("occurredAt", Timestamp.from(occurredAt))
+                .addValue("description", description),
+            Long.class);
+    if (ledgerEntryId == null) {
+      throw new IllegalStateException("ledger_entry insert did not return id");
+    }
+    return ledgerEntryId;
+  }
+
+  private void insertReadModel(
+      long ledgerEntryId,
+      long accountId,
+      String transactionReference,
+      String direction,
+      long amountMinor,
+      long balanceAfterMinor,
+      String summary,
+      String counterpartyMaskedName,
+      Instant bookedAt) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO transaction_read_model (
+            ledger_entry_id,
+            account_id,
+            transaction_reference,
+            direction,
+            transaction_status,
+            amount_minor,
+            balance_after_minor,
+            currency_code,
+            summary,
+            counterparty_masked_name,
+            booked_at,
+            created_at
+        )
+        VALUES (
+            :ledgerEntryId,
+            :accountId,
+            :transactionReference,
+            :direction,
+            'BOOKED',
+            :amountMinor,
+            :balanceAfterMinor,
+            'KRW',
+            :summary,
+            :counterpartyMaskedName,
+            :bookedAt,
+            :bookedAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("ledgerEntryId", ledgerEntryId)
+            .addValue("accountId", accountId)
+            .addValue("transactionReference", transactionReference)
+            .addValue("direction", direction)
+            .addValue("amountMinor", amountMinor)
+            .addValue("balanceAfterMinor", balanceAfterMinor)
+            .addValue("summary", summary)
+            .addValue("counterpartyMaskedName", counterpartyMaskedName)
+            .addValue("bookedAt", Timestamp.from(bookedAt)));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/security/TransactionDetailJwtSecurityIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/TransactionDetailJwtSecurityIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.aquilabank.global.security;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.auth.model.AccountAccessScope;
+import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
+import com.aquilabank.domain.transaction.model.TransactionDetail;
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.port.TransactionDetailReadPort;
+import com.aquilabank.domain.transaction.port.TransactionReadPort;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class TransactionDetailJwtSecurityIntegrationTest {
+
+  private static final String TEST_SECRET = "test-local-jwt-secret-test-local-jwt-secret";
+
+  @Autowired private WebApplicationContext context;
+
+  @MockitoBean private AccountAccessUseCase accountAccessUseCase;
+
+  @MockitoBean private TransactionReadPort transactionReadPort;
+
+  @MockitoBean private TransactionDetailReadPort transactionDetailReadPort;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUpMockMvc() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void acceptsBearerJwtAndReturnsMappedTransactionDetail() throws Exception {
+    when(accountAccessUseCase.verify(55L, 555L, AccountAccessScope.READ)).thenReturn(555L);
+    when(transactionDetailReadPort.find(
+            argThat(
+                query -> query.accountId() == 555L && "TX-1".equals(query.transactionReference()))))
+        .thenReturn(
+            Optional.of(
+                new TransactionDetail(
+                    555L,
+                    "TX-1",
+                    TransactionDirection.DEBIT,
+                    TransactionStatus.BOOKED,
+                    5000L,
+                    10000L,
+                    "KRW",
+                    "salary",
+                    "COMPANY",
+                    Instant.parse("2026-04-16T09:00:00Z"),
+                    "ENT-1",
+                    TransactionStatus.BOOKED,
+                    Instant.parse("2026-04-16T09:00:01Z"),
+                    "salary")));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/TX-1")
+                .header("Authorization", "Bearer " + issueToken("user-555", 55L))
+                .param("accountId", "555"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountId").value(555L))
+        .andExpect(jsonPath("$.transactionReference").value("TX-1"))
+        .andExpect(jsonPath("$.entryReference").value("ENT-1"));
+  }
+
+  @Test
+  void rejectsRequestWithoutJwtOrBootstrapHeader() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/transactions/TX-1").param("accountId", "555"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  private String issueToken(String subject, long userId) throws JOSEException {
+    Instant now = Instant.now();
+    JWTClaimsSet claimsSet =
+        new JWTClaimsSet.Builder()
+            .subject(subject)
+            .issueTime(Date.from(now))
+            .expirationTime(Date.from(now.plusSeconds(300)))
+            .claim("user_id", userId)
+            .build();
+
+    SignedJWT signedJwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(), claimsSet);
+    signedJwt.sign(new MACSigner(TEST_SECRET.getBytes(StandardCharsets.UTF_8)));
+    return signedJwt.serialize();
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -124,6 +124,57 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void transactionDetailReturnsAllowedAccountDataAnd404ForMissingReference() throws Exception {
+    String token = login("alice", "password123!");
+
+    MvcResult transferResult =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers")
+                    .header("Authorization", "Bearer " + token)
+                    .header("X-Request-Id", "jwt-detail-request")
+                    .header("Idempotency-Key", "jwt-detail-001")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "targetAccountId": %d,
+                          "amountMinor": 1500,
+                          "currencyCode": "KRW",
+                          "summary": "rent"
+                        }
+                        """
+                            .formatted(allowedSourceAccountId, targetAccountId)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String transactionReference = transactionReference(transferResult);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/%s".formatted(transactionReference))
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountId").value(allowedSourceAccountId))
+        .andExpect(jsonPath("$.transactionReference").value(transactionReference))
+        .andExpect(jsonPath("$.direction").value("DEBIT"))
+        .andExpect(jsonPath("$.transactionStatus").value("BOOKED"))
+        .andExpect(jsonPath("$.entryStatus").value("BOOKED"))
+        .andExpect(jsonPath("$.entryReference").isString())
+        .andExpect(jsonPath("$.summary").value("rent"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/TRX-MISSING-DETAIL")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("transaction detail is not found"));
+  }
+
+  @Test
   void rejectsUnmappedAccountAccess() throws Exception {
     String token = login("alice", "password123!");
 
@@ -161,6 +212,28 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     }
                     """
                         .formatted(deniedAccountId, targetAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
+  @Test
+  void transactionDetailRejectsUnmappedAccountAndBootstrapMismatch() throws Exception {
+    String token = login("alice", "password123!");
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/TRX-DENIED")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(deniedAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/TRX-BOOTSTRAP-MISMATCH")
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account")
+                .param("accountId", String.valueOf(targetAccountId)))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
   }
@@ -478,6 +551,11 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
 
   private String login(String loginId, String password) throws Exception {
     return login(loginId, password, null);
+  }
+
+  private String transactionReference(MvcResult result) throws Exception {
+    JsonNode body = objectMapper.readTree(result.getResponse().getContentAsByteArray());
+    return body.get("transactionReference").asText();
   }
 
   private String login(String loginId, String password, String requestId) throws Exception {

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionDetailControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionDetailControllerTest.java
@@ -1,0 +1,101 @@
+package com.aquilabank.global.web.transaction;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
+import com.aquilabank.domain.transaction.model.TransactionDetail;
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.usecase.TransactionDetailQueryUseCase;
+import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class TransactionDetailControllerTest {
+
+  private TransactionDetailQueryUseCase transactionDetailQueryUseCase;
+  private RequestAccountAuthorizationService requestAccountAuthorizationService;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    transactionDetailQueryUseCase = mock(TransactionDetailQueryUseCase.class);
+    requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new TransactionDetailController(
+                    transactionDetailQueryUseCase, requestAccountAuthorizationService))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
+            .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
+            .build();
+  }
+
+  @Test
+  void returnsTransactionDetail() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(any(), eq(101L)))
+        .thenReturn(101L);
+    when(transactionDetailQueryUseCase.getTransactionDetail(any()))
+        .thenReturn(
+            new TransactionDetail(
+                101L,
+                "TX-101",
+                TransactionDirection.DEBIT,
+                TransactionStatus.BOOKED,
+                1200L,
+                8800L,
+                "KRW",
+                "card payment",
+                "STORE",
+                Instant.parse("2026-04-16T09:00:00Z"),
+                "ENT-101",
+                TransactionStatus.BOOKED,
+                Instant.parse("2026-04-16T09:00:01Z"),
+                "card payment"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/TX-101")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.transactionReference").value("TX-101"))
+        .andExpect(jsonPath("$.transactionStatus").value("BOOKED"))
+        .andExpect(jsonPath("$.entryReference").value("ENT-101"));
+  }
+
+  @Test
+  void returnsNotFoundWhenTransactionDetailIsMissing() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(any(), eq(101L)))
+        .thenReturn(101L);
+    when(transactionDetailQueryUseCase.getTransactionDetail(any()))
+        .thenThrow(new TransactionDetailNotFoundException("transaction detail is not found"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/TX-404")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("transaction detail is not found"));
+  }
+
+  @Test
+  void rejectsMissingAuthenticationHeader() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/transactions/TX-101").param("accountId", "101"))
+        .andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #38

## 📝 Summary
- `GET /api/v1/transactions/{transactionReference}` 상세 조회 endpoint를 추가했습니다.
- 계좌 READ 권한을 먼저 검증한 뒤 `accountId + transactionReference` exact lookup 으로 `transaction_read_model + ledger_entry` 한 건만 응답합니다.

## 🛠 Changes
- 거래 상세 조회용 domain 모델, query, port, use case, not-found 예외를 추가했습니다.
- `ledger_entry.transaction_reference` 시작점의 JDBC exact lookup adapter와 bean wiring을 추가했습니다.
- 상세 controller/response, 404 매핑, controller/JWT/persistence/login-flow 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests com.aquilabank.global.web.transaction.TransactionDetailControllerTest --tests com.aquilabank.global.security.TransactionDetailJwtSecurityIntegrationTest --tests com.aquilabank.global.persistence.transaction.JdbcTransactionDetailRepositoryIntegrationTest --tests com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- `GET /api/v1/transactions/{transactionReference}?accountId={accountId}`
- 응답 필드: `transactionReference`, `accountId`, `direction`, `transactionStatus`, `amountMinor`, `balanceAfterMinor`, `currencyCode`, `summary`, `counterpartyMaskedName`, `bookedAt`, `entryReference`, `entryStatus`, `occurredAt`, `description`

## ⚠️ Risk & Rollback
- 예상 리스크:
  - 같은 계좌에서 동일 `transactionReference` 로 2건 이상 조회되면 `IllegalStateException` 으로 실패합니다.
  - 새 상세 endpoint가 추가되어 보안/권한 순서가 바뀌면 `403/404` 계약이 흔들릴 수 있습니다.
- 롤백 방법:
  - PR revert 시 상세 controller/use case/adapter/test가 함께 제거되고 기존 목록/송금 경로에는 영향이 없습니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.