### PR TITLE
[Feat] 알림 목록/읽음 처리 API 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/notification/exception/NotificationNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.notification.exception;
+
+/** 알림 read 처리 대상이 없거나 접근 범위 밖일 때 not found 로 숨깁니다. */
+public class NotificationNotFoundException extends RuntimeException {
+
+  public NotificationNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationCursor.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationCursor.java
@@ -1,0 +1,16 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** inbox read model 정렬 컬럼으로 만드는 keyset cursor */
+public record NotificationCursor(Instant createdAt, long id) {
+
+  public NotificationCursor {
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt must not be null");
+    }
+    if (id <= 0) {
+      throw new IllegalArgumentException("id must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationListQuery.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationListQuery.java
@@ -1,0 +1,11 @@
+package com.aquilabank.domain.notification.model;
+
+/** 검색/필터 없이 inbox page 한 장만 조회하는 최소 조건 */
+public record NotificationListQuery(int limit, NotificationCursor cursor) {
+
+  public NotificationListQuery {
+    if (limit < 1 || limit > 100) {
+      throw new IllegalArgumentException("limit must be between 1 and 100");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSlice.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSlice.java
@@ -1,0 +1,18 @@
+package com.aquilabank.domain.notification.model;
+
+import java.util.List;
+
+/** 알림 목록 조회 결과 한 page */
+public record NotificationSlice(
+    List<NotificationSummary> items, NotificationCursor nextCursor, boolean hasNext, int limit) {
+
+  public NotificationSlice {
+    items = List.copyOf(items);
+    if (limit < 1 || limit > 100) {
+      throw new IllegalArgumentException("limit must be between 1 and 100");
+    }
+    if (!hasNext && nextCursor != null) {
+      throw new IllegalArgumentException("nextCursor must be null when hasNext is false");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSummary.java
@@ -1,0 +1,13 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** 알림 inbox 목록 응답용 read model projection */
+public record NotificationSummary(
+    long id,
+    long accountId,
+    String eventType,
+    String title,
+    String message,
+    Instant createdAt,
+    Instant readAt) {}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxReadPort.java
@@ -1,0 +1,16 @@
+package com.aquilabank.domain.notification.port;
+
+import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationSlice;
+
+/** user/account inbox read path를 persistence adapter 로 위임합니다. */
+public interface NotificationInboxReadPort {
+
+  NotificationSlice fetchByUserId(long userId, NotificationListQuery query);
+
+  NotificationSlice fetchByAccountId(long accountId, NotificationListQuery query);
+
+  long countUnreadByUserId(long userId);
+
+  long countUnreadByAccountId(long accountId);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxWritePort.java
@@ -1,0 +1,11 @@
+package com.aquilabank.domain.notification.port;
+
+import java.time.Instant;
+
+/** 읽음 처리 같은 inbox 상태 전이를 persistence adapter 로 위임합니다. */
+public interface NotificationInboxWritePort {
+
+  boolean markAsReadByUserId(long userId, long notificationId, Instant readAt);
+
+  boolean markAsReadByAccountId(long accountId, long notificationId, Instant readAt);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationQueryService.java
@@ -1,0 +1,53 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationSlice;
+import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
+
+/** controller 가 principal 별 inbox 조회 차이만 고르고 실제 read 는 port 로 위임합니다. */
+public final class NotificationQueryService implements NotificationQueryUseCase {
+
+  private final NotificationInboxReadPort notificationInboxReadPort;
+
+  public NotificationQueryService(NotificationInboxReadPort notificationInboxReadPort) {
+    this.notificationInboxReadPort = notificationInboxReadPort;
+  }
+
+  @Override
+  public NotificationSlice getNotificationsForUser(long userId, NotificationListQuery query) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (query == null) {
+      throw new IllegalArgumentException("query is required");
+    }
+    return notificationInboxReadPort.fetchByUserId(userId, query);
+  }
+
+  @Override
+  public NotificationSlice getNotificationsForAccount(long accountId, NotificationListQuery query) {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (query == null) {
+      throw new IllegalArgumentException("query is required");
+    }
+    return notificationInboxReadPort.fetchByAccountId(accountId, query);
+  }
+
+  @Override
+  public long getUnreadCountForUser(long userId) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    return notificationInboxReadPort.countUnreadByUserId(userId);
+  }
+
+  @Override
+  public long getUnreadCountForAccount(long accountId) {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    return notificationInboxReadPort.countUnreadByAccountId(accountId);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationQueryUseCase.java
@@ -1,0 +1,15 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationSlice;
+
+public interface NotificationQueryUseCase {
+
+  NotificationSlice getNotificationsForUser(long userId, NotificationListQuery query);
+
+  NotificationSlice getNotificationsForAccount(long accountId, NotificationListQuery query);
+
+  long getUnreadCountForUser(long userId);
+
+  long getUnreadCountForAccount(long accountId);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationReadService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationReadService.java
@@ -1,0 +1,42 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
+import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
+import java.time.Instant;
+
+/** 읽음 처리는 idempotent no-op 을 허용하되 접근 범위 밖 대상은 not found 로 숨깁니다. */
+public final class NotificationReadService implements NotificationReadUseCase {
+
+  private final NotificationInboxWritePort notificationInboxWritePort;
+
+  public NotificationReadService(NotificationInboxWritePort notificationInboxWritePort) {
+    this.notificationInboxWritePort = notificationInboxWritePort;
+  }
+
+  @Override
+  public void markAsReadForUser(long userId, long notificationId) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (notificationId <= 0) {
+      throw new IllegalArgumentException("notificationId must be positive");
+    }
+    if (!notificationInboxWritePort.markAsReadByUserId(userId, notificationId, Instant.now())) {
+      throw new NotificationNotFoundException("notification is not found");
+    }
+  }
+
+  @Override
+  public void markAsReadForAccount(long accountId, long notificationId) {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (notificationId <= 0) {
+      throw new IllegalArgumentException("notificationId must be positive");
+    }
+    if (!notificationInboxWritePort.markAsReadByAccountId(
+        accountId, notificationId, Instant.now())) {
+      throw new NotificationNotFoundException("notification is not found");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationReadUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationReadUseCase.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.notification.usecase;
+
+public interface NotificationReadUseCase {
+
+  void markAsReadForUser(long userId, long notificationId);
+
+  void markAsReadForAccount(long accountId, long notificationId);
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
@@ -1,0 +1,27 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
+import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
+import com.aquilabank.domain.notification.usecase.NotificationQueryService;
+import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
+import com.aquilabank.domain.notification.usecase.NotificationReadService;
+import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** notification inbox read API용 use case wiring */
+@Configuration
+public class NotificationConfiguration {
+
+  @Bean
+  NotificationQueryUseCase notificationQueryUseCase(
+      NotificationInboxReadPort notificationInboxReadPort) {
+    return new NotificationQueryService(notificationInboxReadPort);
+  }
+
+  @Bean
+  NotificationReadUseCase notificationReadUseCase(
+      NotificationInboxWritePort notificationInboxWritePort) {
+    return new NotificationReadService(notificationInboxWritePort);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -1,0 +1,325 @@
+package com.aquilabank.global.persistence.notification;
+
+import com.aquilabank.domain.notification.model.NotificationCursor;
+import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationSlice;
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
+import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** JWT user inbox join 과 bootstrap account inbox exact lookup 을 한 adapter 로 묶습니다. */
+@Repository
+public class JdbcNotificationInboxRepository
+    implements NotificationInboxReadPort, NotificationInboxWritePort {
+
+  private static final RowMapper<NotificationSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcNotificationInboxRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public NotificationSlice fetchByUserId(long userId, NotificationListQuery query) {
+    List<NotificationSummary> rows =
+        query.cursor() == null
+            ? fetchByUserIdFirstPage(userId, query)
+            : fetchByUserIdNextPage(userId, query);
+    return toSlice(rows, query.limit());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public NotificationSlice fetchByAccountId(long accountId, NotificationListQuery query) {
+    List<NotificationSummary> rows =
+        query.cursor() == null
+            ? fetchByAccountIdFirstPage(accountId, query)
+            : fetchByAccountIdNextPage(accountId, query);
+    return toSlice(rows, query.limit());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public long countUnreadByUserId(long userId) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM notification_inbox n
+            JOIN user_account_membership m
+              ON m.account_id = n.account_id
+            JOIN bank_user u
+              ON u.id = m.user_id
+            WHERE m.user_id = :userId
+              AND m.membership_status = 'ACTIVE'
+              AND u.user_status = 'ACTIVE'
+              AND n.read_at IS NULL
+            """,
+            new MapSqlParameterSource().addValue("userId", userId),
+            Long.class);
+    return count == null ? 0L : count;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public long countUnreadByAccountId(long accountId) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM notification_inbox
+            WHERE account_id = :accountId
+              AND read_at IS NULL
+            """,
+            new MapSqlParameterSource().addValue("accountId", accountId),
+            Long.class);
+    return count == null ? 0L : count;
+  }
+
+  @Override
+  @Transactional
+  public boolean markAsReadByUserId(long userId, long notificationId, Instant readAt) {
+    AccessibleNotification notification =
+        jdbcTemplate
+            .query(
+                """
+                SELECT n.account_id, n.read_at
+                FROM notification_inbox n
+                JOIN user_account_membership m
+                  ON m.account_id = n.account_id
+                JOIN bank_user u
+                  ON u.id = m.user_id
+                WHERE n.id = :notificationId
+                  AND m.user_id = :userId
+                  AND m.membership_status = 'ACTIVE'
+                  AND u.user_status = 'ACTIVE'
+                LIMIT 1
+                """,
+                new MapSqlParameterSource()
+                    .addValue("notificationId", notificationId)
+                    .addValue("userId", userId),
+                (rs, rowNum) -> accessibleNotification(rs))
+            .stream()
+            .findFirst()
+            .orElse(null);
+    if (notification == null) {
+      return false;
+    }
+    if (notification.readAt() != null) {
+      return true;
+    }
+    jdbcTemplate.update(
+        """
+        UPDATE notification_inbox
+        SET read_at = :readAt
+        WHERE id = :notificationId
+          AND account_id = :accountId
+          AND read_at IS NULL
+        """,
+        new MapSqlParameterSource()
+            .addValue("readAt", Timestamp.from(readAt))
+            .addValue("notificationId", notificationId)
+            .addValue("accountId", notification.accountId()));
+    return true;
+  }
+
+  @Override
+  @Transactional
+  public boolean markAsReadByAccountId(long accountId, long notificationId, Instant readAt) {
+    AccessibleNotification notification =
+        jdbcTemplate
+            .query(
+                """
+                SELECT account_id, read_at
+                FROM notification_inbox
+                WHERE id = :notificationId
+                  AND account_id = :accountId
+                LIMIT 1
+                """,
+                new MapSqlParameterSource()
+                    .addValue("notificationId", notificationId)
+                    .addValue("accountId", accountId),
+                (rs, rowNum) -> accessibleNotification(rs))
+            .stream()
+            .findFirst()
+            .orElse(null);
+    if (notification == null) {
+      return false;
+    }
+    if (notification.readAt() != null) {
+      return true;
+    }
+    jdbcTemplate.update(
+        """
+        UPDATE notification_inbox
+        SET read_at = :readAt
+        WHERE id = :notificationId
+          AND account_id = :accountId
+          AND read_at IS NULL
+        """,
+        new MapSqlParameterSource()
+            .addValue("readAt", Timestamp.from(readAt))
+            .addValue("notificationId", notificationId)
+            .addValue("accountId", accountId));
+    return true;
+  }
+
+  private NotificationSlice toSlice(List<NotificationSummary> rows, int limit) {
+    boolean hasNext = rows.size() > limit;
+    List<NotificationSummary> items = hasNext ? new ArrayList<>(rows.subList(0, limit)) : rows;
+    NotificationCursor nextCursor = hasNext ? toCursor(items.getLast()) : null;
+    return new NotificationSlice(items, nextCursor, hasNext, limit);
+  }
+
+  private static NotificationSummary mapRow(ResultSet rs) throws SQLException {
+    return new NotificationSummary(
+        rs.getLong("id"),
+        rs.getLong("account_id"),
+        rs.getString("event_type"),
+        rs.getString("title"),
+        rs.getString("message"),
+        rs.getObject("created_at", OffsetDateTime.class).toInstant(),
+        nullableInstant(rs, "read_at"));
+  }
+
+  private AccessibleNotification accessibleNotification(ResultSet rs) throws SQLException {
+    return new AccessibleNotification(rs.getLong("account_id"), nullableInstant(rs, "read_at"));
+  }
+
+  private static NotificationCursor toCursor(NotificationSummary item) {
+    return new NotificationCursor(item.createdAt(), item.id());
+  }
+
+  private static Instant nullableInstant(ResultSet rs, String columnName) throws SQLException {
+    OffsetDateTime value = rs.getObject(columnName, OffsetDateTime.class);
+    return value == null ? null : value.toInstant();
+  }
+
+  private List<NotificationSummary> fetchByUserIdFirstPage(
+      long userId, NotificationListQuery query) {
+    return jdbcTemplate.query(
+        """
+        SELECT n.id,
+               n.account_id,
+               n.event_type,
+               n.title,
+               n.message,
+               n.created_at,
+               n.read_at
+        FROM notification_inbox n
+        JOIN user_account_membership m
+          ON m.account_id = n.account_id
+        JOIN bank_user u
+          ON u.id = m.user_id
+        WHERE m.user_id = :userId
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+        ORDER BY n.created_at DESC, n.id DESC
+        LIMIT :limitPlusOne
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("limitPlusOne", query.limit() + 1),
+        ROW_MAPPER);
+  }
+
+  private List<NotificationSummary> fetchByUserIdNextPage(
+      long userId, NotificationListQuery query) {
+    return jdbcTemplate.query(
+        """
+        SELECT n.id,
+               n.account_id,
+               n.event_type,
+               n.title,
+               n.message,
+               n.created_at,
+               n.read_at
+        FROM notification_inbox n
+        JOIN user_account_membership m
+          ON m.account_id = n.account_id
+        JOIN bank_user u
+          ON u.id = m.user_id
+        WHERE m.user_id = :userId
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+          AND (
+                n.created_at < :cursorCreatedAt
+             OR (n.created_at = :cursorCreatedAt AND n.id < :cursorId)
+              )
+        ORDER BY n.created_at DESC, n.id DESC
+        LIMIT :limitPlusOne
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("limitPlusOne", query.limit() + 1)
+            .addValue("cursorCreatedAt", Timestamp.from(query.cursor().createdAt()))
+            .addValue("cursorId", query.cursor().id()),
+        ROW_MAPPER);
+  }
+
+  private List<NotificationSummary> fetchByAccountIdFirstPage(
+      long accountId, NotificationListQuery query) {
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               account_id,
+               event_type,
+               title,
+               message,
+               created_at,
+               read_at
+        FROM notification_inbox
+        WHERE account_id = :accountId
+        ORDER BY created_at DESC, id DESC
+        LIMIT :limitPlusOne
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("limitPlusOne", query.limit() + 1),
+        ROW_MAPPER);
+  }
+
+  private List<NotificationSummary> fetchByAccountIdNextPage(
+      long accountId, NotificationListQuery query) {
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               account_id,
+               event_type,
+               title,
+               message,
+               created_at,
+               read_at
+        FROM notification_inbox
+        WHERE account_id = :accountId
+          AND (
+                created_at < :cursorCreatedAt
+             OR (created_at = :cursorCreatedAt AND id < :cursorId)
+              )
+        ORDER BY created_at DESC, id DESC
+        LIMIT :limitPlusOne
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("limitPlusOne", query.limit() + 1)
+            .addValue("cursorCreatedAt", Timestamp.from(query.cursor().createdAt()))
+            .addValue("cursorId", query.cursor().id()),
+        ROW_MAPPER);
+  }
+
+  private record AccessibleNotification(long accountId, Instant readAt) {}
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -12,6 +12,7 @@ import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
 import com.aquilabank.domain.ledger.exception.SnapshotNotFoundException;
+import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
 import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
 import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
 import com.aquilabank.global.security.BootstrapHeaderAuthProperties;
@@ -100,6 +101,7 @@ public class ApiExceptionHandler {
     AuthStatusChangeAuditNotFoundException.class,
     AuthUserNotFoundException.class,
     UserAccountMembershipNotFoundException.class,
+    NotificationNotFoundException.class,
     TransactionDetailNotFoundException.class
   })
   ResponseEntity<ApiErrorResponse> handleNotFound(RuntimeException ex, HttpServletRequest request) {

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
@@ -1,0 +1,109 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.NotificationCursor;
+import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
+import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
+import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/** notification inbox 목록, unread count, read 처리 API */
+@Validated
+@RestController
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+  private final NotificationQueryUseCase notificationQueryUseCase;
+  private final NotificationReadUseCase notificationReadUseCase;
+
+  public NotificationController(
+      NotificationQueryUseCase notificationQueryUseCase,
+      NotificationReadUseCase notificationReadUseCase) {
+    this.notificationQueryUseCase = notificationQueryUseCase;
+    this.notificationReadUseCase = notificationReadUseCase;
+  }
+
+  @GetMapping
+  public NotificationQueryResponse getNotifications(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @RequestParam(defaultValue = "20") int limit,
+      @RequestParam(required = false) String cursor) {
+    try {
+      NotificationCursor decodedCursor =
+          cursor == null || cursor.isBlank() ? null : NotificationCursorCodec.decode(cursor);
+      NotificationListQuery query = new NotificationListQuery(limit, decodedCursor);
+      return NotificationQueryResponse.from(resolveNotifications(principal, query));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+
+  @GetMapping("/unread-count")
+  public NotificationUnreadCountResponse getUnreadCount(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal) {
+    try {
+      return new NotificationUnreadCountResponse(resolveUnreadCount(principal));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+
+  @PostMapping("/{notificationId}/read")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void markAsRead(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @PathVariable @Positive(message = "notificationId must be positive") long notificationId) {
+    try {
+      dispatchMarkAsRead(principal, notificationId);
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+
+  private com.aquilabank.domain.notification.model.NotificationSlice resolveNotifications(
+      AuthenticatedRequestPrincipal principal, NotificationListQuery query) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      return notificationQueryUseCase.getNotificationsForUser(userPrincipal.userId(), query);
+    }
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      return notificationQueryUseCase.getNotificationsForAccount(
+          accountPrincipal.accountId(), query);
+    }
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+
+  private long resolveUnreadCount(AuthenticatedRequestPrincipal principal) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      return notificationQueryUseCase.getUnreadCountForUser(userPrincipal.userId());
+    }
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      return notificationQueryUseCase.getUnreadCountForAccount(accountPrincipal.accountId());
+    }
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+
+  private void dispatchMarkAsRead(AuthenticatedRequestPrincipal principal, long notificationId) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      notificationReadUseCase.markAsReadForUser(userPrincipal.userId(), notificationId);
+      return;
+    }
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      notificationReadUseCase.markAsReadForAccount(accountPrincipal.accountId(), notificationId);
+      return;
+    }
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationCursorCodec.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationCursorCodec.java
@@ -1,0 +1,37 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.NotificationCursor;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+/** keyset cursor를 HTTP query string 으로 옮길 때만 쓰는 transport codec */
+public final class NotificationCursorCodec {
+
+  private static final String DELIMITER = "|";
+
+  private NotificationCursorCodec() {}
+
+  public static String encode(NotificationCursor cursor) {
+    String payload = cursor.createdAt().toString() + DELIMITER + cursor.id();
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static NotificationCursor decode(String rawCursor) {
+    try {
+      String decoded =
+          new String(
+              Base64.getUrlDecoder().decode(rawCursor.getBytes(StandardCharsets.UTF_8)),
+              StandardCharsets.UTF_8);
+      String[] tokens = decoded.split("\\|", 2);
+      if (tokens.length != 2) {
+        throw new IllegalArgumentException("cursor format is invalid");
+      }
+      return new NotificationCursor(Instant.parse(tokens[0]), Long.parseLong(tokens[1]));
+    } catch (RuntimeException ex) {
+      throw new IllegalArgumentException("cursor format is invalid", ex);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationQueryResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationQueryResponse.java
@@ -1,0 +1,43 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.NotificationSlice;
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import java.time.Instant;
+import java.util.List;
+
+/** notification inbox 목록 응답 */
+public record NotificationQueryResponse(
+    List<NotificationItemResponse> items, String nextCursor, boolean hasNext, int limit) {
+
+  public static NotificationQueryResponse from(NotificationSlice slice) {
+    return new NotificationQueryResponse(
+        slice.items().stream().map(NotificationItemResponse::from).toList(),
+        slice.nextCursor() == null ? null : NotificationCursorCodec.encode(slice.nextCursor()),
+        slice.hasNext(),
+        slice.limit());
+  }
+
+  /** 클라이언트가 바로 렌더링할 수 있는 flat item shape */
+  public record NotificationItemResponse(
+      long notificationId,
+      long accountId,
+      String eventType,
+      String title,
+      String message,
+      boolean read,
+      Instant createdAt,
+      Instant readAt) {
+
+    static NotificationItemResponse from(NotificationSummary item) {
+      return new NotificationItemResponse(
+          item.id(),
+          item.accountId(),
+          item.eventType(),
+          item.title(),
+          item.message(),
+          item.readAt() != null,
+          item.createdAt(),
+          item.readAt());
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationUnreadCountResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationUnreadCountResponse.java
@@ -1,0 +1,4 @@
+package com.aquilabank.global.web.notification;
+
+/** unread count exact lookup 응답 */
+public record NotificationUnreadCountResponse(long unreadCount) {}

--- a/back/src/main/resources/db/migration/V9__add_notification_inbox.sql
+++ b/back/src/main/resources/db/migration/V9__add_notification_inbox.sql
@@ -1,0 +1,20 @@
+-- notification inbox read model은 consumer 이후 제품 API가 바로 조회할 수 있는 최소 shape 로 둡니다.
+CREATE TABLE notification_inbox (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    account_id BIGINT NOT NULL,
+    event_key VARCHAR(80) NOT NULL,
+    event_type VARCHAR(60) NOT NULL,
+    title VARCHAR(120) NOT NULL,
+    message VARCHAR(280) NOT NULL,
+    read_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_notification_inbox_event_key UNIQUE (event_key),
+    CONSTRAINT fk_notification_inbox_account
+        FOREIGN KEY (account_id) REFERENCES bank_account (id)
+);
+
+CREATE INDEX idx_notification_inbox_account_cursor
+    ON notification_inbox (account_id, created_at DESC, id DESC);
+
+CREATE INDEX idx_notification_inbox_account_unread
+    ON notification_inbox (account_id, read_at, id DESC);

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -1,0 +1,246 @@
+package com.aquilabank.global.persistence.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationSlice;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcNotificationInboxRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void fetchesOnlyAccessibleNotificationsForUser() {
+    long[] userId = new long[1];
+    long[] accountIds = new long[3];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("user-1");
+          accountIds[0] = insertAccount("daily account");
+          accountIds[1] = insertAccount("salary account");
+          accountIds[2] = insertAccount("revoked account");
+          insertMembership(userId[0], accountIds[0], "OWNER", "ACTIVE");
+          insertMembership(userId[0], accountIds[1], "VIEWER", "ACTIVE");
+          insertMembership(userId[0], accountIds[2], "VIEWER", "REVOKED");
+          insertNotification(accountIds[0], "evt-1", "TransferBooked", "입금 1", "첫 알림", null, base);
+          insertNotification(
+              accountIds[1],
+              "evt-2",
+              "TransferBooked",
+              "입금 2",
+              "둘째 알림",
+              null,
+              base.plusSeconds(10));
+          insertNotification(
+              accountIds[2],
+              "evt-3",
+              "TransferBooked",
+              "입금 3",
+              "숨김 알림",
+              null,
+              base.plusSeconds(20));
+        });
+
+    NotificationSlice slice =
+        repository.fetchByUserId(userId[0], new NotificationListQuery(10, null));
+
+    assertThat(slice.items()).hasSize(2);
+    assertThat(slice.items()).extracting("title").containsExactly("입금 2", "입금 1");
+    assertThat(slice.items()).extracting("accountId").containsExactly(accountIds[1], accountIds[0]);
+  }
+
+  @Test
+  void countsUnreadAndMarksAsReadIdempotently() {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[3];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("user-2");
+          accountId[0] = insertAccount("main account");
+          insertMembership(userId[0], accountId[0], "OWNER", "ACTIVE");
+          notificationIds[0] =
+              insertNotification(accountId[0], "evt-10", "TransferBooked", "A", "A", null, base);
+          notificationIds[1] =
+              insertNotification(
+                  accountId[0],
+                  "evt-11",
+                  "TransferBooked",
+                  "B",
+                  "B",
+                  base.plusSeconds(5),
+                  base.plusSeconds(5));
+          notificationIds[2] =
+              insertNotification(
+                  accountId[0], "evt-12", "TransferBooked", "C", "C", null, base.plusSeconds(10));
+        });
+
+    assertThat(repository.countUnreadByUserId(userId[0])).isEqualTo(2L);
+    assertThat(repository.markAsReadByUserId(userId[0], notificationIds[0], base.plusSeconds(30)))
+        .isTrue();
+    assertThat(repository.countUnreadByUserId(userId[0])).isEqualTo(1L);
+    assertThat(repository.markAsReadByUserId(userId[0], notificationIds[0], base.plusSeconds(40)))
+        .isTrue();
+    assertThat(repository.countUnreadByUserId(userId[0])).isEqualTo(1L);
+    assertThat(repository.markAsReadByUserId(userId[0], 99999L, base.plusSeconds(50))).isFalse();
+  }
+
+  private long insertUser(String loginId) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private long insertAccount(String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertMembership(long userId, long accountId, String role, String status) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO user_account_membership (
+            user_id,
+            account_id,
+            membership_role,
+            membership_status,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :accountId,
+            :role,
+            :status,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("accountId", accountId)
+            .addValue("role", role)
+            .addValue("status", status));
+  }
+
+  private long insertNotification(
+      long accountId,
+      String eventKey,
+      String eventType,
+      String title,
+      String message,
+      Instant readAt,
+      Instant createdAt) {
+    Long notificationId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO notification_inbox (
+                account_id,
+                event_key,
+                event_type,
+                title,
+                message,
+                read_at,
+                created_at
+            )
+            VALUES (
+                :accountId,
+                :eventKey,
+                :eventType,
+                :title,
+                :message,
+                :readAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("eventKey", eventKey)
+                .addValue("eventType", eventType)
+                .addValue("title", title)
+                .addValue("message", message)
+                .addValue("readAt", readAt == null ? null : Timestamp.from(readAt))
+                .addValue("createdAt", Timestamp.from(createdAt)),
+            Long.class);
+    if (notificationId == null) {
+      throw new IllegalStateException("notification_inbox insert did not return id");
+    }
+    return notificationId;
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.aquilabank.support.PostgresContainerTestSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,8 +107,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
             get("/api/v1/transactions")
                 .header("Authorization", "Bearer " + token)
                 .param("accountId", String.valueOf(allowedSourceAccountId))
-                .param("from", "2026-04-01T00:00:00Z")
-                .param("to", "2026-04-17T00:00:00Z"))
+                .param("from", transactionQueryFrom())
+                .param("to", transactionQueryTo()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId))
         .andExpect(jsonPath("$.items[0].transactionReference").isString());
@@ -190,8 +191,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
             get("/api/v1/transactions")
                 .header("Authorization", "Bearer " + token)
                 .param("accountId", String.valueOf(deniedAccountId))
-                .param("from", "2026-04-01T00:00:00Z")
-                .param("to", "2026-04-17T00:00:00Z"))
+                .param("from", transactionQueryFrom())
+                .param("to", transactionQueryTo()))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
 
@@ -248,8 +249,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
             get("/api/v1/transactions")
                 .header("Authorization", "Bearer " + token)
                 .param("accountId", String.valueOf(allowedSourceAccountId))
-                .param("from", "2026-04-01T00:00:00Z")
-                .param("to", "2026-04-17T00:00:00Z"))
+                .param("from", transactionQueryFrom())
+                .param("to", transactionQueryTo()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId));
 
@@ -402,8 +403,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
             get("/api/v1/transactions")
                 .header("Authorization", "Bearer " + token)
                 .param("accountId", String.valueOf(allowedSourceAccountId))
-                .param("from", "2026-04-01T00:00:00Z")
-                .param("to", "2026-04-17T00:00:00Z"))
+                .param("from", transactionQueryFrom())
+                .param("to", transactionQueryTo()))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
 
@@ -458,8 +459,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
             get("/api/v1/transactions")
                 .header("Authorization", "Bearer " + token)
                 .param("accountId", String.valueOf(allowedSourceAccountId))
-                .param("from", "2026-04-01T00:00:00Z")
-                .param("to", "2026-04-17T00:00:00Z"))
+                .param("from", transactionQueryFrom())
+                .param("to", transactionQueryTo()))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
 
@@ -810,6 +811,14 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
 
   private Instant toInstant(java.sql.Timestamp timestamp) {
     return timestamp == null ? null : timestamp.toInstant();
+  }
+
+  private String transactionQueryFrom() {
+    return Instant.now().minus(Duration.ofHours(1)).toString();
+  }
+
+  private String transactionQueryTo() {
+    return Instant.now().plus(Duration.ofHours(1)).toString();
   }
 
   private record AuthStatusChangeAuditView(

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
@@ -1,0 +1,278 @@
+package com.aquilabank.global.web.notification;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
+
+  private static final String TEST_SECRET = "test-local-jwt-secret-test-local-jwt-secret";
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void listsUnreadCountAndMarkAsReadForJwtUser() throws Exception {
+    long[] userId = new long[1];
+    long[] accountIds = new long[3];
+    long[] notificationIds = new long[3];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("api-user");
+          accountIds[0] = insertAccount("daily account");
+          accountIds[1] = insertAccount("salary account");
+          accountIds[2] = insertAccount("hidden account");
+          insertMembership(userId[0], accountIds[0], "OWNER", "ACTIVE");
+          insertMembership(userId[0], accountIds[1], "VIEWER", "ACTIVE");
+          insertMembership(userId[0], accountIds[2], "VIEWER", "REVOKED");
+          notificationIds[0] =
+              insertNotification(
+                  accountIds[0], "evt-api-1", "TransferBooked", "첫 알림", "A", null, base);
+          notificationIds[1] =
+              insertNotification(
+                  accountIds[1],
+                  "evt-api-2",
+                  "TransferBooked",
+                  "둘째 알림",
+                  "B",
+                  null,
+                  base.plusSeconds(10));
+          notificationIds[2] =
+              insertNotification(
+                  accountIds[2],
+                  "evt-api-3",
+                  "TransferBooked",
+                  "숨김 알림",
+                  "C",
+                  null,
+                  base.plusSeconds(20));
+        });
+
+    String token = issueToken("user-55", userId[0]);
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].title").value("둘째 알림"))
+        .andExpect(jsonPath("$.items[1].title").value("첫 알림"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(2));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/" + notificationIds[0] + "/read")
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(1));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/" + notificationIds[2] + "/read")
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("notification is not found"));
+  }
+
+  private long insertUser(String loginId) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private long insertAccount(String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertMembership(long userId, long accountId, String role, String status) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO user_account_membership (
+            user_id,
+            account_id,
+            membership_role,
+            membership_status,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :accountId,
+            :role,
+            :status,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("accountId", accountId)
+            .addValue("role", role)
+            .addValue("status", status));
+  }
+
+  private long insertNotification(
+      long accountId,
+      String eventKey,
+      String eventType,
+      String title,
+      String message,
+      Instant readAt,
+      Instant createdAt) {
+    Long notificationId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO notification_inbox (
+                account_id,
+                event_key,
+                event_type,
+                title,
+                message,
+                read_at,
+                created_at
+            )
+            VALUES (
+                :accountId,
+                :eventKey,
+                :eventType,
+                :title,
+                :message,
+                :readAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("eventKey", eventKey)
+                .addValue("eventType", eventType)
+                .addValue("title", title)
+                .addValue("message", message)
+                .addValue("readAt", readAt == null ? null : Timestamp.from(readAt))
+                .addValue("createdAt", Timestamp.from(createdAt)),
+            Long.class);
+    if (notificationId == null) {
+      throw new IllegalStateException("notification_inbox insert did not return id");
+    }
+    return notificationId;
+  }
+
+  private String issueToken(String subject, long userId) throws JOSEException {
+    Instant now = Instant.now();
+    JWTClaimsSet claimsSet =
+        new JWTClaimsSet.Builder()
+            .subject(subject)
+            .issueTime(Date.from(now))
+            .expirationTime(Date.from(now.plusSeconds(300)))
+            .claim("user_id", userId)
+            .build();
+
+    SignedJWT signedJwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(), claimsSet);
+    signedJwt.sign(new MACSigner(TEST_SECRET.getBytes(StandardCharsets.UTF_8)));
+    return signedJwt.serialize();
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -1,0 +1,121 @@
+package com.aquilabank.global.web.notification;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
+import com.aquilabank.domain.notification.model.NotificationCursor;
+import com.aquilabank.domain.notification.model.NotificationSlice;
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
+import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class NotificationControllerTest {
+
+  private NotificationQueryUseCase notificationQueryUseCase;
+  private NotificationReadUseCase notificationReadUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    notificationQueryUseCase = mock(NotificationQueryUseCase.class);
+    notificationReadUseCase = mock(NotificationReadUseCase.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new NotificationController(notificationQueryUseCase, notificationReadUseCase))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
+            .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
+            .build();
+  }
+
+  @Test
+  void returnsNotificationSlice() throws Exception {
+    NotificationCursor nextCursor =
+        new NotificationCursor(Instant.parse("2026-04-17T00:00:00Z"), 9L);
+    when(notificationQueryUseCase.getNotificationsForAccount(anyLong(), any()))
+        .thenReturn(
+            new NotificationSlice(
+                List.of(
+                    new NotificationSummary(
+                        10L,
+                        101L,
+                        "TransferBooked",
+                        "입금 완료",
+                        "급여가 입금되었습니다.",
+                        Instant.parse("2026-04-17T00:10:00Z"),
+                        null)),
+                nextCursor,
+                true,
+                20));
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("X-Account-Id", "101"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].notificationId").value(10L))
+        .andExpect(jsonPath("$.items[0].accountId").value(101L))
+        .andExpect(jsonPath("$.items[0].title").value("입금 완료"))
+        .andExpect(jsonPath("$.items[0].read").value(false))
+        .andExpect(jsonPath("$.hasNext").value(true))
+        .andExpect(jsonPath("$.nextCursor").isString());
+  }
+
+  @Test
+  void returnsUnreadCount() throws Exception {
+    when(notificationQueryUseCase.getUnreadCountForAccount(101L)).thenReturn(3L);
+
+    mockMvc
+        .perform(get("/api/v1/notifications/unread-count").header("X-Account-Id", "101"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(3L));
+  }
+
+  @Test
+  void marksNotificationAsRead() throws Exception {
+    mockMvc
+        .perform(post("/api/v1/notifications/10/read").header("X-Account-Id", "101"))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void returnsNotFoundWhenNotificationIsMissing() throws Exception {
+    doThrow(new NotificationNotFoundException("notification is not found"))
+        .when(notificationReadUseCase)
+        .markAsReadForAccount(eq(101L), eq(999L));
+
+    mockMvc
+        .perform(post("/api/v1/notifications/999/read").header("X-Account-Id", "101"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("notification is not found"));
+  }
+
+  @Test
+  void rejectsInvalidCursor() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/notifications").header("X-Account-Id", "101").param("cursor", "broken"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectsMissingAuthenticationHeader() throws Exception {
+    mockMvc.perform(get("/api/v1/notifications")).andExpect(status().isUnauthorized());
+  }
+}

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -45,6 +45,7 @@ public abstract class PostgresContainerTestSupport {
                         """
                         TRUNCATE TABLE
                             auth_status_change_audit,
+                            notification_inbox,
                             transaction_read_model,
                             ledger_entry,
                             command_idempotency,


### PR DESCRIPTION
## 🔗 Related Issue
- close #40

## 📝 Summary
- consumer 이후 실제 제품 기능을 닫기 위한 최소 notification inbox API를 추가했습니다.
- 알림 목록, unread count, 단건 read 처리만 먼저 열고 검색/필터/bulk action 은 후속 이슈로 분리했습니다.
- 목록과 count 를 분리해 `t3.micro` 기준 읽기 비용과 잠금 범위를 낮췄습니다.

## 🛠 Changes
- notification domain 조회/read 계약, cursor 응답 모델, use case 를 추가했습니다.
- `notification_inbox` read model 스키마와 JDBC list/count/read adapter 를 추가했습니다.
- `GET /api/v1/notifications`, `GET /api/v1/notifications/unread-count`, `POST /api/v1/notifications/{notificationId}/read` 를 추가했습니다.
- JWT user / bootstrap account principal 별 소유 범위 조회와 read idempotency 검증을 추가했습니다.
- 기존 auth integration test 의 UTC 자정 경계 flaky transaction query 범위를 최소 보정했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-notification ./back/gradlew -p back test --tests '*Notification*'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- `GET /api/v1/notifications`
- `GET /api/v1/notifications/unread-count`
- `POST /api/v1/notifications/{notificationId}/read`

## ⚠️ Risk & Rollback
- 예상 리스크: consumer 적재 데이터 shape 가 `notification_inbox` 스키마와 어긋나면 API 는 열려도 실제 알림이 비어 보일 수 있습니다.
- 롤백 방법: PR revert 후 `V9__add_notification_inbox.sql` 반영 전 환경이면 배포 중단, 반영 후 환경이면 API 비노출 상태로 운영하고 후속 migration 으로 정리합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.