### PR TITLE
[Feat] 알림 inbox 적재 consumer 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationInboxEntry.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationInboxEntry.java
@@ -1,0 +1,34 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** notification_inbox 적재용 account-scoped row 모델 */
+public record NotificationInboxEntry(
+    long accountId,
+    String eventKey,
+    String eventType,
+    String title,
+    String message,
+    Instant createdAt) {
+
+  public NotificationInboxEntry {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (eventKey == null || eventKey.isBlank() || eventKey.length() > 80) {
+      throw new IllegalArgumentException("eventKey must be between 1 and 80 characters");
+    }
+    if (eventType == null || eventType.isBlank() || eventType.length() > 60) {
+      throw new IllegalArgumentException("eventType must be between 1 and 60 characters");
+    }
+    if (title == null || title.isBlank() || title.length() > 120) {
+      throw new IllegalArgumentException("title must be between 1 and 120 characters");
+    }
+    if (message == null || message.isBlank() || message.length() > 280) {
+      throw new IllegalArgumentException("message must be between 1 and 280 characters");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt must not be null");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/TransferBookedNotificationCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/TransferBookedNotificationCommand.java
@@ -1,0 +1,48 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** outbox TransferBooked payload를 inbox fan-out 용 command 로 고정합니다. */
+public record TransferBookedNotificationCommand(
+    String eventKey,
+    String transactionReference,
+    long sourceAccountId,
+    long targetAccountId,
+    long amountMinor,
+    String currencyCode,
+    String summary,
+    Instant bookedAt) {
+
+  public TransferBookedNotificationCommand {
+    if (eventKey == null || eventKey.isBlank() || eventKey.length() > 80) {
+      throw new IllegalArgumentException("eventKey must be between 1 and 80 characters");
+    }
+    if (transactionReference == null
+        || transactionReference.isBlank()
+        || transactionReference.length() > 64) {
+      throw new IllegalArgumentException(
+          "transactionReference must be between 1 and 64 characters");
+    }
+    if (sourceAccountId <= 0) {
+      throw new IllegalArgumentException("sourceAccountId must be positive");
+    }
+    if (targetAccountId <= 0) {
+      throw new IllegalArgumentException("targetAccountId must be positive");
+    }
+    if (sourceAccountId == targetAccountId) {
+      throw new IllegalArgumentException("sourceAccountId and targetAccountId must differ");
+    }
+    if (amountMinor <= 0) {
+      throw new IllegalArgumentException("amountMinor must be positive");
+    }
+    if (currencyCode == null || !currencyCode.matches("^[A-Z]{3}$")) {
+      throw new IllegalArgumentException("currencyCode must be a 3-letter uppercase code");
+    }
+    if (summary == null || summary.isBlank() || summary.length() > 120) {
+      throw new IllegalArgumentException("summary must be between 1 and 120 characters");
+    }
+    if (bookedAt == null) {
+      throw new IllegalArgumentException("bookedAt must not be null");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxAppendPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxAppendPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.notification.port;
+
+import com.aquilabank.domain.notification.model.NotificationInboxEntry;
+import java.util.List;
+
+/** consumer 가 만든 account-scoped inbox row 적재를 persistence adapter 로 위임합니다. */
+public interface NotificationInboxAppendPort {
+
+  void appendAllIfAbsent(List<NotificationInboxEntry> items);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestService.java
@@ -1,0 +1,48 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.NotificationInboxEntry;
+import com.aquilabank.domain.notification.model.TransferBookedNotificationCommand;
+import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
+import java.util.List;
+
+/** transfer-level event를 inbox row 두 건으로 fan-out 해 consumer 중복 로직을 막습니다. */
+public final class NotificationInboxIngestService implements NotificationInboxIngestUseCase {
+
+  private static final String TRANSFER_BOOKED = "TransferBooked";
+  private static final String TRANSFER_BOOKED_TITLE = "이체 완료";
+
+  private final NotificationInboxAppendPort notificationInboxAppendPort;
+
+  public NotificationInboxIngestService(NotificationInboxAppendPort notificationInboxAppendPort) {
+    this.notificationInboxAppendPort = notificationInboxAppendPort;
+  }
+
+  @Override
+  public void ingestTransferBooked(TransferBookedNotificationCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+    notificationInboxAppendPort.appendAllIfAbsent(
+        List.of(
+            toEntry(command, command.sourceAccountId(), "출금"),
+            toEntry(command, command.targetAccountId(), "입금")));
+  }
+
+  private NotificationInboxEntry toEntry(
+      TransferBookedNotificationCommand command, long accountId, String directionLabel) {
+    return new NotificationInboxEntry(
+        accountId,
+        accountScopedEventKey(command.eventKey(), accountId),
+        TRANSFER_BOOKED,
+        TRANSFER_BOOKED_TITLE,
+        "%d %s %s · %s"
+            .formatted(
+                command.amountMinor(), command.currencyCode(), directionLabel, command.summary()),
+        command.bookedAt());
+  }
+
+  private String accountScopedEventKey(String eventKey, long accountId) {
+    // 기존 notification_inbox.event_key unique 제약을 재사용하려고 account scope를 suffix로 붙입니다.
+    return eventKey + ":ACCOUNT-" + accountId;
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.TransferBookedNotificationCommand;
+
+/** consumer 가 inbox 적재를 시작할 때 호출하는 use case 진입점 */
+public interface NotificationInboxIngestUseCase {
+
+  void ingestTransferBooked(TransferBookedNotificationCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerConfiguration.java
@@ -1,0 +1,96 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
+import com.aquilabank.domain.notification.usecase.NotificationInboxIngestService;
+import com.aquilabank.domain.notification.usecase.NotificationInboxIngestUseCase;
+import com.aquilabank.global.notification.TransferBookedNotificationConsumer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+/** TransferBooked consumer 와 inbox 적재 use case wiring */
+@Configuration
+@EnableKafka
+@EnableConfigurationProperties(NotificationInboxConsumerProperties.class)
+public class NotificationInboxConsumerConfiguration {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(NotificationInboxConsumerConfiguration.class);
+
+  @Bean
+  NotificationInboxIngestUseCase notificationInboxIngestUseCase(
+      NotificationInboxAppendPort notificationInboxAppendPort) {
+    return new NotificationInboxIngestService(notificationInboxAppendPort);
+  }
+
+  @Bean
+  @Conditional(NotificationInboxKafkaConsumerCondition.class)
+  ConsumerFactory<String, String> notificationInboxConsumerFactory(
+      NotificationInboxConsumerProperties properties) {
+    Map<String, Object> config = new HashMap<>();
+    config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, properties.bootstrapServers());
+    config.put(ConsumerConfig.GROUP_ID_CONFIG, properties.groupId());
+    config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, properties.autoOffsetReset());
+    config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    config.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+    return new DefaultKafkaConsumerFactory<>(config);
+  }
+
+  @Bean
+  @ConditionalOnBean(name = "notificationInboxConsumerFactory")
+  ConcurrentKafkaListenerContainerFactory<String, String>
+      notificationInboxKafkaListenerContainerFactory(
+          ConsumerFactory<String, String> notificationInboxConsumerFactory) {
+    ConcurrentKafkaListenerContainerFactory<String, String> factory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(notificationInboxConsumerFactory);
+    factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+    factory.setCommonErrorHandler(notificationInboxKafkaErrorHandler());
+    return factory;
+  }
+
+  @Bean
+  @ConditionalOnBean(name = "notificationInboxKafkaListenerContainerFactory")
+  TransferBookedNotificationConsumer transferBookedNotificationConsumer(
+      NotificationInboxIngestUseCase notificationInboxIngestUseCase,
+      ObjectMapper objectMapper,
+      NotificationInboxConsumerProperties properties) {
+    log.info(
+        "notification inbox consumer enabled. groupId={}, topic={}",
+        properties.groupId(),
+        properties.transferBooked().topic());
+    return new TransferBookedNotificationConsumer(notificationInboxIngestUseCase, objectMapper);
+  }
+
+  private DefaultErrorHandler notificationInboxKafkaErrorHandler() {
+    // duplicate 외 실패는 skip 하지 않고 listener failure 로 남겨 최소 한 번 전달 전제를 유지합니다.
+    DefaultErrorHandler errorHandler =
+        new DefaultErrorHandler(
+            (record, ex) -> {
+              throw ex instanceof RuntimeException runtimeException
+                  ? runtimeException
+                  : new IllegalStateException("notification inbox consume failed", ex);
+            },
+            new FixedBackOff(0L, 0L));
+    errorHandler.setAckAfterHandle(false);
+    errorHandler.setCommitRecovered(false);
+    return errorHandler;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerProperties.java
@@ -1,0 +1,37 @@
+package com.aquilabank.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/** notification inbox consumer 설정을 outbox producer/poller 와 분리합니다. */
+@ConfigurationProperties(prefix = "notification.inbox.consumer")
+public record NotificationInboxConsumerProperties(
+    boolean enabled,
+    boolean autoStartup,
+    String bootstrapServers,
+    String groupId,
+    String autoOffsetReset,
+    TransferBookedProperties transferBooked) {
+
+  public NotificationInboxConsumerProperties {
+    autoStartup = autoStartup || !enabled;
+    groupId = StringUtils.hasText(groupId) ? groupId : "aquila-bank-notification-inbox-consumer";
+    autoOffsetReset = StringUtils.hasText(autoOffsetReset) ? autoOffsetReset : "earliest";
+    transferBooked = transferBooked == null ? new TransferBookedProperties(null) : transferBooked;
+  }
+
+  public String disabledReason() {
+    if (!enabled) {
+      return "notification.inbox.consumer.enabled=false";
+    }
+    if (!StringUtils.hasText(bootstrapServers)) {
+      return "notification.inbox.consumer.bootstrap-servers is blank";
+    }
+    if (!StringUtils.hasText(transferBooked.topic())) {
+      return "notification.inbox.consumer.transfer-booked.topic is blank";
+    }
+    return "ready";
+  }
+
+  public record TransferBookedProperties(String topic) {}
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxKafkaConsumerCondition.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxKafkaConsumerCondition.java
@@ -1,0 +1,23 @@
+package com.aquilabank.global.config;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+/** 필수 consumer 설정이 있을 때만 Kafka listener bean 을 올려 테스트/로컬 fallback 을 단순화합니다. */
+final class NotificationInboxKafkaConsumerCondition implements Condition {
+
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    return context
+            .getEnvironment()
+            .getProperty("notification.inbox.consumer.enabled", Boolean.class, false)
+        && StringUtils.hasText(
+            context.getEnvironment().getProperty("notification.inbox.consumer.bootstrap-servers"))
+        && StringUtils.hasText(
+            context
+                .getEnvironment()
+                .getProperty("notification.inbox.consumer.transfer-booked.topic"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/TransferBookedNotificationConsumer.java
+++ b/back/src/main/java/com/aquilabank/global/notification/TransferBookedNotificationConsumer.java
@@ -1,0 +1,58 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.TransferBookedNotificationCommand;
+import com.aquilabank.domain.notification.usecase.NotificationInboxIngestUseCase;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+
+/** Kafka payload parsing 은 adapter 에 두고, inbox fan-out 규칙은 domain use case 로 위임합니다. */
+public class TransferBookedNotificationConsumer {
+
+  private final NotificationInboxIngestUseCase notificationInboxIngestUseCase;
+  private final ObjectMapper objectMapper;
+
+  public TransferBookedNotificationConsumer(
+      NotificationInboxIngestUseCase notificationInboxIngestUseCase, ObjectMapper objectMapper) {
+    this.notificationInboxIngestUseCase = notificationInboxIngestUseCase;
+    this.objectMapper = objectMapper;
+  }
+
+  @KafkaListener(
+      id = "transferBookedNotificationConsumer",
+      topics = "${notification.inbox.consumer.transfer-booked.topic}",
+      containerFactory = "notificationInboxKafkaListenerContainerFactory",
+      autoStartup = "${notification.inbox.consumer.auto-startup:true}")
+  public void consume(@Header(KafkaHeaders.RECEIVED_KEY) String eventKey, String payload) {
+    notificationInboxIngestUseCase.ingestTransferBooked(toCommand(eventKey, payload));
+  }
+
+  private TransferBookedNotificationCommand toCommand(String eventKey, String payload) {
+    try {
+      TransferBookedPayload item = objectMapper.readValue(payload, TransferBookedPayload.class);
+      return new TransferBookedNotificationCommand(
+          eventKey,
+          item.transactionReference(),
+          item.sourceAccountId(),
+          item.targetAccountId(),
+          item.amountMinor(),
+          item.currencyCode(),
+          item.summary(),
+          item.bookedAt());
+    } catch (JsonProcessingException ex) {
+      throw new IllegalArgumentException("TransferBooked payload is invalid", ex);
+    }
+  }
+
+  private record TransferBookedPayload(
+      String transactionReference,
+      long sourceAccountId,
+      long targetAccountId,
+      long amountMinor,
+      String currencyCode,
+      String summary,
+      Instant bookedAt) {}
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -1,9 +1,11 @@
 package com.aquilabank.global.persistence.notification;
 
 import com.aquilabank.domain.notification.model.NotificationCursor;
+import com.aquilabank.domain.notification.model.NotificationInboxEntry;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
 import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.domain.notification.model.NotificationSummary;
+import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
 import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
 import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
 import java.sql.ResultSet;
@@ -22,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 /** JWT user inbox join 과 bootstrap account inbox exact lookup 을 한 adapter 로 묶습니다. */
 @Repository
 public class JdbcNotificationInboxRepository
-    implements NotificationInboxReadPort, NotificationInboxWritePort {
+    implements NotificationInboxReadPort, NotificationInboxWritePort, NotificationInboxAppendPort {
 
   private static final RowMapper<NotificationSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
 
@@ -176,6 +178,44 @@ public class JdbcNotificationInboxRepository
             .addValue("notificationId", notificationId)
             .addValue("accountId", accountId));
     return true;
+  }
+
+  @Override
+  @Transactional
+  public void appendAllIfAbsent(List<NotificationInboxEntry> items) {
+    List<NotificationInboxEntry> entries = List.copyOf(items);
+    if (entries.isEmpty()) {
+      throw new IllegalArgumentException("items must not be empty");
+    }
+    for (NotificationInboxEntry item : entries) {
+      jdbcTemplate.update(
+          """
+          INSERT INTO notification_inbox (
+              account_id,
+              event_key,
+              event_type,
+              title,
+              message,
+              created_at
+          )
+          VALUES (
+              :accountId,
+              :eventKey,
+              :eventType,
+              :title,
+              :message,
+              :createdAt
+          )
+          ON CONFLICT (event_key) DO NOTHING
+          """,
+          new MapSqlParameterSource()
+              .addValue("accountId", item.accountId())
+              .addValue("eventKey", item.eventKey())
+              .addValue("eventType", item.eventType())
+              .addValue("title", item.title())
+              .addValue("message", item.message())
+              .addValue("createdAt", Timestamp.from(item.createdAt())));
+    }
   }
 
   private NotificationSlice toSlice(List<NotificationSummary> rows, int limit) {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -95,6 +95,17 @@ outbox:
       enable-idempotence: ${OUTBOX_KAFKA_PRODUCER_ENABLE_IDEMPOTENCE:true}
       max-in-flight-requests-per-connection: ${OUTBOX_KAFKA_PRODUCER_MAX_IN_FLIGHT:1}
 
+notification:
+  inbox:
+    consumer:
+      enabled: ${NOTIFICATION_INBOX_CONSUMER_ENABLED:false}
+      auto-startup: ${NOTIFICATION_INBOX_CONSUMER_AUTO_STARTUP:true}
+      bootstrap-servers: ${NOTIFICATION_INBOX_CONSUMER_BOOTSTRAP_SERVERS:}
+      group-id: ${NOTIFICATION_INBOX_CONSUMER_GROUP_ID:aquila-bank-notification-inbox-consumer}
+      auto-offset-reset: ${NOTIFICATION_INBOX_CONSUMER_AUTO_OFFSET_RESET:earliest}
+      transfer-booked:
+        topic: ${NOTIFICATION_INBOX_CONSUMER_TRANSFER_BOOKED_TOPIC:}
+
 security:
   jwt:
     secret: ${SECURITY_JWT_SECRET}

--- a/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestServiceTest.java
@@ -1,0 +1,52 @@
+package com.aquilabank.domain.notification.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.aquilabank.domain.notification.model.TransferBookedNotificationCommand;
+import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class NotificationInboxIngestServiceTest {
+
+  private NotificationInboxAppendPort notificationInboxAppendPort;
+  private NotificationInboxIngestService notificationInboxIngestService;
+
+  @BeforeEach
+  void setUp() {
+    notificationInboxAppendPort = mock(NotificationInboxAppendPort.class);
+    notificationInboxIngestService =
+        new NotificationInboxIngestService(notificationInboxAppendPort);
+  }
+
+  @Test
+  void fansOutTransferBookedIntoSourceAndTargetInboxRows() {
+    Instant bookedAt = Instant.parse("2026-04-17T00:00:00Z");
+
+    notificationInboxIngestService.ingestTransferBooked(
+        new TransferBookedNotificationCommand(
+            "transfer-booked:TRX-100", "TRX-100", 101L, 202L, 1500L, "KRW", "rent", bookedAt));
+
+    verify(notificationInboxAppendPort)
+        .appendAllIfAbsent(
+            argThat(
+                items -> {
+                  assertThat(items).hasSize(2);
+                  assertThat(items).extracting("accountId").containsExactly(101L, 202L);
+                  assertThat(items)
+                      .extracting("eventKey")
+                      .containsExactly(
+                          "transfer-booked:TRX-100:ACCOUNT-101",
+                          "transfer-booked:TRX-100:ACCOUNT-202");
+                  assertThat(items)
+                      .extracting("message")
+                      .containsExactly("1500 KRW 출금 · rent", "1500 KRW 입금 · rent");
+                  assertThat(items).extracting("createdAt").containsExactly(bookedAt, bookedAt);
+                  return true;
+                }));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/NotificationInboxConsumerConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/NotificationInboxConsumerConfigurationTest.java
@@ -1,0 +1,49 @@
+package com.aquilabank.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class NotificationInboxConsumerConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(NotificationInboxConsumerConfiguration.class)
+          .withBean(
+              NotificationInboxAppendPort.class, () -> mock(NotificationInboxAppendPort.class))
+          .withBean(ObjectMapper.class, ObjectMapper::new);
+
+  @Test
+  void doesNotCreateKafkaConsumerBeansWhenConsumerIsDisabled() {
+    contextRunner
+        .withPropertyValues("notification.inbox.consumer.enabled=false")
+        .run(
+            context -> {
+              assertThat(context)
+                  .hasSingleBean(
+                      com.aquilabank.domain.notification.usecase.NotificationInboxIngestUseCase
+                          .class);
+              assertThat(context).doesNotHaveBean("notificationInboxConsumerFactory");
+              assertThat(context).doesNotHaveBean("transferBookedNotificationConsumer");
+            });
+  }
+
+  @Test
+  void createsKafkaConsumerBeansWhenRequiredPropertiesArePresent() {
+    contextRunner
+        .withPropertyValues(
+            "notification.inbox.consumer.enabled=true",
+            "notification.inbox.consumer.bootstrap-servers=localhost:9092",
+            "notification.inbox.consumer.transfer-booked.topic=bank.transfer.booked.v1")
+        .run(
+            context -> {
+              assertThat(context).hasBean("notificationInboxConsumerFactory");
+              assertThat(context).hasBean("notificationInboxKafkaListenerContainerFactory");
+              assertThat(context).hasBean("transferBookedNotificationConsumer");
+            });
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/notification/TransferBookedNotificationConsumerTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/TransferBookedNotificationConsumerTest.java
@@ -1,0 +1,59 @@
+package com.aquilabank.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.aquilabank.domain.notification.usecase.NotificationInboxIngestUseCase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TransferBookedNotificationConsumerTest {
+
+  private NotificationInboxIngestUseCase notificationInboxIngestUseCase;
+  private TransferBookedNotificationConsumer consumer;
+
+  @BeforeEach
+  void setUp() {
+    notificationInboxIngestUseCase = mock(NotificationInboxIngestUseCase.class);
+    ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    consumer = new TransferBookedNotificationConsumer(notificationInboxIngestUseCase, objectMapper);
+  }
+
+  @Test
+  void parsesPayloadAndDelegatesToUseCase() {
+    consumer.consume(
+        "transfer-booked:TRX-100",
+        """
+        {
+          "transactionReference": "TRX-100",
+          "sourceAccountId": 101,
+          "targetAccountId": 202,
+          "amountMinor": 1500,
+          "currencyCode": "KRW",
+          "summary": "rent",
+          "bookedAt": "2026-04-17T00:00:00Z"
+        }
+        """);
+
+    verify(notificationInboxIngestUseCase)
+        .ingestTransferBooked(
+            argThat(
+                command ->
+                    "transfer-booked:TRX-100".equals(command.eventKey())
+                        && "TRX-100".equals(command.transactionReference())
+                        && command.sourceAccountId() == 101L
+                        && command.targetAccountId() == 202L
+                        && command.amountMinor() == 1500L));
+  }
+
+  @Test
+  void throwsWhenPayloadIsInvalid() {
+    assertThatThrownBy(() -> consumer.consume("transfer-booked:TRX-100", "{"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("TransferBooked payload is invalid");
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -2,11 +2,13 @@ package com.aquilabank.global.persistence.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.aquilabank.domain.notification.model.NotificationInboxEntry;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
 import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.support.PostgresContainerTestSupport;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -109,6 +111,54 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
         .isTrue();
     assertThat(repository.countUnreadByUserId(userId[0])).isEqualTo(1L);
     assertThat(repository.markAsReadByUserId(userId[0], 99999L, base.plusSeconds(50))).isFalse();
+  }
+
+  @Test
+  void appendsTransferBookedRowsIdempotently() {
+    long[] accountIds = new long[2];
+    Instant createdAt = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          accountIds[0] = insertAccount("source account");
+          accountIds[1] = insertAccount("target account");
+          repository.appendAllIfAbsent(
+              List.of(
+                  new NotificationInboxEntry(
+                      accountIds[0],
+                      "transfer-booked:TRX-200:ACCOUNT-" + accountIds[0],
+                      "TransferBooked",
+                      "이체 완료",
+                      "1500 KRW 출금 · rent",
+                      createdAt),
+                  new NotificationInboxEntry(
+                      accountIds[1],
+                      "transfer-booked:TRX-200:ACCOUNT-" + accountIds[1],
+                      "TransferBooked",
+                      "이체 완료",
+                      "1500 KRW 입금 · rent",
+                      createdAt)));
+          repository.appendAllIfAbsent(
+              List.of(
+                  new NotificationInboxEntry(
+                      accountIds[0],
+                      "transfer-booked:TRX-200:ACCOUNT-" + accountIds[0],
+                      "TransferBooked",
+                      "이체 완료",
+                      "1500 KRW 출금 · rent",
+                      createdAt),
+                  new NotificationInboxEntry(
+                      accountIds[1],
+                      "transfer-booked:TRX-200:ACCOUNT-" + accountIds[1],
+                      "TransferBooked",
+                      "이체 완료",
+                      "1500 KRW 입금 · rent",
+                      createdAt)));
+        });
+
+    assertThat(totalNotifications()).isEqualTo(2L);
+    assertThat(findNotificationMessages())
+        .containsExactlyInAnyOrder("1500 KRW 출금 · rent", "1500 KRW 입금 · rent");
   }
 
   private long insertUser(String loginId) {
@@ -242,5 +292,23 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
       throw new IllegalStateException("notification_inbox insert did not return id");
     }
     return notificationId;
+  }
+
+  private long totalNotifications() {
+    Long count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM notification_inbox", new MapSqlParameterSource(), Long.class);
+    return count == null ? 0L : count;
+  }
+
+  private List<String> findNotificationMessages() {
+    return jdbcTemplate.query(
+        """
+        SELECT message
+        FROM notification_inbox
+        ORDER BY id
+        """,
+        new MapSqlParameterSource(),
+        (rs, rowNum) -> rs.getString("message"));
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #42

## 📝 Summary
- `TransferBooked` Kafka consumer 를 추가해 기존 `notification_inbox` read model 로 알림을 적재합니다.
- 최소 한 번 전달 전제를 유지하기 위해 duplicate 는 `event_key + account scope` 기반으로 no-op 처리하고, 일반 실패는 listener failure 로 남깁니다.

## 🛠 Changes
- transfer event 를 source/target account inbox row 두 건으로 fan-out 하는 domain 적재 계약을 추가했습니다.
- `JdbcNotificationInboxRepository` 에 `ON CONFLICT (event_key) DO NOTHING` 기반 idempotent append 경로를 추가했습니다.
- consumer 설정, listener bean, fan-out/idempotency/config/repository 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests com.aquilabank.domain.notification.usecase.NotificationInboxIngestServiceTest --tests com.aquilabank.global.notification.TransferBookedNotificationConsumerTest --tests com.aquilabank.global.config.NotificationInboxConsumerConfigurationTest --tests com.aquilabank.global.persistence.notification.JdbcNotificationInboxRepositoryIntegrationTest`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- N/A

## ⚠️ Risk & Rollback
- 예상 리스크:
  - inbox row key 파생 규칙이 바뀌면 duplicate no-op 이 깨질 수 있습니다.
  - listener error handler 설정이 바뀌면 일반 실패를 skip 해 최소 한 번 전달 전제가 흔들릴 수 있습니다.
- 롤백 방법:
  - PR revert 시 consumer/config/domain append 경로만 제거되고 기존 notification API/read path 는 유지됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.