### PR TITLE
[Chore] outbox/알림 운영 회수 경로와 health 기준 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -394,6 +394,93 @@ tools/ops/internal-auth-find-status-change-audit.sh \
 - wrapper script 내부에서 exact lookup endpoint, `X-Auth-Bootstrap-Token`, `requestId` query를 고정합니다.
 - failure 원본은 structured log이므로 incident 시작점은 항상 로그 검색입니다.
 
+## Outbox Ops Runbook
+
+Kafka producer 를 붙인 이후 outbox backlog 는 actuator health 와 내부 ops 경로를 같이 봐야 복구 판단이 빨라집니다.
+
+- 내부 ops endpoint:
+  - `GET /internal/api/v1/outbox/summary`
+  - `GET /internal/api/v1/outbox/failed-events?limit=<n>`
+  - `POST /internal/api/v1/outbox/recovery/stale-sending`
+- health endpoint:
+  - `GET /actuator/health`
+
+### 준비할 env
+
+```bash
+OUTBOX_OPS_ENABLED=true
+OUTBOX_OPS_TOKEN_HEADER=X-Outbox-Ops-Token
+OUTBOX_OPS_TOKEN=dev-outbox-ops-token
+OUTBOX_OPS_FAILED_LIST_LIMIT=20
+OUTBOX_OPS_HEALTH_MAX_LAG_SECONDS=120
+OUTBOX_OPS_HEALTH_MAX_FAILED_COUNT=10
+OUTBOX_OPS_HEALTH_MAX_STALE_SENDING_COUNT=0
+```
+
+### 예시 스크립트
+
+failed backlog 조회:
+
+```bash
+tools/ops/outbox-find-failed-events.sh \
+  http://localhost:8080 \
+  "$OUTBOX_OPS_TOKEN" \
+  20
+```
+
+stale `SENDING` 수동 회수:
+
+```bash
+tools/ops/outbox-recover-stale-sending.sh \
+  http://localhost:8080 \
+  "$OUTBOX_OPS_TOKEN"
+```
+
+### 직접 호출 예시
+
+summary 조회:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  --get \
+  --header "X-Outbox-Ops-Token: ${OUTBOX_OPS_TOKEN}" \
+  "http://localhost:8080/internal/api/v1/outbox/summary"
+```
+
+health 확인:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  --get \
+  "http://localhost:8080/actuator/health"
+```
+
+### health 상태 해석
+
+- `UP`: `lagSeconds`, `failedCount`, `staleSendingCount` 가 모두 설정 임계값 이하다.
+- `OUT_OF_SERVICE`: outbox backlog 가 임계값을 넘었고 `/actuator/health` 는 `503`으로 내려간다.
+- `OUT_OF_SERVICE` 여도 앱 전체 장애와 동일시하지 말고 먼저 `/internal/api/v1/outbox/summary` 로 lag/failure/stale 축 중 어떤 값이 넘었는지 확인한다.
+
+### 기본 triage 순서
+
+1. `/actuator/health` 가 `503`이면 `/internal/api/v1/outbox/summary` 를 조회해 `lagSeconds`, `failedCount`, `staleSendingCount` 중 초과 축을 확인합니다.
+2. `failedCount` 가 크면 `tools/ops/outbox-find-failed-events.sh` 로 bounded failed list 를 보고 `eventKey`, `retryCount`, `lastError` 를 먼저 확인합니다.
+3. `staleSendingCount` 가 0보다 크면 `tools/ops/outbox-recover-stale-sending.sh` 를 한 번만 호출하고, 응답의 `recoveredCount` 와 이후 summary 변화를 확인합니다.
+4. recovery 이후에도 `lagSeconds` 또는 `failedCount` 가 계속 증가하면 broker 연결, Kafka topic 설정, consumer 적재 지연을 별도 incident 로 분리합니다.
+
+### 운영 주의사항
+
+- stale recovery 는 직접 publish 가 아니라 stale `SENDING` row 를 `PENDING` 으로 되돌리는 동작입니다.
+- recovery 대상은 `outbox.poller.stale-after-seconds` 를 넘긴 row 만 포함합니다.
+- failed list 는 `availableAt ASC, id ASC` 순서의 bounded query 이므로, 대량 backlog 에서도 즉시 재시도 대상부터 확인할 수 있습니다.
+- `lastError` 는 outbox table 의 짧은 힌트만 남기므로, 상세 stack trace 는 앱 로그와 Kafka client 로그를 같이 봐야 합니다.
+
+### rollback 기준
+
+- 운영에서 내부 ops 경로를 임시 차단해야 하면 `OUTBOX_OPS_ENABLED=false` 로 내려 endpoint 노출만 끕니다.
+- 수동 recovery 가 과도하게 반복되면 더 이상 반복 호출하지 말고 poller 자동 reclaim 과 broker 장애 복구를 먼저 확인합니다.
+- 이 runbook 경로는 outbox schema 나 payload 를 수정하지 않으므로, rollback 은 endpoint 비활성화와 PR revert 로 제한합니다.
+
 ## Test
 
 ```bash

--- a/back/src/main/java/com/aquilabank/domain/notification/model/OutboxFailedEvent.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/OutboxFailedEvent.java
@@ -1,0 +1,15 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** 운영자가 failed backlog 를 확인할 때 필요한 최소 outbox row 스냅샷 */
+public record OutboxFailedEvent(
+    long id,
+    String aggregateType,
+    String aggregateId,
+    String eventType,
+    String eventKey,
+    int retryCount,
+    Instant availableAt,
+    Instant updatedAt,
+    String lastError) {}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/OutboxOpsSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/OutboxOpsSummary.java
@@ -1,0 +1,28 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/** health 와 운영 triage 가 같은 기준을 보도록 lag/stale/failed 핵심 값만 묶습니다. */
+public record OutboxOpsSummary(
+    Instant observedAt,
+    Instant oldestDispatchableAt,
+    Duration oldestDispatchLag,
+    long failedCount,
+    long staleSendingCount) {
+
+  public OutboxOpsSummary {
+    if (observedAt == null) {
+      throw new IllegalArgumentException("observedAt is required");
+    }
+    if (oldestDispatchLag == null || oldestDispatchLag.isNegative()) {
+      throw new IllegalArgumentException("oldestDispatchLag must not be negative");
+    }
+    if (failedCount < 0) {
+      throw new IllegalArgumentException("failedCount must not be negative");
+    }
+    if (staleSendingCount < 0) {
+      throw new IllegalArgumentException("staleSendingCount must not be negative");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/OutboxStaleRecoveryResult.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/OutboxStaleRecoveryResult.java
@@ -1,0 +1,21 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/** 수동 회수 결과를 로그/응답/runbook 에 같은 형태로 남기기 위한 값 객체 */
+public record OutboxStaleRecoveryResult(
+    Instant recoveredAt, Duration staleAfter, int recoveredCount) {
+
+  public OutboxStaleRecoveryResult {
+    if (recoveredAt == null) {
+      throw new IllegalArgumentException("recoveredAt is required");
+    }
+    if (staleAfter == null || staleAfter.isNegative() || staleAfter.isZero()) {
+      throw new IllegalArgumentException("staleAfter must be positive");
+    }
+    if (recoveredCount < 0) {
+      throw new IllegalArgumentException("recoveredCount must not be negative");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/OutboxOpsReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/OutboxOpsReadPort.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.notification.port;
+
+import com.aquilabank.domain.notification.model.OutboxFailedEvent;
+import com.aquilabank.domain.notification.model.OutboxOpsSummary;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+public interface OutboxOpsReadPort {
+
+  List<OutboxFailedEvent> findFailedEvents(int limit);
+
+  OutboxOpsSummary getSummary(Duration staleAfter, Instant observedAt);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/OutboxOpsRecoveryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/OutboxOpsRecoveryPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.notification.port;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public interface OutboxOpsRecoveryPort {
+
+  int recoverStaleSending(Duration staleAfter, Instant recoveredAt);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxOpsQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxOpsQueryService.java
@@ -1,0 +1,39 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.OutboxFailedEvent;
+import com.aquilabank.domain.notification.model.OutboxOpsSummary;
+import com.aquilabank.domain.notification.port.OutboxOpsReadPort;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+/** stale 기준을 use case 에 고정해 controller 와 health 가 같은 summary 를 공유합니다. */
+public final class OutboxOpsQueryService implements OutboxOpsQueryUseCase {
+
+  private final OutboxOpsReadPort outboxOpsReadPort;
+  private final Duration staleAfter;
+
+  public OutboxOpsQueryService(OutboxOpsReadPort outboxOpsReadPort, Duration staleAfter) {
+    if (outboxOpsReadPort == null) {
+      throw new IllegalArgumentException("outboxOpsReadPort is required");
+    }
+    if (staleAfter == null || staleAfter.isNegative() || staleAfter.isZero()) {
+      throw new IllegalArgumentException("staleAfter must be positive");
+    }
+    this.outboxOpsReadPort = outboxOpsReadPort;
+    this.staleAfter = staleAfter;
+  }
+
+  @Override
+  public List<OutboxFailedEvent> getFailedEvents(int limit) {
+    if (limit <= 0) {
+      throw new IllegalArgumentException("limit must be positive");
+    }
+    return outboxOpsReadPort.findFailedEvents(limit);
+  }
+
+  @Override
+  public OutboxOpsSummary getSummary() {
+    return outboxOpsReadPort.getSummary(staleAfter, Instant.now());
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxOpsQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxOpsQueryUseCase.java
@@ -1,0 +1,12 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.OutboxFailedEvent;
+import com.aquilabank.domain.notification.model.OutboxOpsSummary;
+import java.util.List;
+
+public interface OutboxOpsQueryUseCase {
+
+  List<OutboxFailedEvent> getFailedEvents(int limit);
+
+  OutboxOpsSummary getSummary();
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxOpsRecoveryService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxOpsRecoveryService.java
@@ -1,0 +1,32 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.OutboxStaleRecoveryResult;
+import com.aquilabank.domain.notification.port.OutboxOpsRecoveryPort;
+import java.time.Duration;
+import java.time.Instant;
+
+/** 직접 publish 대신 stale row 를 dispatch queue 로 되돌리는 수동 회수 진입점 */
+public final class OutboxOpsRecoveryService implements OutboxOpsRecoveryUseCase {
+
+  private final OutboxOpsRecoveryPort outboxOpsRecoveryPort;
+  private final Duration staleAfter;
+
+  public OutboxOpsRecoveryService(
+      OutboxOpsRecoveryPort outboxOpsRecoveryPort, Duration staleAfter) {
+    if (outboxOpsRecoveryPort == null) {
+      throw new IllegalArgumentException("outboxOpsRecoveryPort is required");
+    }
+    if (staleAfter == null || staleAfter.isNegative() || staleAfter.isZero()) {
+      throw new IllegalArgumentException("staleAfter must be positive");
+    }
+    this.outboxOpsRecoveryPort = outboxOpsRecoveryPort;
+    this.staleAfter = staleAfter;
+  }
+
+  @Override
+  public OutboxStaleRecoveryResult recoverStaleSending() {
+    Instant now = Instant.now();
+    int recoveredCount = outboxOpsRecoveryPort.recoverStaleSending(staleAfter, now);
+    return new OutboxStaleRecoveryResult(now, staleAfter, recoveredCount);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxOpsRecoveryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxOpsRecoveryUseCase.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.OutboxStaleRecoveryResult;
+
+public interface OutboxOpsRecoveryUseCase {
+
+  OutboxStaleRecoveryResult recoverStaleSending();
+}

--- a/back/src/main/java/com/aquilabank/global/config/OutboxConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/OutboxConfiguration.java
@@ -2,10 +2,17 @@ package com.aquilabank.global.config;
 
 import com.aquilabank.domain.notification.port.OutboxEventPublishPort;
 import com.aquilabank.domain.notification.port.OutboxEventStore;
+import com.aquilabank.domain.notification.port.OutboxOpsReadPort;
+import com.aquilabank.domain.notification.port.OutboxOpsRecoveryPort;
 import com.aquilabank.domain.notification.usecase.OutboxDispatchService;
 import com.aquilabank.domain.notification.usecase.OutboxDispatchUseCase;
+import com.aquilabank.domain.notification.usecase.OutboxOpsQueryService;
+import com.aquilabank.domain.notification.usecase.OutboxOpsQueryUseCase;
+import com.aquilabank.domain.notification.usecase.OutboxOpsRecoveryService;
+import com.aquilabank.domain.notification.usecase.OutboxOpsRecoveryUseCase;
 import com.aquilabank.global.notification.KafkaOutboxEventPublisher;
 import com.aquilabank.global.notification.LoggingOutboxEventPublisher;
+import com.aquilabank.global.notification.OutboxHealthIndicator;
 import com.aquilabank.global.notification.OutboxTopicResolver;
 import java.time.Duration;
 import java.util.HashMap;
@@ -17,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -29,7 +37,11 @@ import org.springframework.util.ClassUtils;
 /** Spring adapter와 scheduler를 domain outbox use case에 연결 */
 @Configuration
 @EnableScheduling
-@EnableConfigurationProperties({OutboxProperties.class, OutboxKafkaProperties.class})
+@EnableConfigurationProperties({
+  OutboxProperties.class,
+  OutboxKafkaProperties.class,
+  OutboxOpsProperties.class
+})
 public class OutboxConfiguration {
 
   private static final Logger log = LoggerFactory.getLogger(OutboxConfiguration.class);
@@ -46,6 +58,26 @@ public class OutboxConfiguration {
         outboxProperties.batchSize(),
         Duration.ofSeconds(outboxProperties.staleAfterSeconds()),
         Duration.ofSeconds(outboxProperties.maxRetryDelaySeconds()));
+  }
+
+  @Bean
+  OutboxOpsQueryUseCase outboxOpsQueryUseCase(
+      OutboxOpsReadPort outboxOpsReadPort, OutboxProperties outboxProperties) {
+    return new OutboxOpsQueryService(
+        outboxOpsReadPort, Duration.ofSeconds(outboxProperties.staleAfterSeconds()));
+  }
+
+  @Bean
+  OutboxOpsRecoveryUseCase outboxOpsRecoveryUseCase(
+      OutboxOpsRecoveryPort outboxOpsRecoveryPort, OutboxProperties outboxProperties) {
+    return new OutboxOpsRecoveryService(
+        outboxOpsRecoveryPort, Duration.ofSeconds(outboxProperties.staleAfterSeconds()));
+  }
+
+  @Bean
+  HealthIndicator outboxHealthIndicator(
+      OutboxOpsQueryUseCase outboxOpsQueryUseCase, OutboxOpsProperties outboxOpsProperties) {
+    return new OutboxHealthIndicator(outboxOpsQueryUseCase, outboxOpsProperties.health());
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/config/OutboxOpsProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/OutboxOpsProperties.java
@@ -1,0 +1,42 @@
+package com.aquilabank.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** 내부 outbox ops 경로 보호값과 health 기준을 poller/Kafka 설정과 분리합니다. */
+@ConfigurationProperties(prefix = "outbox.ops")
+public record OutboxOpsProperties(
+    boolean enabled, String tokenHeader, String token, int failedListLimit, Health health) {
+
+  public OutboxOpsProperties {
+    if (tokenHeader == null || tokenHeader.isBlank()) {
+      throw new IllegalArgumentException("outbox.ops.token-header must not be blank");
+    }
+    if (enabled && (token == null || token.isBlank())) {
+      throw new IllegalArgumentException("outbox.ops.token must not be blank when enabled");
+    }
+    if (failedListLimit <= 0) {
+      throw new IllegalArgumentException("outbox.ops.failed-list-limit must be positive");
+    }
+    if (health == null) {
+      throw new IllegalArgumentException("outbox.ops.health is required");
+    }
+  }
+
+  public record Health(long maxLagSeconds, long maxFailedCount, long maxStaleSendingCount) {
+
+    public Health {
+      if (maxLagSeconds < 0) {
+        throw new IllegalArgumentException(
+            "outbox.ops.health.max-lag-seconds must not be negative");
+      }
+      if (maxFailedCount < 0) {
+        throw new IllegalArgumentException(
+            "outbox.ops.health.max-failed-count must not be negative");
+      }
+      if (maxStaleSendingCount < 0) {
+        throw new IllegalArgumentException(
+            "outbox.ops.health.max-stale-sending-count must not be negative");
+      }
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/OutboxHealthIndicator.java
+++ b/back/src/main/java/com/aquilabank/global/notification/OutboxHealthIndicator.java
@@ -1,0 +1,56 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.OutboxOpsSummary;
+import com.aquilabank.domain.notification.usecase.OutboxOpsQueryUseCase;
+import com.aquilabank.global.config.OutboxOpsProperties;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.boot.health.contributor.Status;
+
+/** 외부 health 는 상태 신호만 주고 상세 drill-down 은 내부 ops 경로로 분리합니다. */
+public final class OutboxHealthIndicator implements HealthIndicator {
+
+  private final OutboxOpsQueryUseCase outboxOpsQueryUseCase;
+  private final OutboxOpsProperties.Health healthProperties;
+
+  public OutboxHealthIndicator(
+      OutboxOpsQueryUseCase outboxOpsQueryUseCase, OutboxOpsProperties.Health healthProperties) {
+    this.outboxOpsQueryUseCase = outboxOpsQueryUseCase;
+    this.healthProperties = healthProperties;
+  }
+
+  @Override
+  public Health health() {
+    try {
+      OutboxOpsSummary summary = outboxOpsQueryUseCase.getSummary();
+      long lagSeconds = summary.oldestDispatchLag().toSeconds();
+      boolean lagExceeded = lagSeconds > healthProperties.maxLagSeconds();
+      boolean failedExceeded = summary.failedCount() > healthProperties.maxFailedCount();
+      boolean staleExceeded = summary.staleSendingCount() > healthProperties.maxStaleSendingCount();
+      List<String> reasons = new ArrayList<>();
+      if (lagExceeded) {
+        reasons.add("lag");
+      }
+      if (failedExceeded) {
+        reasons.add("failed");
+      }
+      if (staleExceeded) {
+        reasons.add("staleSending");
+      }
+      Health.Builder builder =
+          reasons.isEmpty() ? Health.up() : Health.status(Status.OUT_OF_SERVICE);
+      return builder
+          .withDetail("observedAt", summary.observedAt())
+          .withDetail("oldestDispatchableAt", summary.oldestDispatchableAt())
+          .withDetail("lagSeconds", lagSeconds)
+          .withDetail("failedCount", summary.failedCount())
+          .withDetail("staleSendingCount", summary.staleSendingCount())
+          .withDetail("reasons", reasons)
+          .build();
+    } catch (RuntimeException ex) {
+      return Health.down(ex).build();
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcOutboxOpsRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcOutboxOpsRepository.java
@@ -1,0 +1,139 @@
+package com.aquilabank.global.persistence.notification;
+
+import com.aquilabank.domain.notification.model.OutboxFailedEvent;
+import com.aquilabank.domain.notification.model.OutboxOpsSummary;
+import com.aquilabank.domain.notification.port.OutboxOpsReadPort;
+import com.aquilabank.domain.notification.port.OutboxOpsRecoveryPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** outbox ops 조회와 stale recovery 를 같은 JDBC adapter 로 묶어 기준 drift 를 줄입니다. */
+@Repository
+public class JdbcOutboxOpsRepository implements OutboxOpsReadPort, OutboxOpsRecoveryPort {
+
+  private static final RowMapper<OutboxFailedEvent> FAILED_EVENT_ROW_MAPPER =
+      (rs, rowNum) -> mapFailedEvent(rs);
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcOutboxOpsRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<OutboxFailedEvent> findFailedEvents(int limit) {
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               aggregate_type,
+               aggregate_id,
+               event_type,
+               event_key,
+               retry_count,
+               available_at,
+               updated_at,
+               last_error
+        FROM outbox_event
+        WHERE publish_status = 'FAILED'
+        ORDER BY available_at ASC, id ASC
+        LIMIT :limit
+        """,
+        new MapSqlParameterSource().addValue("limit", limit),
+        FAILED_EVENT_ROW_MAPPER);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public OutboxOpsSummary getSummary(Duration staleAfter, Instant observedAt) {
+    SummaryRow row =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT (
+                       SELECT MIN(available_at)
+                       FROM outbox_event
+                       WHERE publish_status IN ('PENDING', 'FAILED')
+                         AND available_at <= :observedAt
+                   ) AS oldest_dispatchable_at,
+                   (
+                       SELECT COUNT(*)
+                       FROM outbox_event
+                       WHERE publish_status = 'FAILED'
+                   ) AS failed_count,
+                   (
+                       SELECT COUNT(*)
+                       FROM outbox_event
+                       WHERE publish_status = 'SENDING'
+                         AND updated_at <= :staleCutoff
+                   ) AS stale_sending_count
+            """,
+            new MapSqlParameterSource()
+                .addValue("observedAt", Timestamp.from(observedAt))
+                .addValue("staleCutoff", Timestamp.from(observedAt.minus(staleAfter))),
+            (rs, rowNum) ->
+                new SummaryRow(
+                    nullableInstant(rs, "oldest_dispatchable_at"),
+                    rs.getLong("failed_count"),
+                    rs.getLong("stale_sending_count")));
+    if (row == null) {
+      throw new IllegalStateException("outbox ops summary query returned null");
+    }
+    Duration lag =
+        row.oldestDispatchableAt() == null
+            ? Duration.ZERO
+            : Duration.between(row.oldestDispatchableAt(), observedAt);
+    if (lag.isNegative()) {
+      lag = Duration.ZERO;
+    }
+    return new OutboxOpsSummary(
+        observedAt, row.oldestDispatchableAt(), lag, row.failedCount(), row.staleSendingCount());
+  }
+
+  @Override
+  @Transactional
+  public int recoverStaleSending(Duration staleAfter, Instant recoveredAt) {
+    return jdbcTemplate.update(
+        """
+        UPDATE outbox_event
+        SET publish_status = 'PENDING',
+            available_at = :recoveredAt,
+            updated_at = :recoveredAt
+        WHERE publish_status = 'SENDING'
+          AND updated_at <= :staleCutoff
+        """,
+        new MapSqlParameterSource()
+            .addValue("recoveredAt", Timestamp.from(recoveredAt))
+            .addValue("staleCutoff", Timestamp.from(recoveredAt.minus(staleAfter))));
+  }
+
+  private static OutboxFailedEvent mapFailedEvent(ResultSet rs) throws SQLException {
+    return new OutboxFailedEvent(
+        rs.getLong("id"),
+        rs.getString("aggregate_type"),
+        rs.getString("aggregate_id"),
+        rs.getString("event_type"),
+        rs.getString("event_key"),
+        rs.getInt("retry_count"),
+        rs.getObject("available_at", OffsetDateTime.class).toInstant(),
+        rs.getObject("updated_at", OffsetDateTime.class).toInstant(),
+        rs.getString("last_error"));
+  }
+
+  private static Instant nullableInstant(ResultSet rs, String columnName) throws SQLException {
+    OffsetDateTime value = rs.getObject(columnName, OffsetDateTime.class);
+    return value == null ? null : value.toInstant();
+  }
+
+  private record SummaryRow(
+      Instant oldestDispatchableAt, long failedCount, long staleSendingCount) {}
+}

--- a/back/src/main/java/com/aquilabank/global/security/OutboxOpsTokenGuard.java
+++ b/back/src/main/java/com/aquilabank/global/security/OutboxOpsTokenGuard.java
@@ -1,0 +1,23 @@
+package com.aquilabank.global.security;
+
+import com.aquilabank.global.config.OutboxOpsProperties;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+/** 내부 outbox ops 경로는 단순 shared token 규칙으로만 보호합니다. */
+@Component
+public class OutboxOpsTokenGuard {
+
+  private final OutboxOpsProperties outboxOpsProperties;
+
+  public OutboxOpsTokenGuard(OutboxOpsProperties outboxOpsProperties) {
+    this.outboxOpsProperties = outboxOpsProperties;
+  }
+
+  public void validate(HttpServletRequest request) {
+    String token = request.getHeader(outboxOpsProperties.tokenHeader());
+    if (token == null || token.isBlank() || !outboxOpsProperties.token().equals(token)) {
+      throw new BootstrapApiAccessDeniedException("outbox ops token is invalid");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -63,6 +63,8 @@ public class SecurityConfiguration {
                     // 내부 bootstrap API는 JWT 대신 별도 shared token으로 보호합니다.
                     .requestMatchers("/internal/api/v1/accounts/bootstrap")
                     .permitAll()
+                    .requestMatchers("/internal/api/v1/outbox/**")
+                    .permitAll()
                     .requestMatchers("/internal/api/v1/auth/**")
                     .permitAll()
                     .anyRequest()

--- a/back/src/main/java/com/aquilabank/global/web/notification/OutboxFailedEventListResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/OutboxFailedEventListResponse.java
@@ -1,0 +1,39 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.OutboxFailedEvent;
+import java.time.Instant;
+import java.util.List;
+
+/** 내부 ops 에서 bounded failed backlog 를 그대로 보여주는 응답 */
+public record OutboxFailedEventListResponse(List<OutboxFailedEventItemResponse> items, int limit) {
+
+  public static OutboxFailedEventListResponse from(List<OutboxFailedEvent> items, int limit) {
+    return new OutboxFailedEventListResponse(
+        items.stream().map(OutboxFailedEventItemResponse::from).toList(), limit);
+  }
+
+  public record OutboxFailedEventItemResponse(
+      long id,
+      String aggregateType,
+      String aggregateId,
+      String eventType,
+      String eventKey,
+      int retryCount,
+      Instant availableAt,
+      Instant updatedAt,
+      String lastError) {
+
+    static OutboxFailedEventItemResponse from(OutboxFailedEvent item) {
+      return new OutboxFailedEventItemResponse(
+          item.id(),
+          item.aggregateType(),
+          item.aggregateId(),
+          item.eventType(),
+          item.eventKey(),
+          item.retryCount(),
+          item.availableAt(),
+          item.updatedAt(),
+          item.lastError());
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/OutboxOpsController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/OutboxOpsController.java
@@ -1,0 +1,64 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.usecase.OutboxOpsQueryUseCase;
+import com.aquilabank.domain.notification.usecase.OutboxOpsRecoveryUseCase;
+import com.aquilabank.global.config.OutboxOpsProperties;
+import com.aquilabank.global.security.OutboxOpsTokenGuard;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** outbox backlog 조회와 stale recovery 를 운영 전용 내부 surface 로 묶습니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/outbox")
+@ConditionalOnProperty(name = "outbox.ops.enabled", havingValue = "true")
+public class OutboxOpsController {
+
+  private final OutboxOpsQueryUseCase outboxOpsQueryUseCase;
+  private final OutboxOpsRecoveryUseCase outboxOpsRecoveryUseCase;
+  private final OutboxOpsTokenGuard outboxOpsTokenGuard;
+  private final OutboxOpsProperties outboxOpsProperties;
+
+  public OutboxOpsController(
+      OutboxOpsQueryUseCase outboxOpsQueryUseCase,
+      OutboxOpsRecoveryUseCase outboxOpsRecoveryUseCase,
+      OutboxOpsTokenGuard outboxOpsTokenGuard,
+      OutboxOpsProperties outboxOpsProperties) {
+    this.outboxOpsQueryUseCase = outboxOpsQueryUseCase;
+    this.outboxOpsRecoveryUseCase = outboxOpsRecoveryUseCase;
+    this.outboxOpsTokenGuard = outboxOpsTokenGuard;
+    this.outboxOpsProperties = outboxOpsProperties;
+  }
+
+  @GetMapping("/summary")
+  public OutboxOpsSummaryResponse getSummary(HttpServletRequest request) {
+    outboxOpsTokenGuard.validate(request);
+    return OutboxOpsSummaryResponse.from(outboxOpsQueryUseCase.getSummary());
+  }
+
+  @GetMapping("/failed-events")
+  public OutboxFailedEventListResponse getFailedEvents(
+      HttpServletRequest request,
+      @RequestParam(required = false) @Positive(message = "limit must be positive") Integer limit) {
+    outboxOpsTokenGuard.validate(request);
+    int resolvedLimit =
+        limit == null
+            ? outboxOpsProperties.failedListLimit()
+            : Math.min(limit, outboxOpsProperties.failedListLimit());
+    return OutboxFailedEventListResponse.from(
+        outboxOpsQueryUseCase.getFailedEvents(resolvedLimit), resolvedLimit);
+  }
+
+  @PostMapping("/recovery/stale-sending")
+  public OutboxStaleRecoveryResponse recoverStaleSending(HttpServletRequest request) {
+    outboxOpsTokenGuard.validate(request);
+    return OutboxStaleRecoveryResponse.from(outboxOpsRecoveryUseCase.recoverStaleSending());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/OutboxOpsSummaryResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/OutboxOpsSummaryResponse.java
@@ -1,0 +1,22 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.OutboxOpsSummary;
+import java.time.Instant;
+
+/** health 가 DOWN 일 때 운영자가 바로 확인할 핵심 summary 응답 */
+public record OutboxOpsSummaryResponse(
+    Instant observedAt,
+    Instant oldestDispatchableAt,
+    long lagSeconds,
+    long failedCount,
+    long staleSendingCount) {
+
+  public static OutboxOpsSummaryResponse from(OutboxOpsSummary summary) {
+    return new OutboxOpsSummaryResponse(
+        summary.observedAt(),
+        summary.oldestDispatchableAt(),
+        summary.oldestDispatchLag().toSeconds(),
+        summary.failedCount(),
+        summary.staleSendingCount());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/OutboxStaleRecoveryResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/OutboxStaleRecoveryResponse.java
@@ -1,0 +1,14 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.OutboxStaleRecoveryResult;
+import java.time.Instant;
+
+/** stale recovery 는 직접 publish 가 아니라 재진입 건수만 응답합니다. */
+public record OutboxStaleRecoveryResponse(
+    Instant recoveredAt, long staleAfterSeconds, int recoveredCount) {
+
+  public static OutboxStaleRecoveryResponse from(OutboxStaleRecoveryResult result) {
+    return new OutboxStaleRecoveryResponse(
+        result.recoveredAt(), result.staleAfter().toSeconds(), result.recoveredCount());
+  }
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -94,6 +94,15 @@ outbox:
       acks: ${OUTBOX_KAFKA_PRODUCER_ACKS:all}
       enable-idempotence: ${OUTBOX_KAFKA_PRODUCER_ENABLE_IDEMPOTENCE:true}
       max-in-flight-requests-per-connection: ${OUTBOX_KAFKA_PRODUCER_MAX_IN_FLIGHT:1}
+  ops:
+    enabled: ${OUTBOX_OPS_ENABLED:false}
+    token-header: ${OUTBOX_OPS_TOKEN_HEADER:X-Outbox-Ops-Token}
+    token: ${OUTBOX_OPS_TOKEN:}
+    failed-list-limit: ${OUTBOX_OPS_FAILED_LIST_LIMIT:20}
+    health:
+      max-lag-seconds: ${OUTBOX_OPS_HEALTH_MAX_LAG_SECONDS:120}
+      max-failed-count: ${OUTBOX_OPS_HEALTH_MAX_FAILED_COUNT:10}
+      max-stale-sending-count: ${OUTBOX_OPS_HEALTH_MAX_STALE_SENDING_COUNT:0}
 
 notification:
   inbox:

--- a/back/src/test/java/com/aquilabank/global/config/OutboxConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/OutboxConfigurationTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.mock;
 
 import com.aquilabank.domain.notification.port.OutboxEventPublishPort;
 import com.aquilabank.domain.notification.port.OutboxEventStore;
+import com.aquilabank.domain.notification.port.OutboxOpsReadPort;
+import com.aquilabank.domain.notification.port.OutboxOpsRecoveryPort;
 import com.aquilabank.global.notification.KafkaOutboxEventPublisher;
 import com.aquilabank.global.notification.LoggingOutboxEventPublisher;
 import org.junit.jupiter.api.Test;
@@ -16,13 +18,21 @@ class OutboxConfigurationTest {
       new ApplicationContextRunner()
           .withUserConfiguration(OutboxConfiguration.class)
           .withBean(OutboxEventStore.class, () -> mock(OutboxEventStore.class))
+          .withBean(OutboxOpsReadPort.class, () -> mock(OutboxOpsReadPort.class))
+          .withBean(OutboxOpsRecoveryPort.class, () -> mock(OutboxOpsRecoveryPort.class))
           .withPropertyValues(
               "outbox.poller.enabled=false",
               "outbox.poller.fixed-delay-ms=1000",
               "outbox.poller.initial-delay-ms=3000",
               "outbox.poller.batch-size=20",
               "outbox.poller.stale-after-seconds=30",
-              "outbox.poller.max-retry-delay-seconds=60");
+              "outbox.poller.max-retry-delay-seconds=60",
+              "outbox.ops.enabled=false",
+              "outbox.ops.token-header=X-Outbox-Ops-Token",
+              "outbox.ops.failed-list-limit=20",
+              "outbox.ops.health.max-lag-seconds=120",
+              "outbox.ops.health.max-failed-count=10",
+              "outbox.ops.health.max-stale-sending-count=0");
 
   @Test
   void usesLoggingFallbackWhenKafkaIsDisabled() {

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcOutboxOpsRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcOutboxOpsRepositoryIntegrationTest.java
@@ -1,0 +1,232 @@
+package com.aquilabank.global.persistence.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.notification.model.OutboxFailedEvent;
+import com.aquilabank.domain.notification.model.OutboxOpsSummary;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcOutboxOpsRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcOutboxOpsRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void returnsFailedEventsInDispatchOrder() {
+    Instant base = Instant.parse("2026-04-17T01:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          insertOutboxEvent("evt-pending", "PENDING", 0, null, base.plusSeconds(5), base);
+          insertOutboxEvent("evt-failed-1", "FAILED", 1, "broker down", base.plusSeconds(10), base);
+          insertOutboxEvent(
+              "evt-failed-2", "FAILED", 2, "timeout", base.plusSeconds(2), base.plusSeconds(1));
+          insertOutboxEvent(
+              "evt-failed-3",
+              "FAILED",
+              3,
+              "serialization",
+              base.plusSeconds(30),
+              base.plusSeconds(2));
+        });
+
+    List<OutboxFailedEvent> items = repository.findFailedEvents(2);
+
+    assertThat(items).hasSize(2);
+    assertThat(items)
+        .extracting(OutboxFailedEvent::eventKey)
+        .containsExactly("evt-failed-2", "evt-failed-1");
+    assertThat(items)
+        .extracting(OutboxFailedEvent::lastError)
+        .containsExactly("timeout", "broker down");
+  }
+
+  @Test
+  void summarizesDispatchableLagFailedCountAndStaleSendingCount() {
+    Instant observedAt = Instant.parse("2026-04-17T01:00:30Z");
+    commit(
+        transactionManager,
+        () -> {
+          insertOutboxEvent(
+              "evt-pending-old",
+              "PENDING",
+              0,
+              null,
+              observedAt.minusSeconds(20),
+              observedAt.minusSeconds(40));
+          insertOutboxEvent(
+              "evt-failed-now",
+              "FAILED",
+              2,
+              "timeout",
+              observedAt.minusSeconds(10),
+              observedAt.minusSeconds(20));
+          insertOutboxEvent(
+              "evt-failed-future",
+              "FAILED",
+              3,
+              "retry later",
+              observedAt.plusSeconds(30),
+              observedAt.minusSeconds(5));
+          insertOutboxEvent(
+              "evt-sending-stale",
+              "SENDING",
+              1,
+              null,
+              observedAt.minusSeconds(15),
+              observedAt.minusSeconds(40));
+          insertOutboxEvent(
+              "evt-sending-fresh",
+              "SENDING",
+              1,
+              null,
+              observedAt.minusSeconds(5),
+              observedAt.minusSeconds(10));
+        });
+
+    OutboxOpsSummary summary = repository.getSummary(Duration.ofSeconds(30), observedAt);
+
+    assertThat(summary.oldestDispatchableAt()).isEqualTo(observedAt.minusSeconds(20));
+    assertThat(summary.oldestDispatchLag()).isEqualTo(Duration.ofSeconds(20));
+    assertThat(summary.failedCount()).isEqualTo(2L);
+    assertThat(summary.staleSendingCount()).isEqualTo(1L);
+  }
+
+  @Test
+  void recoversOnlyStaleSendingRowsToPending() {
+    Instant recoveredAt = Instant.parse("2026-04-17T01:10:00Z");
+    long[] ids = new long[3];
+    commit(
+        transactionManager,
+        () -> {
+          ids[0] =
+              insertOutboxEvent(
+                  "evt-sending-stale-1",
+                  "SENDING",
+                  1,
+                  null,
+                  recoveredAt.minusSeconds(20),
+                  recoveredAt.minusSeconds(50));
+          ids[1] =
+              insertOutboxEvent(
+                  "evt-sending-fresh",
+                  "SENDING",
+                  1,
+                  null,
+                  recoveredAt.minusSeconds(10),
+                  recoveredAt.minusSeconds(5));
+          ids[2] =
+              insertOutboxEvent(
+                  "evt-failed",
+                  "FAILED",
+                  2,
+                  "broker down",
+                  recoveredAt.minusSeconds(30),
+                  recoveredAt.minusSeconds(60));
+        });
+
+    int recoveredCount = repository.recoverStaleSending(Duration.ofSeconds(30), recoveredAt);
+
+    assertThat(recoveredCount).isEqualTo(1);
+    assertThat(findStatus(ids[0])).isEqualTo("PENDING");
+    assertThat(findAvailableAt(ids[0])).isEqualTo(recoveredAt);
+    assertThat(findUpdatedAt(ids[0])).isEqualTo(recoveredAt);
+    assertThat(findStatus(ids[1])).isEqualTo("SENDING");
+    assertThat(findStatus(ids[2])).isEqualTo("FAILED");
+  }
+
+  private long insertOutboxEvent(
+      String eventKey,
+      String publishStatus,
+      int retryCount,
+      String lastError,
+      Instant availableAt,
+      Instant updatedAt) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO outbox_event (
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                event_key,
+                payload,
+                publish_status,
+                available_at,
+                retry_count,
+                last_error,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                'TRANSFER',
+                'TRX-' || right(:eventKey, 3),
+                'TransferBooked',
+                :eventKey,
+                '{"transactionReference":"seed"}'::jsonb,
+                :publishStatus,
+                :availableAt,
+                :retryCount,
+                :lastError,
+                :updatedAt,
+                :updatedAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("eventKey", eventKey)
+                .addValue("publishStatus", publishStatus)
+                .addValue("availableAt", Timestamp.from(availableAt))
+                .addValue("retryCount", retryCount)
+                .addValue("lastError", lastError)
+                .addValue("updatedAt", Timestamp.from(updatedAt)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("outbox_event insert did not return id");
+    }
+    return id;
+  }
+
+  private String findStatus(long id) {
+    return jdbcTemplate.queryForObject(
+        "SELECT publish_status FROM outbox_event WHERE id = :id",
+        new MapSqlParameterSource().addValue("id", id),
+        String.class);
+  }
+
+  private Instant findAvailableAt(long id) {
+    return jdbcTemplate.queryForObject(
+        "SELECT available_at FROM outbox_event WHERE id = :id",
+        new MapSqlParameterSource().addValue("id", id),
+        (rs, rowNum) -> rs.getTimestamp("available_at").toInstant());
+  }
+
+  private Instant findUpdatedAt(long id) {
+    return jdbcTemplate.queryForObject(
+        "SELECT updated_at FROM outbox_event WHERE id = :id",
+        new MapSqlParameterSource().addValue("id", id),
+        (rs, rowNum) -> rs.getTimestamp("updated_at").toInstant());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/notification/OutboxOpsApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/OutboxOpsApiIntegrationTest.java
@@ -1,0 +1,217 @@
+package com.aquilabank.global.web.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      "spring.flyway.enabled=true",
+      "management.health.db.enabled=true",
+      "outbox.ops.enabled=true",
+      "outbox.ops.token-header=X-Outbox-Ops-Token",
+      "outbox.ops.token=test-outbox-ops-token",
+      "outbox.ops.failed-list-limit=2",
+      "outbox.ops.health.max-lag-seconds=15",
+      "outbox.ops.health.max-failed-count=1",
+      "outbox.ops.health.max-stale-sending-count=0"
+    })
+class OutboxOpsApiIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void returnsSummaryAndFailedEventsWithoutJwtWhenOpsTokenMatches() throws Exception {
+    Instant base = Instant.now();
+    commit(
+        transactionManager,
+        () -> {
+          insertOutboxEvent(
+              "evt-pending-old", "PENDING", 0, null, base.minusSeconds(20), base.minusSeconds(40));
+          insertOutboxEvent(
+              "evt-failed-1",
+              "FAILED",
+              1,
+              "broker down",
+              base.minusSeconds(5),
+              base.minusSeconds(15));
+          insertOutboxEvent(
+              "evt-failed-2", "FAILED", 2, "timeout", base.plusSeconds(30), base.minusSeconds(10));
+        });
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/outbox/summary")
+                .header("X-Outbox-Ops-Token", "test-outbox-ops-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.failedCount").value(2))
+        .andExpect(jsonPath("$.staleSendingCount").value(0))
+        .andExpect(jsonPath("$.lagSeconds", greaterThanOrEqualTo(20)));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/outbox/failed-events")
+                .header("X-Outbox-Ops-Token", "test-outbox-ops-token")
+                .param("limit", "5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.limit").value(2))
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].eventKey").value("evt-failed-1"))
+        .andExpect(jsonPath("$.items[1].eventKey").value("evt-failed-2"));
+  }
+
+  @Test
+  void recoversStaleSendingRows() throws Exception {
+    Instant base = Instant.now();
+    long[] ids = new long[2];
+    commit(
+        transactionManager,
+        () -> {
+          ids[0] =
+              insertOutboxEvent(
+                  "evt-sending-stale",
+                  "SENDING",
+                  1,
+                  null,
+                  base.minusSeconds(5),
+                  base.minusSeconds(50));
+          ids[1] =
+              insertOutboxEvent(
+                  "evt-sending-fresh",
+                  "SENDING",
+                  1,
+                  null,
+                  base.minusSeconds(5),
+                  base.minusSeconds(10));
+        });
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/outbox/recovery/stale-sending")
+                .header("X-Outbox-Ops-Token", "test-outbox-ops-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.recoveredCount").value(1))
+        .andExpect(jsonPath("$.staleAfterSeconds").value(30));
+
+    assertThat(findStatus(ids[0])).isEqualTo("PENDING");
+    assertThat(findStatus(ids[1])).isEqualTo("SENDING");
+  }
+
+  @Test
+  void rejectsMissingOpsToken() throws Exception {
+    mockMvc
+        .perform(get("/internal/api/v1/outbox/summary"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("outbox ops token is invalid"));
+  }
+
+  @Test
+  void degradesActuatorHealthWhenOutboxThresholdIsExceeded() throws Exception {
+    Instant base = Instant.now();
+    commit(
+        transactionManager,
+        () -> {
+          insertOutboxEvent(
+              "evt-pending-old", "PENDING", 0, null, base.minusSeconds(20), base.minusSeconds(40));
+          insertOutboxEvent(
+              "evt-sending-stale", "SENDING", 1, null, base.minusSeconds(5), base.minusSeconds(50));
+        });
+
+    mockMvc
+        .perform(get("/actuator/health"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.status").value("OUT_OF_SERVICE"));
+  }
+
+  private long insertOutboxEvent(
+      String eventKey,
+      String publishStatus,
+      int retryCount,
+      String lastError,
+      Instant availableAt,
+      Instant updatedAt) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO outbox_event (
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                event_key,
+                payload,
+                publish_status,
+                available_at,
+                retry_count,
+                last_error,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                'TRANSFER',
+                'TRX-' || right(:eventKey, 3),
+                'TransferBooked',
+                :eventKey,
+                '{"transactionReference":"seed"}'::jsonb,
+                :publishStatus,
+                :availableAt,
+                :retryCount,
+                :lastError,
+                :updatedAt,
+                :updatedAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("eventKey", eventKey)
+                .addValue("publishStatus", publishStatus)
+                .addValue("availableAt", Timestamp.from(availableAt))
+                .addValue("retryCount", retryCount)
+                .addValue("lastError", lastError)
+                .addValue("updatedAt", Timestamp.from(updatedAt)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("outbox_event insert did not return id");
+    }
+    return id;
+  }
+
+  private String findStatus(long id) {
+    return jdbcTemplate.queryForObject(
+        "SELECT publish_status FROM outbox_event WHERE id = :id",
+        new MapSqlParameterSource().addValue("id", id),
+        String.class);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/notification/OutboxOpsScriptSmokeSupport.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/OutboxOpsScriptSmokeSupport.java
@@ -1,0 +1,177 @@
+package com.aquilabank.global.web.notification;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/** fake curl 로 실제 네트워크 없이 outbox ops script argv 만 캡처합니다. */
+final class OutboxOpsScriptSmokeSupport {
+
+  static final ScriptSpec FAILED_EVENTS_SPEC =
+      new ScriptSpec(
+          "outbox-failed-events",
+          repoRoot().resolve("tools/ops/outbox-find-failed-events.sh"),
+          "usage: tools/ops/outbox-find-failed-events.sh",
+          List.of("http://localhost:8080", "test-outbox-ops-token", "20"),
+          List.of(
+              "--fail-with-body",
+              "--silent",
+              "--show-error",
+              "--get",
+              "--header",
+              "X-Outbox-Ops-Token: test-outbox-ops-token",
+              "--data-urlencode",
+              "limit=20",
+              "http://localhost:8080/internal/api/v1/outbox/failed-events"),
+          List.of(
+              "tools/ops/outbox-find-failed-events.sh \\",
+              "http://localhost:8080 \\",
+              "\"$OUTBOX_OPS_TOKEN\" \\",
+              "\"X-Outbox-Ops-Token: ${OUTBOX_OPS_TOKEN}\"",
+              "\"http://localhost:8080/internal/api/v1/outbox/summary\"",
+              "\"http://localhost:8080/actuator/health\"",
+              "OUT_OF_SERVICE",
+              "503"));
+
+  static final ScriptSpec RECOVER_STALE_SENDING_SPEC =
+      new ScriptSpec(
+          "outbox-recover-stale-sending",
+          repoRoot().resolve("tools/ops/outbox-recover-stale-sending.sh"),
+          "usage: tools/ops/outbox-recover-stale-sending.sh",
+          List.of("http://localhost:8080", "test-outbox-ops-token"),
+          List.of(
+              "--fail-with-body",
+              "--silent",
+              "--show-error",
+              "--request",
+              "POST",
+              "--header",
+              "X-Outbox-Ops-Token: test-outbox-ops-token",
+              "http://localhost:8080/internal/api/v1/outbox/recovery/stale-sending"),
+          List.of(
+              "tools/ops/outbox-recover-stale-sending.sh \\",
+              "http://localhost:8080 \\",
+              "\"$OUTBOX_OPS_TOKEN\"",
+              "stale `SENDING` row 를 `PENDING` 으로 되돌리는",
+              "`OUTBOX_OPS_ENABLED=false`"));
+
+  private static final Duration SCRIPT_TIMEOUT = Duration.ofSeconds(5);
+
+  private OutboxOpsScriptSmokeSupport() {}
+
+  static ScriptResult run(Path tempDir, ScriptSpec spec, List<String> args)
+      throws IOException, InterruptedException {
+    Path fakeCurlDir = Files.createDirectories(tempDir.resolve("fake-bin"));
+    Path fakeCurlArgsFile = tempDir.resolve(spec.name() + "-curl-args.bin");
+    writeFakeCurl(fakeCurlDir.resolve("curl"), fakeCurlArgsFile);
+
+    ProcessBuilder processBuilder =
+        new ProcessBuilder(buildCommand(spec.scriptPath().toString(), args));
+    processBuilder.directory(repoRoot().toFile());
+    processBuilder.environment().put("PATH", fakeCurlDir + pathSeparator() + currentPath());
+    processBuilder.environment().put("FAKE_CURL_ARGS_FILE", fakeCurlArgsFile.toString());
+
+    Process process = processBuilder.start();
+    boolean finished = process.waitFor(SCRIPT_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+    if (!finished) {
+      process.destroyForcibly();
+      throw new IllegalStateException("script execution timed out: " + spec.name());
+    }
+
+    return new ScriptResult(
+        process.exitValue(),
+        new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8),
+        new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8),
+        readCapturedArgs(fakeCurlArgsFile));
+  }
+
+  static String readReadme() throws IOException {
+    return Files.readString(repoRoot().resolve("back/README.md"), StandardCharsets.UTF_8);
+  }
+
+  private static List<String> buildCommand(String scriptPath, List<String> args) {
+    List<String> command = new java.util.ArrayList<>();
+    command.add("bash");
+    command.add(scriptPath);
+    command.addAll(args);
+    return command;
+  }
+
+  private static List<String> readCapturedArgs(Path fakeCurlArgsFile) throws IOException {
+    if (!Files.exists(fakeCurlArgsFile)) {
+      return List.of();
+    }
+    String raw = Files.readString(fakeCurlArgsFile, StandardCharsets.UTF_8);
+    if (raw.isEmpty()) {
+      return List.of();
+    }
+    String[] parts = raw.split("\n", -1);
+    int size = raw.endsWith("\n") ? parts.length - 1 : parts.length;
+    return List.of(parts).subList(0, size);
+  }
+
+  private static void writeFakeCurl(Path fakeCurlPath, Path fakeCurlArgsFile) throws IOException {
+    String script =
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        : "${FAKE_CURL_ARGS_FILE:?}"
+        : > "${FAKE_CURL_ARGS_FILE}"
+        for arg in "$@"; do
+          printf '%s\n' "$arg" >> "${FAKE_CURL_ARGS_FILE}"
+        done
+        exit 0
+        """;
+    Files.writeString(fakeCurlPath, script, StandardCharsets.UTF_8);
+    try {
+      Files.setPosixFilePermissions(
+          fakeCurlPath,
+          Set.of(
+              PosixFilePermission.OWNER_READ,
+              PosixFilePermission.OWNER_WRITE,
+              PosixFilePermission.OWNER_EXECUTE));
+    } catch (UnsupportedOperationException ignored) {
+      fakeCurlPath.toFile().setExecutable(true);
+    }
+    if (Files.notExists(fakeCurlArgsFile)) {
+      Files.createFile(fakeCurlArgsFile);
+    }
+  }
+
+  private static Path repoRoot() {
+    Path current = Path.of("").toAbsolutePath().normalize();
+    if (Files.exists(current.resolve("back/README.md"))) {
+      return current;
+    }
+    Path parent = current.getParent();
+    if (parent != null && Files.exists(parent.resolve("back/README.md"))) {
+      return parent;
+    }
+    throw new IllegalStateException("repo root is not found from " + current);
+  }
+
+  private static String currentPath() {
+    String path = System.getenv("PATH");
+    return path == null ? "" : path;
+  }
+
+  private static String pathSeparator() {
+    return System.getProperty("path.separator");
+  }
+
+  record ScriptSpec(
+      String name,
+      Path scriptPath,
+      String usagePrefix,
+      List<String> args,
+      List<String> expectedCurlArgs,
+      List<String> requiredReadmeSnippets) {}
+
+  record ScriptResult(int exitCode, String stdout, String stderr, List<String> curlArgs) {}
+}

--- a/back/src/test/java/com/aquilabank/global/web/notification/OutboxOpsScriptSmokeTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/OutboxOpsScriptSmokeTest.java
@@ -1,0 +1,89 @@
+package com.aquilabank.global.web.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class OutboxOpsScriptSmokeTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void failedEventsScriptRejectsMissingArgs() throws Exception {
+    OutboxOpsScriptSmokeSupport.ScriptResult result =
+        OutboxOpsScriptSmokeSupport.run(
+            tempDir,
+            OutboxOpsScriptSmokeSupport.FAILED_EVENTS_SPEC,
+            OutboxOpsScriptSmokeSupport.FAILED_EVENTS_SPEC.args().subList(0, 2));
+
+    assertThat(result.exitCode()).isEqualTo(1);
+    assertThat(result.stderr())
+        .contains(OutboxOpsScriptSmokeSupport.FAILED_EVENTS_SPEC.usagePrefix());
+    assertThat(result.curlArgs()).isEmpty();
+  }
+
+  @Test
+  void recoverStaleSendingScriptRejectsMissingArgs() throws Exception {
+    OutboxOpsScriptSmokeSupport.ScriptResult result =
+        OutboxOpsScriptSmokeSupport.run(
+            tempDir,
+            OutboxOpsScriptSmokeSupport.RECOVER_STALE_SENDING_SPEC,
+            OutboxOpsScriptSmokeSupport.RECOVER_STALE_SENDING_SPEC.args().subList(0, 1));
+
+    assertThat(result.exitCode()).isEqualTo(1);
+    assertThat(result.stderr())
+        .contains(OutboxOpsScriptSmokeSupport.RECOVER_STALE_SENDING_SPEC.usagePrefix());
+    assertThat(result.curlArgs()).isEmpty();
+  }
+
+  @Test
+  void failedEventsScriptBuildsExpectedCurlRequest() throws Exception {
+    OutboxOpsScriptSmokeSupport.ScriptResult result =
+        OutboxOpsScriptSmokeSupport.run(
+            tempDir,
+            OutboxOpsScriptSmokeSupport.FAILED_EVENTS_SPEC,
+            OutboxOpsScriptSmokeSupport.FAILED_EVENTS_SPEC.args());
+
+    assertThat(result.exitCode()).isZero();
+    assertThat(result.stderr()).isEmpty();
+    assertThat(result.stdout()).isEmpty();
+    assertThat(result.curlArgs())
+        .containsExactlyElementsOf(
+            OutboxOpsScriptSmokeSupport.FAILED_EVENTS_SPEC.expectedCurlArgs());
+  }
+
+  @Test
+  void recoverStaleSendingScriptBuildsExpectedCurlRequest() throws Exception {
+    OutboxOpsScriptSmokeSupport.ScriptResult result =
+        OutboxOpsScriptSmokeSupport.run(
+            tempDir,
+            OutboxOpsScriptSmokeSupport.RECOVER_STALE_SENDING_SPEC,
+            OutboxOpsScriptSmokeSupport.RECOVER_STALE_SENDING_SPEC.args());
+
+    assertThat(result.exitCode()).isZero();
+    assertThat(result.stderr()).isEmpty();
+    assertThat(result.stdout()).isEmpty();
+    assertThat(result.curlArgs())
+        .containsExactlyElementsOf(
+            OutboxOpsScriptSmokeSupport.RECOVER_STALE_SENDING_SPEC.expectedCurlArgs());
+  }
+
+  @Test
+  void readmeContainsOutboxFailedEventsRunbook() throws Exception {
+    assertReadmeContains(OutboxOpsScriptSmokeSupport.FAILED_EVENTS_SPEC);
+  }
+
+  @Test
+  void readmeContainsOutboxRecoveryRunbook() throws Exception {
+    assertReadmeContains(OutboxOpsScriptSmokeSupport.RECOVER_STALE_SENDING_SPEC);
+  }
+
+  private void assertReadmeContains(OutboxOpsScriptSmokeSupport.ScriptSpec spec) throws Exception {
+    String readme = OutboxOpsScriptSmokeSupport.readReadme();
+    for (String snippet : spec.requiredReadmeSnippets()) {
+      assertThat(readme).contains(snippet);
+    }
+  }
+}

--- a/back/src/test/resources/application-test.yml
+++ b/back/src/test/resources/application-test.yml
@@ -21,6 +21,15 @@ outbox:
     enabled: false
   kafka:
     enabled: false
+  ops:
+    enabled: false
+    token-header: X-Outbox-Ops-Token
+    token: ""
+    failed-list-limit: 20
+    health:
+      max-lag-seconds: 120
+      max-failed-count: 10
+      max-stale-sending-count: 0
 
 security:
   jwt:

--- a/tools/ops/outbox-find-failed-events.sh
+++ b/tools/ops/outbox-find-failed-events.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  cat <<'USAGE' >&2
+usage: tools/ops/outbox-find-failed-events.sh <base_url> <ops_token> <limit>
+
+example:
+  tools/ops/outbox-find-failed-events.sh \
+    http://localhost:8080 \
+    "$OUTBOX_OPS_TOKEN" \
+    20
+USAGE
+  exit 1
+fi
+
+base_url="$1"
+ops_token="$2"
+limit="$3"
+
+# failed list 는 dispatch 순서 기준으로 잘라서 보도록 limit query 를 항상 고정합니다.
+curl --fail-with-body --silent --show-error \
+  --get \
+  --header "X-Outbox-Ops-Token: ${ops_token}" \
+  --data-urlencode "limit=${limit}" \
+  "${base_url%/}/internal/api/v1/outbox/failed-events"

--- a/tools/ops/outbox-recover-stale-sending.sh
+++ b/tools/ops/outbox-recover-stale-sending.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  cat <<'USAGE' >&2
+usage: tools/ops/outbox-recover-stale-sending.sh <base_url> <ops_token>
+
+example:
+  tools/ops/outbox-recover-stale-sending.sh \
+    http://localhost:8080 \
+    "$OUTBOX_OPS_TOKEN"
+USAGE
+  exit 1
+fi
+
+base_url="$1"
+ops_token="$2"
+
+# stale recovery 는 직접 publish 가 아니라 stale SENDING row 를 PENDING 으로 재진입시킵니다.
+curl --fail-with-body --silent --show-error \
+  --request POST \
+  --header "X-Outbox-Ops-Token: ${ops_token}" \
+  "${base_url%/}/internal/api/v1/outbox/recovery/stale-sending"


### PR DESCRIPTION
## 🔗 Related Issue
- close #44

## 📝 Summary
- Kafka producer 연결 이후 outbox backlog 를 운영에서 바로 확인하고 회수할 수 있는 내부 ops 경로와 health 기준을 추가했습니다.
- failed 조회, stale `SENDING` 수동 회수, lag 기반 health degrade, README/tools runbook 을 한 PR로 정리했습니다.
- 기존 poller 의 claim/backoff 계약은 유지하고, 수동 recovery 는 직접 publish 가 아니라 `PENDING` 재진입으로 제한했습니다.

## 🛠 Changes
- outbox ops domain 계약과 `outbox.ops.*` 설정 모델, query/recovery use case 를 추가했습니다.
- `JdbcOutboxOpsRepository` 로 failed list, lag summary, stale `SENDING` recovery SQL 과 integration test 를 추가했습니다.
- `/internal/api/v1/outbox/summary`, `/internal/api/v1/outbox/failed-events`, `/internal/api/v1/outbox/recovery/stale-sending` 내부 ops API 와 shared token guard 를 추가했습니다.
- `OutboxHealthIndicator` 를 추가해 lag/failed/stale 기준 초과 시 `/actuator/health` 가 `OUT_OF_SERVICE` 와 HTTP `503`을 반환하도록 했습니다.
- `back/README.md`, `tools/ops/outbox-find-failed-events.sh`, `tools/ops/outbox-recover-stale-sending.sh`, smoke test 로 운영 runbook 과 script 계약을 고정했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-outbox ./back/gradlew -p back test --tests '*Outbox*'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- `bash -n tools/ops/outbox-find-failed-events.sh`
- `bash -n tools/ops/outbox-recover-stale-sending.sh`

## 📸 Screenshot / API Example
- `GET /internal/api/v1/outbox/summary`
- `GET /internal/api/v1/outbox/failed-events?limit=20`
- `POST /internal/api/v1/outbox/recovery/stale-sending`
- `/actuator/health` 가 기준 초과 시 `503` + `OUT_OF_SERVICE`

## ⚠️ Risk & Rollback
- 예상 리스크: stale recovery 를 반복 호출하면 실제 broker 장애 원인보다 수동 재진입이 먼저 늘어 backlog 원인 해석이 흐려질 수 있습니다.
- 예상 리스크: `OUTBOX_OPS_HEALTH_*` 기준을 너무 공격적으로 잡으면 일시적 지연도 `503`으로 보일 수 있습니다.
- 롤백 방법: `OUTBOX_OPS_ENABLED=false` 로 내부 ops surface 를 즉시 끄고, 필요하면 PR revert 로 health indicator 와 runbook/script 를 함께 되돌립니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.