### PR TITLE
[Feat] refresh token 재발급 경로 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -114,6 +114,34 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
 | `previousLockedUntil` | reset 전 잠금 만료 시각 |
 | `path` | 현재 요청 path |
 
+## Refresh Token Session
+
+공개 인증 경로는 access token JWT와 함께 refresh token rotation을 기본 지원합니다.
+
+- 공개 endpoint:
+  - `POST /api/v1/auth/login`
+  - `POST /api/v1/auth/refresh`
+- 응답 필드:
+  - `accessToken`
+  - `refreshToken`
+  - `tokenType`
+  - `expiresAt`
+  - `refreshExpiresAt`
+  - `userId`
+- 기본값:
+  - `SECURITY_JWT_ACCESS_TOKEN_TTL_SECONDS=900`
+  - `SECURITY_JWT_REFRESH_TOKEN_TTL_SECONDS=1209600`
+- 저장 기준:
+  - raw refresh token은 응답으로만 한 번 내려가고 DB에는 `SHA-256 token_hash`만 저장
+  - 저장 테이블은 `auth_refresh_token_session`
+  - 성공 refresh 시 기존 row는 `ROTATED`, 새 row는 `ACTIVE`
+- 거절 기준:
+  - 만료, 이미 rotation 된 token, 존재하지 않는 token은 모두 `401 refresh failed`
+  - `user_status=LOCKED|DISABLED` 사용자는 refresh로 새 token pair를 발급받지 못함
+- 운영 주의:
+  - 최소 범위에서는 logout / logout-all / 세션 목록 조회를 제공하지 않음
+  - raw refresh token, plaintext secret은 로그/DB에 남기지 않음
+
 ## Internal Auth Admin Runbook
 
 내부 auth status update는 공개 로그인 경로와 분리된 내부 운영 surface 입니다.

--- a/back/src/main/java/com/aquilabank/domain/auth/model/IssuedAccessToken.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/IssuedAccessToken.java
@@ -2,30 +2,19 @@ package com.aquilabank.domain.auth.model;
 
 import java.time.Instant;
 
-/** 로그인 성공 후 반환하는 bearer token 결과 */
-public record LoginResult(
-    String accessToken,
-    String refreshToken,
-    String tokenType,
-    Instant expiresAt,
-    Instant refreshExpiresAt,
-    long userId) {
+/** JWT signer가 만든 access token 결과만 분리해 전달합니다. */
+public record IssuedAccessToken(
+    String accessToken, String tokenType, Instant expiresAt, long userId) {
 
-  public LoginResult {
+  public IssuedAccessToken {
     if (accessToken == null || accessToken.isBlank()) {
       throw new IllegalArgumentException("accessToken is required");
-    }
-    if (refreshToken == null || refreshToken.isBlank()) {
-      throw new IllegalArgumentException("refreshToken is required");
     }
     if (tokenType == null || tokenType.isBlank()) {
       throw new IllegalArgumentException("tokenType is required");
     }
     if (expiresAt == null) {
       throw new IllegalArgumentException("expiresAt is required");
-    }
-    if (refreshExpiresAt == null) {
-      throw new IllegalArgumentException("refreshExpiresAt is required");
     }
     if (userId <= 0) {
       throw new IllegalArgumentException("userId must be positive");

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenCommand.java
@@ -1,0 +1,11 @@
+package com.aquilabank.domain.auth.model;
+
+/** refresh token 재발급 요청의 최소 입력값입니다. */
+public record RefreshTokenCommand(String refreshToken) {
+
+  public RefreshTokenCommand {
+    if (refreshToken == null || refreshToken.isBlank()) {
+      throw new IllegalArgumentException("refreshToken is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenPolicy.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenPolicy.java
@@ -1,0 +1,13 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Duration;
+
+/** refresh token 만료 기준을 domain 값으로 고정합니다. */
+public record RefreshTokenPolicy(Duration ttl) {
+
+  public RefreshTokenPolicy {
+    if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+      throw new IllegalArgumentException("ttl must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSession.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSession.java
@@ -1,0 +1,41 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** refresh token exact lookup과 rotation 판단에 필요한 조회 모델입니다. */
+public record RefreshTokenSession(
+    long sessionId,
+    long userId,
+    String loginId,
+    UserStatus userStatus,
+    String tokenHash,
+    RefreshTokenSessionStatus sessionStatus,
+    Instant expiresAt,
+    Instant lastUsedAt,
+    Instant rotatedAt,
+    Long replacedBySessionId) {
+
+  public RefreshTokenSession {
+    if (sessionId <= 0) {
+      throw new IllegalArgumentException("sessionId must be positive");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (userStatus == null) {
+      throw new IllegalArgumentException("userStatus is required");
+    }
+    if (tokenHash == null || tokenHash.isBlank()) {
+      throw new IllegalArgumentException("tokenHash is required");
+    }
+    if (sessionStatus == null) {
+      throw new IllegalArgumentException("sessionStatus is required");
+    }
+    if (expiresAt == null) {
+      throw new IllegalArgumentException("expiresAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionCreateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionCreateCommand.java
@@ -1,0 +1,23 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 새 refresh token session 저장에 필요한 최소 write 모델입니다. */
+public record RefreshTokenSessionCreateCommand(
+    long userId, String tokenHash, Instant expiresAt, Instant createdAt) {
+
+  public RefreshTokenSessionCreateCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (tokenHash == null || tokenHash.isBlank()) {
+      throw new IllegalArgumentException("tokenHash is required");
+    }
+    if (expiresAt == null) {
+      throw new IllegalArgumentException("expiresAt is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionRotateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionRotateCommand.java
@@ -1,0 +1,20 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 기존 refresh token을 rotation 완료 상태로 바꾸는 write 모델입니다. */
+public record RefreshTokenSessionRotateCommand(
+    long sessionId, long replacedBySessionId, Instant rotatedAt) {
+
+  public RefreshTokenSessionRotateCommand {
+    if (sessionId <= 0) {
+      throw new IllegalArgumentException("sessionId must be positive");
+    }
+    if (replacedBySessionId <= 0) {
+      throw new IllegalArgumentException("replacedBySessionId must be positive");
+    }
+    if (rotatedAt == null) {
+      throw new IllegalArgumentException("rotatedAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionStatus.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.model;
+
+/** refresh token session lifecycle을 고정값으로 관리합니다. */
+public enum RefreshTokenSessionStatus {
+  ACTIVE,
+  ROTATED,
+  REVOKED
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AuthTokenIssuePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AuthTokenIssuePort.java
@@ -1,9 +1,10 @@
 package com.aquilabank.domain.auth.port;
 
-import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.IssuedAccessToken;
+import java.time.Instant;
 
-/** 인증 완료 user 정보로 access token을 발급하는 port */
+/** 인증 완료 user 정보로 JWT access token만 발급하는 port */
 public interface AuthTokenIssuePort {
 
-  LoginResult issue(long userId, String subject);
+  IssuedAccessToken issue(long userId, String subject, Instant issuedAt);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSecretPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSecretPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.port;
+
+/** refresh token raw 값 생성과 hash 계산을 분리하는 port 입니다. */
+public interface RefreshTokenSecretPort {
+
+  String createToken();
+
+  String hash(String rawToken);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionLoadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionLoadPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.RefreshTokenSession;
+import java.util.Optional;
+
+/** refresh token session exact lookup을 읽기 port로 분리합니다. */
+public interface RefreshTokenSessionLoadPort {
+
+  Optional<RefreshTokenSession> findByTokenHashForUpdate(String tokenHash);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionWritePort.java
@@ -1,0 +1,12 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
+
+/** refresh token session 생성과 rotation 저장을 쓰기 port로 분리합니다. */
+public interface RefreshTokenSessionWritePort {
+
+  long create(RefreshTokenSessionCreateCommand command);
+
+  void rotate(RefreshTokenSessionRotateCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/LoginService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/LoginService.java
@@ -1,6 +1,7 @@
 package com.aquilabank.domain.auth.usecase;
 
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.IssuedAccessToken;
 import com.aquilabank.domain.auth.model.LoginCommand;
 import com.aquilabank.domain.auth.model.LoginFailureAuditEntry;
 import com.aquilabank.domain.auth.model.LoginFailureReason;
@@ -10,11 +11,15 @@ import com.aquilabank.domain.auth.model.LoginResetAuditEntry;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.model.LoginSuccessUpdateCommand;
 import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
 import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
 import java.time.Clock;
 import java.time.Instant;
@@ -26,8 +31,11 @@ public final class LoginService implements LoginUseCase {
   private final LoginAttemptUpdatePort loginAttemptUpdatePort;
   private final LoginAttemptAuditPort loginAttemptAuditPort;
   private final PasswordHashPort passwordHashPort;
+  private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
+  private final RefreshTokenSecretPort refreshTokenSecretPort;
   private final AuthTokenIssuePort authTokenIssuePort;
   private final LoginProtectionPolicy loginProtectionPolicy;
+  private final RefreshTokenPolicy refreshTokenPolicy;
   private final String dummyPasswordHash;
   private final Clock clock;
 
@@ -36,16 +44,22 @@ public final class LoginService implements LoginUseCase {
       LoginAttemptUpdatePort loginAttemptUpdatePort,
       LoginAttemptAuditPort loginAttemptAuditPort,
       PasswordHashPort passwordHashPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      RefreshTokenSecretPort refreshTokenSecretPort,
       AuthTokenIssuePort authTokenIssuePort,
       LoginProtectionPolicy loginProtectionPolicy,
+      RefreshTokenPolicy refreshTokenPolicy,
       String dummyPasswordHash,
       Clock clock) {
     this.userCredentialLoadPort = userCredentialLoadPort;
     this.loginAttemptUpdatePort = loginAttemptUpdatePort;
     this.loginAttemptAuditPort = loginAttemptAuditPort;
     this.passwordHashPort = passwordHashPort;
+    this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
+    this.refreshTokenSecretPort = refreshTokenSecretPort;
     this.authTokenIssuePort = authTokenIssuePort;
     this.loginProtectionPolicy = loginProtectionPolicy;
+    this.refreshTokenPolicy = refreshTokenPolicy;
     this.dummyPasswordHash = dummyPasswordHash;
     this.clock = clock;
   }
@@ -105,7 +119,7 @@ public final class LoginService implements LoginUseCase {
           new LoginResetAuditEntry(
               command.loginId(), user.userId(), user.failedLoginCount(), user.loginLockedUntil()));
     }
-    return authTokenIssuePort.issue(user.userId(), user.loginId());
+    return issueTokenPair(user.userId(), user.loginId(), now);
   }
 
   private LoginUser consumeMissingUserPath(String loginId, String password) {
@@ -162,5 +176,21 @@ public final class LoginService implements LoginUseCase {
 
   private boolean shouldLogReset(LoginUser user) {
     return user.failedLoginCount() > 0 || user.loginLockedUntil() != null;
+  }
+
+  private LoginResult issueTokenPair(long userId, String loginId, Instant now) {
+    String refreshToken = refreshTokenSecretPort.createToken();
+    Instant refreshExpiresAt = now.plus(refreshTokenPolicy.ttl());
+    refreshTokenSessionWritePort.create(
+        new RefreshTokenSessionCreateCommand(
+            userId, refreshTokenSecretPort.hash(refreshToken), refreshExpiresAt, now));
+    IssuedAccessToken issuedAccessToken = authTokenIssuePort.issue(userId, loginId, now);
+    return new LoginResult(
+        issuedAccessToken.accessToken(),
+        refreshToken,
+        issuedAccessToken.tokenType(),
+        issuedAccessToken.expiresAt(),
+        refreshExpiresAt,
+        issuedAccessToken.userId());
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenService.java
@@ -1,0 +1,84 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.IssuedAccessToken;
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.RefreshTokenCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
+import com.aquilabank.domain.auth.model.RefreshTokenSession;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** refresh token exact lookup 뒤 새 token pair 발급과 rotation을 같은 흐름으로 묶습니다. */
+public final class RefreshTokenService implements RefreshTokenUseCase {
+
+  private final RefreshTokenSessionLoadPort refreshTokenSessionLoadPort;
+  private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
+  private final RefreshTokenSecretPort refreshTokenSecretPort;
+  private final AuthTokenIssuePort authTokenIssuePort;
+  private final RefreshTokenPolicy refreshTokenPolicy;
+  private final Clock clock;
+
+  public RefreshTokenService(
+      RefreshTokenSessionLoadPort refreshTokenSessionLoadPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      RefreshTokenSecretPort refreshTokenSecretPort,
+      AuthTokenIssuePort authTokenIssuePort,
+      RefreshTokenPolicy refreshTokenPolicy,
+      Clock clock) {
+    this.refreshTokenSessionLoadPort = refreshTokenSessionLoadPort;
+    this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
+    this.refreshTokenSecretPort = refreshTokenSecretPort;
+    this.authTokenIssuePort = authTokenIssuePort;
+    this.refreshTokenPolicy = refreshTokenPolicy;
+    this.clock = clock;
+  }
+
+  @Override
+  public LoginResult refresh(RefreshTokenCommand command) {
+    Instant now = Instant.now(clock);
+    String tokenHash = refreshTokenSecretPort.hash(command.refreshToken());
+    RefreshTokenSession session =
+        refreshTokenSessionLoadPort
+            .findByTokenHashForUpdate(tokenHash)
+            .orElseThrow(() -> new InvalidCredentialsException("refresh failed"));
+
+    if (session.sessionStatus() != RefreshTokenSessionStatus.ACTIVE) {
+      throw new InvalidCredentialsException("refresh failed");
+    }
+    if (!session.expiresAt().isAfter(now)) {
+      throw new InvalidCredentialsException("refresh failed");
+    }
+    if (session.userStatus() != UserStatus.ACTIVE) {
+      throw new InvalidCredentialsException("refresh failed");
+    }
+
+    String nextRefreshToken = refreshTokenSecretPort.createToken();
+    String nextTokenHash = refreshTokenSecretPort.hash(nextRefreshToken);
+    Instant refreshExpiresAt = now.plus(refreshTokenPolicy.ttl());
+    long newSessionId =
+        refreshTokenSessionWritePort.create(
+            new RefreshTokenSessionCreateCommand(
+                session.userId(), nextTokenHash, refreshExpiresAt, now));
+    refreshTokenSessionWritePort.rotate(
+        new RefreshTokenSessionRotateCommand(session.sessionId(), newSessionId, now));
+
+    IssuedAccessToken issuedAccessToken =
+        authTokenIssuePort.issue(session.userId(), session.loginId(), now);
+    return new LoginResult(
+        issuedAccessToken.accessToken(),
+        nextRefreshToken,
+        issuedAccessToken.tokenType(),
+        issuedAccessToken.expiresAt(),
+        refreshExpiresAt,
+        issuedAccessToken.userId());
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.RefreshTokenCommand;
+
+/** refresh token으로 새 token pair를 재발급합니다. */
+public interface RefreshTokenUseCase {
+
+  LoginResult refresh(RefreshTokenCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -64,7 +64,8 @@ public class AuthConfiguration {
 
   @Bean
   RefreshTokenPolicy refreshTokenPolicy(SecurityJwtProperties securityJwtProperties) {
-    return new RefreshTokenPolicy(Duration.ofSeconds(securityJwtProperties.refreshTokenTtlSeconds()));
+    return new RefreshTokenPolicy(
+        Duration.ofSeconds(securityJwtProperties.refreshTokenTtlSeconds()));
   }
 
   @Bean
@@ -141,7 +142,8 @@ public class AuthConfiguration {
             authClock);
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
     return command -> {
-      LoginResult result = transactionTemplate.execute(status -> refreshTokenService.refresh(command));
+      LoginResult result =
+          transactionTemplate.execute(status -> refreshTokenService.refresh(command));
       if (result == null) {
         throw new IllegalStateException("refresh transaction returned null result");
       }

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -3,12 +3,16 @@ package com.aquilabank.global.config;
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
 import com.aquilabank.domain.auth.model.LoginProtectionPolicy;
 import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipQueryPort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipStatusUpdatePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
@@ -24,6 +28,8 @@ import com.aquilabank.domain.auth.usecase.AuthUserQueryService;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
 import com.aquilabank.domain.auth.usecase.LoginService;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
+import com.aquilabank.domain.auth.usecase.RefreshTokenService;
+import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryService;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateService;
@@ -35,6 +41,7 @@ import com.aquilabank.domain.auth.usecase.UserBootstrapUseCase;
 import com.aquilabank.domain.auth.usecase.UserStatusUpdateService;
 import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
 import com.aquilabank.global.security.LoginProtectionProperties;
+import com.aquilabank.global.security.SecurityJwtProperties;
 import com.aquilabank.global.security.StructuredLoginAttemptAuditLogger;
 import java.time.Clock;
 import java.time.Duration;
@@ -56,13 +63,27 @@ public class AuthConfiguration {
   }
 
   @Bean
+  RefreshTokenPolicy refreshTokenPolicy(SecurityJwtProperties securityJwtProperties) {
+    return new RefreshTokenPolicy(Duration.ofSeconds(securityJwtProperties.refreshTokenTtlSeconds()));
+  }
+
+  @Bean
+  Clock authClock() {
+    return Clock.systemUTC();
+  }
+
+  @Bean
   LoginUseCase loginUseCase(
       UserCredentialLoadPort userCredentialLoadPort,
       LoginAttemptUpdatePort loginAttemptUpdatePort,
       LoginAttemptAuditPort loginAttemptAuditPort,
       PasswordHashPort passwordHashPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      RefreshTokenSecretPort refreshTokenSecretPort,
       AuthTokenIssuePort authTokenIssuePort,
       LoginProtectionPolicy loginProtectionPolicy,
+      RefreshTokenPolicy refreshTokenPolicy,
+      Clock authClock,
       PlatformTransactionManager platformTransactionManager) {
     LoginService loginService =
         new LoginService(
@@ -70,10 +91,13 @@ public class AuthConfiguration {
             loginAttemptUpdatePort,
             loginAttemptAuditPort,
             passwordHashPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
             authTokenIssuePort,
             loginProtectionPolicy,
+            refreshTokenPolicy,
             passwordHashPort.encode("login-dummy-password"),
-            Clock.systemUTC());
+            authClock);
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
     return command -> {
       LoginTransactionResult transactionResult =
@@ -95,6 +119,33 @@ public class AuthConfiguration {
         throw new IllegalStateException("login transaction returned null result");
       }
       return transactionResult.result();
+    };
+  }
+
+  @Bean
+  RefreshTokenUseCase refreshTokenUseCase(
+      RefreshTokenSessionLoadPort refreshTokenSessionLoadPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      RefreshTokenSecretPort refreshTokenSecretPort,
+      AuthTokenIssuePort authTokenIssuePort,
+      RefreshTokenPolicy refreshTokenPolicy,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    RefreshTokenService refreshTokenService =
+        new RefreshTokenService(
+            refreshTokenSessionLoadPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            authTokenIssuePort,
+            refreshTokenPolicy,
+            authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command -> {
+      LoginResult result = transactionTemplate.execute(status -> refreshTokenService.refresh(command));
+      if (result == null) {
+        throw new IllegalStateException("refresh transaction returned null result");
+      }
+      return result;
     };
   }
 

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -10,11 +10,14 @@ import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.LoginUser;
 import com.aquilabank.domain.auth.model.MembershipRole;
 import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.RefreshTokenSession;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
 import com.aquilabank.domain.auth.model.UserAccountMembership;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipQueryPort;
 import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
 import com.aquilabank.domain.auth.port.UserQueryPort;
@@ -31,6 +34,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class JdbcAuthRepository
     implements UserCredentialLoadPort,
+        RefreshTokenSessionLoadPort,
         AccountAccessPort,
         UserQueryPort,
         UserAccountMembershipQueryPort,
@@ -83,6 +87,33 @@ public class JdbcAuthRepository
             """,
             new MapSqlParameterSource().addValue("loginId", loginId),
             (rs, rowNum) -> mapLoginUser(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<RefreshTokenSession> findByTokenHashForUpdate(String tokenHash) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT s.id,
+                   s.user_id,
+                   u.login_id,
+                   u.user_status,
+                   s.token_hash,
+                   s.session_status,
+                   s.expires_at,
+                   s.last_used_at,
+                   s.rotated_at,
+                   s.replaced_by_session_id
+            FROM auth_refresh_token_session s
+            JOIN bank_user u
+              ON u.id = s.user_id
+            WHERE s.token_hash = :tokenHash
+            FOR UPDATE OF s, u
+            """,
+            new MapSqlParameterSource().addValue("tokenHash", tokenHash),
+            (rs, rowNum) -> mapRefreshTokenSession(rs))
         .stream()
         .findFirst();
   }
@@ -210,6 +241,20 @@ public class JdbcAuthRepository
         toNullableInstant(rs.getTimestamp("last_login_failed_at")),
         toNullableInstant(rs.getTimestamp("login_locked_until")),
         toNullableInstant(rs.getTimestamp("last_login_succeeded_at")));
+  }
+
+  private RefreshTokenSession mapRefreshTokenSession(ResultSet rs) throws SQLException {
+    return new RefreshTokenSession(
+        rs.getLong("id"),
+        rs.getLong("user_id"),
+        rs.getString("login_id"),
+        UserStatus.valueOf(rs.getString("user_status")),
+        rs.getString("token_hash"),
+        RefreshTokenSessionStatus.valueOf(rs.getString("session_status")),
+        toInstant(rs.getTimestamp("expires_at")),
+        toNullableInstant(rs.getTimestamp("last_used_at")),
+        toNullableInstant(rs.getTimestamp("rotated_at")),
+        rs.getObject("replaced_by_session_id", Long.class));
   }
 
   private UserAccountMembership mapMembership(ResultSet rs) throws SQLException {

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -9,6 +9,8 @@ import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.LoginFailureUpdateCommand;
 import com.aquilabank.domain.auth.model.LoginSuccessUpdateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
 import com.aquilabank.domain.auth.model.UserAccountMembership;
 import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
@@ -18,6 +20,7 @@ import com.aquilabank.domain.auth.model.UserBootstrapWriteCommand;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipStatusUpdatePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
 import com.aquilabank.domain.auth.port.UserBootstrapPort;
@@ -37,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcAuthWriteRepository
     implements UserBootstrapPort,
         LoginAttemptUpdatePort,
+        RefreshTokenSessionWritePort,
         UserAccountMembershipUpsertPort,
         UserStatusUpdatePort,
         UserAccountMembershipStatusUpdatePort {
@@ -134,6 +138,66 @@ public class JdbcAuthWriteRepository
                 .addValue("userId", command.userId())
                 .addValue("succeededAt", Timestamp.from(command.succeededAt())));
     assertUserUpdated(updated);
+  }
+
+  @Override
+  @Transactional
+  public long create(RefreshTokenSessionCreateCommand command) {
+    Long sessionId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO auth_refresh_token_session (
+                user_id,
+                token_hash,
+                session_status,
+                expires_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :userId,
+                :tokenHash,
+                'ACTIVE',
+                :expiresAt,
+                :createdAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("userId", command.userId())
+                .addValue("tokenHash", command.tokenHash())
+                .addValue("expiresAt", Timestamp.from(command.expiresAt()))
+                .addValue("createdAt", Timestamp.from(command.createdAt())),
+            Long.class);
+    if (sessionId == null) {
+      throw new IllegalStateException("refresh token session insert did not return an id");
+    }
+    return sessionId;
+  }
+
+  @Override
+  @Transactional
+  public void rotate(RefreshTokenSessionRotateCommand command) {
+    int updated =
+        jdbcTemplate.update(
+            """
+            UPDATE auth_refresh_token_session
+            SET session_status = 'ROTATED',
+                last_used_at = :rotatedAt,
+                rotated_at = :rotatedAt,
+                replaced_by_session_id = :replacedBySessionId,
+                updated_at = :rotatedAt
+            WHERE id = :sessionId
+              AND session_status = 'ACTIVE'
+            """,
+            new MapSqlParameterSource()
+                .addValue("sessionId", command.sessionId())
+                .addValue("replacedBySessionId", command.replacedBySessionId())
+                .addValue("rotatedAt", Timestamp.from(command.rotatedAt())));
+    if (updated != 1) {
+      throw new IllegalStateException("refresh token session is not active");
+    }
   }
 
   @Override

--- a/back/src/main/java/com/aquilabank/global/security/HmacAccessTokenIssuer.java
+++ b/back/src/main/java/com/aquilabank/global/security/HmacAccessTokenIssuer.java
@@ -1,6 +1,6 @@
 package com.aquilabank.global.security;
 
-import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.IssuedAccessToken;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JOSEObjectType;
@@ -28,14 +28,13 @@ public class HmacAccessTokenIssuer implements AuthTokenIssuePort {
   }
 
   @Override
-  public LoginResult issue(long userId, String subject) {
-    Instant now = Instant.now();
-    Instant expiresAt = now.plusSeconds(accessTokenTtlSeconds);
+  public IssuedAccessToken issue(long userId, String subject, Instant issuedAt) {
+    Instant expiresAt = issuedAt.plusSeconds(accessTokenTtlSeconds);
 
     JWTClaimsSet.Builder claims =
         new JWTClaimsSet.Builder()
             .subject(subject)
-            .issueTime(Date.from(now))
+            .issueTime(Date.from(issuedAt))
             .expirationTime(Date.from(expiresAt))
             .claim("user_id", userId);
     if (issuer != null && !issuer.isBlank()) {
@@ -51,6 +50,6 @@ public class HmacAccessTokenIssuer implements AuthTokenIssuePort {
     } catch (JOSEException ex) {
       throw new IllegalStateException("access token signing failed", ex);
     }
-    return new LoginResult(signedJwt.serialize(), "Bearer", expiresAt, userId);
+    return new IssuedAccessToken(signedJwt.serialize(), "Bearer", expiresAt, userId);
   }
 }

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -2,6 +2,7 @@ package com.aquilabank.global.security;
 
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
 import com.aquilabank.global.web.InternalAuthStatusAuditRequestCachingFilter;
 import com.aquilabank.global.web.RequestIdFilter;
 import javax.crypto.spec.SecretKeySpec;
@@ -59,6 +60,8 @@ public class SecurityConfiguration {
                 auth.requestMatchers("/actuator/health", "/actuator/info")
                     .permitAll()
                     .requestMatchers("/api/v1/auth/login")
+                    .permitAll()
+                    .requestMatchers("/api/v1/auth/refresh")
                     .permitAll()
                     // 내부 bootstrap API는 JWT 대신 별도 shared token으로 보호합니다.
                     .requestMatchers("/internal/api/v1/accounts/bootstrap")
@@ -145,6 +148,11 @@ public class SecurityConfiguration {
         return passwordEncoder.matches(rawPassword, passwordHash);
       }
     };
+  }
+
+  @Bean
+  RefreshTokenSecretPort refreshTokenSecretPort() {
+    return new Sha256RefreshTokenManager();
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/security/SecurityJwtProperties.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityJwtProperties.java
@@ -4,4 +4,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** 로컬 bootstrap과 배포 resource server 검증이 함께 쓰는 JWT 설정 */
 @ConfigurationProperties(prefix = "security.jwt")
-public record SecurityJwtProperties(String secret, String issuer, long accessTokenTtlSeconds) {}
+public record SecurityJwtProperties(
+    String secret, String issuer, long accessTokenTtlSeconds, long refreshTokenTtlSeconds) {}

--- a/back/src/main/java/com/aquilabank/global/security/Sha256RefreshTokenManager.java
+++ b/back/src/main/java/com/aquilabank/global/security/Sha256RefreshTokenManager.java
@@ -1,0 +1,35 @@
+package com.aquilabank.global.security;
+
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HexFormat;
+
+/** raw refresh token은 랜덤으로 만들고 저장은 SHA-256 hash만 남깁니다. */
+public class Sha256RefreshTokenManager implements RefreshTokenSecretPort {
+
+  private final SecureRandom secureRandom = new SecureRandom();
+
+  @Override
+  public String createToken() {
+    byte[] bytes = new byte[32];
+    secureRandom.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  @Override
+  public String hash(String rawToken) {
+    if (rawToken == null || rawToken.isBlank()) {
+      throw new IllegalArgumentException("rawToken is required");
+    }
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(rawToken.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -2,10 +2,13 @@ package com.aquilabank.global.web.auth;
 
 import com.aquilabank.domain.auth.model.LoginCommand;
 import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.RefreshTokenCommand;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
+import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import java.time.Instant;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,9 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class LoginController {
 
   private final LoginUseCase loginUseCase;
+  private final RefreshTokenUseCase refreshTokenUseCase;
 
-  public LoginController(LoginUseCase loginUseCase) {
+  public LoginController(LoginUseCase loginUseCase, RefreshTokenUseCase refreshTokenUseCase) {
     this.loginUseCase = loginUseCase;
+    this.refreshTokenUseCase = refreshTokenUseCase;
   }
 
   @PostMapping("/login")
@@ -31,18 +36,39 @@ public class LoginController {
     return LoginResponse.from(result);
   }
 
+  @PostMapping("/refresh")
+  public LoginResponse refresh(@Valid @RequestBody RefreshRequest request) {
+    LoginResult result =
+        refreshTokenUseCase.refresh(new RefreshTokenCommand(request.refreshToken()));
+    return LoginResponse.from(result);
+  }
+
   /** 로그인 요청 body */
   public record LoginRequest(
       @NotBlank(message = "loginId is required") @Size(max = 80, message = "loginId must be 80 characters or less") String loginId,
       @NotBlank(message = "password is required") @Size(max = 120, message = "password must be 120 characters or less") String password) {}
 
-  /** access token 발급 응답 */
+  /** refresh token 재발급 요청 body */
+  public record RefreshRequest(
+      @NotBlank(message = "refreshToken is required") @Size(max = 160, message = "refreshToken must be 160 characters or less") String refreshToken) {}
+
+  /** access/refresh token 발급 응답 */
   public record LoginResponse(
-      String accessToken, String tokenType, java.time.Instant expiresAt, long userId) {
+      String accessToken,
+      String refreshToken,
+      String tokenType,
+      Instant expiresAt,
+      Instant refreshExpiresAt,
+      long userId) {
 
     private static LoginResponse from(LoginResult result) {
       return new LoginResponse(
-          result.accessToken(), result.tokenType(), result.expiresAt(), result.userId());
+          result.accessToken(),
+          result.refreshToken(),
+          result.tokenType(),
+          result.expiresAt(),
+          result.refreshExpiresAt(),
+          result.userId());
     }
   }
 }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -120,6 +120,7 @@ security:
     secret: ${SECURITY_JWT_SECRET}
     issuer: ${SECURITY_JWT_ISSUER:}
     access-token-ttl-seconds: ${SECURITY_JWT_ACCESS_TOKEN_TTL_SECONDS:900}
+    refresh-token-ttl-seconds: ${SECURITY_JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
   login-protection:
     max-failures: ${SECURITY_LOGIN_PROTECTION_MAX_FAILURES:5}
     lock-seconds: ${SECURITY_LOGIN_PROTECTION_LOCK_SECONDS:900}

--- a/back/src/main/resources/db/migration/V10__add_auth_refresh_token_session.sql
+++ b/back/src/main/resources/db/migration/V10__add_auth_refresh_token_session.sql
@@ -1,0 +1,21 @@
+CREATE TABLE auth_refresh_token_session (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    token_hash VARCHAR(64) NOT NULL,
+    session_status VARCHAR(16) NOT NULL
+        CHECK (session_status IN ('ACTIVE', 'ROTATED', 'REVOKED')),
+    expires_at TIMESTAMPTZ NOT NULL,
+    last_used_at TIMESTAMPTZ,
+    rotated_at TIMESTAMPTZ,
+    replaced_by_session_id BIGINT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_auth_refresh_token_session_token_hash UNIQUE (token_hash),
+    CONSTRAINT fk_auth_refresh_token_session_user
+        FOREIGN KEY (user_id) REFERENCES bank_user (id),
+    CONSTRAINT fk_auth_refresh_token_session_replaced_by
+        FOREIGN KEY (replaced_by_session_id) REFERENCES auth_refresh_token_session (id)
+);
+
+CREATE INDEX idx_auth_refresh_token_session_user_status_expires
+    ON auth_refresh_token_session (user_id, session_status, expires_at DESC, id DESC);

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/LoginServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/LoginServiceTest.java
@@ -64,7 +64,8 @@ class LoginServiceTest {
     verify(loginAttemptUpdatePort, never()).recordLoginFailure(Mockito.any());
     verify(loginAttemptUpdatePort, never()).recordLoginSuccess(Mockito.any());
     verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
-    verify(authTokenIssuePort, never()).issue(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
+    verify(authTokenIssuePort, never())
+        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
     verify(userCredentialLoadPort).findByLoginIdForUpdate(eq("missing-user"));
   }
 }

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/LoginServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/LoginServiceTest.java
@@ -9,10 +9,13 @@ import static org.mockito.Mockito.when;
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
 import com.aquilabank.domain.auth.model.LoginCommand;
 import com.aquilabank.domain.auth.model.LoginProtectionPolicy;
+import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
 import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
 import java.time.Clock;
 import java.time.Duration;
@@ -30,6 +33,9 @@ class LoginServiceTest {
     LoginAttemptUpdatePort loginAttemptUpdatePort = Mockito.mock(LoginAttemptUpdatePort.class);
     LoginAttemptAuditPort loginAttemptAuditPort = Mockito.mock(LoginAttemptAuditPort.class);
     PasswordHashPort passwordHashPort = Mockito.mock(PasswordHashPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
     AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
 
     when(userCredentialLoadPort.findByLoginIdForUpdate("missing-user"))
@@ -42,8 +48,11 @@ class LoginServiceTest {
             loginAttemptUpdatePort,
             loginAttemptAuditPort,
             passwordHashPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
             authTokenIssuePort,
             new LoginProtectionPolicy(5, Duration.ofMinutes(15), Duration.ofMinutes(15)),
+            new RefreshTokenPolicy(Duration.ofDays(14)),
             "dummy-hash",
             Clock.fixed(Instant.parse("2026-04-17T00:00:00Z"), ZoneOffset.UTC));
 
@@ -54,7 +63,8 @@ class LoginServiceTest {
     verify(passwordHashPort).matches("wrong-password", "dummy-hash");
     verify(loginAttemptUpdatePort, never()).recordLoginFailure(Mockito.any());
     verify(loginAttemptUpdatePort, never()).recordLoginSuccess(Mockito.any());
-    verify(authTokenIssuePort, never()).issue(Mockito.anyLong(), Mockito.anyString());
+    verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
+    verify(authTokenIssuePort, never()).issue(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
     verify(userCredentialLoadPort).findByLoginIdForUpdate(eq("missing-user"));
   }
 }

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenServiceTest.java
@@ -1,0 +1,178 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.IssuedAccessToken;
+import com.aquilabank.domain.auth.model.RefreshTokenCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
+import com.aquilabank.domain.auth.model.RefreshTokenSession;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RefreshTokenServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-17T01:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+  @Test
+  void rotatesActiveRefreshTokenAndIssuesNewTokenPair() {
+    RefreshTokenSessionLoadPort refreshTokenSessionLoadPort =
+        Mockito.mock(RefreshTokenSessionLoadPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("token-hash");
+    when(refreshTokenSessionLoadPort.findByTokenHashForUpdate("token-hash"))
+        .thenReturn(Optional.of(activeSession()));
+    when(refreshTokenSecretPort.createToken()).thenReturn("next-refresh-token");
+    when(refreshTokenSecretPort.hash("next-refresh-token")).thenReturn("next-token-hash");
+    when(refreshTokenSessionWritePort.create(
+            new RefreshTokenSessionCreateCommand(
+                7L, "next-token-hash", NOW.plus(Duration.ofDays(14)), NOW)))
+        .thenReturn(33L);
+    when(authTokenIssuePort.issue(7L, "alice", NOW))
+        .thenReturn(new IssuedAccessToken("access-token", "Bearer", NOW.plusSeconds(900), 7L));
+
+    RefreshTokenService refreshTokenService =
+        new RefreshTokenService(
+            refreshTokenSessionLoadPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            CLOCK);
+
+    var result = refreshTokenService.refresh(new RefreshTokenCommand("refresh-token"));
+
+    assertEquals("access-token", result.accessToken());
+    assertEquals("next-refresh-token", result.refreshToken());
+    assertEquals("Bearer", result.tokenType());
+    assertEquals(NOW.plusSeconds(900), result.expiresAt());
+    assertEquals(NOW.plus(Duration.ofDays(14)), result.refreshExpiresAt());
+    assertEquals(7L, result.userId());
+    verify(refreshTokenSessionWritePort)
+        .rotate(new RefreshTokenSessionRotateCommand(11L, 33L, NOW));
+  }
+
+  @Test
+  void rejectsExpiredRefreshToken() {
+    RefreshTokenSessionLoadPort refreshTokenSessionLoadPort =
+        Mockito.mock(RefreshTokenSessionLoadPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("token-hash");
+    when(refreshTokenSessionLoadPort.findByTokenHashForUpdate("token-hash"))
+        .thenReturn(
+            Optional.of(
+                new RefreshTokenSession(
+                    11L,
+                    7L,
+                    "alice",
+                    UserStatus.ACTIVE,
+                    "token-hash",
+                    RefreshTokenSessionStatus.ACTIVE,
+                    NOW.minusSeconds(1),
+                    null,
+                    null,
+                    null)));
+
+    RefreshTokenService refreshTokenService =
+        new RefreshTokenService(
+            refreshTokenSessionLoadPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            CLOCK);
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () -> refreshTokenService.refresh(new RefreshTokenCommand("refresh-token")));
+
+    verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
+    verify(refreshTokenSessionWritePort, never()).rotate(Mockito.any());
+    verify(authTokenIssuePort, never())
+        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
+  }
+
+  @Test
+  void rejectsDisabledUserRefreshToken() {
+    RefreshTokenSessionLoadPort refreshTokenSessionLoadPort =
+        Mockito.mock(RefreshTokenSessionLoadPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("token-hash");
+    when(refreshTokenSessionLoadPort.findByTokenHashForUpdate("token-hash"))
+        .thenReturn(
+            Optional.of(
+                new RefreshTokenSession(
+                    11L,
+                    7L,
+                    "alice",
+                    UserStatus.DISABLED,
+                    "token-hash",
+                    RefreshTokenSessionStatus.ACTIVE,
+                    NOW.plusSeconds(30),
+                    null,
+                    null,
+                    null)));
+
+    RefreshTokenService refreshTokenService =
+        new RefreshTokenService(
+            refreshTokenSessionLoadPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            CLOCK);
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () -> refreshTokenService.refresh(new RefreshTokenCommand("refresh-token")));
+
+    verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
+    verify(refreshTokenSessionWritePort, never()).rotate(Mockito.any());
+    verify(authTokenIssuePort, never())
+        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
+  }
+
+  private RefreshTokenSession activeSession() {
+    return new RefreshTokenSession(
+        11L,
+        7L,
+        "alice",
+        UserStatus.ACTIVE,
+        "token-hash",
+        RefreshTokenSessionStatus.ACTIVE,
+        NOW.plusSeconds(30),
+        null,
+        null,
+        null);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.web.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -10,6 +11,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
 import com.aquilabank.support.PostgresContainerTestSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,7 +42,8 @@ import org.springframework.web.context.WebApplicationContext;
       "management.health.db.enabled=true",
       "security.login-protection.max-failures=3",
       "security.login-protection.lock-seconds=1",
-      "security.login-protection.reset-window-seconds=900"
+      "security.login-protection.reset-window-seconds=900",
+      "security.jwt.refresh-token-ttl-seconds=2"
     })
 class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSupport {
 
@@ -53,6 +56,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
 
   @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private RefreshTokenSecretPort refreshTokenSecretPort;
 
   private MockMvc mockMvc;
   private long userId;
@@ -325,6 +330,41 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void refreshRotatesTokenAndRejectsReusedToken() throws Exception {
+    TokenPairResponseView loginResult = loginResult("alice", "password123!", "refresh-login-001");
+    assertNotNull(loginResult.refreshToken());
+    assertNotNull(loginResult.refreshExpiresAt());
+
+    RefreshTokenSessionView initialSession = loadRefreshTokenSession(loginResult.refreshToken());
+    assertEquals("ACTIVE", initialSession.sessionStatus());
+
+    TokenPairResponseView refreshed = refresh(loginResult.refreshToken(), "refresh-rotate-001");
+    assertNotNull(refreshed.accessToken());
+    assertNotNull(refreshed.refreshToken());
+    assertNotEquals(loginResult.refreshToken(), refreshed.refreshToken());
+
+    RefreshTokenSessionView rotatedSession = loadRefreshTokenSession(loginResult.refreshToken());
+    assertEquals("ROTATED", rotatedSession.sessionStatus());
+    assertNotNull(rotatedSession.lastUsedAt());
+    assertNotNull(rotatedSession.rotatedAt());
+    assertNotNull(rotatedSession.replacedBySessionId());
+
+    RefreshTokenSessionView newSession = loadRefreshTokenSession(refreshed.refreshToken());
+    assertEquals("ACTIVE", newSession.sessionStatus());
+    assertNull(newSession.lastUsedAt());
+    assertNull(newSession.rotatedAt());
+
+    refreshExpectUnauthorized(loginResult.refreshToken(), "refresh-reuse-001");
+  }
+
+  @Test
+  void expiredRefreshTokenIsRejected() throws Exception {
+    TokenPairResponseView loginResult = loginResult("alice", "password123!", "refresh-expire-001");
+    Thread.sleep(2200L);
+    refreshExpectUnauthorized(loginResult.refreshToken(), "refresh-expire-002");
+  }
+
+  @Test
   void logsFailureAndResetWithRequestIdAndMaskedLoginKey(CapturedOutput output) throws Exception {
     loginExpectUnauthorized("alice", "wrong-password", "login-log-failure-001");
     login("alice", "password123!", "login-log-reset-001");
@@ -381,7 +421,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
 
   @Test
   void disabledUserCannotLoginOrUseExistingJwt() throws Exception {
-    String token = login("alice", "password123!");
+    TokenPairResponseView loginResult = loginResult("alice", "password123!", null);
+    String token = loginResult.accessToken();
     updateLegacyUserStatus(userId, "DISABLED", "fraud-review", "user-disabled-request");
 
     mockMvc
@@ -397,6 +438,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.message").value("login failed"));
+
+    refreshExpectUnauthorized(loginResult.refreshToken(), "refresh-disabled-001");
 
     mockMvc
         .perform(
@@ -560,13 +603,14 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   private String login(String loginId, String password, String requestId) throws Exception {
+    return loginResult(loginId, password, requestId).accessToken();
+  }
+
+  private TokenPairResponseView loginResult(String loginId, String password, String requestId)
+      throws Exception {
     MvcResult result =
         performLogin(loginId, password, requestId).andExpect(status().isOk()).andReturn();
-
-    JsonNode body = objectMapper.readTree(result.getResponse().getContentAsByteArray());
-    assertEquals("Bearer", body.get("tokenType").asText());
-    assertNotNull(body.get("expiresAt"));
-    return body.get("accessToken").asText();
+    return readTokenPair(result);
   }
 
   private void loginExpectUnauthorized(String loginId, String password, String requestId)
@@ -589,6 +633,36 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                 }
                 """
                     .formatted(loginId, password));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private TokenPairResponseView refresh(String refreshToken, String requestId) throws Exception {
+    MvcResult result =
+        performRefresh(refreshToken, requestId).andExpect(status().isOk()).andReturn();
+    return readTokenPair(result);
+  }
+
+  private void refreshExpectUnauthorized(String refreshToken, String requestId) throws Exception {
+    performRefresh(refreshToken, requestId)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("refresh failed"));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performRefresh(
+      String refreshToken, String requestId) throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        post("/api/v1/auth/refresh")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "refreshToken": "%s"
+                }
+                """
+                    .formatted(refreshToken));
     if (requestId != null && !requestId.isBlank()) {
       requestBuilder.header("X-Request-Id", requestId);
     }
@@ -809,6 +883,46 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .orElseThrow(() -> new AssertionError("login protection state is not found"));
   }
 
+  private RefreshTokenSessionView loadRefreshTokenSession(String refreshToken) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT session_status,
+                   expires_at,
+                   last_used_at,
+                   rotated_at,
+                   replaced_by_session_id
+            FROM auth_refresh_token_session
+            WHERE token_hash = :tokenHash
+            """,
+            new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
+                .addValue("tokenHash", refreshTokenSecretPort.hash(refreshToken)),
+            (rs, rowNum) ->
+                new RefreshTokenSessionView(
+                    rs.getString("session_status"),
+                    toInstant(rs.getTimestamp("expires_at")),
+                    toInstant(rs.getTimestamp("last_used_at")),
+                    toInstant(rs.getTimestamp("rotated_at")),
+                    rs.getObject("replaced_by_session_id", Long.class)))
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("refresh token session is not found"));
+  }
+
+  private TokenPairResponseView readTokenPair(MvcResult result) throws Exception {
+    JsonNode body = objectMapper.readTree(result.getResponse().getContentAsByteArray());
+    assertEquals("Bearer", body.get("tokenType").asText());
+    assertNotNull(body.get("expiresAt"));
+    assertNotNull(body.get("refreshExpiresAt"));
+    return new TokenPairResponseView(
+        body.get("accessToken").asText(),
+        body.get("refreshToken").asText(),
+        body.get("tokenType").asText(),
+        Instant.parse(body.get("expiresAt").asText()),
+        Instant.parse(body.get("refreshExpiresAt").asText()),
+        body.get("userId").asLong());
+  }
+
   private Instant toInstant(java.sql.Timestamp timestamp) {
     return timestamp == null ? null : timestamp.toInstant();
   }
@@ -839,4 +953,19 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
       Instant lastLoginFailedAt,
       Instant loginLockedUntil,
       Instant lastLoginSucceededAt) {}
+
+  private record TokenPairResponseView(
+      String accessToken,
+      String refreshToken,
+      String tokenType,
+      Instant expiresAt,
+      Instant refreshExpiresAt,
+      long userId) {}
+
+  private record RefreshTokenSessionView(
+      String sessionStatus,
+      Instant expiresAt,
+      Instant lastUsedAt,
+      Instant rotatedAt,
+      Long replacedBySessionId) {}
 }

--- a/back/src/test/resources/application-test.yml
+++ b/back/src/test/resources/application-test.yml
@@ -34,6 +34,7 @@ outbox:
 security:
   jwt:
     secret: test-local-jwt-secret-test-local-jwt-secret
+    refresh-token-ttl-seconds: 1209600
   login-protection:
     max-failures: 5
     lock-seconds: 900


### PR DESCRIPTION
## 🔗 Related Issue
- close #46

## 📝 Summary
- access token 단일 발급 구조를 access + refresh token pair 구조로 확장했습니다.
- login 응답에 refresh token과 refresh 만료 시각을 추가하고, `POST /api/v1/auth/refresh` 회전 재발급 경로를 연결했습니다.
- disabled user 차단, rotated/expired refresh token 거절, 운영 README 기준까지 최소 범위를 먼저 고정했습니다.

## 🛠 Changes
- `auth_refresh_token_session` 저장소와 refresh TTL 설정을 추가하고, raw token 대신 SHA-256 hash만 저장하도록 구성했습니다.
- `LoginService`와 `RefreshTokenService`에 refresh token 발급, rotation, 만료/disabled user 차단 로직을 추가했습니다.
- `/api/v1/auth/refresh` API, 통합 테스트, `RefreshTokenServiceTest`, 운영 README를 반영했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth-refresh ./back/gradlew -p back test --tests '*LoginAndAccountAccessApiIntegrationTest' --tests '*RefreshTokenServiceTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back clean check --no-daemon --stacktrace`
- `./back/gradlew -p back check` (pre-commit hook 재검증)

## 📸 Screenshot / API Example
- `POST /api/v1/auth/login` 응답 필드: `accessToken`, `refreshToken`, `tokenType`, `expiresAt`, `refreshExpiresAt`, `userId`
- `POST /api/v1/auth/refresh` 요청 body: `{ "refreshToken": "..." }`
- refresh 성공 시 새 token pair를 반환하고, 직전 refresh token 재사용은 `401 refresh failed` 입니다.

## ⚠️ Risk & Rollback
- 예상 리스크: login 응답 계약이 확장되어 기존 클라이언트 파서가 엄격한 필드 검증을 하면 영향이 있을 수 있습니다. refresh 저장소 migration이 auth bootstrap 초기화 단계에 추가됩니다.
- 롤백 방법: PR revert 후 배포하고, 사용하지 않는 `auth_refresh_token_session` 테이블과 refresh client 호출을 중단합니다. access token 기존 login 경로만 사용하므로 기능 롤백 범위는 auth session 경로로 한정됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.