### PR TITLE
[Feat] ledger reversal 기반 송금 취소/정정 경로 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -69,6 +69,39 @@ set +a
 - 운영 기본 인증 방식은 bearer JWT 입니다.
 - `dev`/`test` 프로필에서는 필요 시 `X-Account-Id` 헤더 fallback을 사용할 수 있습니다.
 
+## Transfer Reversal
+
+기존 BOOKED 송금은 직접 수정하지 않고 reversal transaction을 추가해 취소/정정합니다.
+
+- 공개 endpoint:
+  - `POST /api/v1/transfers`
+  - `POST /api/v1/transfers/{transactionReference}/reversal`
+- reversal 요청 필드:
+  - `sourceAccountId`
+  - `reversalReason`: `CANCEL` | `CORRECTION`
+  - `summary`
+- reversal 응답 필드:
+  - `originalTransactionReference`
+  - `reversalTransactionReference`
+  - `sourceAccountId`
+  - `targetAccountId`
+  - `amountMinor`
+  - `currencyCode`
+  - `availableBalanceAfterMinor`
+  - `bookedAt`
+  - `status`
+- write 기준:
+  - 원본 transfer와 reversal 관계는 `transfer_reversal` 테이블로 관리
+  - 원본 ledger row는 수정하지 않고 반대 방향 ledger entry 2건을 새 transaction reference로 추가
+  - 원본 `transaction_read_model` 상태는 `REVERSED` 로 전이하고 reversal read model row 2건을 추가
+  - outbox는 `TransferReversed` event를 별도 적재
+- 충돌 기준:
+  - 같은 원본 transfer를 다시 reversal 하면 `409 transfer is already reversed`
+  - reversal 시 target 계좌 잔액이 부족하면 `409 reversal target balance is not enough`
+- 운영 주의:
+  - 이번 범위는 full reversal만 지원하고 partial reversal은 제외
+  - notification inbox consumer는 아직 `TransferReversed` fan-out을 처리하지 않음
+
 ## Public Login Protection
 
 공개 login 경로 `/api/v1/auth/login`에는 brute-force 1차 방어 기준이 기본 적용됩니다.

--- a/back/src/main/java/com/aquilabank/domain/ledger/exception/TransferReversalNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/exception/TransferReversalNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.ledger.exception;
+
+/** reversal 대상 원본 transfer를 찾지 못했을 때 반환하는 예외 */
+public final class TransferReversalNotFoundException extends RuntimeException {
+
+  public TransferReversalNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/model/TransferReversalCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/model/TransferReversalCommand.java
@@ -1,0 +1,41 @@
+package com.aquilabank.domain.ledger.model;
+
+/** 송금 reversal 명령 입력 모델 */
+public record TransferReversalCommand(
+    String originalTransactionReference,
+    long sourceAccountId,
+    TransferReversalReason reversalReason,
+    String summary,
+    String idempotencyKey) {
+
+  public TransferReversalCommand {
+    if (originalTransactionReference == null
+        || originalTransactionReference.isBlank()
+        || originalTransactionReference.length() > 64) {
+      throw new IllegalArgumentException(
+          "originalTransactionReference must be between 1 and 64 characters");
+    }
+    if (sourceAccountId <= 0) {
+      throw new IllegalArgumentException("sourceAccountId must be positive");
+    }
+    if (reversalReason == null) {
+      throw new IllegalArgumentException("reversalReason is required");
+    }
+    if (summary == null || summary.isBlank() || summary.length() > 120) {
+      throw new IllegalArgumentException("summary must be between 1 and 120 characters");
+    }
+    if (idempotencyKey == null || idempotencyKey.isBlank() || idempotencyKey.length() > 80) {
+      throw new IllegalArgumentException("idempotencyKey must be between 1 and 80 characters");
+    }
+  }
+
+  public String fingerprint() {
+    return originalTransactionReference
+        + "|"
+        + sourceAccountId
+        + "|"
+        + reversalReason
+        + "|"
+        + summary;
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/model/TransferReversalReason.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/model/TransferReversalReason.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.ledger.model;
+
+/** 송금 reversal 사유를 짧은 enum으로 고정합니다. */
+public enum TransferReversalReason {
+  CANCEL,
+  CORRECTION
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/model/TransferReversalResult.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/model/TransferReversalResult.java
@@ -1,0 +1,43 @@
+package com.aquilabank.domain.ledger.model;
+
+import java.time.Instant;
+
+/** 송금 reversal 완료 결과 모델 */
+public record TransferReversalResult(
+    String originalTransactionReference,
+    String reversalTransactionReference,
+    long sourceAccountId,
+    long targetAccountId,
+    long amountMinor,
+    String currencyCode,
+    long availableBalanceAfterMinor,
+    Instant bookedAt,
+    String status) {
+
+  public TransferReversalResult {
+    if (originalTransactionReference == null || originalTransactionReference.isBlank()) {
+      throw new IllegalArgumentException("originalTransactionReference is required");
+    }
+    if (reversalTransactionReference == null || reversalTransactionReference.isBlank()) {
+      throw new IllegalArgumentException("reversalTransactionReference is required");
+    }
+    if (sourceAccountId <= 0) {
+      throw new IllegalArgumentException("sourceAccountId must be positive");
+    }
+    if (targetAccountId <= 0) {
+      throw new IllegalArgumentException("targetAccountId must be positive");
+    }
+    if (amountMinor <= 0) {
+      throw new IllegalArgumentException("amountMinor must be positive");
+    }
+    if (currencyCode == null || currencyCode.isBlank()) {
+      throw new IllegalArgumentException("currencyCode is required");
+    }
+    if (bookedAt == null) {
+      throw new IllegalArgumentException("bookedAt is required");
+    }
+    if (status == null || status.isBlank()) {
+      throw new IllegalArgumentException("status is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/port/TransferReversalWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/port/TransferReversalWritePort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.ledger.port;
+
+import com.aquilabank.domain.ledger.model.TransferReversalCommand;
+import com.aquilabank.domain.ledger.model.TransferReversalResult;
+
+/** reversal command 쓰기 경로를 ledger adapter에 위임합니다. */
+public interface TransferReversalWritePort {
+
+  TransferReversalResult reverse(TransferReversalCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferReversalCommandService.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferReversalCommandService.java
@@ -1,0 +1,20 @@
+package com.aquilabank.domain.ledger.usecase;
+
+import com.aquilabank.domain.ledger.model.TransferReversalCommand;
+import com.aquilabank.domain.ledger.model.TransferReversalResult;
+import com.aquilabank.domain.ledger.port.TransferReversalWritePort;
+
+/** reversal use case는 write port에 위임하고 adapter 경계를 유지합니다. */
+public final class TransferReversalCommandService implements TransferReversalUseCase {
+
+  private final TransferReversalWritePort transferReversalWritePort;
+
+  public TransferReversalCommandService(TransferReversalWritePort transferReversalWritePort) {
+    this.transferReversalWritePort = transferReversalWritePort;
+  }
+
+  @Override
+  public TransferReversalResult reverse(TransferReversalCommand command) {
+    return transferReversalWritePort.reverse(command);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferReversalUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferReversalUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.ledger.usecase;
+
+import com.aquilabank.domain.ledger.model.TransferReversalCommand;
+import com.aquilabank.domain.ledger.model.TransferReversalResult;
+
+/** 송금 reversal command 진입점 */
+public interface TransferReversalUseCase {
+
+  TransferReversalResult reverse(TransferReversalCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/TransferCommandConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/TransferCommandConfiguration.java
@@ -1,8 +1,11 @@
 package com.aquilabank.global.config;
 
+import com.aquilabank.domain.ledger.port.TransferReversalWritePort;
 import com.aquilabank.domain.ledger.port.TransferWritePort;
 import com.aquilabank.domain.ledger.usecase.TransferCommandService;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
+import com.aquilabank.domain.ledger.usecase.TransferReversalCommandService;
+import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,5 +17,11 @@ public class TransferCommandConfiguration {
   TransferCommandUseCase transferCommandUseCase(TransferWritePort transferWritePort) {
     // 쓰기 path도 configuration에서만 adapter를 조립하고 domain service는 순수하게 유지합니다.
     return new TransferCommandService(transferWritePort);
+  }
+
+  @Bean
+  TransferReversalUseCase transferReversalUseCase(
+      TransferReversalWritePort transferReversalWritePort) {
+    return new TransferReversalCommandService(transferReversalWritePort);
   }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferWriteRepository.java
@@ -4,8 +4,12 @@ import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
 import com.aquilabank.domain.ledger.exception.SnapshotNotFoundException;
+import com.aquilabank.domain.ledger.exception.TransferReversalNotFoundException;
 import com.aquilabank.domain.ledger.model.TransferCommand;
 import com.aquilabank.domain.ledger.model.TransferResult;
+import com.aquilabank.domain.ledger.model.TransferReversalCommand;
+import com.aquilabank.domain.ledger.model.TransferReversalResult;
+import com.aquilabank.domain.ledger.port.TransferReversalWritePort;
 import com.aquilabank.domain.ledger.port.TransferWritePort;
 import com.aquilabank.global.web.RequestTraceContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -15,8 +19,10 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -25,7 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** 송금 쓰기 명령을 ledger, snapshot, read model, outbox 적재로 풀어내는 JDBC adapter */
 @Repository
-public class JdbcTransferWriteRepository implements TransferWritePort {
+public class JdbcTransferWriteRepository implements TransferWritePort, TransferReversalWritePort {
 
   private static final RowMapper<IdempotencyRecord> IDEMPOTENCY_ROW_MAPPER =
       (rs, rowNum) -> mapIdempotencyRecord(rs);
@@ -53,7 +59,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
         throw new CommandConflictException("idempotencyKey is already used with another request");
       }
       if ("COMPLETED".equals(record.processingStatus()) && record.responsePayload() != null) {
-        return readStoredResult(record.responsePayload());
+        return readStoredResult(record.responsePayload(), TransferResult.class);
       }
       if ("STARTED".equals(record.processingStatus()) && record.lockedUntil().isAfter(now)) {
         throw new CommandConflictException("same command is already in progress");
@@ -87,7 +93,8 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
             command.amountMinor(),
             command.currencyCode(),
             command.summary(),
-            bookedAt);
+            bookedAt,
+            "{}");
     long creditEntryId =
         insertLedgerEntry(
             command.targetAccountId(),
@@ -96,7 +103,8 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
             command.amountMinor(),
             command.currencyCode(),
             command.summary(),
-            bookedAt);
+            bookedAt,
+            "{}");
 
     updateBalanceSnapshot(command.sourceAccountId(), debitEntryId, sourceBalanceAfter, bookedAt);
     updateBalanceSnapshot(command.targetAccountId(), creditEntryId, targetBalanceAfter, bookedAt);
@@ -107,6 +115,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
         command.sourceAccountId(),
         transactionReference,
         "DEBIT",
+        "BOOKED",
         command.amountMinor(),
         sourceBalanceAfter,
         command.currencyCode(),
@@ -118,6 +127,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
         command.targetAccountId(),
         transactionReference,
         "CREDIT",
+        "BOOKED",
         command.amountMinor(),
         targetBalanceAfter,
         command.currencyCode(),
@@ -139,6 +149,121 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
             bookedAt,
             "BOOKED");
     // 최종 응답을 저장해 동일 요청 재시도 시 같은 결과를 재사용합니다.
+    completeIdempotency(command.idempotencyKey(), result, bookedAt);
+    return result;
+  }
+
+  @Override
+  @Transactional
+  public TransferReversalResult reverse(TransferReversalCommand command) {
+    Instant now = Instant.now();
+    boolean inserted = tryInsertIdempotency(command.idempotencyKey(), command.fingerprint(), now);
+
+    if (!inserted) {
+      IdempotencyRecord record = loadIdempotencyForUpdate(command.idempotencyKey());
+      if (!record.requestFingerprint().equals(command.fingerprint())) {
+        throw new CommandConflictException("idempotencyKey is already used with another request");
+      }
+      if ("COMPLETED".equals(record.processingStatus()) && record.responsePayload() != null) {
+        return readStoredResult(record.responsePayload(), TransferReversalResult.class);
+      }
+      if ("STARTED".equals(record.processingStatus()) && record.lockedUntil().isAfter(now)) {
+        throw new CommandConflictException("same command is already in progress");
+      }
+      refreshIdempotencyLock(command.idempotencyKey(), now);
+    }
+
+    OriginalTransferRecord original =
+        loadOriginalTransferForUpdate(
+            command.originalTransactionReference(), command.sourceAccountId());
+    ensureNotAlreadyReversed(command.originalTransactionReference());
+
+    LockedBalanceSnapshot source = loadBalanceSnapshot(original.sourceAccountId());
+    LockedBalanceSnapshot target = loadBalanceSnapshot(original.targetAccountId());
+    if (!source.currencyCode().equals(original.currencyCode())
+        || !target.currencyCode().equals(original.currencyCode())) {
+      throw new CurrencyMismatchException("currency does not match original transfer");
+    }
+    if (target.availableBalanceMinor() < original.amountMinor()) {
+      throw new InsufficientBalanceException("reversal target balance is not enough");
+    }
+
+    Instant bookedAt = now;
+    String reversalTransactionReference = "TRX-" + UUID.randomUUID();
+    long sourceBalanceAfter = source.availableBalanceMinor() + original.amountMinor();
+    long targetBalanceAfter = target.availableBalanceMinor() - original.amountMinor();
+    String reversalMetadata =
+        toJson(
+            Map.of(
+                "originalTransactionReference", original.transactionReference(),
+                "reversalReason", command.reversalReason().name()));
+
+    long sourceReversalEntryId =
+        insertLedgerEntry(
+            original.sourceAccountId(),
+            reversalTransactionReference,
+            "CREDIT",
+            original.amountMinor(),
+            original.currencyCode(),
+            command.summary(),
+            bookedAt,
+            reversalMetadata);
+    long targetReversalEntryId =
+        insertLedgerEntry(
+            original.targetAccountId(),
+            reversalTransactionReference,
+            "DEBIT",
+            original.amountMinor(),
+            original.currencyCode(),
+            command.summary(),
+            bookedAt,
+            reversalMetadata);
+
+    updateBalanceSnapshot(
+        original.sourceAccountId(), sourceReversalEntryId, sourceBalanceAfter, bookedAt);
+    updateBalanceSnapshot(
+        original.targetAccountId(), targetReversalEntryId, targetBalanceAfter, bookedAt);
+
+    markTransactionReadModelReversed(original.transactionReference());
+    insertTransactionReadModel(
+        sourceReversalEntryId,
+        original.sourceAccountId(),
+        reversalTransactionReference,
+        "CREDIT",
+        "BOOKED",
+        original.amountMinor(),
+        sourceBalanceAfter,
+        original.currencyCode(),
+        command.summary(),
+        "ACCOUNT-" + original.targetAccountId(),
+        bookedAt);
+    insertTransactionReadModel(
+        targetReversalEntryId,
+        original.targetAccountId(),
+        reversalTransactionReference,
+        "DEBIT",
+        "BOOKED",
+        original.amountMinor(),
+        targetBalanceAfter,
+        original.currencyCode(),
+        command.summary(),
+        "ACCOUNT-" + original.sourceAccountId(),
+        bookedAt);
+
+    insertTransferReversal(original, reversalTransactionReference, command, bookedAt);
+    insertReversalOutboxEvent(original, reversalTransactionReference, command, bookedAt);
+
+    TransferReversalResult result =
+        new TransferReversalResult(
+            original.transactionReference(),
+            reversalTransactionReference,
+            original.sourceAccountId(),
+            original.targetAccountId(),
+            original.amountMinor(),
+            original.currencyCode(),
+            sourceBalanceAfter,
+            bookedAt,
+            "REVERSED");
     completeIdempotency(command.idempotencyKey(), result, bookedAt);
     return result;
   }
@@ -255,7 +380,8 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
       long amountMinor,
       String currencyCode,
       String summary,
-      Instant bookedAt) {
+      Instant bookedAt,
+      String metadataJson) {
     String traceId = RequestTraceContext.currentRequestId().orElse(null);
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -266,6 +392,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
             .addValue("amountMinor", amountMinor)
             .addValue("currencyCode", currencyCode)
             .addValue("summary", summary)
+            .addValue("metadata", metadataJson)
             .addValue("traceId", traceId)
             .addValue("bookedAt", Timestamp.from(bookedAt));
 
@@ -283,6 +410,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
                 booked_at,
                 description,
                 trace_id,
+                metadata,
                 occurred_at,
                 created_at,
                 updated_at
@@ -298,6 +426,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
                 :bookedAt,
                 :summary,
                 :traceId,
+                CAST(:metadata AS jsonb),
                 :bookedAt,
                 :bookedAt,
                 :bookedAt
@@ -341,6 +470,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
       long accountId,
       String transactionReference,
       String direction,
+      String transactionStatus,
       long amountMinor,
       long balanceAfterMinor,
       String currencyCode,
@@ -353,6 +483,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
             .addValue("accountId", accountId)
             .addValue("transactionReference", transactionReference)
             .addValue("direction", direction)
+            .addValue("transactionStatus", transactionStatus)
             .addValue("amountMinor", amountMinor)
             .addValue("balanceAfterMinor", balanceAfterMinor)
             .addValue("currencyCode", currencyCode)
@@ -381,7 +512,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
             :accountId,
             :transactionReference,
             :direction,
-            'BOOKED',
+            :transactionStatus,
             :amountMinor,
             :balanceAfterMinor,
             :currencyCode,
@@ -431,7 +562,196 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
         params);
   }
 
-  private void completeIdempotency(String key, TransferResult result, Instant completedAt) {
+  private void insertReversalOutboxEvent(
+      OriginalTransferRecord original,
+      String reversalTransactionReference,
+      TransferReversalCommand command,
+      Instant bookedAt) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("aggregateId", reversalTransactionReference)
+            .addValue("eventKey", "transfer-reversed:" + original.transactionReference())
+            .addValue(
+                "payload",
+                toJson(
+                    Map.of(
+                        "originalTransactionReference", original.transactionReference(),
+                        "reversalTransactionReference", reversalTransactionReference,
+                        "sourceAccountId", original.sourceAccountId(),
+                        "targetAccountId", original.targetAccountId(),
+                        "amountMinor", original.amountMinor(),
+                        "currencyCode", original.currencyCode(),
+                        "reversalReason", command.reversalReason().name(),
+                        "bookedAt", bookedAt.toString())))
+            .addValue("bookedAt", Timestamp.from(bookedAt));
+
+    jdbcTemplate.update(
+        """
+        INSERT INTO outbox_event (
+            aggregate_type,
+            aggregate_id,
+            event_type,
+            event_key,
+            payload,
+            publish_status,
+            available_at,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            'TRANSFER',
+            :aggregateId,
+            'TransferReversed',
+            :eventKey,
+            CAST(:payload AS jsonb),
+            'PENDING',
+            :bookedAt,
+            :bookedAt,
+            :bookedAt
+        )
+        """,
+        params);
+  }
+
+  private void insertTransferReversal(
+      OriginalTransferRecord original,
+      String reversalTransactionReference,
+      TransferReversalCommand command,
+      Instant createdAt) {
+    try {
+      jdbcTemplate.update(
+          """
+          INSERT INTO transfer_reversal (
+              original_transaction_reference,
+              reversal_transaction_reference,
+              source_account_id,
+              target_account_id,
+              amount_minor,
+              currency_code,
+              reversal_reason,
+              summary,
+              created_at
+          )
+          VALUES (
+              :originalTransactionReference,
+              :reversalTransactionReference,
+              :sourceAccountId,
+              :targetAccountId,
+              :amountMinor,
+              :currencyCode,
+              :reversalReason,
+              :summary,
+              :createdAt
+          )
+          """,
+          new MapSqlParameterSource()
+              .addValue("originalTransactionReference", original.transactionReference())
+              .addValue("reversalTransactionReference", reversalTransactionReference)
+              .addValue("sourceAccountId", original.sourceAccountId())
+              .addValue("targetAccountId", original.targetAccountId())
+              .addValue("amountMinor", original.amountMinor())
+              .addValue("currencyCode", original.currencyCode())
+              .addValue("reversalReason", command.reversalReason().name())
+              .addValue("summary", command.summary())
+              .addValue("createdAt", Timestamp.from(createdAt)));
+    } catch (DuplicateKeyException ex) {
+      throw new CommandConflictException("transfer is already reversed");
+    }
+  }
+
+  private void ensureNotAlreadyReversed(String originalTransactionReference) {
+    boolean exists =
+        jdbcTemplate
+            .query(
+                """
+                SELECT 1
+                FROM transfer_reversal
+                WHERE original_transaction_reference = :originalTransactionReference
+                FOR UPDATE
+                """,
+                new MapSqlParameterSource()
+                    .addValue("originalTransactionReference", originalTransactionReference),
+                (rs, rowNum) -> rs.getInt(1))
+            .stream()
+            .findFirst()
+            .isPresent();
+    if (exists) {
+      throw new CommandConflictException("transfer is already reversed");
+    }
+  }
+
+  private OriginalTransferRecord loadOriginalTransferForUpdate(
+      String originalTransactionReference, long sourceAccountId) {
+    List<OriginalTransferLedgerEntry> entries =
+        jdbcTemplate.query(
+            """
+            SELECT account_id,
+                   transaction_reference,
+                   direction,
+                   amount_minor,
+                   currency_code,
+                   description
+            FROM ledger_entry
+            WHERE transaction_reference = :transactionReference
+            ORDER BY id
+            FOR UPDATE
+            """,
+            new MapSqlParameterSource()
+                .addValue("transactionReference", originalTransactionReference),
+            (rs, rowNum) ->
+                new OriginalTransferLedgerEntry(
+                    rs.getLong("account_id"),
+                    rs.getString("transaction_reference"),
+                    rs.getString("direction"),
+                    rs.getLong("amount_minor"),
+                    rs.getString("currency_code"),
+                    rs.getString("description")));
+    if (entries.size() != 2) {
+      throw new TransferReversalNotFoundException("transfer reversal target is not found");
+    }
+
+    OriginalTransferLedgerEntry debit = null;
+    OriginalTransferLedgerEntry credit = null;
+    for (OriginalTransferLedgerEntry entry : entries) {
+      if ("DEBIT".equals(entry.direction())) {
+        debit = entry;
+      } else if ("CREDIT".equals(entry.direction())) {
+        credit = entry;
+      }
+    }
+    if (debit == null || credit == null) {
+      throw new TransferReversalNotFoundException("transfer reversal target is not found");
+    }
+    if (debit.accountId() != sourceAccountId) {
+      throw new TransferReversalNotFoundException("transfer reversal target is not found");
+    }
+    if (debit.amountMinor() != credit.amountMinor()
+        || !debit.currencyCode().equals(credit.currencyCode())) {
+      throw new IllegalStateException("original transfer ledger rows are inconsistent");
+    }
+    return new OriginalTransferRecord(
+        debit.transactionReference(),
+        debit.accountId(),
+        credit.accountId(),
+        debit.amountMinor(),
+        debit.currencyCode());
+  }
+
+  private void markTransactionReadModelReversed(String transactionReference) {
+    int updated =
+        jdbcTemplate.update(
+            """
+            UPDATE transaction_read_model
+            SET transaction_status = 'REVERSED'
+            WHERE transaction_reference = :transactionReference
+            """,
+            new MapSqlParameterSource().addValue("transactionReference", transactionReference));
+    if (updated != 2) {
+      throw new IllegalStateException("original transaction read model update failed");
+    }
+  }
+
+  private void completeIdempotency(String key, Object result, Instant completedAt) {
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("idempotencyKey", key)
@@ -452,10 +772,10 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
         params);
   }
 
-  private TransferResult readStoredResult(String rawPayload) {
+  private <T> T readStoredResult(String rawPayload, Class<T> type) {
     try {
       // 완료된 idempotency 요청은 저장된 payload를 그대로 복원해 재응답합니다.
-      return objectMapper.readValue(rawPayload, TransferResult.class);
+      return objectMapper.readValue(rawPayload, type);
     } catch (JsonProcessingException ex) {
       throw new IllegalStateException("stored idempotency payload is invalid", ex);
     }
@@ -505,6 +825,21 @@ public class JdbcTransferWriteRepository implements TransferWritePort {
       String processingStatus,
       String responsePayload,
       Instant lockedUntil) {}
+
+  private record OriginalTransferLedgerEntry(
+      long accountId,
+      String transactionReference,
+      String direction,
+      long amountMinor,
+      String currencyCode,
+      String summary) {}
+
+  private record OriginalTransferRecord(
+      String transactionReference,
+      long sourceAccountId,
+      long targetAccountId,
+      long amountMinor,
+      String currencyCode) {}
 
   private record LockedBalanceSnapshot(
       long accountId,

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -12,6 +12,7 @@ import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
 import com.aquilabank.domain.ledger.exception.SnapshotNotFoundException;
+import com.aquilabank.domain.ledger.exception.TransferReversalNotFoundException;
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
 import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
 import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
@@ -98,6 +99,7 @@ public class ApiExceptionHandler {
   @ExceptionHandler({
     AccountSummaryNotFoundException.class,
     SnapshotNotFoundException.class,
+    TransferReversalNotFoundException.class,
     AuthStatusChangeAuditNotFoundException.class,
     AuthUserNotFoundException.class,
     UserAccountMembershipNotFoundException.class,

--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
@@ -2,16 +2,23 @@ package com.aquilabank.global.web.ledger;
 
 import com.aquilabank.domain.ledger.model.TransferCommand;
 import com.aquilabank.domain.ledger.model.TransferResult;
+import com.aquilabank.domain.ledger.model.TransferReversalCommand;
+import com.aquilabank.domain.ledger.model.TransferReversalReason;
+import com.aquilabank.domain.ledger.model.TransferReversalResult;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
+import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
 import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+import java.time.Instant;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -25,12 +32,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class TransferCommandController {
 
   private final TransferCommandUseCase transferCommandUseCase;
+  private final TransferReversalUseCase transferReversalUseCase;
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
 
   public TransferCommandController(
       TransferCommandUseCase transferCommandUseCase,
+      TransferReversalUseCase transferReversalUseCase,
       RequestAccountAuthorizationService requestAccountAuthorizationService) {
     this.transferCommandUseCase = transferCommandUseCase;
+    this.transferReversalUseCase = transferReversalUseCase;
     this.requestAccountAuthorizationService = requestAccountAuthorizationService;
   }
 
@@ -54,6 +64,26 @@ public class TransferCommandController {
     return TransferResponse.from(result);
   }
 
+  @PostMapping("/{transactionReference}/reversal")
+  public TransferReversalResponse reverse(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @PathVariable String transactionReference,
+      @RequestHeader("Idempotency-Key") String idempotencyKey,
+      @Valid @RequestBody TransferReversalRequest request) {
+    long sourceAccountId =
+        requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            principal, request.sourceAccountId());
+    TransferReversalResult result =
+        transferReversalUseCase.reverse(
+            new TransferReversalCommand(
+                transactionReference,
+                sourceAccountId,
+                request.reversalReason(),
+                request.summary(),
+                idempotencyKey));
+    return TransferReversalResponse.from(result);
+  }
+
   /** 송금 요청 body */
   public record TransferRequest(
       @Positive(message = "sourceAccountId must be positive") long sourceAccountId,
@@ -63,6 +93,12 @@ public class TransferCommandController {
               regexp = "^[A-Z]{3}$",
               message = "currencyCode must be a 3-letter uppercase code")
           String currencyCode,
+      @NotBlank(message = "summary is required") @Size(max = 120, message = "summary must be 120 characters or less") String summary) {}
+
+  /** 송금 reversal 요청 body */
+  public record TransferReversalRequest(
+      @Positive(message = "sourceAccountId must be positive") long sourceAccountId,
+      @NotNull(message = "reversalReason is required") TransferReversalReason reversalReason,
       @NotBlank(message = "summary is required") @Size(max = 120, message = "summary must be 120 characters or less") String summary) {}
 
   /** 송금 완료 응답 */
@@ -79,6 +115,32 @@ public class TransferCommandController {
     static TransferResponse from(TransferResult result) {
       return new TransferResponse(
           result.transactionReference(),
+          result.sourceAccountId(),
+          result.targetAccountId(),
+          result.amountMinor(),
+          result.currencyCode(),
+          result.availableBalanceAfterMinor(),
+          result.bookedAt(),
+          result.status());
+    }
+  }
+
+  /** 송금 reversal 완료 응답 */
+  public record TransferReversalResponse(
+      String originalTransactionReference,
+      String reversalTransactionReference,
+      long sourceAccountId,
+      long targetAccountId,
+      long amountMinor,
+      String currencyCode,
+      long availableBalanceAfterMinor,
+      Instant bookedAt,
+      String status) {
+
+    static TransferReversalResponse from(TransferReversalResult result) {
+      return new TransferReversalResponse(
+          result.originalTransactionReference(),
+          result.reversalTransactionReference(),
           result.sourceAccountId(),
           result.targetAccountId(),
           result.amountMinor(),

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -81,6 +81,7 @@ outbox:
       default-name: ${OUTBOX_KAFKA_TOPIC_DEFAULT:}
       event-type-overrides:
         TransferBooked: ${OUTBOX_KAFKA_TOPIC_TRANSFER_BOOKED:}
+        TransferReversed: ${OUTBOX_KAFKA_TOPIC_TRANSFER_REVERSED:}
     serializer:
       key-class: ${OUTBOX_KAFKA_KEY_SERIALIZER:org.apache.kafka.common.serialization.StringSerializer}
       value-class: ${OUTBOX_KAFKA_VALUE_SERIALIZER:org.apache.kafka.common.serialization.StringSerializer}

--- a/back/src/main/resources/db/migration/V11__add_transfer_reversal.sql
+++ b/back/src/main/resources/db/migration/V11__add_transfer_reversal.sql
@@ -1,0 +1,20 @@
+CREATE TABLE transfer_reversal (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    original_transaction_reference VARCHAR(64) NOT NULL,
+    reversal_transaction_reference VARCHAR(64) NOT NULL,
+    source_account_id BIGINT NOT NULL,
+    target_account_id BIGINT NOT NULL,
+    amount_minor BIGINT NOT NULL CHECK (amount_minor > 0),
+    currency_code VARCHAR(3) NOT NULL CHECK (currency_code ~ '^[A-Z]{3}$'),
+    reversal_reason VARCHAR(16) NOT NULL
+        CHECK (reversal_reason IN ('CANCEL', 'CORRECTION')),
+    summary VARCHAR(120) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_transfer_reversal_original_reference
+        UNIQUE (original_transaction_reference),
+    CONSTRAINT uq_transfer_reversal_reversal_reference
+        UNIQUE (reversal_transaction_reference)
+);
+
+CREATE INDEX idx_transfer_reversal_source_created_at
+    ON transfer_reversal (source_account_id, created_at DESC, id DESC);

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionDetailRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionDetailRepositoryIntegrationTest.java
@@ -50,6 +50,7 @@ class JdbcTransactionDetailRepositoryIntegrationTest extends PostgresContainerTe
               accountIds[0],
               "TRX-1",
               "DEBIT",
+              "BOOKED",
               1500L,
               8500L,
               "rent",
@@ -63,6 +64,7 @@ class JdbcTransactionDetailRepositoryIntegrationTest extends PostgresContainerTe
               accountIds[1],
               "TRX-1",
               "CREDIT",
+              "BOOKED",
               1500L,
               1500L,
               "rent",
@@ -97,6 +99,7 @@ class JdbcTransactionDetailRepositoryIntegrationTest extends PostgresContainerTe
               accountId[0],
               "TRX-DUP",
               "DEBIT",
+              "BOOKED",
               100L,
               900L,
               "dup",
@@ -116,6 +119,7 @@ class JdbcTransactionDetailRepositoryIntegrationTest extends PostgresContainerTe
               accountId[0],
               "TRX-DUP",
               "DEBIT",
+              "BOOKED",
               100L,
               800L,
               "dup",
@@ -126,6 +130,54 @@ class JdbcTransactionDetailRepositoryIntegrationTest extends PostgresContainerTe
     assertThatThrownBy(() -> repository.find(new TransactionDetailQuery(accountId[0], "TRX-DUP")))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("multiple rows");
+  }
+
+  @Test
+  void returnsReversedTransactionStatusWhileKeepingBookedLedgerEntryStatus() {
+    Instant bookedAt = Instant.parse("2026-04-16T09:00:00Z");
+    Instant occurredAt = Instant.parse("2026-04-16T09:00:01Z");
+    long[] accountIds = new long[2];
+    commit(
+        transactionManager,
+        () -> {
+          accountIds[0] = insertBankAccount("source account");
+          accountIds[1] = insertBankAccount("target account");
+          long sourceLedgerEntryId =
+              insertLedgerEntry(
+                  accountIds[0], "TRX-REV-1", "ENT-REV-1", "DEBIT", bookedAt, occurredAt, "rent");
+          insertReadModel(
+              sourceLedgerEntryId,
+              accountIds[0],
+              "TRX-REV-1",
+              "DEBIT",
+              "REVERSED",
+              1500L,
+              8_500L,
+              "rent",
+              "TARGET",
+              bookedAt);
+          long targetLedgerEntryId =
+              insertLedgerEntry(
+                  accountIds[1], "TRX-REV-1", "ENT-REV-2", "CREDIT", bookedAt, occurredAt, "rent");
+          insertReadModel(
+              targetLedgerEntryId,
+              accountIds[1],
+              "TRX-REV-1",
+              "CREDIT",
+              "REVERSED",
+              1500L,
+              1_500L,
+              "rent",
+              "SOURCE",
+              bookedAt);
+        });
+
+    Optional<com.aquilabank.domain.transaction.model.TransactionDetail> result =
+        repository.find(new TransactionDetailQuery(accountIds[0], "TRX-REV-1"));
+
+    assertThat(result).isPresent();
+    assertThat(result.orElseThrow().transactionStatus()).hasToString("REVERSED");
+    assertThat(result.orElseThrow().entryStatus()).hasToString("BOOKED");
   }
 
   private long insertBankAccount(String displayName) {
@@ -221,6 +273,7 @@ class JdbcTransactionDetailRepositoryIntegrationTest extends PostgresContainerTe
       long accountId,
       String transactionReference,
       String direction,
+      String transactionStatus,
       long amountMinor,
       long balanceAfterMinor,
       String summary,
@@ -247,7 +300,7 @@ class JdbcTransactionDetailRepositoryIntegrationTest extends PostgresContainerTe
             :accountId,
             :transactionReference,
             :direction,
-            'BOOKED',
+            :transactionStatus,
             :amountMinor,
             :balanceAfterMinor,
             'KRW',
@@ -262,6 +315,7 @@ class JdbcTransactionDetailRepositoryIntegrationTest extends PostgresContainerTe
             .addValue("accountId", accountId)
             .addValue("transactionReference", transactionReference)
             .addValue("direction", direction)
+            .addValue("transactionStatus", transactionStatus)
             .addValue("amountMinor", amountMinor)
             .addValue("balanceAfterMinor", balanceAfterMinor)
             .addValue("summary", summary)

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
@@ -133,6 +133,80 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
     assertEquals(0L, balanceOf(targetAccountId));
   }
 
+  @Test
+  void reversesTransferAndPersistsReversalLedgerReadModelOutboxAndIdempotency() throws Exception {
+    TransferResponseView booked = invokeTransfer("transfer-004", targetAccountId, 1_500L, "rent");
+
+    TransferReversalResponseView reversed =
+        invokeReversal(booked.transactionReference(), "reversal-001", "CANCEL", "cancel rent");
+
+    assertEquals(booked.transactionReference(), reversed.originalTransactionReference());
+    assertEquals(sourceAccountId, reversed.sourceAccountId());
+    assertEquals(targetAccountId, reversed.targetAccountId());
+    assertEquals(10_000L, reversed.availableBalanceAfterMinor());
+    assertEquals("reversal-001-request", reversed.requestId());
+    assertEquals(2L, countRows("ledger_entry", booked.transactionReference()));
+    assertEquals(2L, countRows("ledger_entry", reversed.reversalTransactionReference()));
+    assertEquals(2L, countRows("transaction_read_model", reversed.reversalTransactionReference()));
+    assertEquals(2L, transactionStatusCount(booked.transactionReference(), "REVERSED"));
+    assertEquals(10_000L, balanceOf(sourceAccountId));
+    assertEquals(0L, balanceOf(targetAccountId));
+    assertEquals(1L, transferReversalCount(booked.transactionReference()));
+    assertEquals(2L, countTraceRows(reversed.requestId()));
+
+    Map<String, Object> commandState = idempotencyState("reversal-001");
+    assertEquals("COMPLETED", commandState.get("processing_status"));
+    assertEquals(200, ((Number) commandState.get("response_code")).intValue());
+
+    Map<String, Object> outboxState = outboxState(reversed.reversalTransactionReference());
+    assertEquals("TRANSFER", outboxState.get("aggregate_type"));
+    assertEquals("TransferReversed", outboxState.get("event_type"));
+    assertEquals("PENDING", outboxState.get("publish_status"));
+    assertTrue(String.valueOf(outboxState.get("payload")).contains(booked.transactionReference()));
+    assertTrue(
+        String.valueOf(outboxState.get("payload"))
+            .contains(reversed.reversalTransactionReference()));
+  }
+
+  @Test
+  void rejectsDuplicateReversalForSameOriginalTransfer() throws Exception {
+    TransferResponseView booked =
+        invokeTransfer("transfer-005", targetAccountId, 1_200L, "tuition");
+    TransferReversalResponseView reversed =
+        invokeReversal(booked.transactionReference(), "reversal-002", "CORRECTION", "fix tuition");
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers/%s/reversal".formatted(booked.transactionReference()))
+                    .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", "reversal-003-request")
+                    .header("Idempotency-Key", "reversal-003")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "reversalReason": "CANCEL",
+                          "summary": "duplicate cancel"
+                        }
+                        """
+                            .formatted(sourceAccountId)))
+            .andReturn();
+
+    assertEquals(409, result.getResponse().getStatus(), result.getResponse().getContentAsString());
+    assertEquals(
+        "transfer is already reversed",
+        objectMapper
+            .readTree(result.getResponse().getContentAsByteArray())
+            .get("message")
+            .asText());
+    assertEquals(1L, transferReversalCount(booked.transactionReference()));
+    assertEquals(2L, countRows("ledger_entry", reversed.reversalTransactionReference()));
+    assertEquals(1L, outboxCount(reversed.reversalTransactionReference()));
+    assertEquals(0L, idempotencyCount("reversal-003"));
+  }
+
   private AccountBootstrapResponseView bootstrapAccount(
       String displayName, long initialBalanceMinor) throws Exception {
     MvcResult result =
@@ -192,6 +266,40 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
         result.getResponse().getHeader("X-Request-Id"));
   }
 
+  private TransferReversalResponseView invokeReversal(
+      String originalTransactionReference,
+      String idempotencyKey,
+      String reversalReason,
+      String summary)
+      throws Exception {
+    String requestId = idempotencyKey + "-request";
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers/%s/reversal".formatted(originalTransactionReference))
+                    .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", requestId)
+                    .header("Idempotency-Key", idempotencyKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "reversalReason": "%s",
+                          "summary": "%s"
+                        }
+                        """
+                            .formatted(sourceAccountId, reversalReason, summary)))
+            .andReturn();
+
+    assertEquals(200, result.getResponse().getStatus(), result.getResponse().getContentAsString());
+
+    return new TransferReversalResponseView(
+        objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(), TransferReversalResponseBody.class),
+        result.getResponse().getHeader("X-Request-Id"));
+  }
+
   private void updateBalance(long accountId, long availableBalanceMinor) {
     jdbcTemplate.update(
         """
@@ -237,6 +345,32 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
         WHERE aggregate_id = :transactionReference
         """,
         new MapSqlParameterSource().addValue("transactionReference", transactionReference),
+        Long.class);
+  }
+
+  private long transferReversalCount(String originalTransactionReference) {
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT COUNT(*)
+        FROM transfer_reversal
+        WHERE original_transaction_reference = :originalTransactionReference
+        """,
+        new MapSqlParameterSource()
+            .addValue("originalTransactionReference", originalTransactionReference),
+        Long.class);
+  }
+
+  private long transactionStatusCount(String transactionReference, String transactionStatus) {
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT COUNT(*)
+        FROM transaction_read_model
+        WHERE transaction_reference = :transactionReference
+          AND transaction_status = :transactionStatus
+        """,
+        new MapSqlParameterSource()
+            .addValue("transactionReference", transactionReference)
+            .addValue("transactionStatus", transactionStatus),
         Long.class);
   }
 
@@ -304,8 +438,42 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
     }
   }
 
+  private record TransferReversalResponseView(TransferReversalResponseBody body, String requestId) {
+
+    private String originalTransactionReference() {
+      return body.originalTransactionReference();
+    }
+
+    private String reversalTransactionReference() {
+      return body.reversalTransactionReference();
+    }
+
+    private long sourceAccountId() {
+      return body.sourceAccountId();
+    }
+
+    private long targetAccountId() {
+      return body.targetAccountId();
+    }
+
+    private long availableBalanceAfterMinor() {
+      return body.availableBalanceAfterMinor();
+    }
+  }
+
   private record TransferResponseBody(
       String transactionReference,
+      long sourceAccountId,
+      long targetAccountId,
+      long amountMinor,
+      String currencyCode,
+      long availableBalanceAfterMinor,
+      Instant bookedAt,
+      String status) {}
+
+  private record TransferReversalResponseBody(
+      String originalTransactionReference,
+      String reversalTransactionReference,
       long sourceAccountId,
       long targetAccountId,
       long amountMinor,

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -9,7 +9,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.aquilabank.domain.ledger.model.TransferResult;
+import com.aquilabank.domain.ledger.model.TransferReversalResult;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
+import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
@@ -23,17 +25,21 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class TransferCommandControllerTest {
 
   private TransferCommandUseCase transferCommandUseCase;
+  private TransferReversalUseCase transferReversalUseCase;
   private RequestAccountAuthorizationService requestAccountAuthorizationService;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
     transferCommandUseCase = mock(TransferCommandUseCase.class);
+    transferReversalUseCase = mock(TransferReversalUseCase.class);
     requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new TransferCommandController(
-                    transferCommandUseCase, requestAccountAuthorizationService))
+                    transferCommandUseCase,
+                    transferReversalUseCase,
+                    requestAccountAuthorizationService))
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .setControllerAdvice(new ApiExceptionHandler())
@@ -80,6 +86,48 @@ class TransferCommandControllerTest {
 
     verify(transferCommandUseCase)
         .transfer(argThat(command -> "transfer-001".equals(command.idempotencyKey())));
+  }
+
+  @Test
+  void reversesTransferUsingAuthenticatedAccountAndIdempotencyKey() throws Exception {
+    when(transferReversalUseCase.reverse(
+            argThat(command -> "TRX-1".equals(command.originalTransactionReference()))))
+        .thenReturn(
+            new TransferReversalResult(
+                "TRX-1",
+                "TRX-2",
+                101L,
+                202L,
+                1500L,
+                "KRW",
+                10_000L,
+                java.time.Instant.parse("2026-04-16T10:10:00Z"),
+                "REVERSED"));
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers/TRX-1/reversal")
+                .header("X-Account-Id", "101")
+                .header("Idempotency-Key", "reversal-001")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": 101,
+                      "reversalReason": "CANCEL",
+                      "summary": "cancel transfer"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.originalTransactionReference").value("TRX-1"))
+        .andExpect(jsonPath("$.reversalTransactionReference").value("TRX-2"))
+        .andExpect(jsonPath("$.availableBalanceAfterMinor").value(10000));
+
+    verify(transferReversalUseCase)
+        .reverse(argThat(command -> "reversal-001".equals(command.idempotencyKey())));
   }
 
   @Test


### PR DESCRIPTION
## 🔗 Related Issue
- close #48

## 📝 Summary
- BOOKED 단방향 송금에 대해 ledger append-only 기준의 reversal 경로를 추가했습니다.
- reversal transaction, snapshot 복구, read model 상태 전이, `TransferReversed` outbox 적재를 같은 write transaction 안에서 처리합니다.
- 공개 reversal API와 통합 테스트, 운영 README 기준까지 같이 반영했습니다.

## 🛠 Changes
- `transfer_reversal` 관계 테이블과 reversal domain command/result/use case 계약을 추가했습니다.
- `JdbcTransferWriteRepository` 에 reversal write 경로를 추가하고, `TransferCommandController` 에 `/api/v1/transfers/{transactionReference}/reversal` endpoint를 열었습니다.
- `TransferCommandApiIntegrationTest`, `JdbcTransactionDetailRepositoryIntegrationTest`, `README.md` 에 reversal 검증과 운영 기준을 반영했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-compile ./back/gradlew -p back compileJava compileTestJava`
- `tools/test/with-resource-lock.sh back-gradle-ledger-controller ./back/gradlew -p back test --tests '*TransferCommandControllerTest'`
- `tools/test/with-resource-lock.sh back-gradle-transfer-reversal ./back/gradlew -p back test --tests '*TransferCommandApiIntegrationTest' --tests '*JdbcTransactionDetailRepositoryIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back clean check --no-daemon --stacktrace`
- `./back/gradlew -p back check` (pre-commit hook 재검증)

## 📸 Screenshot / API Example
- reversal 요청: `POST /api/v1/transfers/{transactionReference}/reversal`
- 요청 body: `{ "sourceAccountId": 101, "reversalReason": "CANCEL", "summary": "cancel transfer" }`
- 성공 응답 필드: `originalTransactionReference`, `reversalTransactionReference`, `sourceAccountId`, `targetAccountId`, `amountMinor`, `currencyCode`, `availableBalanceAfterMinor`, `bookedAt`, `status`

## ⚠️ Risk & Rollback
- 예상 리스크: reversal 시 target 계좌 잔액이 부족하면 `409` 로 거절되므로 운영 취소 기대와 실제 결과가 어긋날 수 있습니다. `TransferReversed` event는 생산만 추가했고 inbox consumer fan-out은 아직 없습니다.
- 롤백 방법: PR revert 후 배포하고 reversal endpoint 호출을 중단합니다. 새로 추가된 `transfer_reversal` 테이블과 `TransferReversed` outbox row는 이후 운영 정리 대상으로 분리합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.