### PR TITLE
[Perf] 거래 조회 p95 기준선 명시 보강

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -38,6 +38,39 @@ com.aquilabank
 - Spring JDBC / HikariCP
 - Spring Boot Actuator
 
+## Transaction Query Baseline
+
+거래 조회 성능 기준선은 `GET /api/v1/transactions` 의 query shape, index 사용 여부, timeout 가드, p95 목표를 함께 보도록 고정합니다.
+
+- baseline fixture:
+  - hot account `8만 건`
+  - noise account `6계좌 x 4천 건`
+  - 30일 조회 창
+  - fixture 적재 뒤 `ANALYZE` 수행
+- 대표 조회 3종:
+  - 첫 page: `accountId + from/to + limit`
+  - 후속 cursor page: `accountId + from/to + cursor + limit`
+  - 상태 필터 page: `accountId + from/to + status + cursor/limit`
+- baseline p95 목표:
+  - 첫 page `<= 120ms`
+  - 후속 cursor page `<= 150ms`
+  - 상태 필터 page `<= 150ms`
+- timeout 보호 순서:
+  - datasource `statement_timeout=3000ms`
+  - Spring JDBC `query-timeout=3s`
+  - MVC async `request-timeout=5000ms`
+- 운영 해석 기준:
+  - p95 목표는 baseline fixture 기준 회귀 감지선입니다.
+  - 1억 건 전체를 로컬에 적재하는 대신, planner가 계좌/기간/status/cursor 조건으로 bounded index range scan을 유지하는지 먼저 확인합니다.
+  - `Seq Scan`, 불필요한 `Sort`, timeout 근접 실행 시간이 보이면 index 또는 query shape를 다시 검토합니다.
+
+재현 명령:
+
+```bash
+tools/test/with-resource-lock.sh back-transaction-baseline \
+  tools/test/run-transaction-query-baseline.sh
+```
+
 ## Run
 
 ```bash

--- a/tools/test/run-transaction-query-baseline.sh
+++ b/tools/test/run-transaction-query-baseline.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "[transaction-baseline] fixture: hot account 80000 rows + noise 6x4000 rows"
+echo "[transaction-baseline] target p95: first-page<=120ms cursor-page<=150ms status-page<=150ms"
+echo "[transaction-baseline] timeout order: statement_timeout=3000ms query-timeout=3s request-timeout=5000ms"
+
 ./back/gradlew -p back test \
   --tests '*JdbcTransactionReadRepositoryBaselineIntegrationTest' \
   --tests '*TransactionDatasourceStatementTimeoutIntegrationTest' \


### PR DESCRIPTION
## 🔗 Related Issue
- close #50

## 📝 Summary
- 이미 merge된 거래 조회 baseline/EXPLAIN/timeout 검증 위에 대표 조회 3종의 numeric p95 목표를 추가로 고정했습니다.
- `back/README.md` 와 baseline 실행 스크립트에서 같은 기준을 바로 확인할 수 있게 정리했습니다.

## 🛠 Changes
- `back/README.md` 에 거래 조회 baseline fixture, 대표 조회 3종, p95 목표, timeout 보호 순서를 추가했습니다.
- `tools/test/run-transaction-query-baseline.sh` 가 실행 전에 같은 p95/timeout 기준을 출력하도록 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-transaction-baseline tools/test/run-transaction-query-baseline.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - p95 목표는 baseline fixture 기준 회귀 감지선이라 실제 운영 트래픽 분포와 1:1로 동일하지는 않습니다.
  - 목표를 너무 공격적으로 낮추면 local/Testcontainers 편차로 해석이 흔들릴 수 있습니다.
- 롤백 방법:
  - README baseline 섹션과 스크립트 출력 문구를 revert 하면 됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [ ] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.