### PR TITLE
[Build] 로컬 Kafka 실행 환경과 알림 end-to-end 검증 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -44,15 +44,19 @@ com.aquilabank
 ./gradlew bootRun
 ```
 
-## Local Database
+## Local Infra
 
 ```bash
 cp ../.env.example ../.env
 cd ..
-docker compose up -d postgres
+docker compose up -d postgres kafka
 ```
 
-로컬 DB는 루트 [compose.yml](/Users/aquila/Custom/GitProjects/aquila-bank/compose.yml)의 `postgres:18` 컨테이너를 기준으로 사용합니다.
+루트 [compose.yml](/Users/aquila/Custom/GitProjects/aquila-bank/compose.yml)은 `postgres:18`과 단일 노드 Kafka broker를 함께 올립니다.
+
+- PostgreSQL 기본 포트: `localhost:5432`
+- Kafka 기본 포트: `localhost:9092`
+- Kafka topic은 broker 기본 auto-create를 사용하되, app 설정은 `TransferBooked`/`TransferReversed`를 분리해 consumer 충돌을 막습니다.
 
 백엔드는 [back/.env.example](/Users/aquila/Custom/GitProjects/aquila-bank/back/.env.example)를 복사한 뒤 실행합니다.
 
@@ -60,6 +64,8 @@ docker compose up -d postgres
 cp back/.env.example back/.env
 set -a
 source back/.env
+export OUTBOX_KAFKA_ENABLED=true
+export NOTIFICATION_INBOX_CONSUMER_ENABLED=true
 set +a
 ./back/gradlew -p back bootRun
 ```
@@ -68,6 +74,20 @@ set +a
 - 기본값은 `t3.micro`를 전제로 작은 커넥션 풀과 짧은 DB 타임아웃을 사용합니다.
 - 운영 기본 인증 방식은 bearer JWT 입니다.
 - `dev`/`test` 프로필에서는 필요 시 `X-Account-Id` 헤더 fallback을 사용할 수 있습니다.
+- `dev` 프로필은 `OUTBOX_KAFKA_ENABLED=true`, `NOTIFICATION_INBOX_CONSUMER_ENABLED=true`만 주면 `localhost:9092`와 기본 topic 이름을 자동 사용합니다.
+- Kafka 포트를 바꾸면 `OUTBOX_KAFKA_BOOTSTRAP_SERVERS`, `NOTIFICATION_INBOX_CONSUMER_BOOTSTRAP_SERVERS`를 같은 값으로 같이 넘깁니다.
+
+### Local Notification E2E
+
+실제 broker를 통과하는 알림 검증은 transfer write path와 outbox dispatch를 같이 봐야 합니다.
+
+```bash
+tools/test/with-resource-lock.sh back-gradle-check \
+  ./back/gradlew -p back test --tests '*NotificationKafkaE2eIntegrationTest'
+```
+
+- 위 테스트는 Testcontainers PostgreSQL + Kafka를 띄워 `transfer API -> outbox -> Kafka -> notification_inbox` 전체 경로를 검증합니다.
+- 로컬 앱을 직접 띄운 뒤 수동 확인이 필요하면 transfer 호출 후 notification API 또는 DB `notification_inbox` row를 확인합니다.
 
 ## Transfer Reversal
 

--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.testcontainers:kafka")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/back/src/main/java/com/aquilabank/global/config/OutboxConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/OutboxConfiguration.java
@@ -155,13 +155,28 @@ public class OutboxConfiguration {
         outboxKafkaProperties.producer().maxInFlightRequestsPerConnection());
     config.put(ProducerConfig.RETRIES_CONFIG, outboxKafkaProperties.retry().retries());
     config.put(
-        ProducerConfig.RETRY_BACKOFF_MS_CONFIG, outboxKafkaProperties.retry().retryBackoffMs());
+        ProducerConfig.RETRY_BACKOFF_MS_CONFIG,
+        toKafkaInt(
+            "outbox.kafka.retry.retry-backoff-ms", outboxKafkaProperties.retry().retryBackoffMs()));
     config.put(
         ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG,
-        outboxKafkaProperties.retry().deliveryTimeoutMs());
+        toKafkaInt(
+            "outbox.kafka.retry.delivery-timeout-ms",
+            outboxKafkaProperties.retry().deliveryTimeoutMs()));
     config.put(
-        ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, outboxKafkaProperties.retry().requestTimeoutMs());
+        ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG,
+        toKafkaInt(
+            "outbox.kafka.retry.request-timeout-ms",
+            outboxKafkaProperties.retry().requestTimeoutMs()));
     return config;
+  }
+
+  private int toKafkaInt(String propertyName, long value) {
+    // env 바인딩은 long 으로 받고, Kafka client 직전만 int 계약으로 맞춰 설정 오류를 막습니다.
+    if (value < 0 || value > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(propertyName + " must fit into Kafka int config range");
+    }
+    return (int) value;
   }
 
   @SuppressWarnings("unchecked")

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -23,3 +23,19 @@ security:
   auth-bootstrap-api:
     enabled: ${SECURITY_AUTH_BOOTSTRAP_API_ENABLED:true}
     token: ${SECURITY_AUTH_BOOTSTRAP_API_TOKEN:dev-auth-bootstrap-api-token}
+
+outbox:
+  kafka:
+    bootstrap-servers: ${OUTBOX_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    topic:
+      default-name: ${OUTBOX_KAFKA_TOPIC_DEFAULT:bank.notification.outbox.v1}
+      event-type-overrides:
+        TransferBooked: ${OUTBOX_KAFKA_TOPIC_TRANSFER_BOOKED:bank.transfer.booked.v1}
+        TransferReversed: ${OUTBOX_KAFKA_TOPIC_TRANSFER_REVERSED:bank.transfer.reversed.v1}
+
+notification:
+  inbox:
+    consumer:
+      bootstrap-servers: ${NOTIFICATION_INBOX_CONSUMER_BOOTSTRAP_SERVERS:localhost:9092}
+      transfer-booked:
+        topic: ${NOTIFICATION_INBOX_CONSUMER_TRANSFER_BOOKED_TOPIC:bank.transfer.booked.v1}

--- a/back/src/test/java/com/aquilabank/global/config/OutboxConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/OutboxConfigurationTest.java
@@ -9,8 +9,11 @@ import com.aquilabank.domain.notification.port.OutboxOpsReadPort;
 import com.aquilabank.domain.notification.port.OutboxOpsRecoveryPort;
 import com.aquilabank.global.notification.KafkaOutboxEventPublisher;
 import com.aquilabank.global.notification.LoggingOutboxEventPublisher;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.ProducerFactory;
 
 class OutboxConfigurationTest {
 
@@ -68,5 +71,40 @@ class OutboxConfigurationTest {
                 assertInstanceOf(
                     LoggingOutboxEventPublisher.class,
                     context.getBean("outboxEventPublishPort", OutboxEventPublishPort.class)));
+  }
+
+  @Test
+  void usesIntegerKafkaTimeoutConfigsWhenKafkaPublisherIsEnabled() {
+    contextRunner
+        .withPropertyValues(
+            "outbox.kafka.enabled=true",
+            "outbox.kafka.bootstrap-servers=localhost:9092",
+            "outbox.kafka.topic.default-name=bank.notification.outbox.v1",
+            "outbox.kafka.retry.retry-backoff-ms=1000",
+            "outbox.kafka.retry.delivery-timeout-ms=30000",
+            "outbox.kafka.retry.request-timeout-ms=3000")
+        .run(
+            context -> {
+              @SuppressWarnings("unchecked")
+              DefaultKafkaProducerFactory<String, String> producerFactory =
+                  (DefaultKafkaProducerFactory<String, String>)
+                      context.getBean("outboxKafkaProducerFactory", ProducerFactory.class);
+
+              assertInstanceOf(
+                  Integer.class,
+                  producerFactory
+                      .getConfigurationProperties()
+                      .get(ProducerConfig.RETRY_BACKOFF_MS_CONFIG));
+              assertInstanceOf(
+                  Integer.class,
+                  producerFactory
+                      .getConfigurationProperties()
+                      .get(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG));
+              assertInstanceOf(
+                  Integer.class,
+                  producerFactory
+                      .getConfigurationProperties()
+                      .get(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG));
+            });
   }
 }

--- a/back/src/test/java/com/aquilabank/global/notification/NotificationKafkaE2eIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/NotificationKafkaE2eIntegrationTest.java
@@ -1,0 +1,231 @@
+package com.aquilabank.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.aquilabank.domain.notification.usecase.OutboxDispatchUseCase;
+import com.aquilabank.support.PostgresKafkaContainerTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class NotificationKafkaE2eIntegrationTest extends PostgresKafkaContainerTestSupport {
+
+  private static final Duration NOTIFICATION_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(200);
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private OutboxDispatchUseCase outboxDispatchUseCase;
+
+  private MockMvc mockMvc;
+  private long sourceAccountId;
+  private long targetAccountId;
+
+  @BeforeEach
+  void setUpDatabase() throws Exception {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    commit(transactionManager, () -> resetBankingTables(jdbcTemplate));
+
+    sourceAccountId = bootstrapAccount("notification-source", 10_000L).accountId();
+    targetAccountId = bootstrapAccount("notification-target", 0L).accountId();
+  }
+
+  @Test
+  void deliversTransferBookedEventToNotificationInboxThroughKafka() throws Exception {
+    TransferResponseBody response =
+        invokeTransfer("notification-e2e-001", targetAccountId, 1500L, "rent");
+    OutboxEventRow outboxEvent = findOutboxEvent(response.transactionReference());
+
+    int dispatched = outboxDispatchUseCase.dispatchPendingEvents();
+    OutboxEventRow publishedEvent = findOutboxEvent(response.transactionReference());
+
+    assertThat(dispatched).isEqualTo(1);
+    assertThat(publishedEvent.publishStatus())
+        .withFailMessage("outbox lastError=%s", publishedEvent.lastError())
+        .isEqualTo("PUBLISHED");
+
+    awaitCondition(
+        "notification inbox rows",
+        NOTIFICATION_TIMEOUT,
+        POLL_INTERVAL,
+        () -> countNotificationRows(outboxEvent.eventKey()) == 2L);
+
+    List<NotificationInboxRow> items = findNotificationRows(outboxEvent.eventKey());
+    assertThat(items)
+        .extracting(NotificationInboxRow::accountId)
+        .containsExactlyInAnyOrder(sourceAccountId, targetAccountId);
+    assertThat(items).extracting(NotificationInboxRow::eventType).containsOnly("TransferBooked");
+    assertThat(items).extracting(NotificationInboxRow::title).containsOnly("이체 완료");
+    assertThat(items)
+        .extracting(NotificationInboxRow::message)
+        .containsExactlyInAnyOrder("1500 KRW 출금 · rent", "1500 KRW 입금 · rent");
+  }
+
+  private AccountBootstrapResponseBody bootstrapAccount(
+      String displayName, long initialBalanceMinor) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/internal/api/v1/accounts/bootstrap")
+                    .header("X-Request-Id", "bootstrap-" + displayName)
+                    .header("X-Bootstrap-Token", "test-bootstrap-api-token")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "displayName": "%s",
+                          "currencyCode": "KRW",
+                          "initialBalanceMinor": %d
+                        }
+                        """
+                            .formatted(displayName, initialBalanceMinor)))
+            .andReturn();
+
+    assertThat(result.getResponse().getStatus()).isEqualTo(200);
+    return objectMapper.readValue(
+        result.getResponse().getContentAsByteArray(), AccountBootstrapResponseBody.class);
+  }
+
+  private TransferResponseBody invokeTransfer(
+      String idempotencyKey, long targetAccountId, long amountMinor, String summary)
+      throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers")
+                    .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", idempotencyKey + "-request")
+                    .header("Idempotency-Key", idempotencyKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "targetAccountId": %d,
+                          "amountMinor": %d,
+                          "currencyCode": "KRW",
+                          "summary": "%s"
+                        }
+                        """
+                            .formatted(sourceAccountId, targetAccountId, amountMinor, summary)))
+            .andReturn();
+
+    assertThat(result.getResponse().getStatus()).isEqualTo(200);
+    return objectMapper.readValue(
+        result.getResponse().getContentAsByteArray(), TransferResponseBody.class);
+  }
+
+  private OutboxEventRow findOutboxEvent(String transactionReference) {
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT event_key,
+               publish_status,
+               payload::text AS payload,
+               last_error
+        FROM outbox_event
+        WHERE aggregate_id = :transactionReference
+        """,
+        new MapSqlParameterSource().addValue("transactionReference", transactionReference),
+        (rs, rowNum) ->
+            new OutboxEventRow(
+                rs.getString("event_key"),
+                rs.getString("publish_status"),
+                rs.getString("payload"),
+                rs.getString("last_error")));
+  }
+
+  private long countNotificationRows(String eventKey) {
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT COUNT(*)
+        FROM notification_inbox
+        WHERE event_key IN (:eventKeys)
+        """,
+        new MapSqlParameterSource().addValue("eventKeys", notificationEventKeys(eventKey)),
+        Long.class);
+  }
+
+  private List<NotificationInboxRow> findNotificationRows(String eventKey) {
+    return jdbcTemplate.query(
+        """
+        SELECT account_id,
+               event_type,
+               title,
+               message,
+               created_at
+        FROM notification_inbox
+        WHERE event_key IN (:eventKeys)
+        ORDER BY account_id ASC
+        """,
+        new MapSqlParameterSource().addValue("eventKeys", notificationEventKeys(eventKey)),
+        (rs, rowNum) ->
+            new NotificationInboxRow(
+                rs.getLong("account_id"),
+                rs.getString("event_type"),
+                rs.getString("title"),
+                rs.getString("message"),
+                rs.getObject("created_at", OffsetDateTime.class).toInstant()));
+  }
+
+  private List<String> notificationEventKeys(String eventKey) {
+    return List.of(
+        accountScopedEventKey(eventKey, sourceAccountId),
+        accountScopedEventKey(eventKey, targetAccountId));
+  }
+
+  private String accountScopedEventKey(String eventKey, long accountId) {
+    return eventKey + ":ACCOUNT-" + accountId;
+  }
+
+  private record AccountBootstrapResponseBody(
+      long accountId,
+      String accountNumber,
+      String displayName,
+      String currencyCode,
+      long availableBalanceMinor,
+      String accountStatus,
+      Instant createdAt) {}
+
+  private record TransferResponseBody(
+      String transactionReference,
+      long sourceAccountId,
+      long targetAccountId,
+      long amountMinor,
+      String currencyCode,
+      long availableBalanceAfterMinor,
+      Instant bookedAt,
+      String status) {}
+
+  private record OutboxEventRow(
+      String eventKey, String publishStatus, String payload, String lastError) {}
+
+  private record NotificationInboxRow(
+      long accountId, String eventType, String title, String message, Instant createdAt) {}
+}

--- a/back/src/test/java/com/aquilabank/support/PostgresKafkaContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresKafkaContainerTestSupport.java
@@ -1,0 +1,101 @@
+package com.aquilabank.support;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers(disabledWithoutDocker = true)
+public abstract class PostgresKafkaContainerTestSupport extends PostgresContainerTestSupport {
+
+  protected static final String OUTBOX_DEFAULT_TOPIC = "bank.notification.outbox.v1";
+  protected static final String TRANSFER_BOOKED_TOPIC = "bank.transfer.booked.v1";
+  protected static final String TRANSFER_REVERSED_TOPIC = "bank.transfer.reversed.v1";
+
+  private static final DockerImageName KAFKA_IMAGE =
+      DockerImageName.parse("apache/kafka-native:3.8.0");
+
+  @Container private static final KafkaContainer KAFKA = new KafkaContainer(KAFKA_IMAGE);
+
+  private static final AtomicBoolean KAFKA_TOPICS_READY = new AtomicBoolean(false);
+
+  @DynamicPropertySource
+  static void registerKafkaProperties(DynamicPropertyRegistry registry) {
+    ensureKafkaTopics();
+    registry.add("outbox.kafka.enabled", () -> true);
+    registry.add("outbox.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+    registry.add("outbox.kafka.topic.default-name", () -> OUTBOX_DEFAULT_TOPIC);
+    registry.add(
+        "outbox.kafka.topic.event-type-overrides.TransferBooked", () -> TRANSFER_BOOKED_TOPIC);
+    registry.add(
+        "outbox.kafka.topic.event-type-overrides.TransferReversed", () -> TRANSFER_REVERSED_TOPIC);
+    registry.add("notification.inbox.consumer.enabled", () -> true);
+    registry.add("notification.inbox.consumer.bootstrap-servers", KAFKA::getBootstrapServers);
+    registry.add("notification.inbox.consumer.group-id", () -> "aquila-bank-notification-e2e");
+    registry.add("notification.inbox.consumer.transfer-booked.topic", () -> TRANSFER_BOOKED_TOPIC);
+  }
+
+  protected void awaitCondition(
+      String description, Duration timeout, Duration interval, BooleanSupplier condition) {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      try {
+        Thread.sleep(interval.toMillis());
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("condition wait interrupted", ex);
+      }
+    }
+    Assertions.fail(description + " was not satisfied within " + timeout);
+  }
+
+  private static void ensureKafkaTopics() {
+    if (KAFKA_TOPICS_READY.get()) {
+      return;
+    }
+    synchronized (KAFKA_TOPICS_READY) {
+      if (KAFKA_TOPICS_READY.get()) {
+        return;
+      }
+      if (!KAFKA.isRunning()) {
+        KAFKA.start();
+      }
+      try (AdminClient adminClient =
+          AdminClient.create(
+              Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers()))) {
+        createTopic(adminClient, OUTBOX_DEFAULT_TOPIC);
+        createTopic(adminClient, TRANSFER_BOOKED_TOPIC);
+        createTopic(adminClient, TRANSFER_REVERSED_TOPIC);
+      }
+      KAFKA_TOPICS_READY.set(true);
+    }
+  }
+
+  private static void createTopic(AdminClient adminClient, String topicName) {
+    try {
+      // 단일 broker 테스트는 1 partition/1 replica 로 두어 ordering과 자원 사용량을 단순화합니다.
+      adminClient.createTopics(List.of(new NewTopic(topicName, 1, (short) 1))).all().get();
+    } catch (Exception ex) {
+      Throwable cause = ex.getCause();
+      if (cause instanceof TopicExistsException) {
+        return;
+      }
+      throw new IllegalStateException("failed to create Kafka topic: " + topicName, ex);
+    }
+  }
+}

--- a/compose.yml
+++ b/compose.yml
@@ -23,5 +23,43 @@ services:
       retries: 10
       start_period: 10s
 
+  kafka:
+    image: bitnami/kafka:4.2
+    container_name: aquila-bank-kafka
+    restart: unless-stopped
+    ports:
+      - "${KAFKA_PORT:-9092}:9092"
+    environment:
+      TZ: Asia/Seoul
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_NODE_ID: 0
+      KAFKA_CFG_PROCESS_ROLES: controller,broker
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://localhost:${KAFKA_PORT:-9092}
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@kafka:9093
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_CFG_NUM_PARTITIONS: 1
+      KAFKA_KRAFT_CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    volumes:
+      - aquila-bank-kafka-data:/bitnami/kafka
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
 volumes:
   aquila-bank-postgres-data:
+  aquila-bank-kafka-data:


### PR DESCRIPTION
## 🔗 Related Issue
- close #52

## 📝 Summary
- 로컬 `compose.yml`에 Kafka broker를 추가하고 `dev` 프로필 기본값을 맞춰 PostgreSQL + Kafka 로컬 실행 경로를 채웠습니다.
- 실제 broker를 통과하는 `transfer API -> outbox -> Kafka -> notification_inbox` E2E 테스트를 추가했습니다.
- E2E 검증 중 드러난 Kafka producer timeout 설정 타입 오류를 함께 보정했습니다.

## 🛠 Changes
- `compose.yml`에 단일 노드 Kafka broker와 healthcheck, volume 설정 추가
- `application-dev.yml`에 로컬 Kafka bootstrap/topic 기본값 추가
- `OutboxConfiguration`의 Kafka timeout config를 client 계약에 맞는 `int` 값으로 변환
- `PostgresKafkaContainerTestSupport`, `NotificationKafkaE2eIntegrationTest`, `OutboxConfigurationTest` 추가
- `back/README.md`에 로컬 Kafka 실행 및 알림 E2E 검증 절차 문서화

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*OutboxConfigurationTest' --tests '*NotificationKafkaE2eIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- `docker compose config`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - 로컬 `9092` 포트 사용 중이면 Kafka broker 기동 시 충돌할 수 있습니다.
  - 단일 broker 기준이라 로컬 startup 직후 topic metadata 준비 타이밍이 느린 환경에서는 첫 기동이 몇 초 더 걸릴 수 있습니다.
- 롤백 방법:
  - 로컬 Kafka 사용을 중단하려면 `OUTBOX_KAFKA_ENABLED=false`, `NOTIFICATION_INBOX_CONSUMER_ENABLED=false`로 비활성화합니다.
  - 변경 전체 롤백은 본 PR revert로 처리합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [ ] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [ ] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.