### PR TITLE
[Feat] notification 읽음 상태를 user 기준으로 분리

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -69,6 +69,12 @@ set +a
 - 운영 기본 인증 방식은 bearer JWT 입니다.
 - `dev`/`test` 프로필에서는 필요 시 `X-Account-Id` 헤더 fallback을 사용할 수 있습니다.
 
+## Notification Read State
+
+- JWT user 경로의 읽음 상태는 `notification_user_read_state`에 user별로 저장됩니다.
+- `notification_inbox`는 account-scoped read model 본체를 유지하고, `read_at`은 account principal/internal 경로 의미로 분리됩니다.
+- 기존 shared `read_at` 값은 user read state로 자동 backfill 하지 않으므로, 배포 이전 알림은 JWT user 기준에서 다시 unread로 보일 수 있습니다.
+
 ## Transfer Reversal
 
 기존 BOOKED 송금은 직접 수정하지 않고 reversal transaction을 추가해 취소/정정합니다.

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -66,10 +66,13 @@ public class JdbcNotificationInboxRepository
               ON m.account_id = n.account_id
             JOIN bank_user u
               ON u.id = m.user_id
+            LEFT JOIN notification_user_read_state r
+              ON r.user_id = :userId
+             AND r.notification_id = n.id
             WHERE m.user_id = :userId
               AND m.membership_status = 'ACTIVE'
               AND u.user_status = 'ACTIVE'
-              AND n.read_at IS NULL
+              AND r.notification_id IS NULL
             """,
             new MapSqlParameterSource().addValue("userId", userId),
             Long.class);
@@ -95,11 +98,11 @@ public class JdbcNotificationInboxRepository
   @Override
   @Transactional
   public boolean markAsReadByUserId(long userId, long notificationId, Instant readAt) {
-    AccessibleNotification notification =
-        jdbcTemplate
-            .query(
-                """
-                SELECT n.account_id, n.read_at
+    Boolean accessible =
+        jdbcTemplate.queryForObject(
+            """
+            WITH accessible_notification AS (
+                SELECT n.id
                 FROM notification_inbox n
                 JOIN user_account_membership m
                   ON m.account_id = n.account_id
@@ -110,33 +113,25 @@ public class JdbcNotificationInboxRepository
                   AND m.membership_status = 'ACTIVE'
                   AND u.user_status = 'ACTIVE'
                 LIMIT 1
-                """,
-                new MapSqlParameterSource()
-                    .addValue("notificationId", notificationId)
-                    .addValue("userId", userId),
-                (rs, rowNum) -> accessibleNotification(rs))
-            .stream()
-            .findFirst()
-            .orElse(null);
-    if (notification == null) {
-      return false;
-    }
-    if (notification.readAt() != null) {
-      return true;
-    }
-    jdbcTemplate.update(
-        """
-        UPDATE notification_inbox
-        SET read_at = :readAt
-        WHERE id = :notificationId
-          AND account_id = :accountId
-          AND read_at IS NULL
-        """,
-        new MapSqlParameterSource()
-            .addValue("readAt", Timestamp.from(readAt))
-            .addValue("notificationId", notificationId)
-            .addValue("accountId", notification.accountId()));
-    return true;
+            ),
+            inserted_read_state AS (
+                INSERT INTO notification_user_read_state (
+                    user_id,
+                    notification_id,
+                    read_at
+                )
+                SELECT :userId, id, :readAt
+                FROM accessible_notification
+                ON CONFLICT (user_id, notification_id) DO NOTHING
+            )
+            SELECT EXISTS(SELECT 1 FROM accessible_notification)
+            """,
+            new MapSqlParameterSource()
+                .addValue("notificationId", notificationId)
+                .addValue("userId", userId)
+                .addValue("readAt", Timestamp.from(readAt)),
+            Boolean.class);
+    return Boolean.TRUE.equals(accessible);
   }
 
   @Override
@@ -259,12 +254,15 @@ public class JdbcNotificationInboxRepository
                n.title,
                n.message,
                n.created_at,
-               n.read_at
+               r.read_at
         FROM notification_inbox n
         JOIN user_account_membership m
           ON m.account_id = n.account_id
         JOIN bank_user u
           ON u.id = m.user_id
+        LEFT JOIN notification_user_read_state r
+          ON r.user_id = :userId
+         AND r.notification_id = n.id
         WHERE m.user_id = :userId
           AND m.membership_status = 'ACTIVE'
           AND u.user_status = 'ACTIVE'
@@ -287,12 +285,15 @@ public class JdbcNotificationInboxRepository
                n.title,
                n.message,
                n.created_at,
-               n.read_at
+               r.read_at
         FROM notification_inbox n
         JOIN user_account_membership m
           ON m.account_id = n.account_id
         JOIN bank_user u
           ON u.id = m.user_id
+        LEFT JOIN notification_user_read_state r
+          ON r.user_id = :userId
+         AND r.notification_id = n.id
         WHERE m.user_id = :userId
           AND m.membership_status = 'ACTIVE'
           AND u.user_status = 'ACTIVE'

--- a/back/src/main/resources/db/migration/V12__split_notification_user_read_state.sql
+++ b/back/src/main/resources/db/migration/V12__split_notification_user_read_state.sql
@@ -1,0 +1,14 @@
+-- JWT user 읽음은 공동 계좌 사용자별로 분리하고, 기존 notification_inbox.read_at 는 account-scoped 의미로 남깁니다.
+CREATE TABLE notification_user_read_state (
+    user_id BIGINT NOT NULL,
+    notification_id BIGINT NOT NULL,
+    read_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (user_id, notification_id),
+    CONSTRAINT fk_notification_user_read_state_user
+        FOREIGN KEY (user_id) REFERENCES bank_user (id),
+    CONSTRAINT fk_notification_user_read_state_notification
+        FOREIGN KEY (notification_id) REFERENCES notification_inbox (id)
+);
+
+CREATE INDEX idx_notification_user_read_state_notification_user
+    ON notification_user_read_state (notification_id, user_id);

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -37,6 +37,7 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
   void fetchesOnlyAccessibleNotificationsForUser() {
     long[] userId = new long[1];
     long[] accountIds = new long[3];
+    long[] notificationIds = new long[3];
     Instant base = Instant.parse("2026-04-17T00:00:00Z");
     commit(
         transactionManager,
@@ -48,23 +49,28 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
           insertMembership(userId[0], accountIds[0], "OWNER", "ACTIVE");
           insertMembership(userId[0], accountIds[1], "VIEWER", "ACTIVE");
           insertMembership(userId[0], accountIds[2], "VIEWER", "REVOKED");
-          insertNotification(accountIds[0], "evt-1", "TransferBooked", "입금 1", "첫 알림", null, base);
-          insertNotification(
-              accountIds[1],
-              "evt-2",
-              "TransferBooked",
-              "입금 2",
-              "둘째 알림",
-              null,
-              base.plusSeconds(10));
-          insertNotification(
-              accountIds[2],
-              "evt-3",
-              "TransferBooked",
-              "입금 3",
-              "숨김 알림",
-              null,
-              base.plusSeconds(20));
+          notificationIds[0] =
+              insertNotification(
+                  accountIds[0], "evt-1", "TransferBooked", "입금 1", "첫 알림", null, base);
+          notificationIds[1] =
+              insertNotification(
+                  accountIds[1],
+                  "evt-2",
+                  "TransferBooked",
+                  "입금 2",
+                  "둘째 알림",
+                  null,
+                  base.plusSeconds(10));
+          notificationIds[2] =
+              insertNotification(
+                  accountIds[2],
+                  "evt-3",
+                  "TransferBooked",
+                  "입금 3",
+                  "숨김 알림",
+                  null,
+                  base.plusSeconds(20));
+          insertUserReadState(userId[0], notificationIds[0], base.plusSeconds(30));
         });
 
     NotificationSlice slice =
@@ -73,44 +79,77 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
     assertThat(slice.items()).hasSize(2);
     assertThat(slice.items()).extracting("title").containsExactly("입금 2", "입금 1");
     assertThat(slice.items()).extracting("accountId").containsExactly(accountIds[1], accountIds[0]);
+    assertThat(slice.items()).extracting("readAt").containsExactly(null, base.plusSeconds(30));
   }
 
   @Test
-  void countsUnreadAndMarksAsReadIdempotently() {
-    long[] userId = new long[1];
+  void countsUnreadAndMarksAsReadIdempotentlyPerUser() {
+    long[] userIds = new long[2];
     long[] accountId = new long[1];
-    long[] notificationIds = new long[3];
+    long[] notificationIds = new long[2];
     Instant base = Instant.parse("2026-04-17T00:00:00Z");
     commit(
         transactionManager,
         () -> {
-          userId[0] = insertUser("user-2");
+          userIds[0] = insertUser("user-2");
+          userIds[1] = insertUser("user-3");
           accountId[0] = insertAccount("main account");
-          insertMembership(userId[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
           notificationIds[0] =
               insertNotification(accountId[0], "evt-10", "TransferBooked", "A", "A", null, base);
           notificationIds[1] =
               insertNotification(
+                  accountId[0], "evt-11", "TransferBooked", "B", "B", null, base.plusSeconds(5));
+        });
+
+    assertThat(repository.countUnreadByUserId(userIds[0])).isEqualTo(2L);
+    assertThat(repository.countUnreadByUserId(userIds[1])).isEqualTo(2L);
+    assertThat(repository.markAsReadByUserId(userIds[0], notificationIds[0], base.plusSeconds(30)))
+        .isTrue();
+    assertThat(repository.countUnreadByUserId(userIds[0])).isEqualTo(1L);
+    assertThat(repository.countUnreadByUserId(userIds[1])).isEqualTo(2L);
+    assertThat(repository.markAsReadByUserId(userIds[0], notificationIds[0], base.plusSeconds(40)))
+        .isTrue();
+    assertThat(repository.countUnreadByUserId(userIds[0])).isEqualTo(1L);
+    assertThat(repository.countUnreadByUserId(userIds[1])).isEqualTo(2L);
+    assertThat(repository.markAsReadByUserId(userIds[0], 99999L, base.plusSeconds(50))).isFalse();
+  }
+
+  @Test
+  void keepsAccountScopedReadPathOnNotificationInbox() {
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[2];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          accountId[0] = insertAccount("account read model");
+          notificationIds[0] =
+              insertNotification(accountId[0], "evt-20", "TransferBooked", "A", "A", null, base);
+          notificationIds[1] =
+              insertNotification(
                   accountId[0],
-                  "evt-11",
+                  "evt-21",
                   "TransferBooked",
                   "B",
                   "B",
                   base.plusSeconds(5),
                   base.plusSeconds(5));
-          notificationIds[2] =
-              insertNotification(
-                  accountId[0], "evt-12", "TransferBooked", "C", "C", null, base.plusSeconds(10));
         });
 
-    assertThat(repository.countUnreadByUserId(userId[0])).isEqualTo(2L);
-    assertThat(repository.markAsReadByUserId(userId[0], notificationIds[0], base.plusSeconds(30)))
+    assertThat(repository.countUnreadByAccountId(accountId[0])).isEqualTo(1L);
+    assertThat(
+            repository.markAsReadByAccountId(
+                accountId[0], notificationIds[0], base.plusSeconds(30)))
         .isTrue();
-    assertThat(repository.countUnreadByUserId(userId[0])).isEqualTo(1L);
-    assertThat(repository.markAsReadByUserId(userId[0], notificationIds[0], base.plusSeconds(40)))
+    assertThat(repository.countUnreadByAccountId(accountId[0])).isEqualTo(0L);
+    assertThat(
+            repository.markAsReadByAccountId(
+                accountId[0], notificationIds[0], base.plusSeconds(40)))
         .isTrue();
-    assertThat(repository.countUnreadByUserId(userId[0])).isEqualTo(1L);
-    assertThat(repository.markAsReadByUserId(userId[0], 99999L, base.plusSeconds(50))).isFalse();
+    assertThat(repository.markAsReadByAccountId(accountId[0], 99999L, base.plusSeconds(50)))
+        .isFalse();
   }
 
   @Test
@@ -292,6 +331,26 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
       throw new IllegalStateException("notification_inbox insert did not return id");
     }
     return notificationId;
+  }
+
+  private void insertUserReadState(long userId, long notificationId, Instant readAt) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_user_read_state (
+            user_id,
+            notification_id,
+            read_at
+        )
+        VALUES (
+            :userId,
+            :notificationId,
+            :readAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("notificationId", notificationId)
+            .addValue("readAt", Timestamp.from(readAt)));
   }
 
   private long totalNotifications() {

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
@@ -126,6 +126,75 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
         .andExpect(jsonPath("$.message").value("notification is not found"));
   }
 
+  @Test
+  void keepsReadStateSeparatedBetweenSharedAccountUsers() throws Exception {
+    long[] userIds = new long[2];
+    long[] accountId = new long[1];
+    long[] notificationId = new long[1];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userIds[0] = insertUser("shared-user-a");
+          userIds[1] = insertUser("shared-user-b");
+          accountId[0] = insertAccount("shared account");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
+          notificationId[0] =
+              insertNotification(
+                  accountId[0], "evt-shared-1", "TransferBooked", "공동 알림", "shared", null, base);
+        });
+
+    String tokenA = issueToken("shared-user-a-subject", userIds[0]);
+    String tokenB = issueToken("shared-user-b-subject", userIds[1]);
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + tokenA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(1));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + tokenB))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(1));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/" + notificationId[0] + "/read")
+                .header("Authorization", "Bearer " + tokenA))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + tokenA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].notificationId").value(notificationId[0]))
+        .andExpect(jsonPath("$.items[0].read").value(true))
+        .andExpect(jsonPath("$.items[0].readAt").isNotEmpty());
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + tokenB))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].notificationId").value(notificationId[0]))
+        .andExpect(jsonPath("$.items[0].read").value(false))
+        .andExpect(jsonPath("$.items[0].readAt").isEmpty());
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + tokenA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(0));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + tokenB))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(1));
+  }
+
   private long insertUser(String loginId) {
     Long userId =
         jdbcTemplate.queryForObject(

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -45,6 +45,7 @@ public abstract class PostgresContainerTestSupport {
                         """
                         TRUNCATE TABLE
                             auth_status_change_audit,
+                            notification_user_read_state,
                             notification_inbox,
                             transaction_read_model,
                             ledger_entry,


### PR DESCRIPTION
## 🔗 Related Issue
- close #54

## 📝 Summary
- JWT user 기준 notification 읽음 상태를 `notification_user_read_state`로 분리해 공동 계좌에서 한 사용자의 읽음이 다른 사용자 unread 상태에 전파되지 않게 했습니다.
- `notification_inbox`는 account-scoped read model로 유지하고, account principal/internal 경로의 `read_at` 의미는 그대로 남겼습니다.
- repository query와 API 통합 테스트를 보강해 user별 read 격리를 검증했습니다.

## 🛠 Changes
- `V12__split_notification_user_read_state.sql` 추가
- `JdbcNotificationInboxRepository`의 JWT user list/count/read 경로를 user read state 조인/insert 기준으로 전환
- 공동 계좌 사용자 간 read 격리 repository/API integration test 추가
- README에 user-scoped read state와 no-backfill 주의사항 문서화

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*Notification*'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - 배포 이전 `notification_inbox.read_at` 값은 user read state로 backfill 하지 않으므로, 기존 읽음 이력이 JWT user 기준에서 다시 unread로 보일 수 있습니다.
  - 공동 계좌 알림 조회 시 user read state 조인이 추가되므로 notification read path 인덱스가 어긋나면 count/list 비용이 늘 수 있습니다.
- 롤백 방법:
  - PR revert 시 user query는 다시 `notification_inbox.read_at`만 보도록 복귀합니다.
  - 스키마 롤백이 필요하면 `notification_user_read_state` 테이블 제거와 앱 revert를 함께 진행합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [ ] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.