### PR TITLE
[Feat] 실시간 알림 SSE 스트림 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -128,6 +128,28 @@ tools/test/with-resource-lock.sh back-gradle-check \
 - `notification_inbox`는 account-scoped read model 본체를 유지하고, `read_at`은 account principal/internal 경로 의미로 분리됩니다.
 - 기존 shared `read_at` 값은 user read state로 자동 backfill 하지 않으므로, 배포 이전 알림은 JWT user 기준에서 다시 unread로 보일 수 있습니다.
 
+## Notification SSE Stream
+
+- endpoint:
+  - `GET /api/v1/notifications/stream`
+- 인증 기준:
+  - 운영 기본선은 bearer JWT user
+  - `dev`/`test` 에서는 `X-Account-Id` bootstrap header도 같은 endpoint로 사용 가능
+- SSE event 이름:
+  - `connected`: stream handshake 완료
+  - `notification`: 새 inbox row payload
+  - `heartbeat`: idle 연결 유지
+- 전달 계약:
+  - SSE push는 `notification_inbox` insert 성공 이후에만 발행됩니다.
+  - duplicate Kafka consume로 insert가 `ON CONFLICT DO NOTHING` 이면 SSE도 추가 발행하지 않습니다.
+  - user stream fan-out 대상은 `ACTIVE membership + ACTIVE user` 조건으로만 계산합니다.
+  - ordering 보장 범위는 현재 단일 app instance 안의 publish 순서까지입니다.
+  - reconnect 사이에 놓친 알림은 기존 `GET /api/v1/notifications` pull API로 재동기화합니다.
+- 기본 설정:
+  - `NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS=1800000`
+  - `NOTIFICATION_SSE_HEARTBEAT_INTERVAL_MS=10000`
+  - `NOTIFICATION_SSE_RECONNECT_DELAY_MS=3000`
+
 ## Transfer Reversal
 
 기존 BOOKED 송금은 직접 수정하지 않고 reversal transaction을 추가해 취소/정정합니다.

--- a/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
@@ -6,11 +6,13 @@ import com.aquilabank.domain.notification.usecase.NotificationQueryService;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadService;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /** notification inbox read API용 use case wiring */
 @Configuration
+@EnableConfigurationProperties(NotificationSseProperties.class)
 public class NotificationConfiguration {
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
@@ -1,0 +1,22 @@
+package com.aquilabank.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** SSE 연결 유지 시간과 heartbeat 간격을 notification read API 설정과 분리합니다. */
+@ConfigurationProperties(prefix = "notification.sse")
+public record NotificationSseProperties(
+    long connectionTimeoutMs, long heartbeatIntervalMs, long reconnectDelayMs) {
+
+  public NotificationSseProperties {
+    if (connectionTimeoutMs <= 0) {
+      throw new IllegalArgumentException("notification.sse.connection-timeout-ms must be positive");
+    }
+    if (heartbeatIntervalMs <= 0) {
+      throw new IllegalArgumentException("notification.sse.heartbeat-interval-ms must be positive");
+    }
+    if (reconnectDelayMs < 0) {
+      throw new IllegalArgumentException(
+          "notification.sse.reconnect-delay-ms must not be negative");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationInboxInsertedEvent.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationInboxInsertedEvent.java
@@ -1,0 +1,15 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import java.util.List;
+
+/** notification_inbox insert 성공 후에만 real-time fan-out을 연결하려는 adapter-local event */
+public record NotificationInboxInsertedEvent(List<NotificationSummary> items) {
+
+  public NotificationInboxInsertedEvent {
+    items = List.copyOf(items);
+    if (items.isEmpty()) {
+      throw new IllegalArgumentException("items must not be empty");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
@@ -1,0 +1,246 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import com.aquilabank.global.config.NotificationSseProperties;
+import com.aquilabank.global.web.notification.NotificationQueryResponse.NotificationItemResponse;
+import com.aquilabank.global.web.notification.NotificationStreamConnectedResponse;
+import com.aquilabank.global.web.notification.NotificationStreamHeartbeatResponse;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/** SSE emitter registry는 app instance local 메모리에만 두고 cleanup/heartbeat 만 담당합니다. */
+@Component
+public class NotificationSseBroker {
+
+  private static final Logger log = LoggerFactory.getLogger(NotificationSseBroker.class);
+
+  private final NotificationSseProperties notificationSseProperties;
+  private final NotificationSseTargetResolver notificationSseTargetResolver;
+  private final Map<Long, Map<String, NotificationSseSession>> accountSessions =
+      new ConcurrentHashMap<>();
+  private final Map<Long, Map<String, NotificationSseSession>> userSessions =
+      new ConcurrentHashMap<>();
+
+  public NotificationSseBroker(
+      NotificationSseProperties notificationSseProperties,
+      NotificationSseTargetResolver notificationSseTargetResolver) {
+    this.notificationSseProperties = notificationSseProperties;
+    this.notificationSseTargetResolver = notificationSseTargetResolver;
+  }
+
+  public SseEmitter subscribeAccount(long accountId, String subject) {
+    return subscribe(accountSessions, accountId, subject, "account");
+  }
+
+  public SseEmitter subscribeUser(long userId, String subject) {
+    return subscribe(userSessions, userId, subject, "user");
+  }
+
+  @Scheduled(fixedDelayString = "${notification.sse.heartbeat-interval-ms:25000}")
+  void sendHeartbeats() {
+    sendHeartbeats(accountSessions, "account");
+    sendHeartbeats(userSessions, "user");
+  }
+
+  @EventListener
+  public void handleNotificationInboxInserted(NotificationInboxInsertedEvent event) {
+    if (accountSessions.isEmpty() && userSessions.isEmpty()) {
+      return;
+    }
+    Map<Long, List<NotificationSummary>> itemsByAccountId = groupByAccountId(event.items());
+    for (Map.Entry<Long, List<NotificationSummary>> entry : itemsByAccountId.entrySet()) {
+      long accountId = entry.getKey();
+      List<NotificationSummary> items = entry.getValue();
+      publishToAccountSessions(accountId, items);
+      publishToUserSessions(accountId, items);
+    }
+  }
+
+  private SseEmitter subscribe(
+      Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
+      long principalId,
+      String subject,
+      String principalType) {
+    String sessionId = UUID.randomUUID().toString();
+    SseEmitter emitter = new SseEmitter(notificationSseProperties.connectionTimeoutMs());
+    NotificationSseSession session = new NotificationSseSession(sessionId, subject, emitter);
+    sessionsByPrincipalId
+        .computeIfAbsent(principalId, ignored -> new ConcurrentHashMap<>())
+        .put(sessionId, session);
+    emitter.onCompletion(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
+    emitter.onTimeout(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
+    emitter.onError(error -> removeSession(sessionsByPrincipalId, principalId, sessionId));
+    scheduleConnectedEvent(sessionsByPrincipalId, principalId, principalType, session);
+    log.debug(
+        "notification SSE subscribed principalType={} principalId={} sessionId={}",
+        principalType,
+        principalId,
+        sessionId);
+    return emitter;
+  }
+
+  private void sendConnectedEvent(NotificationSseSession session) throws IOException {
+    session
+        .emitter()
+        .send(
+            SseEmitter.event()
+                .name("connected")
+                .reconnectTime(notificationSseProperties.reconnectDelayMs())
+                .data(new NotificationStreamConnectedResponse(Instant.now())));
+  }
+
+  private void scheduleConnectedEvent(
+      Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
+      long principalId,
+      String principalType,
+      NotificationSseSession session) {
+    Thread.startVirtualThread(
+        () -> {
+          try {
+            sendConnectedEvent(session);
+          } catch (IOException ex) {
+            log.debug(
+                "notification SSE connected event failed principalType={} principalId={} sessionId={} subject={}",
+                principalType,
+                principalId,
+                session.sessionId(),
+                session.subject(),
+                ex);
+            removeSession(sessionsByPrincipalId, principalId, session.sessionId());
+          }
+        });
+  }
+
+  private void sendHeartbeats(
+      Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId, String principalType) {
+    if (sessionsByPrincipalId.isEmpty()) {
+      return;
+    }
+    for (Map.Entry<Long, Map<String, NotificationSseSession>> entry :
+        sessionsByPrincipalId.entrySet()) {
+      long principalId = entry.getKey();
+      for (NotificationSseSession session : entry.getValue().values()) {
+        try {
+          session
+              .emitter()
+              .send(
+                  SseEmitter.event()
+                      .name("heartbeat")
+                      .data(new NotificationStreamHeartbeatResponse(Instant.now())));
+        } catch (IOException ex) {
+          log.debug(
+              "notification SSE heartbeat failed principalType={} principalId={} sessionId={}",
+              principalType,
+              principalId,
+              session.sessionId(),
+              ex);
+          removeSession(sessionsByPrincipalId, principalId, session.sessionId());
+        }
+      }
+    }
+  }
+
+  private void publishToAccountSessions(long accountId, List<NotificationSummary> items) {
+    Map<String, NotificationSseSession> sessions = accountSessions.get(accountId);
+    if (sessions == null || sessions.isEmpty()) {
+      return;
+    }
+    for (NotificationSummary item : items) {
+      NotificationItemResponse payload = NotificationItemResponse.from(item);
+      for (NotificationSseSession session : sessions.values()) {
+        try {
+          session
+              .emitter()
+              .send(
+                  SseEmitter.event()
+                      .id(Long.toString(item.id()))
+                      .name("notification")
+                      .data(payload));
+        } catch (IOException ex) {
+          log.debug(
+              "notification SSE push failed principalType=account accountId={} sessionId={} subject={}",
+              accountId,
+              session.sessionId(),
+              session.subject(),
+              ex);
+          removeSession(accountSessions, accountId, session.sessionId());
+        }
+      }
+    }
+  }
+
+  private void publishToUserSessions(long accountId, List<NotificationSummary> items) {
+    if (userSessions.isEmpty()) {
+      return;
+    }
+    List<Long> userIds = notificationSseTargetResolver.findActiveUserIdsByAccountId(accountId);
+    if (userIds.isEmpty()) {
+      return;
+    }
+    for (Long userId : userIds) {
+      Map<String, NotificationSseSession> sessions = userSessions.get(userId);
+      if (sessions == null || sessions.isEmpty()) {
+        continue;
+      }
+      for (NotificationSummary item : items) {
+        NotificationItemResponse payload = NotificationItemResponse.from(item);
+        for (NotificationSseSession session : sessions.values()) {
+          try {
+            session
+                .emitter()
+                .send(
+                    SseEmitter.event()
+                        .id(Long.toString(item.id()))
+                        .name("notification")
+                        .data(payload));
+          } catch (IOException ex) {
+            log.debug(
+                "notification SSE push failed principalType=user userId={} sessionId={} subject={}",
+                userId,
+                session.sessionId(),
+                session.subject(),
+                ex);
+            removeSession(userSessions, userId, session.sessionId());
+          }
+        }
+      }
+    }
+  }
+
+  private Map<Long, List<NotificationSummary>> groupByAccountId(List<NotificationSummary> items) {
+    Map<Long, List<NotificationSummary>> itemsByAccountId = new LinkedHashMap<>();
+    for (NotificationSummary item : items) {
+      itemsByAccountId
+          .computeIfAbsent(item.accountId(), ignored -> new java.util.ArrayList<>())
+          .add(item);
+    }
+    return itemsByAccountId;
+  }
+
+  private void removeSession(
+      Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
+      long principalId,
+      String sessionId) {
+    Map<String, NotificationSseSession> sessions = sessionsByPrincipalId.get(principalId);
+    if (sessions == null) {
+      return;
+    }
+    sessions.remove(sessionId);
+    if (sessions.isEmpty()) {
+      sessionsByPrincipalId.remove(principalId, sessions);
+    }
+  }
+
+  private record NotificationSseSession(String sessionId, String subject, SseEmitter emitter) {}
+}

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseTargetResolver.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseTargetResolver.java
@@ -1,0 +1,9 @@
+package com.aquilabank.global.notification;
+
+import java.util.List;
+
+/** user stream fan-out 대상은 active membership/exact query 결과만 사용합니다. */
+public interface NotificationSseTargetResolver {
+
+  List<Long> findActiveUserIdsByAccountId(long accountId);
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -8,6 +8,7 @@ import com.aquilabank.domain.notification.model.NotificationSummary;
 import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
 import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
 import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
+import com.aquilabank.global.notification.NotificationInboxInsertedEvent;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -15,11 +16,14 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /** JWT user inbox join 과 bootstrap account inbox exact lookup 을 한 adapter 로 묶습니다. */
 @Repository
@@ -29,9 +33,13 @@ public class JdbcNotificationInboxRepository
   private static final RowMapper<NotificationSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
-  public JdbcNotificationInboxRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+  public JdbcNotificationInboxRepository(
+      NamedParameterJdbcTemplate jdbcTemplate,
+      ApplicationEventPublisher applicationEventPublisher) {
     this.jdbcTemplate = jdbcTemplate;
+    this.applicationEventPublisher = applicationEventPublisher;
   }
 
   @Override
@@ -182,9 +190,11 @@ public class JdbcNotificationInboxRepository
     if (entries.isEmpty()) {
       throw new IllegalArgumentException("items must not be empty");
     }
+    List<NotificationSummary> insertedItems = new ArrayList<>();
     for (NotificationInboxEntry item : entries) {
-      jdbcTemplate.update(
-          """
+      insertedItems.addAll(
+          jdbcTemplate.query(
+              """
           INSERT INTO notification_inbox (
               account_id,
               event_key,
@@ -202,15 +212,42 @@ public class JdbcNotificationInboxRepository
               :createdAt
           )
           ON CONFLICT (event_key) DO NOTHING
+          RETURNING id,
+                    account_id,
+                    event_type,
+                    title,
+                    message,
+                    created_at,
+                    NULL::timestamptz AS read_at
           """,
-          new MapSqlParameterSource()
-              .addValue("accountId", item.accountId())
-              .addValue("eventKey", item.eventKey())
-              .addValue("eventType", item.eventType())
-              .addValue("title", item.title())
-              .addValue("message", item.message())
-              .addValue("createdAt", Timestamp.from(item.createdAt())));
+              new MapSqlParameterSource()
+                  .addValue("accountId", item.accountId())
+                  .addValue("eventKey", item.eventKey())
+                  .addValue("eventType", item.eventType())
+                  .addValue("title", item.title())
+                  .addValue("message", item.message())
+                  .addValue("createdAt", Timestamp.from(item.createdAt())),
+              ROW_MAPPER));
     }
+    publishInsertedNotifications(insertedItems);
+  }
+
+  private void publishInsertedNotifications(List<NotificationSummary> insertedItems) {
+    if (insertedItems.isEmpty()) {
+      return;
+    }
+    NotificationInboxInsertedEvent event = new NotificationInboxInsertedEvent(insertedItems);
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      applicationEventPublisher.publishEvent(event);
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            applicationEventPublisher.publishEvent(event);
+          }
+        });
   }
 
   private NotificationSlice toSlice(List<NotificationSummary> rows, int limit) {

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationSseTargetResolver.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationSseTargetResolver.java
@@ -1,0 +1,37 @@
+package com.aquilabank.global.persistence.notification;
+
+import com.aquilabank.global.notification.NotificationSseTargetResolver;
+import java.util.List;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** revoked/disabled 사용자를 stream fan-out 대상에서 제외하려고 membership exact query를 분리합니다. */
+@Repository
+public class JdbcNotificationSseTargetResolver implements NotificationSseTargetResolver {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcNotificationSseTargetResolver(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<Long> findActiveUserIdsByAccountId(long accountId) {
+    return jdbcTemplate.queryForList(
+        """
+        SELECT m.user_id
+        FROM user_account_membership m
+        JOIN bank_user u
+          ON u.id = m.user_id
+        WHERE m.account_id = :accountId
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+        ORDER BY m.user_id
+        """,
+        new MapSqlParameterSource().addValue("accountId", accountId),
+        Long.class);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
@@ -4,12 +4,16 @@ import com.aquilabank.domain.notification.model.NotificationCursor;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import com.aquilabank.global.notification.NotificationSseBroker;
 import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
 import jakarta.validation.constraints.Positive;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /** notification inbox 목록, unread count, read 처리 API */
 @Validated
@@ -28,12 +33,15 @@ public class NotificationController {
 
   private final NotificationQueryUseCase notificationQueryUseCase;
   private final NotificationReadUseCase notificationReadUseCase;
+  private final NotificationSseBroker notificationSseBroker;
 
   public NotificationController(
       NotificationQueryUseCase notificationQueryUseCase,
-      NotificationReadUseCase notificationReadUseCase) {
+      NotificationReadUseCase notificationReadUseCase,
+      NotificationSseBroker notificationSseBroker) {
     this.notificationQueryUseCase = notificationQueryUseCase;
     this.notificationReadUseCase = notificationReadUseCase;
+    this.notificationSseBroker = notificationSseBroker;
   }
 
   @GetMapping
@@ -46,6 +54,19 @@ public class NotificationController {
           cursor == null || cursor.isBlank() ? null : NotificationCursorCodec.decode(cursor);
       NotificationListQuery query = new NotificationListQuery(limit, decodedCursor);
       return NotificationQueryResponse.from(resolveNotifications(principal, query));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+
+  @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public ResponseEntity<SseEmitter> streamNotifications(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal) {
+    try {
+      return ResponseEntity.ok()
+          .cacheControl(CacheControl.noStore())
+          .header("X-Accel-Buffering", "no")
+          .body(openStream(principal));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }
@@ -103,6 +124,17 @@ public class NotificationController {
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
       notificationReadUseCase.markAsReadForAccount(accountPrincipal.accountId(), notificationId);
       return;
+    }
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+
+  private SseEmitter openStream(AuthenticatedRequestPrincipal principal) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      return notificationSseBroker.subscribeUser(userPrincipal.userId(), userPrincipal.subject());
+    }
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      return notificationSseBroker.subscribeAccount(
+          accountPrincipal.accountId(), accountPrincipal.subject());
     }
     throw new IllegalArgumentException("unsupported principal type");
   }

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationQueryResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationQueryResponse.java
@@ -28,7 +28,7 @@ public record NotificationQueryResponse(
       Instant createdAt,
       Instant readAt) {
 
-    static NotificationItemResponse from(NotificationSummary item) {
+    public static NotificationItemResponse from(NotificationSummary item) {
       return new NotificationItemResponse(
           item.id(),
           item.accountId(),

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationStreamConnectedResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationStreamConnectedResponse.java
@@ -1,0 +1,6 @@
+package com.aquilabank.global.web.notification;
+
+import java.time.Instant;
+
+/** stream 연결 직후 client 가 handshake 상태를 확인하는 최소 payload */
+public record NotificationStreamConnectedResponse(Instant connectedAt) {}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationStreamHeartbeatResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationStreamHeartbeatResponse.java
@@ -1,0 +1,6 @@
+package com.aquilabank.global.web.notification;
+
+import java.time.Instant;
+
+/** proxy/idle timeout 사이에 연결 유지를 확인하는 heartbeat payload */
+public record NotificationStreamHeartbeatResponse(Instant sentAt) {}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -106,6 +106,10 @@ outbox:
       max-stale-sending-count: ${OUTBOX_OPS_HEALTH_MAX_STALE_SENDING_COUNT:0}
 
 notification:
+  sse:
+    connection-timeout-ms: ${NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS:1800000}
+    heartbeat-interval-ms: ${NOTIFICATION_SSE_HEARTBEAT_INTERVAL_MS:10000}
+    reconnect-delay-ms: ${NOTIFICATION_SSE_RECONNECT_DELAY_MS:3000}
   inbox:
     consumer:
       enabled: ${NOTIFICATION_INBOX_CONSUMER_ENABLED:false}

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
@@ -17,6 +19,7 @@ import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.domain.notification.model.NotificationSummary;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import com.aquilabank.global.notification.NotificationSseBroker;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
@@ -26,20 +29,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 class NotificationControllerTest {
 
   private NotificationQueryUseCase notificationQueryUseCase;
   private NotificationReadUseCase notificationReadUseCase;
+  private NotificationSseBroker notificationSseBroker;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
     notificationQueryUseCase = mock(NotificationQueryUseCase.class);
     notificationReadUseCase = mock(NotificationReadUseCase.class);
+    notificationSseBroker = mock(NotificationSseBroker.class);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
-                new NotificationController(notificationQueryUseCase, notificationReadUseCase))
+                new NotificationController(
+                    notificationQueryUseCase, notificationReadUseCase, notificationSseBroker))
             .setControllerAdvice(new ApiExceptionHandler())
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
@@ -112,6 +119,18 @@ class NotificationControllerTest {
         .perform(
             get("/api/v1/notifications").header("X-Account-Id", "101").param("cursor", "broken"))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void opensNotificationStream() throws Exception {
+    when(notificationSseBroker.subscribeAccount(101L, "bootstrap"))
+        .thenReturn(new SseEmitter(60_000L));
+
+    mockMvc
+        .perform(get("/api/v1/notifications/stream").header("X-Account-Id", "101"))
+        .andExpect(status().isOk())
+        .andExpect(request().asyncStarted())
+        .andExpect(header().string("X-Accel-Buffering", "no"));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationSseIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationSseIntegrationTest.java
@@ -1,0 +1,397 @@
+package com.aquilabank.global.web.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.global.notification.TransferBookedNotificationConsumer;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "spring.flyway.enabled=true",
+      "management.health.db.enabled=true",
+      "server.shutdown=immediate",
+      "notification.inbox.consumer.enabled=true",
+      "notification.inbox.consumer.auto-startup=false",
+      "notification.inbox.consumer.bootstrap-servers=localhost:9092",
+      "notification.inbox.consumer.transfer-booked.topic=bank.transfer.booked.test"
+    })
+class NotificationSseIntegrationTest extends PostgresContainerTestSupport {
+
+  private static final String TEST_SECRET = "test-local-jwt-secret-test-local-jwt-secret";
+
+  @LocalServerPort private int port;
+
+  @Autowired private TransferBookedNotificationConsumer transferBookedNotificationConsumer;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  @Timeout(15)
+  void pushesNotificationToJwtUserStreamAfterConsumerIngest() throws Exception {
+    long[] userId = new long[1];
+    long[] accountIds = new long[2];
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("stream-user");
+          accountIds[0] = insertAccount("visible account");
+          accountIds[1] = insertAccount("hidden account");
+          insertMembership(userId[0], accountIds[0], "OWNER", "ACTIVE");
+          insertMembership(userId[0], accountIds[1], "VIEWER", "REVOKED");
+        });
+
+    String token = issueToken("stream-user-subject", userId[0]);
+    try (NotificationSseStream stream = openJwtStream(token)) {
+      assertThat(stream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      transferBookedNotificationConsumer.consume(
+          "transfer-booked:TRX-SSE-100",
+          transferBookedPayload(accountIds[0], accountIds[1], 1500L, "rent"));
+
+      SseEvent notification = stream.awaitEvent("notification", Duration.ofSeconds(3));
+      JsonNode payload = objectMapper.readTree(notification.data());
+      assertThat(payload.get("accountId").asLong()).isEqualTo(accountIds[0]);
+      assertThat(payload.get("eventType").asText()).isEqualTo("TransferBooked");
+      assertThat(payload.get("title").asText()).isEqualTo("이체 완료");
+      assertThat(payload.get("message").asText()).contains("출금").contains("rent");
+      assertThat(payload.get("read").asBoolean()).isFalse();
+    }
+  }
+
+  @Test
+  @Timeout(15)
+  void doesNotPushDuplicateNotificationWhenInboxInsertIsNoOp() throws Exception {
+    long[] accountIds = new long[2];
+    commit(
+        transactionManager,
+        () -> {
+          accountIds[0] = insertAccount("source account");
+          accountIds[1] = insertAccount("target account");
+        });
+
+    try (NotificationSseStream stream = openAccountStream(accountIds[0])) {
+      assertThat(stream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      String eventKey = "transfer-booked:TRX-SSE-200";
+      String payload = transferBookedPayload(accountIds[0], accountIds[1], 2200L, "salary");
+      transferBookedNotificationConsumer.consume(eventKey, payload);
+
+      SseEvent firstNotification = stream.awaitEvent("notification", Duration.ofSeconds(3));
+      JsonNode firstPayload = objectMapper.readTree(firstNotification.data());
+      assertThat(firstPayload.get("accountId").asLong()).isEqualTo(accountIds[0]);
+      assertThat(countNotificationsByEventPrefix(eventKey)).isEqualTo(2L);
+
+      transferBookedNotificationConsumer.consume(eventKey, payload);
+
+      stream.assertNoEvent("notification", Duration.ofMillis(800));
+      assertThat(countNotificationsByEventPrefix(eventKey)).isEqualTo(2L);
+    }
+  }
+
+  private NotificationSseStream openJwtStream(String token) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder(
+                URI.create("http://localhost:%d/api/v1/notifications/stream".formatted(port)))
+            .header("Accept", "text/event-stream")
+            .header("Authorization", "Bearer " + token)
+            .GET()
+            .build();
+    return openStream(request);
+  }
+
+  private NotificationSseStream openAccountStream(long accountId) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder(
+                URI.create("http://localhost:%d/api/v1/notifications/stream".formatted(port)))
+            .header("Accept", "text/event-stream")
+            .header("X-Account-Id", Long.toString(accountId))
+            .header("X-Subject", "sse-test")
+            .GET()
+            .build();
+    return openStream(request);
+  }
+
+  private NotificationSseStream openStream(HttpRequest request) throws Exception {
+    HttpClient client = HttpClient.newHttpClient();
+    HttpResponse<InputStream> response =
+        client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.headers().firstValue("content-type"))
+        .hasValueSatisfying(value -> assertThat(value).contains("text/event-stream"));
+    return new NotificationSseStream(response.body());
+  }
+
+  private String transferBookedPayload(
+      long sourceAccountId, long targetAccountId, long amountMinor, String summary) {
+    return """
+        {
+          "transactionReference": "TRX-SSE",
+          "sourceAccountId": %d,
+          "targetAccountId": %d,
+          "amountMinor": %d,
+          "currencyCode": "KRW",
+          "summary": "%s",
+          "bookedAt": "2026-04-17T00:00:00Z"
+        }
+        """
+        .formatted(sourceAccountId, targetAccountId, amountMinor, summary);
+  }
+
+  private long countNotificationsByEventPrefix(String eventKey) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM notification_inbox
+            WHERE event_key LIKE :eventPrefix
+            """,
+            new MapSqlParameterSource().addValue("eventPrefix", eventKey + "%"),
+            Long.class);
+    return count == null ? 0L : count;
+  }
+
+  private long insertUser(String loginId) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private long insertAccount(String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertMembership(long userId, long accountId, String role, String status) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO user_account_membership (
+            user_id,
+            account_id,
+            membership_role,
+            membership_status,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :accountId,
+            :role,
+            :status,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("accountId", accountId)
+            .addValue("role", role)
+            .addValue("status", status));
+  }
+
+  private String issueToken(String subject, long userId) throws JOSEException {
+    Instant now = Instant.now();
+    JWTClaimsSet claimsSet =
+        new JWTClaimsSet.Builder()
+            .subject(subject)
+            .issueTime(Date.from(now))
+            .expirationTime(Date.from(now.plusSeconds(300)))
+            .claim("user_id", userId)
+            .build();
+
+    SignedJWT signedJwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(), claimsSet);
+    signedJwt.sign(new MACSigner(TEST_SECRET.getBytes(StandardCharsets.UTF_8)));
+    return signedJwt.serialize();
+  }
+
+  private static final class NotificationSseStream implements AutoCloseable {
+
+    private final BlockingQueue<SseEvent> events = new LinkedBlockingQueue<>();
+    private final BufferedReader reader;
+    private final Thread readerThread;
+    private volatile boolean closed;
+
+    private NotificationSseStream(InputStream inputStream) {
+      this.reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+      this.readerThread = Thread.ofPlatform().daemon(true).start(this::readLoop);
+    }
+
+    private SseEvent awaitEvent(String eventName, Duration timeout) throws InterruptedException {
+      long deadlineNanos = System.nanoTime() + timeout.toNanos();
+      while (true) {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+          throw new AssertionError("SSE event timed out: " + eventName);
+        }
+        SseEvent event = events.poll(remainingNanos, TimeUnit.NANOSECONDS);
+        if (event == null) {
+          throw new AssertionError("SSE event timed out: " + eventName);
+        }
+        if (eventName.equals(event.name())) {
+          return event;
+        }
+      }
+    }
+
+    private void assertNoEvent(String eventName, Duration duration) throws InterruptedException {
+      long deadlineNanos = System.nanoTime() + duration.toNanos();
+      while (true) {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+          return;
+        }
+        SseEvent event = events.poll(remainingNanos, TimeUnit.NANOSECONDS);
+        if (event == null) {
+          return;
+        }
+        if (eventName.equals(event.name())) {
+          throw new AssertionError("Unexpected SSE event: " + eventName);
+        }
+      }
+    }
+
+    private void readLoop() {
+      String eventName = "message";
+      String eventId = null;
+      StringBuilder data = new StringBuilder();
+      try {
+        String line;
+        while (!closed && (line = reader.readLine()) != null) {
+          if (line.isEmpty()) {
+            if (data.length() > 0) {
+              events.offer(new SseEvent(eventId, eventName, data.toString()));
+            }
+            eventName = "message";
+            eventId = null;
+            data = new StringBuilder();
+            continue;
+          }
+          if (line.startsWith("event:")) {
+            eventName = line.substring("event:".length()).trim();
+            continue;
+          }
+          if (line.startsWith("id:")) {
+            eventId = line.substring("id:".length()).trim();
+            continue;
+          }
+          if (line.startsWith("data:")) {
+            if (data.length() > 0) {
+              data.append('\n');
+            }
+            data.append(line.substring("data:".length()).trim());
+          }
+        }
+      } catch (IOException ignored) {
+        if (!closed) {
+          events.offer(new SseEvent(null, "stream-error", ignored.getMessage()));
+        }
+      }
+    }
+
+    @Override
+    public void close() throws Exception {
+      closed = true;
+      reader.close();
+      readerThread.join(1000L);
+    }
+  }
+
+  private record SseEvent(String id, String name, String data) {}
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #56

## 📝 Summary
- `GET /api/v1/notifications/stream` SSE endpoint를 추가해 기존 notification 인증 principal(account header / JWT user)로 실시간 알림을 구독할 수 있게 했습니다.
- `notification_inbox` insert 성공 후 commit 완료 시점에만 SSE를 발행하도록 연결해 duplicate consume no-op 상황의 중복 push를 막았습니다.
- user stream fan-out은 active membership + active user exact query만 사용하고, reconnect gap은 기존 pull API로 보완하는 운영 기준을 README에 정리했습니다.

## 🛠 Changes
- SSE 설정, emitter registry, connected/heartbeat/notification event 발행과 account/user principal 구독 endpoint 추가
- `notification_inbox` append adapter에서 insert 성공 row만 `NotificationInboxInsertedEvent`로 publish하고, JDBC membership lookup 기반 user fan-out resolver 추가
- controller/unit/integration test와 backend README의 SSE 운영 메모 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh notification-sse ./back/gradlew -p back test --tests '*Notification*'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- SSE example:
```text
event: notification
data: {"notificationId":123,"accountId":101,"eventType":"TransferBooked","title":"이체 완료","message":"1500 KRW 출금 · rent","read":false,"createdAt":"2026-04-17T00:00:00Z","readAt":null}
```

## ⚠️ Risk & Rollback
- 예상 리스크: 현재 emitter registry는 app instance local 메모리 기준이라 multi-instance fan-out까지는 보장하지 않습니다. 연결 단절 중 누락 구간은 pull API 재조회로 보완합니다.
- 롤백 방법: 이 PR revert 시 notification SSE endpoint와 insert-success fan-out 연결이 제거되고 기존 pull-only notification 경로로 복귀합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.