### PR TITLE
[Feat] 내 계좌 목록 조회 API 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/account/model/AccountSummaryList.java
+++ b/back/src/main/java/com/aquilabank/domain/account/model/AccountSummaryList.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.account.model;
+
+import java.util.List;
+
+/** 내 계좌 목록 조회 결과를 한 번에 묶는 최소 응답 모델 */
+public record AccountSummaryList(List<AccountSummary> items) {
+
+  public AccountSummaryList {
+    items = List.copyOf(items);
+    if (items.stream().anyMatch(java.util.Objects::isNull)) {
+      throw new IllegalArgumentException("items must not contain null");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/port/AccountListReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/account/port/AccountListReadPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.account.port;
+
+import com.aquilabank.domain.account.model.AccountSummaryList;
+
+/** 사용자 membership 범위 안의 계좌 목록 조회를 저장소 계층에 위임합니다. */
+public interface AccountListReadPort {
+
+  AccountSummaryList findByUserId(long userId);
+}

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountListQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountListQueryService.java
@@ -1,0 +1,22 @@
+package com.aquilabank.domain.account.usecase;
+
+import com.aquilabank.domain.account.model.AccountSummaryList;
+import com.aquilabank.domain.account.port.AccountListReadPort;
+
+/** 내 계좌 목록 조회 입력 검증과 저장소 위임을 묶습니다. */
+public final class AccountListQueryService implements AccountListQueryUseCase {
+
+  private final AccountListReadPort accountListReadPort;
+
+  public AccountListQueryService(AccountListReadPort accountListReadPort) {
+    this.accountListReadPort = accountListReadPort;
+  }
+
+  @Override
+  public AccountSummaryList getByUserId(long userId) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    return accountListReadPort.findByUserId(userId);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountListQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountListQueryUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.account.usecase;
+
+import com.aquilabank.domain.account.model.AccountSummaryList;
+
+/** 고객이 접근 가능한 계좌 목록 조회 진입점 */
+public interface AccountListQueryUseCase {
+
+  AccountSummaryList getByUserId(long userId);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AccountListConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AccountListConfiguration.java
@@ -1,0 +1,17 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.account.port.AccountListReadPort;
+import com.aquilabank.domain.account.usecase.AccountListQueryService;
+import com.aquilabank.domain.account.usecase.AccountListQueryUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** account list use case와 JDBC adapter를 조립 */
+@Configuration
+public class AccountListConfiguration {
+
+  @Bean
+  AccountListQueryUseCase accountListQueryUseCase(AccountListReadPort accountListReadPort) {
+    return new AccountListQueryService(accountListReadPort);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountListRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountListRepository.java
@@ -1,0 +1,82 @@
+package com.aquilabank.global.persistence.account;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.model.AccountSummaryList;
+import com.aquilabank.domain.account.port.AccountListReadPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 내 계좌 목록 조회를 membership 범위와 snapshot join 한 번으로 읽어옵니다. */
+@Repository
+public class JdbcAccountListRepository implements AccountListReadPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcAccountListRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public AccountSummaryList findByUserId(long userId) {
+    return new AccountSummaryList(
+        jdbcTemplate.query(
+            """
+            SELECT account.id,
+                   account.account_number,
+                   account.display_name,
+                   account.account_status,
+                   account.currency_code AS account_currency_code,
+                   snapshot.available_balance_minor,
+                   snapshot.pending_balance_minor,
+                   snapshot.currency_code AS snapshot_currency_code,
+                   account.created_at,
+                   snapshot.updated_at
+            FROM user_account_membership membership
+            JOIN bank_user bank_user
+              ON bank_user.id = membership.user_id
+            JOIN bank_account account
+              ON account.id = membership.account_id
+            JOIN account_balance_snapshot snapshot
+              ON snapshot.account_id = account.id
+            WHERE membership.user_id = :userId
+              AND membership.membership_status = 'ACTIVE'
+              AND bank_user.user_status = 'ACTIVE'
+            ORDER BY membership.account_id ASC
+            """,
+            new MapSqlParameterSource().addValue("userId", userId),
+            (rs, rowNum) -> mapAccountSummary(rs)));
+  }
+
+  private AccountSummary mapAccountSummary(ResultSet rs) throws SQLException {
+    String accountCurrencyCode = rs.getString("account_currency_code");
+    String snapshotCurrencyCode = rs.getString("snapshot_currency_code");
+    if (!accountCurrencyCode.equals(snapshotCurrencyCode)) {
+      throw new IllegalStateException("account snapshot currency does not match");
+    }
+
+    return new AccountSummary(
+        rs.getLong("id"),
+        rs.getString("account_number"),
+        rs.getString("display_name"),
+        rs.getString("account_status"),
+        accountCurrencyCode,
+        rs.getLong("available_balance_minor"),
+        rs.getLong("pending_balance_minor"),
+        toInstant(rs.getTimestamp("created_at")),
+        toInstant(rs.getTimestamp("updated_at")));
+  }
+
+  private Instant toInstant(Timestamp timestamp) {
+    if (timestamp == null) {
+      throw new IllegalStateException("timestamp must not be null");
+    }
+    return timestamp.toInstant();
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/account/AccountListController.java
+++ b/back/src/main/java/com/aquilabank/global/web/account/AccountListController.java
@@ -1,0 +1,92 @@
+package com.aquilabank.global.web.account;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.model.AccountSummaryList;
+import com.aquilabank.domain.account.usecase.AccountListQueryUseCase;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
+import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/** 고객 계좌 목록 조회를 principal 종류에 맞춰 노출하는 HTTP adapter */
+@Validated
+@RestController
+@RequestMapping("/api/v1/accounts")
+public class AccountListController {
+
+  private final AccountListQueryUseCase accountListQueryUseCase;
+  private final AccountSummaryQueryUseCase accountSummaryQueryUseCase;
+
+  public AccountListController(
+      AccountListQueryUseCase accountListQueryUseCase,
+      AccountSummaryQueryUseCase accountSummaryQueryUseCase) {
+    this.accountListQueryUseCase = accountListQueryUseCase;
+    this.accountSummaryQueryUseCase = accountSummaryQueryUseCase;
+  }
+
+  @GetMapping
+  public AccountListResponse getAccounts(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal) {
+    try {
+      return AccountListResponse.from(resolveAccountSummaryList(principal));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+
+  private AccountSummaryList resolveAccountSummaryList(AuthenticatedRequestPrincipal principal) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      return accountListQueryUseCase.getByUserId(userPrincipal.userId());
+    }
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      // bootstrap account principal도 같은 요약 모델을 재사용해 dev/test 응답 계약을 단순화합니다.
+      return new AccountSummaryList(
+          List.of(accountSummaryQueryUseCase.getByAccountId(accountPrincipal.accountId())));
+    }
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+
+  /** 고객 계좌 목록 응답 */
+  public record AccountListResponse(List<AccountItemResponse> items) {
+
+    static AccountListResponse from(AccountSummaryList summaryList) {
+      return new AccountListResponse(
+          summaryList.items().stream().map(AccountItemResponse::from).toList());
+    }
+  }
+
+  /** 고객 계좌 목록 item 응답 */
+  public record AccountItemResponse(
+      long accountId,
+      String accountNumber,
+      String displayName,
+      String accountStatus,
+      String currencyCode,
+      long availableBalanceMinor,
+      long pendingBalanceMinor,
+      Instant createdAt,
+      Instant balanceUpdatedAt) {
+
+    static AccountItemResponse from(AccountSummary summary) {
+      return new AccountItemResponse(
+          summary.accountId(),
+          summary.accountNumber(),
+          summary.displayName(),
+          summary.accountStatus(),
+          summary.currencyCode(),
+          summary.availableBalanceMinor(),
+          summary.pendingBalanceMinor(),
+          summary.createdAt(),
+          summary.balanceUpdatedAt());
+    }
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/security/AccountListJwtSecurityIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/AccountListJwtSecurityIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.aquilabank.global.security;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.model.AccountSummaryList;
+import com.aquilabank.domain.account.port.AccountListReadPort;
+import com.aquilabank.domain.account.port.AccountSummaryReadPort;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class AccountListJwtSecurityIntegrationTest {
+
+  private static final String TEST_SECRET = "test-local-jwt-secret-test-local-jwt-secret";
+
+  @Autowired private WebApplicationContext context;
+
+  @MockitoBean private AccountListReadPort accountListReadPort;
+
+  @MockitoBean private AccountSummaryReadPort accountSummaryReadPort;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUpMockMvc() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void acceptsBearerJwtAndReturnsMappedAccountList() throws Exception {
+    when(accountListReadPort.findByUserId(55L))
+        .thenReturn(
+            new AccountSummaryList(
+                List.of(
+                    new AccountSummary(
+                        555L,
+                        "100000000000001",
+                        "salary account",
+                        "ACTIVE",
+                        "KRW",
+                        15_000L,
+                        0L,
+                        Instant.parse("2026-04-16T09:00:00Z"),
+                        Instant.parse("2026-04-16T09:05:00Z")),
+                    new AccountSummary(
+                        777L,
+                        "100000000000002",
+                        "saving account",
+                        "ACTIVE",
+                        "KRW",
+                        20_000L,
+                        0L,
+                        Instant.parse("2026-04-16T10:00:00Z"),
+                        Instant.parse("2026-04-16T10:05:00Z")))));
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts").header("Authorization", "Bearer " + issueToken("user-55", 55L)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].accountId").value(555L))
+        .andExpect(jsonPath("$.items[1].accountId").value(777L))
+        .andExpect(jsonPath("$.items[0].availableBalanceMinor").value(15_000L));
+  }
+
+  @Test
+  void rejectsRequestWithoutJwtOrBootstrapHeader() throws Exception {
+    mockMvc.perform(get("/api/v1/accounts")).andExpect(status().isUnauthorized());
+  }
+
+  private String issueToken(String subject, long userId) throws JOSEException {
+    Instant now = Instant.now();
+    JWTClaimsSet claimsSet =
+        new JWTClaimsSet.Builder()
+            .subject(subject)
+            .issueTime(Date.from(now))
+            .expirationTime(Date.from(now.plusSeconds(300)))
+            .claim("user_id", userId)
+            .build();
+
+    SignedJWT signedJwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(), claimsSet);
+    signedJwt.sign(new MACSigner(TEST_SECRET.getBytes(StandardCharsets.UTF_8)));
+    return signedJwt.serialize();
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/account/AccountListControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/account/AccountListControllerTest.java
@@ -1,0 +1,74 @@
+package com.aquilabank.global.web.account;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.usecase.AccountListQueryUseCase;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AccountListControllerTest {
+
+  private AccountListQueryUseCase accountListQueryUseCase;
+  private AccountSummaryQueryUseCase accountSummaryQueryUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    accountListQueryUseCase = mock(AccountListQueryUseCase.class);
+    accountSummaryQueryUseCase = mock(AccountSummaryQueryUseCase.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new AccountListController(accountListQueryUseCase, accountSummaryQueryUseCase))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
+            .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
+            .build();
+  }
+
+  @Test
+  void returnsSingleAccountForBootstrapPrincipal() throws Exception {
+    when(accountSummaryQueryUseCase.getByAccountId(101L))
+        .thenReturn(
+            new AccountSummary(
+                101L,
+                "100000000000001",
+                "daily account",
+                "ACTIVE",
+                "KRW",
+                8_000L,
+                0L,
+                Instant.parse("2026-04-16T09:00:00Z"),
+                Instant.parse("2026-04-16T09:05:00Z")));
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts")
+                .header("X-Account-Id", "101")
+                .header("X-Subject", "bootstrap-account"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].accountId").value(101L))
+        .andExpect(jsonPath("$.items[0].accountNumber").value("100000000000001"))
+        .andExpect(jsonPath("$.items[0].availableBalanceMinor").value(8_000L));
+
+    verifyNoInteractions(accountListQueryUseCase);
+  }
+
+  @Test
+  void rejectsMissingAuthenticationHeader() throws Exception {
+    mockMvc.perform(get("/api/v1/accounts")).andExpect(status().isUnauthorized());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -127,6 +127,37 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.currencyCode").value("KRW"))
         .andExpect(jsonPath("$.availableBalanceMinor").value(8500L))
         .andExpect(jsonPath("$.pendingBalanceMinor").value(0));
+
+    mockMvc
+        .perform(get("/api/v1/accounts").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId))
+        .andExpect(jsonPath("$.items[0].availableBalanceMinor").value(8500L));
+  }
+
+  @Test
+  void accountListReturnsOnlyActiveAccessibleAccountsAndBootstrapAccount() throws Exception {
+    upsertMembership(userId, targetAccountId, "VIEWER", "ACTIVE");
+    upsertMembership(userId, deniedAccountId, "OWNER", "REVOKED");
+    String token = login("alice", "password123!");
+
+    mockMvc
+        .perform(get("/api/v1/accounts").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId))
+        .andExpect(jsonPath("$.items[1].accountId").value(targetAccountId));
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts")
+                .header("X-Account-Id", String.valueOf(targetAccountId))
+                .header("X-Subject", "bootstrap-account"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].accountId").value(targetAccountId))
+        .andExpect(jsonPath("$.items[0].availableBalanceMinor").value(0L));
   }
 
   @Test
@@ -526,6 +557,11 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                         .formatted(allowedSourceAccountId, targetAccountId)))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(get("/api/v1/accounts").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(0));
   }
 
   @Test


### PR DESCRIPTION
## 🔗 Related Issue
- close #58

## 📝 Summary
- JWT 사용자 기준으로 접근 가능한 계좌 목록을 반환하는 `GET /api/v1/accounts` 읽기 경로를 추가했습니다.
- bootstrap account principal도 같은 endpoint에서 자기 계좌 1건 목록으로 응답하도록 맞춰 dev/test 흐름과 응답 계약을 단순화했습니다.

## 🛠 Changes
- domain 계층에 `AccountSummaryList`, `AccountListReadPort`, `AccountListQueryUseCase/Service`를 추가했습니다.
- `user_account_membership + bank_user + bank_account + account_balance_snapshot` 기반 JDBC 목록 조회 adapter와 configuration wiring을 추가했습니다.
- 계좌 목록 controller, bootstrap/JWT 보안 테스트, 실제 로그인 플로우 integration test를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-account-list ./back/gradlew -p back test --tests '*AccountListControllerTest' --tests '*AccountListJwtSecurityIntegrationTest' --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-spotless ./back/gradlew -p back spotlessJavaCheck`
- pre-commit hook `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 응답 예시
```json
{
  "items": [
    {
      "accountId": 101,
      "accountNumber": "100000000000001",
      "displayName": "daily account",
      "accountStatus": "ACTIVE",
      "currencyCode": "KRW",
      "availableBalanceMinor": 8500,
      "pendingBalanceMinor": 0,
      "createdAt": "2026-04-16T09:00:00Z",
      "balanceUpdatedAt": "2026-04-16T09:05:00Z"
    }
  ]
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: disabled user는 목록 쿼리에서 `bank_user.user_status = 'ACTIVE'` 조건으로 빈 목록을 받으므로, 향후 상태코드 정책이 필요하면 별도 auth use case로 승격해야 합니다.
- 롤백 방법: `AccountListController`, `AccountListConfiguration`, `JdbcAccountListRepository`, 관련 domain/test 파일을 되돌려 새 endpoint를 제거합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [ ] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.