### PR TITLE
[CI] develop -> main release 자동머지 복구

### DIFF
--- a/.github/release_pull_request_template.md
+++ b/.github/release_pull_request_template.md
@@ -1,0 +1,17 @@
+## 🔄 Release Summary
+- source branch: `develop`
+- target branch: `main`
+- release unit: deployable bundle only
+
+## ✅ Release Conditions
+- [x] latest `develop` commit passed backend/frontend release gate
+- [x] `develop` is ahead of `main`
+- [x] release scope is limited to deployable changes only
+- [ ] production smoke check after merge
+
+## 🧪 Validation
+- Backend Release Check
+- Frontend Release Check
+
+## ↩️ Rollback
+- revert the release merge commit on `main` when rollback is needed

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,129 @@
+name: Release PR
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-pr-develop
+  cancel-in-progress: true
+
+jobs:
+  backend-release-check:
+    name: Backend Release Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: back
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant Gradle wrapper execute permission
+        run: chmod +x gradlew
+
+      - name: Run backend release check
+        run: ./gradlew check --no-daemon --stacktrace
+
+  frontend-release-check:
+    name: Frontend Release Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: front
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+          cache-dependency-path: front/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Run frontend lint
+        run: yarn lint
+
+      - name: Run frontend build
+        run: yarn build
+
+  release-pr:
+    name: Open Release PR
+    runs-on: ubuntu-latest
+    needs:
+      - backend-release-check
+      - frontend-release-check
+    if: ${{ needs.backend-release-check.result == 'success' && needs.frontend-release-check.result == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main and develop
+        run: git fetch origin main develop
+
+      - name: Check release diff
+        id: diff
+        run: |
+          ahead_count="$(git rev-list --right-only --count origin/main...origin/develop)"
+          echo "ahead_count=${ahead_count}" >> "$GITHUB_OUTPUT"
+          if [[ "${ahead_count}" == "0" ]]; then
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip when develop is not ahead of main
+        if: steps.diff.outputs.has_diff != 'true'
+        run: echo "develop branch has no release diff against main"
+
+      - name: Create or update release PR
+        if: steps.diff.outputs.has_diff == 'true'
+        id: release_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_number="$(gh pr list --base main --head develop --state open --json number --jq '.[0].number')"
+          if [[ -z "${pr_number}" ]]; then
+            gh pr create \
+              --base main \
+              --head develop \
+              --title "chore(release): develop -> main release sync" \
+              --body-file .github/release_pull_request_template.md
+            pr_number="$(gh pr list --base main --head develop --state open --json number --jq '.[0].number')"
+          else
+            gh pr edit \
+              "${pr_number}" \
+              --title "chore(release): develop -> main release sync" \
+              --body-file .github/release_pull_request_template.md
+          fi
+          echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        if: steps.diff.outputs.has_diff == 'true' && steps.release_pr.outputs.number != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge "${{ steps.release_pr.outputs.number }}" --auto --merge

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -110,20 +110,19 @@ jobs:
             gh pr create \
               --base main \
               --head develop \
-              --title "chore(release): develop -> main release sync" \
+              --title "[CI] develop -> main release sync" \
               --body-file .github/release_pull_request_template.md
             pr_number="$(gh pr list --base main --head develop --state open --json number --jq '.[0].number')"
           else
             gh pr edit \
               "${pr_number}" \
-              --title "chore(release): develop -> main release sync" \
+              --title "[CI] develop -> main release sync" \
               --body-file .github/release_pull_request_template.md
           fi
           echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge
         if: steps.diff.outputs.has_diff == 'true' && steps.release_pr.outputs.number != ''
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge "${{ steps.release_pr.outputs.number }}" --auto --merge


### PR DESCRIPTION
## 🔗 Related Issue
- close #60

## 📝 Summary
- `develop`에 누락된 release workflow와 전용 release PR template을 복구했습니다.
- `develop -> main` release PR 제목을 저장소 규칙 형식으로 맞추고, auto-merge 실패가 workflow green으로 숨지 않게 보강했습니다.

## 🛠 Changes
- `.github/workflows/release-pr.yml` 추가
- `.github/release_pull_request_template.md` 추가
- release PR 제목을 `[CI] develop -> main release sync`로 통일
- `gh pr merge --auto --merge` 실패를 더 이상 `continue-on-error`로 무시하지 않도록 변경

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-pr.yml"); puts "release-pr.yml: ok"'`
- `git rev-list --count origin/develop..HEAD`
- `git diff --stat origin/develop...HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - 저장소에서 auto-merge 기능 또는 `GITHUB_TOKEN`의 PR merge 권한이 막혀 있으면 release workflow가 실패 상태로 드러날 수 있습니다.
  - 기존 운영 메모가 `chore(release): ...` 제목에 의존한다면 `[CI] ...` 제목으로 후속 정렬이 필요할 수 있습니다.
- 롤백 방법:
  - `caf062f`, `ee71369` 두 커밋을 순서대로 revert 하면 release workflow/template 복구와 가시성 보강을 함께 되돌릴 수 있습니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.