### PR TITLE
[CI] release PR token fallback 추가

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -99,30 +99,69 @@ jobs:
         if: steps.diff.outputs.has_diff != 'true'
         run: echo "develop branch has no release diff against main"
 
+      - name: Resolve release token source
+        if: steps.diff.outputs.has_diff == 'true'
+        id: auth
+        env:
+          RELEASE_PR_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+        run: |
+          if [[ -n "${RELEASE_PR_TOKEN}" ]]; then
+            echo "token_source=RELEASE_PR_TOKEN" >> "$GITHUB_OUTPUT"
+          else
+            echo "token_source=GITHUB_TOKEN" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create or update release PR
         if: steps.diff.outputs.has_diff == 'true'
         id: release_pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          TOKEN_SOURCE: ${{ steps.auth.outputs.token_source }}
         run: |
-          pr_number="$(gh pr list --base main --head develop --state open --json number --jq '.[0].number')"
-          if [[ -z "${pr_number}" ]]; then
-            gh pr create \
-              --base main \
-              --head develop \
-              --title "[CI] develop -> main release sync" \
-              --body-file .github/release_pull_request_template.md
+          set -euo pipefail
+
+          create_or_update_release_pr() {
+            local pr_number
             pr_number="$(gh pr list --base main --head develop --state open --json number --jq '.[0].number')"
-          else
-            gh pr edit \
-              "${pr_number}" \
-              --title "[CI] develop -> main release sync" \
-              --body-file .github/release_pull_request_template.md
+            if [[ -z "${pr_number}" ]]; then
+              gh pr create \
+                --base main \
+                --head develop \
+                --title "[CI] develop -> main release sync" \
+                --body-file .github/release_pull_request_template.md
+              pr_number="$(gh pr list --base main --head develop --state open --json number --jq '.[0].number')"
+            else
+              gh pr edit \
+                "${pr_number}" \
+                --title "[CI] develop -> main release sync" \
+                --body-file .github/release_pull_request_template.md
+            fi
+            echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
+          }
+
+          # 설정 미스매치 시 즉시 원인과 우회 경로가 로그에 남도록 처리
+          if ! create_or_update_release_pr 2>release-pr-error.log; then
+            cat release-pr-error.log >&2
+            if grep -q "GitHub Actions is not permitted to create or approve pull requests" release-pr-error.log \
+              && [[ "${TOKEN_SOURCE}" == "GITHUB_TOKEN" ]]; then
+              echo "::error::Settings > Actions > General > Workflow permissions 에서 'Allow GitHub Actions to create and approve pull requests'를 켜거나 RELEASE_PR_TOKEN secret을 추가하세요." >&2
+            fi
+            exit 1
           fi
-          echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge
         if: steps.diff.outputs.has_diff == 'true' && steps.release_pr.outputs.number != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge "${{ steps.release_pr.outputs.number }}" --auto --merge
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          TOKEN_SOURCE: ${{ steps.auth.outputs.token_source }}
+        run: |
+          set -euo pipefail
+
+          if ! gh pr merge "${{ steps.release_pr.outputs.number }}" --auto --merge 2>auto-merge-error.log; then
+            cat auto-merge-error.log >&2
+            if grep -q "GitHub Actions is not permitted to create or approve pull requests" auto-merge-error.log \
+              && [[ "${TOKEN_SOURCE}" == "GITHUB_TOKEN" ]]; then
+              echo "::error::Settings > Actions > General > Workflow permissions 에서 'Allow GitHub Actions to create and approve pull requests'를 켜거나 RELEASE_PR_TOKEN secret을 추가하세요." >&2
+            fi
+            exit 1
+          fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #60

## 📝 Summary
- release workflow가 `GITHUB_TOKEN` 권한 제한으로 PR 생성에 실패할 때를 대비해 `RELEASE_PR_TOKEN` secret fallback을 추가했습니다.
- fallback이 없고 저장소 설정도 꺼져 있으면, GitHub Actions 로그에 정확한 설정 경로가 바로 보이도록 에러 메시지를 보강했습니다.

## 🛠 Changes
- `.github/workflows/release-pr.yml`에 `RELEASE_PR_TOKEN` 우선 선택 step 추가
- release PR 생성/auto-merge step의 `GH_TOKEN`을 `RELEASE_PR_TOKEN || github.token`으로 정렬
- `createPullRequest` 권한 에러 발생 시 `Settings > Actions > General > Workflow permissions` 경로와 secret 대안을 명시적으로 출력

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-pr.yml"); puts "release-pr.yml: ok"'`
- `git rev-list --count origin/develop..HEAD`
- `git diff --stat origin/develop...HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - `RELEASE_PR_TOKEN` secret이 없고 저장소의 `Allow GitHub Actions to create and approve pull requests` 설정도 꺼져 있으면 workflow는 계속 실패합니다.
  - fallback token에 repo 권한이 부족하면 `gh pr create`/`gh pr merge --auto`가 동일하게 실패합니다.
- 롤백 방법:
  - `14a062b` 커밋을 revert 하면 fallback/에러 가이드 변경만 되돌릴 수 있습니다.

## ☑️ Checklist
- [x] base branch가 `develop`인지 확인했다.
- [x] GitHub issue를 먼저 만들고 번호를 연결했다.
- [x] 하나의 리뷰 목적을 유지했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 커밋을 논리 단위로 정리했다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.