### PR TITLE
[CI] release PR 번호 캡처 보강

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -122,20 +122,27 @@ jobs:
 
           create_or_update_release_pr() {
             local pr_number
+            local pr_url
             pr_number="$(gh pr list --base main --head develop --state open --json number --jq '.[0].number')"
             if [[ -z "${pr_number}" ]]; then
-              gh pr create \
+              pr_url="$(gh pr create \
                 --base main \
                 --head develop \
                 --title "[CI] develop -> main release sync" \
-                --body-file .github/release_pull_request_template.md
-              pr_number="$(gh pr list --base main --head develop --state open --json number --jq '.[0].number')"
+                --body-file .github/release_pull_request_template.md)"
+              pr_number="${pr_url##*/}"
             else
               gh pr edit \
                 "${pr_number}" \
                 --title "[CI] develop -> main release sync" \
                 --body-file .github/release_pull_request_template.md
             fi
+
+            if [[ -z "${pr_number}" ]]; then
+              echo "::error::release PR 번호를 확인하지 못했습니다. gh pr create/list 결과를 확인하세요." >&2
+              return 1
+            fi
+
             echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
           }
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #60

## 📝 Summary
- `Release PR` workflow에서 release PR 생성 step이 성공해도 PR 번호 output이 비어 `Enable auto-merge`가 skip되는 문제를 보강했습니다.
- 신규 PR 생성 시 `gh pr create`가 반환한 URL에서 PR 번호를 즉시 추출하고, 번호가 비면 바로 실패하도록 바꿨습니다.

## 🛠 Changes
- `.github/workflows/release-pr.yml`의 신규 생성 경로에서 `gh pr create` stdout URL을 받아 PR 번호를 파싱
- `steps.release_pr.outputs.number`가 비면 workflow를 success로 넘기지 않고 즉시 실패
- 모호한 success 대신 원인 드러나는 failure로 정렬

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-pr.yml"); puts "release-pr.yml: ok"'`
- `git diff -- .github/workflows/release-pr.yml`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - `gh pr create` stdout 형식이 URL 단일 출력에서 바뀌면 번호 파싱 로직도 함께 바꿔야 합니다.
  - 저장소 설정/secret 권한이 여전히 없으면 이번에는 skip 대신 failure로 보일 수 있습니다.
- 롤백 방법:
  - `9981c06` 커밋을 revert 하면 번호 캡처 보강만 되돌릴 수 있습니다.

## ☑️ Checklist
- [x] base branch가 `develop`인지 확인했다.
- [x] GitHub issue를 먼저 만들고 번호를 연결했다.
- [x] 하나의 리뷰 목적을 유지했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 커밋을 논리 단위로 정리했다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.