### PR TITLE
[Perf] 거래 조회 필터 확장과 인덱스 보강

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionQuery.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionQuery.java
@@ -10,7 +10,11 @@ public record TransactionQuery(
     Instant to,
     int limit,
     TransactionCursor cursor,
-    TransactionStatus status) {
+    TransactionStatus status,
+    TransactionDirection direction,
+    Long minAmountMinor,
+    Long maxAmountMinor,
+    String transactionReference) {
 
   private static final Duration MAX_RANGE = Duration.ofDays(31);
 
@@ -26,6 +30,24 @@ public record TransactionQuery(
     }
     if (limit < 1 || limit > 100) {
       throw new IllegalArgumentException("limit must be between 1 and 100");
+    }
+    if (minAmountMinor != null && minAmountMinor < 0) {
+      throw new IllegalArgumentException("minAmountMinor must be zero or positive");
+    }
+    if (maxAmountMinor != null && maxAmountMinor < 0) {
+      throw new IllegalArgumentException("maxAmountMinor must be zero or positive");
+    }
+    if (minAmountMinor != null && maxAmountMinor != null && minAmountMinor > maxAmountMinor) {
+      throw new IllegalArgumentException(
+          "minAmountMinor must be less than or equal to maxAmountMinor");
+    }
+    if (transactionReference != null) {
+      if (transactionReference.isBlank()) {
+        throw new IllegalArgumentException("transactionReference must not be blank");
+      }
+      if (transactionReference.length() > 64) {
+        throw new IllegalArgumentException("transactionReference must be 64 characters or less");
+      }
     }
     // 작은 인프라에서도 예측 가능한 scan 비용 유지를 위한 조회 기간 상한
     if (Duration.between(from, to).compareTo(MAX_RANGE) > 0) {

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionReadQueryStatement.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionReadQueryStatement.java
@@ -49,6 +49,27 @@ final class TransactionReadQueryStatement {
       params.addValue("status", query.status().name());
     }
 
+    if (query.direction() != null) {
+      sql.append("\n  AND direction = :direction");
+      params.addValue("direction", query.direction().name());
+    }
+
+    if (query.minAmountMinor() != null) {
+      sql.append("\n  AND amount_minor >= :minAmountMinor");
+      params.addValue("minAmountMinor", query.minAmountMinor());
+    }
+
+    if (query.maxAmountMinor() != null) {
+      sql.append("\n  AND amount_minor <= :maxAmountMinor");
+      params.addValue("maxAmountMinor", query.maxAmountMinor());
+    }
+
+    if (query.transactionReference() != null) {
+      // transactionReference exact lookup은 account scope 안에서 먼저 좁혀 전용 exact index 경로를 타게 둡니다.
+      sql.append("\n  AND transaction_reference = :transactionReference");
+      params.addValue("transactionReference", query.transactionReference());
+    }
+
     if (query.cursor() != null) {
       // keyset cursor와 ORDER BY tuple을 같게 두어 composite index range scan으로 이어지게 합니다.
       sql.append("\n  AND (booked_at, id) < (:cursorBookedAt, :cursorId)");

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.web.transaction;
 
 import com.aquilabank.domain.transaction.model.TransactionCursor;
+import com.aquilabank.domain.transaction.model.TransactionDirection;
 import com.aquilabank.domain.transaction.model.TransactionQuery;
 import com.aquilabank.domain.transaction.model.TransactionStatus;
 import com.aquilabank.domain.transaction.usecase.TransactionQueryUseCase;
@@ -42,7 +43,11 @@ public class TransactionQueryController {
       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
       @RequestParam(defaultValue = "20") int limit,
       @RequestParam(required = false) String cursor,
-      @RequestParam(required = false) TransactionStatus status) {
+      @RequestParam(required = false) TransactionStatus status,
+      @RequestParam(required = false) TransactionDirection direction,
+      @RequestParam(required = false) Long minAmountMinor,
+      @RequestParam(required = false) Long maxAmountMinor,
+      @RequestParam(required = false) String transactionReference) {
     try {
       // 첫 page와 후속 page를 같은 endpoint로 통일
       TransactionCursor decodedCursor =
@@ -51,7 +56,16 @@ public class TransactionQueryController {
           requestAccountAuthorizationService.resolveReadableAccountId(principal, accountId);
       TransactionQuery query =
           new TransactionQuery(
-              resolvedAccountId, from.toInstant(), to.toInstant(), limit, decodedCursor, status);
+              resolvedAccountId,
+              from.toInstant(),
+              to.toInstant(),
+              limit,
+              decodedCursor,
+              status,
+              direction,
+              minAmountMinor,
+              maxAmountMinor,
+              transactionReference);
       return TransactionQueryResponse.from(transactionQueryUseCase.getTransactions(query));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);

--- a/back/src/main/resources/db/migration/V13__add_transaction_query_filter_indexes.sql
+++ b/back/src/main/resources/db/migration/V13__add_transaction_query_filter_indexes.sql
@@ -1,0 +1,11 @@
+CREATE INDEX idx_transaction_read_model_account_reference_cursor
+    ON transaction_read_model (account_id, transaction_reference, booked_at DESC, id DESC);
+
+COMMENT ON INDEX idx_transaction_read_model_account_cursor IS
+    'GET /api/v1/transactions 첫 page/후속 cursor page용. direction/amount range 보조 조건도 account_id + booked_at DESC, id DESC bounded scan 뒤 post-filter';
+
+COMMENT ON INDEX idx_transaction_read_model_account_status_cursor IS
+    'GET /api/v1/transactions status filter page용. status 뒤에도 booked_at DESC, id DESC keyset 정렬 유지, direction/amount range 조합은 post-filter';
+
+COMMENT ON INDEX idx_transaction_read_model_account_reference_cursor IS
+    'GET /api/v1/transactions transactionReference exact lookup 보조 조건용. account_id + transaction_reference exact match 뒤 booked_at DESC, id DESC 정렬 유지';

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
@@ -66,6 +66,10 @@ class JdbcTransactionReadRepositoryBaselineIntegrationTest extends PostgresConta
             baselineWindow.to(),
             50,
             null,
+            null,
+            null,
+            null,
+            null,
             null);
 
     TransactionSlice slice = repository.fetch(query);
@@ -89,6 +93,10 @@ class JdbcTransactionReadRepositoryBaselineIntegrationTest extends PostgresConta
             baselineWindow.to(),
             50,
             null,
+            null,
+            null,
+            null,
+            null,
             null);
     TransactionSlice firstSlice = repository.fetch(firstPageQuery);
 
@@ -99,6 +107,10 @@ class JdbcTransactionReadRepositoryBaselineIntegrationTest extends PostgresConta
             baselineWindow.to(),
             50,
             firstSlice.nextCursor(),
+            null,
+            null,
+            null,
+            null,
             null);
 
     TransactionSlice nextSlice = repository.fetch(nextPageQuery);
@@ -122,7 +134,11 @@ class JdbcTransactionReadRepositoryBaselineIntegrationTest extends PostgresConta
             baselineWindow.to(),
             50,
             null,
-            TransactionStatus.BOOKED);
+            TransactionStatus.BOOKED,
+            null,
+            null,
+            null,
+            null);
     TransactionSlice firstSlice = repository.fetch(firstPageQuery);
 
     TransactionQuery nextPageQuery =
@@ -132,7 +148,11 @@ class JdbcTransactionReadRepositoryBaselineIntegrationTest extends PostgresConta
             baselineWindow.to(),
             50,
             firstSlice.nextCursor(),
-            TransactionStatus.BOOKED);
+            TransactionStatus.BOOKED,
+            null,
+            null,
+            null,
+            null);
 
     TransactionSlice nextSlice = repository.fetch(nextPageQuery);
     TransactionExplainPlan plan = explain(nextPageQuery);

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryBaselineIntegrationTest.java
@@ -2,6 +2,7 @@ package com.aquilabank.global.persistence.transaction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.aquilabank.domain.transaction.model.TransactionDirection;
 import com.aquilabank.domain.transaction.model.TransactionQuery;
 import com.aquilabank.domain.transaction.model.TransactionSlice;
 import com.aquilabank.domain.transaction.model.TransactionStatus;
@@ -161,6 +162,81 @@ class JdbcTransactionReadRepositoryBaselineIntegrationTest extends PostgresConta
     assertThat(nextSlice.items()).hasSize(50);
     assertThat(nextSlice.items()).allMatch(item -> item.status() == TransactionStatus.BOOKED);
     assertThat(plan.usesIndex("idx_transaction_read_model_account_status_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void directionFilteredPageUsesAccountCursorIndex() {
+    TransactionQuery query =
+        new TransactionQuery(
+            baselineWindow.hotAccountId(),
+            baselineWindow.from(),
+            baselineWindow.to(),
+            50,
+            null,
+            null,
+            TransactionDirection.DEBIT,
+            null,
+            null,
+            null);
+
+    TransactionSlice slice = repository.fetch(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(50);
+    assertThat(slice.items()).allMatch(item -> item.direction() == TransactionDirection.DEBIT);
+    assertThat(plan.usesIndex("idx_transaction_read_model_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void amountRangeFilteredPageUsesAccountCursorIndex() {
+    TransactionQuery query =
+        new TransactionQuery(
+            baselineWindow.hotAccountId(),
+            baselineWindow.from(),
+            baselineWindow.to(),
+            50,
+            null,
+            null,
+            null,
+            1700L,
+            1700L,
+            null);
+
+    TransactionSlice slice = repository.fetch(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(50);
+    assertThat(slice.items()).allMatch(item -> item.amountMinor() == 1700L);
+    assertThat(plan.usesIndex("idx_transaction_read_model_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void transactionReferenceExactLookupUsesReferenceCursorIndex() {
+    TransactionQuery query =
+        new TransactionQuery(
+            baselineWindow.hotAccountId(),
+            baselineWindow.from(),
+            baselineWindow.to(),
+            20,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "hot-account-trx-40000");
+
+    TransactionSlice slice = repository.fetch(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(1);
+    assertThat(slice.items().getFirst().transactionReference()).isEqualTo("hot-account-trx-40000");
+    assertThat(plan.usesIndex("idx_transaction_read_model_account_reference_cursor")).isTrue();
     assertThat(plan.hasNodeType("Seq Scan")).isFalse();
     assertThat(plan.hasNodeType("Sort")).isFalse();
   }

--- a/back/src/test/java/com/aquilabank/global/security/TransactionJwtSecurityIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/TransactionJwtSecurityIntegrationTest.java
@@ -93,6 +93,53 @@ class TransactionJwtSecurityIntegrationTest {
   }
 
   @Test
+  void passesExpandedFiltersThroughJwtProtectedQuery() throws Exception {
+    when(transactionReadPort.fetch(
+            argThat(
+                query ->
+                    query.accountId() == 555L
+                        && query.status() == TransactionStatus.BOOKED
+                        && query.direction() == TransactionDirection.CREDIT
+                        && Long.valueOf(4000L).equals(query.minAmountMinor())
+                        && Long.valueOf(6000L).equals(query.maxAmountMinor())
+                        && "TX-1".equals(query.transactionReference()))))
+        .thenReturn(
+            new TransactionSlice(
+                List.of(
+                    new TransactionSummary(
+                        1L,
+                        555L,
+                        "TX-1",
+                        TransactionDirection.CREDIT,
+                        TransactionStatus.BOOKED,
+                        5000L,
+                        15000L,
+                        "KRW",
+                        "salary",
+                        "COMPANY",
+                        Instant.parse("2026-04-16T09:00:00Z"))),
+                null,
+                false,
+                20));
+    when(accountAccessUseCase.verify(55L, 555L, AccountAccessScope.READ)).thenReturn(555L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("Authorization", "Bearer " + issueToken("user-555", 55L))
+                .param("accountId", "555")
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z")
+                .param("status", "BOOKED")
+                .param("direction", "CREDIT")
+                .param("minAmountMinor", "4000")
+                .param("maxAmountMinor", "6000")
+                .param("transactionReference", "TX-1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].transactionReference").value("TX-1"));
+  }
+
+  @Test
   void rejectsRequestWithoutJwtOrBootstrapHeader() throws Exception {
     mockMvc
         .perform(

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -134,6 +134,26 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.items.length()").value(1))
         .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId))
         .andExpect(jsonPath("$.items[0].availableBalanceMinor").value(8500L));
+
+    String transactionReference = transactionReference(transferResult);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId))
+                .param("from", transactionQueryFrom())
+                .param("to", transactionQueryTo())
+                .param("status", "BOOKED")
+                .param("direction", "DEBIT")
+                .param("minAmountMinor", "1500")
+                .param("maxAmountMinor", "1500")
+                .param("transactionReference", transactionReference))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].transactionReference").value(transactionReference))
+        .andExpect(jsonPath("$.items[0].direction").value("DEBIT"))
+        .andExpect(jsonPath("$.items[0].amountMinor").value(1500L));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.aquilabank.domain.transaction.model.TransactionCursor;
 import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionQuery;
 import com.aquilabank.domain.transaction.model.TransactionSlice;
 import com.aquilabank.domain.transaction.model.TransactionStatus;
 import com.aquilabank.domain.transaction.model.TransactionSummary;
@@ -127,6 +128,50 @@ class TransactionQueryControllerTest {
   }
 
   @Test
+  void passesExpandedFiltersIntoQuery() throws Exception {
+    when(transactionQueryUseCase.getTransactions(argThat(this::matchesExpandedFilters)))
+        .thenReturn(new TransactionSlice(List.of(), null, false, 20));
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z")
+                .param("limit", "20")
+                .param("status", "BOOKED")
+                .param("direction", "DEBIT")
+                .param("minAmountMinor", "1000")
+                .param("maxAmountMinor", "2000")
+                .param("transactionReference", "TX-777"))
+        .andExpect(status().isOk());
+
+    verify(transactionQueryUseCase).getTransactions(argThat(this::matchesExpandedFilters));
+  }
+
+  @Test
+  void rejectsInvalidAmountRange() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z")
+                .param("minAmountMinor", "2000")
+                .param("maxAmountMinor", "1000"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   void rejectsMissingAuthenticationHeader() throws Exception {
     mockMvc
         .perform(
@@ -136,5 +181,14 @@ class TransactionQueryControllerTest {
                 .param("to", "2026-04-17T00:00:00Z")
                 .param("limit", "20"))
         .andExpect(status().isUnauthorized());
+  }
+
+  private boolean matchesExpandedFilters(TransactionQuery query) {
+    return query.accountId() == 101L
+        && query.status() == TransactionStatus.BOOKED
+        && query.direction() == TransactionDirection.DEBIT
+        && Long.valueOf(1000L).equals(query.minAmountMinor())
+        && Long.valueOf(2000L).equals(query.maxAmountMinor())
+        && "TX-777".equals(query.transactionReference());
   }
 }

--- a/tools/test/run-transaction-query-baseline.sh
+++ b/tools/test/run-transaction-query-baseline.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "[transaction-baseline] fixture: hot account 80000 rows + noise 6x4000 rows"
-echo "[transaction-baseline] target p95: first-page<=120ms cursor-page<=150ms status-page<=150ms"
+echo "[transaction-baseline] target p95: first-page<=120ms cursor-page<=150ms status-page<=150ms direction-page<=150ms amount-page<=180ms reference-exact<=80ms"
 echo "[transaction-baseline] timeout order: statement_timeout=3000ms query-timeout=3s request-timeout=5000ms"
 
 ./back/gradlew -p back test \


### PR DESCRIPTION
## 🔗 Related Issue
- close #66

## 📝 Summary
- `GET /api/v1/transactions` 에 `direction`, `minAmountMinor`, `maxAmountMinor`, `transactionReference` 보조 조건을 추가했습니다.
- `transactionReference` exact lookup 보조 조건은 read-model 전용 index로 보강하고, `direction`/`amount range` 는 기존 account/date keyset bounded scan 위 post-filter 전략으로 유지했습니다.

## 🛠 Changes
- `TransactionQuery` 와 `TransactionQueryController` 에 새 필터 계약과 validation 을 추가했습니다.
- `TransactionReadQueryStatement` 와 `V13__add_transaction_query_filter_indexes.sql` 로 exact lookup index 및 index intent comment 를 추가했습니다.
- controller/security/login integration/baseline EXPLAIN 테스트와 baseline 실행 스크립트를 새 필터 기준으로 확장했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-transaction-filters ./back/gradlew -p back test --tests '*TransactionQueryControllerTest' --tests '*TransactionJwtSecurityIntegrationTest' --tests '*JdbcTransactionReadRepositoryBaselineIntegrationTest' --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-transaction-baseline tools/test/run-transaction-query-baseline.sh`
- pre-commit hook `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 요청 예시
```http
GET /api/v1/transactions?accountId=101&from=2026-04-01T00:00:00Z&to=2026-04-17T00:00:00Z&status=BOOKED&direction=DEBIT&minAmountMinor=1500&maxAmountMinor=1500&transactionReference=TX-777
```

## ⚠️ Risk & Rollback
- 예상 리스크: `direction`/`amount range` 는 전용 index 대신 기존 `idx_transaction_read_model_account_cursor` 또는 `idx_transaction_read_model_account_status_cursor` bounded scan 뒤 post-filter 로 처리하므로, 실제 데이터 분포가 baseline 보다 더 skew 되면 추가 index 검토가 다시 필요할 수 있습니다.
- 롤백 방법: `V13__add_transaction_query_filter_indexes.sql` 을 되돌리고 `TransactionQuery`, `TransactionQueryController`, `TransactionReadQueryStatement`, 관련 테스트/스크립트 변경을 함께 revert 합니다.

## ☑️ Checklist
- [x] 관련 이슈를 연결했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 필요한 테스트를 수행했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [ ] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.