### PR TITLE
[Feat] notification SSE 멀티 인스턴스 fan-out 경로 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -141,10 +141,11 @@ tools/test/with-resource-lock.sh back-gradle-check \
   - `heartbeat`: idle 연결 유지
 - 전달 계약:
   - SSE push는 `notification_inbox` insert 성공 이후에만 발행됩니다.
+  - 같은 인스턴스 안에서는 local event로 즉시 fan-out 하고, 다른 인스턴스에는 PostgreSQL `LISTEN/NOTIFY` signal로 fan-out 합니다.
   - duplicate Kafka consume로 insert가 `ON CONFLICT DO NOTHING` 이면 SSE도 추가 발행하지 않습니다.
   - user stream fan-out 대상은 `ACTIVE membership + ACTIVE user` 조건으로만 계산합니다.
-  - ordering 보장 범위는 현재 단일 app instance 안의 publish 순서까지입니다.
-  - reconnect 사이에 놓친 알림은 기존 `GET /api/v1/notifications` pull API로 재동기화합니다.
+  - ordering 보장 범위는 같은 fan-out signal 안의 `notification_inbox.id ASC` 처리 순서와 단일 app instance 안의 publish 순서까지입니다.
+  - PostgreSQL LISTEN 연결 재수립 또는 reconnect 사이에 놓친 알림은 기존 `GET /api/v1/notifications` pull API로 재동기화합니다.
 - 기본 설정:
   - `NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS=1800000`
   - `NOTIFICATION_SSE_HEARTBEAT_INTERVAL_MS=10000`

--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
+    compileOnly("org.postgresql:postgresql")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.springframework.security:spring-security-test")

--- a/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
@@ -6,6 +6,8 @@ import com.aquilabank.domain.notification.usecase.NotificationQueryService;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadService;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import com.aquilabank.global.notification.NotificationSseFanoutInstanceId;
+import java.util.UUID;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,5 +27,10 @@ public class NotificationConfiguration {
   NotificationReadUseCase notificationReadUseCase(
       NotificationInboxWritePort notificationInboxWritePort) {
     return new NotificationReadService(notificationInboxWritePort);
+  }
+
+  @Bean
+  NotificationSseFanoutInstanceId notificationSseFanoutInstanceId() {
+    return new NotificationSseFanoutInstanceId(UUID.randomUUID().toString());
   }
 }

--- a/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
@@ -5,7 +5,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /** SSE 연결 유지 시간과 heartbeat 간격을 notification read API 설정과 분리합니다. */
 @ConfigurationProperties(prefix = "notification.sse")
 public record NotificationSseProperties(
-    long connectionTimeoutMs, long heartbeatIntervalMs, long reconnectDelayMs) {
+    long connectionTimeoutMs,
+    long heartbeatIntervalMs,
+    long reconnectDelayMs,
+    String fanoutChannel,
+    long fanoutListenTimeoutMs,
+    long fanoutRetryDelayMs) {
 
   public NotificationSseProperties {
     if (connectionTimeoutMs <= 0) {
@@ -17,6 +22,19 @@ public record NotificationSseProperties(
     if (reconnectDelayMs < 0) {
       throw new IllegalArgumentException(
           "notification.sse.reconnect-delay-ms must not be negative");
+    }
+    if (fanoutChannel == null || fanoutChannel.isBlank()) {
+      throw new IllegalArgumentException("notification.sse.fanout-channel must not be blank");
+    }
+    if (!fanoutChannel.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+      throw new IllegalArgumentException("notification.sse.fanout-channel format is invalid");
+    }
+    if (fanoutListenTimeoutMs <= 0) {
+      throw new IllegalArgumentException(
+          "notification.sse.fanout-listen-timeout-ms must be positive");
+    }
+    if (fanoutRetryDelayMs <= 0) {
+      throw new IllegalArgumentException("notification.sse.fanout-retry-delay-ms must be positive");
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -47,24 +46,27 @@ public class NotificationSseBroker {
     return subscribe(userSessions, userId, subject, "user");
   }
 
+  public boolean hasActiveSessions() {
+    return !accountSessions.isEmpty() || !userSessions.isEmpty();
+  }
+
+  public void publishInsertedItems(List<NotificationSummary> items) {
+    if (items.isEmpty() || !hasActiveSessions()) {
+      return;
+    }
+    Map<Long, List<NotificationSummary>> itemsByAccountId = groupByAccountId(items);
+    for (Map.Entry<Long, List<NotificationSummary>> entry : itemsByAccountId.entrySet()) {
+      long accountId = entry.getKey();
+      List<NotificationSummary> accountItems = entry.getValue();
+      publishToAccountSessions(accountId, accountItems);
+      publishToUserSessions(accountId, accountItems);
+    }
+  }
+
   @Scheduled(fixedDelayString = "${notification.sse.heartbeat-interval-ms:25000}")
   void sendHeartbeats() {
     sendHeartbeats(accountSessions, "account");
     sendHeartbeats(userSessions, "user");
-  }
-
-  @EventListener
-  public void handleNotificationInboxInserted(NotificationInboxInsertedEvent event) {
-    if (accountSessions.isEmpty() && userSessions.isEmpty()) {
-      return;
-    }
-    Map<Long, List<NotificationSummary>> itemsByAccountId = groupByAccountId(event.items());
-    for (Map.Entry<Long, List<NotificationSummary>> entry : itemsByAccountId.entrySet()) {
-      long accountId = entry.getKey();
-      List<NotificationSummary> items = entry.getValue();
-      publishToAccountSessions(accountId, items);
-      publishToUserSessions(accountId, items);
-    }
   }
 
   private SseEmitter subscribe(

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseFanoutInstanceId.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseFanoutInstanceId.java
@@ -1,0 +1,11 @@
+package com.aquilabank.global.notification;
+
+/** 같은 인스턴스가 보낸 fan-out signal 재수신을 무시하려고 런타임별 식별자를 둡니다. */
+public record NotificationSseFanoutInstanceId(String value) {
+
+  public NotificationSseFanoutInstanceId {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("value must not be blank");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseFanoutSignal.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseFanoutSignal.java
@@ -1,0 +1,27 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import java.util.List;
+
+/** payload 크기를 낮추려고 remote fan-out 은 origin instance 와 notification id 목록만 보냅니다. */
+public record NotificationSseFanoutSignal(String originInstanceId, List<Long> notificationIds) {
+
+  public NotificationSseFanoutSignal {
+    notificationIds = List.copyOf(notificationIds);
+    if (originInstanceId == null || originInstanceId.isBlank()) {
+      throw new IllegalArgumentException("originInstanceId must not be blank");
+    }
+    if (notificationIds.isEmpty()) {
+      throw new IllegalArgumentException("notificationIds must not be empty");
+    }
+    if (notificationIds.stream().anyMatch(id -> id == null || id <= 0)) {
+      throw new IllegalArgumentException("notificationIds must contain positive ids");
+    }
+  }
+
+  public static NotificationSseFanoutSignal fromItems(
+      NotificationSseFanoutInstanceId instanceId, List<NotificationSummary> items) {
+    return new NotificationSseFanoutSignal(
+        instanceId.value(), items.stream().map(NotificationSummary::id).toList());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseFanoutSignalCodec.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseFanoutSignalCodec.java
@@ -1,0 +1,32 @@
+package com.aquilabank.global.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+/** LISTEN/NOTIFY payload 를 고정 포맷 JSON 으로 유지해 배포 간 호환성을 맞춥니다. */
+@Component
+public class NotificationSseFanoutSignalCodec {
+
+  private final ObjectMapper objectMapper;
+
+  public NotificationSseFanoutSignalCodec(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public String encode(NotificationSseFanoutSignal signal) {
+    try {
+      return objectMapper.writeValueAsString(signal);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException("notification SSE fanout signal encode failed", ex);
+    }
+  }
+
+  public NotificationSseFanoutSignal decode(String payload) {
+    try {
+      return objectMapper.readValue(payload, NotificationSseFanoutSignal.class);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalArgumentException("notification SSE fanout signal decode failed", ex);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseLocalFanoutDispatcher.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseLocalFanoutDispatcher.java
@@ -1,0 +1,20 @@
+package com.aquilabank.global.notification;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/** local insert 성공 fan-out 과 remote signal fan-out 이 같은 broker 경로를 타게 맞춥니다. */
+@Component
+public class NotificationSseLocalFanoutDispatcher {
+
+  private final NotificationSseBroker notificationSseBroker;
+
+  public NotificationSseLocalFanoutDispatcher(NotificationSseBroker notificationSseBroker) {
+    this.notificationSseBroker = notificationSseBroker;
+  }
+
+  @EventListener
+  public void handleNotificationInboxInserted(NotificationInboxInsertedEvent event) {
+    notificationSseBroker.publishInsertedItems(event.items());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/PostgresNotificationSseFanoutListener.java
+++ b/back/src/main/java/com/aquilabank/global/notification/PostgresNotificationSseFanoutListener.java
@@ -1,0 +1,164 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import com.aquilabank.global.config.NotificationSseProperties;
+import com.aquilabank.global.persistence.notification.JdbcNotificationSseFanoutReadRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.sql.DataSource;
+import org.postgresql.PGConnection;
+import org.postgresql.PGNotification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** 다른 인스턴스가 보낸 notification_inbox insert 신호를 LISTEN/NOTIFY 로 받아 local SSE 세션에 fan-out 합니다. */
+@Component
+public class PostgresNotificationSseFanoutListener {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(PostgresNotificationSseFanoutListener.class);
+
+  private final DataSource dataSource;
+  private final NotificationSseProperties notificationSseProperties;
+  private final NotificationSseFanoutInstanceId notificationSseFanoutInstanceId;
+  private final NotificationSseFanoutSignalCodec notificationSseFanoutSignalCodec;
+  private final JdbcNotificationSseFanoutReadRepository jdbcNotificationSseFanoutReadRepository;
+  private final NotificationSseBroker notificationSseBroker;
+  private final AtomicBoolean running = new AtomicBoolean(false);
+
+  private volatile Thread listenerThread;
+  private volatile Connection listeningConnection;
+
+  public PostgresNotificationSseFanoutListener(
+      DataSource dataSource,
+      NotificationSseProperties notificationSseProperties,
+      NotificationSseFanoutInstanceId notificationSseFanoutInstanceId,
+      NotificationSseFanoutSignalCodec notificationSseFanoutSignalCodec,
+      JdbcNotificationSseFanoutReadRepository jdbcNotificationSseFanoutReadRepository,
+      NotificationSseBroker notificationSseBroker) {
+    this.dataSource = dataSource;
+    this.notificationSseProperties = notificationSseProperties;
+    this.notificationSseFanoutInstanceId = notificationSseFanoutInstanceId;
+    this.notificationSseFanoutSignalCodec = notificationSseFanoutSignalCodec;
+    this.jdbcNotificationSseFanoutReadRepository = jdbcNotificationSseFanoutReadRepository;
+    this.notificationSseBroker = notificationSseBroker;
+  }
+
+  @PostConstruct
+  void start() {
+    if (!running.compareAndSet(false, true)) {
+      return;
+    }
+    listenerThread =
+        Thread.ofVirtual().name("notification-sse-fanout-listener").start(this::listenLoop);
+  }
+
+  @PreDestroy
+  void stop() {
+    running.set(false);
+    closeListeningConnection();
+    Thread thread = listenerThread;
+    if (thread != null) {
+      thread.interrupt();
+    }
+  }
+
+  private void listenLoop() {
+    while (running.get()) {
+      if (!notificationSseBroker.hasActiveSessions()) {
+        sleepListenTimeout();
+        continue;
+      }
+      try (Connection connection = dataSource.getConnection();
+          Statement statement = connection.createStatement()) {
+        connection.setAutoCommit(true);
+        listeningConnection = connection;
+        statement.execute("LISTEN " + notificationSseProperties.fanoutChannel());
+        PGConnection pgConnection = connection.unwrap(PGConnection.class);
+        while (running.get()) {
+          PGNotification[] notifications =
+              pgConnection.getNotifications(
+                  Math.toIntExact(notificationSseProperties.fanoutListenTimeoutMs()));
+          if (notifications == null || notifications.length == 0) {
+            continue;
+          }
+          for (PGNotification notification : notifications) {
+            handleSignalPayload(notification.getParameter());
+          }
+        }
+      } catch (SQLException ex) {
+        if (!running.get()) {
+          return;
+        }
+        if (!notificationSseBroker.hasActiveSessions()) {
+          sleepListenTimeout();
+          continue;
+        }
+        log.warn(
+            "notification SSE fanout listener reconnecting channel={}",
+            notificationSseProperties.fanoutChannel(),
+            ex);
+        sleepRetryDelay();
+      } finally {
+        listeningConnection = null;
+      }
+    }
+  }
+
+  private void handleSignalPayload(String payload) {
+    NotificationSseFanoutSignal signal;
+    try {
+      signal = notificationSseFanoutSignalCodec.decode(payload);
+    } catch (IllegalArgumentException ex) {
+      log.warn("notification SSE fanout signal decode failed", ex);
+      return;
+    }
+    if (notificationSseFanoutInstanceId.value().equals(signal.originInstanceId())) {
+      return;
+    }
+    if (!notificationSseBroker.hasActiveSessions()) {
+      return;
+    }
+    List<NotificationSummary> items =
+        jdbcNotificationSseFanoutReadRepository.findByIds(signal.notificationIds());
+    if (items.isEmpty()) {
+      return;
+    }
+    notificationSseBroker.publishInsertedItems(items);
+  }
+
+  private void sleepRetryDelay() {
+    try {
+      Thread.sleep(notificationSseProperties.fanoutRetryDelayMs());
+    } catch (InterruptedException ignored) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private void sleepListenTimeout() {
+    try {
+      Thread.sleep(notificationSseProperties.fanoutListenTimeoutMs());
+    } catch (InterruptedException ignored) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private void closeListeningConnection() {
+    Connection connection = listeningConnection;
+    listeningConnection = null;
+    if (connection == null) {
+      return;
+    }
+    try {
+      connection.close();
+    } catch (SQLException ignored) {
+      // 종료 중 close 실패는 무시
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/PostgresNotificationSseFanoutPublisher.java
+++ b/back/src/main/java/com/aquilabank/global/notification/PostgresNotificationSseFanoutPublisher.java
@@ -1,0 +1,48 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.global.config.NotificationSseProperties;
+import java.sql.PreparedStatement;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/** scale-out SSE fan-out 신호는 transaction commit 이후 PostgreSQL NOTIFY 로만 퍼뜨립니다. */
+@Component
+public class PostgresNotificationSseFanoutPublisher {
+
+  private final JdbcTemplate jdbcTemplate;
+  private final NotificationSseProperties notificationSseProperties;
+  private final NotificationSseFanoutInstanceId notificationSseFanoutInstanceId;
+  private final NotificationSseFanoutSignalCodec notificationSseFanoutSignalCodec;
+
+  public PostgresNotificationSseFanoutPublisher(
+      JdbcTemplate jdbcTemplate,
+      NotificationSseProperties notificationSseProperties,
+      NotificationSseFanoutInstanceId notificationSseFanoutInstanceId,
+      NotificationSseFanoutSignalCodec notificationSseFanoutSignalCodec) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.notificationSseProperties = notificationSseProperties;
+    this.notificationSseFanoutInstanceId = notificationSseFanoutInstanceId;
+    this.notificationSseFanoutSignalCodec = notificationSseFanoutSignalCodec;
+  }
+
+  @EventListener
+  public void handleNotificationInboxInserted(NotificationInboxInsertedEvent event) {
+    NotificationSseFanoutSignal signal =
+        NotificationSseFanoutSignal.fromItems(notificationSseFanoutInstanceId, event.items());
+    String payload = notificationSseFanoutSignalCodec.encode(signal);
+    jdbcTemplate.execute(
+        (ConnectionCallback<Void>)
+            connection -> {
+              connection.setAutoCommit(true);
+              try (PreparedStatement statement =
+                  connection.prepareStatement("SELECT pg_notify(?, ?)")) {
+                statement.setString(1, notificationSseProperties.fanoutChannel());
+                statement.setString(2, payload);
+                statement.execute();
+              }
+              return null;
+            });
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationSseFanoutReadRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationSseFanoutReadRepository.java
@@ -1,0 +1,57 @@
+package com.aquilabank.global.persistence.notification;
+
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** remote fan-out signal 은 notification id 목록만 오므로 SSE payload 는 DB row 로 다시 읽습니다. */
+@Repository
+public class JdbcNotificationSseFanoutReadRepository {
+
+  private static final RowMapper<NotificationSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcNotificationSseFanoutReadRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Transactional(readOnly = true)
+  public List<NotificationSummary> findByIds(List<Long> notificationIds) {
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               account_id,
+               event_type,
+               title,
+               message,
+               created_at,
+               read_at
+        FROM notification_inbox
+        WHERE id IN (:notificationIds)
+        ORDER BY id ASC
+        """,
+        new MapSqlParameterSource().addValue("notificationIds", notificationIds),
+        ROW_MAPPER);
+  }
+
+  private static NotificationSummary mapRow(ResultSet rs) throws SQLException {
+    OffsetDateTime createdAt = rs.getObject("created_at", OffsetDateTime.class);
+    OffsetDateTime readAt = rs.getObject("read_at", OffsetDateTime.class);
+    return new NotificationSummary(
+        rs.getLong("id"),
+        rs.getLong("account_id"),
+        rs.getString("event_type"),
+        rs.getString("title"),
+        rs.getString("message"),
+        createdAt.toInstant(),
+        readAt == null ? null : readAt.toInstant());
+  }
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -110,6 +110,9 @@ notification:
     connection-timeout-ms: ${NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS:1800000}
     heartbeat-interval-ms: ${NOTIFICATION_SSE_HEARTBEAT_INTERVAL_MS:10000}
     reconnect-delay-ms: ${NOTIFICATION_SSE_RECONNECT_DELAY_MS:3000}
+    fanout-channel: ${NOTIFICATION_SSE_FANOUT_CHANNEL:notification_sse_fanout}
+    fanout-listen-timeout-ms: ${NOTIFICATION_SSE_FANOUT_LISTEN_TIMEOUT_MS:1000}
+    fanout-retry-delay-ms: ${NOTIFICATION_SSE_FANOUT_RETRY_DELAY_MS:2000}
   inbox:
     consumer:
       enabled: ${NOTIFICATION_INBOX_CONSUMER_ENABLED:false}

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationSseIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationSseIntegrationTest.java
@@ -2,6 +2,10 @@ package com.aquilabank.global.web.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.aquilabank.global.config.NotificationSseProperties;
+import com.aquilabank.global.notification.NotificationSseFanoutInstanceId;
+import com.aquilabank.global.notification.NotificationSseFanoutSignal;
+import com.aquilabank.global.notification.NotificationSseFanoutSignalCodec;
 import com.aquilabank.global.notification.TransferBookedNotificationConsumer;
 import com.aquilabank.support.PostgresContainerTestSupport;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -22,6 +26,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.sql.PreparedStatement;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
@@ -64,6 +69,12 @@ class NotificationSseIntegrationTest extends PostgresContainerTestSupport {
   @Autowired private PlatformTransactionManager transactionManager;
 
   @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private NotificationSseProperties notificationSseProperties;
+
+  @Autowired private NotificationSseFanoutInstanceId notificationSseFanoutInstanceId;
+
+  @Autowired private NotificationSseFanoutSignalCodec notificationSseFanoutSignalCodec;
 
   @BeforeEach
   void setUp() {
@@ -132,6 +143,74 @@ class NotificationSseIntegrationTest extends PostgresContainerTestSupport {
 
       stream.assertNoEvent("notification", Duration.ofMillis(800));
       assertThat(countNotificationsByEventPrefix(eventKey)).isEqualTo(2L);
+    }
+  }
+
+  @Test
+  @Timeout(15)
+  void pushesNotificationToJwtUserStreamAfterRemoteFanoutSignal() throws Exception {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("remote-stream-user");
+          accountId[0] = insertAccount("remote visible account");
+          insertMembership(userId[0], accountId[0], "OWNER", "ACTIVE");
+        });
+
+    String token = issueToken("remote-stream-subject", userId[0]);
+    try (NotificationSseStream stream = openJwtStream(token)) {
+      assertThat(stream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      long[] notificationId = new long[1];
+      commit(
+          transactionManager,
+          () ->
+              notificationId[0] =
+                  insertNotification(
+                      accountId[0],
+                      "remote-fanout:TRX-SSE-300",
+                      "TransferBooked",
+                      "이체 완료",
+                      "3200 KRW 입금 · remote"));
+      publishFanoutSignal("remote-instance", notificationId[0]);
+
+      SseEvent notification = stream.awaitEvent("notification", Duration.ofSeconds(3));
+      JsonNode payload = objectMapper.readTree(notification.data());
+      assertThat(payload.get("accountId").asLong()).isEqualTo(accountId[0]);
+      assertThat(payload.get("eventType").asText()).isEqualTo("TransferBooked");
+      assertThat(payload.get("title").asText()).isEqualTo("이체 완료");
+      assertThat(payload.get("message").asText()).contains("remote");
+      assertThat(payload.get("read").asBoolean()).isFalse();
+    }
+  }
+
+  @Test
+  @Timeout(15)
+  void ignoresSameInstanceFanoutSignalToPreventDuplicatePush() throws Exception {
+    long[] accountId = new long[1];
+    commit(transactionManager, () -> accountId[0] = insertAccount("same-instance account"));
+
+    try (NotificationSseStream stream = openAccountStream(accountId[0])) {
+      assertThat(stream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      long[] notificationId = new long[1];
+      commit(
+          transactionManager,
+          () ->
+              notificationId[0] =
+                  insertNotification(
+                      accountId[0],
+                      "same-instance:TRX-SSE-400",
+                      "TransferBooked",
+                      "이체 완료",
+                      "1100 KRW 입금 · same-instance"));
+      publishFanoutSignal(notificationSseFanoutInstanceId.value(), notificationId[0]);
+
+      stream.assertNoEvent("notification", Duration.ofMillis(800));
     }
   }
 
@@ -282,6 +361,63 @@ class NotificationSseIntegrationTest extends PostgresContainerTestSupport {
             .addValue("accountId", accountId)
             .addValue("role", role)
             .addValue("status", status));
+  }
+
+  private long insertNotification(
+      long accountId, String eventKey, String eventType, String title, String message) {
+    Long notificationId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO notification_inbox (
+                account_id,
+                event_key,
+                event_type,
+                title,
+                message,
+                created_at
+            )
+            VALUES (
+                :accountId,
+                :eventKey,
+                :eventType,
+                :title,
+                :message,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("eventKey", eventKey)
+                .addValue("eventType", eventType)
+                .addValue("title", title)
+                .addValue("message", message),
+            Long.class);
+    if (notificationId == null) {
+      throw new IllegalStateException("notification_inbox insert did not return id");
+    }
+    return notificationId;
+  }
+
+  private void publishFanoutSignal(String originInstanceId, long... notificationIds) {
+    String payload =
+        notificationSseFanoutSignalCodec.encode(
+            new NotificationSseFanoutSignal(
+                originInstanceId, java.util.Arrays.stream(notificationIds).boxed().toList()));
+    jdbcTemplate
+        .getJdbcTemplate()
+        .execute(
+            (org.springframework.jdbc.core.ConnectionCallback<Void>)
+                connection -> {
+                  connection.setAutoCommit(true);
+                  try (PreparedStatement statement =
+                      connection.prepareStatement("SELECT pg_notify(?, ?)")) {
+                    statement.setString(1, notificationSseProperties.fanoutChannel());
+                    statement.setString(2, payload);
+                    statement.execute();
+                  }
+                  return null;
+                });
   }
 
   private String issueToken(String subject, long userId) throws JOSEException {

--- a/back/src/test/resources/application-test.yml
+++ b/back/src/test/resources/application-test.yml
@@ -32,6 +32,10 @@ outbox:
       max-stale-sending-count: 0
 
 notification:
+  sse:
+    fanout-channel: notification_sse_fanout
+    fanout-listen-timeout-ms: 200
+    fanout-retry-delay-ms: 200
   inbox:
     consumer:
       dlq:


### PR DESCRIPTION
## 🔗 Related Issue
- close #80

## 🌿 Base Branch
- `main`

## 📝 Summary
- 인스턴스 로컬 메모리 SSE broker만 보던 경로에 PostgreSQL `LISTEN/NOTIFY` fan-out을 추가했습니다.
- `notification_inbox` insert 성공 이후 다른 인스턴스 세션도 같은 알림을 실시간 수신하고, same-instance 신호는 무시해 중복 push를 막습니다.
- remote signal payload는 notification id 목록만 전달하고 실제 SSE payload는 DB 재조회로 맞춥니다.

## 🛠 Changes
- `NotificationSseBroker`를 local dispatch와 remote fan-out publish/listen 구조로 분리하고 PostgreSQL signal codec, instance id, read repository를 추가했습니다.
- remote fan-out 수신과 same-instance ignore를 검증하는 SSE integration test를 추가했습니다.
- README에 ordering 보장 범위와 LISTEN reconnect 시 pull API 재동기화 한계를 반영했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*NotificationSseIntegrationTest' --tests '*NotificationControllerTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - PostgreSQL `LISTEN` reconnect gap 동안 remote SSE fan-out은 기존 pull API 재동기화에 의존합니다.
  - signal decode 또는 remote row 재조회 실패 시 해당 인스턴스의 실시간 push가 누락될 수 있습니다.
- 롤백 방법:
  - 이 PR을 revert 하면 기존 local memory broker 기반 SSE 경로로 복구됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했다.
- [x] GitHub issue를 먼저 만들고 번호를 연결했다.
- [x] 하나의 리뷰 목적을 유지했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 커밋을 논리 단위로 정리했다.
- [x] 필요한 테스트를 수행했다.
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.