### PR TITLE
[Feat] notification SSE Last-Event-ID replay 지원 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -143,12 +143,15 @@ tools/test/with-resource-lock.sh back-gradle-check \
   - SSE push는 `notification_inbox` insert 성공 이후에만 발행됩니다.
   - duplicate Kafka consume로 insert가 `ON CONFLICT DO NOTHING` 이면 SSE도 추가 발행하지 않습니다.
   - user stream fan-out 대상은 `ACTIVE membership + ACTIVE user` 조건으로만 계산합니다.
-  - ordering 보장 범위는 현재 단일 app instance 안의 publish 순서까지입니다.
-  - reconnect 사이에 놓친 알림은 기존 `GET /api/v1/notifications` pull API로 재동기화합니다.
+  - `Last-Event-ID` header가 있으면 `notification_inbox.id > header` 범위를 `id ASC` 순서로 replay 합니다.
+  - replay 중 들어온 live 알림은 같은 session lock 안에서 이어 보내 duplicate/out-of-order push를 막습니다.
+  - replay 는 `NOTIFICATION_SSE_REPLAY_LIMIT` 기본값 100건까지만 수행하고, 더 큰 reconnect gap 은 기존 `GET /api/v1/notifications` pull API로 재동기화합니다.
+  - ordering 보장 범위는 단일 app instance 안의 live publish 순서와 같은 reconnect session 안의 replay `id ASC` 순서까지입니다.
 - 기본 설정:
   - `NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS=1800000`
   - `NOTIFICATION_SSE_HEARTBEAT_INTERVAL_MS=10000`
   - `NOTIFICATION_SSE_RECONNECT_DELAY_MS=3000`
+  - `NOTIFICATION_SSE_REPLAY_LIMIT=100`
 
 ## Transfer Reversal
 

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationReplayQuery.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationReplayQuery.java
@@ -1,0 +1,16 @@
+package com.aquilabank.domain.notification.model;
+
+/** SSE reconnect gap 복구용 replay 조건 */
+public record NotificationReplayQuery(long lastEventId, int limit) {
+
+  public static final int MAX_LIMIT = 100;
+
+  public NotificationReplayQuery {
+    if (lastEventId <= 0) {
+      throw new IllegalArgumentException("lastEventId must be positive");
+    }
+    if (limit < 1 || limit > MAX_LIMIT) {
+      throw new IllegalArgumentException("limit must be between 1 and 100");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxReadPort.java
@@ -1,7 +1,10 @@
 package com.aquilabank.domain.notification.port;
 
 import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationReplayQuery;
 import com.aquilabank.domain.notification.model.NotificationSlice;
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import java.util.List;
 
 /** user/account inbox read path를 persistence adapter 로 위임합니다. */
 public interface NotificationInboxReadPort {
@@ -9,6 +12,10 @@ public interface NotificationInboxReadPort {
   NotificationSlice fetchByUserId(long userId, NotificationListQuery query);
 
   NotificationSlice fetchByAccountId(long accountId, NotificationListQuery query);
+
+  List<NotificationSummary> fetchReplayByUserId(long userId, NotificationReplayQuery query);
+
+  List<NotificationSummary> fetchReplayByAccountId(long accountId, NotificationReplayQuery query);
 
   long countUnreadByUserId(long userId);
 

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationQueryService.java
@@ -1,8 +1,11 @@
 package com.aquilabank.domain.notification.usecase;
 
 import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationReplayQuery;
 import com.aquilabank.domain.notification.model.NotificationSlice;
+import com.aquilabank.domain.notification.model.NotificationSummary;
 import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
+import java.util.List;
 
 /** controller 가 principal 별 inbox 조회 차이만 고르고 실제 read 는 port 로 위임합니다. */
 public final class NotificationQueryService implements NotificationQueryUseCase {
@@ -33,6 +36,30 @@ public final class NotificationQueryService implements NotificationQueryUseCase 
       throw new IllegalArgumentException("query is required");
     }
     return notificationInboxReadPort.fetchByAccountId(accountId, query);
+  }
+
+  @Override
+  public List<NotificationSummary> getReplayNotificationsForUser(
+      long userId, NotificationReplayQuery query) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (query == null) {
+      throw new IllegalArgumentException("query is required");
+    }
+    return notificationInboxReadPort.fetchReplayByUserId(userId, query);
+  }
+
+  @Override
+  public List<NotificationSummary> getReplayNotificationsForAccount(
+      long accountId, NotificationReplayQuery query) {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (query == null) {
+      throw new IllegalArgumentException("query is required");
+    }
+    return notificationInboxReadPort.fetchReplayByAccountId(accountId, query);
   }
 
   @Override

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationQueryUseCase.java
@@ -1,13 +1,22 @@
 package com.aquilabank.domain.notification.usecase;
 
 import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationReplayQuery;
 import com.aquilabank.domain.notification.model.NotificationSlice;
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import java.util.List;
 
 public interface NotificationQueryUseCase {
 
   NotificationSlice getNotificationsForUser(long userId, NotificationListQuery query);
 
   NotificationSlice getNotificationsForAccount(long accountId, NotificationListQuery query);
+
+  List<NotificationSummary> getReplayNotificationsForUser(
+      long userId, NotificationReplayQuery query);
+
+  List<NotificationSummary> getReplayNotificationsForAccount(
+      long accountId, NotificationReplayQuery query);
 
   long getUnreadCountForUser(long userId);
 

--- a/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
@@ -1,11 +1,12 @@
 package com.aquilabank.global.config;
 
+import com.aquilabank.domain.notification.model.NotificationReplayQuery;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** SSE 연결 유지 시간과 heartbeat 간격을 notification read API 설정과 분리합니다. */
 @ConfigurationProperties(prefix = "notification.sse")
 public record NotificationSseProperties(
-    long connectionTimeoutMs, long heartbeatIntervalMs, long reconnectDelayMs) {
+    long connectionTimeoutMs, long heartbeatIntervalMs, long reconnectDelayMs, int replayLimit) {
 
   public NotificationSseProperties {
     if (connectionTimeoutMs <= 0) {
@@ -17,6 +18,9 @@ public record NotificationSseProperties(
     if (reconnectDelayMs < 0) {
       throw new IllegalArgumentException(
           "notification.sse.reconnect-delay-ms must not be negative");
+    }
+    if (replayLimit < 1 || replayLimit > NotificationReplayQuery.MAX_LIMIT) {
+      throw new IllegalArgumentException("notification.sse.replay-limit must be between 1 and 100");
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
@@ -1,17 +1,22 @@
 package com.aquilabank.global.notification;
 
+import com.aquilabank.domain.notification.model.NotificationReplayQuery;
 import com.aquilabank.domain.notification.model.NotificationSummary;
+import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.global.config.NotificationSseProperties;
 import com.aquilabank.global.web.notification.NotificationQueryResponse.NotificationItemResponse;
 import com.aquilabank.global.web.notification.NotificationStreamConnectedResponse;
 import com.aquilabank.global.web.notification.NotificationStreamHeartbeatResponse;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
@@ -27,6 +32,7 @@ public class NotificationSseBroker {
 
   private final NotificationSseProperties notificationSseProperties;
   private final NotificationSseTargetResolver notificationSseTargetResolver;
+  private final NotificationQueryUseCase notificationQueryUseCase;
   private final Map<Long, Map<String, NotificationSseSession>> accountSessions =
       new ConcurrentHashMap<>();
   private final Map<Long, Map<String, NotificationSseSession>> userSessions =
@@ -34,17 +40,47 @@ public class NotificationSseBroker {
 
   public NotificationSseBroker(
       NotificationSseProperties notificationSseProperties,
-      NotificationSseTargetResolver notificationSseTargetResolver) {
+      NotificationSseTargetResolver notificationSseTargetResolver,
+      NotificationQueryUseCase notificationQueryUseCase) {
     this.notificationSseProperties = notificationSseProperties;
     this.notificationSseTargetResolver = notificationSseTargetResolver;
+    this.notificationQueryUseCase = notificationQueryUseCase;
   }
 
   public SseEmitter subscribeAccount(long accountId, String subject) {
-    return subscribe(accountSessions, accountId, subject, "account");
+    return subscribeAccount(accountId, subject, null);
+  }
+
+  public SseEmitter subscribeAccount(long accountId, String subject, Long lastEventId) {
+    return subscribe(
+        accountSessions,
+        accountId,
+        subject,
+        "account",
+        lastEventId,
+        replayLastEventId ->
+            notificationQueryUseCase.getReplayNotificationsForAccount(
+                accountId,
+                new NotificationReplayQuery(
+                    replayLastEventId, notificationSseProperties.replayLimit())));
   }
 
   public SseEmitter subscribeUser(long userId, String subject) {
-    return subscribe(userSessions, userId, subject, "user");
+    return subscribeUser(userId, subject, null);
+  }
+
+  public SseEmitter subscribeUser(long userId, String subject, Long lastEventId) {
+    return subscribe(
+        userSessions,
+        userId,
+        subject,
+        "user",
+        lastEventId,
+        replayLastEventId ->
+            notificationQueryUseCase.getReplayNotificationsForUser(
+                userId,
+                new NotificationReplayQuery(
+                    replayLastEventId, notificationSseProperties.replayLimit())));
   }
 
   @Scheduled(fixedDelayString = "${notification.sse.heartbeat-interval-ms:25000}")
@@ -55,15 +91,19 @@ public class NotificationSseBroker {
 
   @EventListener
   public void handleNotificationInboxInserted(NotificationInboxInsertedEvent event) {
+    publishInsertedItems(event.items());
+  }
+
+  public void publishInsertedItems(List<NotificationSummary> items) {
     if (accountSessions.isEmpty() && userSessions.isEmpty()) {
       return;
     }
-    Map<Long, List<NotificationSummary>> itemsByAccountId = groupByAccountId(event.items());
+    Map<Long, List<NotificationSummary>> itemsByAccountId = groupByAccountId(items);
     for (Map.Entry<Long, List<NotificationSummary>> entry : itemsByAccountId.entrySet()) {
       long accountId = entry.getKey();
-      List<NotificationSummary> items = entry.getValue();
-      publishToAccountSessions(accountId, items);
-      publishToUserSessions(accountId, items);
+      List<NotificationSummary> accountItems = entry.getValue();
+      publishToAccountSessions(accountId, accountItems);
+      publishToUserSessions(accountId, accountItems);
     }
   }
 
@@ -71,17 +111,21 @@ public class NotificationSseBroker {
       Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
       long principalId,
       String subject,
-      String principalType) {
+      String principalType,
+      Long lastEventId,
+      LongFunction<List<NotificationSummary>> replayLoader) {
     String sessionId = UUID.randomUUID().toString();
     SseEmitter emitter = new SseEmitter(notificationSseProperties.connectionTimeoutMs());
-    NotificationSseSession session = new NotificationSseSession(sessionId, subject, emitter);
+    NotificationSseSession session =
+        new NotificationSseSession(sessionId, subject, emitter, lastEventId);
     sessionsByPrincipalId
         .computeIfAbsent(principalId, ignored -> new ConcurrentHashMap<>())
         .put(sessionId, session);
     emitter.onCompletion(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
     emitter.onTimeout(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
     emitter.onError(error -> removeSession(sessionsByPrincipalId, principalId, sessionId));
-    scheduleConnectedEvent(sessionsByPrincipalId, principalId, principalType, session);
+    scheduleConnectedEvent(
+        sessionsByPrincipalId, principalId, principalType, session, lastEventId, replayLoader);
     log.debug(
         "notification SSE subscribed principalType={} principalId={} sessionId={}",
         principalType,
@@ -91,27 +135,32 @@ public class NotificationSseBroker {
   }
 
   private void sendConnectedEvent(NotificationSseSession session) throws IOException {
-    session
-        .emitter()
-        .send(
-            SseEmitter.event()
-                .name("connected")
-                .reconnectTime(notificationSseProperties.reconnectDelayMs())
-                .data(new NotificationStreamConnectedResponse(Instant.now())));
+    synchronized (session.monitor()) {
+      session
+          .emitter()
+          .send(
+              SseEmitter.event()
+                  .name("connected")
+                  .reconnectTime(notificationSseProperties.reconnectDelayMs())
+                  .data(new NotificationStreamConnectedResponse(Instant.now())));
+    }
   }
 
   private void scheduleConnectedEvent(
       Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
       long principalId,
       String principalType,
-      NotificationSseSession session) {
+      NotificationSseSession session,
+      Long lastEventId,
+      LongFunction<List<NotificationSummary>> replayLoader) {
     Thread.startVirtualThread(
         () -> {
           try {
             sendConnectedEvent(session);
-          } catch (IOException ex) {
+            replayMissedNotifications(session, lastEventId, replayLoader);
+          } catch (Exception ex) {
             log.debug(
-                "notification SSE connected event failed principalType={} principalId={} sessionId={} subject={}",
+                "notification SSE subscribe bootstrap failed principalType={} principalId={} sessionId={} subject={}",
                 principalType,
                 principalId,
                 session.sessionId(),
@@ -132,12 +181,14 @@ public class NotificationSseBroker {
       long principalId = entry.getKey();
       for (NotificationSseSession session : entry.getValue().values()) {
         try {
-          session
-              .emitter()
-              .send(
-                  SseEmitter.event()
-                      .name("heartbeat")
-                      .data(new NotificationStreamHeartbeatResponse(Instant.now())));
+          synchronized (session.monitor()) {
+            session
+                .emitter()
+                .send(
+                    SseEmitter.event()
+                        .name("heartbeat")
+                        .data(new NotificationStreamHeartbeatResponse(Instant.now())));
+          }
         } catch (IOException ex) {
           log.debug(
               "notification SSE heartbeat failed principalType={} principalId={} sessionId={}",
@@ -157,16 +208,9 @@ public class NotificationSseBroker {
       return;
     }
     for (NotificationSummary item : items) {
-      NotificationItemResponse payload = NotificationItemResponse.from(item);
       for (NotificationSseSession session : sessions.values()) {
         try {
-          session
-              .emitter()
-              .send(
-                  SseEmitter.event()
-                      .id(Long.toString(item.id()))
-                      .name("notification")
-                      .data(payload));
+          queueOrSendNotification(session, item);
         } catch (IOException ex) {
           log.debug(
               "notification SSE push failed principalType=account accountId={} sessionId={} subject={}",
@@ -194,16 +238,9 @@ public class NotificationSseBroker {
         continue;
       }
       for (NotificationSummary item : items) {
-        NotificationItemResponse payload = NotificationItemResponse.from(item);
         for (NotificationSseSession session : sessions.values()) {
           try {
-            session
-                .emitter()
-                .send(
-                    SseEmitter.event()
-                        .id(Long.toString(item.id()))
-                        .name("notification")
-                        .data(payload));
+            queueOrSendNotification(session, item);
           } catch (IOException ex) {
             log.debug(
                 "notification SSE push failed principalType=user userId={} sessionId={} subject={}",
@@ -216,6 +253,62 @@ public class NotificationSseBroker {
         }
       }
     }
+  }
+
+  private void replayMissedNotifications(
+      NotificationSseSession session,
+      Long lastEventId,
+      LongFunction<List<NotificationSummary>> replayLoader)
+      throws IOException {
+    if (lastEventId == null) {
+      return;
+    }
+    List<NotificationSummary> replayItems = replayLoader.apply(lastEventId);
+    synchronized (session.monitor()) {
+      // replay 중 새 live event는 pendingItems 에 모았다가 같은 세션 lock 안에서 이어 보냅니다.
+      for (NotificationSummary item : replayItems) {
+        sendNotification(session, item);
+      }
+      flushPendingNotifications(session);
+      session.finishReplay();
+    }
+  }
+
+  private void queueOrSendNotification(NotificationSseSession session, NotificationSummary item)
+      throws IOException {
+    synchronized (session.monitor()) {
+      if (item.id() <= session.lastDeliveredEventId()) {
+        return;
+      }
+      if (session.isReplaying()) {
+        session.addPendingItem(item);
+        return;
+      }
+      sendNotification(session, item);
+    }
+  }
+
+  private void flushPendingNotifications(NotificationSseSession session) throws IOException {
+    session.pendingItems().sort(Comparator.comparingLong(NotificationSummary::id));
+    for (NotificationSummary pendingItem : session.pendingItems()) {
+      sendNotification(session, pendingItem);
+    }
+    session.pendingItems().clear();
+  }
+
+  private void sendNotification(NotificationSseSession session, NotificationSummary item)
+      throws IOException {
+    if (item.id() <= session.lastDeliveredEventId()) {
+      return;
+    }
+    session
+        .emitter()
+        .send(
+            SseEmitter.event()
+                .id(Long.toString(item.id()))
+                .name("notification")
+                .data(NotificationItemResponse.from(item)));
+    session.markDelivered(item.id());
   }
 
   private Map<Long, List<NotificationSummary>> groupByAccountId(List<NotificationSummary> items) {
@@ -242,5 +335,63 @@ public class NotificationSseBroker {
     }
   }
 
-  private record NotificationSseSession(String sessionId, String subject, SseEmitter emitter) {}
+  private static final class NotificationSseSession {
+
+    private final String sessionId;
+    private final String subject;
+    private final SseEmitter emitter;
+    private final Object monitor = new Object();
+    private final List<NotificationSummary> pendingItems = new ArrayList<>();
+    private long lastDeliveredEventId;
+    private boolean replaying;
+
+    private NotificationSseSession(
+        String sessionId, String subject, SseEmitter emitter, Long lastEventId) {
+      this.sessionId = sessionId;
+      this.subject = subject;
+      this.emitter = emitter;
+      this.lastDeliveredEventId = lastEventId == null ? 0L : lastEventId;
+      this.replaying = lastEventId != null;
+    }
+
+    private String sessionId() {
+      return sessionId;
+    }
+
+    private String subject() {
+      return subject;
+    }
+
+    private SseEmitter emitter() {
+      return emitter;
+    }
+
+    private Object monitor() {
+      return monitor;
+    }
+
+    private List<NotificationSummary> pendingItems() {
+      return pendingItems;
+    }
+
+    private long lastDeliveredEventId() {
+      return lastDeliveredEventId;
+    }
+
+    private boolean isReplaying() {
+      return replaying;
+    }
+
+    private void addPendingItem(NotificationSummary item) {
+      pendingItems.add(item);
+    }
+
+    private void markDelivered(long notificationId) {
+      lastDeliveredEventId = notificationId;
+    }
+
+    private void finishReplay() {
+      replaying = false;
+    }
+  }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.persistence.notification;
 import com.aquilabank.domain.notification.model.NotificationCursor;
 import com.aquilabank.domain.notification.model.NotificationInboxEntry;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationReplayQuery;
 import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.domain.notification.model.NotificationSummary;
 import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
@@ -60,6 +61,66 @@ public class JdbcNotificationInboxRepository
             ? fetchByAccountIdFirstPage(accountId, query)
             : fetchByAccountIdNextPage(accountId, query);
     return toSlice(rows, query.limit());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<NotificationSummary> fetchReplayByUserId(long userId, NotificationReplayQuery query) {
+    return jdbcTemplate.query(
+        """
+        SELECT n.id,
+               n.account_id,
+               n.event_type,
+               n.title,
+               n.message,
+               n.created_at,
+               r.read_at
+        FROM notification_inbox n
+        JOIN user_account_membership m
+          ON m.account_id = n.account_id
+        JOIN bank_user u
+          ON u.id = m.user_id
+        LEFT JOIN notification_user_read_state r
+          ON r.user_id = :userId
+         AND r.notification_id = n.id
+        WHERE m.user_id = :userId
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+          AND n.id > :lastEventId
+        ORDER BY n.id ASC
+        LIMIT :limit
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("lastEventId", query.lastEventId())
+            .addValue("limit", query.limit()),
+        ROW_MAPPER);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<NotificationSummary> fetchReplayByAccountId(
+      long accountId, NotificationReplayQuery query) {
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               account_id,
+               event_type,
+               title,
+               message,
+               created_at,
+               read_at
+        FROM notification_inbox
+        WHERE account_id = :accountId
+          AND id > :lastEventId
+        ORDER BY id ASC
+        LIMIT :limit
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("lastEventId", query.lastEventId())
+            .addValue("limit", query.limit()),
+        ROW_MAPPER);
   }
 
   @Override

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
@@ -18,6 +18,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -61,12 +62,13 @@ public class NotificationController {
 
   @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public ResponseEntity<SseEmitter> streamNotifications(
-      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal) {
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @RequestHeader(name = "Last-Event-ID", required = false) String lastEventIdHeader) {
     try {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.noStore())
           .header("X-Accel-Buffering", "no")
-          .body(openStream(principal));
+          .body(openStream(principal, parseLastEventId(lastEventIdHeader)));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }
@@ -128,14 +130,30 @@ public class NotificationController {
     throw new IllegalArgumentException("unsupported principal type");
   }
 
-  private SseEmitter openStream(AuthenticatedRequestPrincipal principal) {
+  private SseEmitter openStream(AuthenticatedRequestPrincipal principal, Long lastEventId) {
     if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
-      return notificationSseBroker.subscribeUser(userPrincipal.userId(), userPrincipal.subject());
+      return notificationSseBroker.subscribeUser(
+          userPrincipal.userId(), userPrincipal.subject(), lastEventId);
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
       return notificationSseBroker.subscribeAccount(
-          accountPrincipal.accountId(), accountPrincipal.subject());
+          accountPrincipal.accountId(), accountPrincipal.subject(), lastEventId);
     }
     throw new IllegalArgumentException("unsupported principal type");
+  }
+
+  private Long parseLastEventId(String lastEventIdHeader) {
+    if (lastEventIdHeader == null || lastEventIdHeader.isBlank()) {
+      return null;
+    }
+    try {
+      long lastEventId = Long.parseLong(lastEventIdHeader.trim());
+      if (lastEventId <= 0) {
+        throw new IllegalArgumentException("Last-Event-ID must be positive");
+      }
+      return lastEventId;
+    } catch (NumberFormatException ex) {
+      throw new IllegalArgumentException("Last-Event-ID must be numeric", ex);
+    }
   }
 }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -110,6 +110,7 @@ notification:
     connection-timeout-ms: ${NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS:1800000}
     heartbeat-interval-ms: ${NOTIFICATION_SSE_HEARTBEAT_INTERVAL_MS:10000}
     reconnect-delay-ms: ${NOTIFICATION_SSE_RECONNECT_DELAY_MS:3000}
+    replay-limit: ${NOTIFICATION_SSE_REPLAY_LIMIT:100}
   inbox:
     consumer:
       enabled: ${NOTIFICATION_INBOX_CONSUMER_ENABLED:false}

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -123,7 +124,7 @@ class NotificationControllerTest {
 
   @Test
   void opensNotificationStream() throws Exception {
-    when(notificationSseBroker.subscribeAccount(101L, "bootstrap"))
+    when(notificationSseBroker.subscribeAccount(101L, "bootstrap", null))
         .thenReturn(new SseEmitter(60_000L));
 
     mockMvc
@@ -131,6 +132,33 @@ class NotificationControllerTest {
         .andExpect(status().isOk())
         .andExpect(request().asyncStarted())
         .andExpect(header().string("X-Accel-Buffering", "no"));
+  }
+
+  @Test
+  void opensNotificationStreamWithLastEventIdReplay() throws Exception {
+    when(notificationSseBroker.subscribeAccount(101L, "bootstrap", 7L))
+        .thenReturn(new SseEmitter(60_000L));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/stream")
+                .header("X-Account-Id", "101")
+                .header("Last-Event-ID", "7"))
+        .andExpect(status().isOk())
+        .andExpect(request().asyncStarted())
+        .andExpect(header().string("X-Accel-Buffering", "no"));
+
+    verify(notificationSseBroker).subscribeAccount(101L, "bootstrap", 7L);
+  }
+
+  @Test
+  void rejectsInvalidLastEventIdHeader() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/stream")
+                .header("X-Account-Id", "101")
+                .header("Last-Event-ID", "broken"))
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationSseIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationSseIntegrationTest.java
@@ -24,7 +24,9 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +48,8 @@ import org.springframework.transaction.PlatformTransactionManager;
       "spring.flyway.enabled=true",
       "management.health.db.enabled=true",
       "server.shutdown=immediate",
+      "notification.sse.connection-timeout-ms=4000",
+      "spring.mvc.async.request-timeout=5000",
       "notification.inbox.consumer.enabled=true",
       "notification.inbox.consumer.auto-startup=false",
       "notification.inbox.consumer.bootstrap-servers=localhost:9092",
@@ -135,27 +139,241 @@ class NotificationSseIntegrationTest extends PostgresContainerTestSupport {
     }
   }
 
+  @Test
+  @Timeout(15)
+  void replaysMissedNotificationsToReconnectedAccountStreamAfterLastEventId() throws Exception {
+    long[] accountIds = new long[2];
+    commit(
+        transactionManager,
+        () -> {
+          accountIds[0] = insertAccount("replay source account");
+          accountIds[1] = insertAccount("replay target account");
+        });
+
+    long lastEventId;
+    try (NotificationSseStream stream = openAccountStream(accountIds[0])) {
+      assertThat(stream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      String liveEventKey = "transfer-booked:TRX-SSE-300";
+      transferBookedNotificationConsumer.consume(
+          liveEventKey, transferBookedPayload(accountIds[0], accountIds[1], 1500L, "live"));
+
+      SseEvent liveEvent = stream.awaitEvent("notification", Duration.ofSeconds(3));
+      lastEventId = Long.parseLong(liveEvent.id());
+      assertThat(lastEventId).isEqualTo(findNotificationIdByEventKey(liveEventKey, accountIds[0]));
+    }
+
+    long firstReplayId =
+        commitAndReturn(
+            () ->
+                insertNotification(
+                    accountIds[0],
+                    "account-replay:TRX-SSE-301",
+                    "TransferBooked",
+                    "이체 완료",
+                    "1700 KRW 입금 · replay-1"));
+    long secondReplayId =
+        commitAndReturn(
+            () ->
+                insertNotification(
+                    accountIds[0],
+                    "account-replay:TRX-SSE-302",
+                    "TransferBooked",
+                    "이체 완료",
+                    "1900 KRW 입금 · replay-2"));
+
+    try (NotificationSseStream replayStream = openAccountStream(accountIds[0], lastEventId)) {
+      assertThat(replayStream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      SseEvent firstReplay = replayStream.awaitEvent("notification", Duration.ofSeconds(3));
+      SseEvent secondReplay = replayStream.awaitEvent("notification", Duration.ofSeconds(3));
+
+      assertThat(Long.parseLong(firstReplay.id())).isEqualTo(firstReplayId);
+      assertThat(Long.parseLong(secondReplay.id())).isEqualTo(secondReplayId);
+    }
+  }
+
+  @Test
+  @Timeout(15)
+  void replaysOnlyAccessibleNotificationsToJwtUserStreamAfterLastEventId() throws Exception {
+    long[] userId = new long[1];
+    long[] visibleAccountId = new long[1];
+    long[] hiddenAccountId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("replay-user");
+          visibleAccountId[0] = insertAccount("visible account");
+          hiddenAccountId[0] = insertAccount("hidden account");
+          insertMembership(userId[0], visibleAccountId[0], "OWNER", "ACTIVE");
+          insertMembership(userId[0], hiddenAccountId[0], "VIEWER", "REVOKED");
+        });
+
+    String token = issueToken("replay-user-subject", userId[0]);
+    long lastEventId;
+    try (NotificationSseStream stream = openJwtStream(token)) {
+      assertThat(stream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      String liveEventKey = "transfer-booked:TRX-SSE-400";
+      transferBookedNotificationConsumer.consume(
+          liveEventKey,
+          transferBookedPayload(visibleAccountId[0], hiddenAccountId[0], 2100L, "jwt-live"));
+
+      SseEvent liveEvent = stream.awaitEvent("notification", Duration.ofSeconds(3));
+      lastEventId = Long.parseLong(liveEvent.id());
+      assertThat(lastEventId)
+          .isEqualTo(findNotificationIdByEventKey(liveEventKey, visibleAccountId[0]));
+    }
+
+    long replayVisibleId =
+        commitAndReturn(
+            () ->
+                insertNotification(
+                    visibleAccountId[0],
+                    "jwt-replay:TRX-SSE-401",
+                    "TransferBooked",
+                    "이체 완료",
+                    "2300 KRW 입금 · jwt-replay"));
+    commitAndReturn(
+        () ->
+            insertNotification(
+                hiddenAccountId[0],
+                "jwt-hidden:TRX-SSE-402",
+                "TransferBooked",
+                "이체 완료",
+                "2500 KRW 입금 · hidden"));
+
+    try (NotificationSseStream replayStream = openJwtStream(token, lastEventId)) {
+      assertThat(replayStream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      SseEvent replayEvent = replayStream.awaitEvent("notification", Duration.ofSeconds(3));
+      JsonNode payload = objectMapper.readTree(replayEvent.data());
+      assertThat(Long.parseLong(replayEvent.id())).isEqualTo(replayVisibleId);
+      assertThat(payload.get("accountId").asLong()).isEqualTo(visibleAccountId[0]);
+      assertThat(payload.get("message").asText()).contains("jwt-replay");
+      replayStream.assertNoEvent("notification", Duration.ofMillis(800));
+    }
+  }
+
+  @Test
+  @Timeout(15)
+  void keepsNotificationOrderWhenLiveEventArrivesDuringReplay() throws Exception {
+    long[] accountIds = new long[2];
+    commit(
+        transactionManager,
+        () -> {
+          accountIds[0] = insertAccount("ordered replay account");
+          accountIds[1] = insertAccount("ordered replay target");
+        });
+
+    long lastEventId;
+    try (NotificationSseStream stream = openAccountStream(accountIds[0])) {
+      assertThat(stream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      String liveEventKey = "transfer-booked:TRX-SSE-500";
+      transferBookedNotificationConsumer.consume(
+          liveEventKey, transferBookedPayload(accountIds[0], accountIds[1], 1000L, "order-live"));
+
+      SseEvent liveEvent = stream.awaitEvent("notification", Duration.ofSeconds(3));
+      lastEventId = Long.parseLong(liveEvent.id());
+      assertThat(lastEventId).isEqualTo(findNotificationIdByEventKey(liveEventKey, accountIds[0]));
+    }
+
+    List<Long> replayIds = new ArrayList<>();
+    for (int index = 0; index < 12; index++) {
+      int replaySuffix = index;
+      long notificationId =
+          commitAndReturn(
+              () ->
+                  insertNotification(
+                      accountIds[0],
+                      "replay-order:TRX-SSE-%d".formatted(510 + replaySuffix),
+                      "TransferBooked",
+                      "이체 완료",
+                      "replay-order-%d".formatted(replaySuffix)));
+      replayIds.add(notificationId);
+    }
+
+    try (NotificationSseStream replayStream = openAccountStream(accountIds[0], lastEventId)) {
+      assertThat(replayStream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      List<Long> receivedIds = new ArrayList<>();
+      receivedIds.add(
+          Long.parseLong(replayStream.awaitEvent("notification", Duration.ofSeconds(3)).id()));
+
+      String liveDuringReplayEventKey = "transfer-booked:TRX-SSE-600";
+      transferBookedNotificationConsumer.consume(
+          liveDuringReplayEventKey,
+          transferBookedPayload(accountIds[0], accountIds[1], 3300L, "live-during-replay"));
+      long liveDuringReplayId =
+          findNotificationIdByEventKey(liveDuringReplayEventKey, accountIds[0]);
+
+      for (int index = 0; index < replayIds.size(); index++) {
+        receivedIds.add(
+            Long.parseLong(replayStream.awaitEvent("notification", Duration.ofSeconds(3)).id()));
+      }
+
+      assertThat(receivedIds)
+          .containsExactly(
+              replayIds.get(0),
+              replayIds.get(1),
+              replayIds.get(2),
+              replayIds.get(3),
+              replayIds.get(4),
+              replayIds.get(5),
+              replayIds.get(6),
+              replayIds.get(7),
+              replayIds.get(8),
+              replayIds.get(9),
+              replayIds.get(10),
+              replayIds.get(11),
+              liveDuringReplayId);
+    }
+  }
+
   private NotificationSseStream openJwtStream(String token) throws Exception {
-    HttpRequest request =
-        HttpRequest.newBuilder(
-                URI.create("http://localhost:%d/api/v1/notifications/stream".formatted(port)))
-            .header("Accept", "text/event-stream")
-            .header("Authorization", "Bearer " + token)
-            .GET()
-            .build();
+    return openJwtStream(token, null);
+  }
+
+  private NotificationSseStream openJwtStream(String token, Long lastEventId) throws Exception {
+    HttpRequest.Builder requestBuilder =
+        streamRequestBuilder().header("Authorization", "Bearer " + token);
+    addLastEventIdHeader(requestBuilder, lastEventId);
+    HttpRequest request = requestBuilder.GET().build();
     return openStream(request);
   }
 
   private NotificationSseStream openAccountStream(long accountId) throws Exception {
-    HttpRequest request =
-        HttpRequest.newBuilder(
-                URI.create("http://localhost:%d/api/v1/notifications/stream".formatted(port)))
-            .header("Accept", "text/event-stream")
+    return openAccountStream(accountId, null);
+  }
+
+  private NotificationSseStream openAccountStream(long accountId, Long lastEventId)
+      throws Exception {
+    HttpRequest.Builder requestBuilder =
+        streamRequestBuilder()
             .header("X-Account-Id", Long.toString(accountId))
-            .header("X-Subject", "sse-test")
-            .GET()
-            .build();
+            .header("X-Subject", "sse-test");
+    addLastEventIdHeader(requestBuilder, lastEventId);
+    HttpRequest request = requestBuilder.GET().build();
     return openStream(request);
+  }
+
+  private HttpRequest.Builder streamRequestBuilder() {
+    return HttpRequest.newBuilder(
+            URI.create("http://localhost:%d/api/v1/notifications/stream".formatted(port)))
+        .header("Accept", "text/event-stream");
+  }
+
+  private void addLastEventIdHeader(HttpRequest.Builder requestBuilder, Long lastEventId) {
+    if (lastEventId != null) {
+      requestBuilder.header("Last-Event-ID", Long.toString(lastEventId));
+    }
   }
 
   private NotificationSseStream openStream(HttpRequest request) throws Exception {
@@ -257,6 +475,58 @@ class NotificationSseIntegrationTest extends PostgresContainerTestSupport {
     return accountId;
   }
 
+  private long findNotificationIdByEventKey(String eventKey, long accountId) {
+    Long notificationId =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT id
+            FROM notification_inbox
+            WHERE event_key = :eventKey
+            """,
+            new MapSqlParameterSource().addValue("eventKey", eventKey + ":ACCOUNT-" + accountId),
+            Long.class);
+    if (notificationId == null) {
+      throw new IllegalStateException("notification_inbox row was not found");
+    }
+    return notificationId;
+  }
+
+  private long insertNotification(
+      long accountId, String eventKey, String eventType, String title, String message) {
+    Long notificationId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO notification_inbox (
+                account_id,
+                event_key,
+                event_type,
+                title,
+                message,
+                created_at
+            )
+            VALUES (
+                :accountId,
+                :eventKey,
+                :eventType,
+                :title,
+                :message,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("eventKey", eventKey)
+                .addValue("eventType", eventType)
+                .addValue("title", title)
+                .addValue("message", message),
+            Long.class);
+    if (notificationId == null) {
+      throw new IllegalStateException("notification_inbox insert did not return id");
+    }
+    return notificationId;
+  }
+
   private void insertMembership(long userId, long accountId, String role, String status) {
     jdbcTemplate.update(
         """
@@ -282,6 +552,20 @@ class NotificationSseIntegrationTest extends PostgresContainerTestSupport {
             .addValue("accountId", accountId)
             .addValue("role", role)
             .addValue("status", status));
+  }
+
+  private long commitAndReturn(java.util.concurrent.Callable<Long> action) {
+    final long[] result = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          try {
+            result[0] = action.call();
+          } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+          }
+        });
+    return result[0];
   }
 
   private String issueToken(String subject, long userId) throws JOSEException {


### PR DESCRIPTION
## 🔗 Related Issue
- close #82

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification SSE stream에 `Last-Event-ID` 기반 reconnect replay를 추가했습니다.
- account bootstrap principal과 JWT user principal 모두 `notification_inbox.id > Last-Event-ID` 범위를 `id ASC`로 replay 하도록 확장했습니다.
- replay 중 들어온 live 알림은 같은 session lock 안에서 이어 보내 duplicate/out-of-order push를 막고, 큰 gap은 기존 pull API fallback으로 남겼습니다.

## 🛠 Changes
- `NotificationReplayQuery`, replay read port/query service, controller header 파싱, SSE broker replay state를 추가했습니다.
- account/JWT replay, invalid header, reconnect 중 live 이어받기까지 controller/integration test를 보강했습니다.
- README에 replay limit 100건과 pull API fallback 운영 한계를 반영했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*NotificationSseIntegrationTest' --tests '*NotificationControllerTest'`
- `./back/gradlew -p back spotlessApply`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - `Last-Event-ID` gap 이 `NOTIFICATION_SSE_REPLAY_LIMIT` 100건을 넘으면 나머지 복구는 기존 pull API 재동기화에 의존합니다.
  - replay session buffering 로직이 틀리면 duplicate/out-of-order SSE push가 생길 수 있습니다.
- 롤백 방법:
  - 이 PR을 revert 하면 기존 connected/heartbeat 중심 SSE stream 동작으로 복구됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했다.
- [x] GitHub issue를 먼저 만들고 번호를 연결했다.
- [x] 하나의 리뷰 목적을 유지했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 커밋을 논리 단위로 정리했다.
- [x] 필요한 테스트를 수행했다.
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.