### PR TITLE
[Chore] notification DLQ redrive 경로 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -558,6 +558,7 @@ Kafka producer 를 붙인 이후 outbox backlog 는 actuator health 와 내부 o
   - `POST /internal/api/v1/outbox/recovery/stale-sending`
   - `GET /internal/api/v1/outbox/notification/summary`
   - `GET /internal/api/v1/outbox/notification/dlq-events?limit=<n>`
+  - `POST /internal/api/v1/outbox/notification/dlq-events/redrive`
 - health endpoint:
   - `GET /actuator/health`
 
@@ -610,7 +611,7 @@ consumer lag 와 DLQ count summary 조회:
 ```bash
 tools/ops/notification-get-consumer-summary.sh \
   http://localhost:8080 \
-  "$OUTBOX_OPS_TOKEN"
+  "$OUTBOX_OPS_SERVICE_TOKEN"
 ```
 
 poison message 최근 항목 조회:
@@ -618,8 +619,18 @@ poison message 최근 항목 조회:
 ```bash
 tools/ops/notification-find-dlq-events.sh \
   http://localhost:8080 \
-  "$OUTBOX_OPS_TOKEN" \
+  "$OUTBOX_OPS_SERVICE_TOKEN" \
   20
+```
+
+preview 좌표 기준 DLQ redrive:
+
+```bash
+tools/ops/notification-redrive-dlq-event.sh \
+  http://localhost:8080 \
+  "$OUTBOX_OPS_SERVICE_TOKEN" \
+  0 \
+  12
 ```
 
 ### 직접 호출 예시
@@ -638,7 +649,7 @@ notification consumer summary 조회:
 ```bash
 curl --fail-with-body --silent --show-error \
   --get \
-  --header "X-Outbox-Ops-Token: ${OUTBOX_OPS_TOKEN}" \
+  --header "Authorization: Bearer ${OUTBOX_OPS_SERVICE_TOKEN}" \
   "http://localhost:8080/internal/api/v1/outbox/notification/summary"
 ```
 
@@ -647,9 +658,20 @@ notification DLQ preview 조회:
 ```bash
 curl --fail-with-body --silent --show-error \
   --get \
-  --header "X-Outbox-Ops-Token: ${OUTBOX_OPS_TOKEN}" \
+  --header "Authorization: Bearer ${OUTBOX_OPS_SERVICE_TOKEN}" \
   --data-urlencode "limit=20" \
   "http://localhost:8080/internal/api/v1/outbox/notification/dlq-events"
+```
+
+notification DLQ redrive:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  --request POST \
+  --header "Authorization: Bearer ${OUTBOX_OPS_SERVICE_TOKEN}" \
+  --header "Content-Type: application/json" \
+  --data '{"partition":0,"offset":12}' \
+  "http://localhost:8080/internal/api/v1/outbox/notification/dlq-events/redrive"
 ```
 
 health 확인:
@@ -672,9 +694,10 @@ curl --fail-with-body --silent --show-error \
 1. `/actuator/health` 가 `503`이면 `/internal/api/v1/outbox/summary` 를 먼저 조회해 `lagSeconds`, `failedCount`, `producerTimeoutFailedCount`, `staleSendingCount` 중 초과 축을 확인합니다.
 2. `producerTimeoutFailedCount` 또는 `failedCount` 가 크면 `tools/ops/outbox-find-failed-events.sh` 로 bounded failed list 를 보고 `eventKey`, `retryCount`, `lastError` 를 먼저 확인합니다.
 3. `/internal/api/v1/outbox/notification/summary` 또는 `tools/ops/notification-get-consumer-summary.sh` 로 consumer lag 와 DLQ count 를 확인합니다.
-4. `dlqCount` 가 0보다 크면 `tools/ops/notification-find-dlq-events.sh` 로 poison message 최근 항목을 보고 `eventKey`, `originalTopic`, `errorClass`, `errorMessage`, `payloadPreview` 를 먼저 확인합니다.
-5. `staleSendingCount` 가 0보다 크면 `tools/ops/outbox-recover-stale-sending.sh` 를 한 번만 호출하고, 응답의 `recoveredCount` 와 이후 summary 변화를 확인합니다.
-6. recovery 이후에도 `lagSeconds`, `lagCount`, `failedCount` 가 계속 증가하면 producer timeout, consumer 중단, broker 연결 문제를 별도 incident 로 분리합니다.
+4. `dlqCount` 가 0보다 크면 `tools/ops/notification-find-dlq-events.sh` 로 poison message 최근 항목을 보고 `eventKey`, `partition`, `offset`, `originalTopic`, `errorClass`, `errorMessage`, `payloadPreview` 를 먼저 확인합니다.
+5. redrive 대상이 명확하면 `tools/ops/notification-redrive-dlq-event.sh` 로 preview -> redrive -> summary 순서로 한 건씩 재처리하고, 응답의 `targetTopic`, `targetPartition`, `targetOffset` 을 기록합니다.
+6. `staleSendingCount` 가 0보다 크면 `tools/ops/outbox-recover-stale-sending.sh` 를 한 번만 호출하고, 응답의 `recoveredCount` 와 이후 summary 변화를 확인합니다.
+7. recovery 이후에도 `lagSeconds`, `lagCount`, `failedCount` 가 계속 증가하면 producer timeout, consumer 중단, broker 연결 문제를 별도 incident 로 분리합니다.
 
 ### 운영 주의사항
 
@@ -684,7 +707,8 @@ curl --fail-with-body --silent --show-error \
 - `lastError` 는 outbox table 의 짧은 힌트만 남기므로, 상세 stack trace 는 앱 로그와 Kafka client 로그를 같이 봐야 합니다.
 - consumer poison message 만 DLQ 로 격리하고, broker/DB 같은 transient failure 는 main topic retry failure 로 남깁니다.
 - DLQ preview 는 최근 bounded item 만 보여주므로, 전문 payload/stack trace 가 필요하면 앱 로그와 Kafka client 로그를 같이 확인합니다.
-- DLQ 항목은 자동 재발행하지 않으므로, payload 수정이나 redrive 는 후속 작업으로 분리합니다.
+- DLQ redrive 는 source DLQ record 를 삭제하지 않고 original topic 으로 한 번 더 publish 하는 동작입니다.
+- payload 또는 참조 데이터가 그대로 잘못돼 있으면 redrive 후 같은 항목이 다시 DLQ 로 돌아올 수 있으므로, preview 에서 `errorClass`, `errorMessage`, `payloadPreview` 를 먼저 확인합니다.
 
 ### rollback 기준
 

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveResult.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveResult.java
@@ -1,0 +1,39 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** redrive 응답은 source DLQ 좌표와 재발행 결과 좌표를 같이 남깁니다. */
+public record NotificationDlqRedriveResult(
+    String sourceTopic,
+    int sourcePartition,
+    long sourceOffset,
+    String eventKey,
+    String targetTopic,
+    int targetPartition,
+    long targetOffset,
+    Instant redrivenAt) {
+
+  public NotificationDlqRedriveResult {
+    if (sourceTopic == null || sourceTopic.isBlank()) {
+      throw new IllegalArgumentException("sourceTopic is required");
+    }
+    if (sourcePartition < 0) {
+      throw new IllegalArgumentException("sourcePartition must not be negative");
+    }
+    if (sourceOffset < 0) {
+      throw new IllegalArgumentException("sourceOffset must not be negative");
+    }
+    if (targetTopic == null || targetTopic.isBlank()) {
+      throw new IllegalArgumentException("targetTopic is required");
+    }
+    if (targetPartition < 0) {
+      throw new IllegalArgumentException("targetPartition must not be negative");
+    }
+    if (targetOffset < 0) {
+      throw new IllegalArgumentException("targetOffset must not be negative");
+    }
+    if (redrivenAt == null) {
+      throw new IllegalArgumentException("redrivenAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveTarget.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveTarget.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.notification.model;
+
+/** DLQ preview 응답 좌표를 그대로 redrive 입력으로 재사용합니다. */
+public record NotificationDlqRedriveTarget(int partition, long offset) {
+
+  public NotificationDlqRedriveTarget {
+    if (partition < 0) {
+      throw new IllegalArgumentException("partition must not be negative");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException("offset must not be negative");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationOpsRecoveryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationOpsRecoveryPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.notification.port;
+
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveResult;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
+
+/** notification DLQ redrive 는 Kafka adapter 가 source record 조회와 재발행을 맡습니다. */
+public interface NotificationOpsRecoveryPort {
+
+  NotificationDlqRedriveResult redrive(NotificationDlqRedriveTarget target);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationOpsRecoveryService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationOpsRecoveryService.java
@@ -1,0 +1,26 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveResult;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
+import com.aquilabank.domain.notification.port.NotificationOpsRecoveryPort;
+
+/** notification DLQ redrive 는 ops adapter 세부 구현을 domain 밖으로 숨깁니다. */
+public final class NotificationOpsRecoveryService implements NotificationOpsRecoveryUseCase {
+
+  private final NotificationOpsRecoveryPort notificationOpsRecoveryPort;
+
+  public NotificationOpsRecoveryService(NotificationOpsRecoveryPort notificationOpsRecoveryPort) {
+    if (notificationOpsRecoveryPort == null) {
+      throw new IllegalArgumentException("notificationOpsRecoveryPort is required");
+    }
+    this.notificationOpsRecoveryPort = notificationOpsRecoveryPort;
+  }
+
+  @Override
+  public NotificationDlqRedriveResult redrive(NotificationDlqRedriveTarget target) {
+    if (target == null) {
+      throw new IllegalArgumentException("target is required");
+    }
+    return notificationOpsRecoveryPort.redrive(target);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationOpsRecoveryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationOpsRecoveryUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveResult;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
+
+public interface NotificationOpsRecoveryUseCase {
+
+  NotificationDlqRedriveResult redrive(NotificationDlqRedriveTarget target);
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerConfiguration.java
@@ -2,10 +2,14 @@ package com.aquilabank.global.config;
 
 import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
 import com.aquilabank.domain.notification.port.NotificationOpsReadPort;
+import com.aquilabank.domain.notification.port.NotificationOpsRecoveryPort;
 import com.aquilabank.domain.notification.usecase.NotificationInboxIngestService;
 import com.aquilabank.domain.notification.usecase.NotificationInboxIngestUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationOpsQueryService;
 import com.aquilabank.domain.notification.usecase.NotificationOpsQueryUseCase;
+import com.aquilabank.domain.notification.usecase.NotificationOpsRecoveryService;
+import com.aquilabank.domain.notification.usecase.NotificationOpsRecoveryUseCase;
+import com.aquilabank.global.notification.KafkaNotificationOpsRecoveryRepository;
 import com.aquilabank.global.notification.KafkaNotificationOpsRepository;
 import com.aquilabank.global.notification.NotificationInboxHealthIndicator;
 import com.aquilabank.global.notification.TransferBookedNotificationConsumer;
@@ -127,10 +131,27 @@ public class NotificationInboxConsumerConfiguration {
   }
 
   @Bean
+  @Conditional(NotificationInboxKafkaOpsCondition.class)
+  @ConditionalOnBean(name = "notificationInboxDlqKafkaTemplate")
+  NotificationOpsRecoveryPort notificationOpsRecoveryPort(
+      NotificationInboxConsumerProperties properties,
+      @Qualifier("notificationInboxDlqKafkaTemplate") KafkaTemplate<String, String> notificationInboxDlqKafkaTemplate) {
+    return new KafkaNotificationOpsRecoveryRepository(
+        properties, notificationInboxDlqKafkaTemplate);
+  }
+
+  @Bean
   @ConditionalOnBean(NotificationOpsReadPort.class)
   NotificationOpsQueryUseCase notificationOpsQueryUseCase(
       NotificationOpsReadPort notificationOpsReadPort) {
     return new NotificationOpsQueryService(notificationOpsReadPort);
+  }
+
+  @Bean
+  @ConditionalOnBean(NotificationOpsRecoveryPort.class)
+  NotificationOpsRecoveryUseCase notificationOpsRecoveryUseCase(
+      NotificationOpsRecoveryPort notificationOpsRecoveryPort) {
+    return new NotificationOpsRecoveryService(notificationOpsRecoveryPort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/notification/KafkaNotificationOpsRecoveryRepository.java
+++ b/back/src/main/java/com/aquilabank/global/notification/KafkaNotificationOpsRecoveryRepository.java
@@ -1,0 +1,158 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveResult;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
+import com.aquilabank.domain.notification.port.NotificationOpsRecoveryPort;
+import com.aquilabank.global.config.NotificationInboxConsumerProperties;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+
+/** preview 좌표 기준 exact seek 만 허용해 DLQ redrive 범위를 넓히지 않습니다. */
+public final class KafkaNotificationOpsRecoveryRepository implements NotificationOpsRecoveryPort {
+
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(2);
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(200);
+  private static final String REDRIVE_SOURCE_TOPIC_HEADER = "notification-redrive-source-topic";
+  private static final String REDRIVE_SOURCE_PARTITION_HEADER =
+      "notification-redrive-source-partition";
+  private static final String REDRIVE_SOURCE_OFFSET_HEADER = "notification-redrive-source-offset";
+
+  private final NotificationInboxConsumerProperties properties;
+  private final KafkaTemplate<String, String> kafkaTemplate;
+
+  public KafkaNotificationOpsRecoveryRepository(
+      NotificationInboxConsumerProperties properties, KafkaTemplate<String, String> kafkaTemplate) {
+    this.properties = properties;
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
+  @Override
+  public NotificationDlqRedriveResult redrive(NotificationDlqRedriveTarget target) {
+    ConsumerRecord<String, String> sourceRecord = findDlqRecord(target);
+    String originalTopic = requiredHeaderValue(sourceRecord, KafkaHeaders.DLT_ORIGINAL_TOPIC);
+    Integer originalPartition = headerInteger(sourceRecord, KafkaHeaders.DLT_ORIGINAL_PARTITION);
+
+    ProducerRecord<String, String> redriveRecord =
+        new ProducerRecord<>(
+            originalTopic, originalPartition, sourceRecord.key(), sourceRecord.value());
+    addRedriveSourceHeaders(redriveRecord.headers(), sourceRecord.topic(), target);
+
+    try {
+      var sendResult = kafkaTemplate.send(redriveRecord).get(5, TimeUnit.SECONDS);
+      return new NotificationDlqRedriveResult(
+          sourceRecord.topic(),
+          sourceRecord.partition(),
+          sourceRecord.offset(),
+          sourceRecord.key(),
+          originalTopic,
+          sendResult.getRecordMetadata().partition(),
+          sendResult.getRecordMetadata().offset(),
+          Instant.now());
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("notification DLQ redrive interrupted", ex);
+    } catch (Exception ex) {
+      throw new IllegalStateException("notification DLQ redrive publish failed", ex);
+    }
+  }
+
+  private ConsumerRecord<String, String> findDlqRecord(NotificationDlqRedriveTarget target) {
+    TopicPartition topicPartition =
+        new TopicPartition(properties.dlq().topic(), target.partition());
+    try (KafkaConsumer<String, String> consumer = redriveConsumer()) {
+      consumer.assign(List.of(topicPartition));
+      long beginningOffset = consumer.beginningOffsets(List.of(topicPartition)).get(topicPartition);
+      long endOffset = consumer.endOffsets(List.of(topicPartition)).get(topicPartition);
+      if (target.offset() < beginningOffset || target.offset() >= endOffset) {
+        throw notFound(target);
+      }
+
+      consumer.seek(topicPartition, target.offset());
+      long deadline = System.nanoTime() + READ_TIMEOUT.toNanos();
+      while (System.nanoTime() < deadline) {
+        for (ConsumerRecord<String, String> record : consumer.poll(POLL_INTERVAL)) {
+          if (record.offset() == target.offset()) {
+            return record;
+          }
+          if (record.offset() > target.offset()) {
+            throw notFound(target);
+          }
+        }
+      }
+      throw notFound(target);
+    } catch (NotificationNotFoundException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new IllegalStateException("notification DLQ redrive source lookup failed", ex);
+    }
+  }
+
+  private KafkaConsumer<String, String> redriveConsumer() {
+    Properties config = new Properties();
+    config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, properties.bootstrapServers());
+    config.put(
+        ConsumerConfig.GROUP_ID_CONFIG, properties.groupId() + "-ops-redrive-" + UUID.randomUUID());
+    config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    config.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+    config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
+    config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    return new KafkaConsumer<>(config);
+  }
+
+  private void addRedriveSourceHeaders(
+      Headers headers, String sourceTopic, NotificationDlqRedriveTarget target) {
+    headers.add(REDRIVE_SOURCE_TOPIC_HEADER, sourceTopic.getBytes(StandardCharsets.UTF_8));
+    headers.add(
+        REDRIVE_SOURCE_PARTITION_HEADER, ByteBuffer.allocate(4).putInt(target.partition()).array());
+    headers.add(
+        REDRIVE_SOURCE_OFFSET_HEADER, ByteBuffer.allocate(8).putLong(target.offset()).array());
+  }
+
+  private String requiredHeaderValue(ConsumerRecord<String, String> record, String headerName) {
+    Header header = record.headers().lastHeader(headerName);
+    if (header == null || header.value() == null) {
+      throw new IllegalArgumentException("notification DLQ record original topic is missing");
+    }
+    String value = new String(header.value(), StandardCharsets.UTF_8);
+    if (value.isBlank()) {
+      throw new IllegalArgumentException("notification DLQ record original topic is missing");
+    }
+    return value;
+  }
+
+  private Integer headerInteger(ConsumerRecord<String, String> record, String headerName) {
+    Header header = record.headers().lastHeader(headerName);
+    if (header == null || header.value() == null) {
+      return null;
+    }
+    byte[] value = header.value();
+    if (value.length != Integer.BYTES) {
+      return null;
+    }
+    return ByteBuffer.wrap(value).getInt();
+  }
+
+  private NotificationNotFoundException notFound(NotificationDlqRedriveTarget target) {
+    return new NotificationNotFoundException(
+        "notification DLQ record is not found: partition=%d offset=%d"
+            .formatted(target.partition(), target.offset()));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationDlqRedriveRequest.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationDlqRedriveRequest.java
@@ -1,0 +1,15 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+/** preview 좌표를 그대로 받아 단건 redrive 범위를 고정합니다. */
+public record NotificationDlqRedriveRequest(
+    @NotNull(message = "partition is required") @PositiveOrZero(message = "partition must not be negative") Integer partition,
+    @NotNull(message = "offset is required") @PositiveOrZero(message = "offset must not be negative") Long offset) {
+
+  NotificationDlqRedriveTarget toTarget() {
+    return new NotificationDlqRedriveTarget(partition, offset);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationDlqRedriveResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationDlqRedriveResponse.java
@@ -1,0 +1,28 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveResult;
+import java.time.Instant;
+
+/** redrive 결과는 source DLQ 좌표와 재발행 좌표를 함께 반환합니다. */
+public record NotificationDlqRedriveResponse(
+    String sourceTopic,
+    int sourcePartition,
+    long sourceOffset,
+    String eventKey,
+    String targetTopic,
+    int targetPartition,
+    long targetOffset,
+    Instant redrivenAt) {
+
+  static NotificationDlqRedriveResponse from(NotificationDlqRedriveResult item) {
+    return new NotificationDlqRedriveResponse(
+        item.sourceTopic(),
+        item.sourcePartition(),
+        item.sourceOffset(),
+        item.eventKey(),
+        item.targetTopic(),
+        item.targetPartition(),
+        item.targetOffset(),
+        item.redrivenAt());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationOpsController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationOpsController.java
@@ -1,14 +1,18 @@
 package com.aquilabank.global.web.notification;
 
 import com.aquilabank.domain.notification.usecase.NotificationOpsQueryUseCase;
+import com.aquilabank.domain.notification.usecase.NotificationOpsRecoveryUseCase;
 import com.aquilabank.global.config.NotificationInboxConsumerProperties;
 import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceScope;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,14 +25,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationOpsController {
 
   private final NotificationOpsQueryUseCase notificationOpsQueryUseCase;
+  private final NotificationOpsRecoveryUseCase notificationOpsRecoveryUseCase;
   private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
   private final NotificationInboxConsumerProperties notificationInboxConsumerProperties;
 
   public NotificationOpsController(
       NotificationOpsQueryUseCase notificationOpsQueryUseCase,
+      NotificationOpsRecoveryUseCase notificationOpsRecoveryUseCase,
       InternalServiceRequestAuthorizer internalServiceRequestAuthorizer,
       NotificationInboxConsumerProperties notificationInboxConsumerProperties) {
     this.notificationOpsQueryUseCase = notificationOpsQueryUseCase;
+    this.notificationOpsRecoveryUseCase = notificationOpsRecoveryUseCase;
     this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
     this.notificationInboxConsumerProperties = notificationInboxConsumerProperties;
   }
@@ -48,5 +55,13 @@ public class NotificationOpsController {
     int resolvedLimit = limit == null ? configuredLimit : Math.min(limit, configuredLimit);
     return NotificationDlqEventListResponse.from(
         notificationOpsQueryUseCase.getDlqEvents(resolvedLimit), resolvedLimit);
+  }
+
+  @PostMapping("/dlq-events/redrive")
+  public NotificationDlqRedriveResponse redriveDlqEvent(
+      HttpServletRequest request, @Valid @RequestBody NotificationDlqRedriveRequest body) {
+    internalServiceRequestAuthorizer.requireScope(request, InternalServiceScope.OUTBOX_OPS);
+    return NotificationDlqRedriveResponse.from(
+        notificationOpsRecoveryUseCase.redrive(body.toTarget()));
   }
 }

--- a/back/src/test/java/com/aquilabank/global/config/NotificationInboxConsumerConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/NotificationInboxConsumerConfigurationTest.java
@@ -63,6 +63,8 @@ class NotificationInboxConsumerConfigurationTest {
               assertThat(context).hasBean("notificationInboxDlqKafkaTemplate");
               assertThat(context).hasBean("notificationOpsReadPort");
               assertThat(context).hasBean("notificationOpsQueryUseCase");
+              assertThat(context).hasBean("notificationOpsRecoveryPort");
+              assertThat(context).hasBean("notificationOpsRecoveryUseCase");
               assertThat(context).hasBean("notificationInboxHealthIndicator");
             });
   }

--- a/back/src/test/java/com/aquilabank/global/notification/NotificationDlqIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/NotificationDlqIntegrationTest.java
@@ -2,6 +2,8 @@ package com.aquilabank.global.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
+import com.aquilabank.domain.notification.usecase.NotificationOpsRecoveryUseCase;
 import com.aquilabank.support.PostgresKafkaContainerTestSupport;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -17,6 +19,7 @@ import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +30,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
@@ -49,6 +53,8 @@ class NotificationDlqIntegrationTest extends PostgresKafkaContainerTestSupport {
   @Qualifier("notificationInboxDlqKafkaTemplate") private KafkaTemplate<String, String> kafkaTemplate;
 
   @Autowired private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
+
+  @Autowired private NotificationOpsRecoveryUseCase notificationOpsRecoveryUseCase;
 
   @BeforeEach
   void waitUntilListenerIsReady() {
@@ -85,6 +91,36 @@ class NotificationDlqIntegrationTest extends PostgresKafkaContainerTestSupport {
         .contains("TransferBooked payload is invalid");
   }
 
+  @Test
+  void redrivesDlqRecordToMainTopicWithSameKeyAndPayload() throws Exception {
+    stopListener();
+    String eventKey = "transfer-booked:REDRIVE-" + System.currentTimeMillis();
+    String payload = validTransferBookedPayload("dlq-redrive");
+
+    ProducerRecord<String, String> record = validDlqRecord(eventKey, payload);
+    var sendResult = kafkaTemplate.send(record).get(5, TimeUnit.SECONDS);
+    NotificationDlqRedriveTarget target =
+        new NotificationDlqRedriveTarget(
+            sendResult.getRecordMetadata().partition(), sendResult.getRecordMetadata().offset());
+
+    var firstResult = notificationOpsRecoveryUseCase.redrive(target);
+    ConsumerRecord<String, String> firstRedrivenRecord =
+        findTopicRecord(TRANSFER_BOOKED_TOPIC, firstResult.targetOffset());
+    assertThat(firstResult.eventKey()).isEqualTo(eventKey);
+    assertThat(firstResult.targetTopic()).isEqualTo(TRANSFER_BOOKED_TOPIC);
+    assertThat(firstRedrivenRecord).isNotNull();
+    assertThat(firstRedrivenRecord.key()).isEqualTo(eventKey);
+    assertThat(firstRedrivenRecord.value()).isEqualTo(payload);
+
+    var secondResult = notificationOpsRecoveryUseCase.redrive(target);
+    ConsumerRecord<String, String> secondRedrivenRecord =
+        findTopicRecord(TRANSFER_BOOKED_TOPIC, secondResult.targetOffset());
+    assertThat(secondResult.targetOffset()).isGreaterThan(firstResult.targetOffset());
+    assertThat(secondRedrivenRecord).isNotNull();
+    assertThat(secondRedrivenRecord.key()).isEqualTo(eventKey);
+    assertThat(secondRedrivenRecord.value()).isEqualTo(payload);
+  }
+
   private ConsumerRecord<String, String> findDlqRecord(String eventKey) {
     TopicPartition partition = new TopicPartition(TRANSFER_BOOKED_DLQ_TOPIC, 0);
     long latestOffset = latestOffset(partition);
@@ -113,6 +149,64 @@ class NotificationDlqIntegrationTest extends PostgresKafkaContainerTestSupport {
       }
       return null;
     }
+  }
+
+  private ProducerRecord<String, String> validDlqRecord(String eventKey, String payload) {
+    ProducerRecord<String, String> record =
+        new ProducerRecord<>(TRANSFER_BOOKED_DLQ_TOPIC, eventKey, payload);
+    record
+        .headers()
+        .add(
+            KafkaHeaders.DLT_ORIGINAL_TOPIC,
+            TRANSFER_BOOKED_TOPIC.getBytes(StandardCharsets.UTF_8));
+    record
+        .headers()
+        .add(
+            KafkaHeaders.DLT_ORIGINAL_PARTITION, java.nio.ByteBuffer.allocate(4).putInt(0).array());
+    return record;
+  }
+
+  private ConsumerRecord<String, String> findTopicRecord(String topic, long offset) {
+    TopicPartition partition = new TopicPartition(topic, 0);
+    Map<String, Object> config =
+        Map.of(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            kafkaBootstrapServers(),
+            ConsumerConfig.GROUP_ID_CONFIG,
+            "notification-topic-inspect-" + UUID.randomUUID(),
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+            "latest",
+            ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+            false,
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class);
+    try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(config)) {
+      consumer.assign(List.of(partition));
+      consumer.seek(partition, offset);
+      for (ConsumerRecord<String, String> record : consumer.poll(Duration.ofSeconds(2))) {
+        if (record.offset() == offset) {
+          return record;
+        }
+      }
+      return null;
+    }
+  }
+
+  private String validTransferBookedPayload(String summary) {
+    return """
+        {
+          "transactionReference": "TRX-DLQ-REDRIVE",
+          "sourceAccountId": 11,
+          "targetAccountId": 22,
+          "amountMinor": 1200,
+          "currencyCode": "KRW",
+          "summary": "%s",
+          "bookedAt": "2026-04-17T00:00:00Z"
+        }
+        """
+        .formatted(summary);
   }
 
   private long latestOffset(TopicPartition partition) {
@@ -154,5 +248,16 @@ class NotificationDlqIntegrationTest extends PostgresKafkaContainerTestSupport {
     } catch (ReflectiveOperationException ex) {
       return container.isRunning();
     }
+  }
+
+  private void stopListener() {
+    MessageListenerContainer container =
+        kafkaListenerEndpointRegistry.getListenerContainer("transferBookedNotificationConsumer");
+    if (container == null) {
+      throw new IllegalStateException("notification consumer container is not found");
+    }
+    container.stop();
+    awaitCondition(
+        "notification consumer stop", DLQ_TIMEOUT, POLL_INTERVAL, () -> !container.isRunning());
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationOpsApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationOpsApiIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -11,6 +12,7 @@ import com.aquilabank.domain.notification.usecase.NotificationOpsQueryUseCase;
 import com.aquilabank.global.security.InternalServiceScope;
 import com.aquilabank.global.security.InternalServiceTokenIssuer;
 import com.aquilabank.support.PostgresKafkaContainerTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -56,6 +58,8 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
   @Qualifier("notificationInboxDlqKafkaTemplate") private KafkaTemplate<String, String> kafkaTemplate;
 
   @Autowired private NotificationOpsQueryUseCase notificationOpsQueryUseCase;
+
+  @Autowired private ObjectMapper objectMapper;
 
   @Autowired private InternalServiceTokenIssuer internalServiceTokenIssuer;
 
@@ -109,6 +113,31 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
   }
 
   @Test
+  void redrivesNotificationDlqRecordWithInternalServiceToken() throws Exception {
+    String eventKey = "transfer-booked:REDRIVE-" + System.currentTimeMillis();
+    ProducerRecord<String, String> record =
+        validDlqRecord(eventKey, "{\"transactionReference\":\"redrive\"}");
+    var sendResult = kafkaTemplate.send(record).get(5, TimeUnit.SECONDS);
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/outbox/notification/dlq-events/redrive")
+                .header("Authorization", outboxOpsAuthorization())
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new NotificationDlqRedriveRequest(
+                            sendResult.getRecordMetadata().partition(),
+                            sendResult.getRecordMetadata().offset()))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.eventKey").value(eventKey))
+        .andExpect(jsonPath("$.sourceTopic").value(TRANSFER_BOOKED_DLQ_TOPIC))
+        .andExpect(jsonPath("$.targetTopic").value(TRANSFER_BOOKED_TOPIC))
+        .andExpect(jsonPath("$.targetPartition").value(0))
+        .andExpect(jsonPath("$.targetOffset", greaterThanOrEqualTo(0)));
+  }
+
+  @Test
   void degradesHealthWhenNotificationLagOrDlqExists() throws Exception {
     String lagEventKey = "transfer-booked:HEALTH-" + System.currentTimeMillis();
     kafkaTemplate
@@ -119,6 +148,54 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
         .perform(get("/actuator/health"))
         .andExpect(status().isServiceUnavailable())
         .andExpect(jsonPath("$.status").value(isOneOf("OUT_OF_SERVICE", "DOWN")));
+  }
+
+  @Test
+  void returnsBadRequestWhenDlqOriginalTopicHeaderIsMissing() throws Exception {
+    String eventKey = "transfer-booked:REDRIVE-MISSING-" + System.currentTimeMillis();
+    ProducerRecord<String, String> record =
+        new ProducerRecord<>(TRANSFER_BOOKED_DLQ_TOPIC, eventKey, "{\"broken\":true}");
+    var sendResult = kafkaTemplate.send(record).get(5, TimeUnit.SECONDS);
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/outbox/notification/dlq-events/redrive")
+                .header("Authorization", outboxOpsAuthorization())
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new NotificationDlqRedriveRequest(
+                            sendResult.getRecordMetadata().partition(),
+                            sendResult.getRecordMetadata().offset()))))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            jsonPath("$.message").value("notification DLQ record original topic is missing"));
+  }
+
+  @Test
+  void returnsNotFoundWhenDlqRecordDoesNotExist() throws Exception {
+    mockMvc
+        .perform(
+            post("/internal/api/v1/outbox/notification/dlq-events/redrive")
+                .header("Authorization", outboxOpsAuthorization())
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(new NotificationDlqRedriveRequest(0, 9999L))))
+        .andExpect(status().isNotFound())
+        .andExpect(
+            jsonPath("$.message")
+                .value("notification DLQ record is not found: partition=0 offset=9999"));
+  }
+
+  @Test
+  void rejectsMissingInternalServiceTokenForRedrive() throws Exception {
+    mockMvc
+        .perform(
+            post("/internal/api/v1/outbox/notification/dlq-events/redrive")
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new NotificationDlqRedriveRequest(0, 0L))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
   }
 
   private ProducerRecord<String, String> dlqRecord(String eventKey) {
@@ -145,6 +222,20 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
         .add(
             KafkaHeaders.DLT_EXCEPTION_MESSAGE,
             "TransferBooked payload is invalid".getBytes(StandardCharsets.UTF_8));
+    return record;
+  }
+
+  private ProducerRecord<String, String> validDlqRecord(String eventKey, String payload) {
+    ProducerRecord<String, String> record =
+        new ProducerRecord<>(TRANSFER_BOOKED_DLQ_TOPIC, eventKey, payload);
+    record
+        .headers()
+        .add(
+            KafkaHeaders.DLT_ORIGINAL_TOPIC,
+            TRANSFER_BOOKED_TOPIC.getBytes(StandardCharsets.UTF_8));
+    record
+        .headers()
+        .add(KafkaHeaders.DLT_ORIGINAL_PARTITION, ByteBuffer.allocate(4).putInt(0).array());
     return record;
   }
 

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationOpsScriptSmokeTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationOpsScriptSmokeTest.java
@@ -39,6 +39,20 @@ class NotificationOpsScriptSmokeTest {
   }
 
   @Test
+  void notificationDlqRedriveScriptRejectsMissingArgs() throws Exception {
+    OutboxOpsScriptSmokeSupport.ScriptResult result =
+        OutboxOpsScriptSmokeSupport.run(
+            tempDir,
+            OutboxOpsScriptSmokeSupport.NOTIFICATION_DLQ_REDRIVE_SPEC,
+            OutboxOpsScriptSmokeSupport.NOTIFICATION_DLQ_REDRIVE_SPEC.args().subList(0, 3));
+
+    assertThat(result.exitCode()).isEqualTo(1);
+    assertThat(result.stderr())
+        .contains(OutboxOpsScriptSmokeSupport.NOTIFICATION_DLQ_REDRIVE_SPEC.usagePrefix());
+    assertThat(result.curlArgs()).isEmpty();
+  }
+
+  @Test
   void notificationSummaryScriptBuildsExpectedCurlRequest() throws Exception {
     OutboxOpsScriptSmokeSupport.ScriptResult result =
         OutboxOpsScriptSmokeSupport.run(
@@ -71,6 +85,22 @@ class NotificationOpsScriptSmokeTest {
   }
 
   @Test
+  void notificationDlqRedriveScriptBuildsExpectedCurlRequest() throws Exception {
+    OutboxOpsScriptSmokeSupport.ScriptResult result =
+        OutboxOpsScriptSmokeSupport.run(
+            tempDir,
+            OutboxOpsScriptSmokeSupport.NOTIFICATION_DLQ_REDRIVE_SPEC,
+            OutboxOpsScriptSmokeSupport.NOTIFICATION_DLQ_REDRIVE_SPEC.args());
+
+    assertThat(result.exitCode()).isZero();
+    assertThat(result.stderr()).isEmpty();
+    assertThat(result.stdout()).isEmpty();
+    assertThat(result.curlArgs())
+        .containsExactlyElementsOf(
+            OutboxOpsScriptSmokeSupport.NOTIFICATION_DLQ_REDRIVE_SPEC.expectedCurlArgs());
+  }
+
+  @Test
   void readmeContainsNotificationSummaryRunbook() throws Exception {
     assertReadmeContains(OutboxOpsScriptSmokeSupport.NOTIFICATION_SUMMARY_SPEC);
   }
@@ -78,6 +108,11 @@ class NotificationOpsScriptSmokeTest {
   @Test
   void readmeContainsNotificationDlqRunbook() throws Exception {
     assertReadmeContains(OutboxOpsScriptSmokeSupport.NOTIFICATION_DLQ_EVENTS_SPEC);
+  }
+
+  @Test
+  void readmeContainsNotificationDlqRedriveRunbook() throws Exception {
+    assertReadmeContains(OutboxOpsScriptSmokeSupport.NOTIFICATION_DLQ_REDRIVE_SPEC);
   }
 
   private void assertReadmeContains(OutboxOpsScriptSmokeSupport.ScriptSpec spec) throws Exception {

--- a/back/src/test/java/com/aquilabank/global/web/notification/OutboxOpsScriptSmokeSupport.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/OutboxOpsScriptSmokeSupport.java
@@ -105,6 +105,32 @@ final class OutboxOpsScriptSmokeSupport {
               "\"http://localhost:8080/internal/api/v1/outbox/notification/dlq-events\"",
               "poison message 최근 항목"));
 
+  static final ScriptSpec NOTIFICATION_DLQ_REDRIVE_SPEC =
+      new ScriptSpec(
+          "notification-dlq-redrive",
+          repoRoot().resolve("tools/ops/notification-redrive-dlq-event.sh"),
+          "usage: tools/ops/notification-redrive-dlq-event.sh",
+          List.of("http://localhost:8080", "test-outbox-ops-service-token", "0", "12"),
+          List.of(
+              "--fail-with-body",
+              "--silent",
+              "--show-error",
+              "--request",
+              "POST",
+              "--header",
+              "Authorization: Bearer test-outbox-ops-service-token",
+              "--header",
+              "Content-Type: application/json",
+              "--data",
+              "{\"partition\":0,\"offset\":12}",
+              "http://localhost:8080/internal/api/v1/outbox/notification/dlq-events/redrive"),
+          List.of(
+              "tools/ops/notification-redrive-dlq-event.sh \\",
+              "\"$OUTBOX_OPS_SERVICE_TOKEN\" \\",
+              "\"http://localhost:8080/internal/api/v1/outbox/notification/dlq-events/redrive\"",
+              "\"partition\":0",
+              "preview -> redrive -> summary"));
+
   private static final Duration SCRIPT_TIMEOUT = Duration.ofSeconds(5);
 
   private OutboxOpsScriptSmokeSupport() {}

--- a/tools/ops/notification-redrive-dlq-event.sh
+++ b/tools/ops/notification-redrive-dlq-event.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  cat <<'USAGE' >&2
+usage: tools/ops/notification-redrive-dlq-event.sh <base_url> <service_token> <partition> <offset>
+
+example:
+  tools/ops/notification-redrive-dlq-event.sh \
+    http://localhost:8080 \
+    "$OUTBOX_OPS_SERVICE_TOKEN" \
+    0 \
+    12
+USAGE
+  exit 1
+fi
+
+base_url="$1"
+service_token="$2"
+partition="$3"
+offset="$4"
+
+# preview 좌표만 받아 서버가 DLQ record 를 직접 읽고 original topic 으로 재발행하게 합니다.
+curl --fail-with-body --silent --show-error \
+  --request POST \
+  --header "Authorization: Bearer ${service_token}" \
+  --header "Content-Type: application/json" \
+  --data "{\"partition\":${partition},\"offset\":${offset}}" \
+  "${base_url%/}/internal/api/v1/outbox/notification/dlq-events/redrive"


### PR DESCRIPTION
## 🔗 Related Issue
- close #84

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification DLQ preview 뒤에 실제 redrive write 경로를 추가했습니다.
- 운영자는 preview 응답의 `partition`/`offset` 기준으로 내부 ops API 또는 기본 shell script만으로 DLQ record 를 original topic 으로 다시 publish 할 수 있습니다.
- README/runbook 을 preview -> redrive -> summary 재확인 순서로 맞췄습니다.

## 🛠 Changes
- notification DLQ redrive domain 계약, recovery use case, Kafka recovery adapter 추가
- `POST /internal/api/v1/outbox/notification/dlq-events/redrive` 내부 ops API와 request/response 모델 추가
- `tools/ops/notification-redrive-dlq-event.sh`, README, script smoke test로 운영 경로 정리

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test --tests '*NotificationInboxConsumerConfigurationTest'`
- `tools/test/with-resource-lock.sh back-gradle-notification-ops ./back/gradlew -p back test --tests '*Notification*Ops*' --tests '*NotificationDlqIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-notification-ops ./back/gradlew -p back test --tests '*NotificationOpsScriptSmokeTest'`
- `bash -n tools/ops/notification-find-dlq-events.sh tools/ops/notification-get-consumer-summary.sh tools/ops/notification-redrive-dlq-event.sh`
- `./back/gradlew -p back spotlessApply`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- `POST /internal/api/v1/outbox/notification/dlq-events/redrive`
- body: `{ "partition": 0, "offset": 12 }`
- response: `sourceTopic`, `sourcePartition`, `sourceOffset`, `eventKey`, `targetTopic`, `targetPartition`, `targetOffset`, `redrivenAt`

## ⚠️ Risk & Rollback
- 예상 리스크: payload 또는 참조 데이터가 여전히 잘못된 경우 redrive 후 같은 항목이 다시 DLQ 로 돌아갈 수 있습니다.
- 롤백 방법: `OUTBOX_OPS_ENABLED=false` 또는 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=false` 로 내부 ops surface 를 내려 차단하고, 필요 시 PR revert 로 redrive endpoint/script 를 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했다.
- [x] GitHub issue를 먼저 만들고 번호를 연결했다.
- [x] 하나의 리뷰 목적을 유지했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 커밋을 논리 단위로 정리했다.
- [x] 필요한 테스트를 수행했다.
- [ ] 미완성 기능이면 feature flag로 기본 비노출 처리했다. N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.