### PR TITLE
[Chore] notification inbox 보존 정책과 cleanup batch 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -127,6 +127,9 @@ tools/test/with-resource-lock.sh back-gradle-check \
 - JWT user 경로의 읽음 상태는 `notification_user_read_state`에 user별로 저장됩니다.
 - `notification_inbox`는 account-scoped read model 본체를 유지하고, `read_at`은 account principal/internal 경로 의미로 분리됩니다.
 - 기존 shared `read_at` 값은 user read state로 자동 backfill 하지 않으므로, 배포 이전 알림은 JWT user 기준에서 다시 unread로 보일 수 있습니다.
+- notification inbox retention cleanup은 `notification_inbox.created_at` 기준으로만 동작해 account/user 경로의 read 의미를 따로 해석하지 않습니다.
+- 오래된 inbox row를 지울 때 연결된 `notification_user_read_state`도 FK cascade로 함께 정리해 read state orphan과 unread 회귀를 막습니다.
+- 기본 설정은 `NOTIFICATION_INBOX_CLEANUP_ENABLED=true`, `NOTIFICATION_INBOX_CLEANUP_RETENTION_DAYS=90`, `NOTIFICATION_INBOX_CLEANUP_BATCH_SIZE=500`, `NOTIFICATION_INBOX_CLEANUP_FIXED_DELAY_MS=300000` 입니다.
 
 ## Notification SSE Stream
 

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxCleanupPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxCleanupPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.notification.port;
+
+import java.time.Instant;
+
+/** inbox retention cutoff 이전 row 정리를 persistence adapter로 위임합니다. */
+public interface NotificationInboxCleanupPort {
+
+  int deleteExpiredNotifications(Instant cutoff, int batchSize);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxCleanupService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxCleanupService.java
@@ -1,0 +1,40 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.port.NotificationInboxCleanupPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/** retention 기준과 batch 크기를 domain use case에서 고정해 scheduler/adapter drift를 막습니다. */
+public final class NotificationInboxCleanupService implements NotificationInboxCleanupUseCase {
+
+  private final NotificationInboxCleanupPort notificationInboxCleanupPort;
+  private final Clock clock;
+  private final Duration retention;
+  private final int batchSize;
+
+  public NotificationInboxCleanupService(
+      NotificationInboxCleanupPort notificationInboxCleanupPort,
+      Clock clock,
+      Duration retention,
+      int batchSize) {
+    this.notificationInboxCleanupPort =
+        Objects.requireNonNull(notificationInboxCleanupPort, "notificationInboxCleanupPort");
+    this.clock = Objects.requireNonNull(clock, "clock");
+    this.retention = Objects.requireNonNull(retention, "retention");
+    if (retention.isZero() || retention.isNegative()) {
+      throw new IllegalArgumentException("retention must be positive");
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("batchSize must be positive");
+    }
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public int cleanupExpiredNotifications() {
+    Instant cutoff = clock.instant().minus(retention);
+    return notificationInboxCleanupPort.deleteExpiredNotifications(cutoff, batchSize);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxCleanupUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxCleanupUseCase.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.notification.usecase;
+
+/** notification inbox retention batch 진입점 */
+public interface NotificationInboxCleanupUseCase {
+
+  int cleanupExpiredNotifications();
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxCleanupConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxCleanupConfiguration.java
@@ -1,0 +1,27 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.notification.port.NotificationInboxCleanupPort;
+import com.aquilabank.domain.notification.usecase.NotificationInboxCleanupService;
+import com.aquilabank.domain.notification.usecase.NotificationInboxCleanupUseCase;
+import java.time.Clock;
+import java.time.Duration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** notification inbox retention cleanup use case와 runtime 설정을 조립합니다. */
+@Configuration
+@EnableConfigurationProperties(NotificationInboxCleanupProperties.class)
+public class NotificationInboxCleanupConfiguration {
+
+  @Bean
+  NotificationInboxCleanupUseCase notificationInboxCleanupUseCase(
+      NotificationInboxCleanupPort notificationInboxCleanupPort,
+      NotificationInboxCleanupProperties notificationInboxCleanupProperties) {
+    return new NotificationInboxCleanupService(
+        notificationInboxCleanupPort,
+        Clock.systemUTC(),
+        Duration.ofDays(notificationInboxCleanupProperties.retentionDays()),
+        notificationInboxCleanupProperties.batchSize());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxCleanupProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxCleanupProperties.java
@@ -1,0 +1,27 @@
+package com.aquilabank.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** inbox retention batch 런타임 기준을 notification 조회 설정과 분리합니다. */
+@ConfigurationProperties(prefix = "notification.inbox.cleanup")
+public record NotificationInboxCleanupProperties(
+    boolean enabled, long fixedDelayMs, long initialDelayMs, int batchSize, long retentionDays) {
+
+  public NotificationInboxCleanupProperties {
+    if (fixedDelayMs <= 0) {
+      throw new IllegalArgumentException(
+          "notification.inbox.cleanup.fixed-delay-ms must be positive");
+    }
+    if (initialDelayMs < 0) {
+      throw new IllegalArgumentException(
+          "notification.inbox.cleanup.initial-delay-ms must not be negative");
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("notification.inbox.cleanup.batch-size must be positive");
+    }
+    if (retentionDays <= 0) {
+      throw new IllegalArgumentException(
+          "notification.inbox.cleanup.retention-days must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationInboxCleanupPoller.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationInboxCleanupPoller.java
@@ -1,0 +1,33 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.usecase.NotificationInboxCleanupUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** 오래된 notification inbox row를 작은 batch로만 정리해 조회/저장 비용 누적을 제한합니다. */
+@Component
+@ConditionalOnProperty(name = "notification.inbox.cleanup.enabled", havingValue = "true")
+public class NotificationInboxCleanupPoller {
+
+  private static final Logger log = LoggerFactory.getLogger(NotificationInboxCleanupPoller.class);
+
+  private final NotificationInboxCleanupUseCase notificationInboxCleanupUseCase;
+
+  public NotificationInboxCleanupPoller(
+      NotificationInboxCleanupUseCase notificationInboxCleanupUseCase) {
+    this.notificationInboxCleanupUseCase = notificationInboxCleanupUseCase;
+  }
+
+  @Scheduled(
+      fixedDelayString = "${notification.inbox.cleanup.fixed-delay-ms:300000}",
+      initialDelayString = "${notification.inbox.cleanup.initial-delay-ms:60000}")
+  void cleanupExpiredNotifications() {
+    int deleted = notificationInboxCleanupUseCase.cleanupExpiredNotifications();
+    if (deleted > 0) {
+      log.info("deleted {} expired notification inbox row(s)", deleted);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -7,6 +7,7 @@ import com.aquilabank.domain.notification.model.NotificationReplayQuery;
 import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.domain.notification.model.NotificationSummary;
 import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
+import com.aquilabank.domain.notification.port.NotificationInboxCleanupPort;
 import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
 import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
 import com.aquilabank.global.notification.NotificationInboxInsertedEvent;
@@ -26,10 +27,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-/** JWT user inbox join 과 bootstrap account inbox exact lookup 을 한 adapter 로 묶습니다. */
+/** JWT user/account inbox 조회, read 처리, retention cleanup 을 한 JDBC adapter로 묶습니다. */
 @Repository
 public class JdbcNotificationInboxRepository
-    implements NotificationInboxReadPort, NotificationInboxWritePort, NotificationInboxAppendPort {
+    implements NotificationInboxReadPort,
+        NotificationInboxWritePort,
+        NotificationInboxAppendPort,
+        NotificationInboxCleanupPort {
 
   private static final RowMapper<NotificationSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
 
@@ -291,6 +295,37 @@ public class JdbcNotificationInboxRepository
               ROW_MAPPER));
     }
     publishInsertedNotifications(insertedItems);
+  }
+
+  @Override
+  @Transactional
+  public int deleteExpiredNotifications(Instant cutoff, int batchSize) {
+    // 여러 인스턴스 cleanup 이 겹쳐도 같은 오래된 row를 두 번 잡지 않게 SKIP LOCKED 로 batch를 나눕니다.
+    Integer deleted =
+        jdbcTemplate.queryForObject(
+            """
+            WITH expired AS (
+                SELECT id
+                FROM notification_inbox
+                WHERE created_at < :cutoff
+                ORDER BY created_at ASC, id ASC
+                FOR UPDATE SKIP LOCKED
+                LIMIT :batchSize
+            ),
+            deleted AS (
+                DELETE FROM notification_inbox n
+                USING expired e
+                WHERE n.id = e.id
+                RETURNING n.id
+            )
+            SELECT COUNT(*)
+            FROM deleted
+            """,
+            new MapSqlParameterSource()
+                .addValue("cutoff", Timestamp.from(cutoff))
+                .addValue("batchSize", batchSize),
+            Integer.class);
+    return deleted == null ? 0 : deleted;
   }
 
   private void publishInsertedNotifications(List<NotificationSummary> insertedItems) {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -115,6 +115,12 @@ notification:
     fanout-listen-timeout-ms: ${NOTIFICATION_SSE_FANOUT_LISTEN_TIMEOUT_MS:1000}
     fanout-retry-delay-ms: ${NOTIFICATION_SSE_FANOUT_RETRY_DELAY_MS:2000}
   inbox:
+    cleanup:
+      enabled: ${NOTIFICATION_INBOX_CLEANUP_ENABLED:true}
+      fixed-delay-ms: ${NOTIFICATION_INBOX_CLEANUP_FIXED_DELAY_MS:300000}
+      initial-delay-ms: ${NOTIFICATION_INBOX_CLEANUP_INITIAL_DELAY_MS:60000}
+      batch-size: ${NOTIFICATION_INBOX_CLEANUP_BATCH_SIZE:500}
+      retention-days: ${NOTIFICATION_INBOX_CLEANUP_RETENTION_DAYS:90}
     consumer:
       enabled: ${NOTIFICATION_INBOX_CONSUMER_ENABLED:false}
       auto-startup: ${NOTIFICATION_INBOX_CONSUMER_AUTO_STARTUP:true}

--- a/back/src/main/resources/db/migration/V14__add_notification_inbox_retention.sql
+++ b/back/src/main/resources/db/migration/V14__add_notification_inbox_retention.sql
@@ -1,0 +1,10 @@
+-- notification inbox retention cleanup 는 created_at 기준 작은 batch 로만 지워 t3.micro 환경의 lock/vacuum 충격을 낮춥니다.
+CREATE INDEX idx_notification_inbox_cleanup_cursor
+    ON notification_inbox (created_at ASC, id ASC);
+
+ALTER TABLE notification_user_read_state
+    DROP CONSTRAINT fk_notification_user_read_state_notification;
+
+ALTER TABLE notification_user_read_state
+    ADD CONSTRAINT fk_notification_user_read_state_notification
+        FOREIGN KEY (notification_id) REFERENCES notification_inbox (id) ON DELETE CASCADE;

--- a/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationInboxCleanupServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationInboxCleanupServiceTest.java
@@ -1,0 +1,38 @@
+package com.aquilabank.domain.notification.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.notification.port.NotificationInboxCleanupPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class NotificationInboxCleanupServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-17T00:00:00Z");
+
+  private final NotificationInboxCleanupPort notificationInboxCleanupPort =
+      mock(NotificationInboxCleanupPort.class);
+
+  @Test
+  void deletesExpiredNotificationsUsingConfiguredRetentionAndBatchSize() {
+    Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    when(notificationInboxCleanupPort.deleteExpiredNotifications(
+            NOW.minus(Duration.ofDays(90)), 500))
+        .thenReturn(3);
+    NotificationInboxCleanupService service =
+        new NotificationInboxCleanupService(
+            notificationInboxCleanupPort, clock, Duration.ofDays(90), 500);
+
+    int deleted = service.cleanupExpiredNotifications();
+
+    assertThat(deleted).isEqualTo(3);
+    verify(notificationInboxCleanupPort)
+        .deleteExpiredNotifications(NOW.minus(Duration.ofDays(90)), 500);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/NotificationInboxCleanupConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/NotificationInboxCleanupConfigurationTest.java
@@ -1,0 +1,62 @@
+package com.aquilabank.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.aquilabank.domain.notification.port.NotificationInboxCleanupPort;
+import com.aquilabank.domain.notification.usecase.NotificationInboxCleanupUseCase;
+import com.aquilabank.global.notification.NotificationInboxCleanupPoller;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class NotificationInboxCleanupConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(
+              NotificationInboxCleanupConfiguration.class, NotificationInboxCleanupPoller.class)
+          .withBean(
+              NotificationInboxCleanupPort.class, () -> mock(NotificationInboxCleanupPort.class))
+          .withPropertyValues(
+              "notification.inbox.cleanup.fixed-delay-ms=300000",
+              "notification.inbox.cleanup.initial-delay-ms=60000",
+              "notification.inbox.cleanup.batch-size=500",
+              "notification.inbox.cleanup.retention-days=90");
+
+  @Test
+  void createsCleanupPollerWhenCleanupIsEnabled() {
+    contextRunner
+        .withPropertyValues("notification.inbox.cleanup.enabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(NotificationInboxCleanupUseCase.class);
+              assertThat(context).hasSingleBean(NotificationInboxCleanupPoller.class);
+            });
+  }
+
+  @Test
+  void doesNotCreateCleanupPollerWhenCleanupIsDisabled() {
+    contextRunner
+        .withPropertyValues("notification.inbox.cleanup.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(NotificationInboxCleanupUseCase.class);
+              assertThat(context).doesNotHaveBean(NotificationInboxCleanupPoller.class);
+            });
+  }
+
+  @Test
+  void rejectsNonPositiveRetentionDays() {
+    contextRunner
+        .withPropertyValues(
+            "notification.inbox.cleanup.enabled=true",
+            "notification.inbox.cleanup.retention-days=0")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .hasRootCauseMessage(
+                      "notification.inbox.cleanup.retention-days must be positive");
+            });
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -200,6 +200,65 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
         .containsExactlyInAnyOrder("1500 KRW 출금 · rent", "1500 KRW 입금 · rent");
   }
 
+  @Test
+  void deletesExpiredNotificationsInBatchesAndCascadesUserReadState() {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[3];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    Instant cutoff = base.minusSeconds(90L * 24 * 60 * 60);
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("cleanup-user");
+          accountId[0] = insertAccount("cleanup account");
+          insertMembership(userId[0], accountId[0], "OWNER", "ACTIVE");
+          notificationIds[0] =
+              insertNotification(
+                  accountId[0],
+                  "evt-cleanup-1",
+                  "TransferBooked",
+                  "old-1",
+                  "old-1",
+                  null,
+                  cutoff.minusSeconds(20));
+          notificationIds[1] =
+              insertNotification(
+                  accountId[0],
+                  "evt-cleanup-2",
+                  "TransferBooked",
+                  "old-2",
+                  "old-2",
+                  null,
+                  cutoff.minusSeconds(10));
+          notificationIds[2] =
+              insertNotification(
+                  accountId[0],
+                  "evt-cleanup-3",
+                  "TransferBooked",
+                  "fresh",
+                  "fresh",
+                  null,
+                  cutoff.plusSeconds(10));
+          insertUserReadState(userId[0], notificationIds[0], base.minusSeconds(100));
+          insertUserReadState(userId[0], notificationIds[1], base.minusSeconds(90));
+          insertUserReadState(userId[0], notificationIds[2], base.minusSeconds(80));
+        });
+
+    int firstDeleted = repository.deleteExpiredNotifications(cutoff, 1);
+
+    assertThat(firstDeleted).isEqualTo(1);
+    assertThat(findNotificationEventKeys())
+        .containsExactlyInAnyOrder("evt-cleanup-2", "evt-cleanup-3");
+    assertThat(totalUserReadStates()).isEqualTo(2L);
+
+    int secondDeleted = repository.deleteExpiredNotifications(cutoff, 10);
+
+    assertThat(secondDeleted).isEqualTo(1);
+    assertThat(findNotificationEventKeys()).containsExactly("evt-cleanup-3");
+    assertThat(totalUserReadStates()).isEqualTo(1L);
+  }
+
   private long insertUser(String loginId) {
     Long userId =
         jdbcTemplate.queryForObject(
@@ -369,5 +428,25 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
         """,
         new MapSqlParameterSource(),
         (rs, rowNum) -> rs.getString("message"));
+  }
+
+  private List<String> findNotificationEventKeys() {
+    return jdbcTemplate.query(
+        """
+        SELECT event_key
+        FROM notification_inbox
+        ORDER BY id
+        """,
+        new MapSqlParameterSource(),
+        (rs, rowNum) -> rs.getString("event_key"));
+  }
+
+  private long totalUserReadStates() {
+    Long count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM notification_user_read_state",
+            new MapSqlParameterSource(),
+            Long.class);
+    return count == null ? 0L : count;
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #86

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification inbox와 `notification_user_read_state`가 장기 누적될 때 조회 성능과 저장 비용이 같이 악화되지 않도록 retention 정책을 추가했습니다.
- 오래된 inbox row를 created_at 기준 작은 batch로 정리하는 cleanup batch를 넣고, read state는 FK cascade로 함께 정리되게 맞췄습니다.
- runtime 설정, JDBC cleanup 경로, 통합 테스트와 README를 같이 보강했습니다.

## 🛠 Changes
- `notification.inbox.cleanup.*` 설정, cleanup use case, scheduler, JDBC bounded delete 추가
- `notification_inbox(created_at, id)` cleanup index 추가 및 `notification_user_read_state -> notification_inbox` FK `ON DELETE CASCADE` 적용
- cleanup 설정 테스트, batch/cascade 통합 테스트, README retention 설명 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-notification-retention ./back/gradlew -p back test --tests '*NotificationInboxCleanup*' --tests '*JdbcNotificationInboxRepositoryIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- N/A

## ⚠️ Risk & Rollback
- 예상 리스크: retention 기간이 짧으면 오래된 notification history가 예상보다 빨리 사라질 수 있습니다. FK cascade 적용 후 delete batch가 커지면 vacuum 비용이 커질 수 있어 batch size 조정이 필요할 수 있습니다.
- 롤백 방법: PR revert로 cleanup scheduler와 runtime 설정을 제거하고, migration rollback 대신 후속 migration으로 cleanup poller 비활성화 또는 FK/index 원복을 적용합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했다.
- [x] GitHub issue를 먼저 만들고 번호를 연결했다.
- [x] 하나의 리뷰 목적을 유지했다.
- [x] PR 범위 밖 변경은 포함하지 않았다.
- [x] 커밋을 논리 단위로 정리했다.
- [x] 필요한 테스트를 수행했다.
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했다.
- [ ] 보안/권한/개인정보 영향이 있으면 본문에 적었다.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었다.
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했다.