### PR TITLE
[Feat] refresh token session 목록 조회 API 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -242,6 +242,7 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
 
 - 공개 endpoint:
   - `POST /api/v1/auth/login`
+  - `GET /api/v1/auth/sessions`
   - `POST /api/v1/auth/refresh`
   - `POST /api/v1/auth/logout`
 - 응답 필드:
@@ -259,13 +260,19 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
   - 저장 테이블은 `auth_refresh_token_session`
   - 성공 refresh 시 기존 row는 `ROTATED`, 새 row는 `ACTIVE`
   - 성공 logout 시 현재 사용자 `ACTIVE` session은 `REVOKED`
+- 세션 목록 조회 기준:
+  - `GET /api/v1/auth/sessions`
+  - 현재 JWT user만 호출 가능하고 bootstrap account principal은 `403`
+  - query parameter `size`는 기본 `20`, 최대 `50`
+  - 응답은 현재 user의 `ACTIVE` 이면서 아직 만료되지 않은 session만 `expires_at DESC, id DESC` 순서로 반환
+  - item 필드는 `sessionId`, `sessionStatus`, `expiresAt`, `lastUsedAt`, `createdAt`
 - 거절 기준:
   - 만료, 이미 rotation 된 token, 존재하지 않는 token은 모두 `401 refresh failed`
   - `user_status=LOCKED|DISABLED` 사용자는 refresh로 새 token pair를 발급받지 못함
 - 운영 주의:
   - logout은 access token 즉시 폐기가 아니라 refresh 재발급 차단까지만 처리
   - 다른 사용자 token, 이미 `ROTATED|REVOKED` 상태인 token, 존재하지 않는 token으로 logout 요청 시 `204` no-op 유지
-  - 최소 범위에서는 logout-all / 세션 목록 조회를 제공하지 않음
+  - 이번 범위는 logout-all, 세션별 강제 종료를 제공하지 않음
   - raw refresh token, plaintext secret은 로그/DB에 남기지 않음
 
 ## Internal Auth Admin Runbook

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionList.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionList.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+import java.util.List;
+
+/** 현재 user가 확인할 refresh token session 목록 응답 모델입니다. */
+public record AuthSessionList(List<AuthSessionSummary> items) {
+
+  public AuthSessionList {
+    if (items == null) {
+      throw new IllegalArgumentException("items is required");
+    }
+    items = List.copyOf(items);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionListQuery.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionListQuery.java
@@ -1,0 +1,17 @@
+package com.aquilabank.domain.auth.model;
+
+/** 현재 user refresh token session 목록 조회 최소 입력값입니다. */
+public record AuthSessionListQuery(long userId, int size) {
+
+  public AuthSessionListQuery {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (size <= 0) {
+      throw new IllegalArgumentException("size must be positive");
+    }
+    if (size > 50) {
+      throw new IllegalArgumentException("size must be 50 or less");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionSummary.java
@@ -1,0 +1,27 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 세션 목록 응답에 필요한 최소 메타데이터만 분리한 조회 모델입니다. */
+public record AuthSessionSummary(
+    long sessionId,
+    RefreshTokenSessionStatus sessionStatus,
+    Instant expiresAt,
+    Instant lastUsedAt,
+    Instant createdAt) {
+
+  public AuthSessionSummary {
+    if (sessionId <= 0) {
+      throw new IllegalArgumentException("sessionId must be positive");
+    }
+    if (sessionStatus == null) {
+      throw new IllegalArgumentException("sessionStatus is required");
+    }
+    if (expiresAt == null) {
+      throw new IllegalArgumentException("expiresAt is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AuthSessionQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AuthSessionQueryPort.java
@@ -1,0 +1,11 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.AuthSessionSummary;
+import java.time.Instant;
+import java.util.List;
+
+/** 현재 user refresh token session 목록 조회를 읽기 port로 분리합니다. */
+public interface AuthSessionQueryPort {
+
+  List<AuthSessionSummary> findActiveSessionsByUserId(long userId, Instant now, int size);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionListService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionListService.java
@@ -1,0 +1,26 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthSessionList;
+import com.aquilabank.domain.auth.model.AuthSessionListQuery;
+import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** 현재 user의 미만료 ACTIVE refresh token session만 bounded list로 조회합니다. */
+public final class AuthSessionListService implements AuthSessionListUseCase {
+
+  private final AuthSessionQueryPort authSessionQueryPort;
+  private final Clock clock;
+
+  public AuthSessionListService(AuthSessionQueryPort authSessionQueryPort, Clock clock) {
+    this.authSessionQueryPort = authSessionQueryPort;
+    this.clock = clock;
+  }
+
+  @Override
+  public AuthSessionList get(AuthSessionListQuery query) {
+    Instant now = Instant.now(clock);
+    return new AuthSessionList(
+        authSessionQueryPort.findActiveSessionsByUserId(query.userId(), now, query.size()));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionListUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionListUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthSessionList;
+import com.aquilabank.domain.auth.model.AuthSessionListQuery;
+
+public interface AuthSessionListUseCase {
+
+  AuthSessionList get(AuthSessionListQuery query);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -5,6 +5,7 @@ import com.aquilabank.domain.auth.model.LoginProtectionPolicy;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
@@ -22,6 +23,8 @@ import com.aquilabank.domain.auth.port.UserQueryPort;
 import com.aquilabank.domain.auth.port.UserStatusUpdatePort;
 import com.aquilabank.domain.auth.usecase.AccountAccessService;
 import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
+import com.aquilabank.domain.auth.usecase.AuthSessionListService;
+import com.aquilabank.domain.auth.usecase.AuthSessionListUseCase;
 import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryService;
 import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryUseCase;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryService;
@@ -169,6 +172,12 @@ public class AuthConfiguration {
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
     return command ->
         transactionTemplate.executeWithoutResult(status -> logoutService.logout(command));
+  }
+
+  @Bean
+  AuthSessionListUseCase authSessionListUseCase(
+      AuthSessionQueryPort authSessionQueryPort, Clock authClock) {
+    return new AuthSessionListService(authSessionQueryPort, authClock);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.persistence.auth;
 
 import com.aquilabank.domain.auth.model.AccountAccessMembership;
+import com.aquilabank.domain.auth.model.AuthSessionSummary;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
@@ -16,6 +17,7 @@ import com.aquilabank.domain.auth.model.UserAccountMembership;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipQueryPort;
@@ -25,6 +27,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -35,6 +38,7 @@ import org.springframework.stereotype.Repository;
 public class JdbcAuthRepository
     implements UserCredentialLoadPort,
         RefreshTokenSessionLoadPort,
+        AuthSessionQueryPort,
         AccountAccessPort,
         UserQueryPort,
         UserAccountMembershipQueryPort,
@@ -116,6 +120,30 @@ public class JdbcAuthRepository
             (rs, rowNum) -> mapRefreshTokenSession(rs))
         .stream()
         .findFirst();
+  }
+
+  @Override
+  public List<AuthSessionSummary> findActiveSessionsByUserId(long userId, Instant now, int size) {
+    // user_id + session_status + expires_at DESC index 경로를 그대로 쓰려고 조건과 정렬을 고정합니다.
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               session_status,
+               expires_at,
+               last_used_at,
+               created_at
+        FROM auth_refresh_token_session
+        WHERE user_id = :userId
+          AND session_status = 'ACTIVE'
+          AND expires_at > :now
+        ORDER BY expires_at DESC, id DESC
+        LIMIT :size
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("now", Timestamp.from(now))
+            .addValue("size", size),
+        (rs, rowNum) -> mapAuthSessionSummary(rs));
   }
 
   @Override
@@ -255,6 +283,15 @@ public class JdbcAuthRepository
         toNullableInstant(rs.getTimestamp("last_used_at")),
         toNullableInstant(rs.getTimestamp("rotated_at")),
         rs.getObject("replaced_by_session_id", Long.class));
+  }
+
+  private AuthSessionSummary mapAuthSessionSummary(ResultSet rs) throws SQLException {
+    return new AuthSessionSummary(
+        rs.getLong("id"),
+        RefreshTokenSessionStatus.valueOf(rs.getString("session_status")),
+        toInstant(rs.getTimestamp("expires_at")),
+        toNullableInstant(rs.getTimestamp("last_used_at")),
+        toInstant(rs.getTimestamp("created_at")));
   }
 
   private UserAccountMembership mapMembership(ResultSet rs) throws SQLException {

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -1,9 +1,13 @@
 package com.aquilabank.global.web.auth;
 
+import com.aquilabank.domain.auth.model.AuthSessionList;
+import com.aquilabank.domain.auth.model.AuthSessionListQuery;
+import com.aquilabank.domain.auth.model.AuthSessionSummary;
 import com.aquilabank.domain.auth.model.LoginCommand;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.model.LogoutCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenCommand;
+import com.aquilabank.domain.auth.usecase.AuthSessionListUseCase;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutUseCase;
 import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
@@ -12,32 +16,40 @@ import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-/** public auth session 생성, 재발급, 종료 API를 노출합니다. */
+/** public auth session 생성, 조회, 재발급, 종료 API를 노출합니다. */
 @Validated
 @RestController
 @RequestMapping("/api/v1/auth")
 public class LoginController {
 
   private final LoginUseCase loginUseCase;
+  private final AuthSessionListUseCase authSessionListUseCase;
   private final RefreshTokenUseCase refreshTokenUseCase;
   private final LogoutUseCase logoutUseCase;
 
   public LoginController(
       LoginUseCase loginUseCase,
+      AuthSessionListUseCase authSessionListUseCase,
       RefreshTokenUseCase refreshTokenUseCase,
       LogoutUseCase logoutUseCase) {
     this.loginUseCase = loginUseCase;
+    this.authSessionListUseCase = authSessionListUseCase;
     this.refreshTokenUseCase = refreshTokenUseCase;
     this.logoutUseCase = logoutUseCase;
   }
@@ -47,6 +59,16 @@ public class LoginController {
     LoginResult result =
         loginUseCase.login(new LoginCommand(request.loginId(), request.password()));
     return LoginResponse.from(result);
+  }
+
+  @GetMapping("/sessions")
+  public AuthSessionListResponse getSessions(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @RequestParam(defaultValue = "20")
+          @Min(value = 1, message = "size must be at least 1") @Max(value = 50, message = "size must be 50 or less") int size) {
+    AuthSessionList result =
+        authSessionListUseCase.get(new AuthSessionListQuery(resolveUserId(principal), size));
+    return AuthSessionListResponse.from(result);
   }
 
   @PostMapping("/refresh")
@@ -94,6 +116,33 @@ public class LoginController {
           result.expiresAt(),
           result.refreshExpiresAt(),
           result.userId());
+    }
+  }
+
+  /** 현재 user refresh token session 목록 응답 */
+  public record AuthSessionListResponse(List<AuthSessionItemResponse> items) {
+
+    private static AuthSessionListResponse from(AuthSessionList result) {
+      return new AuthSessionListResponse(
+          result.items().stream().map(AuthSessionItemResponse::from).toList());
+    }
+  }
+
+  /** 현재 user refresh token session 목록 item 응답 */
+  public record AuthSessionItemResponse(
+      long sessionId,
+      String sessionStatus,
+      Instant expiresAt,
+      Instant lastUsedAt,
+      Instant createdAt) {
+
+    private static AuthSessionItemResponse from(AuthSessionSummary summary) {
+      return new AuthSessionItemResponse(
+          summary.sessionId(),
+          summary.sessionStatus().name(),
+          summary.expiresAt(),
+          summary.lastUsedAt(),
+          summary.createdAt());
     }
   }
 

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/AuthSessionListServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/AuthSessionListServiceTest.java
@@ -1,0 +1,44 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.model.AuthSessionListQuery;
+import com.aquilabank.domain.auth.model.AuthSessionSummary;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
+import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AuthSessionListServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-17T01:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+  @Test
+  void returnsBoundedActiveSessionListForCurrentUser() {
+    AuthSessionQueryPort authSessionQueryPort = mock(AuthSessionQueryPort.class);
+    AuthSessionSummary summary =
+        new AuthSessionSummary(
+            11L,
+            RefreshTokenSessionStatus.ACTIVE,
+            NOW.plusSeconds(30),
+            NOW.minusSeconds(5),
+            NOW.minusSeconds(10));
+    when(authSessionQueryPort.findActiveSessionsByUserId(7L, NOW, 20)).thenReturn(List.of(summary));
+
+    AuthSessionListService authSessionListService =
+        new AuthSessionListService(authSessionQueryPort, CLOCK);
+
+    var result = authSessionListService.get(new AuthSessionListQuery(7L, 20));
+
+    assertEquals(1, result.items().size());
+    assertEquals(summary, result.items().getFirst());
+    verify(authSessionQueryPort).findActiveSessionsByUserId(7L, NOW, 20);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -411,6 +411,65 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void authSessionListReturnsOnlyCurrentUsersUnexpiredActiveSessions() throws Exception {
+    TokenPairResponseView expired = loginResult("alice", "password123!", "session-list-login-001");
+    Thread.sleep(2200L);
+    TokenPairResponseView oldest = loginResult("alice", "password123!", "session-list-login-002");
+    TokenPairResponseView middle = loginResult("alice", "password123!", "session-list-login-003");
+    TokenPairResponseView newest = loginResult("alice", "password123!", "session-list-login-004");
+    TokenPairResponseView revoked = loginResult("alice", "password123!", "session-list-login-005");
+    long otherUserId = bootstrapUser("bob", "Bob", "password123!");
+    upsertMembership(otherUserId, targetAccountId, "VIEWER", "ACTIVE");
+    TokenPairResponseView otherUser =
+        loginResult("bob", "password123!", "session-list-bob-login-001");
+    logout(newest.accessToken(), revoked.refreshToken(), "session-list-logout-001")
+        .andExpect(status().isNoContent());
+
+    refreshExpectUnauthorized(expired.refreshToken(), "session-list-expired-refresh-001");
+    refresh(otherUser.refreshToken(), "session-list-bob-refresh-001");
+
+    long newestSessionId = loadRefreshTokenSessionId(newest.refreshToken());
+    long middleSessionId = loadRefreshTokenSessionId(middle.refreshToken());
+    long oldestSessionId = loadRefreshTokenSessionId(oldest.refreshToken());
+
+    mockMvc
+        .perform(
+            get("/api/v1/auth/sessions")
+                .header("Authorization", "Bearer " + newest.accessToken())
+                .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(3))
+        .andExpect(jsonPath("$.items[0].sessionId").value(newestSessionId))
+        .andExpect(jsonPath("$.items[0].sessionStatus").value("ACTIVE"))
+        .andExpect(jsonPath("$.items[1].sessionId").value(middleSessionId))
+        .andExpect(jsonPath("$.items[2].sessionId").value(oldestSessionId))
+        .andExpect(jsonPath("$.items[0].createdAt").isString());
+  }
+
+  @Test
+  void authSessionListHonorsSizeLimit() throws Exception {
+    TokenPairResponseView oldest =
+        loginResult("alice", "password123!", "session-list-size-login-001");
+    TokenPairResponseView middle =
+        loginResult("alice", "password123!", "session-list-size-login-002");
+    TokenPairResponseView newest =
+        loginResult("alice", "password123!", "session-list-size-login-003");
+    long newestSessionId = loadRefreshTokenSessionId(newest.refreshToken());
+    long middleSessionId = loadRefreshTokenSessionId(middle.refreshToken());
+    assertNotNull(loadRefreshTokenSession(oldest.refreshToken()));
+
+    mockMvc
+        .perform(
+            get("/api/v1/auth/sessions")
+                .header("Authorization", "Bearer " + newest.accessToken())
+                .param("size", "2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].sessionId").value(newestSessionId))
+        .andExpect(jsonPath("$.items[1].sessionId").value(middleSessionId));
+  }
+
+  @Test
   void expiredRefreshTokenIsRejected() throws Exception {
     TokenPairResponseView loginResult = loginResult("alice", "password123!", "refresh-expire-001");
     Thread.sleep(2200L);
@@ -468,6 +527,16 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     }
                     """
                         .formatted(loginResult.refreshToken())))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void bootstrapAccountPrincipalCannotGetAuthSessionList() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/auth/sessions")
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account"))
         .andExpect(status().isForbidden());
   }
 
@@ -1069,6 +1138,22 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .stream()
         .findFirst()
         .orElseThrow(() -> new AssertionError("refresh token session is not found"));
+  }
+
+  private long loadRefreshTokenSessionId(String refreshToken) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT id
+            FROM auth_refresh_token_session
+            WHERE token_hash = :tokenHash
+            """,
+            new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
+                .addValue("tokenHash", refreshTokenSecretPort.hash(refreshToken)),
+            (rs, rowNum) -> rs.getLong("id"))
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("refresh token session id is not found"));
   }
 
   private TokenPairResponseView readTokenPair(MvcResult result) throws Exception {


### PR DESCRIPTION
## 🔗 Related Issue
- close #90

## 🌿 Base Branch
- `main`

## 📝 Summary
- 현재 JWT user가 자신의 refresh token session 목록을 조회할 `GET /api/v1/auth/sessions`를 추가했다.
- 응답은 현재 user의 `ACTIVE` 이면서 아직 만료되지 않은 session만 bounded list로 반환한다.
- bootstrap account principal 차단, size 제한, README 계약을 함께 정리했다.

## 🛠 Changes
- auth session 목록 조회용 domain query 모델, use case, JDBC read port를 추가했다.
- `LoginController`에 session 목록 endpoint를 추가하고 `size` 기본값 20 / 최대 50 계약을 넣었다.
- unit/integration test와 README를 갱신해 정렬, 만료 제외, principal 차단 기준을 검증했다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth-session-list ./back/gradlew -p back test --tests '*AuthSessionListServiceTest' --tests 'com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest.authSessionListReturnsOnlyCurrentUsersUnexpiredActiveSessions' --tests 'com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest.authSessionListHonorsSizeLimit' --tests 'com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest.bootstrapAccountPrincipalCannotGetAuthSessionList'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- API 예시:
```http
GET /api/v1/auth/sessions?size=20
Authorization: Bearer <access-token>
```
- 응답 예시:
```json
{
  "items": [
    {
      "sessionId": 17,
      "sessionStatus": "ACTIVE",
      "expiresAt": "2026-04-30T12:00:00Z",
      "lastUsedAt": null,
      "createdAt": "2026-04-16T09:00:00Z"
    }
  ]
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: 클라이언트가 `sessionId`를 장기 식별자로 과하게 해석할 수 있다. README와 응답 범위를 현재 user의 session 정리 기준으로만 제한했다.
- 예상 리스크: 무제한 목록 조회를 열면 auth read cost가 커질 수 있어 `size` 상한 50과 인덱스 정렬을 고정했다.
- 롤백 방법: PR revert로 auth session query use case, controller endpoint, README 항목을 함께 제거한다.
- 롤백 방법: 세션 목록 계약만 후퇴해야 하면 후속 docs/API revert 커밋으로 endpoint와 문서를 같이 원복한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?