### PR TITLE
[Chore] user status 비활성화 시 refresh token session 일괄 revoke 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -287,6 +287,10 @@ public class JdbcAuthWriteRepository
             .stream()
             .findFirst()
             .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
+    // disable 직후 옛 refresh token이 재활성화와 함께 되살아나는 경로를 막으려고 ACTIVE session만 같이 정리합니다.
+    if (shouldRevokeActiveRefreshTokenSessions(beforeStatus, summary.status())) {
+      revokeActiveRefreshTokenSessions(command.userId(), now);
+    }
     insertStatusChangeAudit(
         new AuthStatusChangeAuditEntry(
             AuthStatusChangeType.USER_STATUS,
@@ -359,6 +363,26 @@ public class JdbcAuthWriteRepository
         .stream()
         .findFirst()
         .orElseThrow(() -> new AuthUserNotFoundException("user is not found"));
+  }
+
+  private boolean shouldRevokeActiveRefreshTokenSessions(
+      UserStatus beforeStatus, UserStatus afterStatus) {
+    return beforeStatus != UserStatus.DISABLED && afterStatus == UserStatus.DISABLED;
+  }
+
+  private void revokeActiveRefreshTokenSessions(long userId, Instant revokedAt) {
+    jdbcTemplate.update(
+        """
+        UPDATE auth_refresh_token_session
+        SET session_status = 'REVOKED',
+            last_used_at = :revokedAt,
+            updated_at = :revokedAt
+        WHERE user_id = :userId
+          AND session_status = 'ACTIVE'
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("revokedAt", Timestamp.from(revokedAt)));
   }
 
   private com.aquilabank.domain.auth.model.MembershipStatus loadCurrentMembershipStatusForUpdate(

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -658,6 +658,52 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void disableRevokesOnlyActiveRefreshSessionsAndOldRefreshStaysBlockedAfterReactivate()
+      throws Exception {
+    TokenPairResponseView rotatedSource =
+        loginResult("alice", "password123!", "disable-session-login-001");
+    TokenPairResponseView rotatedTarget =
+        refresh(rotatedSource.refreshToken(), "disable-session-rotate-001");
+    TokenPairResponseView parallelSession =
+        loginResult("alice", "password123!", "disable-session-login-002");
+
+    RefreshTokenSessionView rotatedBeforeDisable =
+        loadRefreshTokenSession(rotatedSource.refreshToken());
+    RefreshTokenSessionView refreshedBeforeDisable =
+        loadRefreshTokenSession(rotatedTarget.refreshToken());
+    RefreshTokenSessionView parallelBeforeDisable =
+        loadRefreshTokenSession(parallelSession.refreshToken());
+    assertEquals("ROTATED", rotatedBeforeDisable.sessionStatus());
+    assertEquals("ACTIVE", refreshedBeforeDisable.sessionStatus());
+    assertEquals("ACTIVE", parallelBeforeDisable.sessionStatus());
+
+    updateLegacyUserStatus(userId, "DISABLED", "fraud-review", "disable-session-disable-001");
+
+    RefreshTokenSessionView rotatedAfterDisable =
+        loadRefreshTokenSession(rotatedSource.refreshToken());
+    RefreshTokenSessionView refreshedAfterDisable =
+        loadRefreshTokenSession(rotatedTarget.refreshToken());
+    RefreshTokenSessionView parallelAfterDisable =
+        loadRefreshTokenSession(parallelSession.refreshToken());
+    assertEquals("ROTATED", rotatedAfterDisable.sessionStatus());
+    assertNotNull(rotatedAfterDisable.rotatedAt());
+    assertNotNull(rotatedAfterDisable.replacedBySessionId());
+    assertEquals("REVOKED", refreshedAfterDisable.sessionStatus());
+    assertNotNull(refreshedAfterDisable.lastUsedAt());
+    assertNull(refreshedAfterDisable.rotatedAt());
+    assertNull(refreshedAfterDisable.replacedBySessionId());
+    assertEquals("REVOKED", parallelAfterDisable.sessionStatus());
+    assertNotNull(parallelAfterDisable.lastUsedAt());
+    assertNull(parallelAfterDisable.rotatedAt());
+    assertNull(parallelAfterDisable.replacedBySessionId());
+
+    updateLegacyUserStatus(userId, "ACTIVE", "manual-reactivate", "disable-session-reactivate-001");
+
+    refreshExpectUnauthorized(rotatedTarget.refreshToken(), "disable-session-old-refresh-001");
+    refreshExpectUnauthorized(parallelSession.refreshToken(), "disable-session-old-refresh-002");
+  }
+
+  @Test
   void revokedMembershipBlocksExistingJwtAccess() throws Exception {
     String token = login("alice", "password123!");
     updateMembershipStatus(


### PR DESCRIPTION
## 🔗 Related Issue
- close #92

## 🌿 Base Branch
- `main`

## 📝 Summary
- user status를 `DISABLED`로 바꿀 때 같은 JDBC 트랜잭션에서 해당 user의 active refresh token session을 `REVOKED`로 전환했습니다.
- 재활성화 후에도 disable 이전 refresh token으로 재발급되지 않도록 회귀 테스트를 추가했습니다.

## 🛠 Changes
- `JdbcAuthWriteRepository.updateStatus`에서 `ACTIVE/LOCKED -> DISABLED` 전환만 감지해 active refresh session bulk revoke를 추가했습니다.
- revoke 쿼리는 `user_id`와 `session_status = 'ACTIVE'` 조건만 사용해 rotated metadata를 덮어쓰지 않게 유지했습니다.
- `LoginAndAccountAccessApiIntegrationTest`에 disable -> reactivate 후 old refresh 거절 회귀 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth-disable-revoke ./back/gradlew -p back test --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: user status를 `DISABLED`로 바꾸는 내부 admin 요청은 이제 해당 user의 모든 active refresh session을 즉시 종료합니다.
- 롤백 방법: PR revert로 bulk revoke와 회귀 테스트를 함께 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A, 기존 내부 상태 변경 경로 보강)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (N/A, 스키마/API 변경 없음)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (N/A, 운영 문서/모니터링 변경 없음)