### PR TITLE
[Feat] 계좌 상태 변경 internal API 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/account/model/AccountStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/account/model/AccountStatus.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.account.model;
+
+/** 운영에서 계좌 lifecycle을 고정된 상태값으로만 바꾸게 제한합니다. */
+public enum AccountStatus {
+  ACTIVE,
+  LOCKED,
+  CLOSED
+}

--- a/back/src/main/java/com/aquilabank/domain/account/model/AccountStatusUpdateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/account/model/AccountStatusUpdateCommand.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.account.model;
+
+/** 내부 운영 경로가 계좌 상태를 갱신할 때 필요한 최소 입력입니다. */
+public record AccountStatusUpdateCommand(long accountId, AccountStatus status) {
+
+  public AccountStatusUpdateCommand {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/port/AccountStatusUpdatePort.java
+++ b/back/src/main/java/com/aquilabank/domain/account/port/AccountStatusUpdatePort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.account.port;
+
+import com.aquilabank.domain.account.model.AccountStatusUpdateCommand;
+import com.aquilabank.domain.account.model.AccountSummary;
+
+/** 계좌 상태 exact update를 저장소 계층으로 위임합니다. */
+public interface AccountStatusUpdatePort {
+
+  AccountSummary updateStatus(AccountStatusUpdateCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountStatusUpdateService.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountStatusUpdateService.java
@@ -1,0 +1,23 @@
+package com.aquilabank.domain.account.usecase;
+
+import com.aquilabank.domain.account.model.AccountStatusUpdateCommand;
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.port.AccountStatusUpdatePort;
+
+/** 계좌 상태 변경 명령을 저장소 port로 위임하는 기본 use case 구현입니다. */
+public final class AccountStatusUpdateService implements AccountStatusUpdateUseCase {
+
+  private final AccountStatusUpdatePort accountStatusUpdatePort;
+
+  public AccountStatusUpdateService(AccountStatusUpdatePort accountStatusUpdatePort) {
+    this.accountStatusUpdatePort = accountStatusUpdatePort;
+  }
+
+  @Override
+  public AccountSummary update(AccountStatusUpdateCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+    return accountStatusUpdatePort.updateStatus(command);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountStatusUpdateUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountStatusUpdateUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.account.usecase;
+
+import com.aquilabank.domain.account.model.AccountStatusUpdateCommand;
+import com.aquilabank.domain.account.model.AccountSummary;
+
+/** 내부 운영 계좌 상태 변경 진입점입니다. */
+public interface AccountStatusUpdateUseCase {
+
+  AccountSummary update(AccountStatusUpdateCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AccountAdminConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AccountAdminConfiguration.java
@@ -1,0 +1,18 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.account.port.AccountStatusUpdatePort;
+import com.aquilabank.domain.account.usecase.AccountStatusUpdateService;
+import com.aquilabank.domain.account.usecase.AccountStatusUpdateUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** account internal admin write 경로와 JDBC adapter를 조립합니다. */
+@Configuration
+public class AccountAdminConfiguration {
+
+  @Bean
+  AccountStatusUpdateUseCase accountStatusUpdateUseCase(
+      AccountStatusUpdatePort accountStatusUpdatePort) {
+    return new AccountStatusUpdateService(accountStatusUpdatePort);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountStatusUpdateRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountStatusUpdateRepository.java
@@ -1,0 +1,94 @@
+package com.aquilabank.global.persistence.account;
+
+import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
+import com.aquilabank.domain.account.model.AccountStatusUpdateCommand;
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.port.AccountStatusUpdatePort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 계좌 상태 변경과 응답 요약 조회를 한 adapter로 묶어 exact update 비용을 고정합니다. */
+@Repository
+public class JdbcAccountStatusUpdateRepository implements AccountStatusUpdatePort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcAccountStatusUpdateRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional
+  public AccountSummary updateStatus(AccountStatusUpdateCommand command) {
+    Instant updatedAt = Instant.now();
+    return jdbcTemplate
+        .query(
+            """
+            WITH updated_account AS (
+                UPDATE bank_account
+                SET account_status = :accountStatus,
+                    updated_at = :updatedAt
+                WHERE id = :accountId
+                RETURNING id,
+                          account_number,
+                          display_name,
+                          account_status,
+                          currency_code,
+                          created_at
+            )
+            SELECT updated_account.id,
+                   updated_account.account_number,
+                   updated_account.display_name,
+                   updated_account.account_status,
+                   updated_account.currency_code AS account_currency_code,
+                   snapshot.available_balance_minor,
+                   snapshot.pending_balance_minor,
+                   snapshot.currency_code AS snapshot_currency_code,
+                   updated_account.created_at,
+                   snapshot.updated_at
+            FROM updated_account
+            JOIN account_balance_snapshot snapshot
+              ON snapshot.account_id = updated_account.id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", command.accountId())
+                .addValue("accountStatus", command.status().name())
+                .addValue("updatedAt", Timestamp.from(updatedAt)),
+            (rs, rowNum) -> mapAccountSummary(rs))
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new AccountSummaryNotFoundException("account summary is not found"));
+  }
+
+  private AccountSummary mapAccountSummary(ResultSet rs) throws SQLException {
+    String accountCurrencyCode = rs.getString("account_currency_code");
+    String snapshotCurrencyCode = rs.getString("snapshot_currency_code");
+    if (!accountCurrencyCode.equals(snapshotCurrencyCode)) {
+      throw new IllegalStateException("account snapshot currency does not match");
+    }
+
+    return new AccountSummary(
+        rs.getLong("id"),
+        rs.getString("account_number"),
+        rs.getString("display_name"),
+        rs.getString("account_status"),
+        accountCurrencyCode,
+        rs.getLong("available_balance_minor"),
+        rs.getLong("pending_balance_minor"),
+        toInstant(rs.getTimestamp("created_at")),
+        toInstant(rs.getTimestamp("updated_at")));
+  }
+
+  private Instant toInstant(Timestamp timestamp) {
+    if (timestamp == null) {
+      throw new IllegalStateException("timestamp must not be null");
+    }
+    return timestamp.toInstant();
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/InternalServiceScope.java
+++ b/back/src/main/java/com/aquilabank/global/security/InternalServiceScope.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.security;
 /** 내부 운영 API scope를 고정값으로 관리해 endpoint별 오남용을 줄입니다. */
 public enum InternalServiceScope {
   ACCOUNT_BOOTSTRAP("internal:account-bootstrap"),
+  ACCOUNT_ADMIN("internal:account-admin"),
   AUTH_BOOTSTRAP("internal:auth-bootstrap"),
   AUTH_ADMIN("internal:auth-admin"),
   OUTBOX_OPS("internal:outbox-ops");

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -72,6 +72,8 @@ public class SecurityConfiguration {
                     // 내부 운영 API는 public JWT resolver에서 제외하고 전용 service JWT로만 검증합니다.
                     .requestMatchers("/internal/api/v1/accounts/bootstrap")
                     .permitAll()
+                    .requestMatchers("/internal/api/v1/accounts/*/status")
+                    .permitAll()
                     .requestMatchers("/internal/api/v1/outbox/**")
                     .permitAll()
                     .requestMatchers("/internal/api/v1/auth/**")

--- a/back/src/main/java/com/aquilabank/global/web/account/InternalAccountAdminController.java
+++ b/back/src/main/java/com/aquilabank/global/web/account/InternalAccountAdminController.java
@@ -1,0 +1,79 @@
+package com.aquilabank.global.web.account;
+
+import com.aquilabank.domain.account.model.AccountStatus;
+import com.aquilabank.domain.account.model.AccountStatusUpdateCommand;
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.usecase.AccountStatusUpdateUseCase;
+import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
+import com.aquilabank.global.security.InternalServiceScope;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 내부 운영 도구가 bootstrap 이후 계좌 상태를 exact update 하는 전용 adapter입니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/accounts")
+@ConditionalOnProperty(name = "security.account-bootstrap-api.enabled", havingValue = "true")
+public class InternalAccountAdminController {
+
+  private final AccountStatusUpdateUseCase accountStatusUpdateUseCase;
+  private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
+
+  public InternalAccountAdminController(
+      AccountStatusUpdateUseCase accountStatusUpdateUseCase,
+      InternalServiceRequestAuthorizer internalServiceRequestAuthorizer) {
+    this.accountStatusUpdateUseCase = accountStatusUpdateUseCase;
+    this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
+  }
+
+  @PutMapping("/{accountId}/status")
+  public AccountResponse updateStatus(
+      HttpServletRequest httpServletRequest,
+      @PathVariable @Positive(message = "accountId must be positive") long accountId,
+      @Valid @RequestBody AccountStatusRequest request) {
+    internalServiceRequestAuthorizer.requireScope(
+        httpServletRequest, InternalServiceScope.ACCOUNT_ADMIN);
+    return AccountResponse.from(
+        accountStatusUpdateUseCase.update(
+            new AccountStatusUpdateCommand(accountId, request.accountStatus())));
+  }
+
+  /** 내부 계좌 상태 변경 요청 body */
+  public record AccountStatusRequest(
+      @NotNull(message = "accountStatus is required") AccountStatus accountStatus) {}
+
+  /** 내부 계좌 상태 변경 응답 */
+  public record AccountResponse(
+      long accountId,
+      String accountNumber,
+      String displayName,
+      String accountStatus,
+      String currencyCode,
+      long availableBalanceMinor,
+      long pendingBalanceMinor,
+      java.time.Instant createdAt,
+      java.time.Instant balanceUpdatedAt) {
+
+    static AccountResponse from(AccountSummary summary) {
+      return new AccountResponse(
+          summary.accountId(),
+          summary.accountNumber(),
+          summary.displayName(),
+          summary.accountStatus(),
+          summary.currencyCode(),
+          summary.availableBalanceMinor(),
+          summary.pendingBalanceMinor(),
+          summary.createdAt(),
+          summary.balanceUpdatedAt());
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
@@ -36,6 +36,7 @@ public class WebMvcSecurityConfiguration implements WebMvcConfigurer {
         .addInterceptor(internalServiceTokenAuthenticationInterceptor)
         .addPathPatterns(
             "/internal/api/v1/accounts/bootstrap",
+            "/internal/api/v1/accounts/*/status",
             "/internal/api/v1/auth/**",
             "/internal/api/v1/outbox/**");
   }

--- a/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminApiIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.aquilabank.global.web.account;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.account.model.AccountBootstrapCommand;
+import com.aquilabank.domain.account.model.AccountBootstrapResult;
+import com.aquilabank.domain.account.usecase.AccountBootstrapUseCase;
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenIssuer;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class InternalAccountAdminApiIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private AccountBootstrapUseCase accountBootstrapUseCase;
+
+  @Autowired private InternalServiceTokenIssuer internalServiceTokenIssuer;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void updatesAccountStatusAndPersistsUpdatedRow() throws Exception {
+    AccountBootstrapResult account =
+        accountBootstrapUseCase.bootstrap(
+            new AccountBootstrapCommand("main account", "KRW", 10000L));
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/accounts/%d/status".formatted(account.accountId()))
+                .header(
+                    "Authorization",
+                    internalServiceAuthorization(
+                        "account-admin", InternalServiceScope.ACCOUNT_ADMIN))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "accountStatus": "CLOSED"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountId").value(account.accountId()))
+        .andExpect(jsonPath("$.accountStatus").value("CLOSED"))
+        .andExpect(jsonPath("$.availableBalanceMinor").value(10000L));
+
+    assertEquals("CLOSED", loadAccountStatus(account.accountId()));
+  }
+
+  @Test
+  void returnsNotFoundWhenAccountDoesNotExist() throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/accounts/999/status")
+                .header(
+                    "Authorization",
+                    internalServiceAuthorization(
+                        "account-admin", InternalServiceScope.ACCOUNT_ADMIN))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "accountStatus": "LOCKED"
+                    }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("account summary is not found"));
+  }
+
+  private String internalServiceAuthorization(String subject, InternalServiceScope scope) {
+    return "Bearer " + internalServiceTokenIssuer.issue(subject, java.util.Set.of(scope));
+  }
+
+  private String loadAccountStatus(long accountId) {
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT account_status
+        FROM bank_account
+        WHERE id = :accountId
+        """,
+        new MapSqlParameterSource().addValue("accountId", accountId),
+        String.class);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminControllerTest.java
@@ -1,0 +1,134 @@
+package com.aquilabank.global.web.account;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.usecase.AccountStatusUpdateUseCase;
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenTestSupport;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class InternalAccountAdminControllerTest {
+
+  private AccountStatusUpdateUseCase accountStatusUpdateUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    accountStatusUpdateUseCase = mock(AccountStatusUpdateUseCase.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new InternalAccountAdminController(
+                    accountStatusUpdateUseCase, InternalServiceTokenTestSupport.authorizer()))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void updatesAccountStatusWithInternalAdminScope() throws Exception {
+    when(accountStatusUpdateUseCase.update(
+            argThat(
+                command ->
+                    command.accountId() == 101L && command.status().name().equals("LOCKED"))))
+        .thenReturn(
+            new AccountSummary(
+                101L,
+                "10000000000001",
+                "main account",
+                "LOCKED",
+                "KRW",
+                12_000L,
+                0L,
+                Instant.parse("2026-04-18T03:00:00Z"),
+                Instant.parse("2026-04-18T03:10:00Z")));
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/accounts/101/status")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        "account-admin-test", InternalServiceScope.ACCOUNT_ADMIN))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "accountStatus": "LOCKED"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountId").value(101))
+        .andExpect(jsonPath("$.accountStatus").value("LOCKED"))
+        .andExpect(jsonPath("$.accountNumber").value("10000000000001"));
+
+    verify(accountStatusUpdateUseCase)
+        .update(
+            argThat(
+                command ->
+                    command.accountId() == 101L && command.status().name().equals("LOCKED")));
+  }
+
+  @Test
+  void rejectsMissingOrWrongInternalServiceToken() throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/accounts/101/status")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "accountStatus": "LOCKED"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/accounts/101/status")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        "account-bootstrap-test", InternalServiceScope.ACCOUNT_BOOTSTRAP))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "accountStatus": "LOCKED"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+
+  @Test
+  void rejectsInvalidBody() throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/accounts/101/status")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        "account-admin-test", InternalServiceScope.ACCOUNT_ADMIN))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("accountStatus is required"));
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #94

## 🌿 Base Branch
- `main`

## 📝 Summary
- bootstrap 이후 운영 도구가 `bank_account.account_status`를 `ACTIVE`/`LOCKED`/`CLOSED`로 갱신할 수 있는 internal API를 추가했습니다.
- 계좌 생성 권한과 운영 상태 변경 권한을 분리하려고 `ACCOUNT_ADMIN` internal scope를 새로 도입했습니다.

## 🛠 Changes
- `AccountStatus`, `AccountStatusUpdateCommand`, `AccountStatusUpdateUseCase/Port`와 JDBC `UPDATE ... RETURNING` adapter를 추가했습니다.
- `PUT /internal/api/v1/accounts/{accountId}/status` controller를 추가하고 `ACCOUNT_ADMIN` scope로 보호했습니다.
- controller/security 테스트와 Postgres 기반 integration 테스트를 추가해 상태 변경 결과와 `404` 경로를 검증했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-account-status ./back/gradlew -p back test --tests '*InternalAccountAdmin*'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 이번 PR은 account status 저장/조회 경계만 추가하므로 `LOCKED`/`CLOSED`의 transfer/access 정책 반영은 후속 작업으로 남아 있습니다.
- 롤백 방법: PR revert로 `ACCOUNT_ADMIN` scope, internal API, status update adapter를 함께 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A, 기존 internal API 확장)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (내부 API 추가, 스키마 변경 없음)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (N/A, 운영 문서/모니터링 변경 없음)