### PR TITLE
[Chore] refresh token session 만료 정리 batch 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -255,11 +255,15 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
 - 기본값:
   - `SECURITY_JWT_ACCESS_TOKEN_TTL_SECONDS=900`
   - `SECURITY_JWT_REFRESH_TOKEN_TTL_SECONDS=1209600`
+  - `AUTH_REFRESH_TOKEN_SESSION_CLEANUP_ENABLED=true`
+  - `AUTH_REFRESH_TOKEN_SESSION_CLEANUP_RETENTION_DAYS=30`
+  - `AUTH_REFRESH_TOKEN_SESSION_CLEANUP_BATCH_SIZE=500`
 - 저장 기준:
   - raw refresh token은 응답으로만 한 번 내려가고 DB에는 `SHA-256 token_hash`만 저장
   - 저장 테이블은 `auth_refresh_token_session`
   - 성공 refresh 시 기존 row는 `ROTATED`, 새 row는 `ACTIVE`
   - 성공 logout 시 현재 사용자 `ACTIVE` session은 `REVOKED`
+  - cleanup batch는 `ACTIVE`는 `expires_at`, `ROTATED|REVOKED`는 `updated_at` 기준으로 retention cutoff 밖 row만 작은 batch로 삭제
 - 세션 목록 조회 기준:
   - `GET /api/v1/auth/sessions`
   - 현재 JWT user만 호출 가능하고 bootstrap account principal은 `403`

--- a/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionCleanupPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionCleanupPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.port;
+
+import java.time.Instant;
+
+/** retention cutoff 이전 refresh token session 정리를 persistence adapter로 위임합니다. */
+public interface RefreshTokenSessionCleanupPort {
+
+  int deleteExpiredSessions(Instant cutoff, int batchSize);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenSessionCleanupService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenSessionCleanupService.java
@@ -1,0 +1,40 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.port.RefreshTokenSessionCleanupPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/** auth session retention 기준과 batch 크기를 domain에서 고정해 scheduler/adapter drift를 막습니다. */
+public final class RefreshTokenSessionCleanupService implements RefreshTokenSessionCleanupUseCase {
+
+  private final RefreshTokenSessionCleanupPort refreshTokenSessionCleanupPort;
+  private final Clock clock;
+  private final Duration retention;
+  private final int batchSize;
+
+  public RefreshTokenSessionCleanupService(
+      RefreshTokenSessionCleanupPort refreshTokenSessionCleanupPort,
+      Clock clock,
+      Duration retention,
+      int batchSize) {
+    this.refreshTokenSessionCleanupPort =
+        Objects.requireNonNull(refreshTokenSessionCleanupPort, "refreshTokenSessionCleanupPort");
+    this.clock = Objects.requireNonNull(clock, "clock");
+    this.retention = Objects.requireNonNull(retention, "retention");
+    if (retention.isZero() || retention.isNegative()) {
+      throw new IllegalArgumentException("retention must be positive");
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("batchSize must be positive");
+    }
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public int cleanupExpiredSessions() {
+    Instant cutoff = clock.instant().minus(retention);
+    return refreshTokenSessionCleanupPort.deleteExpiredSessions(cutoff, batchSize);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenSessionCleanupUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenSessionCleanupUseCase.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.auth.usecase;
+
+/** retention cutoff 밖의 refresh token session cleanup batch 진입점 */
+public interface RefreshTokenSessionCleanupUseCase {
+
+  int cleanupExpiredSessions();
+}

--- a/back/src/main/java/com/aquilabank/global/auth/RefreshTokenSessionCleanupPoller.java
+++ b/back/src/main/java/com/aquilabank/global/auth/RefreshTokenSessionCleanupPoller.java
@@ -1,0 +1,33 @@
+package com.aquilabank.global.auth;
+
+import com.aquilabank.domain.auth.usecase.RefreshTokenSessionCleanupUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** 오래된 auth refresh token session row를 작은 batch로만 정리해 저장 비용 누적을 제한합니다. */
+@Component
+@ConditionalOnProperty(name = "auth.refresh-token-session.cleanup.enabled", havingValue = "true")
+public class RefreshTokenSessionCleanupPoller {
+
+  private static final Logger log = LoggerFactory.getLogger(RefreshTokenSessionCleanupPoller.class);
+
+  private final RefreshTokenSessionCleanupUseCase refreshTokenSessionCleanupUseCase;
+
+  public RefreshTokenSessionCleanupPoller(
+      RefreshTokenSessionCleanupUseCase refreshTokenSessionCleanupUseCase) {
+    this.refreshTokenSessionCleanupUseCase = refreshTokenSessionCleanupUseCase;
+  }
+
+  @Scheduled(
+      fixedDelayString = "${auth.refresh-token-session.cleanup.fixed-delay-ms:300000}",
+      initialDelayString = "${auth.refresh-token-session.cleanup.initial-delay-ms:60000}")
+  void cleanupExpiredSessions() {
+    int deleted = refreshTokenSessionCleanupUseCase.cleanupExpiredSessions();
+    if (deleted > 0) {
+      log.info("deleted {} expired auth refresh token session row(s)", deleted);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/config/RefreshTokenSessionCleanupConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/RefreshTokenSessionCleanupConfiguration.java
@@ -1,0 +1,27 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.auth.port.RefreshTokenSessionCleanupPort;
+import com.aquilabank.domain.auth.usecase.RefreshTokenSessionCleanupService;
+import com.aquilabank.domain.auth.usecase.RefreshTokenSessionCleanupUseCase;
+import java.time.Clock;
+import java.time.Duration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** auth refresh token session retention cleanup use case와 runtime 설정을 조립합니다. */
+@Configuration
+@EnableConfigurationProperties(RefreshTokenSessionCleanupProperties.class)
+public class RefreshTokenSessionCleanupConfiguration {
+
+  @Bean
+  RefreshTokenSessionCleanupUseCase refreshTokenSessionCleanupUseCase(
+      RefreshTokenSessionCleanupPort refreshTokenSessionCleanupPort,
+      RefreshTokenSessionCleanupProperties refreshTokenSessionCleanupProperties) {
+    return new RefreshTokenSessionCleanupService(
+        refreshTokenSessionCleanupPort,
+        Clock.systemUTC(),
+        Duration.ofDays(refreshTokenSessionCleanupProperties.retentionDays()),
+        refreshTokenSessionCleanupProperties.batchSize());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/config/RefreshTokenSessionCleanupProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/RefreshTokenSessionCleanupProperties.java
@@ -1,0 +1,28 @@
+package com.aquilabank.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** auth refresh token session cleanup 런타임 기준을 auth token 설정과 분리합니다. */
+@ConfigurationProperties(prefix = "auth.refresh-token-session.cleanup")
+public record RefreshTokenSessionCleanupProperties(
+    boolean enabled, long fixedDelayMs, long initialDelayMs, int batchSize, long retentionDays) {
+
+  public RefreshTokenSessionCleanupProperties {
+    if (fixedDelayMs <= 0) {
+      throw new IllegalArgumentException(
+          "auth.refresh-token-session.cleanup.fixed-delay-ms must be positive");
+    }
+    if (initialDelayMs < 0) {
+      throw new IllegalArgumentException(
+          "auth.refresh-token-session.cleanup.initial-delay-ms must not be negative");
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException(
+          "auth.refresh-token-session.cleanup.batch-size must be positive");
+    }
+    if (retentionDays <= 0) {
+      throw new IllegalArgumentException(
+          "auth.refresh-token-session.cleanup.retention-days must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -21,6 +21,7 @@ import com.aquilabank.domain.auth.model.UserBootstrapWriteCommand;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionCleanupPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipStatusUpdatePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
@@ -41,6 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcAuthWriteRepository
     implements UserBootstrapPort,
         LoginAttemptUpdatePort,
+        RefreshTokenSessionCleanupPort,
         RefreshTokenSessionWritePort,
         UserAccountMembershipUpsertPort,
         UserStatusUpdatePort,
@@ -220,6 +222,58 @@ public class JdbcAuthWriteRepository
     if (updated != 1) {
       throw new IllegalStateException("refresh token session is not active");
     }
+  }
+
+  @Override
+  @Transactional
+  public int deleteExpiredSessions(Instant cutoff, int batchSize) {
+    // ACTIVE 만료와 비활성 세션 retention 기준이 달라 상태별 index cursor를 따로 태웁니다.
+    Integer deleted =
+        jdbcTemplate.queryForObject(
+            """
+            WITH candidates AS (
+                SELECT id, cleanup_at
+                FROM (
+                    SELECT id, expires_at AS cleanup_at
+                    FROM auth_refresh_token_session
+                    WHERE session_status = 'ACTIVE'
+                      AND expires_at < :cutoff
+                    ORDER BY expires_at ASC, id ASC
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT :batchSize
+                ) active_candidates
+                UNION ALL
+                SELECT id, cleanup_at
+                FROM (
+                    SELECT id, updated_at AS cleanup_at
+                    FROM auth_refresh_token_session
+                    WHERE session_status IN ('ROTATED', 'REVOKED')
+                      AND updated_at < :cutoff
+                    ORDER BY updated_at ASC, id ASC
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT :batchSize
+                ) inactive_candidates
+            ),
+            limited AS (
+                SELECT id
+                FROM candidates
+                ORDER BY cleanup_at ASC, id ASC
+                LIMIT :batchSize
+            ),
+            deleted AS (
+                DELETE FROM auth_refresh_token_session s
+                USING limited l
+                WHERE s.id = l.id
+                RETURNING s.id
+            )
+            SELECT COUNT(*)
+            FROM deleted
+            """,
+            new MapSqlParameterSource()
+                .addValue("cutoff", Timestamp.from(cutoff))
+                .addValue("batchSize", batchSize),
+            Integer.class);
+    return deleted == null ? 0 : deleted;
   }
 
   @Override

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -105,6 +105,15 @@ outbox:
       max-failed-count: ${OUTBOX_OPS_HEALTH_MAX_FAILED_COUNT:10}
       max-stale-sending-count: ${OUTBOX_OPS_HEALTH_MAX_STALE_SENDING_COUNT:0}
 
+auth:
+  refresh-token-session:
+    cleanup:
+      enabled: ${AUTH_REFRESH_TOKEN_SESSION_CLEANUP_ENABLED:true}
+      fixed-delay-ms: ${AUTH_REFRESH_TOKEN_SESSION_CLEANUP_FIXED_DELAY_MS:300000}
+      initial-delay-ms: ${AUTH_REFRESH_TOKEN_SESSION_CLEANUP_INITIAL_DELAY_MS:60000}
+      batch-size: ${AUTH_REFRESH_TOKEN_SESSION_CLEANUP_BATCH_SIZE:500}
+      retention-days: ${AUTH_REFRESH_TOKEN_SESSION_CLEANUP_RETENTION_DAYS:30}
+
 notification:
   sse:
     connection-timeout-ms: ${NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS:1800000}

--- a/back/src/main/resources/db/migration/V15__add_auth_refresh_token_session_cleanup.sql
+++ b/back/src/main/resources/db/migration/V15__add_auth_refresh_token_session_cleanup.sql
@@ -1,0 +1,8 @@
+-- auth refresh token cleanup 은 ACTIVE 만료 경로와 비활성 세션 보존기간 경로를 분리해 partial index 로 작은 batch delete 를 유지합니다.
+CREATE INDEX idx_auth_refresh_token_session_active_cleanup
+    ON auth_refresh_token_session (expires_at ASC, id ASC)
+    WHERE session_status = 'ACTIVE';
+
+CREATE INDEX idx_auth_refresh_token_session_inactive_cleanup
+    ON auth_refresh_token_session (updated_at ASC, id ASC)
+    WHERE session_status IN ('ROTATED', 'REVOKED');

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenSessionCleanupServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenSessionCleanupServiceTest.java
@@ -1,0 +1,37 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.port.RefreshTokenSessionCleanupPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenSessionCleanupServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-17T00:00:00Z");
+
+  private final RefreshTokenSessionCleanupPort refreshTokenSessionCleanupPort =
+      mock(RefreshTokenSessionCleanupPort.class);
+
+  @Test
+  void deletesExpiredSessionsUsingConfiguredRetentionAndBatchSize() {
+    Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    when(refreshTokenSessionCleanupPort.deleteExpiredSessions(NOW.minus(Duration.ofDays(30)), 500))
+        .thenReturn(3);
+    RefreshTokenSessionCleanupService service =
+        new RefreshTokenSessionCleanupService(
+            refreshTokenSessionCleanupPort, clock, Duration.ofDays(30), 500);
+
+    int deleted = service.cleanupExpiredSessions();
+
+    assertThat(deleted).isEqualTo(3);
+    verify(refreshTokenSessionCleanupPort)
+        .deleteExpiredSessions(NOW.minus(Duration.ofDays(30)), 500);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/RefreshTokenSessionCleanupConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/RefreshTokenSessionCleanupConfigurationTest.java
@@ -1,0 +1,63 @@
+package com.aquilabank.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.aquilabank.domain.auth.port.RefreshTokenSessionCleanupPort;
+import com.aquilabank.domain.auth.usecase.RefreshTokenSessionCleanupUseCase;
+import com.aquilabank.global.auth.RefreshTokenSessionCleanupPoller;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class RefreshTokenSessionCleanupConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(
+              RefreshTokenSessionCleanupConfiguration.class, RefreshTokenSessionCleanupPoller.class)
+          .withBean(
+              RefreshTokenSessionCleanupPort.class,
+              () -> mock(RefreshTokenSessionCleanupPort.class))
+          .withPropertyValues(
+              "auth.refresh-token-session.cleanup.fixed-delay-ms=300000",
+              "auth.refresh-token-session.cleanup.initial-delay-ms=60000",
+              "auth.refresh-token-session.cleanup.batch-size=500",
+              "auth.refresh-token-session.cleanup.retention-days=30");
+
+  @Test
+  void createsCleanupPollerWhenCleanupIsEnabled() {
+    contextRunner
+        .withPropertyValues("auth.refresh-token-session.cleanup.enabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(RefreshTokenSessionCleanupUseCase.class);
+              assertThat(context).hasSingleBean(RefreshTokenSessionCleanupPoller.class);
+            });
+  }
+
+  @Test
+  void doesNotCreateCleanupPollerWhenCleanupIsDisabled() {
+    contextRunner
+        .withPropertyValues("auth.refresh-token-session.cleanup.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(RefreshTokenSessionCleanupUseCase.class);
+              assertThat(context).doesNotHaveBean(RefreshTokenSessionCleanupPoller.class);
+            });
+  }
+
+  @Test
+  void rejectsNonPositiveRetentionDays() {
+    contextRunner
+        .withPropertyValues(
+            "auth.refresh-token-session.cleanup.enabled=true",
+            "auth.refresh-token-session.cleanup.retention-days=0")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .hasRootCauseMessage(
+                      "auth.refresh-token-session.cleanup.retention-days must be positive");
+            });
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepositoryIntegrationTest.java
@@ -1,0 +1,188 @@
+package com.aquilabank.global.persistence.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcAuthWriteRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcAuthWriteRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void deletesExpiredAndInactiveSessionsInBatchesUsingStatusSpecificCutoff() {
+    long[] userId = new long[1];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    Instant cutoff = base.minusSeconds(30L * 24 * 60 * 60);
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("cleanup-user");
+          insertSession(
+              userId[0],
+              "active-expired-old",
+              "ACTIVE",
+              cutoff.minusSeconds(20),
+              null,
+              null,
+              cutoff.minusSeconds(120),
+              cutoff.minusSeconds(120));
+          insertSession(
+              userId[0],
+              "rotated-old",
+              "ROTATED",
+              cutoff.plusSeconds(600),
+              cutoff.minusSeconds(10),
+              cutoff.minusSeconds(10),
+              cutoff.minusSeconds(50),
+              cutoff.minusSeconds(10));
+          insertSession(
+              userId[0],
+              "revoked-old",
+              "REVOKED",
+              cutoff.plusSeconds(1200),
+              cutoff.minusSeconds(5),
+              null,
+              cutoff.minusSeconds(40),
+              cutoff.minusSeconds(5));
+          insertSession(
+              userId[0],
+              "active-fresh",
+              "ACTIVE",
+              cutoff.plusSeconds(30),
+              null,
+              null,
+              cutoff.minusSeconds(30),
+              cutoff.minusSeconds(30));
+          insertSession(
+              userId[0],
+              "rotated-recent",
+              "ROTATED",
+              cutoff.minusSeconds(60),
+              cutoff.plusSeconds(20),
+              cutoff.plusSeconds(20),
+              cutoff.minusSeconds(20),
+              cutoff.plusSeconds(20));
+        });
+
+    int firstDeleted = repository.deleteExpiredSessions(cutoff, 2);
+
+    assertThat(firstDeleted).isEqualTo(2);
+    assertThat(findTokenHashes())
+        .containsExactlyInAnyOrder("revoked-old", "active-fresh", "rotated-recent");
+
+    int secondDeleted = repository.deleteExpiredSessions(cutoff, 10);
+
+    assertThat(secondDeleted).isEqualTo(1);
+    assertThat(findTokenHashes()).containsExactlyInAnyOrder("active-fresh", "rotated-recent");
+  }
+
+  private long insertUser(String loginId) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private void insertSession(
+      long userId,
+      String tokenHash,
+      String sessionStatus,
+      Instant expiresAt,
+      Instant lastUsedAt,
+      Instant rotatedAt,
+      Instant createdAt,
+      Instant updatedAt) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO auth_refresh_token_session (
+            user_id,
+            token_hash,
+            session_status,
+            expires_at,
+            last_used_at,
+            rotated_at,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :tokenHash,
+            :sessionStatus,
+            :expiresAt,
+            :lastUsedAt,
+            :rotatedAt,
+            :createdAt,
+            :updatedAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("tokenHash", tokenHash)
+            .addValue("sessionStatus", sessionStatus)
+            .addValue("expiresAt", Timestamp.from(expiresAt))
+            .addValue("lastUsedAt", toTimestamp(lastUsedAt))
+            .addValue("rotatedAt", toTimestamp(rotatedAt))
+            .addValue("createdAt", Timestamp.from(createdAt))
+            .addValue("updatedAt", Timestamp.from(updatedAt)));
+  }
+
+  private List<String> findTokenHashes() {
+    return jdbcTemplate.queryForList(
+        """
+        SELECT token_hash
+        FROM auth_refresh_token_session
+        ORDER BY token_hash ASC
+        """,
+        new MapSqlParameterSource(),
+        String.class);
+  }
+
+  private Timestamp toTimestamp(Instant value) {
+    return value == null ? null : Timestamp.from(value);
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #96

## 🌿 Base Branch
- `main`

## 📝 Summary
- `auth_refresh_token_session` retention cleanup batch를 추가했습니다.
- `ACTIVE` 세션은 `expires_at`, `ROTATED|REVOKED` 세션은 `updated_at` 기준으로만 정리해 활성 세션 삭제를 피합니다.
- partial index, scheduler, 테스트, README까지 같이 반영했습니다.

## 🛠 Changes
- auth session cleanup port/use case, runtime properties, migration, 기본 설정을 추가했습니다.
- `JdbcAuthWriteRepository`에 `SKIP LOCKED` 기반 batch delete와 auth cleanup poller/config wiring을 추가했습니다.
- cleanup service/config/repository 테스트와 README 운영 설정을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth-session-retention ./back/gradlew -p back test --tests '*RefreshTokenSessionCleanup*' --tests '*JdbcAuthWriteRepositoryIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-auth-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: retention 기간이 너무 짧으면 회전/폐기 세션 운영 추적 기간이 예상보다 줄어들 수 있습니다. 기본값은 30일입니다.
- 롤백 방법: PR revert 후 `AUTH_REFRESH_TOKEN_SESSION_CLEANUP_ENABLED=false`로 scheduler를 즉시 비활성화할 수 있습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?