### PR TITLE
[Perf] transaction read model partition/archive 적합성 검증

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -71,6 +71,36 @@ tools/test/with-resource-lock.sh back-transaction-baseline \
   tools/test/run-transaction-query-baseline.sh
 ```
 
+## Transaction Read Model Partition / Archive Fit
+
+partition/archive 는 `GET /api/v1/transactions` read path를 실제로 줄여줄 때만 고려합니다.
+
+- committed 검증 fixture:
+  - recent window `8만 건`
+  - history window `12개월 x 1.2만 건`
+  - 같은 hot account 에 누적
+- committed 검증 query:
+  - 최근 31일 첫 page
+  - 1년 전 31일 첫 page
+  - 1년 전 31일 `status` 필터 page
+- 현재 결론:
+  - 현재 API는 `accountId + from/to(최대 31일) + keyset cursor`로 강하게 bounded 되어 있습니다.
+  - committed partition-fit 테스트에서 최근 창과 과거 창 모두 `idx_transaction_read_model_account_cursor` 또는 `idx_transaction_read_model_account_status_cursor`를 유지하고 `Seq Scan`/`Sort`가 나오지 않습니다.
+  - 따라서 현재 계약 기준에서는 partition 이 read latency의 첫 레버가 아닙니다.
+  - archive 역시 현재 read latency 최적화 목적만으로는 근거가 부족하고, 보존/백업/autovacuum 비용이 커질 때 재검토하는 편이 맞습니다.
+- 재검토 트리거:
+  - 31일 초과 조회 또는 account scope 없는 조회가 필요해질 때
+  - 최근 31일 hot account 조회가 baseline p95/timeout 기준을 깨기 시작할 때
+  - `transaction_read_model`의 historical row 때문에 autovacuum lag, index bloat, backup 시간이 운영 병목이 될 때
+  - cold history와 hot path의 보존/SLA가 달라 separate archive tier가 필요해질 때
+
+재현 명령:
+
+```bash
+tools/test/with-resource-lock.sh back-transaction-partition-fit \
+  tools/test/run-transaction-read-model-partition-fit.sh
+```
+
 ## Run
 
 ```bash

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryPartitionFitIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepositoryPartitionFitIntegrationTest.java
@@ -1,0 +1,150 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.aquilabank.support.TransactionExplainPlan;
+import com.aquilabank.support.TransactionReadModelPartitionFitFixture;
+import com.aquilabank.support.TransactionReadModelPartitionFitFixture.PartitionFitWindow;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcTransactionReadRepositoryPartitionFitIntegrationTest
+    extends PostgresContainerTestSupport {
+
+  private static final Object SEED_LOCK = new Object();
+
+  private static PartitionFitWindow sharedWindow;
+
+  private final TransactionReadModelPartitionFitFixture fixture =
+      new TransactionReadModelPartitionFitFixture();
+
+  @Autowired private JdbcTransactionReadRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  private PartitionFitWindow partitionFitWindow;
+
+  @BeforeEach
+  void setUpDatabase() {
+    if (sharedWindow != null) {
+      partitionFitWindow = sharedWindow;
+      return;
+    }
+
+    synchronized (SEED_LOCK) {
+      if (sharedWindow == null) {
+        resetBankingTables(jdbcTemplate);
+        // 1년치 히스토리 적재는 baseline보다 크므로 준비 단계 timeout을 별도로 늘립니다.
+        commit(transactionManager, 60, () -> sharedWindow = fixture.seed(jdbcTemplate));
+      }
+      partitionFitWindow = sharedWindow;
+    }
+  }
+
+  @Test
+  void recentWindowKeepsAccountCursorIndexEvenWithLongHistory() {
+    TransactionQuery query =
+        new TransactionQuery(
+            partitionFitWindow.hotAccountId(),
+            partitionFitWindow.recentFrom(),
+            partitionFitWindow.recentTo(),
+            50,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    TransactionSlice slice = repository.fetch(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(50);
+    assertThat(slice.hasNext()).isTrue();
+    assertThat(plan.usesIndex("idx_transaction_read_model_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void historicalWindowStillUsesAccountCursorIndexWithoutSeqScan() {
+    TransactionQuery query =
+        new TransactionQuery(
+            partitionFitWindow.hotAccountId(),
+            partitionFitWindow.historicalFrom(),
+            partitionFitWindow.historicalTo(),
+            50,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    TransactionSlice slice = repository.fetch(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(50);
+    assertThat(slice.hasNext()).isTrue();
+    assertThat(plan.usesIndex("idx_transaction_read_model_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void historicalStatusFilterKeepsStatusCursorIndexWithoutSeqScan() {
+    TransactionQuery query =
+        new TransactionQuery(
+            partitionFitWindow.hotAccountId(),
+            partitionFitWindow.historicalFrom(),
+            partitionFitWindow.historicalTo(),
+            50,
+            null,
+            TransactionStatus.BOOKED,
+            null,
+            null,
+            null,
+            null);
+
+    TransactionSlice slice = repository.fetch(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(50);
+    assertThat(slice.hasNext()).isTrue();
+    assertThat(slice.items()).allMatch(item -> item.status() == TransactionStatus.BOOKED);
+    assertThat(plan.usesIndex("idx_transaction_read_model_account_status_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  private TransactionExplainPlan explain(TransactionQuery query) {
+    TransactionReadQueryStatement statement = TransactionReadQueryStatement.from(query);
+    String explainJson =
+        jdbcTemplate.queryForObject(
+            "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)\n" + statement.sql(),
+            statement.params(),
+            (rs, rowNum) -> rs.getString(1));
+    if (explainJson == null) {
+      throw new IllegalStateException("EXPLAIN did not return JSON");
+    }
+    return TransactionExplainPlan.fromJson(objectMapper, explainJson);
+  }
+}

--- a/back/src/test/java/com/aquilabank/support/TransactionReadModelPartitionFitFixture.java
+++ b/back/src/test/java/com/aquilabank/support/TransactionReadModelPartitionFitFixture.java
@@ -1,0 +1,228 @@
+package com.aquilabank.support;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/** 장기 히스토리 누적 뒤에도 31일 account 조회가 같은 index 경로를 유지하는지 검증하는 fixture */
+public final class TransactionReadModelPartitionFitFixture {
+
+  private static final String ACTIVE = "ACTIVE";
+  private static final String CURRENCY_CODE = "KRW";
+  private static final Instant HISTORY_WINDOW_START = Instant.parse("2025-04-01T00:00:00Z");
+  private static final Instant HISTORY_WINDOW_END = Instant.parse("2025-05-01T00:00:00Z");
+  private static final Instant RECENT_WINDOW_START = Instant.parse("2026-04-01T00:00:00Z");
+  private static final Instant RECENT_WINDOW_END = Instant.parse("2026-05-01T00:00:00Z");
+  private static final long OPENING_BALANCE_MINOR = 1_000_000L;
+  private static final int RECENT_ROW_COUNT = 80_000;
+  private static final int RECENT_STEP_SECONDS = 30;
+  private static final int HISTORY_MONTH_COUNT = 12;
+  private static final int HISTORY_MONTH_ROW_COUNT = 12_000;
+  private static final int HISTORY_STEP_SECONDS = 216;
+  private static final int INSERT_BATCH_SIZE = 5_000;
+
+  public PartitionFitWindow seed(NamedParameterJdbcTemplate jdbcTemplate) {
+    long hotAccountId =
+        insertAccount(jdbcTemplate, "partition-fit-hot-account", HISTORY_WINDOW_START);
+
+    Instant windowStart = HISTORY_WINDOW_START;
+    for (int monthOffset = 0; monthOffset < HISTORY_MONTH_COUNT; monthOffset++) {
+      Instant nextWindowStart = windowStart.plusSeconds(30L * 24 * 60 * 60);
+      insertTimelineRows(
+          jdbcTemplate,
+          hotAccountId,
+          windowStart,
+          HISTORY_MONTH_ROW_COUNT,
+          HISTORY_STEP_SECONDS,
+          "history-" + monthOffset);
+      windowStart = nextWindowStart;
+    }
+
+    insertTimelineRows(
+        jdbcTemplate,
+        hotAccountId,
+        RECENT_WINDOW_START,
+        RECENT_ROW_COUNT,
+        RECENT_STEP_SECONDS,
+        "recent");
+
+    analyzeTables(jdbcTemplate);
+    return new PartitionFitWindow(
+        hotAccountId,
+        RECENT_WINDOW_START,
+        RECENT_WINDOW_END,
+        HISTORY_WINDOW_START,
+        HISTORY_WINDOW_END);
+  }
+
+  private long insertAccount(
+      NamedParameterJdbcTemplate jdbcTemplate, String displayName, Instant createdAt) {
+    String accountNumber =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0')
+            """,
+            new MapSqlParameterSource(),
+            String.class);
+    if (accountNumber == null) {
+      throw new IllegalStateException("partition-fit account number is not generated");
+    }
+
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountNumber,
+                :displayName,
+                :accountStatus,
+                :currencyCode,
+                :createdAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountNumber", accountNumber)
+                .addValue("displayName", displayName)
+                .addValue("accountStatus", ACTIVE)
+                .addValue("currencyCode", CURRENCY_CODE)
+                .addValue("createdAt", Timestamp.from(createdAt)),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("partition-fit account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertTimelineRows(
+      NamedParameterJdbcTemplate jdbcTemplate,
+      long accountId,
+      Instant windowStart,
+      int rowCount,
+      int stepSeconds,
+      String referencePrefix) {
+    for (int startSeq = 1; startSeq <= rowCount; startSeq += INSERT_BATCH_SIZE) {
+      int endSeq = Math.min(startSeq + INSERT_BATCH_SIZE - 1, rowCount);
+      jdbcTemplate.update(
+          """
+          WITH generated AS (
+              SELECT
+                  :accountId AS account_id,
+                  series AS seq,
+                  CAST(:windowStart AS timestamptz)
+                      + make_interval(secs => ((series - 1) * :stepSeconds)::integer) AS booked_at,
+                  CASE WHEN mod(series, 7) = 0 THEN 'DEBIT' ELSE 'CREDIT' END AS direction,
+                  CASE
+                      WHEN mod(series, 53) = 0 THEN 'REVERSED'
+                      WHEN mod(series, 5) = 0 THEN 'PENDING'
+                      ELSE 'BOOKED'
+                  END AS transaction_status,
+                  CASE WHEN mod(series, 7) = 0 THEN 1300 ELSE 1700 END AS amount_minor,
+                  :openingBalanceMinor
+                      + ((series - (series / 7)) * 1700)
+                      - ((series / 7) * 1300) AS balance_after_minor,
+                  :referencePrefix || '-trx-' || series AS transaction_reference,
+                  :referencePrefix || '-entry-' || series AS entry_reference,
+                  'seed-' || :referencePrefix || '-' || series AS summary,
+                  CASE WHEN mod(series, 3) = 0 THEN 'MERCHANT' ELSE 'ATM' END
+                      AS counterparty_masked_name
+              FROM generate_series(:startSeq, :endSeq) AS series
+          ),
+          inserted_ledger AS (
+              INSERT INTO ledger_entry (
+                  account_id,
+                  transaction_reference,
+                  entry_reference,
+                  direction,
+                  entry_status,
+                  amount_minor,
+                  currency_code,
+                  booked_at,
+                  occurred_at,
+                  description,
+                  metadata,
+                  created_at,
+                  updated_at
+              )
+              SELECT
+                  account_id,
+                  transaction_reference,
+                  entry_reference,
+                  direction,
+                  transaction_status,
+                  amount_minor,
+                  :currencyCode,
+                  booked_at,
+                  booked_at,
+                  summary,
+                  '{}'::jsonb,
+                  booked_at,
+                  booked_at
+              FROM generated
+              RETURNING id, entry_reference
+          )
+          INSERT INTO transaction_read_model (
+              ledger_entry_id,
+              account_id,
+              transaction_reference,
+              direction,
+              transaction_status,
+              amount_minor,
+              balance_after_minor,
+              currency_code,
+              summary,
+              counterparty_masked_name,
+              booked_at,
+              created_at
+          )
+          SELECT
+              inserted_ledger.id,
+              generated.account_id,
+              generated.transaction_reference,
+              generated.direction,
+              generated.transaction_status,
+              generated.amount_minor,
+              generated.balance_after_minor,
+              :currencyCode,
+              generated.summary,
+              generated.counterparty_masked_name,
+              generated.booked_at,
+              generated.booked_at
+          FROM generated
+          JOIN inserted_ledger
+            ON inserted_ledger.entry_reference = generated.entry_reference
+          """,
+          new MapSqlParameterSource()
+              .addValue("accountId", accountId)
+              .addValue("currencyCode", CURRENCY_CODE)
+              .addValue("referencePrefix", referencePrefix)
+              .addValue("openingBalanceMinor", OPENING_BALANCE_MINOR)
+              .addValue("startSeq", startSeq)
+              .addValue("endSeq", endSeq)
+              .addValue("stepSeconds", stepSeconds)
+              .addValue("windowStart", Timestamp.from(windowStart)));
+    }
+  }
+
+  private void analyzeTables(NamedParameterJdbcTemplate jdbcTemplate) {
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE bank_account");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE ledger_entry");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE transaction_read_model");
+  }
+
+  public record PartitionFitWindow(
+      long hotAccountId,
+      Instant recentFrom,
+      Instant recentTo,
+      Instant historicalFrom,
+      Instant historicalTo) {}
+}

--- a/tools/test/run-transaction-read-model-partition-fit.sh
+++ b/tools/test/run-transaction-read-model-partition-fit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[transaction-partition-fit] fixture: recent-window=80000 rows history-window=12x12000 rows on one hot account"
+echo "[transaction-partition-fit] expectation: recent/history/status queries keep idx_transaction_read_model_account_* path without Seq Scan or Sort"
+echo "[transaction-partition-fit] current decision: 31일 account-scoped query contract 기준 partition/archive 즉시 도입 불필요"
+echo "[transaction-partition-fit] recheck triggers: >31일 조회, account scope 완화, recent-window p95 회귀, autovacuum/bloat/backup pressure"
+
+./back/gradlew -p back test \
+  --tests '*JdbcTransactionReadRepositoryPartitionFitIntegrationTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #98

## 🌿 Base Branch
- `main`

## 📝 Summary
- 장기 히스토리 누적 뒤에도 `transaction_read_model`이 현재 거래 조회 계약에서 같은 index range scan을 유지하는지 검증 테스트를 추가했습니다.
- README와 실행 스크립트에 partition/archive 현재 결론과 재검토 트리거를 committed 근거로 정리했습니다.

## 🛠 Changes
- 최근 31일 + 1년치 과거 월간 히스토리를 같이 적재하는 partition-fit fixture를 추가했습니다.
- 최근 31일/과거 31일/과거 31일 status filter query가 `Seq Scan`/`Sort` 없이 기존 index를 유지하는 integration test를 추가했습니다.
- `tools/test/run-transaction-read-model-partition-fit.sh` 와 README에 현재 결론, 재현 명령, 재검토 조건을 반영했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-transaction-partition-fit ./back/gradlew -p back test --tests '*JdbcTransactionReadRepositoryPartitionFitIntegrationTest'`
- `tools/test/with-resource-lock.sh back-transaction-partition-fit-script tools/test/run-transaction-read-model-partition-fit.sh`
- `./back/gradlew -p back check` (`test(transaction): partition fit baseline 검증 추가` 커밋 pre-commit hook에서 통과)

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: fixture 분포가 실제 운영의 hot account 편중, 장기 보존 정책, autovacuum 압력을 완전히 대체하지는 못합니다.
- 롤백 방법: PR revert. 이번 변경은 테스트/문서/스크립트만 추가하며 운영 SQL/스키마 계약은 바꾸지 않습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (`N/A`)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (`없음`)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?