### PR TITLE
[Docs] 로컬/배포 런타임 기준 명시

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,19 @@
 - `front`: 고객/운영 웹 애플리케이션
 - `back`: API, 도메인, 배치, 어댑터
 - `.github`: 이슈/PR 템플릿과 협업 메타 설정
-- `compose.yml`: 로컬 개발용 PostgreSQL 18 실행 기준
+- `compose.yml`: 로컬 개발용 Docker Compose 인프라 실행 기준
 
 ## Runtime Baseline
 
 - database: `PostgreSQL 18`
-- local environment: `PostgreSQL 18`
-- deployed environment: `PostgreSQL 18`
+- local environment: `Docker Compose + PostgreSQL 18`
+- deployed environment: `EC2 + RDS PostgreSQL 18`
+
+## Environment Split
+
+- 로컬 개발: `Docker Compose + PostgreSQL 18 + Kafka`
+- 배포 환경: `EC2 + RDS PostgreSQL 18`
+- `compose.yml`은 로컬 개발 전용이며, 배포용 인프라 정의는 포함하지 않습니다.
 
 ## Delivery Flow
 

--- a/back/README.md
+++ b/back/README.md
@@ -128,6 +128,14 @@ docker compose up -d postgres kafka
 - PostgreSQL 기본 포트: `localhost:5432`
 - Kafka 기본 포트: `localhost:9092`
 - Kafka topic은 broker 기본 auto-create를 사용하되, app 설정은 `TransferBooked`/`TransferReversed`를 분리해 consumer 충돌을 막습니다.
+- 이 경로는 로컬 개발 전용입니다.
+
+## Deployment Baseline
+
+- 백엔드 런타임: `EC2`
+- 데이터베이스: `RDS PostgreSQL 18`
+- prod profile은 `DB_URL`, `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` 환경변수를 받아 EC2에서 외부 PostgreSQL에 연결합니다.
+- `compose.yml`은 배포 인프라를 대체하지 않으며, 운영 DB는 local Docker volume이 아니라 관리형 PostgreSQL 기준으로 봅니다.
 
 백엔드는 [back/.env.example](/Users/aquila/Custom/GitProjects/aquila-bank/back/.env.example)를 복사한 뒤 실행합니다.
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #102

## 🌿 Base Branch
- `main`

## 📝 Summary
- 공유 문서에 로컬과 배포 런타임 기준을 분리해 명시했습니다.
- 로컬은 `Docker Compose + PostgreSQL 18`, 배포는 `EC2 + RDS PostgreSQL 18` 전제로 읽히도록 README와 backend README를 정리했습니다.

## 🛠 Changes
- `README.md`에 runtime baseline과 environment split 문구 추가
- `back/README.md`에 local infra는 로컬 전용임을 명시하고 deployment baseline 추가
- `compose.yml`이 배포 인프라 정의가 아니라 로컬 개발용이라는 점을 문서에 반영

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `git diff -- README.md back/README.md`
- 문서에서 `Docker Compose + PostgreSQL 18`, `EC2 + RDS PostgreSQL 18` 문구 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 없음
- 롤백 방법: PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [ ] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [ ] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [ ] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [ ] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?