### PR TITLE
[Build] Nginx reverse proxy와 SSE 운영 설정 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@
 .
 ├── front
 ├── back
+├── ops
 ├── .github
 └── compose.yml
 ```
 
 - `front`: 고객/운영 웹 애플리케이션
 - `back`: API, 도메인, 배치, 어댑터
+- `ops`: reverse proxy 같은 운영 baseline 파일
 - `.github`: 이슈/PR 템플릿과 협업 메타 설정
 - `compose.yml`: 로컬 개발용 Docker Compose 인프라 실행 기준
 
@@ -39,6 +41,7 @@
 
 - 로컬 개발: `Docker Compose + PostgreSQL 18 + Kafka`
 - 배포 환경: `EC2 + RDS PostgreSQL 18`
+- EC2 reverse proxy baseline은 [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)에 둡니다.
 - `compose.yml`은 로컬 개발 전용이며, 배포용 인프라 정의는 포함하지 않습니다.
 
 ## Delivery Flow

--- a/back/README.md
+++ b/back/README.md
@@ -134,6 +134,7 @@ docker compose up -d postgres kafka
 
 - 백엔드 런타임: `EC2`
 - 데이터베이스: `RDS PostgreSQL 18`
+- EC2 reverse proxy baseline: [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)
 - prod profile은 `DB_URL`, `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` 환경변수를 받아 EC2에서 외부 PostgreSQL에 연결합니다.
 - `compose.yml`은 배포 인프라를 대체하지 않으며, 운영 DB는 local Docker volume이 아니라 관리형 PostgreSQL 기준으로 봅니다.
 
@@ -203,6 +204,32 @@ tools/test/with-resource-lock.sh back-gradle-check \
   - `NOTIFICATION_SSE_RECONNECT_DELAY_MS=3000`
   - `NOTIFICATION_SSE_REPLAY_LIMIT=100`
   - `NOTIFICATION_SSE_FANOUT_CHANNEL=notification_sse_fanout`
+
+### Nginx Reverse Proxy Baseline
+
+- 기준 파일: [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)
+- upstream 기본값:
+  - frontend `127.0.0.1:3000`
+  - backend `127.0.0.1:8080`
+- SSE location 운영 기준:
+  - `proxy_buffering off`
+  - `proxy_request_buffering off`
+  - `proxy_cache off`
+  - `gzip off`
+  - `proxy_read_timeout 1900s`
+  - `proxy_send_timeout 1900s`
+- 일반 proxy 기준:
+  - `/api/` 는 `30s`
+  - `/actuator/health` 는 `5s`
+  - `/` frontend 는 `60s`
+- 검증 명령:
+
+```bash
+bash tools/test/check-nginx-sse-proxy.sh
+```
+
+- backend가 이미 `X-Accel-Buffering: no` 헤더를 응답하므로 Nginx도 buffering off 상태를 같이 유지합니다.
+- `NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS` 또는 upstream 포트를 바꾸면 Nginx timeout/upstream도 같이 맞춥니다.
 
 ## Transfer Reversal
 

--- a/ops/nginx/README.md
+++ b/ops/nginx/README.md
@@ -1,0 +1,35 @@
+# Nginx Reverse Proxy Baseline
+
+`ops/nginx/nginx.conf`는 단일 EC2 인스턴스에서 frontend(`3000`)와 backend(`8080`)를 함께 reverse proxy 하는 기준 파일입니다.
+
+## 포함 범위
+
+- `/`: frontend upstream
+- `/api/`: backend upstream
+- `/actuator/health`: backend health check upstream
+- `/api/v1/notifications/stream`: SSE 전용 proxy 설정
+
+## SSE 기준
+
+- `proxy_buffering off`
+- `proxy_request_buffering off`
+- `proxy_cache off`
+- `gzip off`
+- `proxy_read_timeout 1900s`
+- `proxy_send_timeout 1900s`
+
+앱 기본값이 `NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS=1800000`, `NOTIFICATION_SSE_HEARTBEAT_INTERVAL_MS=10000` 이라서, proxy timeout은 연결 종료 기준보다 약간 길게 잡아 heartbeat 사이 idle 구간에서 proxy가 먼저 끊지 않게 둡니다.
+
+## 운영 적용 전 확인
+
+- frontend/backend 포트가 기본값과 다르면 upstream `server` 주소를 같이 수정합니다.
+- TLS termination, `server_name`, rate limit, multi-node load balancer 정책은 이번 baseline 밖입니다.
+- backend는 이미 `X-Accel-Buffering: no` 헤더를 내려주므로 Nginx도 같은 방향으로 buffering을 끈 상태를 유지합니다.
+
+## 검증
+
+```bash
+bash tools/test/check-nginx-sse-proxy.sh
+```
+
+`nginx` binary가 설치된 환경이면 위 smoke check가 추가로 `nginx -t`까지 수행합니다.

--- a/ops/nginx/nginx.conf
+++ b/ops/nginx/nginx.conf
@@ -1,0 +1,73 @@
+worker_processes auto;
+pid /tmp/aquila-bank-nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  default_type application/octet-stream;
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  client_max_body_size 1m;
+
+  upstream aquila_bank_frontend {
+    server 127.0.0.1:3000;
+    keepalive 8;
+  }
+
+  upstream aquila_bank_backend {
+    server 127.0.0.1:8080;
+    keepalive 8;
+  }
+
+  server {
+    listen 80 default_server;
+    server_name _;
+
+    proxy_http_version 1.1;
+    proxy_connect_timeout 3s;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+
+    # SSE는 backend heartbeat가 10초 간격으로 오더라도 proxy buffering이 켜져 있으면 전달이 밀립니다.
+    location = /api/v1/notifications/stream {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Connection "";
+      proxy_buffering off;
+      proxy_request_buffering off;
+      proxy_cache off;
+      gzip off;
+      proxy_read_timeout 1900s;
+      proxy_send_timeout 1900s;
+      add_header X-Accel-Buffering no always;
+    }
+
+    location /api/ {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Connection "";
+      proxy_read_timeout 30s;
+      proxy_send_timeout 30s;
+    }
+
+    location ^~ /actuator/health {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Connection "";
+      proxy_read_timeout 5s;
+      proxy_send_timeout 5s;
+      access_log off;
+    }
+
+    location / {
+      proxy_pass http://aquila_bank_frontend;
+      proxy_set_header Connection "";
+      proxy_read_timeout 60s;
+      proxy_send_timeout 60s;
+    }
+  }
+}

--- a/tools/test/check-nginx-sse-proxy.sh
+++ b/tools/test/check-nginx-sse-proxy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_path="ops/nginx/nginx.conf"
+
+if [[ ! -f "$config_path" ]]; then
+  echo "[nginx-sse-check] missing config: $config_path" >&2
+  exit 1
+fi
+
+required_patterns=(
+  "upstream aquila_bank_frontend"
+  "server 127.0.0.1:3000;"
+  "upstream aquila_bank_backend"
+  "server 127.0.0.1:8080;"
+  "location = /api/v1/notifications/stream"
+  "proxy_buffering off;"
+  "proxy_request_buffering off;"
+  "proxy_cache off;"
+  "proxy_read_timeout 1900s;"
+  "proxy_send_timeout 1900s;"
+  "add_header X-Accel-Buffering no always;"
+  "location /api/"
+  "location ^~ /actuator/health"
+  "location / {"
+)
+
+for pattern in "${required_patterns[@]}"; do
+  if ! rg -F --quiet "$pattern" "$config_path"; then
+    echo "[nginx-sse-check] missing directive: $pattern" >&2
+    exit 1
+  fi
+done
+
+if command -v nginx >/dev/null 2>&1; then
+  nginx -t -c "$PWD/$config_path" >/dev/null
+  echo "[nginx-sse-check] nginx -t passed"
+else
+  echo "[nginx-sse-check] directive smoke check passed"
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #104

## 🌿 Base Branch
- `main`

## 📝 Summary
- EC2 단일 인스턴스 기준 frontend/backend reverse proxy와 SSE 전용 location을 포함한 Nginx baseline을 저장소에 추가했습니다.
- SSE 운영 기본선이 빠지지 않게 smoke check와 README 문서를 같이 정리했습니다.

## 🛠 Changes
- `ops/nginx/nginx.conf`에 frontend `/`, backend `/api/`, health check `/actuator/health`, SSE `/api/v1/notifications/stream` proxy 기준을 추가했습니다.
- SSE 경로에 `proxy_buffering off`, `proxy_request_buffering off`, `proxy_cache off`, `gzip off`, `1900s` timeout을 반영했습니다.
- `tools/test/check-nginx-sse-proxy.sh`를 추가해 필수 directive 누락과 선택적 `nginx -t`를 함께 확인하게 했습니다.
- root/backend README와 `ops/nginx/README.md`에 적용 경로, upstream 포트 가정, 운영 주의점을 정리했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-nginx-sse-proxy.sh`
- `tools/test/with-resource-lock.sh back-notification-controller ./back/gradlew -p back test --tests '*NotificationControllerTest'`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 실제 운영 포트, `server_name`, TLS termination 정책이 기본값과 다르면 `ops/nginx/nginx.conf` upstream과 server block을 같이 조정해야 합니다.
- 롤백 방법: PR revert 후 EC2에 반영한 Nginx 설정 파일을 이전 버전으로 되돌리고 reload 합니다. 이번 변경은 애플리케이션 runtime 코드를 바꾸지 않습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (`N/A`)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (`없음`)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?