### PR TITLE
[Chore] outbox/notification/transaction 메트릭과 Prometheus export 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -157,6 +157,38 @@ set +a
 - `dev` 프로필은 `OUTBOX_KAFKA_ENABLED=true`, `NOTIFICATION_INBOX_CONSUMER_ENABLED=true`만 주면 `localhost:9092`와 기본 topic 이름을 자동 사용합니다.
 - Kafka 포트를 바꾸면 `OUTBOX_KAFKA_BOOTSTRAP_SERVERS`, `NOTIFICATION_INBOX_CONSUMER_BOOTSTRAP_SERVERS`를 같은 값으로 같이 넘깁니다.
 
+## Prometheus Metrics
+
+- export endpoint:
+  - `GET /actuator/prometheus`
+- 보안 기준:
+  - application security는 `/actuator/prometheus`를 permitAll 로 열어 Prometheus scrape를 단순화합니다.
+  - 운영에서는 security group, private subnet, Nginx allowlist 같은 네트워크 경계로 외부 공개를 막는 것을 기본값으로 둡니다.
+- custom metric:
+  - `aquila_outbox_dispatch_lag_seconds`
+  - `aquila_outbox_failed_count`
+  - `aquila_outbox_failed_producer_timeout_count`
+  - `aquila_outbox_sending_stale_count`
+  - `aquila_notification_consumer_lag_count`
+  - `aquila_notification_consumer_dlq_count`
+  - `aquila_notification_sse_sessions{principal_type="account|user|total"}`
+  - `aquila_transaction_query_latency_seconds`
+- 활성화 조건:
+  - outbox metric은 기본 wiring만 있으면 항상 export 됩니다.
+  - notification consumer lag/DLQ metric은 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true` 와 DLQ topic 설정이 있어야 export 됩니다.
+  - transaction latency timer는 `GET /api/v1/transactions` query path가 한 번이라도 호출되면 `query_shape` tag 기준으로 누적됩니다.
+- transaction `query_shape` 기준:
+  - `first_page`
+  - `cursor`
+  - `status_first`, `status_cursor`
+  - `direction_first`, `direction_cursor`
+  - `amount_first`, `amount_cursor`
+  - `mixed_first`, `mixed_cursor`
+  - `reference_exact`
+- 운영 메모:
+  - outbox/notification gauge는 scrape 한 번에 같은 summary를 여러 번 다시 조회하지 않게 `5초` cache 안에서 재사용합니다.
+  - SSE session metric은 현재 app instance 메모리의 active session 수만 보여주므로 multi-instance 전체 합계는 Prometheus 쿼리에서 합산합니다.
+
 ### Local Notification E2E
 
 실제 broker를 통과하는 알림 검증은 transfer write path와 outbox dispatch를 같이 봐야 합니다.

--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:1.21.3"))
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     implementation("org.springframework.boot:spring-boot-flyway")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.kafka:spring-kafka")

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationConsumerPrometheusMetrics.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationConsumerPrometheusMetrics.java
@@ -1,0 +1,91 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.NotificationOpsSummary;
+import com.aquilabank.domain.notification.usecase.NotificationOpsQueryUseCase;
+import com.aquilabank.global.config.NotificationInboxConsumerProperties;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.time.Duration;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+/** notification consumer lag/DLQ는 Kafka admin 조회 비용이 있어 짧은 cache 안에서만 재사용합니다. */
+@Component
+@ConditionalOnBean(NotificationOpsQueryUseCase.class)
+public final class NotificationConsumerPrometheusMetrics implements MeterBinder {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(NotificationConsumerPrometheusMetrics.class);
+
+  private static final Duration SNAPSHOT_TTL = Duration.ofSeconds(5);
+
+  private final NotificationOpsQueryUseCase notificationOpsQueryUseCase;
+  private final Iterable<Tag> lagTags;
+  private final Iterable<Tag> dlqTags;
+
+  private volatile CachedSummary cachedSummary;
+
+  public NotificationConsumerPrometheusMetrics(
+      NotificationOpsQueryUseCase notificationOpsQueryUseCase,
+      NotificationInboxConsumerProperties notificationInboxConsumerProperties) {
+    this.notificationOpsQueryUseCase = notificationOpsQueryUseCase;
+    this.lagTags =
+        java.util.List.of(
+            Tag.of("group_id", notificationInboxConsumerProperties.groupId()),
+            Tag.of("topic", notificationInboxConsumerProperties.transferBooked().topic()));
+    this.dlqTags =
+        java.util.List.of(
+            Tag.of("group_id", notificationInboxConsumerProperties.groupId()),
+            Tag.of("topic", notificationInboxConsumerProperties.dlq().topic()));
+    this.cachedSummary =
+        new CachedSummary(
+            new NotificationOpsSummary(Instant.EPOCH, "-", "-", "-", 0L, 0L), Instant.EPOCH);
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    Gauge.builder(
+            "aquila.notification.consumer.lag.count",
+            this,
+            metrics -> metrics.currentSummary().lagCount())
+        .tags(lagTags)
+        .description("notification consumer lag count")
+        .register(registry);
+    Gauge.builder(
+            "aquila.notification.consumer.dlq.count",
+            this,
+            metrics -> metrics.currentSummary().dlqCount())
+        .tags(dlqTags)
+        .description("notification consumer DLQ count")
+        .register(registry);
+  }
+
+  private NotificationOpsSummary currentSummary() {
+    Instant now = Instant.now();
+    CachedSummary current = cachedSummary;
+    if (current.expiresAt().isAfter(now)) {
+      return current.summary();
+    }
+    synchronized (this) {
+      CachedSummary refreshed = cachedSummary;
+      if (refreshed.expiresAt().isAfter(now)) {
+        return refreshed.summary();
+      }
+      try {
+        NotificationOpsSummary summary = notificationOpsQueryUseCase.getSummary();
+        cachedSummary = new CachedSummary(summary, now.plus(SNAPSHOT_TTL));
+        return summary;
+      } catch (RuntimeException ex) {
+        log.debug("notification prometheus metric refresh failed", ex);
+        return refreshed.summary();
+      }
+    }
+  }
+
+  private record CachedSummary(NotificationOpsSummary summary, Instant expiresAt) {}
+}

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
@@ -86,6 +86,18 @@ public class NotificationSseBroker {
     return !accountSessions.isEmpty() || !userSessions.isEmpty();
   }
 
+  public int accountSessionCount() {
+    return sessionCount(accountSessions);
+  }
+
+  public int userSessionCount() {
+    return sessionCount(userSessions);
+  }
+
+  public int totalSessionCount() {
+    return accountSessionCount() + userSessionCount();
+  }
+
   public void publishInsertedItems(List<NotificationSummary> items) {
     if (items.isEmpty() || !hasActiveSessions()) {
       return;
@@ -317,6 +329,14 @@ public class NotificationSseBroker {
           .add(item);
     }
     return itemsByAccountId;
+  }
+
+  private int sessionCount(Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId) {
+    int count = 0;
+    for (Map<String, NotificationSseSession> sessions : sessionsByPrincipalId.values()) {
+      count += sessions.size();
+    }
+    return count;
   }
 
   private void removeSession(

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSsePrometheusMetrics.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSsePrometheusMetrics.java
@@ -1,0 +1,42 @@
+package com.aquilabank.global.notification;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.stereotype.Component;
+
+/** SSE broker 메모리 상태를 그대로 gauge로 노출해 운영자가 연결 수를 바로 확인하게 합니다. */
+@Component
+public final class NotificationSsePrometheusMetrics implements MeterBinder {
+
+  private final NotificationSseBroker notificationSseBroker;
+
+  public NotificationSsePrometheusMetrics(NotificationSseBroker notificationSseBroker) {
+    this.notificationSseBroker = notificationSseBroker;
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    Gauge.builder(
+            "aquila.notification.sse.sessions",
+            notificationSseBroker,
+            broker -> broker.accountSessionCount())
+        .tag("principal_type", "account")
+        .description("active notification SSE session count")
+        .register(registry);
+    Gauge.builder(
+            "aquila.notification.sse.sessions",
+            notificationSseBroker,
+            broker -> broker.userSessionCount())
+        .tag("principal_type", "user")
+        .description("active notification SSE session count")
+        .register(registry);
+    Gauge.builder(
+            "aquila.notification.sse.sessions",
+            notificationSseBroker,
+            broker -> broker.totalSessionCount())
+        .tag("principal_type", "total")
+        .description("active notification SSE session count")
+        .register(registry);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/OutboxPrometheusMetrics.java
+++ b/back/src/main/java/com/aquilabank/global/notification/OutboxPrometheusMetrics.java
@@ -1,0 +1,82 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.OutboxOpsSummary;
+import com.aquilabank.domain.notification.usecase.OutboxOpsQueryUseCase;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.time.Duration;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** scrape 안에서 같은 summary를 여러 번 다시 조회하지 않게 outbox snapshot을 짧게 cache 합니다. */
+@Component
+public final class OutboxPrometheusMetrics implements MeterBinder {
+
+  private static final Logger log = LoggerFactory.getLogger(OutboxPrometheusMetrics.class);
+
+  private static final Duration SNAPSHOT_TTL = Duration.ofSeconds(5);
+  private static final CachedSummary EMPTY_SUMMARY =
+      new CachedSummary(
+          new OutboxOpsSummary(Instant.EPOCH, null, Duration.ZERO, 0L, 0L, 0L), Instant.EPOCH);
+
+  private final OutboxOpsQueryUseCase outboxOpsQueryUseCase;
+
+  private volatile CachedSummary cachedSummary = EMPTY_SUMMARY;
+
+  public OutboxPrometheusMetrics(OutboxOpsQueryUseCase outboxOpsQueryUseCase) {
+    this.outboxOpsQueryUseCase = outboxOpsQueryUseCase;
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    Gauge.builder(
+            "aquila.outbox.dispatch.lag.seconds",
+            this,
+            metrics -> metrics.currentSummary().oldestDispatchLag().toSeconds())
+        .description("outbox dispatchable backlog lag seconds")
+        .register(registry);
+    Gauge.builder(
+            "aquila.outbox.failed.count", this, metrics -> metrics.currentSummary().failedCount())
+        .description("outbox failed event count")
+        .register(registry);
+    Gauge.builder(
+            "aquila.outbox.failed.producer_timeout.count",
+            this,
+            metrics -> metrics.currentSummary().producerTimeoutFailedCount())
+        .description("outbox failed event count caused by producer timeout")
+        .register(registry);
+    Gauge.builder(
+            "aquila.outbox.sending.stale.count",
+            this,
+            metrics -> metrics.currentSummary().staleSendingCount())
+        .description("outbox stale sending event count")
+        .register(registry);
+  }
+
+  private OutboxOpsSummary currentSummary() {
+    Instant now = Instant.now();
+    CachedSummary current = cachedSummary;
+    if (current.expiresAt().isAfter(now)) {
+      return current.summary();
+    }
+    synchronized (this) {
+      CachedSummary refreshed = cachedSummary;
+      if (refreshed.expiresAt().isAfter(now)) {
+        return refreshed.summary();
+      }
+      try {
+        OutboxOpsSummary summary = outboxOpsQueryUseCase.getSummary();
+        cachedSummary = new CachedSummary(summary, now.plus(SNAPSHOT_TTL));
+        return summary;
+      } catch (RuntimeException ex) {
+        log.debug("outbox prometheus metric refresh failed", ex);
+        return refreshed.summary();
+      }
+    }
+  }
+
+  private record CachedSummary(OutboxOpsSummary summary, Instant expiresAt) {}
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepository.java
@@ -7,6 +7,8 @@ import com.aquilabank.domain.transaction.model.TransactionSlice;
 import com.aquilabank.domain.transaction.model.TransactionStatus;
 import com.aquilabank.domain.transaction.model.TransactionSummary;
 import com.aquilabank.domain.transaction.port.TransactionReadPort;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
@@ -24,23 +26,41 @@ public class JdbcTransactionReadRepository implements TransactionReadPort {
   private static final RowMapper<TransactionSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final MeterRegistry meterRegistry;
 
-  public JdbcTransactionReadRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+  public JdbcTransactionReadRepository(
+      NamedParameterJdbcTemplate jdbcTemplate, MeterRegistry meterRegistry) {
     this.jdbcTemplate = jdbcTemplate;
+    this.meterRegistry = meterRegistry;
   }
 
   @Override
   @Transactional(readOnly = true)
   public TransactionSlice fetch(TransactionQuery query) {
-    TransactionReadQueryStatement statement = TransactionReadQueryStatement.from(query);
-    List<TransactionSummary> rows =
-        jdbcTemplate.query(statement.sql(), statement.params(), ROW_MAPPER);
-    boolean hasNext = rows.size() > query.limit();
-    // hasNext 판단에만 쓴 sentinel row는 응답 전에 제거
-    List<TransactionSummary> items =
-        hasNext ? new ArrayList<>(rows.subList(0, query.limit())) : rows;
-    TransactionCursor nextCursor = hasNext ? toCursor(items.getLast()) : null;
-    return new TransactionSlice(items, nextCursor, hasNext, query.limit());
+    Timer.Sample sample = Timer.start(meterRegistry);
+    String outcome = "success";
+    try {
+      TransactionReadQueryStatement statement = TransactionReadQueryStatement.from(query);
+      List<TransactionSummary> rows =
+          jdbcTemplate.query(statement.sql(), statement.params(), ROW_MAPPER);
+      boolean hasNext = rows.size() > query.limit();
+      // hasNext 판단에만 쓴 sentinel row는 응답 전에 제거
+      List<TransactionSummary> items =
+          hasNext ? new ArrayList<>(rows.subList(0, query.limit())) : rows;
+      TransactionCursor nextCursor = hasNext ? toCursor(items.getLast()) : null;
+      return new TransactionSlice(items, nextCursor, hasNext, query.limit());
+    } catch (RuntimeException ex) {
+      outcome = "error";
+      throw ex;
+    } finally {
+      sample.stop(
+          meterRegistry.timer(
+              "aquila.transaction.query.latency",
+              "query_shape",
+              queryShape(query),
+              "outcome",
+              outcome));
+    }
   }
 
   private static TransactionSummary mapRow(ResultSet rs) throws SQLException {
@@ -62,5 +82,29 @@ public class JdbcTransactionReadRepository implements TransactionReadPort {
   private static TransactionCursor toCursor(TransactionSummary item) {
     // 현재 slice의 마지막 visible row 다음부터 다음 page가 시작되게 cursor 생성
     return new TransactionCursor(item.bookedAt(), item.id());
+  }
+
+  private static String queryShape(TransactionQuery query) {
+    boolean hasCursor = query.cursor() != null;
+    boolean hasStatus = query.status() != null;
+    boolean hasDirection = query.direction() != null;
+    boolean hasAmountRange = query.minAmountMinor() != null || query.maxAmountMinor() != null;
+    if (query.transactionReference() != null) {
+      return "reference_exact";
+    }
+    if (hasStatus && !hasDirection && !hasAmountRange) {
+      return hasCursor ? "status_cursor" : "status_first";
+    }
+    if (!hasStatus && hasDirection && !hasAmountRange) {
+      return hasCursor ? "direction_cursor" : "direction_first";
+    }
+    if (!hasStatus && !hasDirection && hasAmountRange) {
+      return hasCursor ? "amount_cursor" : "amount_first";
+    }
+    // tag cardinality를 낮추려고 filter 조합은 coarse bucket으로만 묶습니다.
+    if (hasStatus || hasDirection || hasAmountRange) {
+      return hasCursor ? "mixed_cursor" : "mixed_first";
+    }
+    return hasCursor ? "cursor" : "first_page";
   }
 }

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -63,7 +63,7 @@ public class SecurityConfiguration {
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers("/actuator/health", "/actuator/info")
+                auth.requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus")
                     .permitAll()
                     .requestMatchers("/api/v1/auth/login")
                     .permitAll()

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -52,7 +52,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,prometheus
   endpoint:
     health:
       probes:

--- a/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
@@ -1,0 +1,229 @@
+package com.aquilabank.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import com.aquilabank.domain.notification.usecase.NotificationOpsQueryUseCase;
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.global.persistence.transaction.JdbcTransactionReadRepository;
+import com.aquilabank.support.PostgresKafkaContainerTestSupport;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.regex.Pattern;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      "spring.flyway.enabled=true",
+      "management.health.db.enabled=true",
+      "notification.inbox.consumer.enabled=true",
+      "notification.inbox.consumer.auto-startup=false",
+      "notification.inbox.consumer.group-id=aquila-bank-prometheus-metrics",
+      "notification.inbox.consumer.ops.enabled=true"
+    })
+class PrometheusMetricsIntegrationTest extends PostgresKafkaContainerTestSupport {
+
+  private static final Duration SUMMARY_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration SUMMARY_INTERVAL = Duration.ofMillis(200);
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @Autowired private NotificationSseBroker notificationSseBroker;
+
+  @Autowired private NotificationOpsQueryUseCase notificationOpsQueryUseCase;
+
+  @Autowired private JdbcTransactionReadRepository jdbcTransactionReadRepository;
+
+  @Autowired
+  @Qualifier("notificationInboxDlqKafkaTemplate") private KafkaTemplate<String, String> kafkaTemplate;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void exportsOutboxNotificationTransactionAndSseMetrics() throws Exception {
+    Instant base = Instant.now();
+    commit(
+        transactionManager,
+        () ->
+            insertOutboxEvent(
+                "evt-prometheus-failed",
+                "FAILED",
+                1,
+                "kafka publish timed out",
+                base.minusSeconds(10),
+                base.minusSeconds(20)));
+
+    SseEmitter emitter = notificationSseBroker.subscribeAccount(1L, "metrics");
+    try {
+      jdbcTransactionReadRepository.fetch(
+          new TransactionQuery(
+              1L,
+              Instant.parse("2026-04-01T00:00:00Z"),
+              Instant.parse("2026-04-30T00:00:00Z"),
+              50,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null));
+
+      String lagEventKey = "transfer-booked:PROM-LAG-" + System.currentTimeMillis();
+      String dlqEventKey = "transfer-booked:PROM-DLQ-" + System.currentTimeMillis();
+      kafkaTemplate
+          .send(TRANSFER_BOOKED_TOPIC, lagEventKey, "{\"transactionReference\":\"lag\"}")
+          .get();
+      kafkaTemplate.send(dlqRecord(dlqEventKey)).get();
+
+      awaitCondition(
+          "notification metrics summary",
+          SUMMARY_TIMEOUT,
+          SUMMARY_INTERVAL,
+          () ->
+              notificationOpsQueryUseCase.getSummary().lagCount() >= 1
+                  && notificationOpsQueryUseCase.getSummary().dlqCount() >= 1);
+
+      String body =
+          mockMvc
+              .perform(get("/actuator/prometheus"))
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      assertThat(body).contains("# HELP aquila_outbox_dispatch_lag_seconds");
+      assertThat(body).containsPattern("aquila_outbox_failed_count\\s+1\\.0");
+      assertThat(body).containsPattern("aquila_outbox_failed_producer_timeout_count\\s+1\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_notification_consumer_lag_count\\{[^\\n]*topic=\""
+                  + Pattern.quote(TRANSFER_BOOKED_TOPIC)
+                  + "\"[^\\n]*\\}\\s+[1-9][0-9]*\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_notification_consumer_dlq_count\\{[^\\n]*topic=\""
+                  + Pattern.quote(TRANSFER_BOOKED_DLQ_TOPIC)
+                  + "\"[^\\n]*\\}\\s+[1-9][0-9]*\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_notification_sse_sessions\\{[^\\n]*principal_type=\"account\"[^\\n]*\\}\\s+1\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_notification_sse_sessions\\{[^\\n]*principal_type=\"total\"[^\\n]*\\}\\s+1\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_transaction_query_latency_seconds_count\\{[^\\n]*outcome=\"success\"[^\\n]*query_shape=\"first_page\"[^\\n]*\\}\\s+1");
+    } finally {
+      emitter.complete();
+    }
+  }
+
+  private long insertOutboxEvent(
+      String eventKey,
+      String publishStatus,
+      int retryCount,
+      String lastError,
+      Instant availableAt,
+      Instant updatedAt) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO outbox_event (
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                event_key,
+                payload,
+                publish_status,
+                available_at,
+                retry_count,
+                last_error,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                'TRANSFER',
+                'TRX-' || right(:eventKey, 3),
+                'TransferBooked',
+                :eventKey,
+                '{"transactionReference":"seed"}'::jsonb,
+                :publishStatus,
+                :availableAt,
+                :retryCount,
+                :lastError,
+                :updatedAt,
+                :updatedAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("eventKey", eventKey)
+                .addValue("publishStatus", publishStatus)
+                .addValue("availableAt", Timestamp.from(availableAt))
+                .addValue("retryCount", retryCount)
+                .addValue("lastError", lastError)
+                .addValue("updatedAt", Timestamp.from(updatedAt)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("outbox_event insert did not return id");
+    }
+    return id;
+  }
+
+  private ProducerRecord<String, String> dlqRecord(String eventKey) {
+    ProducerRecord<String, String> record =
+        new ProducerRecord<>(TRANSFER_BOOKED_DLQ_TOPIC, eventKey, "{\"broken\":true}");
+    record
+        .headers()
+        .add(
+            KafkaHeaders.DLT_ORIGINAL_TOPIC,
+            TRANSFER_BOOKED_TOPIC.getBytes(StandardCharsets.UTF_8));
+    record
+        .headers()
+        .add(KafkaHeaders.DLT_ORIGINAL_PARTITION, ByteBuffer.allocate(4).putInt(0).array());
+    record
+        .headers()
+        .add(KafkaHeaders.DLT_ORIGINAL_OFFSET, ByteBuffer.allocate(8).putLong(7L).array());
+    record
+        .headers()
+        .add(
+            KafkaHeaders.DLT_EXCEPTION_FQCN,
+            "java.lang.IllegalArgumentException".getBytes(StandardCharsets.UTF_8));
+    record
+        .headers()
+        .add(
+            KafkaHeaders.DLT_EXCEPTION_MESSAGE,
+            "TransferBooked payload is invalid".getBytes(StandardCharsets.UTF_8));
+    return record;
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #106

## 🌿 Base Branch
- `main`

## 📝 Summary
- `/actuator/prometheus` export와 Prometheus registry를 추가해 health/info 밖의 운영 숫자를 scrape 할 수 있게 했습니다.
- outbox lag/failed/stale, notification consumer lag/DLQ, transaction query latency, SSE session 수를 custom metric으로 노출하고 README에 활성화 조건을 정리했습니다.

## 🛠 Changes
- `micrometer-registry-prometheus`를 추가하고 `/actuator/prometheus`를 노출/permitAll 하도록 actuator, security 설정을 보강했습니다.
- outbox summary와 notification consumer summary를 짧은 cache 뒤에서 gauge로 export하는 metric binder를 추가했습니다.
- `NotificationSseBroker` active session 수를 gauge로 export하고, `JdbcTransactionReadRepository`에 low-cardinality `query_shape` tag 기반 latency timer를 추가했습니다.
- `/actuator/prometheus` 응답에서 custom metric line이 실제로 보이는지 확인하는 통합 테스트를 추가했습니다.
- backend README에 metric 이름, notification lag/DLQ 활성화 조건, 운영 노출 주의점을 정리했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-prometheus-metrics ./back/gradlew -p back test --tests '*PrometheusMetricsIntegrationTest'`
- `tools/test/with-resource-lock.sh back-notification-controller ./back/gradlew -p back test --tests '*NotificationControllerTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `/actuator/prometheus`는 permitAll 이라 운영에서는 SG/Nginx/private subnet 같은 네트워크 경계로 막아야 합니다.
- 예상 리스크: `notification.inbox.consumer.ops.enabled=false` 환경에서는 consumer lag/DLQ metric이 비노출됩니다.
- 롤백 방법: PR revert 후 backend 재배포. 이번 변경은 metric/export와 문서만 추가하며 API/스키마 계약은 바꾸지 않습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (`네트워크 경계 필요`)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (`없음`)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?