### PR TITLE
[Perf] notification SSE 세션 상한과 backpressure 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -228,6 +228,8 @@ tools/test/with-resource-lock.sh back-gradle-check \
   - user stream fan-out 대상은 `ACTIVE membership + ACTIVE user` 조건으로만 계산합니다.
   - `Last-Event-ID` header가 있으면 `notification_inbox.id > header` 범위를 `id ASC` 순서로 replay 합니다.
   - replay 중 들어온 live 알림은 같은 session lock 안에서 이어 보내 duplicate/out-of-order push를 막습니다.
+  - 총 active session 수가 `NOTIFICATION_SSE_MAX_TOTAL_SESSIONS`를 넘으면 새 구독은 `503 Service Unavailable`으로 즉시 거절합니다.
+  - replay 중 live backlog 가 `NOTIFICATION_SSE_MAX_PENDING_EVENTS_PER_SESSION`를 넘으면 해당 session만 끊고 client reconnect + pull API 재동기화로 넘깁니다.
   - replay 는 `NOTIFICATION_SSE_REPLAY_LIMIT` 기본값 100건까지만 수행하고, 그보다 큰 reconnect gap 이나 PostgreSQL LISTEN 연결 재수립 사이의 누락은 기존 `GET /api/v1/notifications` pull API로 재동기화합니다.
   - ordering 보장 범위는 같은 fan-out signal 안의 `notification_inbox.id ASC` 처리 순서와, 같은 reconnect session 안의 replay `id ASC` 순서, 그리고 단일 app instance 안의 live publish 순서까지입니다.
 - 기본 설정:
@@ -235,7 +237,13 @@ tools/test/with-resource-lock.sh back-gradle-check \
   - `NOTIFICATION_SSE_HEARTBEAT_INTERVAL_MS=10000`
   - `NOTIFICATION_SSE_RECONNECT_DELAY_MS=3000`
   - `NOTIFICATION_SSE_REPLAY_LIMIT=100`
+  - `NOTIFICATION_SSE_MAX_TOTAL_SESSIONS=64`
+  - `NOTIFICATION_SSE_MAX_PENDING_EVENTS_PER_SESSION=32`
   - `NOTIFICATION_SSE_FANOUT_CHANNEL=notification_sse_fanout`
+- 운영 메트릭:
+  - `aquila_notification_sse_sessions{principal_type="account|user|total"}`
+  - `aquila_notification_sse_subscription_rejected_count{reason="session_limit"}`
+  - `aquila_notification_sse_session_dropped_count{reason="pending_overflow"}`
 
 ### Nginx Reverse Proxy Baseline
 

--- a/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
@@ -10,6 +10,8 @@ public record NotificationSseProperties(
     long heartbeatIntervalMs,
     long reconnectDelayMs,
     int replayLimit,
+    int maxTotalSessions,
+    int maxPendingEventsPerSession,
     String fanoutChannel,
     long fanoutListenTimeoutMs,
     long fanoutRetryDelayMs) {
@@ -27,6 +29,13 @@ public record NotificationSseProperties(
     }
     if (replayLimit < 1 || replayLimit > NotificationReplayQuery.MAX_LIMIT) {
       throw new IllegalArgumentException("notification.sse.replay-limit must be between 1 and 100");
+    }
+    if (maxTotalSessions <= 0) {
+      throw new IllegalArgumentException("notification.sse.max-total-sessions must be positive");
+    }
+    if (maxPendingEventsPerSession <= 0) {
+      throw new IllegalArgumentException(
+          "notification.sse.max-pending-events-per-session must be positive");
     }
     if (fanoutChannel == null || fanoutChannel.isBlank()) {
       throw new IllegalArgumentException("notification.sse.fanout-channel must not be blank");

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +30,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class NotificationSseBroker {
 
   private static final Logger log = LoggerFactory.getLogger(NotificationSseBroker.class);
+  private static final String OVERLOAD_MESSAGE =
+      "notification SSE stream is temporarily overloaded";
 
   private final NotificationSseProperties notificationSseProperties;
   private final NotificationSseTargetResolver notificationSseTargetResolver;
@@ -36,6 +40,9 @@ public class NotificationSseBroker {
       new ConcurrentHashMap<>();
   private final Map<Long, Map<String, NotificationSseSession>> userSessions =
       new ConcurrentHashMap<>();
+  private final AtomicInteger activeSessionCount = new AtomicInteger();
+  private final AtomicLong rejectedSubscriptionCount = new AtomicLong();
+  private final AtomicLong backpressureDropCount = new AtomicLong();
 
   public NotificationSseBroker(
       NotificationSseProperties notificationSseProperties,
@@ -83,7 +90,7 @@ public class NotificationSseBroker {
   }
 
   public boolean hasActiveSessions() {
-    return !accountSessions.isEmpty() || !userSessions.isEmpty();
+    return activeSessionCount.get() > 0;
   }
 
   public int accountSessionCount() {
@@ -95,7 +102,15 @@ public class NotificationSseBroker {
   }
 
   public int totalSessionCount() {
-    return accountSessionCount() + userSessionCount();
+    return activeSessionCount.get();
+  }
+
+  long rejectedSubscriptionCount() {
+    return rejectedSubscriptionCount.get();
+  }
+
+  long backpressureDropCount() {
+    return backpressureDropCount.get();
   }
 
   public void publishInsertedItems(List<NotificationSummary> items) {
@@ -124,24 +139,46 @@ public class NotificationSseBroker {
       String principalType,
       Long lastEventId,
       LongFunction<List<NotificationSummary>> replayLoader) {
+    if (!reserveSessionSlot()) {
+      long rejectedCount = rejectedSubscriptionCount.incrementAndGet();
+      log.warn(
+          "notification SSE subscribe rejected principalType={} principalId={} activeSessions={} limit={} rejectedCount={}",
+          principalType,
+          principalId,
+          activeSessionCount.get(),
+          notificationSseProperties.maxTotalSessions(),
+          rejectedCount);
+      throw new NotificationSseOverloadException(OVERLOAD_MESSAGE);
+    }
     String sessionId = UUID.randomUUID().toString();
-    SseEmitter emitter = new SseEmitter(notificationSseProperties.connectionTimeoutMs());
-    NotificationSseSession session =
-        new NotificationSseSession(sessionId, subject, emitter, lastEventId);
-    sessionsByPrincipalId
-        .computeIfAbsent(principalId, ignored -> new ConcurrentHashMap<>())
-        .put(sessionId, session);
-    emitter.onCompletion(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
-    emitter.onTimeout(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
-    emitter.onError(error -> removeSession(sessionsByPrincipalId, principalId, sessionId));
-    scheduleConnectedEvent(
-        sessionsByPrincipalId, principalId, principalType, session, lastEventId, replayLoader);
-    log.debug(
-        "notification SSE subscribed principalType={} principalId={} sessionId={}",
-        principalType,
-        principalId,
-        sessionId);
-    return emitter;
+    boolean registered = false;
+    try {
+      SseEmitter emitter = new SseEmitter(notificationSseProperties.connectionTimeoutMs());
+      NotificationSseSession session =
+          new NotificationSseSession(sessionId, subject, emitter, lastEventId);
+      sessionsByPrincipalId
+          .computeIfAbsent(principalId, ignored -> new ConcurrentHashMap<>())
+          .put(sessionId, session);
+      registered = true;
+      emitter.onCompletion(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
+      emitter.onTimeout(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
+      emitter.onError(error -> removeSession(sessionsByPrincipalId, principalId, sessionId));
+      scheduleConnectedEvent(
+          sessionsByPrincipalId, principalId, principalType, session, lastEventId, replayLoader);
+      log.debug(
+          "notification SSE subscribed principalType={} principalId={} sessionId={}",
+          principalType,
+          principalId,
+          sessionId);
+      return emitter;
+    } catch (RuntimeException ex) {
+      if (registered) {
+        removeSession(sessionsByPrincipalId, principalId, sessionId);
+      } else {
+        releaseSessionSlot();
+      }
+      throw ex;
+    }
   }
 
   private void sendConnectedEvent(NotificationSseSession session) throws IOException {
@@ -176,7 +213,7 @@ public class NotificationSseBroker {
                 session.sessionId(),
                 session.subject(),
                 ex);
-            removeSession(sessionsByPrincipalId, principalId, session.sessionId());
+            closeSession(sessionsByPrincipalId, principalId, session);
           }
         });
   }
@@ -206,7 +243,7 @@ public class NotificationSseBroker {
               principalId,
               session.sessionId(),
               ex);
-          removeSession(sessionsByPrincipalId, principalId, session.sessionId());
+          closeSession(sessionsByPrincipalId, principalId, session);
         }
       }
     }
@@ -221,6 +258,13 @@ public class NotificationSseBroker {
       for (NotificationSseSession session : sessions.values()) {
         try {
           queueOrSendNotification(session, item);
+        } catch (NotificationSseSessionBackpressureException ex) {
+          dropSessionDueToBackpressure(
+              accountSessions,
+              accountId,
+              "account",
+              session,
+              notificationSseProperties.maxPendingEventsPerSession());
         } catch (IOException ex) {
           log.debug(
               "notification SSE push failed principalType=account accountId={} sessionId={} subject={}",
@@ -228,7 +272,7 @@ public class NotificationSseBroker {
               session.sessionId(),
               session.subject(),
               ex);
-          removeSession(accountSessions, accountId, session.sessionId());
+          closeSession(accountSessions, accountId, session);
         }
       }
     }
@@ -251,6 +295,13 @@ public class NotificationSseBroker {
         for (NotificationSseSession session : sessions.values()) {
           try {
             queueOrSendNotification(session, item);
+          } catch (NotificationSseSessionBackpressureException ex) {
+            dropSessionDueToBackpressure(
+                userSessions,
+                userId,
+                "user",
+                session,
+                notificationSseProperties.maxPendingEventsPerSession());
           } catch (IOException ex) {
             log.debug(
                 "notification SSE push failed principalType=user userId={} sessionId={} subject={}",
@@ -258,7 +309,7 @@ public class NotificationSseBroker {
                 session.sessionId(),
                 session.subject(),
                 ex);
-            removeSession(userSessions, userId, session.sessionId());
+            closeSession(userSessions, userId, session);
           }
         }
       }
@@ -275,6 +326,9 @@ public class NotificationSseBroker {
     }
     List<NotificationSummary> replayItems = replayLoader.apply(lastEventId);
     synchronized (session.monitor()) {
+      if (session.isClosed()) {
+        return;
+      }
       // replay 중 새 live event는 pendingItems 에 모았다가 같은 세션 lock 안에서 이어 보냅니다.
       for (NotificationSummary item : replayItems) {
         sendNotification(session, item);
@@ -287,10 +341,17 @@ public class NotificationSseBroker {
   private void queueOrSendNotification(NotificationSseSession session, NotificationSummary item)
       throws IOException {
     synchronized (session.monitor()) {
+      if (session.isClosed()) {
+        return;
+      }
       if (item.id() <= session.lastDeliveredEventId()) {
         return;
       }
       if (session.isReplaying()) {
+        // replay gap 동안 live event를 무제한 적재하면 heap이 커지므로 session 단위로 끊습니다.
+        if (session.pendingItemCount() >= notificationSseProperties.maxPendingEventsPerSession()) {
+          throw new NotificationSseSessionBackpressureException();
+        }
         session.addPendingItem(item);
         return;
       }
@@ -308,6 +369,9 @@ public class NotificationSseBroker {
 
   private void sendNotification(NotificationSseSession session, NotificationSummary item)
       throws IOException {
+    if (session.isClosed()) {
+      return;
+    }
     if (item.id() <= session.lastDeliveredEventId()) {
       return;
     }
@@ -339,18 +403,72 @@ public class NotificationSseBroker {
     return count;
   }
 
-  private void removeSession(
+  private boolean reserveSessionSlot() {
+    int limit = notificationSseProperties.maxTotalSessions();
+    while (true) {
+      int current = activeSessionCount.get();
+      if (current >= limit) {
+        return false;
+      }
+      if (activeSessionCount.compareAndSet(current, current + 1)) {
+        return true;
+      }
+    }
+  }
+
+  private void releaseSessionSlot() {
+    activeSessionCount.updateAndGet(current -> current > 0 ? current - 1 : 0);
+  }
+
+  private void dropSessionDueToBackpressure(
+      Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
+      long principalId,
+      String principalType,
+      NotificationSseSession session,
+      int pendingLimit) {
+    if (!closeSession(sessionsByPrincipalId, principalId, session)) {
+      return;
+    }
+    long droppedCount = backpressureDropCount.incrementAndGet();
+    log.warn(
+        "notification SSE session dropped due to pending overflow principalType={} principalId={} sessionId={} subject={} pendingLimit={} droppedCount={}",
+        principalType,
+        principalId,
+        session.sessionId(),
+        session.subject(),
+        pendingLimit,
+        droppedCount);
+  }
+
+  private boolean closeSession(
+      Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
+      long principalId,
+      NotificationSseSession session) {
+    boolean removed = removeSession(sessionsByPrincipalId, principalId, session.sessionId());
+    if (removed) {
+      session.complete();
+    }
+    return removed;
+  }
+
+  private boolean removeSession(
       Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
       long principalId,
       String sessionId) {
     Map<String, NotificationSseSession> sessions = sessionsByPrincipalId.get(principalId);
     if (sessions == null) {
-      return;
+      return false;
     }
-    sessions.remove(sessionId);
+    NotificationSseSession removedSession = sessions.remove(sessionId);
+    if (removedSession == null) {
+      return false;
+    }
+    removedSession.markClosed();
+    releaseSessionSlot();
     if (sessions.isEmpty()) {
       sessionsByPrincipalId.remove(principalId, sessions);
     }
+    return true;
   }
 
   private static final class NotificationSseSession {
@@ -362,6 +480,7 @@ public class NotificationSseBroker {
     private final List<NotificationSummary> pendingItems = new ArrayList<>();
     private long lastDeliveredEventId;
     private boolean replaying;
+    private volatile boolean closed;
 
     private NotificationSseSession(
         String sessionId, String subject, SseEmitter emitter, Long lastEventId) {
@@ -370,6 +489,7 @@ public class NotificationSseBroker {
       this.emitter = emitter;
       this.lastDeliveredEventId = lastEventId == null ? 0L : lastEventId;
       this.replaying = lastEventId != null;
+      this.closed = false;
     }
 
     private String sessionId() {
@@ -400,8 +520,16 @@ public class NotificationSseBroker {
       return replaying;
     }
 
+    private boolean isClosed() {
+      return closed;
+    }
+
     private void addPendingItem(NotificationSummary item) {
       pendingItems.add(item);
+    }
+
+    private int pendingItemCount() {
+      return pendingItems.size();
     }
 
     private void markDelivered(long notificationId) {
@@ -411,5 +539,15 @@ public class NotificationSseBroker {
     private void finishReplay() {
       replaying = false;
     }
+
+    private void markClosed() {
+      closed = true;
+    }
+
+    private void complete() {
+      emitter.complete();
+    }
   }
+
+  private static final class NotificationSseSessionBackpressureException extends RuntimeException {}
 }

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseOverloadException.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseOverloadException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.global.notification;
+
+/** SSE broker 보호 상한을 넘으면 새 구독을 즉시 거절합니다. */
+public final class NotificationSseOverloadException extends RuntimeException {
+
+  public NotificationSseOverloadException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSsePrometheusMetrics.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSsePrometheusMetrics.java
@@ -38,5 +38,19 @@ public final class NotificationSsePrometheusMetrics implements MeterBinder {
         .tag("principal_type", "total")
         .description("active notification SSE session count")
         .register(registry);
+    Gauge.builder(
+            "aquila.notification.sse.subscription.rejected.count",
+            notificationSseBroker,
+            broker -> broker.rejectedSubscriptionCount())
+        .tag("reason", "session_limit")
+        .description("rejected notification SSE subscription count")
+        .register(registry);
+    Gauge.builder(
+            "aquila.notification.sse.session.dropped.count",
+            notificationSseBroker,
+            broker -> broker.backpressureDropCount())
+        .tag("reason", "pending_overflow")
+        .description("dropped notification SSE session count")
+        .register(registry);
   }
 }

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -15,6 +15,7 @@ import com.aquilabank.domain.ledger.exception.SnapshotNotFoundException;
 import com.aquilabank.domain.ledger.exception.TransferReversalNotFoundException;
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
 import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
+import com.aquilabank.global.notification.NotificationSseOverloadException;
 import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
 import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceTokenClaims;
@@ -83,6 +84,12 @@ public class ApiExceptionHandler {
   ResponseEntity<ApiErrorResponse> handleForbidden(
       AccountAccessDeniedException ex, HttpServletRequest request) {
     return response(HttpStatus.FORBIDDEN, ex.getMessage(), request);
+  }
+
+  @ExceptionHandler(NotificationSseOverloadException.class)
+  ResponseEntity<ApiErrorResponse> handleServiceUnavailable(
+      NotificationSseOverloadException ex, HttpServletRequest request) {
+    return response(HttpStatus.SERVICE_UNAVAILABLE, ex.getMessage(), request);
   }
 
   @ExceptionHandler({

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -120,6 +120,8 @@ notification:
     heartbeat-interval-ms: ${NOTIFICATION_SSE_HEARTBEAT_INTERVAL_MS:10000}
     reconnect-delay-ms: ${NOTIFICATION_SSE_RECONNECT_DELAY_MS:3000}
     replay-limit: ${NOTIFICATION_SSE_REPLAY_LIMIT:100}
+    max-total-sessions: ${NOTIFICATION_SSE_MAX_TOTAL_SESSIONS:64}
+    max-pending-events-per-session: ${NOTIFICATION_SSE_MAX_PENDING_EVENTS_PER_SESSION:32}
     fanout-channel: ${NOTIFICATION_SSE_FANOUT_CHANNEL:notification_sse_fanout}
     fanout-listen-timeout-ms: ${NOTIFICATION_SSE_FANOUT_LISTEN_TIMEOUT_MS:1000}
     fanout-retry-delay-ms: ${NOTIFICATION_SSE_FANOUT_RETRY_DELAY_MS:2000}

--- a/back/src/test/java/com/aquilabank/global/notification/NotificationSseBrokerTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/NotificationSseBrokerTest.java
@@ -1,0 +1,122 @@
+package com.aquilabank.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.notification.model.NotificationReplayQuery;
+import com.aquilabank.domain.notification.model.NotificationSummary;
+import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
+import com.aquilabank.global.config.NotificationSseProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class NotificationSseBrokerTest {
+
+  private NotificationQueryUseCase notificationQueryUseCase;
+  private NotificationSseTargetResolver notificationSseTargetResolver;
+
+  @BeforeEach
+  void setUp() {
+    notificationQueryUseCase = mock(NotificationQueryUseCase.class);
+    notificationSseTargetResolver = mock(NotificationSseTargetResolver.class);
+    when(notificationQueryUseCase.getReplayNotificationsForAccount(anyLong(), any()))
+        .thenReturn(List.of());
+    when(notificationQueryUseCase.getReplayNotificationsForUser(anyLong(), any()))
+        .thenReturn(List.of());
+    when(notificationSseTargetResolver.findActiveUserIdsByAccountId(anyLong()))
+        .thenReturn(List.of());
+  }
+
+  @Test
+  void rejectsSubscriptionWhenTotalSessionLimitIsReached() throws Exception {
+    NotificationSseBroker notificationSseBroker = createBroker(1, 2);
+
+    SseEmitter firstEmitter = notificationSseBroker.subscribeAccount(101L, "first-session");
+
+    assertThat(notificationSseBroker.totalSessionCount()).isEqualTo(1);
+    assertThatThrownBy(() -> notificationSseBroker.subscribeUser(202L, "second-session"))
+        .isInstanceOf(NotificationSseOverloadException.class)
+        .hasMessage("notification SSE stream is temporarily overloaded");
+    assertThat(notificationSseBroker.rejectedSubscriptionCount()).isEqualTo(1L);
+    firstEmitter.complete();
+  }
+
+  @Test
+  void dropsReplayingSessionWhenPendingQueueLimitIsExceeded() throws Exception {
+    CountDownLatch replayEntered = new CountDownLatch(1);
+    CountDownLatch releaseReplay = new CountDownLatch(1);
+    when(notificationQueryUseCase.getReplayNotificationsForAccount(
+            eq(101L), any(NotificationReplayQuery.class)))
+        .thenAnswer(
+            ignored -> {
+              replayEntered.countDown();
+              assertThat(releaseReplay.await(3, TimeUnit.SECONDS)).isTrue();
+              return List.of();
+            });
+    NotificationSseBroker notificationSseBroker = createBroker(4, 2);
+
+    notificationSseBroker.subscribeAccount(101L, "replay-session", 10L);
+    assertThat(replayEntered.await(3, TimeUnit.SECONDS)).isTrue();
+
+    notificationSseBroker.publishInsertedItems(
+        List.of(
+            notification(11L, 101L, "one"),
+            notification(12L, 101L, "two"),
+            notification(13L, 101L, "three")));
+
+    awaitCondition(() -> notificationSseBroker.totalSessionCount() == 0, Duration.ofSeconds(2));
+    assertThat(notificationSseBroker.backpressureDropCount()).isEqualTo(1L);
+
+    releaseReplay.countDown();
+  }
+
+  private NotificationSseBroker createBroker(int maxTotalSessions, int maxPendingEventsPerSession) {
+    return new NotificationSseBroker(
+        new NotificationSseProperties(
+            60_000L,
+            10_000L,
+            3_000L,
+            100,
+            maxTotalSessions,
+            maxPendingEventsPerSession,
+            "notification_sse_fanout",
+            1_000L,
+            2_000L),
+        notificationSseTargetResolver,
+        notificationQueryUseCase);
+  }
+
+  private NotificationSummary notification(long id, long accountId, String suffix) {
+    return new NotificationSummary(
+        id,
+        accountId,
+        "TransferBooked",
+        "이체 완료",
+        "message-" + suffix,
+        Instant.parse("2026-04-18T06:30:00Z"),
+        null);
+  }
+
+  private void awaitCondition(BooleanSupplier condition, Duration timeout) throws Exception {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(20L);
+    }
+    assertThat(condition.getAsBoolean()).isTrue();
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
@@ -37,6 +38,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
     properties = {
       "spring.flyway.enabled=true",
       "management.health.db.enabled=true",
+      "notification.sse.max-total-sessions=1",
       "notification.inbox.consumer.enabled=true",
       "notification.inbox.consumer.auto-startup=false",
       "notification.inbox.consumer.group-id=aquila-bank-prometheus-metrics",
@@ -86,6 +88,10 @@ class PrometheusMetricsIntegrationTest extends PostgresKafkaContainerTestSupport
 
     SseEmitter emitter = notificationSseBroker.subscribeAccount(1L, "metrics");
     try {
+      assertThatThrownBy(() -> notificationSseBroker.subscribeAccount(2L, "metrics-overload"))
+          .isInstanceOf(NotificationSseOverloadException.class)
+          .hasMessage("notification SSE stream is temporarily overloaded");
+
       jdbcTransactionReadRepository.fetch(
           new TransactionQuery(
               1L,
@@ -140,6 +146,12 @@ class PrometheusMetricsIntegrationTest extends PostgresKafkaContainerTestSupport
       assertThat(body)
           .containsPattern(
               "aquila_notification_sse_sessions\\{[^\\n]*principal_type=\"total\"[^\\n]*\\}\\s+1\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_notification_sse_subscription_rejected_count\\{[^\\n]*reason=\"session_limit\"[^\\n]*\\}\\s+1\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_notification_sse_session_dropped_count\\{[^\\n]*reason=\"pending_overflow\"[^\\n]*\\}\\s+0\\.0");
       assertThat(body)
           .containsPattern(
               "aquila_transaction_query_latency_seconds_count\\{[^\\n]*outcome=\"success\"[^\\n]*query_shape=\"first_page\"[^\\n]*\\}\\s+1");

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -21,6 +21,7 @@ import com.aquilabank.domain.notification.model.NotificationSummary;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
 import com.aquilabank.global.notification.NotificationSseBroker;
+import com.aquilabank.global.notification.NotificationSseOverloadException;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
@@ -149,6 +150,20 @@ class NotificationControllerTest {
         .andExpect(header().string("X-Accel-Buffering", "no"));
 
     verify(notificationSseBroker).subscribeAccount(101L, "bootstrap", 7L);
+  }
+
+  @Test
+  void rejectsNotificationStreamWhenBrokerIsOverloaded() throws Exception {
+    when(notificationSseBroker.subscribeAccount(101L, "bootstrap", null))
+        .thenThrow(
+            new NotificationSseOverloadException(
+                "notification SSE stream is temporarily overloaded"));
+
+    mockMvc
+        .perform(get("/api/v1/notifications/stream").header("X-Account-Id", "101"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(
+            jsonPath("$.message").value("notification SSE stream is temporarily overloaded"));
   }
 
   @Test

--- a/back/src/test/resources/application-test.yml
+++ b/back/src/test/resources/application-test.yml
@@ -33,6 +33,8 @@ outbox:
 
 notification:
   sse:
+    max-total-sessions: 64
+    max-pending-events-per-session: 32
     fanout-channel: notification_sse_fanout
     fanout-listen-timeout-ms: 200
     fanout-retry-delay-ms: 200


### PR DESCRIPTION
## 🔗 Related Issue
- close #108

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification SSE broker에 총 session 상한과 replay pending queue backpressure 보호를 추가해 `t3.micro` 메모리 방어선을 고정했습니다.
- overload 시 새 구독은 `503 Service Unavailable`로 빠르게 거절하고, pending overflow session은 개별 정리하도록 바꿨습니다.
- Prometheus 지표와 테스트, README 운영 메모를 현재 정책에 맞게 갱신했습니다.

## 🛠 Changes
- `NotificationSseProperties`에 `max-total-sessions`, `max-pending-events-per-session` 설정과 검증을 추가했습니다.
- `NotificationSseBroker`에 atomic session slot, subscribe fail-fast guard, replay pending overflow session drop 정책을 추가했습니다.
- `NotificationSseOverloadException`, `ApiExceptionHandler` 503 처리, controller 테스트를 추가했습니다.
- Prometheus gauge에 subscription rejected / session dropped 누적 count를 노출했습니다.
- broker 단위 테스트, notification metrics 테스트, README SSE 운영 기준을 갱신했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-notification-tests ./back/gradlew -p back test --tests '*Notification*'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit hook `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - `NOTIFICATION_SSE_MAX_TOTAL_SESSIONS`, `NOTIFICATION_SSE_MAX_PENDING_EVENTS_PER_SESSION` 값이 너무 낮으면 정상 reconnect burst도 `503` 또는 reconnect 빈도 증가로 보일 수 있습니다.
- 롤백 방법:
  - env 값 상향으로 즉시 완화하거나, 필요 시 PR revert로 기존 SSE guard 없는 동작으로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (N/A)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (없음)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?