### PR TITLE
[Chore] outbox_event 보존 정책과 cleanup batch 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -189,6 +189,13 @@ set +a
   - outbox/notification gauge는 scrape 한 번에 같은 summary를 여러 번 다시 조회하지 않게 `5초` cache 안에서 재사용합니다.
   - SSE session metric은 현재 app instance 메모리의 active session 수만 보여주므로 multi-instance 전체 합계는 Prometheus 쿼리에서 합산합니다.
 
+## Outbox Retention Cleanup
+
+- outbox retention cleanup은 `publish_status = 'PUBLISHED'` 이고 `published_at` 이 retention cutoff 밖인 row만 정리합니다.
+- `PENDING`, `FAILED`, `SENDING` row는 dispatch 복구와 ops 확인 대상이라 cleanup에서 제외합니다.
+- cleanup batch는 `published_at ASC, id ASC` 순서의 작은 batch delete만 수행해 `t3.micro`에서 lock/vacuum 충격을 낮춥니다.
+- 기본 설정은 `OUTBOX_CLEANUP_ENABLED=true`, `OUTBOX_CLEANUP_RETENTION_DAYS=30`, `OUTBOX_CLEANUP_BATCH_SIZE=500`, `OUTBOX_CLEANUP_FIXED_DELAY_MS=300000` 입니다.
+
 ### Local Notification E2E
 
 실제 broker를 통과하는 알림 검증은 transfer write path와 outbox dispatch를 같이 봐야 합니다.

--- a/back/src/main/java/com/aquilabank/domain/notification/port/OutboxCleanupPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/OutboxCleanupPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.notification.port;
+
+import java.time.Instant;
+
+/** retention cutoff 이전 PUBLISHED outbox row 정리를 persistence adapter로 위임합니다. */
+public interface OutboxCleanupPort {
+
+  int deletePublishedEvents(Instant cutoff, int batchSize);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxCleanupService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxCleanupService.java
@@ -1,0 +1,36 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.port.OutboxCleanupPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/** outbox retention 기준과 batch 크기를 domain에서 고정해 scheduler/adapter drift를 막습니다. */
+public final class OutboxCleanupService implements OutboxCleanupUseCase {
+
+  private final OutboxCleanupPort outboxCleanupPort;
+  private final Clock clock;
+  private final Duration retention;
+  private final int batchSize;
+
+  public OutboxCleanupService(
+      OutboxCleanupPort outboxCleanupPort, Clock clock, Duration retention, int batchSize) {
+    this.outboxCleanupPort = Objects.requireNonNull(outboxCleanupPort, "outboxCleanupPort");
+    this.clock = Objects.requireNonNull(clock, "clock");
+    this.retention = Objects.requireNonNull(retention, "retention");
+    if (retention.isZero() || retention.isNegative()) {
+      throw new IllegalArgumentException("retention must be positive");
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("batchSize must be positive");
+    }
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public int cleanupPublishedEvents() {
+    Instant cutoff = clock.instant().minus(retention);
+    return outboxCleanupPort.deletePublishedEvents(cutoff, batchSize);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxCleanupUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/OutboxCleanupUseCase.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.notification.usecase;
+
+/** retention cutoff 밖의 PUBLISHED outbox cleanup batch 진입점 */
+public interface OutboxCleanupUseCase {
+
+  int cleanupPublishedEvents();
+}

--- a/back/src/main/java/com/aquilabank/global/config/OutboxCleanupConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/OutboxCleanupConfiguration.java
@@ -1,0 +1,26 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.notification.port.OutboxCleanupPort;
+import com.aquilabank.domain.notification.usecase.OutboxCleanupService;
+import com.aquilabank.domain.notification.usecase.OutboxCleanupUseCase;
+import java.time.Clock;
+import java.time.Duration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** outbox retention cleanup use case와 runtime 설정을 조립합니다. */
+@Configuration
+@EnableConfigurationProperties(OutboxCleanupProperties.class)
+public class OutboxCleanupConfiguration {
+
+  @Bean
+  OutboxCleanupUseCase outboxCleanupUseCase(
+      OutboxCleanupPort outboxCleanupPort, OutboxCleanupProperties outboxCleanupProperties) {
+    return new OutboxCleanupService(
+        outboxCleanupPort,
+        Clock.systemUTC(),
+        Duration.ofDays(outboxCleanupProperties.retentionDays()),
+        outboxCleanupProperties.batchSize());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/config/OutboxCleanupProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/OutboxCleanupProperties.java
@@ -1,0 +1,24 @@
+package com.aquilabank.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** outbox retention cleanup 런타임 기준을 dispatch poller 설정과 분리합니다. */
+@ConfigurationProperties(prefix = "outbox.cleanup")
+public record OutboxCleanupProperties(
+    boolean enabled, long fixedDelayMs, long initialDelayMs, int batchSize, long retentionDays) {
+
+  public OutboxCleanupProperties {
+    if (fixedDelayMs <= 0) {
+      throw new IllegalArgumentException("outbox.cleanup.fixed-delay-ms must be positive");
+    }
+    if (initialDelayMs < 0) {
+      throw new IllegalArgumentException("outbox.cleanup.initial-delay-ms must not be negative");
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("outbox.cleanup.batch-size must be positive");
+    }
+    if (retentionDays <= 0) {
+      throw new IllegalArgumentException("outbox.cleanup.retention-days must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/OutboxCleanupPoller.java
+++ b/back/src/main/java/com/aquilabank/global/notification/OutboxCleanupPoller.java
@@ -1,0 +1,32 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.usecase.OutboxCleanupUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** 오래된 PUBLISHED outbox row를 작은 batch로만 정리해 저장 비용 누적을 제한합니다. */
+@Component
+@ConditionalOnProperty(name = "outbox.cleanup.enabled", havingValue = "true")
+public class OutboxCleanupPoller {
+
+  private static final Logger log = LoggerFactory.getLogger(OutboxCleanupPoller.class);
+
+  private final OutboxCleanupUseCase outboxCleanupUseCase;
+
+  public OutboxCleanupPoller(OutboxCleanupUseCase outboxCleanupUseCase) {
+    this.outboxCleanupUseCase = outboxCleanupUseCase;
+  }
+
+  @Scheduled(
+      fixedDelayString = "${outbox.cleanup.fixed-delay-ms:300000}",
+      initialDelayString = "${outbox.cleanup.initial-delay-ms:60000}")
+  void cleanupPublishedEvents() {
+    int deleted = outboxCleanupUseCase.cleanupPublishedEvents();
+    if (deleted > 0) {
+      log.info("deleted {} published outbox event row(s)", deleted);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcOutboxEventRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcOutboxEventRepository.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.persistence.notification;
 
 import com.aquilabank.domain.notification.model.OutboxEvent;
+import com.aquilabank.domain.notification.port.OutboxCleanupPort;
 import com.aquilabank.domain.notification.port.OutboxEventStore;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -17,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** PostgreSQL에서 outbox claim과 retry 상태를 관리하는 JDBC adapter */
 @Repository
-public class JdbcOutboxEventRepository implements OutboxEventStore {
+public class JdbcOutboxEventRepository implements OutboxEventStore, OutboxCleanupPort {
 
   private static final RowMapper<OutboxEvent> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
 
@@ -114,6 +115,38 @@ public class JdbcOutboxEventRepository implements OutboxEventStore {
         WHERE id = :id
         """,
         params);
+  }
+
+  @Override
+  @Transactional
+  public int deletePublishedEvents(Instant cutoff, int batchSize) {
+    // dispatch 중/실패 row를 건드리지 않게 PUBLISHED + published_at index 경로만 정리합니다.
+    Integer deleted =
+        jdbcTemplate.queryForObject(
+            """
+            WITH published AS (
+                SELECT id
+                FROM outbox_event
+                WHERE publish_status = 'PUBLISHED'
+                  AND published_at < :cutoff
+                ORDER BY published_at ASC, id ASC
+                FOR UPDATE SKIP LOCKED
+                LIMIT :batchSize
+            ),
+            deleted AS (
+                DELETE FROM outbox_event o
+                USING published p
+                WHERE o.id = p.id
+                RETURNING o.id
+            )
+            SELECT COUNT(*)
+            FROM deleted
+            """,
+            new MapSqlParameterSource()
+                .addValue("cutoff", Timestamp.from(cutoff))
+                .addValue("batchSize", batchSize),
+            Integer.class);
+    return deleted == null ? 0 : deleted;
   }
 
   private static OutboxEvent mapRow(ResultSet rs) throws SQLException {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -73,6 +73,12 @@ outbox:
     batch-size: ${OUTBOX_POLLER_BATCH_SIZE:20}
     stale-after-seconds: ${OUTBOX_POLLER_STALE_AFTER_SECONDS:30}
     max-retry-delay-seconds: ${OUTBOX_POLLER_MAX_RETRY_DELAY_SECONDS:60}
+  cleanup:
+    enabled: ${OUTBOX_CLEANUP_ENABLED:true}
+    fixed-delay-ms: ${OUTBOX_CLEANUP_FIXED_DELAY_MS:300000}
+    initial-delay-ms: ${OUTBOX_CLEANUP_INITIAL_DELAY_MS:60000}
+    batch-size: ${OUTBOX_CLEANUP_BATCH_SIZE:500}
+    retention-days: ${OUTBOX_CLEANUP_RETENTION_DAYS:30}
   kafka:
     enabled: ${OUTBOX_KAFKA_ENABLED:false}
     bootstrap-servers: ${OUTBOX_KAFKA_BOOTSTRAP_SERVERS:}

--- a/back/src/main/resources/db/migration/V16__add_outbox_event_retention.sql
+++ b/back/src/main/resources/db/migration/V16__add_outbox_event_retention.sql
@@ -1,0 +1,4 @@
+-- PUBLISHED cleanup 은 dispatch queue 조회와 분리해 published_at 기준 partial index를 별도로 탑니다.
+CREATE INDEX idx_outbox_event_published_cleanup
+    ON outbox_event (published_at, id)
+    WHERE publish_status = 'PUBLISHED' AND published_at IS NOT NULL;

--- a/back/src/test/java/com/aquilabank/domain/notification/usecase/OutboxCleanupServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/notification/usecase/OutboxCleanupServiceTest.java
@@ -1,0 +1,34 @@
+package com.aquilabank.domain.notification.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.notification.port.OutboxCleanupPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class OutboxCleanupServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-18T00:00:00Z");
+
+  private final OutboxCleanupPort outboxCleanupPort = mock(OutboxCleanupPort.class);
+
+  @Test
+  void deletesPublishedEventsUsingConfiguredRetentionAndBatchSize() {
+    Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    when(outboxCleanupPort.deletePublishedEvents(NOW.minus(Duration.ofDays(30)), 500))
+        .thenReturn(4);
+    OutboxCleanupService service =
+        new OutboxCleanupService(outboxCleanupPort, clock, Duration.ofDays(30), 500);
+
+    int deleted = service.cleanupPublishedEvents();
+
+    assertThat(deleted).isEqualTo(4);
+    verify(outboxCleanupPort).deletePublishedEvents(NOW.minus(Duration.ofDays(30)), 500);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/OutboxCleanupConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/OutboxCleanupConfigurationTest.java
@@ -1,0 +1,57 @@
+package com.aquilabank.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.aquilabank.domain.notification.port.OutboxCleanupPort;
+import com.aquilabank.domain.notification.usecase.OutboxCleanupUseCase;
+import com.aquilabank.global.notification.OutboxCleanupPoller;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class OutboxCleanupConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(OutboxCleanupConfiguration.class, OutboxCleanupPoller.class)
+          .withBean(OutboxCleanupPort.class, () -> mock(OutboxCleanupPort.class))
+          .withPropertyValues(
+              "outbox.cleanup.fixed-delay-ms=300000",
+              "outbox.cleanup.initial-delay-ms=60000",
+              "outbox.cleanup.batch-size=500",
+              "outbox.cleanup.retention-days=30");
+
+  @Test
+  void createsCleanupPollerWhenCleanupIsEnabled() {
+    contextRunner
+        .withPropertyValues("outbox.cleanup.enabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(OutboxCleanupUseCase.class);
+              assertThat(context).hasSingleBean(OutboxCleanupPoller.class);
+            });
+  }
+
+  @Test
+  void doesNotCreateCleanupPollerWhenCleanupIsDisabled() {
+    contextRunner
+        .withPropertyValues("outbox.cleanup.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(OutboxCleanupUseCase.class);
+              assertThat(context).doesNotHaveBean(OutboxCleanupPoller.class);
+            });
+  }
+
+  @Test
+  void rejectsNonPositiveRetentionDays() {
+    contextRunner
+        .withPropertyValues("outbox.cleanup.enabled=true", "outbox.cleanup.retention-days=0")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .hasRootCauseMessage("outbox.cleanup.retention-days must be positive");
+            });
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcOutboxEventRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcOutboxEventRepositoryIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.aquilabank.global.persistence.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcOutboxEventRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcOutboxEventRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void deletesOnlyPublishedEventsBeforeCutoffUsingBatchSize() {
+    Instant cutoff = Instant.parse("2026-04-18T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          insertOutboxEvent(
+              "evt-published-old-1",
+              "PUBLISHED",
+              cutoff.minusSeconds(200),
+              cutoff.minusSeconds(100),
+              cutoff.minusSeconds(100));
+          insertOutboxEvent(
+              "evt-published-old-2",
+              "PUBLISHED",
+              cutoff.minusSeconds(150),
+              cutoff.minusSeconds(50),
+              cutoff.minusSeconds(50));
+          insertOutboxEvent(
+              "evt-published-fresh",
+              "PUBLISHED",
+              cutoff.plusSeconds(10),
+              cutoff.plusSeconds(10),
+              cutoff.plusSeconds(10));
+          insertOutboxEvent("evt-pending", "PENDING", cutoff.minusSeconds(300), null, cutoff);
+          insertOutboxEvent("evt-failed", "FAILED", cutoff.minusSeconds(250), null, cutoff);
+          insertOutboxEvent("evt-sending", "SENDING", cutoff.minusSeconds(240), null, cutoff);
+        });
+
+    int firstDeleted = repository.deletePublishedEvents(cutoff, 1);
+
+    assertThat(firstDeleted).isEqualTo(1);
+    assertThat(findEventKeys())
+        .containsExactlyInAnyOrder(
+            "evt-published-old-2",
+            "evt-published-fresh",
+            "evt-pending",
+            "evt-failed",
+            "evt-sending");
+
+    int secondDeleted = repository.deletePublishedEvents(cutoff, 10);
+
+    assertThat(secondDeleted).isEqualTo(1);
+    assertThat(findEventKeys())
+        .containsExactlyInAnyOrder(
+            "evt-published-fresh", "evt-pending", "evt-failed", "evt-sending");
+  }
+
+  private void insertOutboxEvent(
+      String eventKey,
+      String publishStatus,
+      Instant createdAt,
+      Instant publishedAt,
+      Instant updatedAt) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO outbox_event (
+            aggregate_type,
+            aggregate_id,
+            event_type,
+            event_key,
+            payload,
+            publish_status,
+            available_at,
+            published_at,
+            retry_count,
+            last_error,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            'TRANSFER',
+            'TRX-' || right(:eventKey, 3),
+            'TransferBooked',
+            :eventKey,
+            '{"transactionReference":"seed"}'::jsonb,
+            :publishStatus,
+            :createdAt,
+            :publishedAt,
+            0,
+            NULL,
+            :createdAt,
+            :updatedAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("eventKey", eventKey)
+            .addValue("publishStatus", publishStatus)
+            .addValue("createdAt", Timestamp.from(createdAt))
+            .addValue("publishedAt", publishedAt == null ? null : Timestamp.from(publishedAt))
+            .addValue("updatedAt", Timestamp.from(updatedAt)));
+  }
+
+  private List<String> findEventKeys() {
+    return jdbcTemplate.queryForList(
+        "SELECT event_key FROM outbox_event ORDER BY id ASC",
+        new MapSqlParameterSource(),
+        String.class);
+  }
+}

--- a/back/src/test/resources/application-test.yml
+++ b/back/src/test/resources/application-test.yml
@@ -19,6 +19,12 @@ outbox:
   poller:
     # scheduled dispatch는 끄고 테스트가 retry 타이밍을 직접 제어하게 합니다.
     enabled: false
+  cleanup:
+    enabled: false
+    fixed-delay-ms: 300000
+    initial-delay-ms: 60000
+    batch-size: 500
+    retention-days: 30
   kafka:
     enabled: false
   ops:


### PR DESCRIPTION
## 🔗 Related Issue
- close #110

## 🌿 Base Branch
- `main`

## 📝 Summary
- `outbox_event`에 `PUBLISHED/published_at` 기준 retention cleanup 경로를 추가했습니다.
- dispatch 중이거나 복구 대상인 `PENDING`, `FAILED`, `SENDING` row는 그대로 유지해 outbox ops 시야를 보존합니다.
- 작은 batch delete, partial index, scheduler, 테스트, README 운영 메모를 함께 반영했습니다.

## 🛠 Changes
- `OutboxCleanupPort`, `OutboxCleanupUseCase`, `OutboxCleanupService`를 추가해 retention cutoff와 batch 크기 계산을 domain에 고정했습니다.
- `outbox.cleanup.*` properties, `OutboxCleanupConfiguration`, `OutboxCleanupPoller`를 추가했습니다.
- `JdbcOutboxEventRepository`에 `PUBLISHED` row bounded delete를 추가하고 `published_at` partial index migration(`V16__add_outbox_event_retention.sql`)을 넣었습니다.
- `application.yml`, `application-test.yml`, domain/config/JDBC 테스트, README를 현재 정책에 맞게 갱신했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-outbox-retention ./back/gradlew -p back test --tests '*OutboxCleanup*' --tests '*JdbcOutbox*RepositoryIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit hook `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - `OUTBOX_CLEANUP_RETENTION_DAYS`가 너무 짧으면 운영자가 오래된 publish 흔적을 확인하기 어려워질 수 있습니다.
  - `published_at` cleanup index가 예상과 다르게 쓰이면 작은 인스턴스에서 vacuum/lock 비용이 커질 수 있습니다.
- 롤백 방법:
  - env 값 상향 또는 `OUTBOX_CLEANUP_ENABLED=false`로 즉시 완화하고, 필요 시 PR revert로 cleanup 경로와 index를 함께 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (N/A)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (`published_at` cleanup partial index 추가)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?