### PR TITLE
[Feat] 계좌 상태 변경 audit trail 및 requestId 조회 API 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/account/exception/AccountStatusChangeAuditNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/account/exception/AccountStatusChangeAuditNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.account.exception;
+
+/** 계좌 상태 변경 감사 row 부재 예외 */
+public class AccountStatusChangeAuditNotFoundException extends RuntimeException {
+
+  public AccountStatusChangeAuditNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/model/AccountStatusChangeAuditEntry.java
+++ b/back/src/main/java/com/aquilabank/domain/account/model/AccountStatusChangeAuditEntry.java
@@ -1,0 +1,34 @@
+package com.aquilabank.domain.account.model;
+
+import java.time.Instant;
+
+/** 계좌 상태 변경 성공 시 저장할 감사 row 입력입니다. */
+public record AccountStatusChangeAuditEntry(
+    String requestId,
+    String actorSubject,
+    long targetAccountId,
+    String beforeStatus,
+    String afterStatus,
+    Instant createdAt) {
+
+  public AccountStatusChangeAuditEntry {
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (targetAccountId <= 0) {
+      throw new IllegalArgumentException("targetAccountId must be positive");
+    }
+    if (beforeStatus == null || beforeStatus.isBlank()) {
+      throw new IllegalArgumentException("beforeStatus is required");
+    }
+    if (afterStatus == null || afterStatus.isBlank()) {
+      throw new IllegalArgumentException("afterStatus is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/model/AccountStatusChangeAuditSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/account/model/AccountStatusChangeAuditSummary.java
@@ -1,0 +1,34 @@
+package com.aquilabank.domain.account.model;
+
+import java.time.Instant;
+
+/** 계좌 상태 변경 requestId exact lookup 응답에 쓰는 최소 감사 row 모델입니다. */
+public record AccountStatusChangeAuditSummary(
+    String requestId,
+    String actorSubject,
+    long targetAccountId,
+    String beforeStatus,
+    String afterStatus,
+    Instant createdAt) {
+
+  public AccountStatusChangeAuditSummary {
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (targetAccountId <= 0) {
+      throw new IllegalArgumentException("targetAccountId must be positive");
+    }
+    if (beforeStatus == null || beforeStatus.isBlank()) {
+      throw new IllegalArgumentException("beforeStatus is required");
+    }
+    if (afterStatus == null || afterStatus.isBlank()) {
+      throw new IllegalArgumentException("afterStatus is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/model/AccountStatusUpdateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/account/model/AccountStatusUpdateCommand.java
@@ -1,7 +1,8 @@
 package com.aquilabank.domain.account.model;
 
 /** 내부 운영 경로가 계좌 상태를 갱신할 때 필요한 최소 입력입니다. */
-public record AccountStatusUpdateCommand(long accountId, AccountStatus status) {
+public record AccountStatusUpdateCommand(
+    long accountId, AccountStatus status, String actorSubject, String requestId) {
 
   public AccountStatusUpdateCommand {
     if (accountId <= 0) {
@@ -9,6 +10,12 @@ public record AccountStatusUpdateCommand(long accountId, AccountStatus status) {
     }
     if (status == null) {
       throw new IllegalArgumentException("status is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/account/port/AccountStatusChangeAuditQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/account/port/AccountStatusChangeAuditQueryPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.account.port;
+
+import com.aquilabank.domain.account.model.AccountStatusChangeAuditSummary;
+import java.util.Optional;
+
+/** 계좌 상태 변경 감사 row requestId exact lookup을 저장소 계층으로 위임합니다. */
+public interface AccountStatusChangeAuditQueryPort {
+
+  Optional<AccountStatusChangeAuditSummary> findByRequestId(String requestId);
+}

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountStatusChangeAuditQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountStatusChangeAuditQueryService.java
@@ -1,0 +1,28 @@
+package com.aquilabank.domain.account.usecase;
+
+import com.aquilabank.domain.account.exception.AccountStatusChangeAuditNotFoundException;
+import com.aquilabank.domain.account.model.AccountStatusChangeAuditSummary;
+import com.aquilabank.domain.account.port.AccountStatusChangeAuditQueryPort;
+
+/** 계좌 상태 변경 감사 requestId exact lookup을 not found 예외와 함께 고정합니다. */
+public final class AccountStatusChangeAuditQueryService
+    implements AccountStatusChangeAuditQueryUseCase {
+
+  private final AccountStatusChangeAuditQueryPort accountStatusChangeAuditQueryPort;
+
+  public AccountStatusChangeAuditQueryService(
+      AccountStatusChangeAuditQueryPort accountStatusChangeAuditQueryPort) {
+    this.accountStatusChangeAuditQueryPort = accountStatusChangeAuditQueryPort;
+  }
+
+  @Override
+  public AccountStatusChangeAuditSummary getByRequestId(String requestId) {
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    return accountStatusChangeAuditQueryPort
+        .findByRequestId(requestId)
+        .orElseThrow(
+            () -> new AccountStatusChangeAuditNotFoundException("audit record is not found"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountStatusChangeAuditQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountStatusChangeAuditQueryUseCase.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.account.usecase;
+
+import com.aquilabank.domain.account.model.AccountStatusChangeAuditSummary;
+
+public interface AccountStatusChangeAuditQueryUseCase {
+
+  AccountStatusChangeAuditSummary getByRequestId(String requestId);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AccountAdminConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AccountAdminConfiguration.java
@@ -1,6 +1,9 @@
 package com.aquilabank.global.config;
 
+import com.aquilabank.domain.account.port.AccountStatusChangeAuditQueryPort;
 import com.aquilabank.domain.account.port.AccountStatusUpdatePort;
+import com.aquilabank.domain.account.usecase.AccountStatusChangeAuditQueryService;
+import com.aquilabank.domain.account.usecase.AccountStatusChangeAuditQueryUseCase;
 import com.aquilabank.domain.account.usecase.AccountStatusUpdateService;
 import com.aquilabank.domain.account.usecase.AccountStatusUpdateUseCase;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +12,12 @@ import org.springframework.context.annotation.Configuration;
 /** account internal admin write 경로와 JDBC adapter를 조립합니다. */
 @Configuration
 public class AccountAdminConfiguration {
+
+  @Bean
+  AccountStatusChangeAuditQueryUseCase accountStatusChangeAuditQueryUseCase(
+      AccountStatusChangeAuditQueryPort accountStatusChangeAuditQueryPort) {
+    return new AccountStatusChangeAuditQueryService(accountStatusChangeAuditQueryPort);
+  }
 
   @Bean
   AccountStatusUpdateUseCase accountStatusUpdateUseCase(

--- a/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountStatusChangeAuditRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountStatusChangeAuditRepository.java
@@ -1,0 +1,54 @@
+package com.aquilabank.global.persistence.account;
+
+import com.aquilabank.domain.account.model.AccountStatusChangeAuditSummary;
+import com.aquilabank.domain.account.port.AccountStatusChangeAuditQueryPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** 계좌 상태 변경 감사 row requestId exact lookup을 JDBC 단건 조회로 고정합니다. */
+@Repository
+public class JdbcAccountStatusChangeAuditRepository implements AccountStatusChangeAuditQueryPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcAccountStatusChangeAuditRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public Optional<AccountStatusChangeAuditSummary> findByRequestId(String requestId) {
+    // requestId exact match만 허용해 단일 index 경로를 그대로 사용합니다.
+    return jdbcTemplate
+        .query(
+            """
+            SELECT request_id,
+                   actor_subject,
+                   target_account_id,
+                   before_status,
+                   after_status,
+                   created_at
+            FROM account_status_change_audit
+            WHERE request_id = :requestId
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            new MapSqlParameterSource().addValue("requestId", requestId),
+            (rs, rowNum) -> mapAuditSummary(rs))
+        .stream()
+        .findFirst();
+  }
+
+  private AccountStatusChangeAuditSummary mapAuditSummary(ResultSet rs) throws SQLException {
+    return new AccountStatusChangeAuditSummary(
+        rs.getString("request_id"),
+        rs.getString("actor_subject"),
+        rs.getLong("target_account_id"),
+        rs.getString("before_status"),
+        rs.getString("after_status"),
+        rs.getTimestamp("created_at").toInstant());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountStatusUpdateRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountStatusUpdateRepository.java
@@ -1,6 +1,8 @@
 package com.aquilabank.global.persistence.account;
 
 import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
+import com.aquilabank.domain.account.model.AccountStatus;
+import com.aquilabank.domain.account.model.AccountStatusChangeAuditEntry;
 import com.aquilabank.domain.account.model.AccountStatusUpdateCommand;
 import com.aquilabank.domain.account.model.AccountSummary;
 import com.aquilabank.domain.account.port.AccountStatusUpdatePort;
@@ -27,9 +29,11 @@ public class JdbcAccountStatusUpdateRepository implements AccountStatusUpdatePor
   @Transactional
   public AccountSummary updateStatus(AccountStatusUpdateCommand command) {
     Instant updatedAt = Instant.now();
-    return jdbcTemplate
-        .query(
-            """
+    AccountStatus beforeStatus = loadCurrentAccountStatusForUpdate(command.accountId());
+    AccountSummary summary =
+        jdbcTemplate
+            .query(
+                """
             WITH updated_account AS (
                 UPDATE bank_account
                 SET account_status = :accountStatus,
@@ -56,14 +60,69 @@ public class JdbcAccountStatusUpdateRepository implements AccountStatusUpdatePor
             JOIN account_balance_snapshot snapshot
               ON snapshot.account_id = updated_account.id
             """,
-            new MapSqlParameterSource()
-                .addValue("accountId", command.accountId())
-                .addValue("accountStatus", command.status().name())
-                .addValue("updatedAt", Timestamp.from(updatedAt)),
-            (rs, rowNum) -> mapAccountSummary(rs))
+                new MapSqlParameterSource()
+                    .addValue("accountId", command.accountId())
+                    .addValue("accountStatus", command.status().name())
+                    .addValue("updatedAt", Timestamp.from(updatedAt)),
+                (rs, rowNum) -> mapAccountSummary(rs))
+            .stream()
+            .findFirst()
+            .orElseThrow(() -> new AccountSummaryNotFoundException("account summary is not found"));
+    insertStatusChangeAudit(
+        new AccountStatusChangeAuditEntry(
+            command.requestId(),
+            command.actorSubject(),
+            command.accountId(),
+            beforeStatus.name(),
+            summary.accountStatus(),
+            updatedAt));
+    return summary;
+  }
+
+  private AccountStatus loadCurrentAccountStatusForUpdate(long accountId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT account_status
+            FROM bank_account
+            WHERE id = :accountId
+            FOR UPDATE
+            """,
+            new MapSqlParameterSource().addValue("accountId", accountId),
+            (rs, rowNum) -> AccountStatus.valueOf(rs.getString("account_status")))
         .stream()
         .findFirst()
         .orElseThrow(() -> new AccountSummaryNotFoundException("account summary is not found"));
+  }
+
+  private void insertStatusChangeAudit(AccountStatusChangeAuditEntry entry) {
+    // 상태 변경과 audit row를 같은 transaction에 묶어 운영 추적 누락을 막습니다.
+    jdbcTemplate.update(
+        """
+        INSERT INTO account_status_change_audit (
+            request_id,
+            actor_subject,
+            target_account_id,
+            before_status,
+            after_status,
+            created_at
+        )
+        VALUES (
+            :requestId,
+            :actorSubject,
+            :targetAccountId,
+            :beforeStatus,
+            :afterStatus,
+            :createdAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("requestId", entry.requestId())
+            .addValue("actorSubject", entry.actorSubject())
+            .addValue("targetAccountId", entry.targetAccountId())
+            .addValue("beforeStatus", entry.beforeStatus())
+            .addValue("afterStatus", entry.afterStatus())
+            .addValue("createdAt", Timestamp.from(entry.createdAt())));
   }
 
   private AccountSummary mapAccountSummary(ResultSet rs) throws SQLException {

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -72,6 +72,8 @@ public class SecurityConfiguration {
                     // 내부 운영 API는 public JWT resolver에서 제외하고 전용 service JWT로만 검증합니다.
                     .requestMatchers("/internal/api/v1/accounts/bootstrap")
                     .permitAll()
+                    .requestMatchers("/internal/api/v1/accounts/status-change-audits/**")
+                    .permitAll()
                     .requestMatchers("/internal/api/v1/accounts/*/status")
                     .permitAll()
                     .requestMatchers("/internal/api/v1/outbox/**")

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.aquilabank.global.web;
 
+import com.aquilabank.domain.account.exception.AccountStatusChangeAuditNotFoundException;
 import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
 import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
 import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
@@ -94,6 +95,7 @@ public class ApiExceptionHandler {
 
   @ExceptionHandler({
     AccountSummaryNotFoundException.class,
+    AccountStatusChangeAuditNotFoundException.class,
     SnapshotNotFoundException.class,
     TransferReversalNotFoundException.class,
     AuthStatusChangeAuditNotFoundException.class,

--- a/back/src/main/java/com/aquilabank/global/web/account/InternalAccountAdminController.java
+++ b/back/src/main/java/com/aquilabank/global/web/account/InternalAccountAdminController.java
@@ -6,6 +6,8 @@ import com.aquilabank.domain.account.model.AccountSummary;
 import com.aquilabank.domain.account.usecase.AccountStatusUpdateUseCase;
 import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenClaims;
+import com.aquilabank.global.web.RequestTraceContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -40,16 +42,34 @@ public class InternalAccountAdminController {
       HttpServletRequest httpServletRequest,
       @PathVariable @Positive(message = "accountId must be positive") long accountId,
       @Valid @RequestBody AccountStatusRequest request) {
-    internalServiceRequestAuthorizer.requireScope(
-        httpServletRequest, InternalServiceScope.ACCOUNT_ADMIN);
+    InternalServiceTokenClaims claims =
+        internalServiceRequestAuthorizer.requireScope(
+            httpServletRequest, InternalServiceScope.ACCOUNT_ADMIN);
     return AccountResponse.from(
         accountStatusUpdateUseCase.update(
-            new AccountStatusUpdateCommand(accountId, request.accountStatus())));
+            new AccountStatusUpdateCommand(
+                accountId,
+                request.accountStatus(),
+                claims.subject(),
+                resolveRequestId(httpServletRequest))));
   }
 
   /** 내부 계좌 상태 변경 요청 body */
   public record AccountStatusRequest(
       @NotNull(message = "accountStatus is required") AccountStatus accountStatus) {}
+
+  private String resolveRequestId(HttpServletRequest httpServletRequest) {
+    return RequestTraceContext.currentRequestId()
+        .orElseGet(
+            () -> {
+              String requestId =
+                  httpServletRequest.getHeader(RequestTraceContext.REQUEST_ID_HEADER);
+              if (requestId == null || requestId.isBlank()) {
+                throw new IllegalStateException("requestId is not initialized");
+              }
+              return requestId;
+            });
+  }
 
   /** 내부 계좌 상태 변경 응답 */
   public record AccountResponse(

--- a/back/src/main/java/com/aquilabank/global/web/account/InternalAccountStatusChangeAuditController.java
+++ b/back/src/main/java/com/aquilabank/global/web/account/InternalAccountStatusChangeAuditController.java
@@ -1,0 +1,63 @@
+package com.aquilabank.global.web.account;
+
+import com.aquilabank.domain.account.model.AccountStatusChangeAuditSummary;
+import com.aquilabank.domain.account.usecase.AccountStatusChangeAuditQueryUseCase;
+import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
+import com.aquilabank.global.security.InternalServiceScope;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 내부 계좌 상태 변경 감사 requestId exact lookup만 분리해 운영 조회 경계를 고정합니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/accounts/status-change-audits")
+@ConditionalOnProperty(name = "security.account-bootstrap-api.enabled", havingValue = "true")
+public class InternalAccountStatusChangeAuditController {
+
+  private final AccountStatusChangeAuditQueryUseCase accountStatusChangeAuditQueryUseCase;
+  private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
+
+  public InternalAccountStatusChangeAuditController(
+      AccountStatusChangeAuditQueryUseCase accountStatusChangeAuditQueryUseCase,
+      InternalServiceRequestAuthorizer internalServiceRequestAuthorizer) {
+    this.accountStatusChangeAuditQueryUseCase = accountStatusChangeAuditQueryUseCase;
+    this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
+  }
+
+  @GetMapping("/by-request-id")
+  public AccountStatusChangeAuditResponse getByRequestId(
+      HttpServletRequest httpServletRequest,
+      @RequestParam @NotBlank(message = "requestId is required") String requestId) {
+    internalServiceRequestAuthorizer.requireScope(
+        httpServletRequest, InternalServiceScope.ACCOUNT_ADMIN);
+    return AccountStatusChangeAuditResponse.from(
+        accountStatusChangeAuditQueryUseCase.getByRequestId(requestId));
+  }
+
+  /** 내부 계좌 상태 변경 감사 exact lookup 응답 */
+  public record AccountStatusChangeAuditResponse(
+      String requestId,
+      String actorSubject,
+      long targetAccountId,
+      String beforeStatus,
+      String afterStatus,
+      Instant createdAt) {
+
+    static AccountStatusChangeAuditResponse from(AccountStatusChangeAuditSummary summary) {
+      return new AccountStatusChangeAuditResponse(
+          summary.requestId(),
+          summary.actorSubject(),
+          summary.targetAccountId(),
+          summary.beforeStatus(),
+          summary.afterStatus(),
+          summary.createdAt());
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
@@ -36,6 +36,7 @@ public class WebMvcSecurityConfiguration implements WebMvcConfigurer {
         .addInterceptor(internalServiceTokenAuthenticationInterceptor)
         .addPathPatterns(
             "/internal/api/v1/accounts/bootstrap",
+            "/internal/api/v1/accounts/status-change-audits/**",
             "/internal/api/v1/accounts/*/status",
             "/internal/api/v1/auth/**",
             "/internal/api/v1/outbox/**");

--- a/back/src/main/resources/db/migration/V17__add_account_status_change_audit.sql
+++ b/back/src/main/resources/db/migration/V17__add_account_status_change_audit.sql
@@ -1,0 +1,16 @@
+CREATE TABLE account_status_change_audit (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    request_id VARCHAR(64) NOT NULL,
+    actor_subject VARCHAR(120) NOT NULL,
+    target_account_id BIGINT NOT NULL,
+    before_status VARCHAR(16) NOT NULL
+        CHECK (before_status IN ('ACTIVE', 'LOCKED', 'CLOSED')),
+    after_status VARCHAR(16) NOT NULL
+        CHECK (after_status IN ('ACTIVE', 'LOCKED', 'CLOSED')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_account_status_change_audit_account
+        FOREIGN KEY (target_account_id) REFERENCES bank_account (id)
+);
+
+CREATE INDEX idx_account_status_change_audit_request_id
+    ON account_status_change_audit (request_id);

--- a/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminApiIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.aquilabank.global.web.account;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -27,6 +29,7 @@ import org.springframework.web.context.WebApplicationContext;
 @ActiveProfiles("test")
 @SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
 class InternalAccountAdminApiIntegrationTest extends PostgresContainerTestSupport {
+  private static final String REQUEST_ID_HEADER = "X-Request-Id";
 
   @Autowired private WebApplicationContext context;
 
@@ -49,6 +52,7 @@ class InternalAccountAdminApiIntegrationTest extends PostgresContainerTestSuppor
     AccountBootstrapResult account =
         accountBootstrapUseCase.bootstrap(
             new AccountBootstrapCommand("main account", "KRW", 10000L));
+    String requestId = "account-closed-request";
 
     mockMvc
         .perform(
@@ -57,6 +61,7 @@ class InternalAccountAdminApiIntegrationTest extends PostgresContainerTestSuppor
                     "Authorization",
                     internalServiceAuthorization(
                         "account-admin", InternalServiceScope.ACCOUNT_ADMIN))
+                .header(REQUEST_ID_HEADER, requestId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -70,6 +75,15 @@ class InternalAccountAdminApiIntegrationTest extends PostgresContainerTestSuppor
         .andExpect(jsonPath("$.availableBalanceMinor").value(10000L));
 
     assertEquals("CLOSED", loadAccountStatus(account.accountId()));
+    AccountStatusChangeAuditView audit =
+        loadAuditByRequestId(requestId)
+            .orElseThrow(() -> new AssertionError("account status audit is not found"));
+    assertEquals(requestId, audit.requestId());
+    assertEquals("account-admin", audit.actorSubject());
+    assertEquals(account.accountId(), audit.targetAccountId());
+    assertEquals("ACTIVE", audit.beforeStatus());
+    assertEquals("CLOSED", audit.afterStatus());
+    assertNotNull(audit.createdAt());
   }
 
   @Test
@@ -81,6 +95,7 @@ class InternalAccountAdminApiIntegrationTest extends PostgresContainerTestSuppor
                     "Authorization",
                     internalServiceAuthorization(
                         "account-admin", InternalServiceScope.ACCOUNT_ADMIN))
+                .header(REQUEST_ID_HEADER, "missing-account-request")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -92,8 +107,77 @@ class InternalAccountAdminApiIntegrationTest extends PostgresContainerTestSuppor
         .andExpect(jsonPath("$.message").value("account summary is not found"));
   }
 
+  @Test
+  void getsStatusChangeAuditByRequestId() throws Exception {
+    AccountBootstrapResult account =
+        accountBootstrapUseCase.bootstrap(
+            new AccountBootstrapCommand("main account", "KRW", 10000L));
+    String requestId = "account-lock-request";
+
+    mockMvc
+        .perform(
+            put("/internal/api/v1/accounts/%d/status".formatted(account.accountId()))
+                .header(
+                    "Authorization",
+                    internalServiceAuthorization(
+                        "account-admin", InternalServiceScope.ACCOUNT_ADMIN))
+                .header(REQUEST_ID_HEADER, requestId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "accountStatus": "LOCKED"
+                    }
+                    """))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/accounts/status-change-audits/by-request-id")
+                .header(
+                    "Authorization",
+                    internalServiceAuthorization(
+                        "account-admin", InternalServiceScope.ACCOUNT_ADMIN))
+                .param("requestId", requestId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.requestId").value(requestId))
+        .andExpect(jsonPath("$.actorSubject").value("account-admin"))
+        .andExpect(jsonPath("$.targetAccountId").value(account.accountId()))
+        .andExpect(jsonPath("$.beforeStatus").value("ACTIVE"))
+        .andExpect(jsonPath("$.afterStatus").value("LOCKED"))
+        .andExpect(jsonPath("$.createdAt").exists());
+  }
+
   private String internalServiceAuthorization(String subject, InternalServiceScope scope) {
     return "Bearer " + internalServiceTokenIssuer.issue(subject, java.util.Set.of(scope));
+  }
+
+  private java.util.Optional<AccountStatusChangeAuditView> loadAuditByRequestId(String requestId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT request_id,
+                   actor_subject,
+                   target_account_id,
+                   before_status,
+                   after_status,
+                   created_at
+            FROM account_status_change_audit
+            WHERE request_id = :requestId
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            new MapSqlParameterSource().addValue("requestId", requestId),
+            (rs, rowNum) ->
+                new AccountStatusChangeAuditView(
+                    rs.getString("request_id"),
+                    rs.getString("actor_subject"),
+                    rs.getLong("target_account_id"),
+                    rs.getString("before_status"),
+                    rs.getString("after_status"),
+                    rs.getTimestamp("created_at").toInstant()))
+        .stream()
+        .findFirst();
   }
 
   private String loadAccountStatus(long accountId) {
@@ -106,4 +190,12 @@ class InternalAccountAdminApiIntegrationTest extends PostgresContainerTestSuppor
         new MapSqlParameterSource().addValue("accountId", accountId),
         String.class);
   }
+
+  private record AccountStatusChangeAuditView(
+      String requestId,
+      String actorSubject,
+      long targetAccountId,
+      String beforeStatus,
+      String afterStatus,
+      java.time.Instant createdAt) {}
 }

--- a/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminControllerTest.java
@@ -21,6 +21,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class InternalAccountAdminControllerTest {
+  private static final String SUBJECT = "account-admin-test";
+  private static final String REQUEST_ID_HEADER = "X-Request-Id";
 
   private AccountStatusUpdateUseCase accountStatusUpdateUseCase;
   private MockMvc mockMvc;
@@ -41,7 +43,10 @@ class InternalAccountAdminControllerTest {
     when(accountStatusUpdateUseCase.update(
             argThat(
                 command ->
-                    command.accountId() == 101L && command.status().name().equals("LOCKED"))))
+                    command.accountId() == 101L
+                        && command.status().name().equals("LOCKED")
+                        && command.actorSubject().equals(SUBJECT)
+                        && command.requestId().equals("account-lock-request"))))
         .thenReturn(
             new AccountSummary(
                 101L,
@@ -60,7 +65,8 @@ class InternalAccountAdminControllerTest {
                 .header(
                     "Authorization",
                     InternalServiceTokenTestSupport.authorization(
-                        "account-admin-test", InternalServiceScope.ACCOUNT_ADMIN))
+                        SUBJECT, InternalServiceScope.ACCOUNT_ADMIN))
+                .header(REQUEST_ID_HEADER, "account-lock-request")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -77,7 +83,10 @@ class InternalAccountAdminControllerTest {
         .update(
             argThat(
                 command ->
-                    command.accountId() == 101L && command.status().name().equals("LOCKED")));
+                    command.accountId() == 101L
+                        && command.status().name().equals("LOCKED")
+                        && command.actorSubject().equals(SUBJECT)
+                        && command.requestId().equals("account-lock-request")));
   }
 
   @Test
@@ -101,7 +110,7 @@ class InternalAccountAdminControllerTest {
                 .header(
                     "Authorization",
                     InternalServiceTokenTestSupport.authorization(
-                        "account-bootstrap-test", InternalServiceScope.ACCOUNT_BOOTSTRAP))
+                        SUBJECT, InternalServiceScope.ACCOUNT_BOOTSTRAP))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -121,7 +130,8 @@ class InternalAccountAdminControllerTest {
                 .header(
                     "Authorization",
                     InternalServiceTokenTestSupport.authorization(
-                        "account-admin-test", InternalServiceScope.ACCOUNT_ADMIN))
+                        SUBJECT, InternalServiceScope.ACCOUNT_ADMIN))
+                .header(REQUEST_ID_HEADER, "account-invalid-body-request")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """

--- a/back/src/test/java/com/aquilabank/global/web/account/InternalAccountStatusChangeAuditControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/account/InternalAccountStatusChangeAuditControllerTest.java
@@ -1,0 +1,93 @@
+package com.aquilabank.global.web.account;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.account.exception.AccountStatusChangeAuditNotFoundException;
+import com.aquilabank.domain.account.model.AccountStatusChangeAuditSummary;
+import com.aquilabank.domain.account.usecase.AccountStatusChangeAuditQueryUseCase;
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenTestSupport;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class InternalAccountStatusChangeAuditControllerTest {
+
+  private AccountStatusChangeAuditQueryUseCase accountStatusChangeAuditQueryUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    accountStatusChangeAuditQueryUseCase = mock(AccountStatusChangeAuditQueryUseCase.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new InternalAccountStatusChangeAuditController(
+                    accountStatusChangeAuditQueryUseCase,
+                    InternalServiceTokenTestSupport.authorizer()))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void getsAuditByRequestId() throws Exception {
+    when(accountStatusChangeAuditQueryUseCase.getByRequestId("account-lock-request"))
+        .thenReturn(
+            new AccountStatusChangeAuditSummary(
+                "account-lock-request",
+                "ops-account-admin",
+                101L,
+                "ACTIVE",
+                "LOCKED",
+                Instant.parse("2026-04-18T03:10:00Z")));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/accounts/status-change-audits/by-request-id")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        "ops-account-admin", InternalServiceScope.ACCOUNT_ADMIN))
+                .param("requestId", "account-lock-request"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.requestId").value("account-lock-request"))
+        .andExpect(jsonPath("$.actorSubject").value("ops-account-admin"))
+        .andExpect(jsonPath("$.targetAccountId").value(101))
+        .andExpect(jsonPath("$.beforeStatus").value("ACTIVE"))
+        .andExpect(jsonPath("$.afterStatus").value("LOCKED"))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-18T03:10:00Z"));
+  }
+
+  @Test
+  void returnsNotFoundWhenRequestIdDoesNotExist() throws Exception {
+    when(accountStatusChangeAuditQueryUseCase.getByRequestId("missing-request"))
+        .thenThrow(new AccountStatusChangeAuditNotFoundException("audit record is not found"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/accounts/status-change-audits/by-request-id")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        "ops-account-admin", InternalServiceScope.ACCOUNT_ADMIN))
+                .param("requestId", "missing-request"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("audit record is not found"));
+  }
+
+  @Test
+  void rejectsMissingOrInvalidInternalServiceToken() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/accounts/status-change-audits/by-request-id")
+                .param("requestId", "account-lock-request"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
close #112

## 🌿 Base Branch
- `main`

## 📝 Summary
- 계좌 상태 변경 internal API에 성공 audit trail을 추가했습니다.
- `requestId` exact lookup 기반 내부 조회 API를 추가해 운영이 상태 변경 이력을 바로 추적할 수 있게 했습니다.
- account 전용 audit 테이블과 internal security path를 분리해 기존 auth 감사 경로와 결합하지 않았습니다.

## 🛠 Changes
- `account_status_change_audit` 테이블과 `requestId` index를 추가했습니다.
- `GET /internal/api/v1/accounts/status-change-audits/by-request-id` exact lookup use case/controller를 추가했습니다.
- account status update command/controller/repository에 `actorSubject`, `requestId`, 성공 audit row 저장을 연결했습니다.
- account admin 관련 unit/integration 테스트를 추가해 audit 저장과 lookup 응답을 검증했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-account-admin ./back/gradlew -p back test --tests '*InternalAccountAdmin*' --tests '*InternalAccountStatusChangeAuditControllerTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- `PUT /internal/api/v1/accounts/{accountId}/status` + `X-Request-Id` 호출 후 `GET /internal/api/v1/accounts/status-change-audits/by-request-id?requestId=...`로 exact lookup 가능

## ⚠️ Risk & Rollback
- 예상 리스크: internal account security matcher에 새 audit lookup 경로가 추가되어 path 보호 설정 누락 시 401/404 drift가 생길 수 있습니다.
- 롤백 방법: PR revert로 controller/security wiring과 `V17__add_account_status_change_audit.sql`을 함께 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?