### PR TITLE
[Feat] auth session 선택 revoke 및 전체 revoke API 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -363,6 +363,8 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
 - 공개 endpoint:
   - `POST /api/v1/auth/login`
   - `GET /api/v1/auth/sessions`
+  - `DELETE /api/v1/auth/sessions/{sessionId}`
+  - `DELETE /api/v1/auth/sessions`
   - `POST /api/v1/auth/refresh`
   - `POST /api/v1/auth/logout`
 - 응답 필드:
@@ -390,13 +392,17 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
   - query parameter `size`는 기본 `20`, 최대 `50`
   - 응답은 현재 user의 `ACTIVE` 이면서 아직 만료되지 않은 session만 `expires_at DESC, id DESC` 순서로 반환
   - item 필드는 `sessionId`, `sessionStatus`, `expiresAt`, `lastUsedAt`, `createdAt`
+- 세션 종료 기준:
+  - `DELETE /api/v1/auth/sessions/{sessionId}`는 현재 user 소유의 `ACTIVE` session 하나만 `REVOKED`로 바꾼다.
+  - `DELETE /api/v1/auth/sessions`는 현재 user의 `ACTIVE` session 전체를 `REVOKED`로 바꾼다.
+  - 두 endpoint 모두 다른 사용자 session, 이미 `ROTATED|REVOKED` 상태, 존재하지 않는 session에 대해 `204` no-op을 유지한다.
 - 거절 기준:
   - 만료, 이미 rotation 된 token, 존재하지 않는 token은 모두 `401 refresh failed`
   - `user_status=LOCKED|DISABLED` 사용자는 refresh로 새 token pair를 발급받지 못함
 - 운영 주의:
   - logout은 access token 즉시 폐기가 아니라 refresh 재발급 차단까지만 처리
   - 다른 사용자 token, 이미 `ROTATED|REVOKED` 상태인 token, 존재하지 않는 token으로 logout 요청 시 `204` no-op 유지
-  - 이번 범위는 logout-all, 세션별 강제 종료를 제공하지 않음
+  - 선택 revoke와 전체 revoke도 access token 즉시 폐기가 아니라 refresh 재발급 차단까지만 처리
   - raw refresh token, plaintext secret은 로그/DB에 남기지 않음
 
 ## Internal Auth Admin Runbook

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionRevokeAllCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionRevokeAllCommand.java
@@ -1,0 +1,11 @@
+package com.aquilabank.domain.auth.model;
+
+/** 현재 JWT user가 자신의 active session 전체를 종료할 때 쓰는 최소 입력값입니다. */
+public record AuthSessionRevokeAllCommand(long userId) {
+
+  public AuthSessionRevokeAllCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionRevokeCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthSessionRevokeCommand.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** 현재 JWT user가 자신의 특정 session 하나를 종료할 때 쓰는 최소 입력값입니다. */
+public record AuthSessionRevokeCommand(long userId, long sessionId) {
+
+  public AuthSessionRevokeCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (sessionId <= 0) {
+      throw new IllegalArgumentException("sessionId must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionLoadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionLoadPort.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 public interface RefreshTokenSessionLoadPort {
 
   Optional<RefreshTokenSession> findByTokenHashForUpdate(String tokenHash);
+
+  Optional<RefreshTokenSession> findBySessionIdForUpdate(long sessionId);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionWritePort.java
@@ -3,6 +3,7 @@ package com.aquilabank.domain.auth.port;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
+import java.time.Instant;
 
 /** refresh token session 생성과 rotation 저장을 쓰기 port로 분리합니다. */
 public interface RefreshTokenSessionWritePort {
@@ -12,4 +13,6 @@ public interface RefreshTokenSessionWritePort {
   void rotate(RefreshTokenSessionRotateCommand command);
 
   void revoke(RefreshTokenSessionRevokeCommand command);
+
+  void revokeActiveSessionsByUserId(long userId, Instant revokedAt);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeAllService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeAllService.java
@@ -1,0 +1,25 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthSessionRevokeAllCommand;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** 현재 user active session 전체 revoke를 bounded update 한 번으로 고정합니다. */
+public final class AuthSessionRevokeAllService implements AuthSessionRevokeAllUseCase {
+
+  private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
+  private final Clock clock;
+
+  public AuthSessionRevokeAllService(
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort, Clock clock) {
+    this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
+    this.clock = clock;
+  }
+
+  @Override
+  public void revokeAll(AuthSessionRevokeAllCommand command) {
+    Instant revokedAt = Instant.now(clock);
+    refreshTokenSessionWritePort.revokeActiveSessionsByUserId(command.userId(), revokedAt);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeAllUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeAllUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthSessionRevokeAllCommand;
+
+/** 현재 user active session 전체 revoke 진입점입니다. */
+public interface AuthSessionRevokeAllUseCase {
+
+  void revokeAll(AuthSessionRevokeAllCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeService.java
@@ -1,0 +1,45 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthSessionRevokeCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSession;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionRevokeCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** 현재 user가 선택한 session만 revoke 하고 존재 여부는 외부에 드러내지 않습니다. */
+public final class AuthSessionRevokeService implements AuthSessionRevokeUseCase {
+
+  private final RefreshTokenSessionLoadPort refreshTokenSessionLoadPort;
+  private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
+  private final Clock clock;
+
+  public AuthSessionRevokeService(
+      RefreshTokenSessionLoadPort refreshTokenSessionLoadPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      Clock clock) {
+    this.refreshTokenSessionLoadPort = refreshTokenSessionLoadPort;
+    this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
+    this.clock = clock;
+  }
+
+  @Override
+  public void revoke(AuthSessionRevokeCommand command) {
+    RefreshTokenSession session =
+        refreshTokenSessionLoadPort.findBySessionIdForUpdate(command.sessionId()).orElse(null);
+    if (session == null) {
+      return;
+    }
+    if (session.userId() != command.userId()) {
+      return;
+    }
+    if (session.sessionStatus() != RefreshTokenSessionStatus.ACTIVE) {
+      return;
+    }
+    Instant revokedAt = Instant.now(clock);
+    refreshTokenSessionWritePort.revoke(
+        new RefreshTokenSessionRevokeCommand(session.sessionId(), revokedAt));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthSessionRevokeCommand;
+
+/** 현재 user가 선택한 session revoke 진입점입니다. */
+public interface AuthSessionRevokeUseCase {
+
+  void revoke(AuthSessionRevokeCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -25,6 +25,10 @@ import com.aquilabank.domain.auth.usecase.AccountAccessService;
 import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionListService;
 import com.aquilabank.domain.auth.usecase.AuthSessionListUseCase;
+import com.aquilabank.domain.auth.usecase.AuthSessionRevokeAllService;
+import com.aquilabank.domain.auth.usecase.AuthSessionRevokeAllUseCase;
+import com.aquilabank.domain.auth.usecase.AuthSessionRevokeService;
+import com.aquilabank.domain.auth.usecase.AuthSessionRevokeUseCase;
 import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryService;
 import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryUseCase;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryService;
@@ -178,6 +182,34 @@ public class AuthConfiguration {
   AuthSessionListUseCase authSessionListUseCase(
       AuthSessionQueryPort authSessionQueryPort, Clock authClock) {
     return new AuthSessionListService(authSessionQueryPort, authClock);
+  }
+
+  @Bean
+  AuthSessionRevokeUseCase authSessionRevokeUseCase(
+      RefreshTokenSessionLoadPort refreshTokenSessionLoadPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    AuthSessionRevokeService authSessionRevokeService =
+        new AuthSessionRevokeService(
+            refreshTokenSessionLoadPort, refreshTokenSessionWritePort, authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command ->
+        transactionTemplate.executeWithoutResult(
+            status -> authSessionRevokeService.revoke(command));
+  }
+
+  @Bean
+  AuthSessionRevokeAllUseCase authSessionRevokeAllUseCase(
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    AuthSessionRevokeAllService authSessionRevokeAllService =
+        new AuthSessionRevokeAllService(refreshTokenSessionWritePort, authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command ->
+        transactionTemplate.executeWithoutResult(
+            status -> authSessionRevokeAllService.revokeAll(command));
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -123,6 +123,33 @@ public class JdbcAuthRepository
   }
 
   @Override
+  public Optional<RefreshTokenSession> findBySessionIdForUpdate(long sessionId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT s.id,
+                   s.user_id,
+                   u.login_id,
+                   u.user_status,
+                   s.token_hash,
+                   s.session_status,
+                   s.expires_at,
+                   s.last_used_at,
+                   s.rotated_at,
+                   s.replaced_by_session_id
+            FROM auth_refresh_token_session s
+            JOIN bank_user u
+              ON u.id = s.user_id
+            WHERE s.id = :sessionId
+            FOR UPDATE OF s, u
+            """,
+            new MapSqlParameterSource().addValue("sessionId", sessionId),
+            (rs, rowNum) -> mapRefreshTokenSession(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
   public List<AuthSessionSummary> findActiveSessionsByUserId(long userId, Instant now, int size) {
     // user_id + session_status + expires_at DESC index 경로를 그대로 쓰려고 조건과 정렬을 고정합니다.
     return jdbcTemplate.query(

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -226,6 +226,12 @@ public class JdbcAuthWriteRepository
 
   @Override
   @Transactional
+  public void revokeActiveSessionsByUserId(long userId, Instant revokedAt) {
+    revokeActiveRefreshTokenSessions(userId, revokedAt);
+  }
+
+  @Override
+  @Transactional
   public int deleteExpiredSessions(Instant cutoff, int batchSize) {
     // ACTIVE 만료와 비활성 세션 retention 기준이 달라 상태별 index cursor를 따로 태웁니다.
     Integer deleted =

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -2,12 +2,16 @@ package com.aquilabank.global.web.auth;
 
 import com.aquilabank.domain.auth.model.AuthSessionList;
 import com.aquilabank.domain.auth.model.AuthSessionListQuery;
+import com.aquilabank.domain.auth.model.AuthSessionRevokeAllCommand;
+import com.aquilabank.domain.auth.model.AuthSessionRevokeCommand;
 import com.aquilabank.domain.auth.model.AuthSessionSummary;
 import com.aquilabank.domain.auth.model.LoginCommand;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.model.LogoutCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenCommand;
 import com.aquilabank.domain.auth.usecase.AuthSessionListUseCase;
+import com.aquilabank.domain.auth.usecase.AuthSessionRevokeAllUseCase;
+import com.aquilabank.domain.auth.usecase.AuthSessionRevokeUseCase;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutUseCase;
 import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
@@ -22,9 +26,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,16 +47,22 @@ public class LoginController {
 
   private final LoginUseCase loginUseCase;
   private final AuthSessionListUseCase authSessionListUseCase;
+  private final AuthSessionRevokeUseCase authSessionRevokeUseCase;
+  private final AuthSessionRevokeAllUseCase authSessionRevokeAllUseCase;
   private final RefreshTokenUseCase refreshTokenUseCase;
   private final LogoutUseCase logoutUseCase;
 
   public LoginController(
       LoginUseCase loginUseCase,
       AuthSessionListUseCase authSessionListUseCase,
+      AuthSessionRevokeUseCase authSessionRevokeUseCase,
+      AuthSessionRevokeAllUseCase authSessionRevokeAllUseCase,
       RefreshTokenUseCase refreshTokenUseCase,
       LogoutUseCase logoutUseCase) {
     this.loginUseCase = loginUseCase;
     this.authSessionListUseCase = authSessionListUseCase;
+    this.authSessionRevokeUseCase = authSessionRevokeUseCase;
+    this.authSessionRevokeAllUseCase = authSessionRevokeAllUseCase;
     this.refreshTokenUseCase = refreshTokenUseCase;
     this.logoutUseCase = logoutUseCase;
   }
@@ -69,6 +82,23 @@ public class LoginController {
     AuthSessionList result =
         authSessionListUseCase.get(new AuthSessionListQuery(resolveUserId(principal), size));
     return AuthSessionListResponse.from(result);
+  }
+
+  @DeleteMapping("/sessions/{sessionId}")
+  public ResponseEntity<Void> revokeSession(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @PathVariable @jakarta.validation.constraints.Positive(message = "sessionId must be positive") long sessionId) {
+    authSessionRevokeUseCase.revoke(
+        new AuthSessionRevokeCommand(resolveUserId(principal), sessionId));
+    return ResponseEntity.noContent().build();
+  }
+
+  @DeleteMapping("/sessions")
+  public ResponseEntity<Void> revokeAllSessions(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal) {
+    authSessionRevokeAllUseCase.revokeAll(
+        new AuthSessionRevokeAllCommand(resolveUserId(principal)));
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping("/refresh")
@@ -151,10 +181,8 @@ public class LoginController {
       return userPrincipal.userId();
     }
     if (principal instanceof AuthenticatedAccountPrincipal) {
-      throw new ResponseStatusException(
-          org.springframework.http.HttpStatus.FORBIDDEN, "user authentication is required");
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "user authentication is required");
     }
-    throw new ResponseStatusException(
-        org.springframework.http.HttpStatus.UNAUTHORIZED, "authentication required");
+    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "authentication required");
   }
 }

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeAllServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeAllServiceTest.java
@@ -1,0 +1,30 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.aquilabank.domain.auth.model.AuthSessionRevokeAllCommand;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class AuthSessionRevokeAllServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-17T01:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+  @Test
+  void revokesAllActiveSessionsForCurrentUser() {
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+
+    AuthSessionRevokeAllService authSessionRevokeAllService =
+        new AuthSessionRevokeAllService(refreshTokenSessionWritePort, CLOCK);
+
+    authSessionRevokeAllService.revokeAll(new AuthSessionRevokeAllCommand(7L));
+
+    verify(refreshTokenSessionWritePort).revokeActiveSessionsByUserId(7L, NOW);
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/AuthSessionRevokeServiceTest.java
@@ -1,0 +1,110 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.model.AuthSessionRevokeCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSession;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionRevokeCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class AuthSessionRevokeServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-17T01:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+  @Test
+  void revokesOnlyCurrentUsersActiveSession() {
+    RefreshTokenSessionLoadPort refreshTokenSessionLoadPort =
+        mock(RefreshTokenSessionLoadPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+    when(refreshTokenSessionLoadPort.findBySessionIdForUpdate(11L))
+        .thenReturn(Optional.of(session(7L, RefreshTokenSessionStatus.ACTIVE)));
+
+    AuthSessionRevokeService authSessionRevokeService =
+        new AuthSessionRevokeService(
+            refreshTokenSessionLoadPort, refreshTokenSessionWritePort, CLOCK);
+
+    authSessionRevokeService.revoke(new AuthSessionRevokeCommand(7L, 11L));
+
+    verify(refreshTokenSessionWritePort).revoke(new RefreshTokenSessionRevokeCommand(11L, NOW));
+  }
+
+  @Test
+  void ignoresOtherUsersSession() {
+    RefreshTokenSessionLoadPort refreshTokenSessionLoadPort =
+        mock(RefreshTokenSessionLoadPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+    when(refreshTokenSessionLoadPort.findBySessionIdForUpdate(11L))
+        .thenReturn(Optional.of(session(9L, RefreshTokenSessionStatus.ACTIVE)));
+
+    AuthSessionRevokeService authSessionRevokeService =
+        new AuthSessionRevokeService(
+            refreshTokenSessionLoadPort, refreshTokenSessionWritePort, CLOCK);
+
+    authSessionRevokeService.revoke(new AuthSessionRevokeCommand(7L, 11L));
+
+    verify(refreshTokenSessionWritePort, never()).revoke(org.mockito.Mockito.any());
+  }
+
+  @Test
+  void ignoresAlreadyInactiveSession() {
+    RefreshTokenSessionLoadPort refreshTokenSessionLoadPort =
+        mock(RefreshTokenSessionLoadPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+    when(refreshTokenSessionLoadPort.findBySessionIdForUpdate(11L))
+        .thenReturn(Optional.of(session(7L, RefreshTokenSessionStatus.ROTATED)));
+
+    AuthSessionRevokeService authSessionRevokeService =
+        new AuthSessionRevokeService(
+            refreshTokenSessionLoadPort, refreshTokenSessionWritePort, CLOCK);
+
+    authSessionRevokeService.revoke(new AuthSessionRevokeCommand(7L, 11L));
+
+    verify(refreshTokenSessionWritePort, never()).revoke(org.mockito.Mockito.any());
+  }
+
+  @Test
+  void ignoresMissingSession() {
+    RefreshTokenSessionLoadPort refreshTokenSessionLoadPort =
+        mock(RefreshTokenSessionLoadPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+    when(refreshTokenSessionLoadPort.findBySessionIdForUpdate(11L)).thenReturn(Optional.empty());
+
+    AuthSessionRevokeService authSessionRevokeService =
+        new AuthSessionRevokeService(
+            refreshTokenSessionLoadPort, refreshTokenSessionWritePort, CLOCK);
+
+    authSessionRevokeService.revoke(new AuthSessionRevokeCommand(7L, 11L));
+
+    verify(refreshTokenSessionWritePort, never()).revoke(org.mockito.Mockito.any());
+  }
+
+  private RefreshTokenSession session(long userId, RefreshTokenSessionStatus sessionStatus) {
+    return new RefreshTokenSession(
+        11L,
+        userId,
+        "alice",
+        UserStatus.ACTIVE,
+        "token-hash",
+        sessionStatus,
+        NOW.plusSeconds(30),
+        null,
+        null,
+        null);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -510,6 +511,84 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void revokeSelectedSessionBySessionIdRevokesOnlyThatSession() throws Exception {
+    TokenPairResponseView oldest =
+        loginResult("alice", "password123!", "session-revoke-select-login-001");
+    TokenPairResponseView target =
+        loginResult("alice", "password123!", "session-revoke-select-login-002");
+    TokenPairResponseView newest =
+        loginResult("alice", "password123!", "session-revoke-select-login-003");
+    long targetSessionId = loadRefreshTokenSessionId(target.refreshToken());
+
+    revokeSession(newest.accessToken(), targetSessionId, "session-revoke-select-001")
+        .andExpect(status().isNoContent());
+
+    RefreshTokenSessionView oldestSession = loadRefreshTokenSession(oldest.refreshToken());
+    RefreshTokenSessionView targetSession = loadRefreshTokenSession(target.refreshToken());
+    RefreshTokenSessionView newestSession = loadRefreshTokenSession(newest.refreshToken());
+    assertEquals("ACTIVE", oldestSession.sessionStatus());
+    assertEquals("REVOKED", targetSession.sessionStatus());
+    assertNotNull(targetSession.lastUsedAt());
+    assertNull(targetSession.rotatedAt());
+    assertNull(targetSession.replacedBySessionId());
+    assertEquals("ACTIVE", newestSession.sessionStatus());
+
+    refreshExpectUnauthorized(target.refreshToken(), "session-revoke-select-refresh-001");
+  }
+
+  @Test
+  void revokeSelectedSessionKeepsOtherUsersSessionUntouched() throws Exception {
+    TokenPairResponseView alice =
+        loginResult("alice", "password123!", "session-revoke-other-login-001");
+    long otherUserId = bootstrapUser("bob", "Bob", "password123!");
+    upsertMembership(otherUserId, targetAccountId, "VIEWER", "ACTIVE");
+    TokenPairResponseView bob =
+        loginResult("bob", "password123!", "session-revoke-other-login-002");
+    long bobSessionId = loadRefreshTokenSessionId(bob.refreshToken());
+
+    revokeSession(alice.accessToken(), bobSessionId, "session-revoke-other-001")
+        .andExpect(status().isNoContent());
+
+    RefreshTokenSessionView bobSession = loadRefreshTokenSession(bob.refreshToken());
+    assertEquals("ACTIVE", bobSession.sessionStatus());
+    assertNull(bobSession.lastUsedAt());
+    refresh(bob.refreshToken(), "session-revoke-other-refresh-001");
+  }
+
+  @Test
+  void revokeAllSessionsRevokesOnlyCurrentUsersActiveSessions() throws Exception {
+    TokenPairResponseView oldest =
+        loginResult("alice", "password123!", "session-revoke-all-login-001");
+    TokenPairResponseView middle =
+        loginResult("alice", "password123!", "session-revoke-all-login-002");
+    TokenPairResponseView newest =
+        loginResult("alice", "password123!", "session-revoke-all-login-003");
+    long otherUserId = bootstrapUser("bob", "Bob", "password123!");
+    upsertMembership(otherUserId, targetAccountId, "VIEWER", "ACTIVE");
+    TokenPairResponseView bob = loginResult("bob", "password123!", "session-revoke-all-login-004");
+
+    revokeAllSessions(newest.accessToken(), "session-revoke-all-001")
+        .andExpect(status().isNoContent());
+
+    RefreshTokenSessionView oldestSession = loadRefreshTokenSession(oldest.refreshToken());
+    RefreshTokenSessionView middleSession = loadRefreshTokenSession(middle.refreshToken());
+    RefreshTokenSessionView newestSession = loadRefreshTokenSession(newest.refreshToken());
+    RefreshTokenSessionView bobSession = loadRefreshTokenSession(bob.refreshToken());
+    assertEquals("REVOKED", oldestSession.sessionStatus());
+    assertEquals("REVOKED", middleSession.sessionStatus());
+    assertEquals("REVOKED", newestSession.sessionStatus());
+    assertNotNull(oldestSession.lastUsedAt());
+    assertNotNull(middleSession.lastUsedAt());
+    assertNotNull(newestSession.lastUsedAt());
+    assertEquals("ACTIVE", bobSession.sessionStatus());
+
+    refreshExpectUnauthorized(oldest.refreshToken(), "session-revoke-all-refresh-001");
+    refreshExpectUnauthorized(middle.refreshToken(), "session-revoke-all-refresh-002");
+    refreshExpectUnauthorized(newest.refreshToken(), "session-revoke-all-refresh-003");
+    refresh(bob.refreshToken(), "session-revoke-all-refresh-004");
+  }
+
+  @Test
   void bootstrapAccountPrincipalCannotCallLogout() throws Exception {
     TokenPairResponseView loginResult =
         loginResult("alice", "password123!", "logout-bootstrap-001");
@@ -527,6 +606,26 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     }
                     """
                         .formatted(loginResult.refreshToken())))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void bootstrapAccountPrincipalCannotRevokeAuthSession() throws Exception {
+    mockMvc
+        .perform(
+            delete("/api/v1/auth/sessions/1")
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void bootstrapAccountPrincipalCannotRevokeAllAuthSessions() throws Exception {
+    mockMvc
+        .perform(
+            delete("/api/v1/auth/sessions")
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account"))
         .andExpect(status().isForbidden());
   }
 
@@ -921,6 +1020,27 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                 }
                 """
                     .formatted(refreshToken));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions revokeSession(
+      String accessToken, long sessionId, String requestId) throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        delete("/api/v1/auth/sessions/{sessionId}", sessionId)
+            .header("Authorization", "Bearer " + accessToken);
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions revokeAllSessions(
+      String accessToken, String requestId) throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        delete("/api/v1/auth/sessions").header("Authorization", "Bearer " + accessToken);
     if (requestId != null && !requestId.isBlank()) {
       requestBuilder.header("X-Request-Id", requestId);
     }


### PR DESCRIPTION
## 🔗 Related Issue
close #114

## 🌿 Base Branch
- `main`

## 📝 Summary
- 현재 JWT user가 자신의 refresh token session을 선택 revoke 하거나 전체 revoke 할 수 있는 public auth API를 추가했습니다.
- 선택 revoke와 전체 revoke 모두 세션 존재 여부를 외부에 드러내지 않도록 `204` no-op 정책을 유지했습니다.
- 기존 `/api/v1/auth/sessions`, `/api/v1/auth/logout`, `/api/v1/auth/refresh` 계약은 유지하면서 refresh session 관리 범위만 확장했습니다.

## 🛠 Changes
- auth domain에 `AuthSessionRevokeCommand`, `AuthSessionRevokeAllCommand`, revoke use case/service를 추가했습니다.
- `RefreshTokenSessionLoadPort`에 `findBySessionIdForUpdate`를, write port에 `revokeActiveSessionsByUserId`를 추가했습니다.
- `LoginController`에 `DELETE /api/v1/auth/sessions/{sessionId}`와 `DELETE /api/v1/auth/sessions`를 추가했습니다.
- unit/integration test로 선택 revoke, 전체 revoke, 타 사용자 보호, bootstrap principal 차단을 검증했습니다.
- `back/README.md`에 새 session revoke 계약을 반영했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth-session-revoke ./back/gradlew -p back test --tests '*AuthSessionRevoke*' --tests '*LogoutServiceTest' --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- `DELETE /api/v1/auth/sessions/{sessionId}`
- `DELETE /api/v1/auth/sessions`
- 두 endpoint 모두 성공/무시 케이스에서 `204 No Content`

## ⚠️ Risk & Rollback
- 예상 리스크: sessionId 단건 revoke가 응답 코드 차이를 드러내면 세션 존재 여부를 추정할 수 있으므로 `204` no-op 정책이 유지되어야 합니다.
- 롤백 방법: PR revert로 revoke endpoint, use case wiring, session load/write 확장을 함께 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?