### PR TITLE
[Feat] 비밀번호 재설정 플로우 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -362,6 +362,7 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
 
 - 공개 endpoint:
   - `POST /api/v1/auth/login`
+  - `POST /api/v1/auth/password-reset`
   - `GET /api/v1/auth/sessions`
   - `DELETE /api/v1/auth/sessions/{sessionId}`
   - `DELETE /api/v1/auth/sessions`
@@ -399,11 +400,19 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
   - `DELETE /api/v1/auth/sessions/{sessionId}`는 현재 user 소유의 `ACTIVE` session 하나만 `REVOKED`로 바꾼다.
   - `DELETE /api/v1/auth/sessions`는 현재 user의 `ACTIVE` session 전체를 `REVOKED`로 바꾼다.
   - 두 endpoint 모두 다른 사용자 session, 이미 `ROTATED|REVOKED` 상태, 존재하지 않는 session에 대해 `204` no-op을 유지한다.
+- 비밀번호 재설정 기준:
+  - `POST /api/v1/auth/password-reset`
+  - 현재 JWT user만 호출 가능하고 bootstrap account principal은 `403`
+  - request body는 `currentPassword`, `newPassword`
+  - `currentPassword`가 맞고 `user_status = ACTIVE`일 때만 비밀번호를 새 `BCrypt password_hash`로 교체한다.
+  - 성공 시 현재 user의 `ACTIVE` refresh session 전체를 `REVOKED`로 바꾼다.
 - 거절 기준:
   - 만료, 이미 rotation 된 token, 존재하지 않는 token은 모두 `401 refresh failed`
   - `user_status=LOCKED|DISABLED` 사용자는 refresh로 새 token pair를 발급받지 못함
+  - wrong `currentPassword` 또는 `user_status != ACTIVE`는 `401 password reset failed`
 - 운영 주의:
   - logout은 access token 즉시 폐기가 아니라 refresh 재발급 차단까지만 처리
+  - password reset도 access token 즉시 폐기가 아니라 refresh 재발급 차단까지만 처리
   - 다른 사용자 token, 이미 `ROTATED|REVOKED` 상태인 token, 존재하지 않는 token으로 logout 요청 시 `204` no-op 유지
   - 선택 revoke와 전체 revoke도 access token 즉시 폐기가 아니라 refresh 재발급 차단까지만 처리
   - raw refresh token, plaintext secret은 로그/DB에 남기지 않음

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordResetCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordResetCommand.java
@@ -1,0 +1,17 @@
+package com.aquilabank.domain.auth.model;
+
+/** 현재 JWT user의 self-service password reset 최소 입력입니다. */
+public record PasswordResetCommand(long userId, String currentPassword, String newPassword) {
+
+  public PasswordResetCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (currentPassword == null || currentPassword.isBlank()) {
+      throw new IllegalArgumentException("currentPassword is required");
+    }
+    if (newPassword == null || newPassword.isBlank()) {
+      throw new IllegalArgumentException("newPassword is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordResetWriteCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordResetWriteCommand.java
@@ -1,0 +1,19 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 검증이 끝난 새 password hash 저장 최소 write 모델입니다. */
+public record PasswordResetWriteCommand(long userId, String passwordHash, Instant changedAt) {
+
+  public PasswordResetWriteCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (passwordHash == null || passwordHash.isBlank()) {
+      throw new IllegalArgumentException("passwordHash is required");
+    }
+    if (changedAt == null) {
+      throw new IllegalArgumentException("changedAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserCredentialLoadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserCredentialLoadPort.java
@@ -9,4 +9,6 @@ public interface UserCredentialLoadPort {
   Optional<LoginUser> findByLoginId(String loginId);
 
   Optional<LoginUser> findByLoginIdForUpdate(String loginId);
+
+  Optional<LoginUser> findByUserIdForUpdate(long userId);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/UserCredentialUpdatePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/UserCredentialUpdatePort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.PasswordResetWriteCommand;
+
+/** user credential 변경 write를 별도 port로 분리합니다. */
+public interface UserCredentialUpdatePort {
+
+  void resetPassword(PasswordResetWriteCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordResetService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordResetService.java
@@ -1,0 +1,57 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.PasswordResetCommand;
+import com.aquilabank.domain.auth.model.PasswordResetWriteCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.port.UserCredentialUpdatePort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** password reset 성공 시 새 hash 저장과 active refresh session revoke를 같이 처리합니다. */
+public final class PasswordResetService implements PasswordResetUseCase {
+
+  private final UserCredentialLoadPort userCredentialLoadPort;
+  private final UserCredentialUpdatePort userCredentialUpdatePort;
+  private final PasswordHashPort passwordHashPort;
+  private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
+  private final Clock clock;
+
+  public PasswordResetService(
+      UserCredentialLoadPort userCredentialLoadPort,
+      UserCredentialUpdatePort userCredentialUpdatePort,
+      PasswordHashPort passwordHashPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      Clock clock) {
+    this.userCredentialLoadPort = userCredentialLoadPort;
+    this.userCredentialUpdatePort = userCredentialUpdatePort;
+    this.passwordHashPort = passwordHashPort;
+    this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
+    this.clock = clock;
+  }
+
+  @Override
+  public void reset(PasswordResetCommand command) {
+    LoginUser user =
+        userCredentialLoadPort
+            .findByUserIdForUpdate(command.userId())
+            .orElseThrow(() -> new InvalidCredentialsException("password reset failed"));
+    if (user.status() != UserStatus.ACTIVE) {
+      throw new InvalidCredentialsException("password reset failed");
+    }
+    if (!passwordHashPort.matches(command.currentPassword(), user.passwordHash())) {
+      throw new InvalidCredentialsException("password reset failed");
+    }
+
+    Instant changedAt = Instant.now(clock);
+    userCredentialUpdatePort.resetPassword(
+        new PasswordResetWriteCommand(
+            command.userId(), passwordHashPort.encode(command.newPassword()), changedAt));
+    // access token 즉시 폐기가 없으므로 남아 있는 refresh session 전체 revoke로 장기 세션 연장을 막습니다.
+    refreshTokenSessionWritePort.revokeActiveSessionsByUserId(command.userId(), changedAt);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordResetUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordResetUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.PasswordResetCommand;
+
+/** 현재 JWT user password reset 진입점입니다. */
+public interface PasswordResetUseCase {
+
+  void reset(PasswordResetCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -19,6 +19,7 @@ import com.aquilabank.domain.auth.port.UserAccountMembershipStatusUpdatePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
 import com.aquilabank.domain.auth.port.UserBootstrapPort;
 import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.port.UserCredentialUpdatePort;
 import com.aquilabank.domain.auth.port.UserQueryPort;
 import com.aquilabank.domain.auth.port.UserStatusUpdatePort;
 import com.aquilabank.domain.auth.usecase.AccountAccessService;
@@ -37,6 +38,8 @@ import com.aquilabank.domain.auth.usecase.LoginService;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutService;
 import com.aquilabank.domain.auth.usecase.LogoutUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordResetService;
+import com.aquilabank.domain.auth.usecase.PasswordResetUseCase;
 import com.aquilabank.domain.auth.usecase.RefreshTokenService;
 import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryService;
@@ -176,6 +179,26 @@ public class AuthConfiguration {
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
     return command ->
         transactionTemplate.executeWithoutResult(status -> logoutService.logout(command));
+  }
+
+  @Bean
+  PasswordResetUseCase passwordResetUseCase(
+      UserCredentialLoadPort userCredentialLoadPort,
+      UserCredentialUpdatePort userCredentialUpdatePort,
+      PasswordHashPort passwordHashPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    PasswordResetService passwordResetService =
+        new PasswordResetService(
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command ->
+        transactionTemplate.executeWithoutResult(status -> passwordResetService.reset(command));
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -96,6 +96,29 @@ public class JdbcAuthRepository
   }
 
   @Override
+  public Optional<LoginUser> findByUserIdForUpdate(long userId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT id,
+                   login_id,
+                   password_hash,
+                   user_status,
+                   failed_login_count,
+                   last_login_failed_at,
+                   login_locked_until,
+                   last_login_succeeded_at
+            FROM bank_user
+            WHERE id = :userId
+            FOR UPDATE
+            """,
+            new MapSqlParameterSource().addValue("userId", userId),
+            (rs, rowNum) -> mapLoginUser(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
   public Optional<RefreshTokenSession> findByTokenHashForUpdate(String tokenHash) {
     return jdbcTemplate
         .query(

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -9,6 +9,7 @@ import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.LoginFailureUpdateCommand;
 import com.aquilabank.domain.auth.model.LoginSuccessUpdateCommand;
+import com.aquilabank.domain.auth.model.PasswordResetWriteCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
@@ -26,6 +27,7 @@ import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipStatusUpdatePort;
 import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
 import com.aquilabank.domain.auth.port.UserBootstrapPort;
+import com.aquilabank.domain.auth.port.UserCredentialUpdatePort;
 import com.aquilabank.domain.auth.port.UserStatusUpdatePort;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -42,6 +44,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcAuthWriteRepository
     implements UserBootstrapPort,
         LoginAttemptUpdatePort,
+        UserCredentialUpdatePort,
         RefreshTokenSessionCleanupPort,
         RefreshTokenSessionWritePort,
         UserAccountMembershipUpsertPort,
@@ -140,6 +143,27 @@ public class JdbcAuthWriteRepository
             new MapSqlParameterSource()
                 .addValue("userId", command.userId())
                 .addValue("succeededAt", Timestamp.from(command.succeededAt())));
+    assertUserUpdated(updated);
+  }
+
+  @Override
+  @Transactional
+  public void resetPassword(PasswordResetWriteCommand command) {
+    int updated =
+        jdbcTemplate.update(
+            """
+            UPDATE bank_user
+            SET password_hash = :passwordHash,
+                failed_login_count = 0,
+                last_login_failed_at = NULL,
+                login_locked_until = NULL,
+                updated_at = :changedAt
+            WHERE id = :userId
+            """,
+            new MapSqlParameterSource()
+                .addValue("userId", command.userId())
+                .addValue("passwordHash", command.passwordHash())
+                .addValue("changedAt", Timestamp.from(command.changedAt())));
     assertUserUpdated(updated);
   }
 

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -8,12 +8,14 @@ import com.aquilabank.domain.auth.model.AuthSessionSummary;
 import com.aquilabank.domain.auth.model.LoginCommand;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.model.LogoutCommand;
+import com.aquilabank.domain.auth.model.PasswordResetCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenCommand;
 import com.aquilabank.domain.auth.usecase.AuthSessionListUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionRevokeAllUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionRevokeUseCase;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordResetUseCase;
 import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
 import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
@@ -52,6 +54,7 @@ public class LoginController {
   private final AuthSessionRevokeAllUseCase authSessionRevokeAllUseCase;
   private final RefreshTokenUseCase refreshTokenUseCase;
   private final LogoutUseCase logoutUseCase;
+  private final PasswordResetUseCase passwordResetUseCase;
   private final AuthSessionMetadataResolver authSessionMetadataResolver;
 
   public LoginController(
@@ -61,6 +64,7 @@ public class LoginController {
       AuthSessionRevokeAllUseCase authSessionRevokeAllUseCase,
       RefreshTokenUseCase refreshTokenUseCase,
       LogoutUseCase logoutUseCase,
+      PasswordResetUseCase passwordResetUseCase,
       AuthSessionMetadataResolver authSessionMetadataResolver) {
     this.loginUseCase = loginUseCase;
     this.authSessionListUseCase = authSessionListUseCase;
@@ -68,6 +72,7 @@ public class LoginController {
     this.authSessionRevokeAllUseCase = authSessionRevokeAllUseCase;
     this.refreshTokenUseCase = refreshTokenUseCase;
     this.logoutUseCase = logoutUseCase;
+    this.passwordResetUseCase = passwordResetUseCase;
     this.authSessionMetadataResolver = authSessionMetadataResolver;
   }
 
@@ -128,6 +133,16 @@ public class LoginController {
     return ResponseEntity.noContent().build();
   }
 
+  @PostMapping("/password-reset")
+  public ResponseEntity<Void> resetPassword(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @Valid @RequestBody PasswordResetRequest request) {
+    passwordResetUseCase.reset(
+        new PasswordResetCommand(
+            resolveUserId(principal), request.currentPassword(), request.newPassword()));
+    return ResponseEntity.noContent().build();
+  }
+
   /** 로그인 요청 body */
   public record LoginRequest(
       @NotBlank(message = "loginId is required") @Size(max = 80, message = "loginId must be 80 characters or less") String loginId,
@@ -140,6 +155,11 @@ public class LoginController {
   /** logout 요청 body */
   public record LogoutRequest(
       @NotBlank(message = "refreshToken is required") @Size(max = 160, message = "refreshToken must be 160 characters or less") String refreshToken) {}
+
+  /** password reset 요청 body */
+  public record PasswordResetRequest(
+      @NotBlank(message = "currentPassword is required") @Size(max = 120, message = "currentPassword must be 120 characters or less") String currentPassword,
+      @NotBlank(message = "newPassword is required") @Size(max = 120, message = "newPassword must be 120 characters or less") String newPassword) {}
 
   /** access/refresh token 발급 응답 */
   public record LoginResponse(

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/PasswordResetServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/PasswordResetServiceTest.java
@@ -1,0 +1,118 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.PasswordResetCommand;
+import com.aquilabank.domain.auth.model.PasswordResetWriteCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.port.UserCredentialUpdatePort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class PasswordResetServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-17T01:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+  @Test
+  void resetsPasswordAndRevokesActiveRefreshSessions() {
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    UserCredentialUpdatePort userCredentialUpdatePort = mock(UserCredentialUpdatePort.class);
+    PasswordHashPort passwordHashPort = mock(PasswordHashPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+
+    when(userCredentialLoadPort.findByUserIdForUpdate(7L)).thenReturn(Optional.of(activeUser()));
+    when(passwordHashPort.matches("password123!", "stored-hash")).thenReturn(true);
+    when(passwordHashPort.encode("newPassword456!")).thenReturn("new-hash");
+
+    PasswordResetService passwordResetService =
+        new PasswordResetService(
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            CLOCK);
+
+    passwordResetService.reset(new PasswordResetCommand(7L, "password123!", "newPassword456!"));
+
+    verify(userCredentialUpdatePort)
+        .resetPassword(new PasswordResetWriteCommand(7L, "new-hash", NOW));
+    verify(refreshTokenSessionWritePort).revokeActiveSessionsByUserId(7L, NOW);
+  }
+
+  @Test
+  void rejectsWrongCurrentPassword() {
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    UserCredentialUpdatePort userCredentialUpdatePort = mock(UserCredentialUpdatePort.class);
+    PasswordHashPort passwordHashPort = mock(PasswordHashPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+
+    when(userCredentialLoadPort.findByUserIdForUpdate(7L)).thenReturn(Optional.of(activeUser()));
+    when(passwordHashPort.matches("wrong-password", "stored-hash")).thenReturn(false);
+
+    PasswordResetService passwordResetService =
+        new PasswordResetService(
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            CLOCK);
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () -> passwordResetService.reset(new PasswordResetCommand(7L, "wrong-password", "next")));
+
+    verify(userCredentialUpdatePort, never()).resetPassword(org.mockito.Mockito.any());
+    verify(refreshTokenSessionWritePort, never()).revokeActiveSessionsByUserId(7L, NOW);
+  }
+
+  @Test
+  void rejectsInactiveUser() {
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    UserCredentialUpdatePort userCredentialUpdatePort = mock(UserCredentialUpdatePort.class);
+    PasswordHashPort passwordHashPort = mock(PasswordHashPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+
+    when(userCredentialLoadPort.findByUserIdForUpdate(7L)).thenReturn(Optional.of(disabledUser()));
+
+    PasswordResetService passwordResetService =
+        new PasswordResetService(
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            CLOCK);
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () ->
+            passwordResetService.reset(
+                new PasswordResetCommand(7L, "password123!", "newPassword456!")));
+
+    verify(userCredentialUpdatePort, never()).resetPassword(org.mockito.Mockito.any());
+    verify(refreshTokenSessionWritePort, never()).revokeActiveSessionsByUserId(7L, NOW);
+  }
+
+  private LoginUser activeUser() {
+    return new LoginUser(7L, "alice", "stored-hash", UserStatus.ACTIVE, 2, NOW, NOW, NOW);
+  }
+
+  private LoginUser disabledUser() {
+    return new LoginUser(7L, "alice", "stored-hash", UserStatus.DISABLED, 0, null, null, NOW);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -439,6 +439,63 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void passwordResetChangesPasswordAndRevokesActiveRefreshSessions() throws Exception {
+    TokenPairResponseView currentSession =
+        loginResult("alice", "password123!", "password-reset-login-001");
+    TokenPairResponseView parallelSession =
+        loginResult("alice", "password123!", "password-reset-login-002");
+
+    passwordReset(
+            currentSession.accessToken(),
+            "password123!",
+            "newPassword456!",
+            "password-reset-request-001")
+        .andExpect(status().isNoContent());
+
+    RefreshTokenSessionView currentRefresh = loadRefreshTokenSession(currentSession.refreshToken());
+    RefreshTokenSessionView parallelRefresh =
+        loadRefreshTokenSession(parallelSession.refreshToken());
+    assertEquals("REVOKED", currentRefresh.sessionStatus());
+    assertEquals("REVOKED", parallelRefresh.sessionStatus());
+    assertNotNull(currentRefresh.lastUsedAt());
+    assertNotNull(parallelRefresh.lastUsedAt());
+
+    refreshExpectUnauthorized(currentSession.refreshToken(), "password-reset-refresh-001");
+    refreshExpectUnauthorized(parallelSession.refreshToken(), "password-reset-refresh-002");
+    loginExpectUnauthorized("alice", "password123!", "password-reset-old-login-001");
+    assertNotNull(login("alice", "newPassword456!", "password-reset-new-login-001"));
+  }
+
+  @Test
+  void passwordResetRejectsWrongCurrentPassword() throws Exception {
+    TokenPairResponseView currentSession =
+        loginResult("alice", "password123!", "password-reset-wrong-login-001");
+
+    passwordResetExpectUnauthorized(
+        currentSession.accessToken(),
+        "wrong-password",
+        "newPassword456!",
+        "password-reset-wrong-request-001");
+
+    RefreshTokenSessionView currentRefresh = loadRefreshTokenSession(currentSession.refreshToken());
+    assertEquals("ACTIVE", currentRefresh.sessionStatus());
+    assertNotNull(login("alice", "password123!", "password-reset-wrong-old-login-001"));
+  }
+
+  @Test
+  void disabledUserCannotResetPassword() throws Exception {
+    TokenPairResponseView currentSession =
+        loginResult("alice", "password123!", "password-reset-disabled-login-001");
+    updateLegacyUserStatus(userId, "DISABLED", "fraud-review", "password-reset-disabled-ops-001");
+
+    passwordResetExpectUnauthorized(
+        currentSession.accessToken(),
+        "password123!",
+        "newPassword456!",
+        "password-reset-disabled-request-001");
+  }
+
+  @Test
   void authSessionListReturnsOnlyCurrentUsersUnexpiredActiveSessions() throws Exception {
     TokenPairResponseView expired =
         loginResult("alice", "password123!", "session-list-login-001", WINDOWS_CHROME);
@@ -674,6 +731,24 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
             get("/api/v1/auth/sessions")
                 .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
                 .header("X-Subject", "bootstrap-account"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void bootstrapAccountPrincipalCannotResetPassword() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/auth/password-reset")
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "currentPassword": "password123!",
+                      "newPassword": "newPassword456!"
+                    }
+                    """))
         .andExpect(status().isForbidden());
   }
 
@@ -1105,6 +1180,35 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
       requestBuilder.header("X-Request-Id", requestId);
     }
     return mockMvc.perform(requestBuilder);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions passwordReset(
+      String accessToken, String currentPassword, String newPassword, String requestId)
+      throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        post("/api/v1/auth/password-reset")
+            .header("Authorization", "Bearer " + accessToken)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "currentPassword": "%s",
+                  "newPassword": "%s"
+                }
+                """
+                    .formatted(currentPassword, newPassword));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private void passwordResetExpectUnauthorized(
+      String accessToken, String currentPassword, String newPassword, String requestId)
+      throws Exception {
+    passwordReset(accessToken, currentPassword, newPassword, requestId)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("password reset failed"));
   }
 
   private org.springframework.test.web.servlet.ResultActions revokeSession(


### PR DESCRIPTION
## 🔗 Related Issue
- close #118

## 🌿 Base Branch
- `main`

## 📝 Summary
- 현재 JWT user가 `currentPassword` 확인 뒤 자신의 비밀번호를 바꿀 수 있는 password reset 경로를 추가했습니다.
- 성공 시 active refresh session 전체를 revoke 해서 기존 장기 세션 연장을 차단하도록 맞췄습니다.
- 관련 단위/통합 테스트와 README 계약도 함께 정리했습니다.

## 🛠 Changes
- `PasswordResetCommand/Service/UseCase`, `UserCredentialUpdatePort` 추가
- `UserCredentialLoadPort.findByUserIdForUpdate`와 JDBC password hash update 경로 추가
- `POST /api/v1/auth/password-reset` public auth API 및 transaction wiring 추가
- `PasswordResetServiceTest`, `LoginAndAccountAccessApiIntegrationTest`에 성공/실패/권한/refresh revoke 검증 추가
- `back/README.md`에 password reset 계약과 운영 주의사항 반영

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back compileJava compileTestJava`
- `tools/test/with-resource-lock.sh back-gradle-auth-password-reset ./back/gradlew -p back test --tests '*PasswordReset*' --tests '*LoginAndAccountAccessApiIntegrationTest'`
- pre-commit hook `./back/gradlew -p back check`

## 📸 Screenshot / API Example
```http
POST /api/v1/auth/password-reset
Authorization: Bearer <access-token>
Content-Type: application/json

{
  "currentPassword": "password123!",
  "newPassword": "newPassword456!"
}
```

성공 응답: `204 No Content`

## ⚠️ Risk & Rollback
- 예상 리스크: password reset 뒤에도 기존 access token은 TTL 만료 전까지 남아 있고, 이번 범위는 refresh 차단까지만 보장합니다.
- 롤백 방법: PR revert 후 `POST /api/v1/auth/password-reset` 경로와 password hash update/revoke 로직을 이전 상태로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [ ] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?