### PR TITLE
[Feat] notification bulk read/delete/archive API 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -211,11 +211,29 @@ tools/test/with-resource-lock.sh back-gradle-check \
 ## Notification Read State
 
 - JWT user 경로의 읽음 상태는 `notification_user_read_state`에 user별로 저장됩니다.
+- JWT user 경로의 bulk archive/delete 도 같은 테이블의 `archived_at`, `deleted_at` 으로 user별 상태를 분리해 공동 사용자 inbox를 보존합니다.
 - `notification_inbox`는 account-scoped read model 본체를 유지하고, `read_at`은 account principal/internal 경로 의미로 분리됩니다.
+- account principal/internal 경로의 bulk archive 는 `notification_inbox.archived_at` 으로 숨기고, bulk delete 는 inbox row 자체를 제거합니다.
 - 기존 shared `read_at` 값은 user read state로 자동 backfill 하지 않으므로, 배포 이전 알림은 JWT user 기준에서 다시 unread로 보일 수 있습니다.
+- archived/deleted 상태는 `GET /api/v1/notifications`, unread count, SSE replay pull 경로에서 기본 제외됩니다.
 - notification inbox retention cleanup은 `notification_inbox.created_at` 기준으로만 동작해 account/user 경로의 read 의미를 따로 해석하지 않습니다.
 - 오래된 inbox row를 지울 때 연결된 `notification_user_read_state`도 FK cascade로 함께 정리해 read state orphan과 unread 회귀를 막습니다.
 - 기본 설정은 `NOTIFICATION_INBOX_CLEANUP_ENABLED=true`, `NOTIFICATION_INBOX_CLEANUP_RETENTION_DAYS=90`, `NOTIFICATION_INBOX_CLEANUP_BATCH_SIZE=500`, `NOTIFICATION_INBOX_CLEANUP_FIXED_DELAY_MS=300000` 입니다.
+
+## Notification Bulk Actions
+
+- endpoint:
+  - `POST /api/v1/notifications/read`
+  - `POST /api/v1/notifications/archive`
+  - `POST /api/v1/notifications/delete`
+- request body:
+  - `{"notificationIds":[10,11,12]}`
+- 계약:
+  - `notificationIds` 는 1건 이상 100건 이하만 허용합니다.
+  - 범위 밖 id 는 not found 로 드러내지 않고 무시합니다.
+  - JWT user bulk delete 는 shared `notification_inbox` row hard delete 대신 per-user `deleted_at` 숨김으로 처리합니다.
+  - account principal bulk delete 만 `notification_inbox` row hard delete 를 수행합니다.
+  - bulk archive/delete 대상은 후속 list/unread-count/replay 조회에서 기본 제외됩니다.
 
 ## Notification SSE Stream
 

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationBulkActionCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationBulkActionCommand.java
@@ -1,0 +1,25 @@
+package com.aquilabank.domain.notification.model;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/** bulk action 은 과도한 IN 절과 메모리 사용을 막기 위해 작은 고정 batch 로 제한합니다. */
+public record NotificationBulkActionCommand(List<Long> notificationIds) {
+
+  private static final int MAX_SIZE = 100;
+
+  public NotificationBulkActionCommand {
+    if (notificationIds == null || notificationIds.isEmpty()) {
+      throw new IllegalArgumentException("notificationIds must not be empty");
+    }
+    if (notificationIds.size() > MAX_SIZE) {
+      throw new IllegalArgumentException("notificationIds size must be 100 or less");
+    }
+    List<Long> normalizedIds = new ArrayList<>(new LinkedHashSet<>(notificationIds));
+    if (normalizedIds.stream().anyMatch(id -> id == null || id <= 0)) {
+      throw new IllegalArgumentException("notificationIds must contain only positive values");
+    }
+    notificationIds = List.copyOf(normalizedIds);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxWritePort.java
@@ -1,11 +1,24 @@
 package com.aquilabank.domain.notification.port;
 
 import java.time.Instant;
+import java.util.List;
 
-/** 읽음 처리 같은 inbox 상태 전이를 persistence adapter 로 위임합니다. */
+/** 읽음, archive, delete 같은 inbox 상태 전이를 persistence adapter 로 위임합니다. */
 public interface NotificationInboxWritePort {
 
   boolean markAsReadByUserId(long userId, long notificationId, Instant readAt);
 
   boolean markAsReadByAccountId(long accountId, long notificationId, Instant readAt);
+
+  int markAllAsReadByUserId(long userId, List<Long> notificationIds, Instant readAt);
+
+  int markAllAsReadByAccountId(long accountId, List<Long> notificationIds, Instant readAt);
+
+  int archiveByUserId(long userId, List<Long> notificationIds, Instant archivedAt);
+
+  int archiveByAccountId(long accountId, List<Long> notificationIds, Instant archivedAt);
+
+  int deleteByUserId(long userId, List<Long> notificationIds, Instant deletedAt);
+
+  int deleteByAccountId(long accountId, List<Long> notificationIds);
 }

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationBulkActionService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationBulkActionService.java
@@ -1,0 +1,72 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
+import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
+import java.time.Instant;
+
+/** bulk action 은 단건 API와 같은 권한 경계를 따르되 SQL 한 번으로 작은 batch 를 처리합니다. */
+public final class NotificationBulkActionService implements NotificationBulkActionUseCase {
+
+  private final NotificationInboxWritePort notificationInboxWritePort;
+
+  public NotificationBulkActionService(NotificationInboxWritePort notificationInboxWritePort) {
+    this.notificationInboxWritePort = notificationInboxWritePort;
+  }
+
+  @Override
+  public void markAsReadForUser(long userId, NotificationBulkActionCommand command) {
+    validateUserCommand(userId, command);
+    notificationInboxWritePort.markAllAsReadByUserId(
+        userId, command.notificationIds(), Instant.now());
+  }
+
+  @Override
+  public void markAsReadForAccount(long accountId, NotificationBulkActionCommand command) {
+    validateAccountCommand(accountId, command);
+    notificationInboxWritePort.markAllAsReadByAccountId(
+        accountId, command.notificationIds(), Instant.now());
+  }
+
+  @Override
+  public void archiveForUser(long userId, NotificationBulkActionCommand command) {
+    validateUserCommand(userId, command);
+    notificationInboxWritePort.archiveByUserId(userId, command.notificationIds(), Instant.now());
+  }
+
+  @Override
+  public void archiveForAccount(long accountId, NotificationBulkActionCommand command) {
+    validateAccountCommand(accountId, command);
+    notificationInboxWritePort.archiveByAccountId(
+        accountId, command.notificationIds(), Instant.now());
+  }
+
+  @Override
+  public void deleteForUser(long userId, NotificationBulkActionCommand command) {
+    validateUserCommand(userId, command);
+    notificationInboxWritePort.deleteByUserId(userId, command.notificationIds(), Instant.now());
+  }
+
+  @Override
+  public void deleteForAccount(long accountId, NotificationBulkActionCommand command) {
+    validateAccountCommand(accountId, command);
+    notificationInboxWritePort.deleteByAccountId(accountId, command.notificationIds());
+  }
+
+  private void validateUserCommand(long userId, NotificationBulkActionCommand command) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+  }
+
+  private void validateAccountCommand(long accountId, NotificationBulkActionCommand command) {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationBulkActionUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationBulkActionUseCase.java
@@ -1,0 +1,18 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
+
+public interface NotificationBulkActionUseCase {
+
+  void markAsReadForUser(long userId, NotificationBulkActionCommand command);
+
+  void markAsReadForAccount(long accountId, NotificationBulkActionCommand command);
+
+  void archiveForUser(long userId, NotificationBulkActionCommand command);
+
+  void archiveForAccount(long accountId, NotificationBulkActionCommand command);
+
+  void deleteForUser(long userId, NotificationBulkActionCommand command);
+
+  void deleteForAccount(long accountId, NotificationBulkActionCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
@@ -2,6 +2,8 @@ package com.aquilabank.global.config;
 
 import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
 import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
+import com.aquilabank.domain.notification.usecase.NotificationBulkActionService;
+import com.aquilabank.domain.notification.usecase.NotificationBulkActionUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationQueryService;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadService;
@@ -27,6 +29,12 @@ public class NotificationConfiguration {
   NotificationReadUseCase notificationReadUseCase(
       NotificationInboxWritePort notificationInboxWritePort) {
     return new NotificationReadService(notificationInboxWritePort);
+  }
+
+  @Bean
+  NotificationBulkActionUseCase notificationBulkActionUseCase(
+      NotificationInboxWritePort notificationInboxWritePort) {
+    return new NotificationBulkActionService(notificationInboxWritePort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-/** JWT user/account inbox 조회, read 처리, retention cleanup 을 한 JDBC adapter로 묶습니다. */
+/** JWT user/account inbox 조회, read/archive/delete 처리, retention cleanup 을 한 JDBC adapter로 묶습니다. */
 @Repository
 public class JdbcNotificationInboxRepository
     implements NotificationInboxReadPort,
@@ -90,6 +90,9 @@ public class JdbcNotificationInboxRepository
         WHERE m.user_id = :userId
           AND m.membership_status = 'ACTIVE'
           AND u.user_status = 'ACTIVE'
+          AND n.archived_at IS NULL
+          AND r.archived_at IS NULL
+          AND r.deleted_at IS NULL
           AND n.id > :lastEventId
         ORDER BY n.id ASC
         LIMIT :limit
@@ -116,6 +119,7 @@ public class JdbcNotificationInboxRepository
                read_at
         FROM notification_inbox
         WHERE account_id = :accountId
+          AND archived_at IS NULL
           AND id > :lastEventId
         ORDER BY id ASC
         LIMIT :limit
@@ -145,7 +149,10 @@ public class JdbcNotificationInboxRepository
             WHERE m.user_id = :userId
               AND m.membership_status = 'ACTIVE'
               AND u.user_status = 'ACTIVE'
-              AND r.notification_id IS NULL
+              AND n.archived_at IS NULL
+              AND r.read_at IS NULL
+              AND r.archived_at IS NULL
+              AND r.deleted_at IS NULL
             """,
             new MapSqlParameterSource().addValue("userId", userId),
             Long.class);
@@ -161,6 +168,7 @@ public class JdbcNotificationInboxRepository
             SELECT COUNT(*)
             FROM notification_inbox
             WHERE account_id = :accountId
+              AND archived_at IS NULL
               AND read_at IS NULL
             """,
             new MapSqlParameterSource().addValue("accountId", accountId),
@@ -171,81 +179,80 @@ public class JdbcNotificationInboxRepository
   @Override
   @Transactional
   public boolean markAsReadByUserId(long userId, long notificationId, Instant readAt) {
-    Boolean accessible =
-        jdbcTemplate.queryForObject(
-            """
-            WITH accessible_notification AS (
-                SELECT n.id
-                FROM notification_inbox n
-                JOIN user_account_membership m
-                  ON m.account_id = n.account_id
-                JOIN bank_user u
-                  ON u.id = m.user_id
-                WHERE n.id = :notificationId
-                  AND m.user_id = :userId
-                  AND m.membership_status = 'ACTIVE'
-                  AND u.user_status = 'ACTIVE'
-                LIMIT 1
-            ),
-            inserted_read_state AS (
-                INSERT INTO notification_user_read_state (
-                    user_id,
-                    notification_id,
-                    read_at
-                )
-                SELECT :userId, id, :readAt
-                FROM accessible_notification
-                ON CONFLICT (user_id, notification_id) DO NOTHING
-            )
-            SELECT EXISTS(SELECT 1 FROM accessible_notification)
-            """,
-            new MapSqlParameterSource()
-                .addValue("notificationId", notificationId)
-                .addValue("userId", userId)
-                .addValue("readAt", Timestamp.from(readAt)),
-            Boolean.class);
-    return Boolean.TRUE.equals(accessible);
+    return markAllAsReadByUserId(userId, List.of(notificationId), readAt) > 0;
   }
 
   @Override
   @Transactional
   public boolean markAsReadByAccountId(long accountId, long notificationId, Instant readAt) {
-    AccessibleNotification notification =
-        jdbcTemplate
-            .query(
-                """
-                SELECT account_id, read_at
-                FROM notification_inbox
-                WHERE id = :notificationId
-                  AND account_id = :accountId
-                LIMIT 1
-                """,
-                new MapSqlParameterSource()
-                    .addValue("notificationId", notificationId)
-                    .addValue("accountId", accountId),
-                (rs, rowNum) -> accessibleNotification(rs))
-            .stream()
-            .findFirst()
-            .orElse(null);
-    if (notification == null) {
-      return false;
-    }
-    if (notification.readAt() != null) {
-      return true;
-    }
-    jdbcTemplate.update(
+    return markAllAsReadByAccountId(accountId, List.of(notificationId), readAt) > 0;
+  }
+
+  @Override
+  @Transactional
+  public int markAllAsReadByUserId(long userId, List<Long> notificationIds, Instant readAt) {
+    return upsertUserNotificationState(userId, notificationIds, readAt, null, null);
+  }
+
+  @Override
+  @Transactional
+  public int markAllAsReadByAccountId(long accountId, List<Long> notificationIds, Instant readAt) {
+    return jdbcTemplate.update(
         """
         UPDATE notification_inbox
-        SET read_at = :readAt
-        WHERE id = :notificationId
-          AND account_id = :accountId
-          AND read_at IS NULL
+        SET read_at = COALESCE(read_at, :readAt)
+        WHERE account_id = :accountId
+          AND archived_at IS NULL
+          AND id IN (:notificationIds)
         """,
         new MapSqlParameterSource()
-            .addValue("readAt", Timestamp.from(readAt))
-            .addValue("notificationId", notificationId)
-            .addValue("accountId", accountId));
-    return true;
+            .addValue("accountId", accountId)
+            .addValue("notificationIds", notificationIds)
+            .addValue("readAt", Timestamp.from(readAt)));
+  }
+
+  @Override
+  @Transactional
+  public int archiveByUserId(long userId, List<Long> notificationIds, Instant archivedAt) {
+    return upsertUserNotificationState(userId, notificationIds, null, archivedAt, null);
+  }
+
+  @Override
+  @Transactional
+  public int archiveByAccountId(long accountId, List<Long> notificationIds, Instant archivedAt) {
+    return jdbcTemplate.update(
+        """
+        UPDATE notification_inbox
+        SET archived_at = COALESCE(archived_at, :archivedAt)
+        WHERE account_id = :accountId
+          AND archived_at IS NULL
+          AND id IN (:notificationIds)
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("notificationIds", notificationIds)
+            .addValue("archivedAt", Timestamp.from(archivedAt)));
+  }
+
+  @Override
+  @Transactional
+  public int deleteByUserId(long userId, List<Long> notificationIds, Instant deletedAt) {
+    // JWT user delete 는 shared inbox row 삭제 대신 per-user deleted_at 으로 숨겨 다른 공동 사용자 inbox를 보존합니다.
+    return upsertUserNotificationState(userId, notificationIds, null, null, deletedAt);
+  }
+
+  @Override
+  @Transactional
+  public int deleteByAccountId(long accountId, List<Long> notificationIds) {
+    return jdbcTemplate.update(
+        """
+        DELETE FROM notification_inbox
+        WHERE account_id = :accountId
+          AND id IN (:notificationIds)
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("notificationIds", notificationIds));
   }
 
   @Override
@@ -364,10 +371,6 @@ public class JdbcNotificationInboxRepository
         nullableInstant(rs, "read_at"));
   }
 
-  private AccessibleNotification accessibleNotification(ResultSet rs) throws SQLException {
-    return new AccessibleNotification(rs.getLong("account_id"), nullableInstant(rs, "read_at"));
-  }
-
   private static NotificationCursor toCursor(NotificationSummary item) {
     return new NotificationCursor(item.createdAt(), item.id());
   }
@@ -375,6 +378,55 @@ public class JdbcNotificationInboxRepository
   private static Instant nullableInstant(ResultSet rs, String columnName) throws SQLException {
     OffsetDateTime value = rs.getObject(columnName, OffsetDateTime.class);
     return value == null ? null : value.toInstant();
+  }
+
+  private Timestamp nullableTimestamp(Instant value) {
+    return value == null ? null : Timestamp.from(value);
+  }
+
+  // JWT user 경로는 shared inbox 원본 row를 건드리지 않고 user별 상태만 upsert 해야 공동 사용자 간 정리 동작이 섞이지 않습니다.
+  private int upsertUserNotificationState(
+      long userId,
+      List<Long> notificationIds,
+      Instant readAt,
+      Instant archivedAt,
+      Instant deletedAt) {
+    return jdbcTemplate.update(
+        """
+        WITH accessible_notification AS (
+            SELECT n.id
+            FROM notification_inbox n
+            JOIN user_account_membership m
+              ON m.account_id = n.account_id
+            JOIN bank_user u
+              ON u.id = m.user_id
+            WHERE m.user_id = :userId
+              AND m.membership_status = 'ACTIVE'
+              AND u.user_status = 'ACTIVE'
+              AND n.archived_at IS NULL
+              AND n.id IN (:notificationIds)
+        )
+        INSERT INTO notification_user_read_state (
+            user_id,
+            notification_id,
+            read_at,
+            archived_at,
+            deleted_at
+        )
+        SELECT :userId, id, :readAt, :archivedAt, :deletedAt
+        FROM accessible_notification
+        ON CONFLICT (user_id, notification_id)
+        DO UPDATE
+        SET read_at = COALESCE(notification_user_read_state.read_at, EXCLUDED.read_at),
+            archived_at = COALESCE(notification_user_read_state.archived_at, EXCLUDED.archived_at),
+            deleted_at = COALESCE(notification_user_read_state.deleted_at, EXCLUDED.deleted_at)
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("notificationIds", notificationIds)
+            .addValue("readAt", nullableTimestamp(readAt))
+            .addValue("archivedAt", nullableTimestamp(archivedAt))
+            .addValue("deletedAt", nullableTimestamp(deletedAt)));
   }
 
   private List<NotificationSummary> fetchByUserIdFirstPage(
@@ -399,6 +451,9 @@ public class JdbcNotificationInboxRepository
         WHERE m.user_id = :userId
           AND m.membership_status = 'ACTIVE'
           AND u.user_status = 'ACTIVE'
+          AND n.archived_at IS NULL
+          AND r.archived_at IS NULL
+          AND r.deleted_at IS NULL
         ORDER BY n.created_at DESC, n.id DESC
         LIMIT :limitPlusOne
         """,
@@ -430,6 +485,9 @@ public class JdbcNotificationInboxRepository
         WHERE m.user_id = :userId
           AND m.membership_status = 'ACTIVE'
           AND u.user_status = 'ACTIVE'
+          AND n.archived_at IS NULL
+          AND r.archived_at IS NULL
+          AND r.deleted_at IS NULL
           AND (
                 n.created_at < :cursorCreatedAt
              OR (n.created_at = :cursorCreatedAt AND n.id < :cursorId)
@@ -458,6 +516,7 @@ public class JdbcNotificationInboxRepository
                read_at
         FROM notification_inbox
         WHERE account_id = :accountId
+          AND archived_at IS NULL
         ORDER BY created_at DESC, id DESC
         LIMIT :limitPlusOne
         """,
@@ -480,6 +539,7 @@ public class JdbcNotificationInboxRepository
                read_at
         FROM notification_inbox
         WHERE account_id = :accountId
+          AND archived_at IS NULL
           AND (
                 created_at < :cursorCreatedAt
              OR (created_at = :cursorCreatedAt AND id < :cursorId)
@@ -494,6 +554,4 @@ public class JdbcNotificationInboxRepository
             .addValue("cursorId", query.cursor().id()),
         ROW_MAPPER);
   }
-
-  private record AccessibleNotification(long accountId, Instant readAt) {}
 }

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
@@ -1,7 +1,9 @@
 package com.aquilabank.global.web.notification;
 
+import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
 import com.aquilabank.domain.notification.model.NotificationCursor;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.usecase.NotificationBulkActionUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
 import com.aquilabank.global.notification.NotificationSseBroker;
@@ -9,7 +11,11 @@ import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -18,6 +24,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,14 +41,17 @@ public class NotificationController {
 
   private final NotificationQueryUseCase notificationQueryUseCase;
   private final NotificationReadUseCase notificationReadUseCase;
+  private final NotificationBulkActionUseCase notificationBulkActionUseCase;
   private final NotificationSseBroker notificationSseBroker;
 
   public NotificationController(
       NotificationQueryUseCase notificationQueryUseCase,
       NotificationReadUseCase notificationReadUseCase,
+      NotificationBulkActionUseCase notificationBulkActionUseCase,
       NotificationSseBroker notificationSseBroker) {
     this.notificationQueryUseCase = notificationQueryUseCase;
     this.notificationReadUseCase = notificationReadUseCase;
+    this.notificationBulkActionUseCase = notificationBulkActionUseCase;
     this.notificationSseBroker = notificationSseBroker;
   }
 
@@ -96,6 +106,42 @@ public class NotificationController {
     }
   }
 
+  @PostMapping("/read")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void markAllAsRead(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @Valid @RequestBody NotificationBulkActionRequest request) {
+    try {
+      dispatchBulkRead(principal, new NotificationBulkActionCommand(request.notificationIds()));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+
+  @PostMapping("/archive")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void archiveNotifications(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @Valid @RequestBody NotificationBulkActionRequest request) {
+    try {
+      dispatchBulkArchive(principal, new NotificationBulkActionCommand(request.notificationIds()));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+
+  @PostMapping("/delete")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void deleteNotifications(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @Valid @RequestBody NotificationBulkActionRequest request) {
+    try {
+      dispatchBulkDelete(principal, new NotificationBulkActionCommand(request.notificationIds()));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+
   private com.aquilabank.domain.notification.model.NotificationSlice resolveNotifications(
       AuthenticatedRequestPrincipal principal, NotificationListQuery query) {
     if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
@@ -130,6 +176,45 @@ public class NotificationController {
     throw new IllegalArgumentException("unsupported principal type");
   }
 
+  private void dispatchBulkRead(
+      AuthenticatedRequestPrincipal principal, NotificationBulkActionCommand command) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      notificationBulkActionUseCase.markAsReadForUser(userPrincipal.userId(), command);
+      return;
+    }
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      notificationBulkActionUseCase.markAsReadForAccount(accountPrincipal.accountId(), command);
+      return;
+    }
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+
+  private void dispatchBulkArchive(
+      AuthenticatedRequestPrincipal principal, NotificationBulkActionCommand command) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      notificationBulkActionUseCase.archiveForUser(userPrincipal.userId(), command);
+      return;
+    }
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      notificationBulkActionUseCase.archiveForAccount(accountPrincipal.accountId(), command);
+      return;
+    }
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+
+  private void dispatchBulkDelete(
+      AuthenticatedRequestPrincipal principal, NotificationBulkActionCommand command) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      notificationBulkActionUseCase.deleteForUser(userPrincipal.userId(), command);
+      return;
+    }
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      notificationBulkActionUseCase.deleteForAccount(accountPrincipal.accountId(), command);
+      return;
+    }
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+
   private SseEmitter openStream(AuthenticatedRequestPrincipal principal, Long lastEventId) {
     if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
       return notificationSseBroker.subscribeUser(
@@ -156,4 +241,9 @@ public class NotificationController {
       throw new IllegalArgumentException("Last-Event-ID must be numeric", ex);
     }
   }
+
+  /** bulk action body 는 작은 id 목록만 허용해 notification inbox SQL 범위를 고정합니다. */
+  public record NotificationBulkActionRequest(
+      @NotEmpty(message = "notificationIds must not be empty") @Size(max = 100, message = "notificationIds size must be 100 or less") List<@Positive(message = "notificationIds must contain only positive values") Long>
+              notificationIds) {}
 }

--- a/back/src/main/resources/db/migration/V20__add_notification_bulk_action_state.sql
+++ b/back/src/main/resources/db/migration/V20__add_notification_bulk_action_state.sql
@@ -11,6 +11,9 @@ CREATE INDEX idx_notification_inbox_account_visible_unread
     WHERE archived_at IS NULL;
 
 ALTER TABLE notification_user_read_state
+    ALTER COLUMN read_at DROP NOT NULL;
+
+ALTER TABLE notification_user_read_state
     ADD COLUMN archived_at TIMESTAMPTZ;
 
 ALTER TABLE notification_user_read_state

--- a/back/src/main/resources/db/migration/V20__add_notification_bulk_action_state.sql
+++ b/back/src/main/resources/db/migration/V20__add_notification_bulk_action_state.sql
@@ -1,0 +1,17 @@
+-- account principal 은 inbox row 자체를 숨기고, JWT user 는 shared inbox 보존을 위해 per-user 상태로 archive/delete 를 분리합니다.
+ALTER TABLE notification_inbox
+    ADD COLUMN archived_at TIMESTAMPTZ;
+
+CREATE INDEX idx_notification_inbox_account_visible_cursor
+    ON notification_inbox (account_id, created_at DESC, id DESC)
+    WHERE archived_at IS NULL;
+
+CREATE INDEX idx_notification_inbox_account_visible_unread
+    ON notification_inbox (account_id, read_at, id DESC)
+    WHERE archived_at IS NULL;
+
+ALTER TABLE notification_user_read_state
+    ADD COLUMN archived_at TIMESTAMPTZ;
+
+ALTER TABLE notification_user_read_state
+    ADD COLUMN deleted_at TIMESTAMPTZ;

--- a/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationBulkActionServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationBulkActionServiceTest.java
@@ -1,0 +1,57 @@
+package com.aquilabank.domain.notification.usecase;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
+import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NotificationBulkActionServiceTest {
+
+  private final NotificationInboxWritePort notificationInboxWritePort =
+      mock(NotificationInboxWritePort.class);
+
+  private final NotificationBulkActionService service =
+      new NotificationBulkActionService(notificationInboxWritePort);
+
+  @Test
+  void marksNotificationsAsReadForAccountUsingBoundedIdList() {
+    Instant before = Instant.now();
+
+    service.markAsReadForAccount(101L, new NotificationBulkActionCommand(List.of(10L, 11L)));
+
+    Instant after = Instant.now();
+    verify(notificationInboxWritePort)
+        .markAllAsReadByAccountId(
+            org.mockito.ArgumentMatchers.eq(101L),
+            org.mockito.ArgumentMatchers.eq(List.of(10L, 11L)),
+            argThat(
+                readAt -> readAt != null && !readAt.isBefore(before) && !readAt.isAfter(after)));
+  }
+
+  @Test
+  void deletesNotificationsPerUserWithoutTouchingSharedInboxRowDirectly() {
+    Instant before = Instant.now();
+
+    service.deleteForUser(55L, new NotificationBulkActionCommand(List.of(20L, 21L)));
+
+    Instant after = Instant.now();
+    verify(notificationInboxWritePort)
+        .deleteByUserId(
+            org.mockito.ArgumentMatchers.eq(55L),
+            org.mockito.ArgumentMatchers.eq(List.of(20L, 21L)),
+            argThat(
+                deletedAt ->
+                    deletedAt != null && !deletedAt.isBefore(before) && !deletedAt.isAfter(after)));
+  }
+
+  @Test
+  void rejectsMissingCommand() {
+    org.junit.jupiter.api.Assertions.assertThrows(
+        IllegalArgumentException.class, () -> service.archiveForAccount(101L, null));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -117,6 +117,48 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
   }
 
   @Test
+  void marksNotificationsAsReadInBulkPerUserWithoutAffectingSharedUsers() {
+    long[] userIds = new long[2];
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[2];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userIds[0] = insertUser("user-bulk-read-a");
+          userIds[1] = insertUser("user-bulk-read-b");
+          accountId[0] = insertAccount("bulk read account");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
+          notificationIds[0] =
+              insertNotification(
+                  accountId[0], "evt-bulk-read-1", "TransferBooked", "A", "A", null, base);
+          notificationIds[1] =
+              insertNotification(
+                  accountId[0],
+                  "evt-bulk-read-2",
+                  "TransferBooked",
+                  "B",
+                  "B",
+                  null,
+                  base.plusSeconds(5));
+        });
+
+    assertThat(
+            repository.markAllAsReadByUserId(
+                userIds[0], List.of(notificationIds[0], notificationIds[1]), base.plusSeconds(30)))
+        .isEqualTo(2);
+    assertThat(repository.countUnreadByUserId(userIds[0])).isEqualTo(0L);
+    assertThat(repository.countUnreadByUserId(userIds[1])).isEqualTo(2L);
+    assertThat(repository.fetchByUserId(userIds[0], new NotificationListQuery(10, null)).items())
+        .extracting("readAt")
+        .allMatch(item -> item != null);
+    assertThat(repository.fetchByUserId(userIds[1], new NotificationListQuery(10, null)).items())
+        .extracting("readAt")
+        .containsExactly(null, null);
+  }
+
+  @Test
   void keepsAccountScopedReadPathOnNotificationInbox() {
     long[] accountId = new long[1];
     long[] notificationIds = new long[2];
@@ -150,6 +192,75 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
         .isTrue();
     assertThat(repository.markAsReadByAccountId(accountId[0], 99999L, base.plusSeconds(50)))
         .isFalse();
+  }
+
+  @Test
+  void archivesAndDeletesNotificationsPerPrincipalScope() {
+    long[] userIds = new long[2];
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[3];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userIds[0] = insertUser("user-bulk-hide-a");
+          userIds[1] = insertUser("user-bulk-hide-b");
+          accountId[0] = insertAccount("bulk hide account");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
+          notificationIds[0] =
+              insertNotification(
+                  accountId[0], "evt-bulk-hide-1", "TransferBooked", "A", "A", null, base);
+          notificationIds[1] =
+              insertNotification(
+                  accountId[0],
+                  "evt-bulk-hide-2",
+                  "TransferBooked",
+                  "B",
+                  "B",
+                  null,
+                  base.plusSeconds(5));
+          notificationIds[2] =
+              insertNotification(
+                  accountId[0],
+                  "evt-bulk-hide-3",
+                  "TransferBooked",
+                  "C",
+                  "C",
+                  null,
+                  base.plusSeconds(10));
+        });
+
+    assertThat(
+            repository.archiveByUserId(
+                userIds[0], List.of(notificationIds[0]), base.plusSeconds(20)))
+        .isEqualTo(1);
+    assertThat(
+            repository.deleteByUserId(
+                userIds[0], List.of(notificationIds[1]), base.plusSeconds(30)))
+        .isEqualTo(1);
+    assertThat(
+            repository.archiveByAccountId(
+                accountId[0], List.of(notificationIds[2]), base.plusSeconds(40)))
+        .isEqualTo(1);
+
+    assertThat(repository.fetchByUserId(userIds[0], new NotificationListQuery(10, null)).items())
+        .isEmpty();
+    assertThat(repository.fetchByUserId(userIds[1], new NotificationListQuery(10, null)).items())
+        .extracting("title")
+        .containsExactly("B", "A");
+    assertThat(
+            repository.fetchByAccountId(accountId[0], new NotificationListQuery(10, null)).items())
+        .extracting("title")
+        .containsExactly("B", "A");
+    assertThat(repository.countUnreadByUserId(userIds[0])).isEqualTo(0L);
+    assertThat(repository.countUnreadByUserId(userIds[1])).isEqualTo(2L);
+    assertThat(repository.countUnreadByAccountId(accountId[0])).isEqualTo(2L);
+
+    assertThat(repository.deleteByAccountId(accountId[0], List.of(notificationIds[1])))
+        .isEqualTo(1);
+    assertThat(findNotificationEventKeys())
+        .containsExactlyInAnyOrder("evt-bulk-hide-1", "evt-bulk-hide-3");
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
@@ -195,6 +195,213 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
         .andExpect(jsonPath("$.unreadCount").value(1));
   }
 
+  @Test
+  void supportsBulkReadArchiveAndDeleteForJwtUser() throws Exception {
+    long[] userIds = new long[2];
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[3];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userIds[0] = insertUser("bulk-user-a");
+          userIds[1] = insertUser("bulk-user-b");
+          accountId[0] = insertAccount("bulk user account");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
+          notificationIds[0] =
+              insertNotification(
+                  accountId[0], "evt-user-bulk-1", "TransferBooked", "첫 알림", "A", null, base);
+          notificationIds[1] =
+              insertNotification(
+                  accountId[0],
+                  "evt-user-bulk-2",
+                  "TransferBooked",
+                  "둘째 알림",
+                  "B",
+                  null,
+                  base.plusSeconds(5));
+          notificationIds[2] =
+              insertNotification(
+                  accountId[0],
+                  "evt-user-bulk-3",
+                  "TransferBooked",
+                  "셋째 알림",
+                  "C",
+                  null,
+                  base.plusSeconds(10));
+        });
+
+    String tokenA = issueToken("bulk-user-a-subject", userIds[0]);
+    String tokenB = issueToken("bulk-user-b-subject", userIds[1]);
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/read")
+                .header("Authorization", "Bearer " + tokenA)
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d,%d]}
+                    """
+                        .formatted(notificationIds[0], notificationIds[1])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + tokenA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(3))
+        .andExpect(jsonPath("$.items[1].notificationId").value(notificationIds[1]))
+        .andExpect(jsonPath("$.items[1].read").value(true))
+        .andExpect(jsonPath("$.items[2].notificationId").value(notificationIds[0]))
+        .andExpect(jsonPath("$.items[2].read").value(true));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/archive")
+                .header("Authorization", "Bearer " + tokenA)
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[0])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/delete")
+                .header("Authorization", "Bearer " + tokenA)
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[1])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + tokenA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].notificationId").value(notificationIds[2]))
+        .andExpect(jsonPath("$.items[0].read").value(false));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + tokenA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(1));
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + tokenB))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(3))
+        .andExpect(jsonPath("$.items[0].read").value(false))
+        .andExpect(jsonPath("$.items[1].read").value(false))
+        .andExpect(jsonPath("$.items[2].read").value(false));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + tokenB))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(3));
+  }
+
+  @Test
+  void supportsBulkReadArchiveAndDeleteForAccountPrincipal() throws Exception {
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[3];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          accountId[0] = insertAccount("bulk account principal");
+          notificationIds[0] =
+              insertNotification(
+                  accountId[0], "evt-account-bulk-1", "TransferBooked", "첫 알림", "A", null, base);
+          notificationIds[1] =
+              insertNotification(
+                  accountId[0],
+                  "evt-account-bulk-2",
+                  "TransferBooked",
+                  "둘째 알림",
+                  "B",
+                  null,
+                  base.plusSeconds(5));
+          notificationIds[2] =
+              insertNotification(
+                  accountId[0],
+                  "evt-account-bulk-3",
+                  "TransferBooked",
+                  "셋째 알림",
+                  "C",
+                  null,
+                  base.plusSeconds(10));
+        });
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/read")
+                .header("X-Account-Id", Long.toString(accountId[0]))
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d,%d]}
+                    """
+                        .formatted(notificationIds[0], notificationIds[1])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(get("/api/v1/notifications/unread-count").header("X-Account-Id", accountId[0]))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(1));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/archive")
+                .header("X-Account-Id", Long.toString(accountId[0]))
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[0])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("X-Account-Id", accountId[0]))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].notificationId").value(notificationIds[2]))
+        .andExpect(jsonPath("$.items[1].notificationId").value(notificationIds[1]))
+        .andExpect(jsonPath("$.items[1].read").value(true));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/delete")
+                .header("X-Account-Id", Long.toString(accountId[0]))
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[2])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("X-Account-Id", accountId[0]))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].notificationId").value(notificationIds[1]))
+        .andExpect(jsonPath("$.items[0].read").value(true));
+
+    mockMvc
+        .perform(get("/api/v1/notifications/unread-count").header("X-Account-Id", accountId[0]))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(0));
+  }
+
   private long insertUser(String loginId) {
     Long userId =
         jdbcTemplate.queryForObject(

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
+import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
 import com.aquilabank.domain.notification.model.NotificationCursor;
 import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.domain.notification.model.NotificationSummary;
@@ -110,6 +111,57 @@ class NotificationControllerTest {
   }
 
   @Test
+  void marksNotificationsAsReadInBulk() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/read")
+                .header("X-Account-Id", "101")
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[10,11]}
+                    """))
+        .andExpect(status().isNoContent());
+
+    verify(notificationBulkActionUseCase)
+        .markAsReadForAccount(eq(101L), eq(new NotificationBulkActionCommand(List.of(10L, 11L))));
+  }
+
+  @Test
+  void archivesNotificationsInBulk() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/archive")
+                .header("X-Account-Id", "101")
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[10,12]}
+                    """))
+        .andExpect(status().isNoContent());
+
+    verify(notificationBulkActionUseCase)
+        .archiveForAccount(eq(101L), eq(new NotificationBulkActionCommand(List.of(10L, 12L))));
+  }
+
+  @Test
+  void deletesNotificationsInBulk() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/delete")
+                .header("X-Account-Id", "101")
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[10,13]}
+                    """))
+        .andExpect(status().isNoContent());
+
+    verify(notificationBulkActionUseCase)
+        .deleteForAccount(eq(101L), eq(new NotificationBulkActionCommand(List.of(10L, 13L))));
+  }
+
+  @Test
   void returnsNotFoundWhenNotificationIsMissing() throws Exception {
     doThrow(new NotificationNotFoundException("notification is not found"))
         .when(notificationReadUseCase)
@@ -126,6 +178,20 @@ class NotificationControllerTest {
     mockMvc
         .perform(
             get("/api/v1/notifications").header("X-Account-Id", "101").param("cursor", "broken"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectsEmptyBulkRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/archive")
+                .header("X-Account-Id", "101")
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[]}
+                    """))
         .andExpect(status().isBadRequest());
   }
 

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -18,6 +18,7 @@ import com.aquilabank.domain.notification.exception.NotificationNotFoundExceptio
 import com.aquilabank.domain.notification.model.NotificationCursor;
 import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.domain.notification.model.NotificationSummary;
+import com.aquilabank.domain.notification.usecase.NotificationBulkActionUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
 import com.aquilabank.global.notification.NotificationSseBroker;
@@ -37,6 +38,7 @@ class NotificationControllerTest {
 
   private NotificationQueryUseCase notificationQueryUseCase;
   private NotificationReadUseCase notificationReadUseCase;
+  private NotificationBulkActionUseCase notificationBulkActionUseCase;
   private NotificationSseBroker notificationSseBroker;
   private MockMvc mockMvc;
 
@@ -44,11 +46,15 @@ class NotificationControllerTest {
   void setUp() {
     notificationQueryUseCase = mock(NotificationQueryUseCase.class);
     notificationReadUseCase = mock(NotificationReadUseCase.class);
+    notificationBulkActionUseCase = mock(NotificationBulkActionUseCase.class);
     notificationSseBroker = mock(NotificationSseBroker.class);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new NotificationController(
-                    notificationQueryUseCase, notificationReadUseCase, notificationSseBroker))
+                    notificationQueryUseCase,
+                    notificationReadUseCase,
+                    notificationBulkActionUseCase,
+                    notificationSseBroker))
             .setControllerAdvice(new ApiExceptionHandler())
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())


### PR DESCRIPTION
## 🔗 Related Issue
- close #122

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification inbox 에 bulk read/archive/delete API 를 추가했습니다.
- JWT user 경로는 per-user 상태 테이블로 archive/delete 를 분리하고, account principal 경로는 inbox row 상태와 hard delete 를 사용합니다.
- list/unread-count/SSE replay pull 경로에서 archived/deleted 상태를 기본 제외하도록 정리했습니다.

## 🛠 Changes
- `V20__add_notification_bulk_action_state.sql`에 account archive 컬럼과 user 상태 확장 컬럼, `read_at` nullable 전환을 추가했습니다.
- `NotificationBulkActionCommand`, `NotificationBulkActionUseCase`, `NotificationBulkActionService`와 `/api/v1/notifications/read|archive|delete` endpoint를 추가했습니다.
- `JdbcNotificationInboxRepository`에 bulk read/archive/delete SQL과 principal별 숨김 규칙을 구현했습니다.
- notification unit/controller/JDBC integration/API integration 테스트와 README를 갱신했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-notification-bulk ./back/gradlew -p back test --tests '*NotificationBulkActionServiceTest' --tests '*NotificationControllerTest' --tests '*JdbcNotificationInboxRepositoryIntegrationTest' --tests '*NotificationApiIntegrationTest'`
- `./back/gradlew -p back spotlessApply`
- `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - JWT user bulk archive/delete 는 `notification_user_read_state.read_at` nullable 전환에 의존하므로 partial deploy 상태가 길어지지 않게 배포해야 합니다.
  - account principal bulk archive 는 즉시 list/unread-count/replay 에서 숨겨지므로 운영 스크립트가 기존 visible set에 의존하면 확인이 필요합니다.
- 롤백 방법:
  - PR revert 로 애플리케이션 코드를 되돌립니다.
  - staging 에서 revert SHA 검증 후 동일 SHA 로 재배포합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?