### PR TITLE
[Build] Nginx TLS·server_name·rate-limit 기준 추가

### DIFF
--- a/ops/nginx/README.md
+++ b/ops/nginx/README.md
@@ -1,6 +1,6 @@
 # Nginx Reverse Proxy Baseline
 
-`ops/nginx/nginx.conf`는 단일 EC2 인스턴스에서 frontend(`3000`)와 backend(`8080`)를 함께 reverse proxy 하는 기준 파일입니다.
+`ops/nginx/nginx.conf`는 단일 EC2 인스턴스에서 frontend(`3000`)와 backend(`8080`)를 함께 reverse proxy 하는 기준 파일입니다. 이번 baseline은 HTTPS 종료, exact `server_name`, API rate limit까지 포함합니다.
 
 ## 포함 범위
 
@@ -8,6 +8,25 @@
 - `/api/`: backend upstream
 - `/actuator/health`: backend health check upstream
 - `/api/v1/notifications/stream`: SSE 전용 proxy 설정
+- `80 -> 443`: 일반 요청 HTTPS redirect
+- `443 ssl`: TLS termination
+- API 단기 burst 보호용 rate limit
+
+## TLS / `server_name` 기준
+
+- `server_name`은 `_` wildcard 대신 실제 FQDN 하나로 고정합니다. 기본값은 `bank.example.com` placeholder입니다.
+- `listen 80`에서는 `/.well-known/acme-challenge/`와 `/actuator/health`만 예외로 두고 나머지는 `308`으로 HTTPS redirect 합니다.
+- `listen 443 ssl http2`에서 TLS termination을 수행합니다.
+- `ssl_certificate`, `ssl_certificate_key`는 placeholder 경로이므로 운영 적용 전에 실제 인증서 경로로 교체해야 합니다.
+- `return 308 https://$server_name$request_uri;`를 써서 요청 `Host` 헤더를 그대로 반사하지 않고 설정한 host 기준으로 redirect 합니다.
+
+## Rate Limit 기준
+
+- `limit_req_zone $binary_remote_addr zone=aquila_bank_api_per_ip:10m rate=30r/s;`
+- `/api/`에만 `limit_req zone=aquila_bank_api_per_ip burst=60 nodelay;`를 적용합니다.
+- `/api/v1/notifications/stream`은 장기 연결이라 일반 API와 성격이 달라 exact location으로 분리하고 rate limit 대상에서 제외합니다.
+- `429`는 Nginx에서 바로 반환해 backend thread/connection 소비를 줄이는 1차 가드로 둡니다.
+- 실제 서비스 트래픽 특성에 따라 `rate`와 `burst`는 조정하되, 로그인/토큰 재발급/SSE 재연결 패턴을 같이 확인합니다.
 
 ## SSE 기준
 
@@ -23,7 +42,9 @@
 ## 운영 적용 전 확인
 
 - frontend/backend 포트가 기본값과 다르면 upstream `server` 주소를 같이 수정합니다.
-- TLS termination, `server_name`, rate limit, multi-node load balancer 정책은 이번 baseline 밖입니다.
+- `bank.example.com`, `/etc/letsencrypt/live/...` placeholder는 실제 운영값으로 교체합니다.
+- HTTP health probe가 필요 없으면 `listen 80`의 `/actuator/health` 예외도 HTTPS로 통일합니다.
+- multi-node load balancer 정책은 이번 baseline 밖입니다.
 - backend는 이미 `X-Accel-Buffering: no` 헤더를 내려주므로 Nginx도 같은 방향으로 buffering을 끈 상태를 유지합니다.
 
 ## 검증
@@ -32,4 +53,4 @@
 bash tools/test/check-nginx-sse-proxy.sh
 ```
 
-`nginx` binary가 설치된 환경이면 위 smoke check가 추가로 `nginx -t`까지 수행합니다.
+`nginx` binary와 실제 TLS 인증서 파일이 모두 있는 환경이면 위 smoke check가 추가로 `nginx -t`까지 수행합니다. placeholder 인증서 경로만 있는 상태에서는 directive smoke check까지만 수행합니다.

--- a/ops/nginx/nginx.conf
+++ b/ops/nginx/nginx.conf
@@ -12,6 +12,10 @@ http {
   tcp_nodelay on;
   keepalive_timeout 65;
   client_max_body_size 1m;
+  limit_req_status 429;
+
+  # 짧은 API 요청만 1차 보호하고, SSE는 exact location에서 별도 처리합니다.
+  limit_req_zone $binary_remote_addr zone=aquila_bank_api_per_ip:10m rate=30r/s;
 
   upstream aquila_bank_frontend {
     server 127.0.0.1:3000;
@@ -25,7 +29,46 @@ http {
 
   server {
     listen 80 default_server;
-    server_name _;
+    server_name bank.example.com;
+
+    proxy_http_version 1.1;
+    proxy_connect_timeout 3s;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+
+    # ACME challenge는 HTTP 경로가 필요해 redirect 예외로 둡니다.
+    location ^~ /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+      default_type text/plain;
+    }
+
+    # 간단한 외부 probe는 HTTP health check로도 유지할 수 있게 둡니다.
+    location ^~ /actuator/health {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Connection "";
+      proxy_read_timeout 5s;
+      proxy_send_timeout 5s;
+      access_log off;
+    }
+
+    location / {
+      return 308 https://$server_name$request_uri;
+    }
+  }
+
+  server {
+    listen 443 ssl http2;
+    server_name bank.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/bank.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/bank.example.com/privkey.pem;
+    ssl_session_cache shared:AquilaBankTLS:10m;
+    ssl_session_timeout 1d;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
 
     proxy_http_version 1.1;
     proxy_connect_timeout 3s;
@@ -51,6 +94,7 @@ http {
     location /api/ {
       proxy_pass http://aquila_bank_backend;
       proxy_set_header Connection "";
+      limit_req zone=aquila_bank_api_per_ip burst=60 nodelay;
       proxy_read_timeout 30s;
       proxy_send_timeout 30s;
     }

--- a/tools/test/check-nginx-sse-proxy.sh
+++ b/tools/test/check-nginx-sse-proxy.sh
@@ -9,10 +9,18 @@ if [[ ! -f "$config_path" ]]; then
 fi
 
 required_patterns=(
+  "limit_req_status 429;"
+  "limit_req_zone \$binary_remote_addr zone=aquila_bank_api_per_ip:10m rate=30r/s;"
   "upstream aquila_bank_frontend"
   "server 127.0.0.1:3000;"
   "upstream aquila_bank_backend"
   "server 127.0.0.1:8080;"
+  "server_name bank.example.com;"
+  "location ^~ /.well-known/acme-challenge/"
+  "return 308 https://\$server_name\$request_uri;"
+  "listen 443 ssl http2;"
+  "ssl_certificate /etc/letsencrypt/live/bank.example.com/fullchain.pem;"
+  "ssl_certificate_key /etc/letsencrypt/live/bank.example.com/privkey.pem;"
   "location = /api/v1/notifications/stream"
   "proxy_buffering off;"
   "proxy_request_buffering off;"
@@ -21,6 +29,7 @@ required_patterns=(
   "proxy_send_timeout 1900s;"
   "add_header X-Accel-Buffering no always;"
   "location /api/"
+  "limit_req zone=aquila_bank_api_per_ip burst=60 nodelay;"
   "location ^~ /actuator/health"
   "location / {"
 )
@@ -32,7 +41,10 @@ for pattern in "${required_patterns[@]}"; do
   fi
 done
 
-if command -v nginx >/dev/null 2>&1; then
+ssl_certificate_path="$(sed -n 's/^[[:space:]]*ssl_certificate[[:space:]]\+\([^;]*\);/\1/p' "$config_path" | head -n 1)"
+ssl_certificate_key_path="$(sed -n 's/^[[:space:]]*ssl_certificate_key[[:space:]]\+\([^;]*\);/\1/p' "$config_path" | head -n 1)"
+
+if command -v nginx >/dev/null 2>&1 && [[ -n "$ssl_certificate_path" ]] && [[ -n "$ssl_certificate_key_path" ]] && [[ -f "$ssl_certificate_path" ]] && [[ -f "$ssl_certificate_key_path" ]]; then
   nginx -t -c "$PWD/$config_path" >/dev/null
   echo "[nginx-sse-check] nginx -t passed"
 else


### PR DESCRIPTION
## 🔗 Related Issue
- close #124

## 🌿 Base Branch
- `main`

## 📝 Summary
- `ops/nginx/nginx.conf`에 HTTPS 종료, exact `server_name`, API rate limit baseline을 추가했습니다.
- SSE와 health probe는 기존 운영 가정을 깨지 않도록 예외 경로로 분리했습니다.
- README와 smoke check를 같은 기준으로 맞춰 운영 문서와 설정 drift를 줄였습니다.

## 🛠 Changes
- `listen 80`에서 ACME challenge와 health check만 예외로 두고 나머지는 HTTPS로 redirect 하도록 정리했습니다.
- `listen 443 ssl http2`, `ssl_certificate`, `ssl_certificate_key`, `server_name` placeholder baseline을 추가했습니다.
- `/api/`에 `limit_req` baseline을 넣고 SSE endpoint는 exact location으로 분리해 제외했습니다.
- `ops/nginx/README.md`에 TLS, `server_name`, rate limit 적용 기준과 placeholder 교체 주의점을 문서화했습니다.
- `tools/test/check-nginx-sse-proxy.sh`가 TLS/rate limit directive를 확인하고, 실제 인증서가 있을 때만 `nginx -t`를 수행하도록 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-nginx-sse-proxy.sh`
- `git diff -- ops/nginx/nginx.conf ops/nginx/README.md tools/test/check-nginx-sse-proxy.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: placeholder `server_name`/인증서 경로를 실제 운영값으로 교체하지 않으면 실배포 시 TLS 기동이 실패할 수 있습니다. 과한 `rate`/`burst` 값 조정은 로그인 또는 토큰 재발급 흐름에 영향이 있을 수 있습니다.
- 롤백 방법: 이 PR을 revert 해서 기존 HTTP reverse proxy/SSE baseline으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?