### PR TITLE
[Perf] 로그인 IP/global throttling 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -340,14 +340,23 @@ bash tools/test/check-nginx-sse-proxy.sh
   - `SECURITY_LOGIN_PROTECTION_MAX_FAILURES=5`
   - `SECURITY_LOGIN_PROTECTION_LOCK_SECONDS=900`
   - `SECURITY_LOGIN_PROTECTION_RESET_WINDOW_SECONDS=900`
+  - `SECURITY_LOGIN_THROTTLING_IP_MAX_ATTEMPTS=20`
+  - `SECURITY_LOGIN_THROTTLING_IP_WINDOW_SECONDS=60`
+  - `SECURITY_LOGIN_THROTTLING_GLOBAL_MAX_ATTEMPTS=40`
+  - `SECURITY_LOGIN_THROTTLING_GLOBAL_WINDOW_SECONDS=10`
+  - `SECURITY_LOGIN_THROTTLING_MAX_TRACKED_IPS=1024`
 - 동작 기준:
   - 같은 `loginId`에서 연속 `5회` 실패하면 `15분` 임시 잠금
   - 마지막 실패 후 `15분`이 지나면 실패 카운트는 다시 `1`부터 계산
+  - 같은 IP에서 `1분` 동안 `20회`를 넘기면 `429 too many login attempts`로 fail-fast
+  - 단일 app instance 기준 전체 login 시도가 `10초` 동안 `40회`를 넘기면 동일하게 `429`로 shed
   - 성공 login 시 `failed_login_count`, `last_login_failed_at`, `login_locked_until`은 reset
-  - 외부 응답은 존재 여부/잠금 여부를 드러내지 않도록 항상 `401 login failed` 유지
+  - `loginId` 잠금은 존재 여부/잠금 여부를 드러내지 않도록 계속 `401 login failed` 유지
+  - request-level throttling은 `Retry-After` 헤더와 함께 `429 too many login attempts`를 반환
 - 상태 우선순위:
   - 수동 운영 상태 `user_status=LOCKED|DISABLED`가 임시 잠금보다 우선
   - 임시 brute-force 잠금은 `login_locked_until`로만 관리하고 `user_status`는 직접 바꾸지 않음
+  - IP/global throttling은 per-instance in-memory 기준이며 multi-node 전체 합산 limit는 보장하지 않음
 
 ### login 실패 감사 로그
 

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottleGuard.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottleGuard.java
@@ -1,0 +1,193 @@
+package com.aquilabank.global.security;
+
+import com.aquilabank.global.web.RequestTraceContext;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HexFormat;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/** login entrypoint 직전에서 IP/global burst를 빠르게 차단합니다. */
+@Component
+public class LoginThrottleGuard {
+
+  private static final Logger log = LoggerFactory.getLogger(LoginThrottleGuard.class);
+
+  private final LoginThrottlingProperties properties;
+  private final Clock clock;
+  private final Deque<Instant> globalWindow = new ArrayDeque<>();
+  private final LinkedHashMap<String, AttemptWindow> ipWindows =
+      new LinkedHashMap<>(16, 0.75f, true);
+
+  public LoginThrottleGuard(LoginThrottlingProperties properties, Clock clock) {
+    this.properties = properties;
+    this.clock = clock;
+  }
+
+  public synchronized void check(String ipAddress) {
+    Instant now = Instant.now(clock);
+    String normalizedIpAddress = normalizeIpAddress(ipAddress);
+
+    // 공개 login QPS는 낮고 tracked IP 수도 작게 제한하므로 단일 monitor로 window 정합성을 유지합니다.
+    pruneWindow(globalWindow, now, properties.global().windowSeconds());
+    pruneIpWindows(now);
+
+    ThrottleDecision ipDecision = evaluateIpWindow(normalizedIpAddress, now);
+    if (ipDecision.blocked()) {
+      logThrottle(
+          LoginThrottleScope.IP,
+          normalizedIpAddress,
+          ipDecision.retryAfterSeconds(),
+          properties.ip().maxAttempts(),
+          properties.ip().windowSeconds());
+      throw new LoginThrottledException(LoginThrottleScope.IP, ipDecision.retryAfterSeconds());
+    }
+
+    ThrottleDecision globalDecision = evaluateGlobalWindow(now);
+    if (globalDecision.blocked()) {
+      logThrottle(
+          LoginThrottleScope.GLOBAL,
+          normalizedIpAddress,
+          globalDecision.retryAfterSeconds(),
+          properties.global().maxAttempts(),
+          properties.global().windowSeconds());
+      throw new LoginThrottledException(
+          LoginThrottleScope.GLOBAL, globalDecision.retryAfterSeconds());
+    }
+
+    ipWindow(normalizedIpAddress).attempts().addLast(now);
+    globalWindow.addLast(now);
+  }
+
+  /** 테스트마다 singleton window state를 비웁니다. */
+  public synchronized void clear() {
+    globalWindow.clear();
+    ipWindows.clear();
+  }
+
+  private ThrottleDecision evaluateIpWindow(String ipAddress, Instant now) {
+    AttemptWindow window = ipWindow(ipAddress);
+    pruneWindow(window.attempts(), now, properties.ip().windowSeconds());
+    if (window.attempts().size() >= properties.ip().maxAttempts()) {
+      return ThrottleDecision.blocked(
+          retryAfterSeconds(window.attempts(), properties.ip().windowSeconds(), now));
+    }
+    return ThrottleDecision.allowed();
+  }
+
+  private ThrottleDecision evaluateGlobalWindow(Instant now) {
+    if (globalWindow.size() >= properties.global().maxAttempts()) {
+      return ThrottleDecision.blocked(
+          retryAfterSeconds(globalWindow, properties.global().windowSeconds(), now));
+    }
+    return ThrottleDecision.allowed();
+  }
+
+  private AttemptWindow ipWindow(String ipAddress) {
+    AttemptWindow window = ipWindows.get(ipAddress);
+    if (window != null) {
+      return window;
+    }
+    while (ipWindows.size() >= properties.maxTrackedIps()) {
+      Iterator<Map.Entry<String, AttemptWindow>> iterator = ipWindows.entrySet().iterator();
+      if (!iterator.hasNext()) {
+        break;
+      }
+      iterator.next();
+      iterator.remove();
+    }
+    AttemptWindow newWindow = new AttemptWindow(new ArrayDeque<>());
+    ipWindows.put(ipAddress, newWindow);
+    return newWindow;
+  }
+
+  private void pruneIpWindows(Instant now) {
+    Iterator<Map.Entry<String, AttemptWindow>> iterator = ipWindows.entrySet().iterator();
+    while (iterator.hasNext()) {
+      AttemptWindow window = iterator.next().getValue();
+      pruneWindow(window.attempts(), now, properties.ip().windowSeconds());
+      if (window.attempts().isEmpty()) {
+        iterator.remove();
+      }
+    }
+  }
+
+  private void pruneWindow(Deque<Instant> window, Instant now, long windowSeconds) {
+    while (!window.isEmpty() && !window.peekFirst().plusSeconds(windowSeconds).isAfter(now)) {
+      window.removeFirst();
+    }
+  }
+
+  private long retryAfterSeconds(Deque<Instant> window, long windowSeconds, Instant now) {
+    Instant retryAt = window.peekFirst().plusSeconds(windowSeconds);
+    long millis = Math.max(Duration.between(now, retryAt).toMillis(), 0L);
+    return Math.max(1L, (millis + 999L) / 1000L);
+  }
+
+  private void logThrottle(
+      LoginThrottleScope scope,
+      String ipAddress,
+      long retryAfterSeconds,
+      int maxAttempts,
+      long windowSeconds) {
+    log.warn(
+        "auth login throttled requestId={} scope={} ipHash={} retryAfterSeconds={} maxAttempts={} windowSeconds={} trackedIpCount={} path={}",
+        RequestTraceContext.currentRequestId().orElse("-"),
+        scope.name(),
+        hashIpAddress(ipAddress),
+        retryAfterSeconds,
+        maxAttempts,
+        windowSeconds,
+        ipWindows.size(),
+        currentPath());
+  }
+
+  private String currentPath() {
+    if (!(RequestContextHolder.getRequestAttributes()
+        instanceof ServletRequestAttributes attributes)) {
+      return "-";
+    }
+    return attributes.getRequest().getRequestURI();
+  }
+
+  private String hashIpAddress(String ipAddress) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(ipAddress.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+
+  private String normalizeIpAddress(String ipAddress) {
+    if (ipAddress == null || ipAddress.isBlank()) {
+      return "unknown";
+    }
+    return ipAddress;
+  }
+
+  private record AttemptWindow(Deque<Instant> attempts) {}
+
+  private record ThrottleDecision(boolean blocked, long retryAfterSeconds) {
+
+    private static ThrottleDecision allowed() {
+      return new ThrottleDecision(false, 0L);
+    }
+
+    private static ThrottleDecision blocked(long retryAfterSeconds) {
+      return new ThrottleDecision(true, retryAfterSeconds);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottleScope.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottleScope.java
@@ -1,0 +1,6 @@
+package com.aquilabank.global.security;
+
+public enum LoginThrottleScope {
+  IP,
+  GLOBAL
+}

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottledException.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottledException.java
@@ -1,0 +1,25 @@
+package com.aquilabank.global.security;
+
+/** login entrypoint throttling 결과를 공통 API error response로 전달합니다. */
+public final class LoginThrottledException extends RuntimeException {
+
+  private final LoginThrottleScope scope;
+  private final long retryAfterSeconds;
+
+  public LoginThrottledException(LoginThrottleScope scope, long retryAfterSeconds) {
+    super("too many login attempts");
+    if (retryAfterSeconds <= 0) {
+      throw new IllegalArgumentException("retryAfterSeconds must be positive");
+    }
+    this.scope = scope;
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+
+  public LoginThrottleScope scope() {
+    return scope;
+  }
+
+  public long retryAfterSeconds() {
+    return retryAfterSeconds;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottlingProperties.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottlingProperties.java
@@ -1,0 +1,29 @@
+package com.aquilabank.global.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** 공개 login entrypoint 전용 IP/global throttling 설정입니다. */
+@ConfigurationProperties(prefix = "security.login-throttling")
+public record LoginThrottlingProperties(
+    int maxTrackedIps, ScopeProperties ip, ScopeProperties global) {
+
+  public LoginThrottlingProperties {
+    maxTrackedIps = maxTrackedIps > 0 ? maxTrackedIps : 1024;
+    ip = ip == null ? new ScopeProperties(20, 60) : ip;
+    global = global == null ? new ScopeProperties(40, 10) : global;
+  }
+
+  public record ScopeProperties(int maxAttempts, long windowSeconds) {
+
+    public ScopeProperties {
+      if (maxAttempts <= 0) {
+        throw new IllegalArgumentException(
+            "security.login-throttling max-attempts must be positive");
+      }
+      if (windowSeconds <= 0) {
+        throw new IllegalArgumentException(
+            "security.login-throttling window-seconds must be positive");
+      }
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
   SecurityJwtProperties.class,
   SecurityTotpProperties.class,
   LoginProtectionProperties.class,
+  LoginThrottlingProperties.class,
   BootstrapHeaderAuthProperties.class,
   AccountBootstrapApiProperties.class,
   AuthBootstrapApiProperties.class

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -20,6 +20,7 @@ import com.aquilabank.global.notification.NotificationSseOverloadException;
 import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
 import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceTokenClaims;
+import com.aquilabank.global.security.LoginThrottledException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import java.nio.charset.StandardCharsets;
@@ -79,6 +80,21 @@ public class ApiExceptionHandler {
   ResponseEntity<ApiErrorResponse> handleUnauthorized(
       InvalidCredentialsException ex, HttpServletRequest request) {
     return response(HttpStatus.UNAUTHORIZED, ex.getMessage(), request);
+  }
+
+  @ExceptionHandler(LoginThrottledException.class)
+  ResponseEntity<ApiErrorResponse> handleTooManyRequests(
+      LoginThrottledException ex, HttpServletRequest request) {
+    logInternalAuthStatusFailure(HttpStatus.TOO_MANY_REQUESTS, request, ex.getMessage());
+    return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+        .header("Retry-After", Long.toString(ex.retryAfterSeconds()))
+        .body(
+            new ApiErrorResponse(
+                Instant.now(),
+                HttpStatus.TOO_MANY_REQUESTS.value(),
+                HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI()));
   }
 
   @ExceptionHandler(AccountAccessDeniedException.class)

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -27,6 +27,7 @@ import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
 import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import com.aquilabank.global.security.LoginThrottleGuard;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -66,6 +67,7 @@ public class LoginController {
   private final LogoutUseCase logoutUseCase;
   private final PasswordResetUseCase passwordResetUseCase;
   private final AuthSessionMetadataResolver authSessionMetadataResolver;
+  private final LoginThrottleGuard loginThrottleGuard;
 
   public LoginController(
       LoginUseCase loginUseCase,
@@ -77,7 +79,8 @@ public class LoginController {
       TotpChallengeVerifyUseCase totpChallengeVerifyUseCase,
       LogoutUseCase logoutUseCase,
       PasswordResetUseCase passwordResetUseCase,
-      AuthSessionMetadataResolver authSessionMetadataResolver) {
+      AuthSessionMetadataResolver authSessionMetadataResolver,
+      LoginThrottleGuard loginThrottleGuard) {
     this.loginUseCase = loginUseCase;
     this.authSessionListUseCase = authSessionListUseCase;
     this.authSessionRevokeUseCase = authSessionRevokeUseCase;
@@ -88,17 +91,17 @@ public class LoginController {
     this.logoutUseCase = logoutUseCase;
     this.passwordResetUseCase = passwordResetUseCase;
     this.authSessionMetadataResolver = authSessionMetadataResolver;
+    this.loginThrottleGuard = loginThrottleGuard;
   }
 
   @PostMapping("/login")
   public LoginResponse login(
       HttpServletRequest httpServletRequest, @Valid @RequestBody LoginRequest request) {
+    var sessionClientMetadata = authSessionMetadataResolver.resolve(httpServletRequest);
+    loginThrottleGuard.check(sessionClientMetadata.ipAddress());
     LoginResult result =
         loginUseCase.login(
-            new LoginCommand(
-                request.loginId(),
-                request.password(),
-                authSessionMetadataResolver.resolve(httpServletRequest)));
+            new LoginCommand(request.loginId(), request.password(), sessionClientMetadata));
     return LoginResponse.from(result);
   }
 

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -180,6 +180,14 @@ security:
     max-failures: ${SECURITY_LOGIN_PROTECTION_MAX_FAILURES:5}
     lock-seconds: ${SECURITY_LOGIN_PROTECTION_LOCK_SECONDS:900}
     reset-window-seconds: ${SECURITY_LOGIN_PROTECTION_RESET_WINDOW_SECONDS:900}
+  login-throttling:
+    max-tracked-ips: ${SECURITY_LOGIN_THROTTLING_MAX_TRACKED_IPS:1024}
+    ip:
+      max-attempts: ${SECURITY_LOGIN_THROTTLING_IP_MAX_ATTEMPTS:20}
+      window-seconds: ${SECURITY_LOGIN_THROTTLING_IP_WINDOW_SECONDS:60}
+    global:
+      max-attempts: ${SECURITY_LOGIN_THROTTLING_GLOBAL_MAX_ATTEMPTS:40}
+      window-seconds: ${SECURITY_LOGIN_THROTTLING_GLOBAL_WINDOW_SECONDS:10}
   bootstrap-header-auth:
     enabled: ${SECURITY_BOOTSTRAP_HEADER_AUTH_ENABLED:false}
     account-id-header: ${SECURITY_BOOTSTRAP_ACCOUNT_ID_HEADER:X-Account-Id}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
 import com.aquilabank.global.security.InternalServiceScope;
 import com.aquilabank.global.security.InternalServiceTokenIssuer;
+import com.aquilabank.global.security.LoginThrottleGuard;
 import com.aquilabank.standard.util.Base32Codec;
 import com.aquilabank.support.PostgresContainerTestSupport;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -87,6 +88,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
 
   @Autowired private RefreshTokenSecretPort refreshTokenSecretPort;
 
+  @Autowired private LoginThrottleGuard loginThrottleGuard;
+
   @Autowired private InternalServiceTokenIssuer internalServiceTokenIssuer;
 
   private MockMvc mockMvc;
@@ -99,6 +102,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   void setUpDatabase() throws Exception {
     mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
     resetBankingTables(jdbcTemplate);
+    loginThrottleGuard.clear();
 
     allowedSourceAccountId = bootstrapAccount("allowed source", 10_000L);
     targetAccountId = bootstrapAccount("allowed target", 0L);

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginThrottlingIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginThrottlingIntegrationTest.java
@@ -1,0 +1,259 @@
+package com.aquilabank.global.web.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenIssuer;
+import com.aquilabank.global.security.LoginThrottleGuard;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      "spring.flyway.enabled=true",
+      "management.health.db.enabled=true",
+      "security.login-protection.max-failures=3",
+      "security.login-protection.lock-seconds=1",
+      "security.login-protection.reset-window-seconds=900",
+      "security.login-throttling.max-tracked-ips=16",
+      "security.login-throttling.ip.max-attempts=2",
+      "security.login-throttling.ip.window-seconds=1",
+      "security.login-throttling.global.max-attempts=4",
+      "security.login-throttling.global.window-seconds=1"
+    })
+class LoginThrottlingIntegrationTest extends PostgresContainerTestSupport {
+
+  private static final RequestClientMetadata WINDOWS_CHROME =
+      new RequestClientMetadata(
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+              + "(KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+          "203.0.113.10, 10.0.0.1");
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private LoginThrottleGuard loginThrottleGuard;
+
+  @Autowired private InternalServiceTokenIssuer internalServiceTokenIssuer;
+
+  private MockMvc mockMvc;
+  private long userId;
+
+  @BeforeEach
+  void setUpDatabase() throws Exception {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    resetBankingTables(jdbcTemplate);
+    loginThrottleGuard.clear();
+    userId = bootstrapUser("alice", "Alice", "password123!");
+  }
+
+  @Test
+  void throttlesRepeatedLoginBurstFromSameIpBeforeDomainLogin(CapturedOutput output)
+      throws Exception {
+    RequestClientMetadata sharedIp = clientMetadata("203.0.113.200");
+    RequestClientMetadata otherIp = clientMetadata("203.0.113.201");
+
+    loginExpectUnauthorized("alice", "wrong-password", "login-ip-throttle-001", sharedIp);
+    loginExpectUnauthorized("alice", "wrong-password", "login-ip-throttle-002", sharedIp);
+
+    LoginProtectionState throttledState = loadLoginProtectionState(userId);
+    assertEquals(2, throttledState.failedLoginCount());
+    assertNotNull(throttledState.lastLoginFailedAt());
+    assertNull(throttledState.loginLockedUntil());
+
+    loginExpectTooManyRequests("alice", "password123!", "login-ip-throttle-003", sharedIp);
+    assertTrue(output.getOut().contains("auth login throttled"));
+    assertTrue(output.getOut().contains("scope=IP"));
+
+    String token = login("alice", "password123!", "login-ip-throttle-004", otherIp);
+    assertNotNull(token);
+  }
+
+  @Test
+  void throttlesGlobalLoginBurstAcrossDifferentIpsAndRecoversAfterWindow() throws Exception {
+    loginExpectUnauthorized(
+        "missing-user-1",
+        "wrong-password",
+        "login-global-throttle-001",
+        clientMetadata("198.51.100.10"));
+    loginExpectUnauthorized(
+        "missing-user-2",
+        "wrong-password",
+        "login-global-throttle-002",
+        clientMetadata("198.51.100.11"));
+    loginExpectUnauthorized(
+        "missing-user-3",
+        "wrong-password",
+        "login-global-throttle-003",
+        clientMetadata("198.51.100.12"));
+    loginExpectUnauthorized(
+        "missing-user-4",
+        "wrong-password",
+        "login-global-throttle-004",
+        clientMetadata("198.51.100.13"));
+
+    loginExpectTooManyRequests(
+        "alice", "password123!", "login-global-throttle-005", clientMetadata("198.51.100.14"));
+
+    Thread.sleep(1200L);
+
+    String token =
+        login(
+            "alice", "password123!", "login-global-throttle-006", clientMetadata("198.51.100.14"));
+    assertNotNull(token);
+  }
+
+  private String login(
+      String loginId, String password, String requestId, RequestClientMetadata clientMetadata)
+      throws Exception {
+    MvcResult result =
+        performLogin(loginId, password, requestId, clientMetadata)
+            .andExpect(status().isOk())
+            .andReturn();
+    return objectMapper
+        .readTree(result.getResponse().getContentAsByteArray())
+        .get("accessToken")
+        .asText();
+  }
+
+  private void loginExpectUnauthorized(
+      String loginId, String password, String requestId, RequestClientMetadata clientMetadata)
+      throws Exception {
+    performLogin(loginId, password, requestId, clientMetadata)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("login failed"));
+  }
+
+  private void loginExpectTooManyRequests(
+      String loginId, String password, String requestId, RequestClientMetadata clientMetadata)
+      throws Exception {
+    performLogin(loginId, password, requestId, clientMetadata)
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.message").value("too many login attempts"))
+        .andExpect(header().string("Retry-After", "1"));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performLogin(
+      String loginId, String password, String requestId, RequestClientMetadata clientMetadata)
+      throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        post("/api/v1/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "loginId": "%s",
+                  "password": "%s"
+                }
+                """
+                    .formatted(loginId, password));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    requestBuilder.header("User-Agent", clientMetadata.userAgent());
+    requestBuilder.header("X-Forwarded-For", clientMetadata.forwardedFor());
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private long bootstrapUser(String loginId, String displayName, String password) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/internal/api/v1/auth/users/bootstrap")
+                    .header(
+                        "Authorization",
+                        internalServiceAuthorization(
+                            "auth-bootstrap", InternalServiceScope.AUTH_BOOTSTRAP))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "loginId": "%s",
+                          "password": "%s",
+                          "displayName": "%s"
+                        }
+                        """
+                            .formatted(loginId, password, displayName)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    return objectMapper
+        .readTree(result.getResponse().getContentAsByteArray())
+        .get("userId")
+        .asLong();
+  }
+
+  private String internalServiceAuthorization(String subject, InternalServiceScope scope) {
+    return "Bearer " + internalServiceTokenIssuer.issue(subject, java.util.Set.of(scope));
+  }
+
+  private LoginProtectionState loadLoginProtectionState(long userId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT failed_login_count,
+                   last_login_failed_at,
+                   login_locked_until,
+                   last_login_succeeded_at
+            FROM bank_user
+            WHERE id = :userId
+            """,
+            new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
+                .addValue("userId", userId),
+            (rs, rowNum) ->
+                new LoginProtectionState(
+                    rs.getInt("failed_login_count"),
+                    toInstant(rs.getTimestamp("last_login_failed_at")),
+                    toInstant(rs.getTimestamp("login_locked_until")),
+                    toInstant(rs.getTimestamp("last_login_succeeded_at"))))
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("login protection state is not found"));
+  }
+
+  private Instant toInstant(java.sql.Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toInstant();
+  }
+
+  private RequestClientMetadata clientMetadata(String ipAddress) {
+    return new RequestClientMetadata(WINDOWS_CHROME.userAgent(), ipAddress + ", 10.0.0.1");
+  }
+
+  private record LoginProtectionState(
+      int failedLoginCount,
+      Instant lastLoginFailedAt,
+      Instant loginLockedUntil,
+      Instant lastLoginSucceededAt) {}
+
+  private record RequestClientMetadata(String userAgent, String forwardedFor) {}
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #130

## 🌿 Base Branch
- `main`

## 📝 Summary
- `/api/v1/auth/login` entrypoint에 per-instance IP/global throttling을 추가해 bcrypt + DB exact lookup 경로 진입 전 burst를 fail-fast 하도록 했습니다.
- 기존 `loginId` 잠금은 그대로 유지하고, request-level throttling은 `429` + `Retry-After`로 분리했습니다.
- throttling 상태는 bounded in-memory window로만 유지해 `t3.micro`에서도 메모리 비용을 작게 고정했습니다.

## 🛠 Changes
- `global/security`에 `LoginThrottlingProperties`, `LoginThrottleGuard`, `LoginThrottledException`을 추가했습니다.
- `LoginController`가 request metadata에서 IP를 해석한 뒤 domain login 전에 IP/global throttle을 검사하도록 바꿨습니다.
- `ApiExceptionHandler`에 login throttling용 `429` 응답과 `Retry-After` 헤더 처리를 추가했습니다.
- 기존 auth 통합 테스트는 throttle state reset만 주입하고, 낮은 throttling 임계치는 `LoginThrottlingIntegrationTest`로 분리했습니다.
- `application.yml`, `README.md`에 기본 임계치와 per-instance 제약을 반영했습니다.
- 스키마 변경 없음. API 계약은 `/api/v1/auth/login`이 throttling 상황에서 `429`를 반환하도록 확장됐습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-auth-throttling ./back/gradlew -p back test --tests com.aquilabank.global.web.auth.LoginThrottlingIntegrationTest --tests com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest`
- `tools/test/with-resource-lock.sh back-auth-check ./back/gradlew -p back check`
- `./back/gradlew -p back check` (pre-commit hook)

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - shared IP / NAT 환경은 공격적인 IP limit에서 정상 사용자가 함께 `429`를 받을 수 있습니다.
  - per-instance in-memory 구현이라 multi-node 전체 합산 limit는 보장하지 않습니다.
- 롤백 방법:
  - PR revert
  - 긴급 우회 시 throttling env 값을 일시 상향해 burst 허용 폭을 넓힙니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [ ] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?