### PR TITLE
[Feat] TransferReversed notification fan-out 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -330,7 +330,7 @@ bash tools/test/check-nginx-sse-proxy.sh
   - reversal 시 target 계좌 잔액이 부족하면 `409 reversal target balance is not enough`
 - 운영 주의:
   - 이번 범위는 full reversal만 지원하고 partial reversal은 제외
-  - notification inbox consumer는 아직 `TransferReversed` fan-out을 처리하지 않음
+  - notification inbox consumer는 `TransferBooked`, `TransferReversed` fan-out을 모두 처리하고 DLQ/ops 집계는 두 topic 합산 기준으로 본다
 
 ## Public Login Protection
 

--- a/back/src/main/java/com/aquilabank/domain/notification/model/TransferReversedNotificationCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/TransferReversedNotificationCommand.java
@@ -1,0 +1,58 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** outbox TransferReversed payload를 inbox fan-out 용 command 로 고정합니다. */
+public record TransferReversedNotificationCommand(
+    String eventKey,
+    String originalTransactionReference,
+    String reversalTransactionReference,
+    long sourceAccountId,
+    long targetAccountId,
+    long amountMinor,
+    String currencyCode,
+    String reversalReason,
+    Instant bookedAt) {
+
+  public TransferReversedNotificationCommand {
+    if (eventKey == null || eventKey.isBlank() || eventKey.length() > 80) {
+      throw new IllegalArgumentException("eventKey must be between 1 and 80 characters");
+    }
+    if (originalTransactionReference == null
+        || originalTransactionReference.isBlank()
+        || originalTransactionReference.length() > 64) {
+      throw new IllegalArgumentException(
+          "originalTransactionReference must be between 1 and 64 characters");
+    }
+    if (reversalTransactionReference == null
+        || reversalTransactionReference.isBlank()
+        || reversalTransactionReference.length() > 64) {
+      throw new IllegalArgumentException(
+          "reversalTransactionReference must be between 1 and 64 characters");
+    }
+    if (sourceAccountId <= 0) {
+      throw new IllegalArgumentException("sourceAccountId must be positive");
+    }
+    if (targetAccountId <= 0) {
+      throw new IllegalArgumentException("targetAccountId must be positive");
+    }
+    if (sourceAccountId == targetAccountId) {
+      throw new IllegalArgumentException("sourceAccountId and targetAccountId must differ");
+    }
+    if (amountMinor <= 0) {
+      throw new IllegalArgumentException("amountMinor must be positive");
+    }
+    if (currencyCode == null || !currencyCode.matches("^[A-Z]{3}$")) {
+      throw new IllegalArgumentException("currencyCode must be a 3-letter uppercase code");
+    }
+    if (reversalReason == null
+        || reversalReason.isBlank()
+        || reversalReason.length() > 40
+        || !reversalReason.matches("^[A-Z_]+$")) {
+      throw new IllegalArgumentException("reversalReason must be an uppercase enum label");
+    }
+    if (bookedAt == null) {
+      throw new IllegalArgumentException("bookedAt must not be null");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestService.java
@@ -2,6 +2,7 @@ package com.aquilabank.domain.notification.usecase;
 
 import com.aquilabank.domain.notification.model.NotificationInboxEntry;
 import com.aquilabank.domain.notification.model.TransferBookedNotificationCommand;
+import com.aquilabank.domain.notification.model.TransferReversedNotificationCommand;
 import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
 import java.util.List;
 
@@ -10,6 +11,7 @@ public final class NotificationInboxIngestService implements NotificationInboxIn
 
   private static final String TRANSFER_BOOKED = "TransferBooked";
   private static final String TRANSFER_BOOKED_TITLE = "이체 완료";
+  private static final String TRANSFER_REVERSED = "TransferReversed";
 
   private final NotificationInboxAppendPort notificationInboxAppendPort;
 
@@ -19,6 +21,17 @@ public final class NotificationInboxIngestService implements NotificationInboxIn
 
   @Override
   public void ingestTransferBooked(TransferBookedNotificationCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+    notificationInboxAppendPort.appendAllIfAbsent(
+        List.of(
+            toEntry(command, command.sourceAccountId(), "출금"),
+            toEntry(command, command.targetAccountId(), "입금")));
+  }
+
+  @Override
+  public void ingestTransferReversed(TransferReversedNotificationCommand command) {
     if (command == null) {
       throw new IllegalArgumentException("command is required");
     }
@@ -41,8 +54,41 @@ public final class NotificationInboxIngestService implements NotificationInboxIn
         command.bookedAt());
   }
 
+  private NotificationInboxEntry toEntry(
+      TransferReversedNotificationCommand command, long accountId, String directionLabel) {
+    return new NotificationInboxEntry(
+        accountId,
+        accountScopedEventKey(command.eventKey(), accountId),
+        TRANSFER_REVERSED,
+        reversalTitle(command.reversalReason()),
+        "%d %s %s %s"
+            .formatted(
+                command.amountMinor(),
+                command.currencyCode(),
+                directionLabel,
+                reversalActionLabel(command.reversalReason())),
+        command.bookedAt());
+  }
+
   private String accountScopedEventKey(String eventKey, long accountId) {
     // 기존 notification_inbox.event_key unique 제약을 재사용하려고 account scope를 suffix로 붙입니다.
     return eventKey + ":ACCOUNT-" + accountId;
+  }
+
+  private String reversalTitle(String reversalReason) {
+    return switch (reversalReason) {
+      case "CORRECTION" -> "이체 정정 완료";
+      case "CANCEL" -> "이체 취소 완료";
+      default -> "이체 취소/정정 완료";
+    };
+  }
+
+  private String reversalActionLabel(String reversalReason) {
+    // reversal outbox payload에는 summary가 없어 사유 기반 고정 문구로 inbox 메시지를 맞춥니다.
+    return switch (reversalReason) {
+      case "CORRECTION" -> "정정";
+      case "CANCEL" -> "취소";
+      default -> "취소/정정";
+    };
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestUseCase.java
@@ -1,9 +1,12 @@
 package com.aquilabank.domain.notification.usecase;
 
 import com.aquilabank.domain.notification.model.TransferBookedNotificationCommand;
+import com.aquilabank.domain.notification.model.TransferReversedNotificationCommand;
 
 /** consumer 가 inbox 적재를 시작할 때 호출하는 use case 진입점 */
 public interface NotificationInboxIngestUseCase {
 
   void ingestTransferBooked(TransferBookedNotificationCommand command);
+
+  void ingestTransferReversed(TransferReversedNotificationCommand command);
 }

--- a/back/src/main/java/com/aquilabank/global/config/KafkaTopicAdministrationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/KafkaTopicAdministrationConfiguration.java
@@ -196,7 +196,9 @@ final class KafkaTopicTopologyResolver {
             bootstrapServers,
             notificationInboxConsumerProperties.bootstrapServers(),
             "notification.inbox.consumer.bootstrap-servers");
-    addTopic(topics, notificationInboxConsumerProperties.transferBooked().topic());
+    for (String topicName : notificationInboxConsumerProperties.mainTopics()) {
+      addTopic(topics, topicName);
+    }
     addTopic(topics, notificationInboxConsumerProperties.dlq().topic());
     return resolvedBootstrapServers;
   }
@@ -265,10 +267,14 @@ final class KafkaTopicAdministrationCondition implements Condition {
         && usesNotificationKafkaRuntime(context)
         && StringUtils.hasText(
             context.getEnvironment().getProperty("notification.inbox.consumer.bootstrap-servers"))
-        && StringUtils.hasText(
-            context
-                .getEnvironment()
-                .getProperty("notification.inbox.consumer.transfer-booked.topic"));
+        && (StringUtils.hasText(
+                context
+                    .getEnvironment()
+                    .getProperty("notification.inbox.consumer.transfer-booked.topic"))
+            || StringUtils.hasText(
+                context
+                    .getEnvironment()
+                    .getProperty("notification.inbox.consumer.transfer-reversed.topic")));
   }
 
   private boolean usesNotificationKafkaRuntime(ConditionContext context) {

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerConfiguration.java
@@ -13,6 +13,7 @@ import com.aquilabank.global.notification.KafkaNotificationOpsRecoveryRepository
 import com.aquilabank.global.notification.KafkaNotificationOpsRepository;
 import com.aquilabank.global.notification.NotificationInboxHealthIndicator;
 import com.aquilabank.global.notification.TransferBookedNotificationConsumer;
+import com.aquilabank.global.notification.TransferReversedNotificationConsumer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
@@ -112,16 +113,29 @@ public class NotificationInboxConsumerConfiguration {
   }
 
   @Bean
-  @ConditionalOnBean(name = "notificationInboxKafkaListenerContainerFactory")
+  @Conditional(NotificationTransferBookedConsumerCondition.class)
   TransferBookedNotificationConsumer transferBookedNotificationConsumer(
       NotificationInboxIngestUseCase notificationInboxIngestUseCase,
       ObjectMapper objectMapper,
       NotificationInboxConsumerProperties properties) {
     log.info(
-        "notification inbox consumer enabled. groupId={}, topic={}",
+        "notification inbox transfer-booked consumer enabled. groupId={}, topic={}",
         properties.groupId(),
         properties.transferBooked().topic());
     return new TransferBookedNotificationConsumer(notificationInboxIngestUseCase, objectMapper);
+  }
+
+  @Bean
+  @Conditional(NotificationTransferReversedConsumerCondition.class)
+  TransferReversedNotificationConsumer transferReversedNotificationConsumer(
+      NotificationInboxIngestUseCase notificationInboxIngestUseCase,
+      ObjectMapper objectMapper,
+      NotificationInboxConsumerProperties properties) {
+    log.info(
+        "notification inbox transfer-reversed consumer enabled. groupId={}, topic={}",
+        properties.groupId(),
+        properties.transferReversed().topic());
+    return new TransferReversedNotificationConsumer(notificationInboxIngestUseCase, objectMapper);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerProperties.java
@@ -1,5 +1,7 @@
 package com.aquilabank.global.config;
 
+import java.util.LinkedHashSet;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.StringUtils;
 
@@ -11,7 +13,8 @@ public record NotificationInboxConsumerProperties(
     String bootstrapServers,
     String groupId,
     String autoOffsetReset,
-    TransferBookedProperties transferBooked,
+    TopicProperties transferBooked,
+    TopicProperties transferReversed,
     DlqProperties dlq,
     OpsProperties ops) {
 
@@ -19,7 +22,8 @@ public record NotificationInboxConsumerProperties(
     autoStartup = autoStartup || !enabled;
     groupId = StringUtils.hasText(groupId) ? groupId : "aquila-bank-notification-inbox-consumer";
     autoOffsetReset = StringUtils.hasText(autoOffsetReset) ? autoOffsetReset : "earliest";
-    transferBooked = transferBooked == null ? new TransferBookedProperties(null) : transferBooked;
+    transferBooked = transferBooked == null ? new TopicProperties(null) : transferBooked;
+    transferReversed = transferReversed == null ? new TopicProperties(null) : transferReversed;
     dlq = dlq == null ? new DlqProperties(null) : dlq;
     ops = ops == null ? new OpsProperties(false, 20, 5, null) : ops;
   }
@@ -31,8 +35,8 @@ public record NotificationInboxConsumerProperties(
     if (!StringUtils.hasText(bootstrapServers)) {
       return "notification.inbox.consumer.bootstrap-servers is blank";
     }
-    if (!StringUtils.hasText(transferBooked.topic())) {
-      return "notification.inbox.consumer.transfer-booked.topic is blank";
+    if (!hasConfiguredMainTopic()) {
+      return "notification.inbox.consumer.transfer-booked.topic and transfer-reversed.topic are blank";
     }
     return "ready";
   }
@@ -47,8 +51,8 @@ public record NotificationInboxConsumerProperties(
     if (!StringUtils.hasText(bootstrapServers)) {
       return "notification.inbox.consumer.bootstrap-servers is blank";
     }
-    if (!StringUtils.hasText(transferBooked.topic())) {
-      return "notification.inbox.consumer.transfer-booked.topic is blank";
+    if (!hasConfiguredMainTopic()) {
+      return "notification.inbox.consumer.transfer-booked.topic and transfer-reversed.topic are blank";
     }
     if (!StringUtils.hasText(dlq.topic())) {
       return "notification.inbox.consumer.dlq.topic is blank";
@@ -56,7 +60,27 @@ public record NotificationInboxConsumerProperties(
     return "ready";
   }
 
-  public record TransferBookedProperties(String topic) {}
+  public boolean hasConfiguredMainTopic() {
+    return !mainTopics().isEmpty();
+  }
+
+  public List<String> mainTopics() {
+    LinkedHashSet<String> topics = new LinkedHashSet<>();
+    if (StringUtils.hasText(transferBooked.topic())) {
+      topics.add(transferBooked.topic());
+    }
+    if (StringUtils.hasText(transferReversed.topic())) {
+      topics.add(transferReversed.topic());
+    }
+    return List.copyOf(topics);
+  }
+
+  public String mainTopicLabel() {
+    List<String> topics = mainTopics();
+    return topics.isEmpty() ? "-" : String.join(",", topics);
+  }
+
+  public record TopicProperties(String topic) {}
 
   public record DlqProperties(String topic) {}
 

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxKafkaConsumerCondition.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxKafkaConsumerCondition.java
@@ -10,14 +10,44 @@ final class NotificationInboxKafkaConsumerCondition implements Condition {
 
   @Override
   public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    return isConsumerEnabled(context)
+        && hasBootstrapServers(context)
+        && (hasConfiguredTopic(context, "notification.inbox.consumer.transfer-booked.topic")
+            || hasConfiguredTopic(context, "notification.inbox.consumer.transfer-reversed.topic"));
+  }
+
+  static boolean hasConfiguredTopic(ConditionContext context, String propertyName) {
+    return StringUtils.hasText(context.getEnvironment().getProperty(propertyName));
+  }
+
+  private boolean isConsumerEnabled(ConditionContext context) {
     return context
-            .getEnvironment()
-            .getProperty("notification.inbox.consumer.enabled", Boolean.class, false)
-        && StringUtils.hasText(
-            context.getEnvironment().getProperty("notification.inbox.consumer.bootstrap-servers"))
-        && StringUtils.hasText(
-            context
-                .getEnvironment()
-                .getProperty("notification.inbox.consumer.transfer-booked.topic"));
+        .getEnvironment()
+        .getProperty("notification.inbox.consumer.enabled", Boolean.class, false);
+  }
+
+  private boolean hasBootstrapServers(ConditionContext context) {
+    return StringUtils.hasText(
+        context.getEnvironment().getProperty("notification.inbox.consumer.bootstrap-servers"));
+  }
+}
+
+final class NotificationTransferBookedConsumerCondition implements Condition {
+
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    return new NotificationInboxKafkaConsumerCondition().matches(context, metadata)
+        && NotificationInboxKafkaConsumerCondition.hasConfiguredTopic(
+            context, "notification.inbox.consumer.transfer-booked.topic");
+  }
+}
+
+final class NotificationTransferReversedConsumerCondition implements Condition {
+
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    return new NotificationInboxKafkaConsumerCondition().matches(context, metadata)
+        && NotificationInboxKafkaConsumerCondition.hasConfiguredTopic(
+            context, "notification.inbox.consumer.transfer-reversed.topic");
   }
 }

--- a/back/src/main/java/com/aquilabank/global/notification/KafkaNotificationOpsRepository.java
+++ b/back/src/main/java/com/aquilabank/global/notification/KafkaNotificationOpsRepository.java
@@ -96,7 +96,7 @@ public final class KafkaNotificationOpsRepository implements NotificationOpsRead
   }
 
   private NotificationOpsSummary loadSummary(Instant observedAt) {
-    List<TopicPartition> mainPartitions = topicPartitions(properties.transferBooked().topic());
+    List<TopicPartition> mainPartitions = topicPartitions(properties.mainTopics());
     List<TopicPartition> dlqPartitions = topicPartitions(properties.dlq().topic());
     try (AdminClient adminClient = adminClient()) {
       Map<TopicPartition, Long> latestMainOffsets = latestOffsets(adminClient, mainPartitions);
@@ -107,11 +107,21 @@ public final class KafkaNotificationOpsRepository implements NotificationOpsRead
       return new NotificationOpsSummary(
           observedAt,
           properties.groupId(),
-          properties.transferBooked().topic(),
+          properties.mainTopicLabel(),
           properties.dlq().topic(),
           lagCount,
           dlqCount);
     }
+  }
+
+  private List<TopicPartition> topicPartitions(List<String> topics) {
+    List<TopicPartition> partitions = new ArrayList<>();
+    try (AdminClient adminClient = adminClient()) {
+      for (String topic : topics) {
+        partitions.addAll(topicPartitions(adminClient, topic));
+      }
+    }
+    return partitions;
   }
 
   private List<TopicPartition> topicPartitions(String topic) {

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationConsumerPrometheusMetrics.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationConsumerPrometheusMetrics.java
@@ -37,14 +37,21 @@ public final class NotificationConsumerPrometheusMetrics implements MeterBinder 
     this.lagTags =
         java.util.List.of(
             Tag.of("group_id", notificationInboxConsumerProperties.groupId()),
-            Tag.of("topic", notificationInboxConsumerProperties.transferBooked().topic()));
+            Tag.of("topic", notificationInboxConsumerProperties.mainTopicLabel()));
     this.dlqTags =
         java.util.List.of(
             Tag.of("group_id", notificationInboxConsumerProperties.groupId()),
             Tag.of("topic", notificationInboxConsumerProperties.dlq().topic()));
     this.cachedSummary =
         new CachedSummary(
-            new NotificationOpsSummary(Instant.EPOCH, "-", "-", "-", 0L, 0L), Instant.EPOCH);
+            new NotificationOpsSummary(
+                Instant.EPOCH,
+                notificationInboxConsumerProperties.groupId(),
+                notificationInboxConsumerProperties.mainTopicLabel(),
+                notificationInboxConsumerProperties.dlq().topic(),
+                0L,
+                0L),
+            Instant.EPOCH);
   }
 
   @Override

--- a/back/src/main/java/com/aquilabank/global/notification/TransferReversedNotificationConsumer.java
+++ b/back/src/main/java/com/aquilabank/global/notification/TransferReversedNotificationConsumer.java
@@ -1,0 +1,61 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.notification.model.TransferReversedNotificationCommand;
+import com.aquilabank.domain.notification.usecase.NotificationInboxIngestUseCase;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+
+/** Kafka payload parsing 은 adapter 에 두고, reversal inbox fan-out 규칙은 domain use case 로 위임합니다. */
+public class TransferReversedNotificationConsumer {
+
+  private final NotificationInboxIngestUseCase notificationInboxIngestUseCase;
+  private final ObjectMapper objectMapper;
+
+  public TransferReversedNotificationConsumer(
+      NotificationInboxIngestUseCase notificationInboxIngestUseCase, ObjectMapper objectMapper) {
+    this.notificationInboxIngestUseCase = notificationInboxIngestUseCase;
+    this.objectMapper = objectMapper;
+  }
+
+  @KafkaListener(
+      id = "transferReversedNotificationConsumer",
+      topics = "${notification.inbox.consumer.transfer-reversed.topic}",
+      groupId = "${notification.inbox.consumer.group-id}",
+      containerFactory = "notificationInboxKafkaListenerContainerFactory",
+      autoStartup = "${notification.inbox.consumer.auto-startup:true}")
+  public void consume(@Header(KafkaHeaders.RECEIVED_KEY) String eventKey, String payload) {
+    notificationInboxIngestUseCase.ingestTransferReversed(toCommand(eventKey, payload));
+  }
+
+  private TransferReversedNotificationCommand toCommand(String eventKey, String payload) {
+    try {
+      TransferReversedPayload item = objectMapper.readValue(payload, TransferReversedPayload.class);
+      return new TransferReversedNotificationCommand(
+          eventKey,
+          item.originalTransactionReference(),
+          item.reversalTransactionReference(),
+          item.sourceAccountId(),
+          item.targetAccountId(),
+          item.amountMinor(),
+          item.currencyCode(),
+          item.reversalReason(),
+          item.bookedAt());
+    } catch (JsonProcessingException ex) {
+      throw new IllegalArgumentException("TransferReversed payload is invalid", ex);
+    }
+  }
+
+  private record TransferReversedPayload(
+      String originalTransactionReference,
+      String reversalTransactionReference,
+      long sourceAccountId,
+      long targetAccountId,
+      long amountMinor,
+      String currencyCode,
+      String reversalReason,
+      Instant bookedAt) {}
+}

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -46,6 +46,8 @@ notification:
       bootstrap-servers: ${NOTIFICATION_INBOX_CONSUMER_BOOTSTRAP_SERVERS:localhost:9092}
       transfer-booked:
         topic: ${NOTIFICATION_INBOX_CONSUMER_TRANSFER_BOOKED_TOPIC:bank.transfer.booked.v1}
+      transfer-reversed:
+        topic: ${NOTIFICATION_INBOX_CONSUMER_TRANSFER_REVERSED_TOPIC:bank.transfer.reversed.v1}
       dlq:
         topic: ${NOTIFICATION_INBOX_CONSUMER_DLQ_TOPIC:bank.transfer.booked.dlq.v1}
       ops:

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -146,6 +146,8 @@ notification:
       auto-offset-reset: ${NOTIFICATION_INBOX_CONSUMER_AUTO_OFFSET_RESET:earliest}
       transfer-booked:
         topic: ${NOTIFICATION_INBOX_CONSUMER_TRANSFER_BOOKED_TOPIC:}
+      transfer-reversed:
+        topic: ${NOTIFICATION_INBOX_CONSUMER_TRANSFER_REVERSED_TOPIC:}
       dlq:
         topic: ${NOTIFICATION_INBOX_CONSUMER_DLQ_TOPIC:}
       ops:

--- a/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationInboxIngestServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.aquilabank.domain.notification.model.TransferBookedNotificationCommand;
+import com.aquilabank.domain.notification.model.TransferReversedNotificationCommand;
 import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +47,71 @@ class NotificationInboxIngestServiceTest {
                       .extracting("message")
                       .containsExactly("1500 KRW 출금 · rent", "1500 KRW 입금 · rent");
                   assertThat(items).extracting("createdAt").containsExactly(bookedAt, bookedAt);
+                  return true;
+                }));
+  }
+
+  @Test
+  void fansOutTransferReversedIntoSourceAndTargetInboxRows() {
+    Instant bookedAt = Instant.parse("2026-04-17T00:00:00Z");
+
+    notificationInboxIngestService.ingestTransferReversed(
+        new TransferReversedNotificationCommand(
+            "transfer-reversed:TRX-100",
+            "TRX-100",
+            "TRX-100-R",
+            101L,
+            202L,
+            1500L,
+            "KRW",
+            "CANCEL",
+            bookedAt));
+
+    verify(notificationInboxAppendPort)
+        .appendAllIfAbsent(
+            argThat(
+                items -> {
+                  assertThat(items).hasSize(2);
+                  assertThat(items).extracting("accountId").containsExactly(101L, 202L);
+                  assertThat(items)
+                      .extracting("eventKey")
+                      .containsExactly(
+                          "transfer-reversed:TRX-100:ACCOUNT-101",
+                          "transfer-reversed:TRX-100:ACCOUNT-202");
+                  assertThat(items).extracting("eventType").containsOnly("TransferReversed");
+                  assertThat(items).extracting("title").containsOnly("이체 취소 완료");
+                  assertThat(items)
+                      .extracting("message")
+                      .containsExactly("1500 KRW 출금 취소", "1500 KRW 입금 취소");
+                  assertThat(items).extracting("createdAt").containsExactly(bookedAt, bookedAt);
+                  return true;
+                }));
+  }
+
+  @Test
+  void usesCorrectionLabelForTransferReversedMessage() {
+    Instant bookedAt = Instant.parse("2026-04-17T00:00:00Z");
+
+    notificationInboxIngestService.ingestTransferReversed(
+        new TransferReversedNotificationCommand(
+            "transfer-reversed:TRX-200",
+            "TRX-200",
+            "TRX-200-R",
+            101L,
+            202L,
+            1700L,
+            "KRW",
+            "CORRECTION",
+            bookedAt));
+
+    verify(notificationInboxAppendPort)
+        .appendAllIfAbsent(
+            argThat(
+                items -> {
+                  assertThat(items).extracting("title").containsOnly("이체 정정 완료");
+                  assertThat(items)
+                      .extracting("message")
+                      .containsExactly("1700 KRW 출금 정정", "1700 KRW 입금 정정");
                   return true;
                 }));
   }

--- a/back/src/test/java/com/aquilabank/global/config/NotificationInboxConsumerConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/NotificationInboxConsumerConfigurationTest.java
@@ -29,6 +29,7 @@ class NotificationInboxConsumerConfigurationTest {
                           .class);
               assertThat(context).doesNotHaveBean("notificationInboxConsumerFactory");
               assertThat(context).doesNotHaveBean("transferBookedNotificationConsumer");
+              assertThat(context).doesNotHaveBean("transferReversedNotificationConsumer");
             });
   }
 
@@ -44,6 +45,23 @@ class NotificationInboxConsumerConfigurationTest {
               assertThat(context).hasBean("notificationInboxConsumerFactory");
               assertThat(context).hasBean("notificationInboxKafkaListenerContainerFactory");
               assertThat(context).hasBean("transferBookedNotificationConsumer");
+              assertThat(context).doesNotHaveBean("transferReversedNotificationConsumer");
+            });
+  }
+
+  @Test
+  void createsTransferReversedConsumerWhenOnlyReversalTopicIsPresent() {
+    contextRunner
+        .withPropertyValues(
+            "notification.inbox.consumer.enabled=true",
+            "notification.inbox.consumer.bootstrap-servers=localhost:9092",
+            "notification.inbox.consumer.transfer-reversed.topic=bank.transfer.reversed.v1")
+        .run(
+            context -> {
+              assertThat(context).hasBean("notificationInboxConsumerFactory");
+              assertThat(context).hasBean("notificationInboxKafkaListenerContainerFactory");
+              assertThat(context).doesNotHaveBean("transferBookedNotificationConsumer");
+              assertThat(context).hasBean("transferReversedNotificationConsumer");
             });
   }
 

--- a/back/src/test/java/com/aquilabank/global/notification/NotificationKafkaE2eIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/NotificationKafkaE2eIntegrationTest.java
@@ -92,6 +92,45 @@ class NotificationKafkaE2eIntegrationTest extends PostgresKafkaContainerTestSupp
         .containsExactlyInAnyOrder("1500 KRW 출금 · rent", "1500 KRW 입금 · rent");
   }
 
+  @Test
+  void deliversTransferReversedEventToNotificationInboxThroughKafka() throws Exception {
+    TransferResponseBody booked =
+        invokeTransfer("notification-e2e-reversal-001", targetAccountId, 1500L, "rent");
+    assertThat(outboxDispatchUseCase.dispatchPendingEvents()).isEqualTo(1);
+
+    TransferReversalResponseBody reversed =
+        invokeReversal(
+            booked.transactionReference(),
+            "notification-e2e-reversal-002",
+            "CANCEL",
+            "cancel rent");
+    OutboxEventRow outboxEvent = findOutboxEvent(reversed.reversalTransactionReference());
+
+    int dispatched = outboxDispatchUseCase.dispatchPendingEvents();
+    OutboxEventRow publishedEvent = findOutboxEvent(reversed.reversalTransactionReference());
+
+    assertThat(dispatched).isEqualTo(1);
+    assertThat(publishedEvent.publishStatus())
+        .withFailMessage("outbox lastError=%s", publishedEvent.lastError())
+        .isEqualTo("PUBLISHED");
+
+    awaitCondition(
+        "transfer reversed notification inbox rows",
+        NOTIFICATION_TIMEOUT,
+        POLL_INTERVAL,
+        () -> countNotificationRows(outboxEvent.eventKey()) == 2L);
+
+    List<NotificationInboxRow> items = findNotificationRows(outboxEvent.eventKey());
+    assertThat(items)
+        .extracting(NotificationInboxRow::accountId)
+        .containsExactlyInAnyOrder(sourceAccountId, targetAccountId);
+    assertThat(items).extracting(NotificationInboxRow::eventType).containsOnly("TransferReversed");
+    assertThat(items).extracting(NotificationInboxRow::title).containsOnly("이체 취소 완료");
+    assertThat(items)
+        .extracting(NotificationInboxRow::message)
+        .containsExactlyInAnyOrder("1500 KRW 출금 취소", "1500 KRW 입금 취소");
+  }
+
   private AccountBootstrapResponseBody bootstrapAccount(
       String displayName, long initialBalanceMinor) throws Exception {
     MvcResult result =
@@ -149,6 +188,36 @@ class NotificationKafkaE2eIntegrationTest extends PostgresKafkaContainerTestSupp
     assertThat(result.getResponse().getStatus()).isEqualTo(200);
     return objectMapper.readValue(
         result.getResponse().getContentAsByteArray(), TransferResponseBody.class);
+  }
+
+  private TransferReversalResponseBody invokeReversal(
+      String originalTransactionReference,
+      String idempotencyKey,
+      String reversalReason,
+      String summary)
+      throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers/%s/reversal".formatted(originalTransactionReference))
+                    .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", idempotencyKey + "-request")
+                    .header("Idempotency-Key", idempotencyKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "reversalReason": "%s",
+                          "summary": "%s"
+                        }
+                        """
+                            .formatted(sourceAccountId, reversalReason, summary)))
+            .andReturn();
+
+    assertThat(result.getResponse().getStatus()).isEqualTo(200);
+    return objectMapper.readValue(
+        result.getResponse().getContentAsByteArray(), TransferReversalResponseBody.class);
   }
 
   private OutboxEventRow findOutboxEvent(String transactionReference) {
@@ -224,6 +293,17 @@ class NotificationKafkaE2eIntegrationTest extends PostgresKafkaContainerTestSupp
 
   private record TransferResponseBody(
       String transactionReference,
+      long sourceAccountId,
+      long targetAccountId,
+      long amountMinor,
+      String currencyCode,
+      long availableBalanceAfterMinor,
+      Instant bookedAt,
+      String status) {}
+
+  private record TransferReversalResponseBody(
+      String originalTransactionReference,
+      String reversalTransactionReference,
       long sourceAccountId,
       long targetAccountId,
       long amountMinor,

--- a/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
@@ -133,7 +133,7 @@ class PrometheusMetricsIntegrationTest extends PostgresKafkaContainerTestSupport
       assertThat(body)
           .containsPattern(
               "aquila_notification_consumer_lag_count\\{[^\\n]*topic=\""
-                  + Pattern.quote(TRANSFER_BOOKED_TOPIC)
+                  + Pattern.quote(TRANSFER_BOOKED_TOPIC + "," + TRANSFER_REVERSED_TOPIC)
                   + "\"[^\\n]*\\}\\s+[1-9][0-9]*\\.0");
       assertThat(body)
           .containsPattern(

--- a/back/src/test/java/com/aquilabank/global/notification/TransferReversedNotificationConsumerTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/TransferReversedNotificationConsumerTest.java
@@ -1,0 +1,63 @@
+package com.aquilabank.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.aquilabank.domain.notification.usecase.NotificationInboxIngestUseCase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TransferReversedNotificationConsumerTest {
+
+  private NotificationInboxIngestUseCase notificationInboxIngestUseCase;
+  private TransferReversedNotificationConsumer consumer;
+
+  @BeforeEach
+  void setUp() {
+    notificationInboxIngestUseCase = mock(NotificationInboxIngestUseCase.class);
+    ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    consumer =
+        new TransferReversedNotificationConsumer(notificationInboxIngestUseCase, objectMapper);
+  }
+
+  @Test
+  void parsesPayloadAndDelegatesToUseCase() {
+    consumer.consume(
+        "transfer-reversed:TRX-100",
+        """
+        {
+          "originalTransactionReference": "TRX-100",
+          "reversalTransactionReference": "TRX-100-R",
+          "sourceAccountId": 101,
+          "targetAccountId": 202,
+          "amountMinor": 1500,
+          "currencyCode": "KRW",
+          "reversalReason": "CANCEL",
+          "bookedAt": "2026-04-17T00:00:00Z"
+        }
+        """);
+
+    verify(notificationInboxIngestUseCase)
+        .ingestTransferReversed(
+            argThat(
+                command ->
+                    "transfer-reversed:TRX-100".equals(command.eventKey())
+                        && "TRX-100".equals(command.originalTransactionReference())
+                        && "TRX-100-R".equals(command.reversalTransactionReference())
+                        && command.sourceAccountId() == 101L
+                        && command.targetAccountId() == 202L
+                        && command.amountMinor() == 1500L
+                        && "CANCEL".equals(command.reversalReason())));
+  }
+
+  @Test
+  void throwsWhenPayloadIsInvalid() {
+    assertThatThrownBy(() -> consumer.consume("transfer-reversed:TRX-100", "{"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("TransferReversed payload is invalid");
+  }
+}

--- a/back/src/test/java/com/aquilabank/support/PostgresKafkaContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresKafkaContainerTestSupport.java
@@ -46,6 +46,8 @@ public abstract class PostgresKafkaContainerTestSupport extends PostgresContaine
     registry.add("notification.inbox.consumer.bootstrap-servers", KAFKA::getBootstrapServers);
     registry.add("notification.inbox.consumer.group-id", () -> "aquila-bank-notification-e2e");
     registry.add("notification.inbox.consumer.transfer-booked.topic", () -> TRANSFER_BOOKED_TOPIC);
+    registry.add(
+        "notification.inbox.consumer.transfer-reversed.topic", () -> TRANSFER_REVERSED_TOPIC);
     registry.add("notification.inbox.consumer.dlq.topic", () -> TRANSFER_BOOKED_DLQ_TOPIC);
   }
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #132

## 🌿 Base Branch
- `main`

## 📝 Summary
- `TransferReversed` outbox event를 notification inbox consumer가 source/target account 알림 2건으로 fan-out 하도록 확장했습니다.
- 기존 `TransferBooked` 전용 consumer/config/ops 가정을 multi-topic 기준으로 정리해 reversal backlog와 metrics도 함께 보이게 맞췄습니다.
- reversal 전용 unit/config/Kafka e2e 검증과 README 운영 기준을 같이 반영했습니다.

## 🛠 Changes
- `TransferReversedNotificationCommand`, `TransferReversedNotificationConsumer` 추가
- notification ingest use case에 reversal fan-out 문구/이벤트 타입 처리 추가
- `notification.inbox.consumer.transfer-reversed.topic` 설정, conditional listener bean, topic admin/ops lag 집계 확장
- Prometheus notification consumer lag topic label을 configured main topics 기준으로 조정
- reversal consumer/config/e2e 테스트와 README 운영 주의사항 갱신

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-notification ./back/gradlew -p back test --tests '*NotificationInboxIngestServiceTest'`
- `tools/test/with-resource-lock.sh back-gradle-notification ./back/gradlew -p back test --tests '*NotificationInboxConsumerConfigurationTest' --tests '*KafkaTopicAdministrationConfigurationTest'`
- `tools/test/with-resource-lock.sh back-gradle-notification ./back/gradlew -p back test --tests '*NotificationOpsApiIntegrationTest' --tests '*PrometheusMetricsIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-notification ./back/gradlew -p back test --tests '*NotificationInboxIngestServiceTest' --tests '*TransferBookedNotificationConsumerTest' --tests '*TransferReversedNotificationConsumerTest' --tests '*NotificationInboxConsumerConfigurationTest' --tests '*KafkaTopicAdministrationConfigurationTest' --tests '*NotificationKafkaE2eIntegrationTest' --tests '*NotificationOpsApiIntegrationTest'`
- pre-commit hook: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - `transfer-reversed.topic` 설정이 운영 환경에 빠지면 reversal consumer는 올라오지 않고 기존 `TransferBooked`만 소비합니다.
  - notification lag topic label이 다중 topic 문자열로 바뀌므로 메트릭 파서가 exact match에 의존하면 조정이 필요할 수 있습니다.
- 롤백 방법:
  - PR revert로 reversal consumer/config/ops 집계를 함께 되돌립니다.
  - 긴급 우회가 필요하면 `NOTIFICATION_INBOX_CONSUMER_TRANSFER_REVERSED_TOPIC`을 비워 reversal listener만 비활성화할 수 있습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?