### PR TITLE
[Chore] Prometheus dashboard와 alert rule baseline 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -191,6 +191,11 @@ set +a
 - 운영 메모:
   - outbox/notification gauge는 scrape 한 번에 같은 summary를 여러 번 다시 조회하지 않게 `5초` cache 안에서 재사용합니다.
   - SSE session metric은 현재 app instance 메모리의 active session 수만 보여주므로 multi-instance 전체 합계는 Prometheus 쿼리에서 합산합니다.
+  - baseline 자산은 `ops/prometheus/` 아래에 두고 dashboard import, alert rule apply, tuning 가이드는 `ops/prometheus/README.md`를 기준으로 봅니다.
+- baseline 파일:
+  - dashboard: `ops/prometheus/grafana/aquila-bank-overview.json`
+  - alert rule: `ops/prometheus/rules/aquila-bank-alerts.yml`
+  - validation: `bash tools/ops/validate-prometheus-assets.sh`
 
 ## Outbox Retention Cleanup
 

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -1,0 +1,82 @@
+# Prometheus Monitoring Baseline
+
+`ops/prometheus`는 Aquila Bank backend가 이미 export 중인 metric을 기준으로 Grafana dashboard와 Prometheus alert rule baseline을 보관하는 디렉터리입니다. 실제 Prometheus server, Grafana provisioning, Alertmanager routing은 환경별로 다르므로 이번 baseline은 import/apply 가능한 자산만 저장소에 고정합니다.
+
+## 포함 파일
+
+- dashboard:
+  - `grafana/aquila-bank-overview.json`
+- alert rule:
+  - `rules/aquila-bank-alerts.yml`
+
+## Dashboard Baseline
+
+`grafana/aquila-bank-overview.json`는 현재 `back/README.md`의 Prometheus metric을 바로 볼 수 있게 만든 overview dashboard입니다.
+
+- 포함 패널:
+  - outbox dispatch lag / failed count / stale sending
+  - notification consumer lag / DLQ count
+  - SSE total session, account/user/total trend, reject/drop trend
+  - transaction query rate by `query_shape`
+  - transaction 평균 latency by `query_shape`
+- datasource 기준:
+  - Grafana datasource variable 이름은 `datasource`입니다.
+  - import 직후 Prometheus datasource를 한 번 선택하면 모든 panel이 그 값을 재사용합니다.
+- query 기준:
+  - transaction latency는 histogram percentile이 아니라 `sum(rate(..._sum)) / sum(rate(..._count))` 평균값을 사용합니다.
+  - notification lag panel은 topic label이 있을 때 topic별로 분리해 보여줍니다.
+  - SSE reject/drop metric은 앱 재시작 전까지 누적되는 gauge 성격이므로 절대값 trend로만 봅니다.
+
+## Dashboard Import
+
+1. Grafana UI에서 `Dashboards -> New -> Import`로 이동합니다.
+2. `ops/prometheus/grafana/aquila-bank-overview.json`를 업로드합니다.
+3. `datasource` 변수에 실제 Prometheus datasource를 연결합니다.
+4. import 직후 panel query preview에서 다음 metric이 보이는지 먼저 확인합니다.
+   - `aquila_outbox_dispatch_lag_seconds`
+   - `aquila_notification_consumer_lag_count`
+   - `aquila_notification_sse_sessions`
+   - `aquila_transaction_query_latency_seconds_count`
+
+## Alert Rule Baseline
+
+`rules/aquila-bank-alerts.yml`는 현재 README와 health/env 기본값을 따라가는 baseline rule 세트입니다.
+
+- outbox baseline:
+  - dispatch lag `> 120s`
+  - failed count `> 10`
+  - producer timeout failed count `> 0`
+  - stale sending count `> 0`
+- notification baseline:
+  - consumer lag `> 100`
+  - DLQ count `> 0`
+  - SSE total session `> 56`
+- transaction baseline:
+  - success query 평균 latency `> 750ms`
+
+## Alert Rule Apply
+
+baseline 파일은 실제 Prometheus `rule_files` 경로에 복사하거나 symlink로 연결해 사용합니다.
+
+예시:
+
+```yaml
+rule_files:
+  - /etc/prometheus/rules/*.yml
+```
+
+실제 환경에서는 아래처럼 baseline 파일을 별도 경로로 배치합니다.
+
+```bash
+cp ops/prometheus/rules/aquila-bank-alerts.yml /etc/prometheus/rules/
+```
+
+그 다음 `promtool check rules` 또는 동등한 검증 후 Prometheus reload를 수행합니다.
+
+## Threshold Tuning
+
+- outbox/notification threshold는 현재 README와 actuator health 기본값을 기준으로 둔 값입니다.
+- `AquilaNotificationSseSessionPressureHigh`의 `56`은 기본 `NOTIFICATION_SSE_MAX_TOTAL_SESSIONS=64`의 `87.5%` baseline입니다.
+- transaction latency `750ms`는 query mix가 가벼운 환경을 전제로 한 출발값입니다. 실제 production에서는 `query_shape`, account volume, DB latency 분포를 보고 조정합니다.
+- notification lag/DLQ alert는 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true`가 아니면 metric 자체가 export되지 않을 수 있습니다.
+- multi-instance SSE 합계는 Grafana/Prometheus 쿼리에서 인스턴스 합산으로 해석하고, 단일 instance alert는 node별 pressure 확인 용도로만 씁니다.

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -73,6 +73,18 @@ cp ops/prometheus/rules/aquila-bank-alerts.yml /etc/prometheus/rules/
 
 그 다음 `promtool check rules` 또는 동등한 검증 후 Prometheus reload를 수행합니다.
 
+## Validation
+
+로컬 baseline 자산 문법 확인은 아래 스크립트로 먼저 닫습니다.
+
+```bash
+bash tools/ops/validate-prometheus-assets.sh
+```
+
+- dashboard JSON은 `uid`, panel 개수, JSON syntax를 같이 확인합니다.
+- alert rule YAML은 group/rule/expr 존재 여부와 YAML syntax를 같이 확인합니다.
+- 실제 Prometheus 적용 전에는 여기에 더해 `promtool check rules`를 추가로 수행합니다.
+
 ## Threshold Tuning
 
 - outbox/notification threshold는 현재 README와 actuator health 기본값을 기준으로 둔 값입니다.

--- a/ops/prometheus/grafana/aquila-bank-overview.json
+++ b/ops/prometheus/grafana/aquila-bank-overview.json
@@ -1,0 +1,603 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 120
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(aquila_outbox_dispatch_lag_seconds)",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbox Dispatch Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(aquila_outbox_failed_count)",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbox Failed Count",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(aquila_notification_consumer_lag_count)",
+          "refId": "A"
+        }
+      ],
+      "title": "Notification Consumer Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(aquila_notification_consumer_dlq_count)",
+          "refId": "A"
+        }
+      ],
+      "title": "Notification DLQ Count",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 48
+              },
+              {
+                "color": "red",
+                "value": 64
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(aquila_notification_sse_sessions{principal_type=\"total\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "SSE Total Sessions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.25
+              },
+              {
+                "color": "red",
+                "value": 0.75
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(aquila_transaction_query_latency_seconds_sum{outcome=\"success\"}[5m])) / clamp_min(sum(rate(aquila_transaction_query_latency_seconds_count{outcome=\"success\"}[5m])), 0.001)",
+          "refId": "A"
+        }
+      ],
+      "title": "Transaction Avg Latency (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 4
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max(aquila_outbox_dispatch_lag_seconds)",
+          "legendFormat": "dispatch_lag_seconds",
+          "refId": "A"
+        },
+        {
+          "expr": "max(aquila_outbox_failed_count)",
+          "legendFormat": "failed_count",
+          "refId": "B"
+        },
+        {
+          "expr": "max(aquila_outbox_failed_producer_timeout_count)",
+          "legendFormat": "producer_timeout_failed_count",
+          "refId": "C"
+        },
+        {
+          "expr": "max(aquila_outbox_sending_stale_count)",
+          "legendFormat": "stale_sending_count",
+          "refId": "D"
+        }
+      ],
+      "title": "Outbox Health Trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 4
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max by (topic) (aquila_notification_consumer_lag_count)",
+          "legendFormat": "{{topic}} lag",
+          "refId": "A"
+        },
+        {
+          "expr": "max(aquila_notification_consumer_dlq_count)",
+          "legendFormat": "dlq_count",
+          "refId": "B"
+        }
+      ],
+      "title": "Notification Consumer Trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max by (principal_type) (aquila_notification_sse_sessions)",
+          "legendFormat": "{{principal_type}} sessions",
+          "refId": "A"
+        },
+        {
+          "expr": "max by (reason) (aquila_notification_sse_subscription_rejected_count)",
+          "legendFormat": "{{reason}} rejected_total",
+          "refId": "B"
+        },
+        {
+          "expr": "max by (reason) (aquila_notification_sse_session_dropped_count)",
+          "legendFormat": "{{reason}} dropped_total",
+          "refId": "C"
+        }
+      ],
+      "title": "SSE Sessions and Pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (query_shape, outcome) (rate(aquila_transaction_query_latency_seconds_count[5m]))",
+          "legendFormat": "{{query_shape}} {{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Transaction Query Rate by Shape",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (query_shape) (rate(aquila_transaction_query_latency_seconds_sum{outcome=\"success\"}[5m])) / clamp_min(sum by (query_shape) (rate(aquila_transaction_query_latency_seconds_count{outcome=\"success\"}[5m])), 0.001)",
+          "legendFormat": "{{query_shape}} avg_latency",
+          "refId": "A"
+        }
+      ],
+      "title": "Transaction Avg Latency by Shape",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "aquila-bank",
+    "ops",
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Aquila Bank Ops Overview",
+  "uid": "aquila-bank-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/ops/prometheus/rules/aquila-bank-alerts.yml
+++ b/ops/prometheus/rules/aquila-bank-alerts.yml
@@ -1,0 +1,122 @@
+# baseline threshold는 현재 back/README.md와 env 기본값 기준입니다.
+# 운영 적용 전 scrape interval, traffic, SSE max session, query volume에 맞게 재조정합니다.
+groups:
+  - name: aquila-bank-outbox
+    interval: 30s
+    rules:
+      - alert: AquilaOutboxDispatchLagHigh
+        expr: max(aquila_outbox_dispatch_lag_seconds) > 120
+        for: 10m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: outbox
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank outbox dispatch lag is high"
+          description: "outbox dispatch lag seconds가 10분 이상 120초를 초과했습니다. backlog와 producer publish path를 같이 확인합니다."
+          runbook_path: "back/README.md#outbox-ops-runbook"
+
+      - alert: AquilaOutboxFailedBacklogHigh
+        expr: max(aquila_outbox_failed_count) > 10
+        for: 10m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: outbox
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank outbox failed backlog is high"
+          description: "outbox failed count가 10분 이상 10건을 초과했습니다. failed event list와 lastError를 먼저 확인합니다."
+          runbook_path: "back/README.md#outbox-ops-runbook"
+
+      - alert: AquilaOutboxProducerTimeoutFailedDetected
+        expr: max(aquila_outbox_failed_producer_timeout_count) > 0
+        for: 15m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: outbox
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank producer timeout failures detected"
+          description: "producer timeout 기반 outbox failure가 15분 이상 0건 초과 상태입니다. broker/connection timeout을 먼저 점검합니다."
+          runbook_path: "back/README.md#outbox-ops-runbook"
+
+      - alert: AquilaOutboxStaleSendingDetected
+        expr: max(aquila_outbox_sending_stale_count) > 0
+        for: 5m
+        labels:
+          severity: critical
+          service: aquila-bank
+          domain: outbox
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank stale outbox sending rows detected"
+          description: "stale sending row가 5분 이상 남아 있습니다. stale recovery와 dispatch health를 즉시 확인합니다."
+          runbook_path: "back/README.md#outbox-ops-runbook"
+
+  - name: aquila-bank-notification
+    interval: 30s
+    rules:
+      - alert: AquilaNotificationConsumerLagHigh
+        expr: max(aquila_notification_consumer_lag_count) > 100
+        for: 10m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: notification
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank notification consumer lag is high"
+          description: "notification consumer lagCount가 10분 이상 100건을 초과했습니다. consumer summary와 DLQ 상태를 같이 확인합니다."
+          runbook_path: "back/README.md#outbox-ops-runbook"
+
+      - alert: AquilaNotificationConsumerDlqDetected
+        expr: max(aquila_notification_consumer_dlq_count) > 0
+        for: 5m
+        labels:
+          severity: critical
+          service: aquila-bank
+          domain: notification
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank notification DLQ messages detected"
+          description: "notification DLQ count가 5분 이상 0건 초과 상태입니다. poison message preview와 redrive 대상 여부를 확인합니다."
+          runbook_path: "back/README.md#outbox-ops-runbook"
+
+      - alert: AquilaNotificationSseSessionPressureHigh
+        expr: max(aquila_notification_sse_sessions{principal_type="total"}) > 56
+        for: 10m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: notification
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank SSE session pressure is high"
+          description: "SSE total session이 10분 이상 56을 초과했습니다. 기본 max-total-sessions=64 기준 87.5% 사용률 baseline입니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
+  - name: aquila-bank-transaction
+    interval: 30s
+    rules:
+      - alert: AquilaTransactionQueryLatencyHigh
+        expr: |
+          (
+            sum(rate(aquila_transaction_query_latency_seconds_sum{outcome="success"}[5m]))
+            /
+            clamp_min(sum(rate(aquila_transaction_query_latency_seconds_count{outcome="success"}[5m])), 0.001)
+          ) > 0.75
+          and
+          sum(rate(aquila_transaction_query_latency_seconds_count{outcome="success"}[5m])) > 0.1
+        for: 15m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: transaction
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank transaction query latency is high"
+          description: "transaction query 평균 latency가 15분 이상 750ms를 초과했습니다. baseline 값이므로 실제 traffic 분포에 맞게 재조정합니다."
+          runbook_path: "back/README.md#prometheus-metrics"

--- a/tools/ops/validate-prometheus-assets.sh
+++ b/tools/ops/validate-prometheus-assets.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DASHBOARD_FILE="${ROOT_DIR}/ops/prometheus/grafana/aquila-bank-overview.json"
+RULES_FILE="${ROOT_DIR}/ops/prometheus/rules/aquila-bank-alerts.yml"
+
+if [[ ! -f "${DASHBOARD_FILE}" ]]; then
+  echo "dashboard file is missing: ${DASHBOARD_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${RULES_FILE}" ]]; then
+  echo "rules file is missing: ${RULES_FILE}" >&2
+  exit 1
+fi
+
+jq -e '.uid == "aquila-bank-overview" and (.panels | type == "array" and length >= 8)' \
+  "${DASHBOARD_FILE}" >/dev/null
+
+ruby -e '
+require "yaml"
+
+data = YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], aliases: false)
+abort("groups missing") unless data.is_a?(Hash) && data["groups"].is_a?(Array) && !data["groups"].empty?
+
+data["groups"].each do |group|
+  abort("group name missing") if group["name"].to_s.empty?
+  rules = group["rules"]
+  abort("rules missing for #{group["name"]}") unless rules.is_a?(Array) && !rules.empty?
+  rules.each do |rule|
+    abort("alert name missing in #{group["name"]}") if rule["alert"].to_s.empty?
+    abort("expr missing in #{group["name"]}/#{rule["alert"]}") if rule["expr"].to_s.empty?
+  end
+end
+' "${RULES_FILE}"
+
+echo "Prometheus dashboard and alert rule baseline look valid."


### PR DESCRIPTION
## 🔗 Related Issue
- close #134

## 🌿 Base Branch
- `main`

## 📝 Summary
- `ops/prometheus` 아래에 Grafana dashboard baseline과 Prometheus alert rule baseline을 추가했습니다.
- 현재 export 중인 outbox, notification, SSE, transaction metric을 기준으로 import/apply 가능한 운영 자산과 tuning 가이드를 저장소에 고정했습니다.
- 로컬 validation 스크립트와 `back/README.md` 경로 안내를 함께 추가했습니다.

## 🛠 Changes
- `ops/prometheus/grafana/aquila-bank-overview.json` 추가
- `ops/prometheus/rules/aquila-bank-alerts.yml` 추가
- `ops/prometheus/README.md`에 dashboard import, alert apply, threshold tuning, validation 가이드 추가
- `tools/ops/validate-prometheus-assets.sh` 추가
- `back/README.md` Prometheus Metrics 섹션에 baseline 자산 경로와 validation 명령 연결

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `jq -e '.uid == "aquila-bank-overview" and (.panels | length >= 8)' ops/prometheus/grafana/aquila-bank-overview.json`
- `ruby -e 'require "yaml"; data = YAML.safe_load(File.read("ops/prometheus/rules/aquila-bank-alerts.yml"), permitted_classes: [], aliases: false); abort("groups missing") unless data.is_a?(Hash) && data["groups"].is_a?(Array) && !data["groups"].empty?; puts data["groups"].map { |group| group["name"] }.join(",")'`
- `bash tools/ops/validate-prometheus-assets.sh`
- `rg -n "ops/prometheus|validate-prometheus-assets|dashboard|alert rule" back/README.md ops/prometheus/README.md`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - Grafana datasource 이름이나 metric export 형식이 다른 환경에서는 panel이 비어 보일 수 있습니다.
  - alert baseline threshold가 환경과 맞지 않으면 오탐 또는 미탐이 생길 수 있습니다.
- 롤백 방법:
  - PR revert로 `ops/prometheus/**`, `tools/ops/validate-prometheus-assets.sh`, `back/README.md` 연결을 함께 되돌립니다.
  - 임시 우회가 필요하면 Prometheus rule include에서 `aquila-bank-alerts.yml`만 제외하고 dashboard import를 보류합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?