### PR TITLE
[Perf] notification SSE per-user 세션 상한 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationSseProperties.java
@@ -11,6 +11,7 @@ public record NotificationSseProperties(
     long reconnectDelayMs,
     int replayLimit,
     int maxTotalSessions,
+    int maxUserSessions,
     int maxPendingEventsPerSession,
     String fanoutChannel,
     long fanoutListenTimeoutMs,
@@ -32,6 +33,13 @@ public record NotificationSseProperties(
     }
     if (maxTotalSessions <= 0) {
       throw new IllegalArgumentException("notification.sse.max-total-sessions must be positive");
+    }
+    if (maxUserSessions <= 0) {
+      throw new IllegalArgumentException("notification.sse.max-user-sessions must be positive");
+    }
+    if (maxUserSessions > maxTotalSessions) {
+      throw new IllegalArgumentException(
+          "notification.sse.max-user-sessions must not exceed notification.sse.max-total-sessions");
     }
     if (maxPendingEventsPerSession <= 0) {
       throw new IllegalArgumentException(

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongFunction;
@@ -32,6 +33,8 @@ public class NotificationSseBroker {
   private static final Logger log = LoggerFactory.getLogger(NotificationSseBroker.class);
   private static final String OVERLOAD_MESSAGE =
       "notification SSE stream is temporarily overloaded";
+  private static final String TOTAL_SESSION_LIMIT_REASON = "total_session_limit";
+  private static final String USER_SESSION_LIMIT_REASON = "user_session_limit";
 
   private final NotificationSseProperties notificationSseProperties;
   private final NotificationSseTargetResolver notificationSseTargetResolver;
@@ -64,6 +67,7 @@ public class NotificationSseBroker {
         subject,
         "account",
         lastEventId,
+        0,
         replayLastEventId ->
             notificationQueryUseCase.getReplayNotificationsForAccount(
                 accountId,
@@ -82,6 +86,7 @@ public class NotificationSseBroker {
         subject,
         "user",
         lastEventId,
+        notificationSseProperties.maxUserSessions(),
         replayLastEventId ->
             notificationQueryUseCase.getReplayNotificationsForUser(
                 userId,
@@ -138,16 +143,15 @@ public class NotificationSseBroker {
       String subject,
       String principalType,
       Long lastEventId,
+      int maxPrincipalSessions,
       LongFunction<List<NotificationSummary>> replayLoader) {
     if (!reserveSessionSlot()) {
-      long rejectedCount = rejectedSubscriptionCount.incrementAndGet();
-      log.warn(
-          "notification SSE subscribe rejected principalType={} principalId={} activeSessions={} limit={} rejectedCount={}",
-          principalType,
+      rejectSubscription(
+          sessionsByPrincipalId,
           principalId,
-          activeSessionCount.get(),
-          notificationSseProperties.maxTotalSessions(),
-          rejectedCount);
+          principalType,
+          TOTAL_SESSION_LIMIT_REASON,
+          notificationSseProperties.maxTotalSessions());
       throw new NotificationSseOverloadException(OVERLOAD_MESSAGE);
     }
     String sessionId = UUID.randomUUID().toString();
@@ -156,9 +160,16 @@ public class NotificationSseBroker {
       SseEmitter emitter = new SseEmitter(notificationSseProperties.connectionTimeoutMs());
       NotificationSseSession session =
           new NotificationSseSession(sessionId, subject, emitter, lastEventId);
-      sessionsByPrincipalId
-          .computeIfAbsent(principalId, ignored -> new ConcurrentHashMap<>())
-          .put(sessionId, session);
+      if (!registerSession(sessionsByPrincipalId, principalId, session, maxPrincipalSessions)) {
+        releaseSessionSlot();
+        rejectSubscription(
+            sessionsByPrincipalId,
+            principalId,
+            principalType,
+            USER_SESSION_LIMIT_REASON,
+            maxPrincipalSessions);
+        throw new NotificationSseOverloadException(OVERLOAD_MESSAGE);
+      }
       registered = true;
       emitter.onCompletion(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
       emitter.onTimeout(() -> removeSession(sessionsByPrincipalId, principalId, sessionId));
@@ -401,6 +412,54 @@ public class NotificationSseBroker {
       count += sessions.size();
     }
     return count;
+  }
+
+  private int sessionCount(
+      Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId, long principalId) {
+    Map<String, NotificationSseSession> sessions = sessionsByPrincipalId.get(principalId);
+    return sessions == null ? 0 : sessions.size();
+  }
+
+  private void rejectSubscription(
+      Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
+      long principalId,
+      String principalType,
+      String reason,
+      int limit) {
+    long rejectedCount = rejectedSubscriptionCount.incrementAndGet();
+    log.warn(
+        "notification SSE subscribe rejected principalType={} principalId={} reason={} activeSessions={} principalSessions={} limit={} rejectedCount={}",
+        principalType,
+        principalId,
+        reason,
+        activeSessionCount.get(),
+        sessionCount(sessionsByPrincipalId, principalId),
+        limit,
+        rejectedCount);
+  }
+
+  private boolean registerSession(
+      Map<Long, Map<String, NotificationSseSession>> sessionsByPrincipalId,
+      long principalId,
+      NotificationSseSession session,
+      int maxPrincipalSessions) {
+    AtomicBoolean registered = new AtomicBoolean(false);
+    sessionsByPrincipalId.compute(
+        principalId,
+        (ignored, currentSessions) -> {
+          if (maxPrincipalSessions > 0
+              && currentSessions != null
+              && currentSessions.size() >= maxPrincipalSessions) {
+            return currentSessions;
+          }
+          // 동일 user reconnect burst가 전체 cap을 잠식하지 않게 user registry 안에서 등록을 직렬화합니다.
+          Map<String, NotificationSseSession> nextSessions =
+              currentSessions == null ? new ConcurrentHashMap<>() : currentSessions;
+          nextSessions.put(session.sessionId(), session);
+          registered.set(true);
+          return nextSessions;
+        });
+    return registered.get();
   }
 
   private boolean reserveSessionSlot() {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -127,6 +127,7 @@ notification:
     reconnect-delay-ms: ${NOTIFICATION_SSE_RECONNECT_DELAY_MS:3000}
     replay-limit: ${NOTIFICATION_SSE_REPLAY_LIMIT:100}
     max-total-sessions: ${NOTIFICATION_SSE_MAX_TOTAL_SESSIONS:64}
+    max-user-sessions: ${NOTIFICATION_SSE_MAX_USER_SESSIONS:4}
     max-pending-events-per-session: ${NOTIFICATION_SSE_MAX_PENDING_EVENTS_PER_SESSION:32}
     fanout-channel: ${NOTIFICATION_SSE_FANOUT_CHANNEL:notification_sse_fanout}
     fanout-listen-timeout-ms: ${NOTIFICATION_SSE_FANOUT_LISTEN_TIMEOUT_MS:1000}

--- a/back/src/test/java/com/aquilabank/global/notification/NotificationSseBrokerTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/NotificationSseBrokerTest.java
@@ -41,7 +41,7 @@ class NotificationSseBrokerTest {
 
   @Test
   void rejectsSubscriptionWhenTotalSessionLimitIsReached() throws Exception {
-    NotificationSseBroker notificationSseBroker = createBroker(1, 2);
+    NotificationSseBroker notificationSseBroker = createBroker(1, 1, 2);
 
     SseEmitter firstEmitter = notificationSseBroker.subscribeAccount(101L, "first-session");
 
@@ -65,7 +65,7 @@ class NotificationSseBrokerTest {
               assertThat(releaseReplay.await(3, TimeUnit.SECONDS)).isTrue();
               return List.of();
             });
-    NotificationSseBroker notificationSseBroker = createBroker(4, 2);
+    NotificationSseBroker notificationSseBroker = createBroker(4, 2, 2);
 
     notificationSseBroker.subscribeAccount(101L, "replay-session", 10L);
     assertThat(replayEntered.await(3, TimeUnit.SECONDS)).isTrue();
@@ -82,7 +82,48 @@ class NotificationSseBrokerTest {
     releaseReplay.countDown();
   }
 
-  private NotificationSseBroker createBroker(int maxTotalSessions, int maxPendingEventsPerSession) {
+  @Test
+  void rejectsSubscriptionWhenUserSessionLimitIsReached() throws Exception {
+    NotificationSseBroker notificationSseBroker = createBroker(4, 2, 2);
+
+    SseEmitter firstEmitter = notificationSseBroker.subscribeUser(202L, "first-user-session");
+    SseEmitter secondEmitter = notificationSseBroker.subscribeUser(202L, "second-user-session");
+
+    assertThatThrownBy(() -> notificationSseBroker.subscribeUser(202L, "third-user-session"))
+        .isInstanceOf(NotificationSseOverloadException.class)
+        .hasMessage("notification SSE stream is temporarily overloaded");
+    assertThat(notificationSseBroker.rejectedSubscriptionCount()).isEqualTo(1L);
+
+    SseEmitter otherUserEmitter = notificationSseBroker.subscribeUser(303L, "other-user-session");
+    assertThat(otherUserEmitter).isNotNull();
+
+    firstEmitter.complete();
+    secondEmitter.complete();
+    otherUserEmitter.complete();
+  }
+
+  @Test
+  void rejectsConfigurationWhenUserSessionLimitExceedsTotalLimit() {
+    assertThatThrownBy(
+            () ->
+                new NotificationSseProperties(
+                    60_000L,
+                    10_000L,
+                    3_000L,
+                    100,
+                    4,
+                    5,
+                    32,
+                    "notification_sse_fanout",
+                    1_000L,
+                    2_000L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "notification.sse.max-user-sessions must not exceed notification.sse.max-total-sessions");
+  }
+
+  private NotificationSseBroker createBroker(
+      int maxTotalSessions, int maxUserSessions, int maxPendingEventsPerSession) {
     return new NotificationSseBroker(
         new NotificationSseProperties(
             60_000L,
@@ -90,6 +131,7 @@ class NotificationSseBrokerTest {
             3_000L,
             100,
             maxTotalSessions,
+            maxUserSessions,
             maxPendingEventsPerSession,
             "notification_sse_fanout",
             1_000L,

--- a/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
@@ -39,6 +39,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
       "spring.flyway.enabled=true",
       "management.health.db.enabled=true",
       "notification.sse.max-total-sessions=1",
+      "notification.sse.max-user-sessions=1",
       "notification.inbox.consumer.enabled=true",
       "notification.inbox.consumer.auto-startup=false",
       "notification.inbox.consumer.group-id=aquila-bank-prometheus-metrics",


### PR DESCRIPTION
## 🔗 Related Issue
- close #138

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification SSE에 `max-user-sessions` 설정을 추가했습니다.
- 동일 사용자 기준 active session 수를 제한해 reconnect burst가 전체 instance session 예산을 잠식하지 않도록 했습니다.

## 🛠 Changes
- `NotificationSseProperties`에 `max-user-sessions`와 `max-total-sessions` 상호 검증을 추가했습니다.
- `NotificationSseBroker`에서 user principal 구독 등록을 원자적으로 제한하고 상한 초과 시 overload 예외를 반환하도록 했습니다.
- broker 테스트에 per-user 상한 거절과 설정 검증을 추가하고, metrics 통합 테스트 프로필에 새 설정을 맞췄습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-notification-tests ./back/gradlew -p back test --tests '*NotificationSseBrokerTest' --tests '*NotificationControllerTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit hook에서 `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `max-user-sessions` 기본값이 너무 낮으면 정상 다중 기기 사용자도 조기 거절될 수 있습니다.
- 롤백 방법: PR revert 또는 `notification.sse.max-user-sessions`를 `max-total-sessions`와 같은 값으로 올려 기존 동작에 가깝게 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [ ] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?