### PR TITLE
[Perf] Redis 도입 필요성 검증과 최소 사용처 확정

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -28,6 +28,12 @@ com.aquilabank
 - inbound/outbound adapter, config, filter, interceptor, repository 구현체는 `global`에 둡니다.
 - 공통 helper는 `standard/util`에 두되, 도메인 규칙이나 유스케이스 판단은 넣지 않습니다.
 
+## Login Throttling Storage
+
+- 기본 저장소는 `memory`입니다.
+- `redis`는 분산 login throttling 이 필요할 때만 opt-in 으로 사용합니다.
+- Redis 경로는 login throttling counter 에만 쓰고, SSE fan-out 은 계속 PostgreSQL `LISTEN/NOTIFY` 를 사용합니다.
+
 ## Stack
 
 - Java 21

--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.flywaydb:flyway-database-postgresql")
     compileOnly("org.postgresql:postgresql")

--- a/back/src/main/java/com/aquilabank/global/config/LoginThrottlingConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/LoginThrottlingConfiguration.java
@@ -27,7 +27,7 @@ public class LoginThrottlingConfiguration {
         throw new IllegalStateException(
             "security.login-throttling.store=redis requires StringRedisTemplate");
       }
-      return new RedisLoginThrottleStore(properties, stringRedisTemplate);
+      return new RedisLoginThrottleStore(properties, stringRedisTemplate, authClock);
     }
     return new MemoryLoginThrottleStore(properties, authClock);
   }

--- a/back/src/main/java/com/aquilabank/global/config/LoginThrottlingConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/LoginThrottlingConfiguration.java
@@ -1,0 +1,39 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.global.security.LoginThrottleGuard;
+import com.aquilabank.global.security.LoginThrottleStore;
+import com.aquilabank.global.security.LoginThrottlingProperties;
+import com.aquilabank.global.security.LoginThrottlingProperties.StoreType;
+import com.aquilabank.global.security.MemoryLoginThrottleStore;
+import com.aquilabank.global.security.RedisLoginThrottleStore;
+import java.time.Clock;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+/** login throttling 저장소를 memory/redis 중 하나로 조립합니다. */
+@Configuration
+public class LoginThrottlingConfiguration {
+
+  @Bean
+  LoginThrottleStore loginThrottleStore(
+      LoginThrottlingProperties properties,
+      Clock authClock,
+      ObjectProvider<StringRedisTemplate> stringRedisTemplateProvider) {
+    if (properties.store() == StoreType.REDIS) {
+      StringRedisTemplate stringRedisTemplate = stringRedisTemplateProvider.getIfAvailable();
+      if (stringRedisTemplate == null) {
+        throw new IllegalStateException(
+            "security.login-throttling.store=redis requires StringRedisTemplate");
+      }
+      return new RedisLoginThrottleStore(properties, stringRedisTemplate);
+    }
+    return new MemoryLoginThrottleStore(properties, authClock);
+  }
+
+  @Bean
+  LoginThrottleGuard loginThrottleGuard(LoginThrottleStore loginThrottleStore) {
+    return new LoginThrottleGuard(loginThrottleStore);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottleGuard.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottleGuard.java
@@ -4,136 +4,41 @@ import com.aquilabank.global.web.RequestTraceContext;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Clock;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.HexFormat;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 /** login entrypoint 직전에서 IP/global burst를 빠르게 차단합니다. */
-@Component
 public class LoginThrottleGuard {
 
   private static final Logger log = LoggerFactory.getLogger(LoginThrottleGuard.class);
 
-  private final LoginThrottlingProperties properties;
-  private final Clock clock;
-  private final Deque<Instant> globalWindow = new ArrayDeque<>();
-  private final LinkedHashMap<String, AttemptWindow> ipWindows =
-      new LinkedHashMap<>(16, 0.75f, true);
+  private final LoginThrottleStore loginThrottleStore;
 
-  public LoginThrottleGuard(LoginThrottlingProperties properties, Clock clock) {
-    this.properties = properties;
-    this.clock = clock;
+  public LoginThrottleGuard(LoginThrottleStore loginThrottleStore) {
+    this.loginThrottleStore = loginThrottleStore;
   }
 
-  public synchronized void check(String ipAddress) {
-    Instant now = Instant.now(clock);
+  public void check(String ipAddress) {
     String normalizedIpAddress = normalizeIpAddress(ipAddress);
-
-    // 공개 login QPS는 낮고 tracked IP 수도 작게 제한하므로 단일 monitor로 window 정합성을 유지합니다.
-    pruneWindow(globalWindow, now, properties.global().windowSeconds());
-    pruneIpWindows(now);
-
-    ThrottleDecision ipDecision = evaluateIpWindow(normalizedIpAddress, now);
-    if (ipDecision.blocked()) {
+    LoginThrottleStore.ThrottleDecision decision = loginThrottleStore.check(normalizedIpAddress);
+    if (decision.throttled()) {
       logThrottle(
-          LoginThrottleScope.IP,
+          decision.scope(),
           normalizedIpAddress,
-          ipDecision.retryAfterSeconds(),
-          properties.ip().maxAttempts(),
-          properties.ip().windowSeconds());
-      throw new LoginThrottledException(LoginThrottleScope.IP, ipDecision.retryAfterSeconds());
-    }
-
-    ThrottleDecision globalDecision = evaluateGlobalWindow(now);
-    if (globalDecision.blocked()) {
-      logThrottle(
-          LoginThrottleScope.GLOBAL,
-          normalizedIpAddress,
-          globalDecision.retryAfterSeconds(),
-          properties.global().maxAttempts(),
-          properties.global().windowSeconds());
-      throw new LoginThrottledException(
-          LoginThrottleScope.GLOBAL, globalDecision.retryAfterSeconds());
-    }
-
-    ipWindow(normalizedIpAddress).attempts().addLast(now);
-    globalWindow.addLast(now);
-  }
-
-  /** 테스트마다 singleton window state를 비웁니다. */
-  public synchronized void clear() {
-    globalWindow.clear();
-    ipWindows.clear();
-  }
-
-  private ThrottleDecision evaluateIpWindow(String ipAddress, Instant now) {
-    AttemptWindow window = ipWindow(ipAddress);
-    pruneWindow(window.attempts(), now, properties.ip().windowSeconds());
-    if (window.attempts().size() >= properties.ip().maxAttempts()) {
-      return ThrottleDecision.blocked(
-          retryAfterSeconds(window.attempts(), properties.ip().windowSeconds(), now));
-    }
-    return ThrottleDecision.allowed();
-  }
-
-  private ThrottleDecision evaluateGlobalWindow(Instant now) {
-    if (globalWindow.size() >= properties.global().maxAttempts()) {
-      return ThrottleDecision.blocked(
-          retryAfterSeconds(globalWindow, properties.global().windowSeconds(), now));
-    }
-    return ThrottleDecision.allowed();
-  }
-
-  private AttemptWindow ipWindow(String ipAddress) {
-    AttemptWindow window = ipWindows.get(ipAddress);
-    if (window != null) {
-      return window;
-    }
-    while (ipWindows.size() >= properties.maxTrackedIps()) {
-      Iterator<Map.Entry<String, AttemptWindow>> iterator = ipWindows.entrySet().iterator();
-      if (!iterator.hasNext()) {
-        break;
-      }
-      iterator.next();
-      iterator.remove();
-    }
-    AttemptWindow newWindow = new AttemptWindow(new ArrayDeque<>());
-    ipWindows.put(ipAddress, newWindow);
-    return newWindow;
-  }
-
-  private void pruneIpWindows(Instant now) {
-    Iterator<Map.Entry<String, AttemptWindow>> iterator = ipWindows.entrySet().iterator();
-    while (iterator.hasNext()) {
-      AttemptWindow window = iterator.next().getValue();
-      pruneWindow(window.attempts(), now, properties.ip().windowSeconds());
-      if (window.attempts().isEmpty()) {
-        iterator.remove();
-      }
+          decision.retryAfterSeconds(),
+          decision.maxAttempts(),
+          decision.windowSeconds(),
+          decision.trackedIpCount());
+      throw new LoginThrottledException(decision.scope(), decision.retryAfterSeconds());
     }
   }
 
-  private void pruneWindow(Deque<Instant> window, Instant now, long windowSeconds) {
-    while (!window.isEmpty() && !window.peekFirst().plusSeconds(windowSeconds).isAfter(now)) {
-      window.removeFirst();
-    }
-  }
-
-  private long retryAfterSeconds(Deque<Instant> window, long windowSeconds, Instant now) {
-    Instant retryAt = window.peekFirst().plusSeconds(windowSeconds);
-    long millis = Math.max(Duration.between(now, retryAt).toMillis(), 0L);
-    return Math.max(1L, (millis + 999L) / 1000L);
+  /** 테스트마다 singleton 상태를 비웁니다. */
+  public void clear() {
+    loginThrottleStore.clear();
   }
 
   private void logThrottle(
@@ -141,7 +46,8 @@ public class LoginThrottleGuard {
       String ipAddress,
       long retryAfterSeconds,
       int maxAttempts,
-      long windowSeconds) {
+      long windowSeconds,
+      int trackedIpCount) {
     log.warn(
         "auth login throttled requestId={} scope={} ipHash={} retryAfterSeconds={} maxAttempts={} windowSeconds={} trackedIpCount={} path={}",
         RequestTraceContext.currentRequestId().orElse("-"),
@@ -150,7 +56,7 @@ public class LoginThrottleGuard {
         retryAfterSeconds,
         maxAttempts,
         windowSeconds,
-        ipWindows.size(),
+        trackedIpCount,
         currentPath());
   }
 
@@ -176,18 +82,5 @@ public class LoginThrottleGuard {
       return "unknown";
     }
     return ipAddress;
-  }
-
-  private record AttemptWindow(Deque<Instant> attempts) {}
-
-  private record ThrottleDecision(boolean blocked, long retryAfterSeconds) {
-
-    private static ThrottleDecision allowed() {
-      return new ThrottleDecision(false, 0L);
-    }
-
-    private static ThrottleDecision blocked(long retryAfterSeconds) {
-      return new ThrottleDecision(true, retryAfterSeconds);
-    }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottleStore.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottleStore.java
@@ -1,0 +1,32 @@
+package com.aquilabank.global.security;
+
+public interface LoginThrottleStore {
+
+  ThrottleDecision check(String ipAddress);
+
+  void clear();
+
+  record ThrottleDecision(
+      boolean throttled,
+      LoginThrottleScope scope,
+      long retryAfterSeconds,
+      int maxAttempts,
+      long windowSeconds,
+      int trackedIpCount) {
+
+    public static ThrottleDecision allowed(
+        int maxAttempts, long windowSeconds, int trackedIpCount) {
+      return new ThrottleDecision(false, null, 0L, maxAttempts, windowSeconds, trackedIpCount);
+    }
+
+    public static ThrottleDecision blocked(
+        LoginThrottleScope scope,
+        long retryAfterSeconds,
+        int maxAttempts,
+        long windowSeconds,
+        int trackedIpCount) {
+      return new ThrottleDecision(
+          true, scope, retryAfterSeconds, maxAttempts, windowSeconds, trackedIpCount);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottlingProperties.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottlingProperties.java
@@ -5,12 +5,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /** 공개 login entrypoint 전용 IP/global throttling 설정입니다. */
 @ConfigurationProperties(prefix = "security.login-throttling")
 public record LoginThrottlingProperties(
-    int maxTrackedIps, ScopeProperties ip, ScopeProperties global) {
+    int maxTrackedIps,
+    ScopeProperties ip,
+    ScopeProperties global,
+    StoreType store,
+    RedisProperties redis) {
 
   public LoginThrottlingProperties {
     maxTrackedIps = maxTrackedIps > 0 ? maxTrackedIps : 1024;
     ip = ip == null ? new ScopeProperties(20, 60) : ip;
     global = global == null ? new ScopeProperties(40, 10) : global;
+    store = store == null ? StoreType.MEMORY : store;
+    redis = redis == null ? new RedisProperties("auth:login:throttle:") : redis;
   }
 
   public record ScopeProperties(int maxAttempts, long windowSeconds) {
@@ -23,6 +29,21 @@ public record LoginThrottlingProperties(
       if (windowSeconds <= 0) {
         throw new IllegalArgumentException(
             "security.login-throttling window-seconds must be positive");
+      }
+    }
+  }
+
+  public enum StoreType {
+    MEMORY,
+    REDIS
+  }
+
+  public record RedisProperties(String keyPrefix) {
+
+    public RedisProperties {
+      if (keyPrefix == null || keyPrefix.isBlank()) {
+        throw new IllegalArgumentException(
+            "security.login-throttling.redis.key-prefix must not be blank");
       }
     }
   }

--- a/back/src/main/java/com/aquilabank/global/security/MemoryLoginThrottleStore.java
+++ b/back/src/main/java/com/aquilabank/global/security/MemoryLoginThrottleStore.java
@@ -1,0 +1,125 @@
+package com.aquilabank.global.security;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** memory 기본 경로에서 login burst 상태를 bounded하게 유지합니다. */
+public final class MemoryLoginThrottleStore implements LoginThrottleStore {
+
+  private final LoginThrottlingProperties properties;
+  private final Clock clock;
+  private final Deque<Instant> globalWindow = new ArrayDeque<>();
+  private final LinkedHashMap<String, AttemptWindow> ipWindows =
+      new LinkedHashMap<>(16, 0.75f, true);
+
+  public MemoryLoginThrottleStore(LoginThrottlingProperties properties, Clock clock) {
+    this.properties = properties;
+    this.clock = clock;
+  }
+
+  @Override
+  public synchronized ThrottleDecision check(String ipAddress) {
+    Instant now = Instant.now(clock);
+
+    pruneWindow(globalWindow, now, properties.global().windowSeconds());
+    pruneIpWindows(now);
+
+    ThrottleDecision ipDecision = evaluateIpWindow(ipAddress, now);
+    if (ipDecision.throttled()) {
+      return ipDecision;
+    }
+
+    ThrottleDecision globalDecision = evaluateGlobalWindow(now);
+    if (globalDecision.throttled()) {
+      return globalDecision;
+    }
+
+    ipWindow(ipAddress).attempts().addLast(now);
+    globalWindow.addLast(now);
+    return ThrottleDecision.allowed(
+        properties.ip().maxAttempts(), properties.ip().windowSeconds(), ipWindows.size());
+  }
+
+  @Override
+  public synchronized void clear() {
+    globalWindow.clear();
+    ipWindows.clear();
+  }
+
+  private ThrottleDecision evaluateIpWindow(String ipAddress, Instant now) {
+    AttemptWindow window = ipWindow(ipAddress);
+    pruneWindow(window.attempts(), now, properties.ip().windowSeconds());
+    if (window.attempts().size() >= properties.ip().maxAttempts()) {
+      return ThrottleDecision.blocked(
+          LoginThrottleScope.IP,
+          retryAfterSeconds(window.attempts(), properties.ip().windowSeconds(), now),
+          properties.ip().maxAttempts(),
+          properties.ip().windowSeconds(),
+          ipWindows.size());
+    }
+    return ThrottleDecision.allowed(
+        properties.ip().maxAttempts(), properties.ip().windowSeconds(), ipWindows.size());
+  }
+
+  private ThrottleDecision evaluateGlobalWindow(Instant now) {
+    if (globalWindow.size() >= properties.global().maxAttempts()) {
+      return ThrottleDecision.blocked(
+          LoginThrottleScope.GLOBAL,
+          retryAfterSeconds(globalWindow, properties.global().windowSeconds(), now),
+          properties.global().maxAttempts(),
+          properties.global().windowSeconds(),
+          ipWindows.size());
+    }
+    return ThrottleDecision.allowed(
+        properties.global().maxAttempts(), properties.global().windowSeconds(), ipWindows.size());
+  }
+
+  private AttemptWindow ipWindow(String ipAddress) {
+    AttemptWindow window = ipWindows.get(ipAddress);
+    if (window != null) {
+      return window;
+    }
+    while (ipWindows.size() >= properties.maxTrackedIps()) {
+      Iterator<Map.Entry<String, AttemptWindow>> iterator = ipWindows.entrySet().iterator();
+      if (!iterator.hasNext()) {
+        break;
+      }
+      iterator.next();
+      iterator.remove();
+    }
+    AttemptWindow newWindow = new AttemptWindow(new ArrayDeque<>());
+    ipWindows.put(ipAddress, newWindow);
+    return newWindow;
+  }
+
+  private void pruneIpWindows(Instant now) {
+    Iterator<Map.Entry<String, AttemptWindow>> iterator = ipWindows.entrySet().iterator();
+    while (iterator.hasNext()) {
+      AttemptWindow window = iterator.next().getValue();
+      pruneWindow(window.attempts(), now, properties.ip().windowSeconds());
+      if (window.attempts().isEmpty()) {
+        iterator.remove();
+      }
+    }
+  }
+
+  private void pruneWindow(Deque<Instant> window, Instant now, long windowSeconds) {
+    while (!window.isEmpty() && !window.peekFirst().plusSeconds(windowSeconds).isAfter(now)) {
+      window.removeFirst();
+    }
+  }
+
+  private long retryAfterSeconds(Deque<Instant> window, long windowSeconds, Instant now) {
+    Instant retryAt = window.peekFirst().plusSeconds(windowSeconds);
+    long millis = Math.max(Duration.between(now, retryAt).toMillis(), 0L);
+    return Math.max(1L, (millis + 999L) / 1000L);
+  }
+
+  private record AttemptWindow(Deque<Instant> attempts) {}
+}

--- a/back/src/main/java/com/aquilabank/global/security/RedisLoginThrottleStore.java
+++ b/back/src/main/java/com/aquilabank/global/security/RedisLoginThrottleStore.java
@@ -1,0 +1,28 @@
+package com.aquilabank.global.security;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+/** Redis 선택 시 연결만 성립하도록 최소 스캐폴드만 둡니다. */
+public final class RedisLoginThrottleStore implements LoginThrottleStore {
+
+  private final LoginThrottlingProperties properties;
+  private final StringRedisTemplate stringRedisTemplate;
+
+  public RedisLoginThrottleStore(
+      LoginThrottlingProperties properties, StringRedisTemplate stringRedisTemplate) {
+    this.properties = properties;
+    this.stringRedisTemplate = stringRedisTemplate;
+  }
+
+  @Override
+  public ThrottleDecision check(String ipAddress) {
+    // 실제 distributed counter 동작은 다음 작업에서 완성합니다.
+    return ThrottleDecision.allowed(
+        properties.ip().maxAttempts(), properties.ip().windowSeconds(), 0);
+  }
+
+  @Override
+  public void clear() {
+    // 현재 단계에서는 Redis 경로의 bean 조립만 보장합니다.
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/RedisLoginThrottleStore.java
+++ b/back/src/main/java/com/aquilabank/global/security/RedisLoginThrottleStore.java
@@ -1,26 +1,260 @@
 package com.aquilabank.global.security;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 
-/** Redis 선택 시 연결만 성립하도록 최소 스캐폴드만 둡니다. */
+/** Redis는 login throttling counter 용도로만 쓰고, IP/global reserve는 한 번에 원자 처리합니다. */
 public final class RedisLoginThrottleStore implements LoginThrottleStore {
+
+  private static final String IP_KEY_SUFFIX = "ip:";
+  private static final String GLOBAL_KEY_SUFFIX = "global";
+  private static final String TRACKED_IPS_KEY_SUFFIX = "tracked-ips";
+  private static final DefaultRedisScript<List> RESERVE_SCRIPT = reserveScript();
 
   private final LoginThrottlingProperties properties;
   private final StringRedisTemplate stringRedisTemplate;
+  private final Clock clock;
 
   public RedisLoginThrottleStore(
       LoginThrottlingProperties properties, StringRedisTemplate stringRedisTemplate) {
-    this.properties = properties;
-    this.stringRedisTemplate = stringRedisTemplate;
+    this(properties, stringRedisTemplate, Clock.systemUTC());
+  }
+
+  public RedisLoginThrottleStore(
+      LoginThrottlingProperties properties, StringRedisTemplate stringRedisTemplate, Clock clock) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+    this.stringRedisTemplate = Objects.requireNonNull(stringRedisTemplate, "stringRedisTemplate");
+    this.clock = Objects.requireNonNull(clock, "clock");
   }
 
   @Override
   public ThrottleDecision check(String ipAddress) {
-    throw new IllegalStateException("redis login throttling counter is not implemented yet");
+    String normalizedIpAddress = normalizeIpAddress(ipAddress);
+    String ipHash = hashIpAddress(normalizedIpAddress);
+    String ipKey = key(IP_KEY_SUFFIX + ipHash);
+    String globalKey = key(GLOBAL_KEY_SUFFIX);
+    String trackedIpsKey = key(TRACKED_IPS_KEY_SUFFIX);
+
+    LoginThrottlingProperties.ScopeProperties ip = properties.ip();
+    LoginThrottlingProperties.ScopeProperties global = properties.global();
+    long nowMillis = Instant.now(clock).toEpochMilli();
+
+    Reservation reservation = reserve(ipKey, globalKey, nowMillis, ip, global);
+    if (reservation.throttled()) {
+      LoginThrottlingProperties.ScopeProperties blockedScope =
+          reservation.scope() == LoginThrottleScope.IP ? ip : global;
+      return ThrottleDecision.blocked(
+          reservation.scope(),
+          reservation.retryAfterSeconds(),
+          blockedScope.maxAttempts(),
+          blockedScope.windowSeconds(),
+          trackedIpCount(trackedIpsKey, nowMillis));
+    }
+
+    trackIp(trackedIpsKey, ipHash, ip.windowSeconds(), nowMillis);
+    return ThrottleDecision.allowed(
+        ip.maxAttempts(), ip.windowSeconds(), trackedIpCount(trackedIpsKey, nowMillis));
   }
 
   @Override
   public void clear() {
-    // 현재 단계에서는 Redis 경로의 bean 조립만 보장합니다.
+    // 테스트 편의용 정리 경로다. 운영 핫패스에서는 사용하지 않는다.
+    String prefix = key("");
+    Set<String> keys = stringRedisTemplate.keys(prefix + "*");
+    if (keys != null && !keys.isEmpty()) {
+      stringRedisTemplate.delete(keys);
+    }
+  }
+
+  private Reservation reserve(
+      String ipKey,
+      String globalKey,
+      long nowMillis,
+      LoginThrottlingProperties.ScopeProperties ip,
+      LoginThrottlingProperties.ScopeProperties global) {
+    List<?> result =
+        stringRedisTemplate.execute(
+            RESERVE_SCRIPT,
+            List.of(ipKey, globalKey),
+            Long.toString(nowMillis),
+            Long.toString(Duration.ofSeconds(ip.windowSeconds()).toMillis()),
+            Long.toString(Duration.ofSeconds(global.windowSeconds()).toMillis()),
+            Integer.toString(ip.maxAttempts()),
+            Integer.toString(global.maxAttempts()),
+            reservationMember(nowMillis),
+            reservationMember(nowMillis));
+    if (result == null || result.size() < 2) {
+      throw new IllegalStateException("failed to reserve redis login throttle slot");
+    }
+
+    long status = toLong(result.get(0));
+    long retryAfterMillis = toLong(result.get(1));
+    if (status == 0L) {
+      return Reservation.allowed();
+    }
+    if (status == 1L) {
+      return Reservation.blocked(LoginThrottleScope.IP, toRetryAfterSeconds(retryAfterMillis));
+    }
+    if (status == 2L) {
+      return Reservation.blocked(LoginThrottleScope.GLOBAL, toRetryAfterSeconds(retryAfterMillis));
+    }
+    throw new IllegalStateException("unexpected redis login throttle status: " + status);
+  }
+
+  private void trackIp(String trackedIpsKey, String ipHash, long windowSeconds, long nowMillis) {
+    pruneTrackedIps(trackedIpsKey, nowMillis);
+    if (stringRedisTemplate.opsForZSet().score(trackedIpsKey, ipHash) == null) {
+      evictIfNeeded(trackedIpsKey);
+    }
+    long expiresAtMillis = nowMillis + Duration.ofSeconds(windowSeconds).toMillis();
+    stringRedisTemplate.opsForZSet().add(trackedIpsKey, ipHash, expiresAtMillis);
+    stringRedisTemplate.expire(trackedIpsKey, Duration.ofSeconds(windowSeconds));
+  }
+
+  private void evictIfNeeded(String trackedIpsKey) {
+    Long trackedIpCount = stringRedisTemplate.opsForZSet().zCard(trackedIpsKey);
+    long trackedCount = trackedIpCount == null ? 0L : trackedIpCount;
+    if (trackedCount < properties.maxTrackedIps()) {
+      return;
+    }
+    long overflow = trackedCount - properties.maxTrackedIps() + 1L;
+    Set<String> oldestIps = stringRedisTemplate.opsForZSet().range(trackedIpsKey, 0, overflow - 1L);
+    if (oldestIps == null || oldestIps.isEmpty()) {
+      return;
+    }
+    for (String ipHash : oldestIps) {
+      stringRedisTemplate.delete(key(IP_KEY_SUFFIX + ipHash));
+    }
+    stringRedisTemplate.opsForZSet().remove(trackedIpsKey, oldestIps.toArray());
+  }
+
+  private int trackedIpCount(String trackedIpsKey, long nowMillis) {
+    pruneTrackedIps(trackedIpsKey, nowMillis);
+    Long trackedCount = stringRedisTemplate.opsForZSet().zCard(trackedIpsKey);
+    refreshTrackedIpsTtl(trackedIpsKey, trackedCount);
+    return trackedCount == null ? 0 : trackedCount.intValue();
+  }
+
+  private void pruneTrackedIps(String trackedIpsKey, long nowMillis) {
+    stringRedisTemplate.opsForZSet().removeRangeByScore(trackedIpsKey, 0.0d, (double) nowMillis);
+  }
+
+  private void refreshTrackedIpsTtl(String trackedIpsKey, Long trackedCount) {
+    if (trackedCount == null || trackedCount <= 0L) {
+      stringRedisTemplate.delete(trackedIpsKey);
+      return;
+    }
+    stringRedisTemplate.expire(trackedIpsKey, Duration.ofSeconds(properties.ip().windowSeconds()));
+  }
+
+  private String reservationMember(long nowMillis) {
+    return nowMillis + ":" + UUID.randomUUID();
+  }
+
+  private long toLong(Object value) {
+    if (value instanceof Number number) {
+      return number.longValue();
+    }
+    throw new IllegalStateException("unexpected redis login throttle script result: " + value);
+  }
+
+  private long toRetryAfterSeconds(long retryAfterMillis) {
+    return Math.max(1L, (Math.max(retryAfterMillis, 0L) + 999L) / 1000L);
+  }
+
+  private String key(String suffix) {
+    String prefix = properties.redis().keyPrefix();
+    if (prefix.endsWith(":")) {
+      return prefix + suffix;
+    }
+    if (suffix.isEmpty()) {
+      return prefix;
+    }
+    return prefix + ":" + suffix;
+  }
+
+  private String hashIpAddress(String ipAddress) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(ipAddress.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+
+  private String normalizeIpAddress(String ipAddress) {
+    if (ipAddress == null || ipAddress.isBlank()) {
+      return "unknown";
+    }
+    return ipAddress;
+  }
+
+  private static DefaultRedisScript<List> reserveScript() {
+    DefaultRedisScript<List> script = new DefaultRedisScript<>();
+    script.setResultType(List.class);
+    script.setScriptText(
+        """
+        local ipKey = KEYS[1]
+        local globalKey = KEYS[2]
+        local nowMillis = tonumber(ARGV[1])
+        local ipWindowMillis = tonumber(ARGV[2])
+        local globalWindowMillis = tonumber(ARGV[3])
+        local ipLimit = tonumber(ARGV[4])
+        local globalLimit = tonumber(ARGV[5])
+        local ipMember = ARGV[6]
+        local globalMember = ARGV[7]
+
+        redis.call('ZREMRANGEBYSCORE', ipKey, '-inf', nowMillis - ipWindowMillis)
+        redis.call('ZREMRANGEBYSCORE', globalKey, '-inf', nowMillis - globalWindowMillis)
+
+        local ipCount = redis.call('ZCARD', ipKey)
+        if ipCount >= ipLimit then
+          local oldest = redis.call('ZRANGE', ipKey, 0, 0, 'WITHSCORES')
+          local retryAfterMillis = ipWindowMillis
+          if oldest[2] ~= nil then
+            retryAfterMillis = math.max(1, tonumber(oldest[2]) + ipWindowMillis - nowMillis)
+          end
+          return {1, retryAfterMillis}
+        end
+
+        local globalCount = redis.call('ZCARD', globalKey)
+        if globalCount >= globalLimit then
+          local oldest = redis.call('ZRANGE', globalKey, 0, 0, 'WITHSCORES')
+          local retryAfterMillis = globalWindowMillis
+          if oldest[2] ~= nil then
+            retryAfterMillis = math.max(1, tonumber(oldest[2]) + globalWindowMillis - nowMillis)
+          end
+          return {2, retryAfterMillis}
+        end
+
+        redis.call('ZADD', ipKey, nowMillis, ipMember)
+        redis.call('PEXPIRE', ipKey, ipWindowMillis)
+        redis.call('ZADD', globalKey, nowMillis, globalMember)
+        redis.call('PEXPIRE', globalKey, globalWindowMillis)
+        return {0, 0}
+        """);
+    return script;
+  }
+
+  private record Reservation(boolean throttled, LoginThrottleScope scope, long retryAfterSeconds) {
+
+    private static Reservation allowed() {
+      return new Reservation(false, null, 0L);
+    }
+
+    private static Reservation blocked(LoginThrottleScope scope, long retryAfterSeconds) {
+      return new Reservation(true, scope, retryAfterSeconds);
+    }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/security/RedisLoginThrottleStore.java
+++ b/back/src/main/java/com/aquilabank/global/security/RedisLoginThrottleStore.java
@@ -16,9 +16,7 @@ public final class RedisLoginThrottleStore implements LoginThrottleStore {
 
   @Override
   public ThrottleDecision check(String ipAddress) {
-    // 실제 distributed counter 동작은 다음 작업에서 완성합니다.
-    return ThrottleDecision.allowed(
-        properties.ip().maxAttempts(), properties.ip().windowSeconds(), 0);
+    throw new IllegalStateException("redis login throttling counter is not implemented yet");
   }
 
   @Override

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -49,6 +49,10 @@ server:
     connection-timeout: 3s
 
 management:
+  health:
+    # Redis는 opt-in throttling store라 기본 memory 경로에서는 actuator DOWN 전파를 막습니다.
+    redis:
+      enabled: ${MANAGEMENT_HEALTH_REDIS_ENABLED:false}
   endpoints:
     web:
       exposure:

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -185,12 +185,15 @@ security:
     reset-window-seconds: ${SECURITY_LOGIN_PROTECTION_RESET_WINDOW_SECONDS:900}
   login-throttling:
     max-tracked-ips: ${SECURITY_LOGIN_THROTTLING_MAX_TRACKED_IPS:1024}
+    store: ${SECURITY_LOGIN_THROTTLING_STORE:memory}
     ip:
       max-attempts: ${SECURITY_LOGIN_THROTTLING_IP_MAX_ATTEMPTS:20}
       window-seconds: ${SECURITY_LOGIN_THROTTLING_IP_WINDOW_SECONDS:60}
     global:
       max-attempts: ${SECURITY_LOGIN_THROTTLING_GLOBAL_MAX_ATTEMPTS:40}
       window-seconds: ${SECURITY_LOGIN_THROTTLING_GLOBAL_WINDOW_SECONDS:10}
+    redis:
+      key-prefix: ${SECURITY_LOGIN_THROTTLING_REDIS_KEY_PREFIX:auth:login:throttle:}
   bootstrap-header-auth:
     enabled: ${SECURITY_BOOTSTRAP_HEADER_AUTH_ENABLED:false}
     account-id-header: ${SECURITY_BOOTSTRAP_ACCOUNT_ID_HEADER:X-Account-Id}

--- a/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
@@ -1,0 +1,67 @@
+package com.aquilabank.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.global.security.LoginThrottleGuard;
+import com.aquilabank.global.security.LoginThrottleStore;
+import com.aquilabank.global.security.LoginThrottlingProperties;
+import com.aquilabank.global.security.MemoryLoginThrottleStore;
+import com.aquilabank.global.security.RedisLoginThrottleStore;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+class LoginThrottlingConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withConfiguration(AutoConfigurations.of(ConfigurationPropertiesAutoConfiguration.class))
+          .withUserConfiguration(TestConfiguration.class);
+
+  @Test
+  void usesMemoryStoreByDefault() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasNotFailed();
+          assertThat(context).hasSingleBean(LoginThrottleGuard.class);
+          assertThat(context).hasSingleBean(LoginThrottleStore.class);
+          assertThat(context.getBean(LoginThrottleStore.class))
+              .isInstanceOf(MemoryLoginThrottleStore.class);
+          assertThat(context).doesNotHaveBean(RedisLoginThrottleStore.class);
+        });
+  }
+
+  @Test
+  void failsFastWhenRedisStoreIsSelectedWithoutStringRedisTemplate() {
+    contextRunner
+        .withPropertyValues("security.login-throttling.store=redis")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .isInstanceOf(org.springframework.beans.factory.BeanCreationException.class)
+                  .hasRootCauseInstanceOf(IllegalStateException.class)
+                  .hasRootCauseMessage(
+                      "security.login-throttling.store=redis requires StringRedisTemplate");
+            });
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @EnableConfigurationProperties(LoginThrottlingProperties.class)
+  @Import(LoginThrottlingConfiguration.class)
+  static class TestConfiguration {
+
+    @Bean
+    Clock authClock() {
+      return Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC);
+    }
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
@@ -1,6 +1,8 @@
 package com.aquilabank.global.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import com.aquilabank.global.security.LoginThrottleGuard;
 import com.aquilabank.global.security.LoginThrottleStore;
@@ -52,6 +54,39 @@ class LoginThrottlingConfigurationTest {
                   .hasRootCauseMessage(
                       "security.login-throttling.store=redis requires StringRedisTemplate");
             });
+  }
+
+  @Test
+  void createsRedisStoreWhenStringRedisTemplateIsPresent() {
+    contextRunner
+        .withPropertyValues("security.login-throttling.store=redis")
+        .withBean(
+            org.springframework.data.redis.core.StringRedisTemplate.class,
+            () -> mock(org.springframework.data.redis.core.StringRedisTemplate.class))
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).hasSingleBean(LoginThrottleStore.class);
+              assertThat(context.getBean(LoginThrottleStore.class))
+                  .isInstanceOf(RedisLoginThrottleStore.class);
+            });
+  }
+
+  @Test
+  void failsClosedWhenRedisThrottleCounterIsNotImplementedYet() {
+    RedisLoginThrottleStore loginThrottleStore =
+        new RedisLoginThrottleStore(
+            new LoginThrottlingProperties(
+                16,
+                new LoginThrottlingProperties.ScopeProperties(2, 60),
+                new LoginThrottlingProperties.ScopeProperties(4, 10),
+                LoginThrottlingProperties.StoreType.REDIS,
+                new LoginThrottlingProperties.RedisProperties("auth:login:throttle:")),
+            mock(org.springframework.data.redis.core.StringRedisTemplate.class));
+
+    assertThatThrownBy(() -> loginThrottleStore.check("203.0.113.10"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("redis login throttling counter is not implemented yet");
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
@@ -1,7 +1,6 @@
 package com.aquilabank.global.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import com.aquilabank.global.security.LoginThrottleGuard;
@@ -73,20 +72,19 @@ class LoginThrottlingConfigurationTest {
   }
 
   @Test
-  void failsClosedWhenRedisThrottleCounterIsNotImplementedYet() {
-    RedisLoginThrottleStore loginThrottleStore =
-        new RedisLoginThrottleStore(
-            new LoginThrottlingProperties(
-                16,
-                new LoginThrottlingProperties.ScopeProperties(2, 60),
-                new LoginThrottlingProperties.ScopeProperties(4, 10),
-                LoginThrottlingProperties.StoreType.REDIS,
-                new LoginThrottlingProperties.RedisProperties("auth:login:throttle:")),
-            mock(org.springframework.data.redis.core.StringRedisTemplate.class));
-
-    assertThatThrownBy(() -> loginThrottleStore.check("203.0.113.10"))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("redis login throttling counter is not implemented yet");
+  void rejectsBlankRedisKeyPrefix() {
+    contextRunner
+        .withPropertyValues(
+            "security.login-throttling.store=redis", "security.login-throttling.redis.key-prefix= ")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .isInstanceOf(org.springframework.beans.factory.BeanCreationException.class)
+                  .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                  .hasRootCauseMessage(
+                      "security.login-throttling.redis.key-prefix must not be blank");
+            });
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/back/src/test/java/com/aquilabank/global/security/RedisLoginThrottleStoreIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/RedisLoginThrottleStoreIntegrationTest.java
@@ -1,0 +1,244 @@
+package com.aquilabank.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedisLoginThrottleStoreIntegrationTest {
+
+  private static final DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:7.4-alpine");
+
+  @Container
+  private static final GenericContainer<?> REDIS =
+      new GenericContainer<>(REDIS_IMAGE).withExposedPorts(6379);
+
+  private final LoginThrottlingProperties properties =
+      new LoginThrottlingProperties(
+          16,
+          new LoginThrottlingProperties.ScopeProperties(2, 2),
+          new LoginThrottlingProperties.ScopeProperties(4, 2),
+          LoginThrottlingProperties.StoreType.REDIS,
+          new LoginThrottlingProperties.RedisProperties("auth:login:throttle:"));
+
+  private StringRedisTemplate stringRedisTemplate;
+
+  @BeforeAll
+  void setUpTemplate() {
+    stringRedisTemplate = createTemplate();
+  }
+
+  @AfterEach
+  void clear() {
+    new RedisLoginThrottleStore(properties, stringRedisTemplate).clear();
+  }
+
+  @Test
+  void sharesSameIpCounterAcrossFreshStoreInstances() {
+    RedisLoginThrottleStore firstStore =
+        new RedisLoginThrottleStore(properties, stringRedisTemplate);
+    RedisLoginThrottleStore secondStore =
+        new RedisLoginThrottleStore(properties, stringRedisTemplate);
+
+    assertThat(firstStore.check("203.0.113.10").throttled()).isFalse();
+    assertThat(firstStore.check("203.0.113.10").throttled()).isFalse();
+
+    LoginThrottleStore.ThrottleDecision blocked = secondStore.check("203.0.113.10");
+
+    assertThat(blocked.throttled()).isTrue();
+    assertThat(blocked.scope()).isEqualTo(LoginThrottleScope.IP);
+    assertThat(blocked.retryAfterSeconds()).isBetween(1L, 2L);
+    assertThat(blocked.maxAttempts()).isEqualTo(2);
+    assertThat(blocked.windowSeconds()).isEqualTo(2);
+    assertThat(blocked.trackedIpCount()).isEqualTo(1);
+  }
+
+  @Test
+  void sharesGlobalCounterAcrossDifferentIps() {
+    RedisLoginThrottleStore firstStore =
+        new RedisLoginThrottleStore(properties, stringRedisTemplate);
+    RedisLoginThrottleStore secondStore =
+        new RedisLoginThrottleStore(properties, stringRedisTemplate);
+
+    assertThat(firstStore.check("203.0.113.11").throttled()).isFalse();
+    assertThat(secondStore.check("203.0.113.12").throttled()).isFalse();
+    assertThat(firstStore.check("203.0.113.13").throttled()).isFalse();
+    assertThat(secondStore.check("203.0.113.14").throttled()).isFalse();
+
+    LoginThrottleStore.ThrottleDecision blocked = firstStore.check("203.0.113.15");
+
+    assertThat(blocked.throttled()).isTrue();
+    assertThat(blocked.scope()).isEqualTo(LoginThrottleScope.GLOBAL);
+    assertThat(blocked.retryAfterSeconds()).isBetween(1L, 2L);
+    assertThat(blocked.maxAttempts()).isEqualTo(4);
+    assertThat(blocked.windowSeconds()).isEqualTo(2);
+    assertThat(blocked.trackedIpCount()).isEqualTo(4);
+  }
+
+  @Test
+  void keepsSlidingWindowSemanticsAcrossBoundary() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-04-20T00:00:00Z"));
+    LoginThrottlingProperties slidingWindowProperties =
+        new LoginThrottlingProperties(
+            16,
+            new LoginThrottlingProperties.ScopeProperties(2, 60),
+            new LoginThrottlingProperties.ScopeProperties(10, 60),
+            LoginThrottlingProperties.StoreType.REDIS,
+            new LoginThrottlingProperties.RedisProperties("auth:login:sliding:"));
+    RedisLoginThrottleStore store =
+        new RedisLoginThrottleStore(slidingWindowProperties, stringRedisTemplate, clock);
+
+    assertThat(store.check("203.0.113.20").throttled()).isFalse();
+
+    clock.plusSeconds(59);
+    assertThat(store.check("203.0.113.20").throttled()).isFalse();
+
+    clock.plusSeconds(1);
+    assertThat(store.check("203.0.113.20").throttled()).isFalse();
+
+    clock.plusSeconds(1);
+    LoginThrottleStore.ThrottleDecision blocked = store.check("203.0.113.20");
+
+    assertThat(blocked.throttled()).isTrue();
+    assertThat(blocked.scope()).isEqualTo(LoginThrottleScope.IP);
+  }
+
+  @Test
+  void enforcesIpCapUnderConcurrentRequests() throws Exception {
+    LoginThrottlingProperties concurrentProperties =
+        new LoginThrottlingProperties(
+            16,
+            new LoginThrottlingProperties.ScopeProperties(2, 60),
+            new LoginThrottlingProperties.ScopeProperties(10, 60),
+            LoginThrottlingProperties.StoreType.REDIS,
+            new LoginThrottlingProperties.RedisProperties("auth:login:concurrent-ip:"));
+
+    List<LoginThrottleStore.ThrottleDecision> decisions =
+        runConcurrently(
+            4,
+            index ->
+                new RedisLoginThrottleStore(concurrentProperties, stringRedisTemplate)
+                    .check("203.0.113.30"));
+
+    assertThat(decisions.stream().filter(decision -> !decision.throttled()).count()).isEqualTo(2);
+    assertThat(
+            decisions.stream()
+                .filter(LoginThrottleStore.ThrottleDecision::throttled)
+                .allMatch(decision -> decision.scope() == LoginThrottleScope.IP))
+        .isTrue();
+  }
+
+  @Test
+  void enforcesGlobalCapUnderConcurrentRequestsFromDifferentIps() throws Exception {
+    LoginThrottlingProperties concurrentProperties =
+        new LoginThrottlingProperties(
+            16,
+            new LoginThrottlingProperties.ScopeProperties(10, 60),
+            new LoginThrottlingProperties.ScopeProperties(4, 60),
+            LoginThrottlingProperties.StoreType.REDIS,
+            new LoginThrottlingProperties.RedisProperties("auth:login:concurrent-global:"));
+
+    List<LoginThrottleStore.ThrottleDecision> decisions =
+        runConcurrently(
+            6,
+            index ->
+                new RedisLoginThrottleStore(concurrentProperties, stringRedisTemplate)
+                    .check("203.0.113." + (40 + index)));
+
+    assertThat(decisions.stream().filter(decision -> !decision.throttled()).count()).isEqualTo(4);
+    assertThat(
+            decisions.stream()
+                .filter(LoginThrottleStore.ThrottleDecision::throttled)
+                .allMatch(decision -> decision.scope() == LoginThrottleScope.GLOBAL))
+        .isTrue();
+  }
+
+  private StringRedisTemplate createTemplate() {
+    LettuceConnectionFactory connectionFactory =
+        new LettuceConnectionFactory(REDIS.getHost(), REDIS.getMappedPort(6379));
+    connectionFactory.afterPropertiesSet();
+    StringRedisTemplate template = new StringRedisTemplate(connectionFactory);
+    template.afterPropertiesSet();
+    return template;
+  }
+
+  private List<LoginThrottleStore.ThrottleDecision> runConcurrently(
+      int concurrency, ThrowingDecisionSupplier decisionSupplier) throws Exception {
+    try (ExecutorService executorService = Executors.newFixedThreadPool(concurrency)) {
+      java.util.concurrent.CountDownLatch readyLatch =
+          new java.util.concurrent.CountDownLatch(concurrency);
+      java.util.concurrent.CountDownLatch startLatch = new java.util.concurrent.CountDownLatch(1);
+      List<Future<LoginThrottleStore.ThrottleDecision>> futures = new ArrayList<>();
+      for (int index = 0; index < concurrency; index++) {
+        int requestIndex = index;
+        futures.add(
+            executorService.submit(
+                () -> {
+                  readyLatch.countDown();
+                  startLatch.await();
+                  return decisionSupplier.get(requestIndex);
+                }));
+      }
+      readyLatch.await();
+      startLatch.countDown();
+
+      List<LoginThrottleStore.ThrottleDecision> decisions = new ArrayList<>();
+      for (Future<LoginThrottleStore.ThrottleDecision> future : futures) {
+        decisions.add(future.get());
+      }
+      return decisions;
+    }
+  }
+
+  private static final class MutableClock extends Clock {
+
+    private Instant instant;
+
+    private MutableClock(Instant instant) {
+      this.instant = instant;
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneId.of("UTC");
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+
+    private void plusSeconds(long seconds) {
+      instant = instant.plusSeconds(seconds);
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingDecisionSupplier {
+
+    LoginThrottleStore.ThrottleDecision get(int index) throws Exception;
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginThrottlingIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginThrottlingIntegrationTest.java
@@ -39,6 +39,7 @@ import org.springframework.web.context.WebApplicationContext;
     properties = {
       "spring.flyway.enabled=true",
       "management.health.db.enabled=true",
+      "security.login-throttling.store=memory",
       "security.login-protection.max-failures=3",
       "security.login-protection.lock-seconds=1",
       "security.login-protection.reset-window-seconds=900",

--- a/docs/superpowers/specs/2026-04-20-redis-fit-evaluation-design.md
+++ b/docs/superpowers/specs/2026-04-20-redis-fit-evaluation-design.md
@@ -1,0 +1,131 @@
+# Redis Fit Evaluation Design
+
+> Issue: `#140`
+> Branch: `perf/redis-fit-evaluation`
+
+## Goal
+
+Redis를 지금 도입해야 하는지 여부를 현재 코드와 운영 제약 기준으로 판단한다. 도입이 필요하다면 첫 사용처를 하나로 좁히고, 기본 운영 경로는 기존 PostgreSQL + bounded in-memory 구조를 유지한다.
+
+## Current State
+
+- notification SSE fan-out은 PostgreSQL `LISTEN/NOTIFY` + local session registry로 동작한다.
+- login throttling은 `LoginThrottleGuard`의 bounded in-memory window로 동작한다.
+- Redis 런타임, 의존성, 설정, 운영 절차는 아직 없다.
+- `t3.micro` 제약상 새 인프라는 분명한 병목 해결 지점이 있을 때만 도입해야 한다.
+
+## Options
+
+### Option A. Redis 미도입 유지
+
+현재 구조를 그대로 유지한다. 운영 단순성과 비용은 가장 좋지만, login throttling은 multi-instance 환경에서 인스턴스별로 분산되어 전체 기준 일관성이 없다. SSE는 이미 PostgreSQL fan-out이 있어 Redis 부재가 즉시 병목으로 보이지 않는다.
+
+### Option B. Redis를 login throttling 첫 사용처로 제한
+
+Redis를 분산 카운터 저장소로만 도입한다. `security.login-throttling.store=memory|redis` 선택을 두고, 기본값은 `memory`로 유지한다. Redis 선택 시에만 IP/global throttle 카운터를 Redis에 저장하고 TTL로 자동 만료한다. 현재 구조에서 instance 간 공유 상태 필요성이 가장 명확한 지점만 보완할 수 있다.
+
+### Option C. Redis를 SSE 분산 제어에 먼저 도입
+
+Redis pub/sub 또는 shared session registry로 SSE 분산 상태를 옮긴다. 그러나 현재 SSE는 PostgreSQL `LISTEN/NOTIFY` 경로가 이미 있고, reconnect/replay/중복 해석까지 함께 복잡해진다. 첫 도입 범위로는 비용 대비 이득이 작다.
+
+## Decision
+
+권장안은 **Option B**다.
+
+- Redis는 “플랫폼 공통 필수 인프라”가 아니라 **좁은 목적의 선택적 저장소**로 도입한다.
+- 첫 사용처는 **login throttling** 하나로 제한한다.
+- SSE는 **PostgreSQL `LISTEN/NOTIFY` 유지**가 기본 결론이다.
+
+## Why This Decision
+
+- login throttling은 현재 구현이 명확히 per-instance 경계에 묶여 있다.
+- SSE는 이미 PostgreSQL 기반 분산 fan-out이 있어 Redis가 중복 투자에 가깝다.
+- bounded in-memory throttling 기본값을 유지하면 Redis 장애나 미설정 상태에서도 현재 단일 인스턴스 운영 패턴이 깨지지 않는다.
+- Redis 도입을 storage abstraction 수준으로 한정하면 이후 필요 시 다른 경로로 확장할 수 있지만, 지금 PR 범위는 작게 유지된다.
+
+## Scope
+
+### In Scope
+
+- Redis 도입 필요성 문서화
+- login throttling 저장소 추상화
+- `memory` 기본 구현 유지
+- `redis` 선택 구현 추가
+- 최소 설정 추가
+- 관련 테스트 및 문서 업데이트
+
+### Out of Scope
+
+- SSE transport/protocol 변경
+- Redis pub/sub, cache, session store, distributed lock
+- domain/persistence 계층 재설계
+- notification fan-out 경로 변경
+
+## Proposed Architecture
+
+### 1. Store abstraction
+
+`LoginThrottleGuard`가 직접 window 상태를 들고 있지 않고, throttle 상태 저장 책임을 별도 저장소 인터페이스로 분리한다.
+
+- `MemoryLoginThrottleStore`
+- `RedisLoginThrottleStore`
+
+`LoginThrottleGuard`는 저장소 선택과 관계없이 다음 계약만 사용한다.
+
+- 현재 IP/global window 검사
+- 시도 기록
+- retry-after 계산에 필요한 최소 정보 조회
+- 테스트용 초기화
+
+### 2. Default path stays memory
+
+기본 설정은 `security.login-throttling.store=memory`로 둔다. Redis 설정이 없어도 기존 동작과 회귀 범위가 유지된다.
+
+### 3. Redis path stays narrow
+
+Redis 구현은 throttle counter만 다룬다.
+
+- IP 키: `auth:login:throttle:ip:<hash>`
+- Global 키: `auth:login:throttle:global`
+
+각 키는 TTL을 window와 동일하게 둔다. 복잡한 Lua script나 광범위 자료구조는 도입하지 않는다. 1차 목표는 “instance 간 공유된 burst counter”이지 정교한 rate-limiting 플랫폼이 아니다.
+
+### 4. Fail-fast configuration
+
+저장소를 `redis`로 선택했는데 Redis 연결 필수 설정이 없으면 부팅 시 차단한다. 잘못된 운영 설정을 runtime fallback으로 숨기지 않는다.
+
+## Config Direction
+
+- `security.login-throttling.store=memory|redis`
+- Redis 설정은 Spring Boot Redis 기본 설정을 활용한다.
+- Redis 선택 시에만 관련 bean이 활성화된다.
+
+## Error Handling
+
+- `memory` 경로는 현재와 동일하게 bounded local state 사용
+- `redis` 경로는 필수 설정 누락 시 부팅 fail-fast
+- Redis 장애 시 이번 범위에서는 조용한 memory fallback을 두지 않는다
+  - 이유: 운영자가 분산 throttle을 기대했는데 silently local throttle로 내려가면 보안/운영 해석이 틀어진다
+
+## Testing
+
+- 기존 login throttling 통합 테스트는 기본 `memory` 경로 회귀 검증으로 유지
+- 저장소 선택 config 테스트 추가
+- Redis 구현에는 Testcontainers Redis 통합 테스트 추가
+- 전체 검증은 `./back/gradlew -p back check`
+
+## Operational Notes
+
+- Redis는 아직 필수 인프라가 아니다
+- 단일 인스턴스 또는 작은 트래픽에서는 `memory` 기본값 유지가 권장안이다
+- multi-instance login burst 일관성이 실제 요구로 확인되면 `redis` 선택을 켠다
+- SSE는 Redis 도입 대상에서 제외하고 PostgreSQL fan-out 유지 근거를 문서에 남긴다
+
+## Revisit Triggers
+
+다음 조건이 확인되면 Redis 사용 범위를 재검토한다.
+
+- login throttling이 multi-instance에서 실제 우회된다
+- Nginx/edge throttling만으로 충분하지 않다
+- PostgreSQL fan-out이 SSE scale-out 병목으로 관측된다
+- 단일 throttle counter를 넘어 shared session/presence가 실운영 요구로 확정된다


### PR DESCRIPTION
## 🔗 Related Issue
- close #140

## 🌿 Base Branch
- `main`

## 📝 Summary
- Redis 도입 필요성을 코드/운영 제약 기준으로 검증하고, 첫 사용처를 login throttling 으로만 제한했습니다.
- 기본 경로는 기존 `memory` 유지, Redis 는 opt-in `store=redis` 일 때만 동작하도록 조립했습니다.
- SSE fan-out 은 PostgreSQL `LISTEN/NOTIFY` 유지로 확정하고, Redis 는 분산 login throttling 범위로만 좁혔습니다.

## 🛠 Changes
- `LoginThrottleGuard` 상태 관리를 저장소 추상화로 분리하고 `memory|redis` 선택을 추가
- Redis login throttling 을 Lua 기반 원자 reserve + sliding window 로 구현
- Redis 구성 fail-fast, blank key-prefix 검증, 동일 IP/global 동시성 회귀 테스트 추가
- auth MVC 통합 테스트에 `memory` store 고정, README 에 Redis/SSE 역할 경계 문서화

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back test --tests '*LoginThrottlingConfigurationTest' --tests '*RedisLoginThrottleStoreIntegrationTest' --tests '*LoginThrottlingIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- `back check` 는 `OutboxOpsApiIntegrationTest.degradesActuatorHealthWhenOutboxThresholdIsExceeded()` 기존 실패 1건으로 종료했고, 이번 변경의 `spotless`/Redis 관련 테스트는 통과했습니다.

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - Redis login throttling 은 Redis 가 없는 환경에서 opt-in 으로만 켜야 합니다.
  - Lua reserve 경로는 login throttling 전용이므로 다른 Redis 용도로 재사용하면 안 됩니다.
- 롤백 방법:
  - PR revert 또는 `SECURITY_LOGIN_THROTTLING_STORE=memory` 로 즉시 memory 경로로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
