### PR TITLE
[Feat] 계좌 상태 LOCKED/CLOSED business effect 적용

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/model/AccountAccessMembership.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AccountAccessMembership.java
@@ -1,12 +1,15 @@
 package com.aquilabank.domain.auth.model;
 
+import com.aquilabank.domain.account.model.AccountStatus;
+
 /** access 검증이 membership 상태와 user 상태를 한 번에 판단하도록 묶은 조회 모델입니다. */
 public record AccountAccessMembership(
     long userId,
     long accountId,
     MembershipRole role,
     MembershipStatus membershipStatus,
-    UserStatus userStatus) {
+    UserStatus userStatus,
+    AccountStatus accountStatus) {
 
   public AccountAccessMembership {
     if (userId <= 0) {
@@ -23,6 +26,9 @@ public record AccountAccessMembership(
     }
     if (userStatus == null) {
       throw new IllegalArgumentException("userStatus is required");
+    }
+    if (accountStatus == null) {
+      throw new IllegalArgumentException("accountStatus is required");
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AccountAccessScope.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AccountAccessScope.java
@@ -1,7 +1,21 @@
 package com.aquilabank.domain.auth.model;
 
+import com.aquilabank.domain.account.model.AccountStatus;
+
 /** 요청 경로별로 필요한 최소 계좌 권한 수준 */
 public enum AccountAccessScope {
   READ,
-  TRANSFER
+  TRANSFER;
+
+  /** `LOCKED`는 read만 허용하고, `CLOSED`는 모든 public access를 막습니다. */
+  public boolean allows(AccountStatus accountStatus) {
+    if (accountStatus == null) {
+      throw new IllegalArgumentException("accountStatus is required");
+    }
+    return switch (accountStatus) {
+      case ACTIVE -> true;
+      case LOCKED -> this == READ;
+      case CLOSED -> false;
+    };
+  }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AccountAccessPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AccountAccessPort.java
@@ -9,15 +9,5 @@ public interface AccountAccessPort {
 
   Optional<UserAccountMembership> findMembership(long userId, long accountId);
 
-  default Optional<AccountAccessMembership> findAccessMembership(long userId, long accountId) {
-    return findMembership(userId, accountId)
-        .map(
-            membership ->
-                new AccountAccessMembership(
-                    membership.userId(),
-                    membership.accountId(),
-                    membership.role(),
-                    membership.status(),
-                    com.aquilabank.domain.auth.model.UserStatus.ACTIVE));
-  }
+  Optional<AccountAccessMembership> findAccessMembership(long userId, long accountId);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AccountStatusAccessPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AccountStatusAccessPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.account.model.AccountStatus;
+import java.util.Optional;
+
+/** bootstrap principal exact access 판단에 필요한 account status만 조회합니다. */
+public interface AccountStatusAccessPort {
+
+  Optional<AccountStatus> findAccountStatus(long accountId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessService.java
@@ -6,27 +6,23 @@ import com.aquilabank.domain.auth.model.AccountAccessScope;
 import com.aquilabank.domain.auth.model.MembershipStatus;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.AccountStatusAccessPort;
 
 /** user-account membership 한 건 조회로 계좌 접근 권한을 판단합니다. */
 public final class AccountAccessService implements AccountAccessUseCase {
 
   private final AccountAccessPort accountAccessPort;
+  private final AccountStatusAccessPort accountStatusAccessPort;
 
-  public AccountAccessService(AccountAccessPort accountAccessPort) {
+  public AccountAccessService(
+      AccountAccessPort accountAccessPort, AccountStatusAccessPort accountStatusAccessPort) {
     this.accountAccessPort = accountAccessPort;
+    this.accountStatusAccessPort = accountStatusAccessPort;
   }
 
   @Override
   public long verify(long userId, long accountId, AccountAccessScope scope) {
-    if (userId <= 0) {
-      throw new IllegalArgumentException("userId must be positive");
-    }
-    if (accountId <= 0) {
-      throw new IllegalArgumentException("accountId must be positive");
-    }
-    if (scope == null) {
-      throw new IllegalArgumentException("scope is required");
-    }
+    validateUserAccessArguments(userId, accountId, scope);
 
     AccountAccessMembership membership =
         accountAccessPort
@@ -35,9 +31,42 @@ public final class AccountAccessService implements AccountAccessUseCase {
 
     if (membership.userStatus() != UserStatus.ACTIVE
         || membership.membershipStatus() != MembershipStatus.ACTIVE
-        || !membership.role().allows(scope)) {
+        || !membership.role().allows(scope)
+        || !scope.allows(membership.accountStatus())) {
       throw new AccountAccessDeniedException("account access is denied");
     }
     return accountId;
+  }
+
+  @Override
+  public long verifyBootstrapAccount(long accountId, AccountAccessScope scope) {
+    validateBootstrapAccessArguments(accountId, scope);
+
+    // bootstrap header auth는 로컬/dev 도구용이라, 없는 account는 downstream not-found 계약을 유지합니다.
+    return accountStatusAccessPort
+        .findAccountStatus(accountId)
+        .filter(accountStatus -> !scope.allows(accountStatus))
+        .map(ignored -> denied())
+        .orElse(accountId);
+  }
+
+  private void validateUserAccessArguments(long userId, long accountId, AccountAccessScope scope) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    validateBootstrapAccessArguments(accountId, scope);
+  }
+
+  private void validateBootstrapAccessArguments(long accountId, AccountAccessScope scope) {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (scope == null) {
+      throw new IllegalArgumentException("scope is required");
+    }
+  }
+
+  private long denied() {
+    throw new AccountAccessDeniedException("account access is denied");
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AccountAccessUseCase.java
@@ -6,4 +6,6 @@ import com.aquilabank.domain.auth.model.AccountAccessScope;
 public interface AccountAccessUseCase {
 
   long verify(long userId, long accountId, AccountAccessScope scope);
+
+  long verifyBootstrapAccount(long accountId, AccountAccessScope scope);
 }

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -5,6 +5,7 @@ import com.aquilabank.domain.auth.model.LoginProtectionPolicy;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.AccountStatusAccessPort;
 import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
@@ -352,8 +353,9 @@ public class AuthConfiguration {
   }
 
   @Bean
-  AccountAccessUseCase accountAccessUseCase(AccountAccessPort accountAccessPort) {
-    return new AccountAccessService(accountAccessPort);
+  AccountAccessUseCase accountAccessUseCase(
+      AccountAccessPort accountAccessPort, AccountStatusAccessPort accountStatusAccessPort) {
+    return new AccountAccessService(accountAccessPort, accountStatusAccessPort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -1,5 +1,6 @@
 package com.aquilabank.global.persistence.auth;
 
+import com.aquilabank.domain.account.model.AccountStatus;
 import com.aquilabank.domain.auth.model.AccountAccessMembership;
 import com.aquilabank.domain.auth.model.AuthSessionSummary;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
@@ -21,6 +22,7 @@ import com.aquilabank.domain.auth.model.UserAccountMembership;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.AccountStatusAccessPort;
 import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
@@ -48,6 +50,7 @@ public class JdbcAuthRepository
         TotpLoginChallengeLoadPort,
         AuthSessionQueryPort,
         AccountAccessPort,
+        AccountStatusAccessPort,
         UserQueryPort,
         UserAccountMembershipQueryPort,
         AuthStatusChangeAuditQueryPort {
@@ -330,15 +333,33 @@ public class JdbcAuthRepository
                    m.account_id,
                    m.membership_role,
                    m.membership_status,
-                   u.user_status
+                   u.user_status,
+                   a.account_status
             FROM user_account_membership m
             JOIN bank_user u
               ON u.id = m.user_id
+            JOIN bank_account a
+              ON a.id = m.account_id
             WHERE m.user_id = :userId
               AND m.account_id = :accountId
             """,
             new MapSqlParameterSource().addValue("userId", userId).addValue("accountId", accountId),
             (rs, rowNum) -> mapAccessMembership(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<AccountStatus> findAccountStatus(long accountId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT account_status
+            FROM bank_account
+            WHERE id = :accountId
+            """,
+            new MapSqlParameterSource().addValue("accountId", accountId),
+            (rs, rowNum) -> AccountStatus.valueOf(rs.getString("account_status")))
         .stream()
         .findFirst();
   }
@@ -463,7 +484,8 @@ public class JdbcAuthRepository
         rs.getLong("account_id"),
         MembershipRole.valueOf(rs.getString("membership_role")),
         MembershipStatus.valueOf(rs.getString("membership_status")),
-        UserStatus.valueOf(rs.getString("user_status")));
+        UserStatus.valueOf(rs.getString("user_status")),
+        AccountStatus.valueOf(rs.getString("account_status")));
   }
 
   private AuthUserSummary mapUserSummary(ResultSet rs) throws SQLException {

--- a/back/src/main/java/com/aquilabank/global/web/security/RequestAccountAuthorizationService.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/RequestAccountAuthorizationService.java
@@ -54,7 +54,7 @@ public class RequestAccountAuthorizationService {
             requestedAccountId);
         throw new AccountAccessDeniedException("account access is denied");
       }
-      return requestedAccountId;
+      return accountAccessUseCase.verifyBootstrapAccount(requestedAccountId, scope);
     }
 
     throw new IllegalArgumentException("unsupported principal type");

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/AccountAccessServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/AccountAccessServiceTest.java
@@ -1,0 +1,110 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.account.model.AccountStatus;
+import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
+import com.aquilabank.domain.auth.model.AccountAccessMembership;
+import com.aquilabank.domain.auth.model.AccountAccessScope;
+import com.aquilabank.domain.auth.model.MembershipRole;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.AccountAccessPort;
+import com.aquilabank.domain.auth.port.AccountStatusAccessPort;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class AccountAccessServiceTest {
+
+  @Test
+  void allowsReadForLockedAccount() {
+    AccountAccessPort accountAccessPort = mock(AccountAccessPort.class);
+    AccountStatusAccessPort accountStatusAccessPort = mock(AccountStatusAccessPort.class);
+    when(accountAccessPort.findAccessMembership(7L, 70L))
+        .thenReturn(Optional.of(accessMembership(MembershipRole.VIEWER, AccountStatus.LOCKED)));
+
+    AccountAccessService accountAccessService =
+        new AccountAccessService(accountAccessPort, accountStatusAccessPort);
+
+    assertEquals(70L, accountAccessService.verify(7L, 70L, AccountAccessScope.READ));
+  }
+
+  @Test
+  void rejectsTransferForLockedAccount() {
+    AccountAccessPort accountAccessPort = mock(AccountAccessPort.class);
+    AccountStatusAccessPort accountStatusAccessPort = mock(AccountStatusAccessPort.class);
+    when(accountAccessPort.findAccessMembership(7L, 70L))
+        .thenReturn(Optional.of(accessMembership(MembershipRole.OWNER, AccountStatus.LOCKED)));
+
+    AccountAccessService accountAccessService =
+        new AccountAccessService(accountAccessPort, accountStatusAccessPort);
+
+    assertThrows(
+        AccountAccessDeniedException.class,
+        () -> accountAccessService.verify(7L, 70L, AccountAccessScope.TRANSFER));
+  }
+
+  @Test
+  void rejectsReadForClosedAccount() {
+    AccountAccessPort accountAccessPort = mock(AccountAccessPort.class);
+    AccountStatusAccessPort accountStatusAccessPort = mock(AccountStatusAccessPort.class);
+    when(accountAccessPort.findAccessMembership(7L, 70L))
+        .thenReturn(Optional.of(accessMembership(MembershipRole.OWNER, AccountStatus.CLOSED)));
+
+    AccountAccessService accountAccessService =
+        new AccountAccessService(accountAccessPort, accountStatusAccessPort);
+
+    assertThrows(
+        AccountAccessDeniedException.class,
+        () -> accountAccessService.verify(7L, 70L, AccountAccessScope.READ));
+  }
+
+  @Test
+  void allowsBootstrapReadForLockedAccount() {
+    AccountAccessPort accountAccessPort = mock(AccountAccessPort.class);
+    AccountStatusAccessPort accountStatusAccessPort = mock(AccountStatusAccessPort.class);
+    when(accountStatusAccessPort.findAccountStatus(70L))
+        .thenReturn(Optional.of(AccountStatus.LOCKED));
+
+    AccountAccessService accountAccessService =
+        new AccountAccessService(accountAccessPort, accountStatusAccessPort);
+
+    assertEquals(70L, accountAccessService.verifyBootstrapAccount(70L, AccountAccessScope.READ));
+  }
+
+  @Test
+  void rejectsBootstrapTransferForLockedAccount() {
+    AccountAccessPort accountAccessPort = mock(AccountAccessPort.class);
+    AccountStatusAccessPort accountStatusAccessPort = mock(AccountStatusAccessPort.class);
+    when(accountStatusAccessPort.findAccountStatus(70L))
+        .thenReturn(Optional.of(AccountStatus.LOCKED));
+
+    AccountAccessService accountAccessService =
+        new AccountAccessService(accountAccessPort, accountStatusAccessPort);
+
+    assertThrows(
+        AccountAccessDeniedException.class,
+        () -> accountAccessService.verifyBootstrapAccount(70L, AccountAccessScope.TRANSFER));
+  }
+
+  @Test
+  void keepsMissingBootstrapAccountForDownstreamNotFoundHandling() {
+    AccountAccessPort accountAccessPort = mock(AccountAccessPort.class);
+    AccountStatusAccessPort accountStatusAccessPort = mock(AccountStatusAccessPort.class);
+    when(accountStatusAccessPort.findAccountStatus(70L)).thenReturn(Optional.empty());
+
+    AccountAccessService accountAccessService =
+        new AccountAccessService(accountAccessPort, accountStatusAccessPort);
+
+    assertEquals(70L, accountAccessService.verifyBootstrapAccount(70L, AccountAccessScope.READ));
+  }
+
+  private AccountAccessMembership accessMembership(
+      MembershipRole membershipRole, AccountStatus accountStatus) {
+    return new AccountAccessMembership(
+        7L, 70L, membershipRole, MembershipStatus.ACTIVE, UserStatus.ACTIVE, accountStatus);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -215,6 +215,220 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void lockedAccountAllowsReadButBlocksTransferAndReversal() throws Exception {
+    String token = login("alice", "password123!");
+
+    MvcResult bookedTransfer =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers")
+                    .header("Authorization", "Bearer " + token)
+                    .header("X-Request-Id", "jwt-locked-booked-001")
+                    .header("Idempotency-Key", "jwt-locked-booked-001")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "targetAccountId": %d,
+                          "amountMinor": 1500,
+                          "currencyCode": "KRW",
+                          "summary": "rent"
+                        }
+                        """
+                            .formatted(allowedSourceAccountId, targetAccountId)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String transactionReference = transactionReference(bookedTransfer);
+    updateAccountStatus(allowedSourceAccountId, "LOCKED", "account-locked-request");
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts/%d".formatted(allowedSourceAccountId))
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountStatus").value("LOCKED"))
+        .andExpect(jsonPath("$.availableBalanceMinor").value(8500L));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId))
+                .param("from", transactionQueryFrom())
+                .param("to", transactionQueryTo()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/%s".formatted(transactionReference))
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.transactionReference").value(transactionReference));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Authorization", "Bearer " + token)
+                .header("X-Request-Id", "jwt-locked-transfer-403")
+                .header("Idempotency-Key", "jwt-locked-transfer-403")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": 500,
+                      "currencyCode": "KRW",
+                      "summary": "locked-blocked"
+                    }
+                    """
+                        .formatted(allowedSourceAccountId, targetAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers/%s/reversal".formatted(transactionReference))
+                .header("Authorization", "Bearer " + token)
+                .header("X-Request-Id", "jwt-locked-reversal-403")
+                .header("Idempotency-Key", "jwt-locked-reversal-403")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "reversalReason": "CANCEL",
+                      "summary": "locked-reversal-blocked"
+                    }
+                    """
+                        .formatted(allowedSourceAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
+  @Test
+  void closedAccountBlocksReadTransferAndReversal() throws Exception {
+    String token = login("alice", "password123!");
+
+    MvcResult bookedTransfer =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers")
+                    .header("Authorization", "Bearer " + token)
+                    .header("X-Request-Id", "jwt-closed-booked-001")
+                    .header("Idempotency-Key", "jwt-closed-booked-001")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "targetAccountId": %d,
+                          "amountMinor": 1500,
+                          "currencyCode": "KRW",
+                          "summary": "rent"
+                        }
+                        """
+                            .formatted(allowedSourceAccountId, targetAccountId)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String transactionReference = transactionReference(bookedTransfer);
+    updateAccountStatus(allowedSourceAccountId, "CLOSED", "account-closed-request");
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts/%d".formatted(allowedSourceAccountId))
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId))
+                .param("from", transactionQueryFrom())
+                .param("to", transactionQueryTo()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/%s".formatted(transactionReference))
+                .header("Authorization", "Bearer " + token)
+                .param("accountId", String.valueOf(allowedSourceAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Authorization", "Bearer " + token)
+                .header("X-Request-Id", "jwt-closed-transfer-403")
+                .header("Idempotency-Key", "jwt-closed-transfer-403")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": 500,
+                      "currencyCode": "KRW",
+                      "summary": "closed-blocked"
+                    }
+                    """
+                        .formatted(allowedSourceAccountId, targetAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers/%s/reversal".formatted(transactionReference))
+                .header("Authorization", "Bearer " + token)
+                .header("X-Request-Id", "jwt-closed-reversal-403")
+                .header("Idempotency-Key", "jwt-closed-reversal-403")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "reversalReason": "CANCEL",
+                      "summary": "closed-reversal-blocked"
+                    }
+                    """
+                        .formatted(allowedSourceAccountId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
+  @Test
+  void bootstrapAccountPrincipalAllowsLockedReadButRejectsClosedRead() throws Exception {
+    updateAccountStatus(allowedSourceAccountId, "LOCKED", "bootstrap-account-locked-request");
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts/%d".formatted(allowedSourceAccountId))
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountStatus").value("LOCKED"));
+
+    updateAccountStatus(allowedSourceAccountId, "CLOSED", "bootstrap-account-closed-request");
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts/%d".formatted(allowedSourceAccountId))
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
+  @Test
   void transactionDetailReturnsAllowedAccountDataAnd404ForMissingReference() throws Exception {
     String token = login("alice", "password123!");
 
@@ -1543,6 +1757,29 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.userId").value(userId))
         .andExpect(jsonPath("$.userStatus").value(userStatus));
+  }
+
+  private void updateAccountStatus(long accountId, String accountStatus, String requestId)
+      throws Exception {
+    mockMvc
+        .perform(
+            put("/internal/api/v1/accounts/%d/status".formatted(accountId))
+                .header(
+                    "Authorization",
+                    internalServiceAuthorization(
+                        "account-admin", InternalServiceScope.ACCOUNT_ADMIN))
+                .header("X-Request-Id", requestId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "accountStatus": "%s"
+                    }
+                    """
+                        .formatted(accountStatus)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accountId").value(accountId))
+        .andExpect(jsonPath("$.accountStatus").value(accountStatus));
   }
 
   private void updateMembershipStatus(

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 import com.aquilabank.global.security.InternalServiceScope;
 import com.aquilabank.global.security.InternalServiceTokenIssuer;
@@ -211,6 +212,102 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
     assertEquals(0L, idempotencyCount("reversal-003"));
   }
 
+  @Test
+  void rejectsTransferWhenSourceAccountIsLockedWithoutWriteSideEffects() throws Exception {
+    updateAccountStatus(sourceAccountId, "LOCKED", "transfer-locked-request");
+
+    long ledgerCountBefore = totalCount("ledger_entry");
+    long transactionCountBefore = totalCount("transaction_read_model");
+    long outboxCountBefore = totalCount("outbox_event");
+    long idempotencyCountBefore = totalCount("command_idempotency");
+    long sourceBalanceBefore = balanceOf(sourceAccountId);
+    long targetBalanceBefore = balanceOf(targetAccountId);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers")
+                    .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", "transfer-locked-001-request")
+                    .header("Idempotency-Key", "transfer-locked-001")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": 1500,
+                      "currencyCode": "KRW",
+                      "summary": "locked"
+                    }
+                    """
+                            .formatted(sourceAccountId, targetAccountId)))
+            .andReturn();
+
+    assertEquals(403, result.getResponse().getStatus(), result.getResponse().getContentAsString());
+    assertEquals(
+        "account access is denied",
+        objectMapper
+            .readTree(result.getResponse().getContentAsByteArray())
+            .get("message")
+            .asText());
+    assertEquals(ledgerCountBefore, totalCount("ledger_entry"));
+    assertEquals(transactionCountBefore, totalCount("transaction_read_model"));
+    assertEquals(outboxCountBefore, totalCount("outbox_event"));
+    assertEquals(idempotencyCountBefore, totalCount("command_idempotency"));
+    assertEquals(sourceBalanceBefore, balanceOf(sourceAccountId));
+    assertEquals(targetBalanceBefore, balanceOf(targetAccountId));
+  }
+
+  @Test
+  void rejectsReversalWhenSourceAccountIsClosedWithoutWriteSideEffects() throws Exception {
+    TransferResponseView booked = invokeTransfer("transfer-006", targetAccountId, 1_500L, "rent");
+
+    updateAccountStatus(sourceAccountId, "CLOSED", "reversal-closed-request");
+
+    long ledgerCountBefore = totalCount("ledger_entry");
+    long transactionCountBefore = totalCount("transaction_read_model");
+    long outboxCountBefore = totalCount("outbox_event");
+    long idempotencyCountBefore = totalCount("command_idempotency");
+    long reversalCountBefore = transferReversalCount(booked.transactionReference());
+    long sourceBalanceBefore = balanceOf(sourceAccountId);
+    long targetBalanceBefore = balanceOf(targetAccountId);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers/%s/reversal".formatted(booked.transactionReference()))
+                    .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", "reversal-closed-001-request")
+                    .header("Idempotency-Key", "reversal-closed-001")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "reversalReason": "CANCEL",
+                          "summary": "closed"
+                        }
+                        """
+                            .formatted(sourceAccountId)))
+            .andReturn();
+
+    assertEquals(403, result.getResponse().getStatus(), result.getResponse().getContentAsString());
+    assertEquals(
+        "account access is denied",
+        objectMapper
+            .readTree(result.getResponse().getContentAsByteArray())
+            .get("message")
+            .asText());
+    assertEquals(ledgerCountBefore, totalCount("ledger_entry"));
+    assertEquals(transactionCountBefore, totalCount("transaction_read_model"));
+    assertEquals(outboxCountBefore, totalCount("outbox_event"));
+    assertEquals(idempotencyCountBefore, totalCount("command_idempotency"));
+    assertEquals(reversalCountBefore, transferReversalCount(booked.transactionReference()));
+    assertEquals(sourceBalanceBefore, balanceOf(sourceAccountId));
+    assertEquals(targetBalanceBefore, balanceOf(targetAccountId));
+  }
+
   private AccountBootstrapResponseView bootstrapAccount(
       String displayName, long initialBalanceMinor) throws Exception {
     MvcResult result =
@@ -333,6 +430,32 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
 
   private long totalCount(String tableName) {
     return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM " + tableName, Map.of(), Long.class);
+  }
+
+  private void updateAccountStatus(long accountId, String accountStatus, String requestId)
+      throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                put("/internal/api/v1/accounts/%d/status".formatted(accountId))
+                    .header("X-Request-Id", requestId)
+                    .header(
+                        "Authorization",
+                        "Bearer "
+                            + internalServiceTokenIssuer.issue(
+                                "account-admin",
+                                java.util.Set.of(InternalServiceScope.ACCOUNT_ADMIN)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "accountStatus": "%s"
+                        }
+                        """
+                            .formatted(accountStatus)))
+            .andReturn();
+
+    assertEquals(200, result.getResponse().getStatus(), result.getResponse().getContentAsString());
   }
 
   private long balanceOf(long accountId) {


### PR DESCRIPTION
## 🔗 Related Issue
close #142

## 🌿 Base Branch
- `main`

## 📝 Summary
- `bank_account.account_status`를 exact account access 판단에 반영했습니다.
- `LOCKED`는 읽기 허용/송금 차단, `CLOSED`는 읽기/송금 차단으로 정리했습니다.
- JWT user와 bootstrap account principal이 같은 status 매트릭스를 따르도록 맞췄습니다.

## 🛠 Changes
- `AccountAccessScope`에 account status 허용 매트릭스를 추가했습니다.
- auth access 조회 모델과 JDBC 조회에 `account_status`를 포함했습니다.
- bootstrap principal 경로에 exact account status 차단을 연결했습니다.
- JWT user/bootstrap principal의 read/transfer/reversal 상태별 integration 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-account-access ./back/gradlew -p back test --tests '*AccountAccessServiceTest'`
- `tools/test/with-resource-lock.sh back-gradle-account-status-effect ./back/gradlew -p back test --tests '*LoginAndAccountAccessApiIntegrationTest' --tests '*TransferCommandApiIntegrationTest'`
- `./back/gradlew -p back check` (pre-commit hook)
- 상태별 응답 매트릭스와 차단 시 write side effect 미발생을 integration test로 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `CLOSED` read 차단 범위를 exact account access 경로에만 적용했으므로 account list/notification은 후속 정책 정리가 필요합니다.
- 롤백 방법: PR revert로 account status access 정책과 bootstrap 연결을 함께 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?