### PR TITLE
[Feat] forgot-password 토큰 복구 플로우 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -448,6 +448,18 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
   - request body는 `currentPassword`, `newPassword`
   - `currentPassword`가 맞고 `user_status = ACTIVE`일 때만 비밀번호를 새 `BCrypt password_hash`로 교체한다.
   - 성공 시 현재 user의 `ACTIVE` refresh session 전체를 `REVOKED`로 바꾼다.
+- forgot-password 복구 기준:
+  - `POST /api/v1/auth/password-recovery/request`
+  - 인증 없이 `loginId`만 받고 항상 `204 No Content`를 반환한다.
+  - 응답에는 trace용 `X-Request-Id`와 별도로 internal handoff용 `X-Password-Recovery-Request-Id`가 내려간다.
+  - active user가 있으면 같은 user의 기존 `PENDING` recovery token을 `SUPERSEDED`로 바꾸고 새 token을 발급한다.
+  - `POST /api/v1/auth/password-recovery/confirm`
+  - 인증 없이 `recoveryToken`, `newPassword`를 받고 성공 시 `204 No Content`
+  - wrong/expired/used token, `user_status != ACTIVE`는 모두 `401 password recovery failed`
+  - recovery token 값은 public 응답에 직접 노출하지 않고
+    `GET /internal/api/v1/auth/password-recovery-tokens/by-request-id?requestId=...` 에서만 확인한다.
+  - internal lookup은 `internal:auth-admin` scope가 필요하고, missing/blank `requestId`는 `400`, unknown `requestId`는 `404`
+  - forgot-password confirm 성공도 기존 self-service reset과 동일하게 현재 user의 `ACTIVE` refresh session 전체를 `REVOKED`로 바꾼다.
 - 거절 기준:
   - 만료, 이미 rotation 된 token, 존재하지 않는 token은 모두 `401 refresh failed`
   - `user_status=LOCKED|DISABLED` 사용자는 refresh로 새 token pair를 발급받지 못함

--- a/back/src/main/java/com/aquilabank/domain/auth/exception/PasswordRecoveryTokenNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/PasswordRecoveryTokenNotFoundException.java
@@ -1,6 +1,6 @@
 package com.aquilabank.domain.auth.exception;
 
-/** requestId 기반 recovery token 조회 실패를 나타내는 예외입니다. */
+/** recovery handoff requestId 기반 token 조회 실패를 나타내는 예외입니다. */
 public class PasswordRecoveryTokenNotFoundException extends RuntimeException {
 
   public PasswordRecoveryTokenNotFoundException(String message) {

--- a/back/src/main/java/com/aquilabank/domain/auth/exception/PasswordRecoveryTokenNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/PasswordRecoveryTokenNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.exception;
+
+/** requestId 기반 recovery token 조회 실패를 나타내는 예외입니다. */
+public class PasswordRecoveryTokenNotFoundException extends RuntimeException {
+
+  public PasswordRecoveryTokenNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/GeneratedPasswordRecoveryToken.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/GeneratedPasswordRecoveryToken.java
@@ -1,0 +1,21 @@
+package com.aquilabank.domain.auth.model;
+
+/** recovery token 생성과 보호 저장값을 함께 담는 결과입니다. */
+public record GeneratedPasswordRecoveryToken(
+    String plainToken, String tokenHash, String tokenCiphertext, String tokenNonce) {
+
+  public GeneratedPasswordRecoveryToken {
+    if (plainToken == null || plainToken.isBlank()) {
+      throw new IllegalArgumentException("plainToken is required");
+    }
+    if (tokenHash == null || tokenHash.isBlank()) {
+      throw new IllegalArgumentException("tokenHash is required");
+    }
+    if (tokenCiphertext == null || tokenCiphertext.isBlank()) {
+      throw new IllegalArgumentException("tokenCiphertext is required");
+    }
+    if (tokenNonce == null || tokenNonce.isBlank()) {
+      throw new IllegalArgumentException("tokenNonce is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryConfirmCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryConfirmCommand.java
@@ -1,0 +1,20 @@
+package com.aquilabank.domain.auth.model;
+
+/** recovery token으로 새 password를 확정할 때 쓰는 입력입니다. */
+public record PasswordRecoveryConfirmCommand(String recoveryToken, String newPassword) {
+
+  public PasswordRecoveryConfirmCommand {
+    if (recoveryToken == null || recoveryToken.isBlank()) {
+      throw new IllegalArgumentException("recoveryToken is required");
+    }
+    if (recoveryToken.length() > 160) {
+      throw new IllegalArgumentException("recoveryToken must be 160 characters or less");
+    }
+    if (newPassword == null || newPassword.isBlank()) {
+      throw new IllegalArgumentException("newPassword is required");
+    }
+    if (newPassword.length() > 120) {
+      throw new IllegalArgumentException("newPassword must be 120 characters or less");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryRequestCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryRequestCommand.java
@@ -1,7 +1,7 @@
 package com.aquilabank.domain.auth.model;
 
 /** 비로그인 password recovery 요청 입력입니다. */
-public record PasswordRecoveryRequestCommand(String loginId, String requestId) {
+public record PasswordRecoveryRequestCommand(String loginId) {
 
   public PasswordRecoveryRequestCommand {
     if (loginId == null || loginId.isBlank()) {
@@ -9,12 +9,6 @@ public record PasswordRecoveryRequestCommand(String loginId, String requestId) {
     }
     if (loginId.length() > 80) {
       throw new IllegalArgumentException("loginId must be 80 characters or less");
-    }
-    if (requestId == null || requestId.isBlank()) {
-      throw new IllegalArgumentException("requestId is required");
-    }
-    if (requestId.length() > 64) {
-      throw new IllegalArgumentException("requestId must be 64 characters or less");
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryRequestCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryRequestCommand.java
@@ -1,0 +1,20 @@
+package com.aquilabank.domain.auth.model;
+
+/** 비로그인 password recovery 요청 입력입니다. */
+public record PasswordRecoveryRequestCommand(String loginId, String requestId) {
+
+  public PasswordRecoveryRequestCommand {
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (loginId.length() > 80) {
+      throw new IllegalArgumentException("loginId must be 80 characters or less");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (requestId.length() > 64) {
+      throw new IllegalArgumentException("requestId must be 64 characters or less");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryRequestResult.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryRequestResult.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** public request 뒤 클라이언트가 전달받는 recovery handoff requestId 결과입니다. */
+public record PasswordRecoveryRequestResult(String handoffRequestId) {
+
+  public PasswordRecoveryRequestResult {
+    if (handoffRequestId == null || handoffRequestId.isBlank()) {
+      throw new IllegalArgumentException("handoffRequestId is required");
+    }
+    if (handoffRequestId.length() > 64) {
+      throw new IllegalArgumentException("handoffRequestId must be 64 characters or less");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenIssueCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenIssueCommand.java
@@ -1,0 +1,48 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** recovery token 발급 저장에 필요한 최소 write 모델입니다. */
+public record PasswordRecoveryTokenIssueCommand(
+    String requestId,
+    long userId,
+    String loginId,
+    String tokenHash,
+    String tokenCiphertext,
+    String tokenNonce,
+    Instant expiresAt,
+    Instant createdAt) {
+
+  public PasswordRecoveryTokenIssueCommand {
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (requestId.length() > 64) {
+      throw new IllegalArgumentException("requestId must be 64 characters or less");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (loginId.length() > 80) {
+      throw new IllegalArgumentException("loginId must be 80 characters or less");
+    }
+    if (tokenHash == null || tokenHash.isBlank()) {
+      throw new IllegalArgumentException("tokenHash is required");
+    }
+    if (tokenCiphertext == null || tokenCiphertext.isBlank()) {
+      throw new IllegalArgumentException("tokenCiphertext is required");
+    }
+    if (tokenNonce == null || tokenNonce.isBlank()) {
+      throw new IllegalArgumentException("tokenNonce is required");
+    }
+    if (expiresAt == null) {
+      throw new IllegalArgumentException("expiresAt is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenLookupView.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenLookupView.java
@@ -1,0 +1,48 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 내부 exact lookup 전용 recovery token 조회 모델입니다. */
+public record PasswordRecoveryTokenLookupView(
+    String requestId,
+    long userId,
+    String loginId,
+    String recoveryToken,
+    PasswordRecoveryTokenStatus tokenStatus,
+    Instant expiresAt,
+    Instant usedAt,
+    Instant createdAt) {
+
+  public PasswordRecoveryTokenLookupView {
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (requestId.length() > 64) {
+      throw new IllegalArgumentException("requestId must be 64 characters or less");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (loginId.length() > 80) {
+      throw new IllegalArgumentException("loginId must be 80 characters or less");
+    }
+    if (recoveryToken == null || recoveryToken.isBlank()) {
+      throw new IllegalArgumentException("recoveryToken is required");
+    }
+    if (recoveryToken.length() > 160) {
+      throw new IllegalArgumentException("recoveryToken must be 160 characters or less");
+    }
+    if (tokenStatus == null) {
+      throw new IllegalArgumentException("tokenStatus is required");
+    }
+    if (expiresAt == null) {
+      throw new IllegalArgumentException("expiresAt is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenQueryRecord.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenQueryRecord.java
@@ -1,0 +1,49 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** requestId exact lookup 응답에 필요한 조회 모델입니다. */
+public record PasswordRecoveryTokenQueryRecord(
+    String requestId,
+    long userId,
+    String loginId,
+    String tokenCiphertext,
+    String tokenNonce,
+    PasswordRecoveryTokenStatus tokenStatus,
+    Instant expiresAt,
+    Instant usedAt,
+    Instant createdAt) {
+
+  public PasswordRecoveryTokenQueryRecord {
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (requestId.length() > 64) {
+      throw new IllegalArgumentException("requestId must be 64 characters or less");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (loginId.length() > 80) {
+      throw new IllegalArgumentException("loginId must be 80 characters or less");
+    }
+    if (tokenCiphertext == null || tokenCiphertext.isBlank()) {
+      throw new IllegalArgumentException("tokenCiphertext is required");
+    }
+    if (tokenNonce == null || tokenNonce.isBlank()) {
+      throw new IllegalArgumentException("tokenNonce is required");
+    }
+    if (tokenStatus == null) {
+      throw new IllegalArgumentException("tokenStatus is required");
+    }
+    if (expiresAt == null) {
+      throw new IllegalArgumentException("expiresAt is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenRecord.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenRecord.java
@@ -1,0 +1,37 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 토큰 exact lookup과 만료 판단에 필요한 최소 조회 모델입니다. */
+public record PasswordRecoveryTokenRecord(
+    long tokenId,
+    long userId,
+    String loginId,
+    String tokenHash,
+    PasswordRecoveryTokenStatus tokenStatus,
+    Instant expiresAt) {
+
+  public PasswordRecoveryTokenRecord {
+    if (tokenId <= 0) {
+      throw new IllegalArgumentException("tokenId must be positive");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (loginId == null || loginId.isBlank()) {
+      throw new IllegalArgumentException("loginId is required");
+    }
+    if (loginId.length() > 80) {
+      throw new IllegalArgumentException("loginId must be 80 characters or less");
+    }
+    if (tokenHash == null || tokenHash.isBlank()) {
+      throw new IllegalArgumentException("tokenHash is required");
+    }
+    if (tokenStatus == null) {
+      throw new IllegalArgumentException("tokenStatus is required");
+    }
+    if (expiresAt == null) {
+      throw new IllegalArgumentException("expiresAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenStatus.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.model;
+
+/** password recovery token 상태를 고정값으로 관리합니다. */
+public enum PasswordRecoveryTokenStatus {
+  PENDING,
+  USED,
+  EXPIRED,
+  SUPERSEDED
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenUseCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryTokenUseCommand.java
@@ -1,0 +1,16 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** recovery token 사용 처리에 필요한 최소 write 모델입니다. */
+public record PasswordRecoveryTokenUseCommand(long tokenId, Instant usedAt) {
+
+  public PasswordRecoveryTokenUseCommand {
+    if (tokenId <= 0) {
+      throw new IllegalArgumentException("tokenId must be positive");
+    }
+    if (usedAt == null) {
+      throw new IllegalArgumentException("usedAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoverySecretPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoverySecretPort.java
@@ -1,0 +1,13 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.GeneratedPasswordRecoveryToken;
+
+/** recovery token 생성과 조회용 복호화를 security adapter로 분리합니다. */
+public interface PasswordRecoverySecretPort {
+
+  GeneratedPasswordRecoveryToken generate();
+
+  String hash(String plainToken);
+
+  String reveal(String tokenCiphertext, String tokenNonce);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryTokenLoadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryTokenLoadPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenRecord;
+import java.util.Optional;
+
+/** tokenHash exact lookup을 위한 읽기 경로입니다. */
+public interface PasswordRecoveryTokenLoadPort {
+
+  Optional<PasswordRecoveryTokenRecord> findByTokenHashForUpdate(String tokenHash);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryTokenQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryTokenQueryPort.java
@@ -3,8 +3,8 @@ package com.aquilabank.domain.auth.port;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenQueryRecord;
 import java.util.Optional;
 
-/** requestId exact lookup을 위한 조회 경로입니다. */
+/** recovery handoff requestId exact lookup을 위한 조회 경로입니다. */
 public interface PasswordRecoveryTokenQueryPort {
 
-  Optional<PasswordRecoveryTokenQueryRecord> findByRequestId(String requestId);
+  Optional<PasswordRecoveryTokenQueryRecord> findByRequestId(String handoffRequestId);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryTokenQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryTokenQueryPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenQueryRecord;
+import java.util.Optional;
+
+/** requestId exact lookup을 위한 조회 경로입니다. */
+public interface PasswordRecoveryTokenQueryPort {
+
+  Optional<PasswordRecoveryTokenQueryRecord> findByRequestId(String requestId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryTokenWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryTokenWritePort.java
@@ -1,0 +1,17 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenIssueCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenUseCommand;
+import java.time.Instant;
+
+/** recovery token의 supersede, issue, 사용 처리를 write port로 분리합니다. */
+public interface PasswordRecoveryTokenWritePort {
+
+  void supersedePendingTokens(long userId, Instant updatedAt);
+
+  void issue(PasswordRecoveryTokenIssueCommand command);
+
+  void markUsed(PasswordRecoveryTokenUseCommand command);
+
+  void markExpired(long tokenId, Instant expiredAt);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryConfirmService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryConfirmService.java
@@ -79,7 +79,8 @@ public final class PasswordRecoveryConfirmService implements PasswordRecoveryCon
     userCredentialUpdatePort.resetPassword(
         new PasswordResetWriteCommand(
             user.userId(), passwordHashPort.encode(command.newPassword()), now));
-    passwordRecoveryTokenWritePort.markUsed(new PasswordRecoveryTokenUseCommand(token.tokenId(), now));
+    passwordRecoveryTokenWritePort.markUsed(
+        new PasswordRecoveryTokenUseCommand(token.tokenId(), now));
     // recovery 완료 뒤 기존 refresh session 전체 revoke로 이전 세션 재사용을 막습니다.
     refreshTokenSessionWritePort.revokeActiveSessionsByUserId(user.userId(), now);
   }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryConfirmService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryConfirmService.java
@@ -1,0 +1,86 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.PasswordRecoveryConfirmCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenRecord;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenStatus;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenUseCommand;
+import com.aquilabank.domain.auth.model.PasswordResetWriteCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenLoadPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenWritePort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.port.UserCredentialUpdatePort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** recovery token 단건 검증 뒤 password reset과 session revoke를 같이 처리합니다. */
+public final class PasswordRecoveryConfirmService implements PasswordRecoveryConfirmUseCase {
+
+  private static final String FAILURE_MESSAGE = "password recovery failed";
+
+  private final PasswordRecoverySecretPort passwordRecoverySecretPort;
+  private final PasswordRecoveryTokenLoadPort passwordRecoveryTokenLoadPort;
+  private final PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort;
+  private final UserCredentialLoadPort userCredentialLoadPort;
+  private final UserCredentialUpdatePort userCredentialUpdatePort;
+  private final PasswordHashPort passwordHashPort;
+  private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
+  private final Clock clock;
+
+  public PasswordRecoveryConfirmService(
+      PasswordRecoverySecretPort passwordRecoverySecretPort,
+      PasswordRecoveryTokenLoadPort passwordRecoveryTokenLoadPort,
+      PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort,
+      UserCredentialLoadPort userCredentialLoadPort,
+      UserCredentialUpdatePort userCredentialUpdatePort,
+      PasswordHashPort passwordHashPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      Clock clock) {
+    this.passwordRecoverySecretPort = passwordRecoverySecretPort;
+    this.passwordRecoveryTokenLoadPort = passwordRecoveryTokenLoadPort;
+    this.passwordRecoveryTokenWritePort = passwordRecoveryTokenWritePort;
+    this.userCredentialLoadPort = userCredentialLoadPort;
+    this.userCredentialUpdatePort = userCredentialUpdatePort;
+    this.passwordHashPort = passwordHashPort;
+    this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
+    this.clock = clock;
+  }
+
+  @Override
+  public void confirm(PasswordRecoveryConfirmCommand command) {
+    Instant now = Instant.now(clock);
+    String tokenHash = passwordRecoverySecretPort.hash(command.recoveryToken());
+    PasswordRecoveryTokenRecord token =
+        passwordRecoveryTokenLoadPort
+            .findByTokenHashForUpdate(tokenHash)
+            .orElseThrow(() -> new InvalidCredentialsException(FAILURE_MESSAGE));
+
+    if (token.tokenStatus() != PasswordRecoveryTokenStatus.PENDING) {
+      throw new InvalidCredentialsException(FAILURE_MESSAGE);
+    }
+    if (!token.expiresAt().isAfter(now)) {
+      passwordRecoveryTokenWritePort.markExpired(token.tokenId(), now);
+      throw new InvalidCredentialsException(FAILURE_MESSAGE);
+    }
+
+    LoginUser user =
+        userCredentialLoadPort
+            .findByUserIdForUpdate(token.userId())
+            .orElseThrow(() -> new InvalidCredentialsException(FAILURE_MESSAGE));
+    if (user.status() != UserStatus.ACTIVE) {
+      throw new InvalidCredentialsException(FAILURE_MESSAGE);
+    }
+
+    userCredentialUpdatePort.resetPassword(
+        new PasswordResetWriteCommand(
+            user.userId(), passwordHashPort.encode(command.newPassword()), now));
+    passwordRecoveryTokenWritePort.markUsed(new PasswordRecoveryTokenUseCommand(token.tokenId(), now));
+    // recovery 완료 뒤 기존 refresh session 전체 revoke로 이전 세션 재사용을 막습니다.
+    refreshTokenSessionWritePort.revokeActiveSessionsByUserId(user.userId(), now);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryConfirmUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryConfirmUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryConfirmCommand;
+
+/** recovery token으로 새 password를 확정하는 진입점입니다. */
+public interface PasswordRecoveryConfirmUseCase {
+
+  void confirm(PasswordRecoveryConfirmCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestService.java
@@ -1,0 +1,71 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.GeneratedPasswordRecoveryToken;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.PasswordRecoveryRequestCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenIssueCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenWritePort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.port.UserQueryPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+/** 사용자 존재 노출 없이 recovery token 발급과 pending supersede를 묶습니다. */
+public final class PasswordRecoveryRequestService implements PasswordRecoveryRequestUseCase {
+
+  private final UserQueryPort userQueryPort;
+  private final UserCredentialLoadPort userCredentialLoadPort;
+  private final PasswordRecoverySecretPort passwordRecoverySecretPort;
+  private final PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort;
+  private final Duration ttl;
+  private final Clock clock;
+
+  public PasswordRecoveryRequestService(
+      UserQueryPort userQueryPort,
+      UserCredentialLoadPort userCredentialLoadPort,
+      PasswordRecoverySecretPort passwordRecoverySecretPort,
+      PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort,
+      Duration ttl,
+      Clock clock) {
+    this.userQueryPort = userQueryPort;
+    this.userCredentialLoadPort = userCredentialLoadPort;
+    this.passwordRecoverySecretPort = passwordRecoverySecretPort;
+    this.passwordRecoveryTokenWritePort = passwordRecoveryTokenWritePort;
+    this.ttl = ttl;
+    this.clock = clock;
+  }
+
+  @Override
+  public void request(PasswordRecoveryRequestCommand command) {
+    AuthUserSummary user = userQueryPort.findSummaryByLoginId(command.loginId()).orElse(null);
+    if (user == null || user.status() != UserStatus.ACTIVE) {
+      return;
+    }
+
+    LoginUser lockedUser =
+        userCredentialLoadPort.findByLoginIdForUpdate(command.loginId()).orElse(null);
+    if (lockedUser == null || lockedUser.status() != UserStatus.ACTIVE) {
+      return;
+    }
+
+    GeneratedPasswordRecoveryToken generatedToken = passwordRecoverySecretPort.generate();
+    Instant issuedAt = Instant.now(clock);
+    Instant expiresAt = issuedAt.plus(ttl);
+
+    passwordRecoveryTokenWritePort.supersedePendingTokens(lockedUser.userId(), issuedAt);
+    passwordRecoveryTokenWritePort.issue(
+        new PasswordRecoveryTokenIssueCommand(
+            command.requestId(),
+            lockedUser.userId(),
+            lockedUser.loginId(),
+            generatedToken.tokenHash(),
+            generatedToken.tokenCiphertext(),
+            generatedToken.tokenNonce(),
+            expiresAt,
+            issuedAt));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestService.java
@@ -4,6 +4,7 @@ import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.GeneratedPasswordRecoveryToken;
 import com.aquilabank.domain.auth.model.LoginUser;
 import com.aquilabank.domain.auth.model.PasswordRecoveryRequestCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryRequestResult;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenIssueCommand;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
@@ -13,6 +14,7 @@ import com.aquilabank.domain.auth.port.UserQueryPort;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.UUID;
 
 /** 사용자 존재 노출 없이 recovery token 발급과 pending supersede를 묶습니다. */
 public final class PasswordRecoveryRequestService implements PasswordRecoveryRequestUseCase {
@@ -40,16 +42,17 @@ public final class PasswordRecoveryRequestService implements PasswordRecoveryReq
   }
 
   @Override
-  public void request(PasswordRecoveryRequestCommand command) {
+  public PasswordRecoveryRequestResult request(PasswordRecoveryRequestCommand command) {
+    String handoffRequestId = UUID.randomUUID().toString();
     AuthUserSummary user = userQueryPort.findSummaryByLoginId(command.loginId()).orElse(null);
     if (user == null || user.status() != UserStatus.ACTIVE) {
-      return;
+      return new PasswordRecoveryRequestResult(handoffRequestId);
     }
 
     LoginUser lockedUser =
         userCredentialLoadPort.findByLoginIdForUpdate(command.loginId()).orElse(null);
     if (lockedUser == null || lockedUser.status() != UserStatus.ACTIVE) {
-      return;
+      return new PasswordRecoveryRequestResult(handoffRequestId);
     }
 
     GeneratedPasswordRecoveryToken generatedToken = passwordRecoverySecretPort.generate();
@@ -59,7 +62,7 @@ public final class PasswordRecoveryRequestService implements PasswordRecoveryReq
     passwordRecoveryTokenWritePort.supersedePendingTokens(lockedUser.userId(), issuedAt);
     passwordRecoveryTokenWritePort.issue(
         new PasswordRecoveryTokenIssueCommand(
-            command.requestId(),
+            handoffRequestId,
             lockedUser.userId(),
             lockedUser.loginId(),
             generatedToken.tokenHash(),
@@ -67,5 +70,6 @@ public final class PasswordRecoveryRequestService implements PasswordRecoveryReq
             generatedToken.tokenNonce(),
             expiresAt,
             issuedAt));
+    return new PasswordRecoveryRequestResult(handoffRequestId);
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestUseCase.java
@@ -1,9 +1,10 @@
 package com.aquilabank.domain.auth.usecase;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryRequestCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryRequestResult;
 
 /** 비로그인 password recovery 요청 진입점입니다. */
 public interface PasswordRecoveryRequestUseCase {
 
-  void request(PasswordRecoveryRequestCommand command);
+  PasswordRecoveryRequestResult request(PasswordRecoveryRequestCommand command);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryRequestCommand;
+
+/** 비로그인 password recovery 요청 진입점입니다. */
+public interface PasswordRecoveryRequestUseCase {
+
+  void request(PasswordRecoveryRequestCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryTokenQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryTokenQueryService.java
@@ -1,0 +1,48 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.PasswordRecoveryTokenNotFoundException;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenLookupView;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenQueryRecord;
+import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenQueryPort;
+
+/** recovery handoff requestId exact lookup 뒤 저장된 token을 복호화해 돌려줍니다. */
+public final class PasswordRecoveryTokenQueryService implements PasswordRecoveryTokenQueryUseCase {
+
+  private static final String NOT_FOUND_MESSAGE = "password recovery token is not found";
+
+  private final PasswordRecoveryTokenQueryPort passwordRecoveryTokenQueryPort;
+  private final PasswordRecoverySecretPort passwordRecoverySecretPort;
+
+  public PasswordRecoveryTokenQueryService(
+      PasswordRecoveryTokenQueryPort passwordRecoveryTokenQueryPort,
+      PasswordRecoverySecretPort passwordRecoverySecretPort) {
+    this.passwordRecoveryTokenQueryPort = passwordRecoveryTokenQueryPort;
+    this.passwordRecoverySecretPort = passwordRecoverySecretPort;
+  }
+
+  @Override
+  public PasswordRecoveryTokenLookupView getByHandoffRequestId(String handoffRequestId) {
+    if (handoffRequestId == null || handoffRequestId.isBlank()) {
+      throw new IllegalArgumentException("handoffRequestId is required");
+    }
+
+    PasswordRecoveryTokenQueryRecord record =
+        passwordRecoveryTokenQueryPort
+            .findByRequestId(handoffRequestId)
+            .orElseThrow(() -> new PasswordRecoveryTokenNotFoundException(NOT_FOUND_MESSAGE));
+
+    String recoveryToken =
+        passwordRecoverySecretPort.reveal(record.tokenCiphertext(), record.tokenNonce());
+
+    return new PasswordRecoveryTokenLookupView(
+        record.requestId(),
+        record.userId(),
+        record.loginId(),
+        recoveryToken,
+        record.tokenStatus(),
+        record.expiresAt(),
+        record.usedAt(),
+        record.createdAt());
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryTokenQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryTokenQueryUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenLookupView;
+
+/** 내부 recovery handoff requestId exact lookup 전용 진입점입니다. */
+public interface PasswordRecoveryTokenQueryUseCase {
+
+  PasswordRecoveryTokenLookupView getByHandoffRequestId(String handoffRequestId);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -12,6 +12,9 @@ import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenLoadPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenQueryPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
@@ -44,6 +47,12 @@ import com.aquilabank.domain.auth.usecase.LoginService;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutService;
 import com.aquilabank.domain.auth.usecase.LogoutUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryConfirmService;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryConfirmUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryRequestService;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryRequestUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryTokenQueryService;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryTokenQueryUseCase;
 import com.aquilabank.domain.auth.usecase.PasswordResetService;
 import com.aquilabank.domain.auth.usecase.PasswordResetUseCase;
 import com.aquilabank.domain.auth.usecase.RefreshTokenService;
@@ -62,7 +71,9 @@ import com.aquilabank.domain.auth.usecase.UserBootstrapService;
 import com.aquilabank.domain.auth.usecase.UserBootstrapUseCase;
 import com.aquilabank.domain.auth.usecase.UserStatusUpdateService;
 import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
+import com.aquilabank.global.persistence.auth.JdbcPasswordRecoveryRepository;
 import com.aquilabank.global.security.LoginProtectionProperties;
+import com.aquilabank.global.security.PasswordRecoveryProperties;
 import com.aquilabank.global.security.SecurityJwtProperties;
 import com.aquilabank.global.security.SecurityTotpProperties;
 import com.aquilabank.global.security.StructuredLoginAttemptAuditLogger;
@@ -70,6 +81,7 @@ import java.time.Clock;
 import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -94,6 +106,12 @@ public class AuthConfiguration {
   @Bean
   Clock authClock() {
     return Clock.systemUTC();
+  }
+
+  @Bean
+  JdbcPasswordRecoveryRepository jdbcPasswordRecoveryRepository(
+      NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+    return new JdbcPasswordRecoveryRepository(namedParameterJdbcTemplate);
   }
 
   @Bean
@@ -311,6 +329,83 @@ public class AuthConfiguration {
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
     return command ->
         transactionTemplate.executeWithoutResult(status -> passwordResetService.reset(command));
+  }
+
+  @Bean
+  PasswordRecoveryRequestUseCase passwordRecoveryRequestUseCase(
+      UserQueryPort userQueryPort,
+      UserCredentialLoadPort userCredentialLoadPort,
+      PasswordRecoverySecretPort passwordRecoverySecretPort,
+      com.aquilabank.domain.auth.port.PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort,
+      PasswordRecoveryProperties passwordRecoveryProperties,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    PasswordRecoveryRequestService passwordRecoveryRequestService =
+        new PasswordRecoveryRequestService(
+            userQueryPort,
+            userCredentialLoadPort,
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenWritePort,
+            Duration.ofSeconds(passwordRecoveryProperties.ttlSeconds()),
+            authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command -> {
+      com.aquilabank.domain.auth.model.PasswordRecoveryRequestResult result =
+          transactionTemplate.execute(status -> passwordRecoveryRequestService.request(command));
+      if (result == null) {
+        throw new IllegalStateException(
+            "password recovery request transaction returned null result");
+      }
+      return result;
+    };
+  }
+
+  @Bean
+  PasswordRecoveryConfirmUseCase passwordRecoveryConfirmUseCase(
+      PasswordRecoverySecretPort passwordRecoverySecretPort,
+      PasswordRecoveryTokenLoadPort passwordRecoveryTokenLoadPort,
+      com.aquilabank.domain.auth.port.PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort,
+      UserCredentialLoadPort userCredentialLoadPort,
+      UserCredentialUpdatePort userCredentialUpdatePort,
+      PasswordHashPort passwordHashPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    PasswordRecoveryConfirmService passwordRecoveryConfirmService =
+        new PasswordRecoveryConfirmService(
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenLoadPort,
+            passwordRecoveryTokenWritePort,
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command ->
+        transactionTemplate.executeWithoutResult(
+            status -> passwordRecoveryConfirmService.confirm(command));
+  }
+
+  @Bean
+  PasswordRecoveryTokenQueryUseCase passwordRecoveryTokenQueryUseCase(
+      PasswordRecoveryTokenQueryPort passwordRecoveryTokenQueryPort,
+      PasswordRecoverySecretPort passwordRecoverySecretPort,
+      PlatformTransactionManager platformTransactionManager) {
+    PasswordRecoveryTokenQueryService passwordRecoveryTokenQueryService =
+        new PasswordRecoveryTokenQueryService(
+            passwordRecoveryTokenQueryPort, passwordRecoverySecretPort);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return handoffRequestId -> {
+      com.aquilabank.domain.auth.model.PasswordRecoveryTokenLookupView result =
+          transactionTemplate.execute(
+              status -> passwordRecoveryTokenQueryService.getByHandoffRequestId(handoffRequestId));
+      if (result == null) {
+        throw new IllegalStateException(
+            "password recovery token query transaction returned null result");
+      }
+      return result;
+    };
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -9,6 +9,8 @@ import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.LoginFailureUpdateCommand;
 import com.aquilabank.domain.auth.model.LoginSuccessUpdateCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenIssueCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenUseCommand;
 import com.aquilabank.domain.auth.model.PasswordResetWriteCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRevokeCommand;
@@ -27,6 +29,7 @@ import com.aquilabank.domain.auth.model.UserBootstrapWriteCommand;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenWritePort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionCleanupPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
 import com.aquilabank.domain.auth.port.TotpCredentialWritePort;
@@ -51,6 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcAuthWriteRepository
     implements UserBootstrapPort,
         LoginAttemptUpdatePort,
+        PasswordRecoveryTokenWritePort,
         UserCredentialUpdatePort,
         RefreshTokenSessionCleanupPort,
         RefreshTokenSessionWritePort,
@@ -174,6 +178,112 @@ public class JdbcAuthWriteRepository
                 .addValue("passwordHash", command.passwordHash())
                 .addValue("changedAt", Timestamp.from(command.changedAt())));
     assertUserUpdated(updated);
+  }
+
+  @Override
+  @Transactional
+  public void supersedePendingTokens(long userId, Instant updatedAt) {
+    jdbcTemplate.update(
+        """
+        UPDATE auth_password_recovery_token
+        SET token_status = 'SUPERSEDED',
+            updated_at = :updatedAt
+        WHERE user_id = :userId
+          AND token_status = 'PENDING'
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("updatedAt", Timestamp.from(updatedAt)));
+  }
+
+  @Override
+  @Transactional
+  public void issue(PasswordRecoveryTokenIssueCommand command) {
+    Long tokenId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO auth_password_recovery_token (
+                request_id,
+                user_id,
+                login_id,
+                token_hash,
+                token_ciphertext,
+                token_nonce,
+                token_status,
+                expires_at,
+                used_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :requestId,
+                :userId,
+                :loginId,
+                :tokenHash,
+                :tokenCiphertext,
+                :tokenNonce,
+                'PENDING',
+                :expiresAt,
+                NULL,
+                :createdAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("requestId", command.requestId())
+                .addValue("userId", command.userId())
+                .addValue("loginId", command.loginId())
+                .addValue("tokenHash", command.tokenHash())
+                .addValue("tokenCiphertext", command.tokenCiphertext())
+                .addValue("tokenNonce", command.tokenNonce())
+                .addValue("expiresAt", Timestamp.from(command.expiresAt()))
+                .addValue("createdAt", Timestamp.from(command.createdAt())),
+            Long.class);
+    if (tokenId == null) {
+      throw new IllegalStateException("password recovery token insert did not return an id");
+    }
+  }
+
+  @Override
+  @Transactional
+  public void markUsed(PasswordRecoveryTokenUseCommand command) {
+    int updated =
+        jdbcTemplate.update(
+            """
+            UPDATE auth_password_recovery_token
+            SET token_status = 'USED',
+                used_at = :usedAt,
+                updated_at = :usedAt
+            WHERE id = :tokenId
+              AND token_status = 'PENDING'
+            """,
+            new MapSqlParameterSource()
+                .addValue("tokenId", command.tokenId())
+                .addValue("usedAt", Timestamp.from(command.usedAt())));
+    if (updated != 1) {
+      throw new IllegalStateException("password recovery token is not pending");
+    }
+  }
+
+  @Override
+  @Transactional
+  public void markExpired(long tokenId, Instant expiredAt) {
+    int updated =
+        jdbcTemplate.update(
+            """
+            UPDATE auth_password_recovery_token
+            SET token_status = 'EXPIRED',
+                updated_at = :expiredAt
+            WHERE id = :tokenId
+              AND token_status = 'PENDING'
+            """,
+            new MapSqlParameterSource()
+                .addValue("tokenId", tokenId)
+                .addValue("expiredAt", Timestamp.from(expiredAt)));
+    if (updated != 1) {
+      throw new IllegalStateException("password recovery token is not pending");
+    }
   }
 
   @Override

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcPasswordRecoveryRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcPasswordRecoveryRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-/** password recovery token exact lookup과 requestId 조회를 전용 JDBC adapter로 분리합니다. */
+/** password recovery token exact lookup과 handoff requestId 조회를 전용 JDBC adapter로 분리합니다. */
 public class JdbcPasswordRecoveryRepository
     implements PasswordRecoveryTokenLoadPort, PasswordRecoveryTokenQueryPort {
 
@@ -47,7 +47,7 @@ public class JdbcPasswordRecoveryRepository
   }
 
   @Override
-  public Optional<PasswordRecoveryTokenQueryRecord> findByRequestId(String requestId) {
+  public Optional<PasswordRecoveryTokenQueryRecord> findByRequestId(String handoffRequestId) {
     return jdbcTemplate
         .query(
             """
@@ -63,7 +63,7 @@ public class JdbcPasswordRecoveryRepository
             FROM auth_password_recovery_token
             WHERE request_id = :requestId
             """,
-            new MapSqlParameterSource().addValue("requestId", requestId),
+            new MapSqlParameterSource().addValue("requestId", handoffRequestId),
             (rs, rowNum) -> mapPasswordRecoveryTokenQueryRecord(rs))
         .stream()
         .findFirst();

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcPasswordRecoveryRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcPasswordRecoveryRepository.java
@@ -1,0 +1,107 @@
+package com.aquilabank.global.persistence.auth;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenQueryRecord;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenRecord;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenStatus;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenLoadPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenQueryPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/** password recovery token exact lookup과 requestId 조회를 전용 JDBC adapter로 분리합니다. */
+public class JdbcPasswordRecoveryRepository
+    implements PasswordRecoveryTokenLoadPort, PasswordRecoveryTokenQueryPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcPasswordRecoveryRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public Optional<PasswordRecoveryTokenRecord> findByTokenHashForUpdate(String tokenHash) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT t.id,
+                   t.user_id,
+                   u.login_id,
+                   t.token_hash,
+                   t.token_status,
+                   t.expires_at
+            FROM auth_password_recovery_token t
+            JOIN bank_user u
+              ON u.id = t.user_id
+            WHERE t.token_hash = :tokenHash
+            FOR UPDATE OF t
+            """,
+            new MapSqlParameterSource().addValue("tokenHash", tokenHash),
+            (rs, rowNum) -> mapPasswordRecoveryTokenRecord(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<PasswordRecoveryTokenQueryRecord> findByRequestId(String requestId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT request_id,
+                   user_id,
+                   login_id,
+                   token_ciphertext,
+                   token_nonce,
+                   token_status,
+                   expires_at,
+                   used_at,
+                   created_at
+            FROM auth_password_recovery_token
+            WHERE request_id = :requestId
+            """,
+            new MapSqlParameterSource().addValue("requestId", requestId),
+            (rs, rowNum) -> mapPasswordRecoveryTokenQueryRecord(rs))
+        .stream()
+        .findFirst();
+  }
+
+  private PasswordRecoveryTokenRecord mapPasswordRecoveryTokenRecord(ResultSet rs)
+      throws SQLException {
+    return new PasswordRecoveryTokenRecord(
+        rs.getLong("id"),
+        rs.getLong("user_id"),
+        rs.getString("login_id"),
+        rs.getString("token_hash"),
+        PasswordRecoveryTokenStatus.valueOf(rs.getString("token_status")),
+        toInstant(rs.getTimestamp("expires_at")));
+  }
+
+  private PasswordRecoveryTokenQueryRecord mapPasswordRecoveryTokenQueryRecord(ResultSet rs)
+      throws SQLException {
+    return new PasswordRecoveryTokenQueryRecord(
+        rs.getString("request_id"),
+        rs.getLong("user_id"),
+        rs.getString("login_id"),
+        rs.getString("token_ciphertext"),
+        rs.getString("token_nonce"),
+        PasswordRecoveryTokenStatus.valueOf(rs.getString("token_status")),
+        toInstant(rs.getTimestamp("expires_at")),
+        toNullableInstant(rs.getTimestamp("used_at")),
+        toInstant(rs.getTimestamp("created_at")));
+  }
+
+  private Instant toInstant(Timestamp timestamp) {
+    if (timestamp == null) {
+      throw new IllegalStateException("timestamp must not be null");
+    }
+    return timestamp.toInstant();
+  }
+
+  private Instant toNullableInstant(Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toInstant();
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/AesPasswordRecoveryTokenManager.java
+++ b/back/src/main/java/com/aquilabank/global/security/AesPasswordRecoveryTokenManager.java
@@ -1,0 +1,116 @@
+package com.aquilabank.global.security;
+
+import com.aquilabank.domain.auth.model.GeneratedPasswordRecoveryToken;
+import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HexFormat;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/** recovery token은 평문 노출 없이 exact lookup hash와 AES-GCM 저장값을 함께 만듭니다. */
+public class AesPasswordRecoveryTokenManager implements PasswordRecoverySecretPort {
+
+  private static final int TOKEN_BYTE_LENGTH = 32;
+  private static final int NONCE_BYTE_LENGTH = 12;
+  private static final int GCM_TAG_BIT_LENGTH = 128;
+
+  private final SecretKeySpec secretKeySpec;
+  private final SecureRandom secureRandom = new SecureRandom();
+
+  public AesPasswordRecoveryTokenManager(
+      PasswordRecoveryProperties passwordRecoveryProperties, String fallbackSecret) {
+    String secretEncryptionKey = passwordRecoveryProperties.secretEncryptionKey();
+    if (secretEncryptionKey == null || secretEncryptionKey.isBlank()) {
+      secretEncryptionKey = fallbackSecret;
+    }
+    if (secretEncryptionKey == null || secretEncryptionKey.isBlank()) {
+      throw new IllegalStateException("security.password-recovery.secret-encryption-key is required");
+    }
+    this.secretKeySpec =
+        new SecretKeySpec(sha256(secretEncryptionKey.getBytes(StandardCharsets.UTF_8)), "AES");
+  }
+
+  @Override
+  public GeneratedPasswordRecoveryToken generate() {
+    byte[] tokenBytes = new byte[TOKEN_BYTE_LENGTH];
+    secureRandom.nextBytes(tokenBytes);
+
+    String plainToken = encode(tokenBytes);
+    byte[] plainTokenBytes = plainToken.getBytes(StandardCharsets.UTF_8);
+    byte[] nonce = new byte[NONCE_BYTE_LENGTH];
+    secureRandom.nextBytes(nonce);
+
+    return new GeneratedPasswordRecoveryToken(
+        plainToken,
+        sha256Hex(plainTokenBytes),
+        encode(encrypt(plainTokenBytes, nonce)),
+        encode(nonce));
+  }
+
+  @Override
+  public String hash(String plainToken) {
+    if (plainToken == null || plainToken.isBlank()) {
+      throw new IllegalArgumentException("plainToken is required");
+    }
+    return sha256Hex(plainToken.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public String reveal(String tokenCiphertext, String tokenNonce) {
+    if (tokenCiphertext == null || tokenCiphertext.isBlank()) {
+      throw new IllegalArgumentException("tokenCiphertext is required");
+    }
+    if (tokenNonce == null || tokenNonce.isBlank()) {
+      throw new IllegalArgumentException("tokenNonce is required");
+    }
+    return new String(decrypt(decode(tokenCiphertext), decode(tokenNonce)), StandardCharsets.UTF_8);
+  }
+
+  private byte[] encrypt(byte[] plainTokenBytes, byte[] nonce) {
+    try {
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(
+          Cipher.ENCRYPT_MODE, secretKeySpec, new GCMParameterSpec(GCM_TAG_BIT_LENGTH, nonce));
+      return cipher.doFinal(plainTokenBytes);
+    } catch (GeneralSecurityException ex) {
+      throw new IllegalStateException("password recovery token encryption failed", ex);
+    }
+  }
+
+  private byte[] decrypt(byte[] tokenCiphertext, byte[] nonce) {
+    try {
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(
+          Cipher.DECRYPT_MODE, secretKeySpec, new GCMParameterSpec(GCM_TAG_BIT_LENGTH, nonce));
+      return cipher.doFinal(tokenCiphertext);
+    } catch (GeneralSecurityException ex) {
+      throw new IllegalStateException("password recovery token decryption failed", ex);
+    }
+  }
+
+  private String encode(byte[] value) {
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(value);
+  }
+
+  private byte[] decode(String value) {
+    return Base64.getUrlDecoder().decode(value);
+  }
+
+  private byte[] sha256(byte[] value) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(value);
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+
+  private String sha256Hex(byte[] value) {
+    return HexFormat.of().formatHex(sha256(value));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/AesPasswordRecoveryTokenManager.java
+++ b/back/src/main/java/com/aquilabank/global/security/AesPasswordRecoveryTokenManager.java
@@ -30,7 +30,8 @@ public class AesPasswordRecoveryTokenManager implements PasswordRecoverySecretPo
       secretEncryptionKey = fallbackSecret;
     }
     if (secretEncryptionKey == null || secretEncryptionKey.isBlank()) {
-      throw new IllegalStateException("security.password-recovery.secret-encryption-key is required");
+      throw new IllegalStateException(
+          "security.password-recovery.secret-encryption-key is required");
     }
     this.secretKeySpec =
         new SecretKeySpec(sha256(secretEncryptionKey.getBytes(StandardCharsets.UTF_8)), "AES");

--- a/back/src/main/java/com/aquilabank/global/security/PasswordRecoveryProperties.java
+++ b/back/src/main/java/com/aquilabank/global/security/PasswordRecoveryProperties.java
@@ -1,0 +1,14 @@
+package com.aquilabank.global.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** password recovery token 만료와 보호 저장 key 설정입니다. */
+@ConfigurationProperties(prefix = "security.password-recovery")
+public record PasswordRecoveryProperties(long ttlSeconds, String secretEncryptionKey) {
+
+  public PasswordRecoveryProperties {
+    if (ttlSeconds <= 0) {
+      throw new IllegalArgumentException("security.password-recovery.ttl-seconds must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -2,6 +2,7 @@ package com.aquilabank.global.security;
 
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
 import com.aquilabank.global.web.InternalAuthStatusAuditRequestCachingFilter;
 import com.aquilabank.global.web.RequestIdFilter;
@@ -38,6 +39,7 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
   SecurityTotpProperties.class,
   LoginProtectionProperties.class,
   LoginThrottlingProperties.class,
+  PasswordRecoveryProperties.class,
   BootstrapHeaderAuthProperties.class,
   AccountBootstrapApiProperties.class,
   AuthBootstrapApiProperties.class
@@ -70,6 +72,10 @@ public class SecurityConfiguration {
                     .requestMatchers("/api/v1/auth/login")
                     .permitAll()
                     .requestMatchers("/api/v1/auth/refresh")
+                    .permitAll()
+                    .requestMatchers("/api/v1/auth/password-recovery/request")
+                    .permitAll()
+                    .requestMatchers("/api/v1/auth/password-recovery/confirm")
                     .permitAll()
                     .requestMatchers("/api/v1/auth/mfa/totp/challenge/verify")
                     .permitAll()
@@ -175,6 +181,14 @@ public class SecurityConfiguration {
   @Bean
   RefreshTokenSecretPort refreshTokenSecretPort() {
     return new Sha256RefreshTokenManager();
+  }
+
+  @Bean
+  PasswordRecoverySecretPort passwordRecoverySecretPort(
+      PasswordRecoveryProperties passwordRecoveryProperties,
+      SecurityJwtProperties securityJwtProperties) {
+    return new AesPasswordRecoveryTokenManager(
+        passwordRecoveryProperties, securityJwtProperties.secret());
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -7,6 +7,7 @@ import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundExcepti
 import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
 import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.exception.PasswordRecoveryTokenNotFoundException;
 import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.ledger.exception.CommandConflictException;
@@ -116,6 +117,7 @@ public class ApiExceptionHandler {
     TransferReversalNotFoundException.class,
     AuthStatusChangeAuditNotFoundException.class,
     AuthUserNotFoundException.class,
+    PasswordRecoveryTokenNotFoundException.class,
     UserAccountMembershipNotFoundException.class,
     NotificationNotFoundException.class,
     TransactionDetailNotFoundException.class

--- a/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
@@ -4,11 +4,13 @@ import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReasonNormalizer;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenLookupView;
 import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryTokenQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
 import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
@@ -44,6 +46,7 @@ public class InternalAuthAdminController {
   private final UserStatusUpdateUseCase userStatusUpdateUseCase;
   private final UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase;
   private final UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase;
+  private final PasswordRecoveryTokenQueryUseCase passwordRecoveryTokenQueryUseCase;
   private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
 
   public InternalAuthAdminController(
@@ -51,11 +54,13 @@ public class InternalAuthAdminController {
       UserStatusUpdateUseCase userStatusUpdateUseCase,
       UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase,
       UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase,
+      PasswordRecoveryTokenQueryUseCase passwordRecoveryTokenQueryUseCase,
       InternalServiceRequestAuthorizer internalServiceRequestAuthorizer) {
     this.authUserQueryUseCase = authUserQueryUseCase;
     this.userStatusUpdateUseCase = userStatusUpdateUseCase;
     this.userAccountMembershipQueryUseCase = userAccountMembershipQueryUseCase;
     this.userAccountMembershipStatusUpdateUseCase = userAccountMembershipStatusUpdateUseCase;
+    this.passwordRecoveryTokenQueryUseCase = passwordRecoveryTokenQueryUseCase;
     this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
   }
 
@@ -86,6 +91,18 @@ public class InternalAuthAdminController {
         httpServletRequest, InternalServiceScope.AUTH_ADMIN);
     return UserAccountMembershipResponse.from(
         userAccountMembershipQueryUseCase.getByUserIdAndAccountId(userId, accountId));
+  }
+
+  /** 내부 운영용 recovery handoff requestId exact lookup endpoint입니다. */
+  @GetMapping("/password-recovery-tokens/by-request-id")
+  public PasswordRecoveryTokenResponse getPasswordRecoveryToken(
+      HttpServletRequest httpServletRequest,
+      @RequestParam("requestId")
+          @NotBlank(message = "requestId is required") @Size(max = 64, message = "requestId must be 64 characters or less") String handoffRequestId) {
+    internalServiceRequestAuthorizer.requireScope(
+        httpServletRequest, InternalServiceScope.AUTH_ADMIN);
+    return PasswordRecoveryTokenResponse.from(
+        passwordRecoveryTokenQueryUseCase.getByHandoffRequestId(handoffRequestId));
   }
 
   @PutMapping("/users/{userId}/status")
@@ -207,6 +224,30 @@ public class InternalAuthAdminController {
           summary.status().name(),
           summary.createdAt(),
           summary.updatedAt());
+    }
+  }
+
+  /** 내부 password recovery handoff requestId exact lookup 응답 */
+  public record PasswordRecoveryTokenResponse(
+      String requestId,
+      long userId,
+      String loginId,
+      String recoveryToken,
+      String tokenStatus,
+      Instant expiresAt,
+      Instant usedAt,
+      Instant createdAt) {
+
+    static PasswordRecoveryTokenResponse from(PasswordRecoveryTokenLookupView view) {
+      return new PasswordRecoveryTokenResponse(
+          view.requestId(),
+          view.userId(),
+          view.loginId(),
+          view.recoveryToken(),
+          view.tokenStatus().name(),
+          view.expiresAt(),
+          view.usedAt(),
+          view.createdAt());
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -8,6 +8,9 @@ import com.aquilabank.domain.auth.model.AuthSessionSummary;
 import com.aquilabank.domain.auth.model.LoginCommand;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.model.LogoutCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryConfirmCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryRequestCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryRequestResult;
 import com.aquilabank.domain.auth.model.PasswordResetCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenCommand;
 import com.aquilabank.domain.auth.model.TotpChallengeVerifyCommand;
@@ -20,6 +23,8 @@ import com.aquilabank.domain.auth.usecase.AuthSessionRevokeAllUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionRevokeUseCase;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryConfirmUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryRequestUseCase;
 import com.aquilabank.domain.auth.usecase.PasswordResetUseCase;
 import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
 import com.aquilabank.domain.auth.usecase.TotpChallengeVerifyUseCase;
@@ -57,6 +62,9 @@ import org.springframework.web.server.ResponseStatusException;
 @RequestMapping("/api/v1/auth")
 public class LoginController {
 
+  private static final String PASSWORD_RECOVERY_HANDOFF_REQUEST_ID_HEADER =
+      "X-Password-Recovery-Request-Id";
+
   private final LoginUseCase loginUseCase;
   private final AuthSessionListUseCase authSessionListUseCase;
   private final AuthSessionRevokeUseCase authSessionRevokeUseCase;
@@ -66,6 +74,8 @@ public class LoginController {
   private final TotpChallengeVerifyUseCase totpChallengeVerifyUseCase;
   private final LogoutUseCase logoutUseCase;
   private final PasswordResetUseCase passwordResetUseCase;
+  private final PasswordRecoveryRequestUseCase passwordRecoveryRequestUseCase;
+  private final PasswordRecoveryConfirmUseCase passwordRecoveryConfirmUseCase;
   private final AuthSessionMetadataResolver authSessionMetadataResolver;
   private final LoginThrottleGuard loginThrottleGuard;
 
@@ -79,6 +89,8 @@ public class LoginController {
       TotpChallengeVerifyUseCase totpChallengeVerifyUseCase,
       LogoutUseCase logoutUseCase,
       PasswordResetUseCase passwordResetUseCase,
+      PasswordRecoveryRequestUseCase passwordRecoveryRequestUseCase,
+      PasswordRecoveryConfirmUseCase passwordRecoveryConfirmUseCase,
       AuthSessionMetadataResolver authSessionMetadataResolver,
       LoginThrottleGuard loginThrottleGuard) {
     this.loginUseCase = loginUseCase;
@@ -90,6 +102,8 @@ public class LoginController {
     this.totpChallengeVerifyUseCase = totpChallengeVerifyUseCase;
     this.logoutUseCase = logoutUseCase;
     this.passwordResetUseCase = passwordResetUseCase;
+    this.passwordRecoveryRequestUseCase = passwordRecoveryRequestUseCase;
+    this.passwordRecoveryConfirmUseCase = passwordRecoveryConfirmUseCase;
     this.authSessionMetadataResolver = authSessionMetadataResolver;
     this.loginThrottleGuard = loginThrottleGuard;
   }
@@ -189,6 +203,26 @@ public class LoginController {
     return ResponseEntity.noContent().build();
   }
 
+  @PostMapping("/password-recovery/request")
+  public ResponseEntity<Void> requestPasswordRecovery(
+      @Valid @RequestBody PasswordRecoveryRequest request) {
+    PasswordRecoveryRequestResult result =
+        passwordRecoveryRequestUseCase.request(
+            new PasswordRecoveryRequestCommand(request.loginId()));
+    return ResponseEntity.noContent()
+        // trace용 X-Request-Id와 분리된 handoff requestId만 별도 header로 반환합니다.
+        .header(PASSWORD_RECOVERY_HANDOFF_REQUEST_ID_HEADER, result.handoffRequestId())
+        .build();
+  }
+
+  @PostMapping("/password-recovery/confirm")
+  public ResponseEntity<Void> confirmPasswordRecovery(
+      @Valid @RequestBody PasswordRecoveryConfirmRequest request) {
+    passwordRecoveryConfirmUseCase.confirm(
+        new PasswordRecoveryConfirmCommand(request.recoveryToken(), request.newPassword()));
+    return ResponseEntity.noContent().build();
+  }
+
   /** 로그인 요청 body */
   public record LoginRequest(
       @NotBlank(message = "loginId is required") @Size(max = 80, message = "loginId must be 80 characters or less") String loginId,
@@ -205,6 +239,15 @@ public class LoginController {
   /** password reset 요청 body */
   public record PasswordResetRequest(
       @NotBlank(message = "currentPassword is required") @Size(max = 120, message = "currentPassword must be 120 characters or less") String currentPassword,
+      @NotBlank(message = "newPassword is required") @Size(max = 120, message = "newPassword must be 120 characters or less") String newPassword) {}
+
+  /** password recovery 요청 body */
+  public record PasswordRecoveryRequest(
+      @NotBlank(message = "loginId is required") @Size(max = 80, message = "loginId must be 80 characters or less") String loginId) {}
+
+  /** password recovery 확정 요청 body */
+  public record PasswordRecoveryConfirmRequest(
+      @NotBlank(message = "recoveryToken is required") @Size(max = 160, message = "recoveryToken must be 160 characters or less") String recoveryToken,
       @NotBlank(message = "newPassword is required") @Size(max = 120, message = "newPassword must be 120 characters or less") String newPassword) {}
 
   /** TOTP code 입력 body */

--- a/back/src/main/resources/application-test.yml
+++ b/back/src/main/resources/application-test.yml
@@ -3,3 +3,6 @@ security:
     secret: ${SECURITY_JWT_SECRET:test-local-jwt-secret-test-local-jwt-secret}
   totp:
     secret-encryption-key: ${SECURITY_TOTP_SECRET_ENCRYPTION_KEY:test-local-totp-secret-encryption-key}
+  password-recovery:
+    ttl-seconds: 900
+    secret-encryption-key: test-local-password-recovery-secret-encryption-key

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -175,6 +175,9 @@ security:
     enrollment-ttl-seconds: ${SECURITY_TOTP_ENROLLMENT_TTL_SECONDS:300}
     challenge-ttl-seconds: ${SECURITY_TOTP_CHALLENGE_TTL_SECONDS:300}
     challenge-max-attempts: ${SECURITY_TOTP_CHALLENGE_MAX_ATTEMPTS:5}
+  password-recovery:
+    ttl-seconds: ${SECURITY_PASSWORD_RECOVERY_TTL_SECONDS:900}
+    secret-encryption-key: ${SECURITY_PASSWORD_RECOVERY_SECRET_ENCRYPTION_KEY:${SECURITY_JWT_SECRET:}}
   internal-service-token:
     issuer: ${SECURITY_INTERNAL_SERVICE_TOKEN_ISSUER:}
     audience: ${SECURITY_INTERNAL_SERVICE_TOKEN_AUDIENCE:}

--- a/back/src/main/resources/db/migration/V21__add_auth_password_recovery_token.sql
+++ b/back/src/main/resources/db/migration/V21__add_auth_password_recovery_token.sql
@@ -1,0 +1,22 @@
+CREATE TABLE auth_password_recovery_token (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    request_id VARCHAR(64) NOT NULL,
+    user_id BIGINT NOT NULL,
+    login_id VARCHAR(80) NOT NULL,
+    token_hash VARCHAR(64) NOT NULL,
+    token_ciphertext VARCHAR(512) NOT NULL,
+    token_nonce VARCHAR(64) NOT NULL,
+    token_status VARCHAR(16) NOT NULL
+        CHECK (token_status IN ('PENDING', 'USED', 'EXPIRED', 'SUPERSEDED')),
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_auth_password_recovery_token_request_id UNIQUE (request_id),
+    CONSTRAINT uq_auth_password_recovery_token_token_hash UNIQUE (token_hash),
+    CONSTRAINT fk_auth_password_recovery_token_user
+        FOREIGN KEY (user_id) REFERENCES bank_user (id)
+);
+
+CREATE INDEX idx_auth_password_recovery_token_status_expiry
+    ON auth_password_recovery_token (token_status, expires_at ASC, user_id ASC);

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryConfirmServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryConfirmServiceTest.java
@@ -1,0 +1,263 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.PasswordRecoveryConfirmCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenRecord;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenStatus;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenUseCommand;
+import com.aquilabank.domain.auth.model.PasswordResetWriteCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.PasswordHashPort;
+import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenLoadPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenWritePort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.port.UserCredentialUpdatePort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class PasswordRecoveryConfirmServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-17T02:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+  @Test
+  void resetsPasswordAndRevokesActiveRefreshSessions() {
+    PasswordRecoverySecretPort passwordRecoverySecretPort = mock(PasswordRecoverySecretPort.class);
+    PasswordRecoveryTokenLoadPort passwordRecoveryTokenLoadPort =
+        mock(PasswordRecoveryTokenLoadPort.class);
+    PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort =
+        mock(PasswordRecoveryTokenWritePort.class);
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    UserCredentialUpdatePort userCredentialUpdatePort = mock(UserCredentialUpdatePort.class);
+    PasswordHashPort passwordHashPort = mock(PasswordHashPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+
+    when(passwordRecoverySecretPort.hash("recovery-token")).thenReturn("token-hash");
+    when(passwordRecoveryTokenLoadPort.findByTokenHashForUpdate("token-hash"))
+        .thenReturn(Optional.of(pendingToken()));
+    when(userCredentialLoadPort.findByUserIdForUpdate(7L)).thenReturn(Optional.of(activeUser()));
+    when(passwordHashPort.encode("newPassword456!")).thenReturn("new-password-hash");
+
+    PasswordRecoveryConfirmService service =
+        new PasswordRecoveryConfirmService(
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenLoadPort,
+            passwordRecoveryTokenWritePort,
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            CLOCK);
+
+    service.confirm(new PasswordRecoveryConfirmCommand("recovery-token", "newPassword456!"));
+
+    verify(userCredentialUpdatePort)
+        .resetPassword(new PasswordResetWriteCommand(7L, "new-password-hash", NOW));
+    verify(passwordRecoveryTokenWritePort).markUsed(new PasswordRecoveryTokenUseCommand(11L, NOW));
+    verify(refreshTokenSessionWritePort).revokeActiveSessionsByUserId(7L, NOW);
+  }
+
+  @Test
+  void rejectsWrongTokenWithGenericFailure() {
+    PasswordRecoverySecretPort passwordRecoverySecretPort = mock(PasswordRecoverySecretPort.class);
+    PasswordRecoveryTokenLoadPort passwordRecoveryTokenLoadPort =
+        mock(PasswordRecoveryTokenLoadPort.class);
+    PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort =
+        mock(PasswordRecoveryTokenWritePort.class);
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    UserCredentialUpdatePort userCredentialUpdatePort = mock(UserCredentialUpdatePort.class);
+    PasswordHashPort passwordHashPort = mock(PasswordHashPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+
+    when(passwordRecoverySecretPort.hash("wrong-token")).thenReturn("wrong-token-hash");
+    when(passwordRecoveryTokenLoadPort.findByTokenHashForUpdate("wrong-token-hash"))
+        .thenReturn(Optional.empty());
+
+    PasswordRecoveryConfirmService service =
+        new PasswordRecoveryConfirmService(
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenLoadPort,
+            passwordRecoveryTokenWritePort,
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            CLOCK);
+
+    InvalidCredentialsException ex =
+        assertThrows(
+            InvalidCredentialsException.class,
+            () -> service.confirm(new PasswordRecoveryConfirmCommand("wrong-token", "next-pass")));
+
+    assertThat(ex).hasMessage("password recovery failed");
+    verifyNoInteractions(
+        userCredentialLoadPort, userCredentialUpdatePort, refreshTokenSessionWritePort);
+    verify(passwordRecoveryTokenWritePort, never()).markUsed(any());
+  }
+
+  @Test
+  void rejectsExpiredTokenWithGenericFailureAndMarksExpired() {
+    PasswordRecoverySecretPort passwordRecoverySecretPort = mock(PasswordRecoverySecretPort.class);
+    PasswordRecoveryTokenLoadPort passwordRecoveryTokenLoadPort =
+        mock(PasswordRecoveryTokenLoadPort.class);
+    PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort =
+        mock(PasswordRecoveryTokenWritePort.class);
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    UserCredentialUpdatePort userCredentialUpdatePort = mock(UserCredentialUpdatePort.class);
+    PasswordHashPort passwordHashPort = mock(PasswordHashPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+
+    when(passwordRecoverySecretPort.hash("recovery-token")).thenReturn("token-hash");
+    when(passwordRecoveryTokenLoadPort.findByTokenHashForUpdate("token-hash"))
+        .thenReturn(Optional.of(expiredToken()));
+
+    PasswordRecoveryConfirmService service =
+        new PasswordRecoveryConfirmService(
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenLoadPort,
+            passwordRecoveryTokenWritePort,
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            CLOCK);
+
+    InvalidCredentialsException ex =
+        assertThrows(
+            InvalidCredentialsException.class,
+            () ->
+                service.confirm(
+                    new PasswordRecoveryConfirmCommand("recovery-token", "newPassword456!")));
+
+    assertThat(ex).hasMessage("password recovery failed");
+    verify(passwordRecoveryTokenWritePort).markExpired(11L, NOW);
+    verify(passwordRecoveryTokenWritePort, never()).markUsed(any());
+    verifyNoInteractions(
+        userCredentialLoadPort, userCredentialUpdatePort, refreshTokenSessionWritePort);
+  }
+
+  @Test
+  void rejectsUsedTokenWithGenericFailure() {
+    PasswordRecoverySecretPort passwordRecoverySecretPort = mock(PasswordRecoverySecretPort.class);
+    PasswordRecoveryTokenLoadPort passwordRecoveryTokenLoadPort =
+        mock(PasswordRecoveryTokenLoadPort.class);
+    PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort =
+        mock(PasswordRecoveryTokenWritePort.class);
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    UserCredentialUpdatePort userCredentialUpdatePort = mock(UserCredentialUpdatePort.class);
+    PasswordHashPort passwordHashPort = mock(PasswordHashPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+
+    when(passwordRecoverySecretPort.hash("recovery-token")).thenReturn("token-hash");
+    when(passwordRecoveryTokenLoadPort.findByTokenHashForUpdate("token-hash"))
+        .thenReturn(Optional.of(usedToken()));
+
+    PasswordRecoveryConfirmService service =
+        new PasswordRecoveryConfirmService(
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenLoadPort,
+            passwordRecoveryTokenWritePort,
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            CLOCK);
+
+    InvalidCredentialsException ex =
+        assertThrows(
+            InvalidCredentialsException.class,
+            () ->
+                service.confirm(
+                    new PasswordRecoveryConfirmCommand("recovery-token", "newPassword456!")));
+
+    assertThat(ex).hasMessage("password recovery failed");
+    verify(passwordRecoveryTokenWritePort, never()).markExpired(anyLong(), any());
+    verify(passwordRecoveryTokenWritePort, never()).markUsed(any());
+    verifyNoInteractions(
+        userCredentialLoadPort, userCredentialUpdatePort, refreshTokenSessionWritePort);
+  }
+
+  @Test
+  void rejectsInactiveUserWithGenericFailure() {
+    PasswordRecoverySecretPort passwordRecoverySecretPort = mock(PasswordRecoverySecretPort.class);
+    PasswordRecoveryTokenLoadPort passwordRecoveryTokenLoadPort =
+        mock(PasswordRecoveryTokenLoadPort.class);
+    PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort =
+        mock(PasswordRecoveryTokenWritePort.class);
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    UserCredentialUpdatePort userCredentialUpdatePort = mock(UserCredentialUpdatePort.class);
+    PasswordHashPort passwordHashPort = mock(PasswordHashPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        mock(RefreshTokenSessionWritePort.class);
+
+    when(passwordRecoverySecretPort.hash("recovery-token")).thenReturn("token-hash");
+    when(passwordRecoveryTokenLoadPort.findByTokenHashForUpdate("token-hash"))
+        .thenReturn(Optional.of(pendingToken()));
+    when(userCredentialLoadPort.findByUserIdForUpdate(7L)).thenReturn(Optional.of(inactiveUser()));
+
+    PasswordRecoveryConfirmService service =
+        new PasswordRecoveryConfirmService(
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenLoadPort,
+            passwordRecoveryTokenWritePort,
+            userCredentialLoadPort,
+            userCredentialUpdatePort,
+            passwordHashPort,
+            refreshTokenSessionWritePort,
+            CLOCK);
+
+    InvalidCredentialsException ex =
+        assertThrows(
+            InvalidCredentialsException.class,
+            () ->
+                service.confirm(
+                    new PasswordRecoveryConfirmCommand("recovery-token", "newPassword456!")));
+
+    assertThat(ex).hasMessage("password recovery failed");
+    verify(passwordRecoveryTokenWritePort, never()).markUsed(any());
+    verifyNoInteractions(userCredentialUpdatePort, refreshTokenSessionWritePort);
+  }
+
+  private PasswordRecoveryTokenRecord pendingToken() {
+    return new PasswordRecoveryTokenRecord(
+        11L, 7L, "alice", "token-hash", PasswordRecoveryTokenStatus.PENDING, NOW.plusSeconds(60));
+  }
+
+  private PasswordRecoveryTokenRecord expiredToken() {
+    return new PasswordRecoveryTokenRecord(
+        11L, 7L, "alice", "token-hash", PasswordRecoveryTokenStatus.PENDING, NOW.minusSeconds(1));
+  }
+
+  private PasswordRecoveryTokenRecord usedToken() {
+    return new PasswordRecoveryTokenRecord(
+        11L, 7L, "alice", "token-hash", PasswordRecoveryTokenStatus.USED, NOW.plusSeconds(60));
+  }
+
+  private LoginUser activeUser() {
+    return new LoginUser(7L, "alice", "stored-hash", UserStatus.ACTIVE, 0, null, null, NOW);
+  }
+
+  private LoginUser inactiveUser() {
+    return new LoginUser(7L, "alice", "stored-hash", UserStatus.DISABLED, 0, null, null, NOW);
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryRequestServiceTest.java
@@ -1,0 +1,159 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.GeneratedPasswordRecoveryToken;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.PasswordRecoveryRequestCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryRequestResult;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenIssueCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
+import com.aquilabank.domain.auth.port.PasswordRecoveryTokenWritePort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import com.aquilabank.domain.auth.port.UserQueryPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class PasswordRecoveryRequestServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-17T01:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+  private static final Duration TTL = Duration.ofMinutes(30);
+
+  @Test
+  void issuesTokenForActiveUserAndSupersedesPendingTokens() {
+    UserQueryPort userQueryPort = mock(UserQueryPort.class);
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    PasswordRecoverySecretPort passwordRecoverySecretPort = mock(PasswordRecoverySecretPort.class);
+    PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort =
+        mock(PasswordRecoveryTokenWritePort.class);
+
+    when(userQueryPort.findSummaryByLoginId("alice")).thenReturn(Optional.of(activeSummary()));
+    when(userCredentialLoadPort.findByLoginIdForUpdate("alice"))
+        .thenReturn(Optional.of(activeUser()));
+    when(passwordRecoverySecretPort.generate())
+        .thenReturn(
+            new GeneratedPasswordRecoveryToken(
+                "plain-token", "token-hash", "token-ciphertext", "token-nonce"));
+
+    PasswordRecoveryRequestService service =
+        new PasswordRecoveryRequestService(
+            userQueryPort,
+            userCredentialLoadPort,
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenWritePort,
+            TTL,
+            CLOCK);
+
+    PasswordRecoveryRequestResult result =
+        service.request(new PasswordRecoveryRequestCommand("alice"));
+
+    assertThat(result.handoffRequestId()).isNotBlank();
+    verify(passwordRecoveryTokenWritePort).supersedePendingTokens(7L, NOW);
+
+    ArgumentCaptor<PasswordRecoveryTokenIssueCommand> commandCaptor =
+        ArgumentCaptor.forClass(PasswordRecoveryTokenIssueCommand.class);
+    verify(passwordRecoveryTokenWritePort).issue(commandCaptor.capture());
+
+    PasswordRecoveryTokenIssueCommand command = commandCaptor.getValue();
+    assertThat(command.requestId()).isEqualTo(result.handoffRequestId());
+    assertThat(command.userId()).isEqualTo(7L);
+    assertThat(command.loginId()).isEqualTo("alice");
+    assertThat(command.tokenHash()).isEqualTo("token-hash");
+    assertThat(command.tokenCiphertext()).isEqualTo("token-ciphertext");
+    assertThat(command.tokenNonce()).isEqualTo("token-nonce");
+    assertThat(command.createdAt()).isEqualTo(NOW);
+    assertThat(command.expiresAt()).isEqualTo(NOW.plus(TTL));
+  }
+
+  @Test
+  void returnsHandoffRequestIdWithoutWritesWhenUserDoesNotExist() {
+    UserQueryPort userQueryPort = mock(UserQueryPort.class);
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    PasswordRecoverySecretPort passwordRecoverySecretPort = mock(PasswordRecoverySecretPort.class);
+    PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort =
+        mock(PasswordRecoveryTokenWritePort.class);
+
+    when(userQueryPort.findSummaryByLoginId("missing")).thenReturn(Optional.empty());
+
+    PasswordRecoveryRequestService service =
+        new PasswordRecoveryRequestService(
+            userQueryPort,
+            userCredentialLoadPort,
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenWritePort,
+            TTL,
+            CLOCK);
+
+    PasswordRecoveryRequestResult result =
+        service.request(new PasswordRecoveryRequestCommand("missing"));
+
+    assertThat(result.handoffRequestId()).isNotBlank();
+    verify(userQueryPort).findSummaryByLoginId("missing");
+    verifyNoInteractions(
+        userCredentialLoadPort, passwordRecoverySecretPort, passwordRecoveryTokenWritePort);
+  }
+
+  @Test
+  void returnsHandoffRequestIdWithoutWritesWhenUserIsInactive() {
+    UserQueryPort userQueryPort = mock(UserQueryPort.class);
+    UserCredentialLoadPort userCredentialLoadPort = mock(UserCredentialLoadPort.class);
+    PasswordRecoverySecretPort passwordRecoverySecretPort = mock(PasswordRecoverySecretPort.class);
+    PasswordRecoveryTokenWritePort passwordRecoveryTokenWritePort =
+        mock(PasswordRecoveryTokenWritePort.class);
+
+    when(userQueryPort.findSummaryByLoginId("alice")).thenReturn(Optional.of(inactiveSummary()));
+
+    PasswordRecoveryRequestService service =
+        new PasswordRecoveryRequestService(
+            userQueryPort,
+            userCredentialLoadPort,
+            passwordRecoverySecretPort,
+            passwordRecoveryTokenWritePort,
+            TTL,
+            CLOCK);
+
+    PasswordRecoveryRequestResult result =
+        service.request(new PasswordRecoveryRequestCommand("alice"));
+
+    assertThat(result.handoffRequestId()).isNotBlank();
+    verify(userQueryPort).findSummaryByLoginId("alice");
+    verifyNoInteractions(
+        userCredentialLoadPort, passwordRecoverySecretPort, passwordRecoveryTokenWritePort);
+  }
+
+  private AuthUserSummary activeSummary() {
+    return new AuthUserSummary(
+        7L,
+        "alice",
+        "Alice",
+        UserStatus.ACTIVE,
+        NOW.minus(Duration.ofDays(1)),
+        NOW.minus(Duration.ofHours(1)));
+  }
+
+  private AuthUserSummary inactiveSummary() {
+    return new AuthUserSummary(
+        7L,
+        "alice",
+        "Alice",
+        UserStatus.DISABLED,
+        NOW.minus(Duration.ofDays(1)),
+        NOW.minus(Duration.ofHours(1)));
+  }
+
+  private LoginUser activeUser() {
+    return new LoginUser(7L, "alice", "stored-hash", UserStatus.ACTIVE, 0, null, null, NOW);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/security/AesPasswordRecoveryTokenManagerTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/AesPasswordRecoveryTokenManagerTest.java
@@ -1,0 +1,52 @@
+package com.aquilabank.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.aquilabank.domain.auth.model.GeneratedPasswordRecoveryToken;
+import org.junit.jupiter.api.Test;
+
+class AesPasswordRecoveryTokenManagerTest {
+
+  @Test
+  void generatesTokenThatRoundTripsThroughHashAndReveal() {
+    AesPasswordRecoveryTokenManager manager =
+        new AesPasswordRecoveryTokenManager(
+            new PasswordRecoveryProperties(900, ""), "fallback-secret");
+
+    GeneratedPasswordRecoveryToken generatedToken = manager.generate();
+
+    assertThat(generatedToken.plainToken()).isNotBlank();
+    assertThat(generatedToken.tokenCiphertext()).isNotBlank();
+    assertThat(generatedToken.tokenNonce()).isNotBlank();
+    assertThat(generatedToken.tokenHash()).isEqualTo(manager.hash(generatedToken.plainToken()));
+    assertThat(manager.reveal(generatedToken.tokenCiphertext(), generatedToken.tokenNonce()))
+        .isEqualTo(generatedToken.plainToken());
+  }
+
+  @Test
+  void hashesPlainTokenDeterministically() {
+    AesPasswordRecoveryTokenManager manager =
+        new AesPasswordRecoveryTokenManager(
+            new PasswordRecoveryProperties(900, "property-secret"), "fallback-secret");
+
+    String firstHash = manager.hash("plain-token");
+    String secondHash = manager.hash("plain-token");
+    String differentHash = manager.hash("plain-token-2");
+
+    assertThat(firstHash).hasSize(64);
+    assertThat(firstHash).isEqualTo(secondHash);
+    assertThat(firstHash).isNotEqualTo(differentHash);
+  }
+
+  @Test
+  void rejectsBlankInputsForHashAndReveal() {
+    AesPasswordRecoveryTokenManager manager =
+        new AesPasswordRecoveryTokenManager(
+            new PasswordRecoveryProperties(900, "property-secret"), "fallback-secret");
+
+    assertThrows(IllegalArgumentException.class, () -> manager.hash(" "));
+    assertThrows(IllegalArgumentException.class, () -> manager.reveal(" ", "nonce"));
+    assertThrows(IllegalArgumentException.class, () -> manager.reveal("cipher", " "));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -16,6 +16,7 @@ import com.aquilabank.domain.auth.model.MembershipStatus;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryTokenQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
 import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
@@ -37,6 +38,7 @@ class InternalAuthAdminControllerTest {
   private UserStatusUpdateUseCase userStatusUpdateUseCase;
   private UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase;
   private UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase;
+  private PasswordRecoveryTokenQueryUseCase passwordRecoveryTokenQueryUseCase;
   private MockMvc mockMvc;
 
   @BeforeEach
@@ -45,6 +47,7 @@ class InternalAuthAdminControllerTest {
     userStatusUpdateUseCase = mock(UserStatusUpdateUseCase.class);
     userAccountMembershipQueryUseCase = mock(UserAccountMembershipQueryUseCase.class);
     userAccountMembershipStatusUpdateUseCase = mock(UserAccountMembershipStatusUpdateUseCase.class);
+    passwordRecoveryTokenQueryUseCase = mock(PasswordRecoveryTokenQueryUseCase.class);
 
     mockMvc =
         MockMvcBuilders.standaloneSetup(
@@ -53,6 +56,7 @@ class InternalAuthAdminControllerTest {
                     userStatusUpdateUseCase,
                     userAccountMembershipQueryUseCase,
                     userAccountMembershipStatusUpdateUseCase,
+                    passwordRecoveryTokenQueryUseCase,
                     InternalServiceTokenTestSupport.authorizer()))
             .setControllerAdvice(new ApiExceptionHandler())
             .build();

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -10,9 +10,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.aquilabank.domain.auth.exception.PasswordRecoveryTokenNotFoundException;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.MembershipRole;
 import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenLookupView;
+import com.aquilabank.domain.auth.model.PasswordRecoveryTokenStatus;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
@@ -98,6 +101,100 @@ class InternalAuthAdminControllerTest {
                 .param("loginId", "alice"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.displayName").value("Alice"));
+  }
+
+  @Test
+  void getsPasswordRecoveryTokenByRequestId() throws Exception {
+    when(passwordRecoveryTokenQueryUseCase.getByHandoffRequestId("handoff-request-001"))
+        .thenReturn(
+            new PasswordRecoveryTokenLookupView(
+                "handoff-request-001",
+                21L,
+                "alice",
+                "recovery-token",
+                PasswordRecoveryTokenStatus.USED,
+                Instant.parse("2026-04-16T12:00:00Z"),
+                Instant.parse("2026-04-16T12:05:00Z"),
+                Instant.parse("2026-04-16T11:00:00Z")));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/password-recovery-tokens/by-request-id")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.AUTH_ADMIN))
+                .param("requestId", "handoff-request-001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.requestId").value("handoff-request-001"))
+        .andExpect(jsonPath("$.userId").value(21))
+        .andExpect(jsonPath("$.loginId").value("alice"))
+        .andExpect(jsonPath("$.recoveryToken").value("recovery-token"))
+        .andExpect(jsonPath("$.tokenStatus").value("USED"))
+        .andExpect(jsonPath("$.expiresAt").value("2026-04-16T12:00:00Z"))
+        .andExpect(jsonPath("$.usedAt").value("2026-04-16T12:05:00Z"))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-16T11:00:00Z"));
+  }
+
+  @Test
+  void rejectsMissingOrBlankRequestIdForPasswordRecoveryLookup() throws Exception {
+    when(passwordRecoveryTokenQueryUseCase.getByHandoffRequestId(" "))
+        .thenThrow(new IllegalArgumentException("handoffRequestId is required"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/password-recovery-tokens/by-request-id")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.AUTH_ADMIN)))
+        .andExpect(status().isBadRequest());
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/password-recovery-tokens/by-request-id")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.AUTH_ADMIN))
+                .param("requestId", " "))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectsMissingOrInvalidInternalServiceTokenForPasswordRecoveryLookup() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/password-recovery-tokens/by-request-id")
+                .param("requestId", "handoff-request-001"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/password-recovery-tokens/by-request-id")
+                .header("Authorization", "Bearer invalid-token")
+                .param("requestId", "handoff-request-001"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+
+  @Test
+  void returnsNotFoundWhenPasswordRecoveryTokenRequestIdIsUnknown() throws Exception {
+    when(passwordRecoveryTokenQueryUseCase.getByHandoffRequestId("missing-handoff-request"))
+        .thenThrow(
+            new PasswordRecoveryTokenNotFoundException("password recovery token is not found"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/password-recovery-tokens/by-request-id")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.AUTH_ADMIN))
+                .param("requestId", "missing-handoff-request"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("password recovery token is not found"));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusFailureLoggingTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusFailureLoggingTest.java
@@ -8,6 +8,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryTokenQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
 import com.aquilabank.domain.auth.usecase.UserStatusUpdateUseCase;
@@ -42,6 +43,8 @@ class InternalAuthStatusFailureLoggingTest {
         Mockito.mock(UserAccountMembershipQueryUseCase.class);
     UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase =
         Mockito.mock(UserAccountMembershipStatusUpdateUseCase.class);
+    PasswordRecoveryTokenQueryUseCase passwordRecoveryTokenQueryUseCase =
+        Mockito.mock(PasswordRecoveryTokenQueryUseCase.class);
     var authorizer = InternalServiceTokenTestSupport.authorizer();
 
     mockMvc =
@@ -51,6 +54,7 @@ class InternalAuthStatusFailureLoggingTest {
                     userStatusUpdateUseCase,
                     userAccountMembershipQueryUseCase,
                     userAccountMembershipStatusUpdateUseCase,
+                    passwordRecoveryTokenQueryUseCase,
                     authorizer))
             .addInterceptors(new InternalServiceTokenAuthenticationInterceptor(authorizer))
             .addFilters(new RequestIdFilter(), new InternalAuthStatusAuditRequestCachingFilter())

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -40,6 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.context.WebApplicationContext;
 
 @ActiveProfiles("test")
@@ -91,6 +92,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   @Autowired private LoginThrottleGuard loginThrottleGuard;
 
   @Autowired private InternalServiceTokenIssuer internalServiceTokenIssuer;
+
+  @Autowired private PlatformTransactionManager transactionManager;
 
   private MockMvc mockMvc;
   private long userId;
@@ -972,8 +975,134 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                       "currentPassword": "password123!",
                       "newPassword": "newPassword456!"
                     }
-                    """))
+                """))
         .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void passwordRecoveryRequestReturnsGenericNoContentWithSeparateHandoffRequestId()
+      throws Exception {
+    MvcResult existingResult =
+        performPasswordRecoveryRequest("alice", "password-recovery-request-existing")
+            .andExpect(status().isNoContent())
+            .andReturn();
+    MvcResult missingResult =
+        performPasswordRecoveryRequest("missing-user", "password-recovery-request-missing")
+            .andExpect(status().isNoContent())
+            .andReturn();
+
+    assertEquals(
+        "password-recovery-request-existing",
+        existingResult.getResponse().getHeader("X-Request-Id"));
+    assertEquals(
+        "password-recovery-request-missing", missingResult.getResponse().getHeader("X-Request-Id"));
+    String existingHandoffRequestId =
+        existingResult.getResponse().getHeader("X-Password-Recovery-Request-Id");
+    String missingHandoffRequestId =
+        missingResult.getResponse().getHeader("X-Password-Recovery-Request-Id");
+
+    assertNotNull(existingHandoffRequestId);
+    assertNotNull(missingHandoffRequestId);
+    assertNotEquals("password-recovery-request-existing", existingHandoffRequestId);
+    assertNotEquals("password-recovery-request-missing", missingHandoffRequestId);
+    assertNotEquals(existingHandoffRequestId, missingHandoffRequestId);
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/password-recovery-tokens/by-request-id")
+                .header(
+                    "Authorization",
+                    internalServiceAuthorization(
+                        AUTH_ADMIN_SUBJECT, InternalServiceScope.AUTH_ADMIN))
+                .param("requestId", missingHandoffRequestId))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void passwordRecoveryConfirmChangesPasswordAndRevokesRefreshSessions() throws Exception {
+    TokenPairResponseView loginResult = loginResult("alice", "password123!", "recovery-login-001");
+    MvcResult requestResult =
+        performPasswordRecoveryRequest("alice", "recovery-request-001")
+            .andExpect(status().isNoContent())
+            .andReturn();
+    String requestId = requestResult.getResponse().getHeader("X-Password-Recovery-Request-Id");
+    JsonNode tokenView = lookupPasswordRecoveryTokenByRequestId(requestId);
+    assertEquals("recovery-request-001", requestResult.getResponse().getHeader("X-Request-Id"));
+    assertEquals(requestId, tokenView.get("requestId").asText());
+    assertEquals("alice", tokenView.get("loginId").asText());
+    assertEquals("PENDING", tokenView.get("tokenStatus").asText());
+
+    performPasswordRecoveryConfirm(
+            tokenView.get("recoveryToken").asText(), "newPassword456!", "recovery-confirm-001")
+        .andExpect(status().isNoContent());
+
+    loginExpectUnauthorized("alice", "password123!", "recovery-old-login-001");
+    refreshExpectUnauthorized(loginResult.refreshToken(), "recovery-old-refresh-001");
+    login("alice", "newPassword456!", "recovery-new-login-001");
+  }
+
+  @Test
+  void passwordRecoveryConfirmRejectsWrongTokenWithGenericUnauthorized() throws Exception {
+    performPasswordRecoveryConfirm(
+            "invalid-recovery-token", "newPassword456!", "recovery-wrong-001")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("password recovery failed"));
+  }
+
+  @Test
+  void passwordRecoveryConfirmRejectsExpiredTokenWithGenericUnauthorized() throws Exception {
+    MvcResult requestResult =
+        performPasswordRecoveryRequest("alice", "recovery-expired-request-001")
+            .andExpect(status().isNoContent())
+            .andReturn();
+    String requestId = requestResult.getResponse().getHeader("X-Password-Recovery-Request-Id");
+    JsonNode tokenView = lookupPasswordRecoveryTokenByRequestId(requestId);
+    expirePasswordRecoveryToken(requestId);
+    assertEquals(
+        "EXPIRED", lookupPasswordRecoveryTokenByRequestId(requestId).get("tokenStatus").asText());
+
+    performPasswordRecoveryConfirm(
+            tokenView.get("recoveryToken").asText(),
+            "newPassword456!",
+            "recovery-expired-confirm-001")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("password recovery failed"));
+  }
+
+  @Test
+  void passwordRecoveryConfirmRejectsUsedTokenReuseWithGenericUnauthorized() throws Exception {
+    MvcResult requestResult =
+        performPasswordRecoveryRequest("alice", "recovery-used-request-001")
+            .andExpect(status().isNoContent())
+            .andReturn();
+    String requestId = requestResult.getResponse().getHeader("X-Password-Recovery-Request-Id");
+    JsonNode tokenView = lookupPasswordRecoveryTokenByRequestId(requestId);
+    String recoveryToken = tokenView.get("recoveryToken").asText();
+
+    performPasswordRecoveryConfirm(recoveryToken, "newPassword456!", "recovery-used-confirm-001")
+        .andExpect(status().isNoContent());
+
+    performPasswordRecoveryConfirm(recoveryToken, "nextPassword789!", "recovery-used-confirm-002")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("password recovery failed"));
+  }
+
+  @Test
+  void passwordRecoveryConfirmRejectsInactiveUserWithGenericUnauthorized() throws Exception {
+    MvcResult requestResult =
+        performPasswordRecoveryRequest("alice", "recovery-inactive-request-001")
+            .andExpect(status().isNoContent())
+            .andReturn();
+    String requestId = requestResult.getResponse().getHeader("X-Password-Recovery-Request-Id");
+    JsonNode tokenView = lookupPasswordRecoveryTokenByRequestId(requestId);
+    updateLegacyUserStatus(userId, "DISABLED", "fraud-review", "recovery-inactive-disable-001");
+
+    performPasswordRecoveryConfirm(
+            tokenView.get("recoveryToken").asText(),
+            "newPassword456!",
+            "recovery-inactive-confirm-001")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("password recovery failed"));
   }
 
   @Test
@@ -1622,6 +1751,77 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
       requestBuilder.header("X-Request-Id", requestId);
     }
     return mockMvc.perform(requestBuilder);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performPasswordRecoveryRequest(
+      String loginId, String requestId) throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        post("/api/v1/auth/password-recovery/request")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "loginId": "%s"
+                }
+                """
+                    .formatted(loginId));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performPasswordRecoveryConfirm(
+      String recoveryToken, String newPassword, String requestId) throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        post("/api/v1/auth/password-recovery/confirm")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "recoveryToken": "%s",
+                  "newPassword": "%s"
+                }
+                """
+                    .formatted(recoveryToken, newPassword));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private JsonNode lookupPasswordRecoveryTokenByRequestId(String requestId) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/internal/api/v1/auth/password-recovery-tokens/by-request-id")
+                    .header(
+                        "Authorization",
+                        internalServiceAuthorization(
+                            AUTH_ADMIN_SUBJECT, InternalServiceScope.AUTH_ADMIN))
+                    .param("requestId", requestId))
+            .andExpect(status().isOk())
+            .andReturn();
+    return objectMapper.readTree(result.getResponse().getContentAsByteArray());
+  }
+
+  private void expirePasswordRecoveryToken(String requestId) {
+    commit(
+        transactionManager,
+        () -> {
+          int updated =
+              jdbcTemplate.update(
+                  """
+                  UPDATE auth_password_recovery_token
+                  SET token_status = 'EXPIRED',
+                      expires_at = CURRENT_TIMESTAMP - INTERVAL '1 minute',
+                      updated_at = CURRENT_TIMESTAMP
+                  WHERE request_id = :requestId
+                  """,
+                  new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
+                      .addValue("requestId", requestId));
+          assertEquals(1, updated);
+        });
   }
 
   private void passwordResetExpectUnauthorized(

--- a/docs/superpowers/specs/2026-04-20-auth-forgot-password-recovery-design.md
+++ b/docs/superpowers/specs/2026-04-20-auth-forgot-password-recovery-design.md
@@ -1,0 +1,195 @@
+# Auth Forgot-Password Recovery Design
+
+## Goal
+
+로그인되지 않은 사용자가 recovery token으로 비밀번호를 재설정할 수 있는 public forgot-password 플로우를 추가한다. 메일/문자 채널이 아직 없으므로, token 값은 public 응답에 직접 노출하지 않고 internal exact lookup으로만 확인할 수 있게 한다.
+
+## Scope
+
+- 포함:
+  - public password recovery request API
+  - public password recovery confirm API
+  - internal recovery token exact lookup API
+  - recovery token 저장 테이블과 TTL/status 관리
+  - 성공 시 password hash 교체 + active refresh session revoke
+- 제외:
+  - 메일/문자 발송 채널
+  - 관리자 강제 비밀번호 초기화
+  - access token 즉시 폐기
+  - forgot-password UI
+  - 비밀번호 정책 확장
+
+## Current Constraints
+
+- 현재 공개 비밀번호 재설정은 JWT user가 current password를 아는 self-service reset만 지원한다.
+- `bank_user`는 `login_id`, `password_hash`, status와 login protection 메타데이터만 가진다.
+- 메일/문자/이메일 컬럼이나 외부 연락 채널이 없다.
+- refresh session revoke는 기존 `RefreshTokenSessionWritePort`로 이미 지원된다.
+- `RequestIdFilter`가 있으므로 public request 뒤 internal exact lookup을 `requestId` 기준으로 연결할 수 있다.
+
+## Approaches Considered
+
+### 1. Public request + public confirm + internal exact lookup
+
+권장안이다. public request는 항상 `204`를 반환하고, active user가 있으면 recovery token을 발급한다. 토큰 값은 `requestId`를 키로 하는 internal lookup에서만 확인한다. 메일/문자 채널이 없는 현재 제약과 user enumeration 방지 요구를 같이 만족한다.
+
+### 2. Public request 응답 본문에 recovery token 직접 반환
+
+구현은 가장 빠르다. 하지만 `loginId`만 알면 token을 받아갈 수 있으므로 보안 경계가 크게 무너진다. 현재 저장소 규칙과 auth generic failure 원칙에 맞지 않는다.
+
+### 3. Internal admin만 발급, public confirm만 제공
+
+안전하지만 forgot-password self-service 플로우라기보다 운영자 보조 reset에 가깝다. 사용자 요청 경로와 후속 메일/문자 채널 재사용성이 떨어진다.
+
+## Selected Design
+
+권장안 1을 채택한다. public request와 confirm은 일반 사용자 경로로 제공하고, recovery token 값 자체는 internal exact lookup에서만 확인한다. 이렇게 하면 현재 연락 채널이 없어도 로컬/운영 검증이 가능하고, 후속 메일/문자 채널을 붙일 때 public API 계약을 바꾸지 않아도 된다.
+
+## API Contract
+
+### `POST /api/v1/auth/password-recovery/request`
+
+- 인증: 없음
+- request body:
+  - `loginId`
+- response:
+  - 항상 `204 No Content`
+  - `X-Request-Id` 헤더는 기존 필터가 채운다.
+- 동작:
+  - active user가 존재하면 새 recovery token을 발급한다.
+  - 같은 user의 기존 `PENDING` token은 `SUPERSEDED` 상태로 바꾼다.
+  - unknown user, non-active user여도 응답은 동일하게 유지한다.
+
+### `POST /api/v1/auth/password-recovery/confirm`
+
+- 인증: 없음
+- request body:
+  - `recoveryToken`
+  - `newPassword`
+- response:
+  - 성공: `204 No Content`
+  - 실패: `401 password recovery failed`
+- 동작:
+  - token hash exact lookup
+  - `PENDING` + `expires_at > now` + user `ACTIVE` 확인
+  - 성공 시 password hash 교체, token `USED`, active refresh session revoke
+
+### `GET /internal/api/v1/auth/password-recovery-tokens/{requestId}`
+
+- 인증: internal service token + `AUTH_ADMIN`
+- response:
+  - `requestId`
+  - `userId`
+  - `loginId`
+  - `recoveryToken`
+  - `tokenStatus`
+  - `expiresAt`
+  - `usedAt`
+  - `createdAt`
+- 실패:
+  - wrong scope/missing token: `401`
+  - missing requestId: `404`
+
+## Data Model
+
+새 테이블 `auth_password_recovery_token`을 추가한다.
+
+- 컬럼:
+  - `id BIGSERIAL PRIMARY KEY`
+  - `request_id VARCHAR(64) NOT NULL UNIQUE`
+  - `user_id BIGINT NOT NULL`
+  - `login_id VARCHAR(80) NOT NULL`
+  - `token_hash VARCHAR(64) NOT NULL UNIQUE`
+  - `token_ciphertext TEXT NOT NULL`
+  - `token_nonce VARCHAR(64) NOT NULL`
+  - `token_status VARCHAR(16) NOT NULL`
+    - `PENDING`, `USED`, `EXPIRED`, `SUPERSEDED`
+  - `expires_at TIMESTAMP WITH TIME ZONE NOT NULL`
+  - `used_at TIMESTAMP WITH TIME ZONE NULL`
+  - `created_at TIMESTAMP WITH TIME ZONE NOT NULL`
+  - `updated_at TIMESTAMP WITH TIME ZONE NOT NULL`
+- 인덱스:
+  - `uq_auth_password_recovery_token_request_id`
+  - `uq_auth_password_recovery_token_hash`
+  - `idx_auth_password_recovery_token_status_expiry (token_status, expires_at ASC, user_id ASC)`
+
+`request_id` exact lookup은 internal retrieval용, `token_hash` exact lookup은 confirm용이다. `status + expires_at` 인덱스는 후속 cleanup이나 만료 스캔을 bounded path로 유지한다.
+
+## Token Generation And Storage
+
+- token plain text:
+  - 32 random bytes를 base64url-no-padding 문자열로 인코딩
+- token hash:
+  - `SHA-256` hex
+- token encrypted storage:
+  - `AES-GCM`
+  - TOTP secret manager와 같은 암호화 패턴을 따르되 password recovery 전용 port로 분리
+- TTL:
+  - 기본 `15분`
+  - property 예시: `security.password-recovery.ttl-seconds`
+
+plain token은 public 응답에 실리지 않는다. DB에는 exact lookup용 hash와 internal 조회용 ciphertext/nonce만 저장한다.
+
+## Request Flow
+
+1. `loginId`로 user exact lookup
+2. user가 없거나 `ACTIVE`가 아니면 아무 token도 만들지 않고 종료
+3. active user면 새 token 생성
+4. 같은 user의 `PENDING` token을 `SUPERSEDED`로 변경
+5. 새 row insert
+
+public 응답은 항상 동일하게 `204`다.
+
+## Confirm Flow
+
+1. `recoveryToken` hash 계산
+2. token row `FOR UPDATE` exact lookup
+3. row가 없거나 status가 `PENDING`이 아니면 generic `401`
+4. `expires_at <= now`면 `EXPIRED`로 갱신 후 generic `401`
+5. user `ACTIVE` 확인, 아니면 generic `401`
+6. password hash 교체
+7. token `USED`, `used_at = now`
+8. active refresh session 전체 revoke
+
+이 순서는 password reset 성공/실패와 token 상태 전이가 같은 transaction 안에서 끝나도록 유지한다.
+
+## Error Policy
+
+- request:
+  - validation 오류만 `400`
+  - 나머지는 user 존재 여부와 관계없이 `204`
+- confirm:
+  - validation 오류 `400`
+  - wrong/expired/used token, inactive user는 모두 `401 password recovery failed`
+- internal lookup:
+  - missing/wrong scope `401`
+  - unknown requestId `404`
+
+## Security Notes
+
+- public request 응답으로 token을 직접 노출하지 않는다.
+- generic failure를 유지해 loginId 존재 여부와 token 상태를 외부에서 추정하지 못하게 한다.
+- access token 즉시 폐기는 하지 않고, 기존 self-service reset과 동일하게 refresh revoke까지만 보장한다.
+- internal lookup은 운영/로컬 검증용 임시 handoff 채널이다. 메일/문자 채널이 붙으면 plain token 전달 책임은 그 채널로 이동한다.
+
+## Testing Strategy
+
+- unit:
+  - request service: active/non-active/unknown user 처리
+  - confirm service: success, wrong token, expired token, used token, inactive user
+  - token secret manager: generate/hash/encrypt/decrypt round-trip
+- integration:
+  - request existing/non-existing `loginId` 모두 `204`
+  - internal lookup returns token only for existing requestId with `AUTH_ADMIN`
+  - confirm success 뒤 old password login 실패, new password login 성공
+  - confirm success 뒤 기존 refresh token refresh 실패
+  - used/expired token 재사용 시 generic `401`
+
+## Rollout And Follow-Ups
+
+- 이번 PR은 forgot-password core flow만 닫는다.
+- 후속 작업:
+  - 메일/문자 발송 채널 연동
+  - request rate limit / abuse protection
+  - expired token cleanup job
+  - 운영 감사 로그/메트릭 추가

--- a/docs/superpowers/specs/2026-04-20-auth-forgot-password-recovery-design.md
+++ b/docs/superpowers/specs/2026-04-20-auth-forgot-password-recovery-design.md
@@ -25,7 +25,7 @@
 - `bank_user`는 `login_id`, `password_hash`, status와 login protection 메타데이터만 가진다.
 - 메일/문자/이메일 컬럼이나 외부 연락 채널이 없다.
 - refresh session revoke는 기존 `RefreshTokenSessionWritePort`로 이미 지원된다.
-- `RequestIdFilter`가 있으므로 public request 뒤 internal exact lookup을 `requestId` 기준으로 연결할 수 있다.
+- `RequestIdFilter`의 `X-Request-Id`는 trace 전용으로 유지하고, password recovery handoff id는 별도로 발급해 internal exact lookup과 연결할 수 있다.
 
 ## Approaches Considered
 
@@ -43,7 +43,7 @@
 
 ## Selected Design
 
-권장안 1을 채택한다. public request와 confirm은 일반 사용자 경로로 제공하고, recovery token 값 자체는 internal exact lookup에서만 확인한다. 이렇게 하면 현재 연락 채널이 없어도 로컬/운영 검증이 가능하고, 후속 메일/문자 채널을 붙일 때 public API 계약을 바꾸지 않아도 된다.
+권장안 1을 채택한다. public request와 confirm은 일반 사용자 경로로 제공하고, recovery token 값 자체는 internal exact lookup에서만 확인한다. public request는 trace용 `X-Request-Id`와 분리된 서버 발급 handoff requestId를 별도 response header로 반환한다. handoff requestId 생성 책임은 controller가 아니라 password recovery use case 안에 둔다. 이렇게 하면 현재 연락 채널이 없어도 로컬/운영 검증이 가능하고, 후속 메일/문자 채널을 붙일 때 public API 계약을 바꾸지 않아도 된다.
 
 ## API Contract
 
@@ -54,8 +54,11 @@
   - `loginId`
 - response:
   - 항상 `204 No Content`
-  - `X-Request-Id` 헤더는 기존 필터가 채운다.
+  - `X-Request-Id` 헤더는 기존 필터가 trace 용도로 채운다.
+  - `X-Password-Recovery-Request-Id` 헤더에 서버가 발급한 handoff requestId를 반환한다.
 - 동작:
+  - caller가 보낸 `X-Request-Id` 값은 recovery token `request_id`로 저장하지 않는다.
+  - password recovery use case가 새 handoff requestId를 생성해 `auth_password_recovery_token.request_id`에 저장한다.
   - active user가 존재하면 새 recovery token을 발급한다.
   - 같은 user의 기존 `PENDING` token은 `SUPERSEDED` 상태로 바꾼다.
   - unknown user, non-active user여도 응답은 동일하게 유지한다.
@@ -74,7 +77,7 @@
   - `PENDING` + `expires_at > now` + user `ACTIVE` 확인
   - 성공 시 password hash 교체, token `USED`, active refresh session revoke
 
-### `GET /internal/api/v1/auth/password-recovery-tokens/{requestId}`
+### `GET /internal/api/v1/auth/password-recovery-tokens/by-request-id?requestId=...`
 
 - 인증: internal service token + `AUTH_ADMIN`
 - response:
@@ -88,7 +91,8 @@
   - `createdAt`
 - 실패:
   - wrong scope/missing token: `401`
-  - missing requestId: `404`
+  - missing/blank requestId: `400`
+  - unknown requestId: `404`
 
 ## Data Model
 
@@ -163,6 +167,7 @@ public 응답은 항상 동일하게 `204`다.
   - wrong/expired/used token, inactive user는 모두 `401 password recovery failed`
 - internal lookup:
   - missing/wrong scope `401`
+  - missing/blank requestId `400`
   - unknown requestId `404`
 
 ## Security Notes
@@ -170,7 +175,7 @@ public 응답은 항상 동일하게 `204`다.
 - public request 응답으로 token을 직접 노출하지 않는다.
 - generic failure를 유지해 loginId 존재 여부와 token 상태를 외부에서 추정하지 못하게 한다.
 - access token 즉시 폐기는 하지 않고, 기존 self-service reset과 동일하게 refresh revoke까지만 보장한다.
-- internal lookup은 운영/로컬 검증용 임시 handoff 채널이다. 메일/문자 채널이 붙으면 plain token 전달 책임은 그 채널로 이동한다.
+- internal lookup은 운영/로컬 검증용 임시 handoff 채널이다. 조회 키는 trace request-id가 아니라 password recovery handoff requestId다. 메일/문자 채널이 붙으면 plain token 전달 책임은 그 채널로 이동한다.
 
 ## Testing Strategy
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #144

## 🌿 Base Branch
- `main`

## 📝 Summary
- 로그인되지 않은 사용자가 recovery token으로 비밀번호를 재설정할 수 있는 forgot-password 복구 플로우를 추가했습니다.
- public request/confirm 경로와 internal by-request-id lookup 경로를 분리하고, token handoff를 `X-Password-Recovery-Request-Id`로 고정했습니다.
- password reset 성공 시 기존 self-service reset과 동일하게 active refresh session revoke까지 보장합니다.

## 🛠 Changes
- `auth_password_recovery_token` 스키마와 domain model/port를 추가했습니다.
- password recovery request/confirm use case, AES-GCM token manager, JDBC repository, internal lookup API를 연결했습니다.
- request/confirm/integration/controller/security 테스트와 README 운영 메모를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth-recovery-contract ./back/gradlew -p back compileJava`
- `tools/test/with-resource-lock.sh back-gradle-auth-recovery-usecase ./back/gradlew -p back compileJava`
- `tools/test/with-resource-lock.sh back-gradle-auth-recovery-api ./back/gradlew -p back compileJava`
- `tools/test/with-resource-lock.sh back-gradle-auth-password-recovery ./back/gradlew -p back test --tests '*PasswordRecovery*' --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - password recovery handoff header와 internal lookup 계약이 운영 스크립트/검증 절차와 어긋나면 token 확인 경로가 깨질 수 있습니다.
  - recovery token 만료/상태 전이 계약이 변경되면 forgot-password 실패 응답이 흔들릴 수 있습니다.
- 롤백 방법:
  - PR revert로 password recovery schema/API/usecase를 함께 되돌리고, staging에서 request/confirm 회귀를 다시 확인합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?