### PR TITLE
[Feat] MFA(TOTP) 해제 API 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -478,12 +478,18 @@ TOTP MFA는 `login -> challenge -> verify` 2단계 경로로만 token pair를 �
 - 공개 endpoint:
   - `POST /api/v1/auth/mfa/totp/enroll`
   - `POST /api/v1/auth/mfa/totp/enroll/verify`
+  - `POST /api/v1/auth/mfa/totp/disable`
   - `POST /api/v1/auth/mfa/totp/challenge/verify`
 - 등록 기준:
   - enrollment start/verify는 현재 JWT user만 호출 가능하고 bootstrap account principal은 `403`
   - start 응답은 `status=PENDING`, `secretKey`, `otpauthUri`, `expiresAt`
   - verify request body는 `totpCode`
   - verify 성공 시 credential 상태는 `ACTIVE`, 응답은 `status=ACTIVE`, `verifiedAt`
+- 해제 기준:
+  - disable request body는 `totpCode`
+  - 현재 JWT user와 현재 `ACTIVE` credential, 유효한 현재 TOTP code가 모두 맞을 때만 `204 No Content`
+  - disable 성공 시 `auth_totp_credential` row는 삭제되고 해당 user의 active refresh session은 전부 `REVOKED`
+  - wrong code, 활성 credential 없음, 비활성 user는 `401 mfa disable failed`
 - 로그인 challenge 기준:
   - `ACTIVE` TOTP credential이 있는 사용자의 `POST /api/v1/auth/login` 응답은 `status=MFA_REQUIRED`
   - 이때 `challengeId`, `challengeType=TOTP`, `challengeExpiresAt`만 내려가고 token pair는 비어 있다

--- a/back/src/main/java/com/aquilabank/domain/auth/model/TotpDisableCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/TotpDisableCommand.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** 현재 JWT user가 MFA 해제를 요청할 때 필요한 최소 입력값입니다. */
+public record TotpDisableCommand(long userId, String totpCode) {
+
+  public TotpDisableCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (totpCode == null || !totpCode.matches("\\d{6}")) {
+      throw new IllegalArgumentException("totpCode must be 6 digits");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/TotpCredentialWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/TotpCredentialWritePort.java
@@ -11,4 +11,6 @@ public interface TotpCredentialWritePort {
   void activate(TotpCredentialActivateCommand command);
 
   void touchLastUsed(TotpCredentialTouchCommand command);
+
+  void deleteByUserId(long userId);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpDisableService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpDisableService.java
@@ -1,0 +1,74 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.TotpCredential;
+import com.aquilabank.domain.auth.model.TotpCredentialStatus;
+import com.aquilabank.domain.auth.model.TotpDisableCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
+import com.aquilabank.domain.auth.port.TotpCredentialWritePort;
+import com.aquilabank.domain.auth.port.TotpSecretPort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** 현재 TOTP code 재검증 뒤 credential 제거와 session 정리를 같은 tx에 묶습니다. */
+public final class TotpDisableService implements TotpDisableUseCase {
+
+  private final UserCredentialLoadPort userCredentialLoadPort;
+  private final TotpCredentialLoadPort totpCredentialLoadPort;
+  private final TotpCredentialWritePort totpCredentialWritePort;
+  private final TotpSecretPort totpSecretPort;
+  private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
+  private final Clock clock;
+
+  public TotpDisableService(
+      UserCredentialLoadPort userCredentialLoadPort,
+      TotpCredentialLoadPort totpCredentialLoadPort,
+      TotpCredentialWritePort totpCredentialWritePort,
+      TotpSecretPort totpSecretPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      Clock clock) {
+    this.userCredentialLoadPort = userCredentialLoadPort;
+    this.totpCredentialLoadPort = totpCredentialLoadPort;
+    this.totpCredentialWritePort = totpCredentialWritePort;
+    this.totpSecretPort = totpSecretPort;
+    this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
+    this.clock = clock;
+  }
+
+  @Override
+  public void disable(TotpDisableCommand command) {
+    Instant now = Instant.now(clock);
+    loadActiveUser(command.userId());
+    TotpCredential credential =
+        totpCredentialLoadPort
+            .findCredentialByUserIdForUpdate(command.userId())
+            .orElseThrow(this::invalidDisable);
+    if (credential.credentialStatus() != TotpCredentialStatus.ACTIVE) {
+      throw invalidDisable();
+    }
+    if (!totpSecretPort.matches(
+        credential.secretCiphertext(), credential.secretNonce(), command.totpCode(), now)) {
+      throw invalidDisable();
+    }
+
+    totpCredentialWritePort.deleteByUserId(command.userId());
+    refreshTokenSessionWritePort.revokeActiveSessionsByUserId(command.userId(), now);
+  }
+
+  private LoginUser loadActiveUser(long userId) {
+    LoginUser user =
+        userCredentialLoadPort.findByUserIdForUpdate(userId).orElseThrow(this::invalidDisable);
+    if (user.status() != UserStatus.ACTIVE) {
+      throw invalidDisable();
+    }
+    return user;
+  }
+
+  private InvalidCredentialsException invalidDisable() {
+    return new InvalidCredentialsException("mfa disable failed");
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpDisableUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpDisableUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.TotpDisableCommand;
+
+/** 현재 로그인 사용자 MFA 해제 진입점입니다. */
+public interface TotpDisableUseCase {
+
+  void disable(TotpDisableCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -59,6 +59,8 @@ import com.aquilabank.domain.auth.usecase.RefreshTokenService;
 import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
 import com.aquilabank.domain.auth.usecase.TotpChallengeVerifyService;
 import com.aquilabank.domain.auth.usecase.TotpChallengeVerifyUseCase;
+import com.aquilabank.domain.auth.usecase.TotpDisableService;
+import com.aquilabank.domain.auth.usecase.TotpDisableUseCase;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentService;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryService;
@@ -291,6 +293,28 @@ public class AuthConfiguration {
       }
       return transactionResult.result();
     };
+  }
+
+  @Bean
+  TotpDisableUseCase totpDisableUseCase(
+      UserCredentialLoadPort userCredentialLoadPort,
+      TotpCredentialLoadPort totpCredentialLoadPort,
+      TotpCredentialWritePort totpCredentialWritePort,
+      TotpSecretPort totpSecretPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    TotpDisableService totpDisableService =
+        new TotpDisableService(
+            userCredentialLoadPort,
+            totpCredentialLoadPort,
+            totpCredentialWritePort,
+            totpSecretPort,
+            refreshTokenSessionWritePort,
+            authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command ->
+        transactionTemplate.executeWithoutResult(status -> totpDisableService.disable(command));
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -466,6 +466,22 @@ public class JdbcAuthWriteRepository
 
   @Override
   @Transactional
+  public void deleteByUserId(long userId) {
+    int updated =
+        jdbcTemplate.update(
+            """
+            DELETE FROM auth_totp_credential
+            WHERE user_id = :userId
+              AND credential_status = 'ACTIVE'
+            """,
+            new MapSqlParameterSource().addValue("userId", userId));
+    if (updated != 1) {
+      throw new IllegalStateException("totp credential is not active");
+    }
+  }
+
+  @Override
+  @Transactional
   public void upsert(TotpLoginChallengeUpsertCommand command) {
     jdbcTemplate.update(
         """

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -14,6 +14,7 @@ import com.aquilabank.domain.auth.model.PasswordRecoveryRequestResult;
 import com.aquilabank.domain.auth.model.PasswordResetCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenCommand;
 import com.aquilabank.domain.auth.model.TotpChallengeVerifyCommand;
+import com.aquilabank.domain.auth.model.TotpDisableCommand;
 import com.aquilabank.domain.auth.model.TotpEnrollmentStartCommand;
 import com.aquilabank.domain.auth.model.TotpEnrollmentStartResult;
 import com.aquilabank.domain.auth.model.TotpEnrollmentVerifyCommand;
@@ -28,6 +29,7 @@ import com.aquilabank.domain.auth.usecase.PasswordRecoveryRequestUseCase;
 import com.aquilabank.domain.auth.usecase.PasswordResetUseCase;
 import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
 import com.aquilabank.domain.auth.usecase.TotpChallengeVerifyUseCase;
+import com.aquilabank.domain.auth.usecase.TotpDisableUseCase;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
 import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
@@ -72,6 +74,7 @@ public class LoginController {
   private final RefreshTokenUseCase refreshTokenUseCase;
   private final TotpEnrollmentUseCase totpEnrollmentUseCase;
   private final TotpChallengeVerifyUseCase totpChallengeVerifyUseCase;
+  private final TotpDisableUseCase totpDisableUseCase;
   private final LogoutUseCase logoutUseCase;
   private final PasswordResetUseCase passwordResetUseCase;
   private final PasswordRecoveryRequestUseCase passwordRecoveryRequestUseCase;
@@ -87,6 +90,7 @@ public class LoginController {
       RefreshTokenUseCase refreshTokenUseCase,
       TotpEnrollmentUseCase totpEnrollmentUseCase,
       TotpChallengeVerifyUseCase totpChallengeVerifyUseCase,
+      TotpDisableUseCase totpDisableUseCase,
       LogoutUseCase logoutUseCase,
       PasswordResetUseCase passwordResetUseCase,
       PasswordRecoveryRequestUseCase passwordRecoveryRequestUseCase,
@@ -100,6 +104,7 @@ public class LoginController {
     this.refreshTokenUseCase = refreshTokenUseCase;
     this.totpEnrollmentUseCase = totpEnrollmentUseCase;
     this.totpChallengeVerifyUseCase = totpChallengeVerifyUseCase;
+    this.totpDisableUseCase = totpDisableUseCase;
     this.logoutUseCase = logoutUseCase;
     this.passwordResetUseCase = passwordResetUseCase;
     this.passwordRecoveryRequestUseCase = passwordRecoveryRequestUseCase;
@@ -146,6 +151,15 @@ public class LoginController {
         totpChallengeVerifyUseCase.verify(
             new TotpChallengeVerifyCommand(request.challengeId(), request.totpCode()));
     return LoginResponse.from(result);
+  }
+
+  @PostMapping("/mfa/totp/disable")
+  public ResponseEntity<Void> disableTotp(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @Valid @RequestBody TotpCodeRequest request) {
+    AuthenticatedUserPrincipal userPrincipal = requireUserPrincipal(principal);
+    totpDisableUseCase.disable(new TotpDisableCommand(userPrincipal.userId(), request.totpCode()));
+    return ResponseEntity.noContent().build();
   }
 
   @GetMapping("/sessions")

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/TotpDisableServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/TotpDisableServiceTest.java
@@ -1,0 +1,108 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.TotpCredential;
+import com.aquilabank.domain.auth.model.TotpCredentialStatus;
+import com.aquilabank.domain.auth.model.TotpDisableCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
+import com.aquilabank.domain.auth.port.TotpCredentialWritePort;
+import com.aquilabank.domain.auth.port.TotpSecretPort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TotpDisableServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-20T08:00:00Z");
+
+  @Test
+  void disableDeletesCredentialAndRevokesActiveSessionsWhenCodeMatches() {
+    UserCredentialLoadPort userCredentialLoadPort = Mockito.mock(UserCredentialLoadPort.class);
+    TotpCredentialLoadPort totpCredentialLoadPort = Mockito.mock(TotpCredentialLoadPort.class);
+    TotpCredentialWritePort totpCredentialWritePort = Mockito.mock(TotpCredentialWritePort.class);
+    TotpSecretPort totpSecretPort = Mockito.mock(TotpSecretPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+
+    when(userCredentialLoadPort.findByUserIdForUpdate(7L)).thenReturn(Optional.of(activeUser()));
+    when(totpCredentialLoadPort.findCredentialByUserIdForUpdate(7L))
+        .thenReturn(Optional.of(activeCredential()));
+    when(totpSecretPort.matches("cipher", "nonce", "123456", NOW)).thenReturn(true);
+
+    TotpDisableService service =
+        new TotpDisableService(
+            userCredentialLoadPort,
+            totpCredentialLoadPort,
+            totpCredentialWritePort,
+            totpSecretPort,
+            refreshTokenSessionWritePort,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    service.disable(new TotpDisableCommand(7L, "123456"));
+
+    verify(totpCredentialWritePort).deleteByUserId(7L);
+    verify(refreshTokenSessionWritePort).revokeActiveSessionsByUserId(7L, NOW);
+  }
+
+  @Test
+  void disableRejectsWrongTotpCodeWithoutDeletingCredential() {
+    UserCredentialLoadPort userCredentialLoadPort = Mockito.mock(UserCredentialLoadPort.class);
+    TotpCredentialLoadPort totpCredentialLoadPort = Mockito.mock(TotpCredentialLoadPort.class);
+    TotpCredentialWritePort totpCredentialWritePort = Mockito.mock(TotpCredentialWritePort.class);
+    TotpSecretPort totpSecretPort = Mockito.mock(TotpSecretPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+
+    when(userCredentialLoadPort.findByUserIdForUpdate(7L)).thenReturn(Optional.of(activeUser()));
+    when(totpCredentialLoadPort.findCredentialByUserIdForUpdate(7L))
+        .thenReturn(Optional.of(activeCredential()));
+    when(totpSecretPort.matches("cipher", "nonce", "123456", NOW)).thenReturn(false);
+
+    TotpDisableService service =
+        new TotpDisableService(
+            userCredentialLoadPort,
+            totpCredentialLoadPort,
+            totpCredentialWritePort,
+            totpSecretPort,
+            refreshTokenSessionWritePort,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () -> service.disable(new TotpDisableCommand(7L, "123456")));
+
+    verify(totpCredentialWritePort, never()).deleteByUserId(anyLong());
+    verify(refreshTokenSessionWritePort, never())
+        .revokeActiveSessionsByUserId(anyLong(), any(Instant.class));
+  }
+
+  private LoginUser activeUser() {
+    return new LoginUser(7L, "alice", "encoded-password", UserStatus.ACTIVE, 0, null, null, null);
+  }
+
+  private TotpCredential activeCredential() {
+    return new TotpCredential(
+        7L,
+        TotpCredentialStatus.ACTIVE,
+        "cipher",
+        "nonce",
+        null,
+        NOW.minus(Duration.ofMinutes(10)),
+        NOW.minus(Duration.ofMinutes(1)));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -980,6 +980,23 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void bootstrapAccountPrincipalCannotDisableTotp() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/auth/mfa/totp/disable")
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "totpCode": "123456"
+                    }
+                    """))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
   void passwordRecoveryRequestReturnsGenericNoContentWithSeparateHandoffRequestId()
       throws Exception {
     MvcResult existingResult =
@@ -1494,6 +1511,46 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         "totp-limit-challenge-after-failed");
   }
 
+  @Test
+  void totpDisableDeletesCredentialRevokesSessionsAndNextLoginReturnsTokenPair() throws Exception {
+    TokenPairResponseView initialSession =
+        loginResult("alice", "password123!", "totp-disable-login-001", WINDOWS_CHROME);
+    TotpEnrollmentStartResponseView enrollment =
+        startTotpEnrollment(initialSession.accessToken(), "totp-disable-start-001");
+    verifyTotpEnrollment(
+        initialSession.accessToken(),
+        currentTotpCode(enrollment.secretKey()),
+        "totp-disable-verify-001");
+
+    disableTotp(
+        initialSession.accessToken(),
+        currentTotpCode(enrollment.secretKey()),
+        "totp-disable-request-001");
+
+    assertEquals(0, countTotpCredentialRows(userId));
+    assertEquals(0, countActiveRefreshSessions(userId));
+
+    loginResult("alice", "password123!", "totp-disable-login-002", WINDOWS_EDGE);
+  }
+
+  @Test
+  void totpDisableRejectsWrongCodeAndKeepsCredential() throws Exception {
+    TokenPairResponseView initialSession =
+        loginResult("alice", "password123!", "totp-disable-wrong-login-001", WINDOWS_CHROME);
+    TotpEnrollmentStartResponseView enrollment =
+        startTotpEnrollment(initialSession.accessToken(), "totp-disable-wrong-start-001");
+    verifyTotpEnrollment(
+        initialSession.accessToken(),
+        currentTotpCode(enrollment.secretKey()),
+        "totp-disable-wrong-verify-001");
+
+    disableTotpExpectUnauthorized(
+        initialSession.accessToken(), "000000", "totp-disable-wrong-request-001");
+
+    assertEquals(1, countTotpCredentialRows(userId));
+    assertEquals(1, countActiveRefreshSessions(userId));
+  }
+
   private String login(String loginId, String password) throws Exception {
     return login(loginId, password, null);
   }
@@ -1654,6 +1711,17 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.message").value("mfa challenge failed"));
   }
 
+  private void disableTotp(String accessToken, String totpCode, String requestId) throws Exception {
+    performDisableTotp(accessToken, totpCode, requestId).andExpect(status().isNoContent());
+  }
+
+  private void disableTotpExpectUnauthorized(String accessToken, String totpCode, String requestId)
+      throws Exception {
+    performDisableTotp(accessToken, totpCode, requestId)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("mfa disable failed"));
+  }
+
   private org.springframework.test.web.servlet.ResultActions performStartTotpEnrollment(
       String accessToken, String requestId) throws Exception {
     MockHttpServletRequestBuilder requestBuilder =
@@ -1701,6 +1769,25 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
       requestBuilder.header("X-Request-Id", requestId);
     }
     applyClientMetadata(requestBuilder, clientMetadata);
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performDisableTotp(
+      String accessToken, String totpCode, String requestId) throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        post("/api/v1/auth/mfa/totp/disable")
+            .header("Authorization", "Bearer " + accessToken)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "totpCode": "%s"
+                }
+                """
+                    .formatted(totpCode));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
     return mockMvc.perform(requestBuilder);
   }
 
@@ -2219,6 +2306,20 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
             FROM auth_refresh_token_session
             WHERE user_id = :userId
               AND session_status = 'ACTIVE'
+            """,
+            new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
+                .addValue("userId", userId),
+            Integer.class);
+    return count == null ? 0 : count;
+  }
+
+  private int countTotpCredentialRows(long userId) {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM auth_totp_credential
+            WHERE user_id = :userId
             """,
             new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
                 .addValue("userId", userId),


### PR DESCRIPTION
## 🔗 Related Issue
- close #148

## 🌿 Base Branch
- `main`

## 📝 Summary
- 로그인된 사용자가 현재 TOTP code를 검증해 MFA를 해제하는 `POST /api/v1/auth/mfa/totp/disable` API를 추가했습니다.
- 해제 성공 시 TOTP credential row를 삭제하고 active refresh session을 전부 revoke 하도록 auth 경계를 고정했습니다.
- 해제 성공/실패, bootstrap principal 거절, 다음 로그인 회귀를 테스트와 README에 반영했습니다.

## 🛠 Changes
- `TotpDisableCommand`, `TotpDisableUseCase`, `TotpDisableService` 추가
- `TotpCredentialWritePort` / `JdbcAuthWriteRepository`에 active credential 삭제 경로 추가
- `LoginController`, `AuthConfiguration`에 disable endpoint/wiring 추가
- `TotpDisableServiceTest`, `LoginAndAccountAccessApiIntegrationTest`에 해제 시나리오 추가
- `back/README.md`에 disable 계약과 session revoke 정책 반영

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth-mfa-disable ./back/gradlew -p back test --tests '*TotpDisableServiceTest' --tests '*LoginServiceTest' --tests 'com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest.totpDisable*' --tests 'com.aquilabank.global.web.auth.LoginAndAccountAccessApiIntegrationTest.bootstrapAccountPrincipalCannotDisableTotp'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- 해제 성공 후 다음 login이 `MFA_REQUIRED` 대신 `SUCCESS`인지 integration test로 확인
- 해제 성공 후 기존 refresh session이 `REVOKED` 처리되는지 integration test로 확인

## 📸 Screenshot / API Example
- 예시 요청:
```http
POST /api/v1/auth/mfa/totp/disable
Authorization: Bearer <access-token>
Content-Type: application/json

{
  "totpCode": "123456"
}
```
- 성공 응답: `204 No Content`

## ⚠️ Risk & Rollback
- 예상 리스크:
  - credential 삭제와 session revoke가 auth 경계 변경이라 기존 클라이언트의 session 기대값과 어긋날 수 있습니다.
  - 해제 직후 남은 access token은 TTL까지 유효하므로 refresh 경로만 즉시 차단됩니다.
- 롤백 방법:
  - PR revert로 disable endpoint와 credential 삭제 경로를 되돌립니다.
  - revert 후 staging 성공 SHA를 기준으로 재배포합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?