### PR TITLE
[Chore] GitHub connector issue/PR fallback 기준 추가

### DIFF
--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -6,6 +6,13 @@
 - 모든 변경은 GitHub issue를 먼저 만들고 `main` 대상 PR로만 병합합니다.
 - 보호 브랜치 직접 push는 금지하고, 리뷰 가능한 한 가지 목적 단위로 PR을 유지합니다.
 
+## GitHub Connector Fallback
+
+- GitHub issue/PR write에서 `403 Resource not accessible by integration`가 나오면 flaky 재시도보다 connector 권한 차이를 먼저 의심합니다.
+- 이 저장소에서는 같은 세션에서 write 성공이 확인된 connector를 표준 경로로 계속 사용합니다.
+- 표준 경로가 아닌 connector에서 403이 나면 blind retry 없이 즉시 표준 write 경로로 fallback 합니다.
+- 표준 write 경로도 실패하면 작업을 멈추고 권한 또는 사용할 connector를 확인합니다.
+
 ## CI Gate
 
 - backend/frontend CI는 `main` 대상 PR에서 실행합니다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #150

## 🌿 Base Branch
- `main`

## 📝 Summary
- GitHub issue/PR write에서 `403 Resource not accessible by integration`를 flaky가 아니라 connector 권한 차이로 우선 분류하는 기준을 추가했습니다.
- blind retry를 금지하고, 같은 세션에서 write 성공이 확인된 connector를 표준 경로로 계속 쓰는 fallback 규칙을 공유 문서에 반영했습니다.
- 로컬 전용 운영 문서인 `docs/AGENT-CONTEXT.md`에도 같은 규칙을 반영해 다음 작업 시작 시 바로 읽히도록 맞췄습니다. 이 파일은 `.gitignore` 대상이라 PR 범위에는 포함되지 않습니다.

## 🛠 Changes
- `docs/delivery-flow.md`에 GitHub connector fallback 섹션 추가
- `403 Resource not accessible by integration` 분류 기준, blind retry 금지, fallback/중단 조건 명시
- 로컬 운영 문서(`docs/AGENT-CONTEXT.md`)에도 동일 기준 반영 완료

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `rg -n "GitHub|connector|fallback|Resource not accessible by integration|permission mismatch|blind retry" docs/AGENT-CONTEXT.md docs/delivery-flow.md`
- `git diff -- docs/delivery-flow.md`
- 로컬 전용 문서(`docs/AGENT-CONTEXT.md`)가 `.gitignore` 대상이라 PR 범위 밖인지 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - connector 권한이 바뀌면 문서 기준이 stale 될 수 있습니다.
  - 공유 PR에는 `docs/delivery-flow.md`만 반영되므로, 로컬 운영 문서 갱신은 각 작업 환경에 남아 있어야 합니다.
- 롤백 방법:
  - 이 PR revert로 공유 fallback 규칙을 되돌립니다.
  - 로컬 `docs/AGENT-CONTEXT.md` 변경은 각 환경에서 별도 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가? (`N/A`, 문서 변경 수동 검토)
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (`N/A`)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?