### PR TITLE
[Feat] MFA backup code 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -479,6 +479,8 @@ TOTP MFA는 `login -> challenge -> verify` 2단계 경로로만 token pair를 �
   - `POST /api/v1/auth/mfa/totp/enroll`
   - `POST /api/v1/auth/mfa/totp/enroll/verify`
   - `POST /api/v1/auth/mfa/totp/disable`
+  - `POST /api/v1/auth/mfa/backup-codes`
+  - `POST /api/v1/auth/mfa/backup-codes/challenge/verify`
   - `POST /api/v1/auth/mfa/totp/challenge/verify`
 - 등록 기준:
   - enrollment start/verify는 현재 JWT user만 호출 가능하고 bootstrap account principal은 `403`
@@ -489,11 +491,19 @@ TOTP MFA는 `login -> challenge -> verify` 2단계 경로로만 token pair를 �
   - disable request body는 `totpCode`
   - 현재 JWT user와 현재 `ACTIVE` credential, 유효한 현재 TOTP code가 모두 맞을 때만 `204 No Content`
   - disable 성공 시 `auth_totp_credential` row는 삭제되고 해당 user의 active refresh session은 전부 `REVOKED`
+  - disable 성공 시 active backup code도 전부 `SUPERSEDED` 처리돼 이전 복구 수단이 남지 않는다
   - wrong code, 활성 credential 없음, 비활성 user는 `401 mfa disable failed`
+- backup code 발급 기준:
+  - request body는 `totpCode`
+  - 발급/재발급은 현재 JWT user, 현재 `ACTIVE` TOTP credential, 유효한 현재 TOTP code가 모두 맞을 때만 성공한다
+  - 응답은 `codeCount`, `backupCodes[]`이고 plain backup code는 이 응답에서만 1회 노출된다
+  - 재발급 시 기존 active backup code는 전부 `SUPERSEDED`로 바뀌고 새 묶음만 `ACTIVE`로 남는다
+  - wrong code, 활성 credential 없음, 비활성 user는 `401 backup code issue failed`
 - 로그인 challenge 기준:
   - `ACTIVE` TOTP credential이 있는 사용자의 `POST /api/v1/auth/login` 응답은 `status=MFA_REQUIRED`
   - 이때 `challengeId`, `challengeType=TOTP`, `challengeExpiresAt`만 내려가고 token pair는 비어 있다
   - challenge verify 성공 시에만 `status=SUCCESS`와 token pair가 발급된다
+  - challenge verify는 `totpCode` 또는 `backupCode` 중 하나를 사용하며 backup code 성공 시 해당 row는 즉시 `USED` 처리된다
   - challenge verify는 로그인 시점의 `device_name`, `ip_address` 메타데이터를 그대로 session row에 저장한다
 - 기본값:
   - `SECURITY_TOTP_ISSUER=Aquila Bank`
@@ -505,9 +515,12 @@ TOTP MFA는 `login -> challenge -> verify` 2단계 경로로만 token pair를 �
   - TOTP secret raw/base32 값은 응답으로만 내려가고 DB에는 AES-GCM 보호 값만 저장
   - credential 테이블은 `auth_totp_credential`
   - login challenge 테이블은 `auth_totp_login_challenge`
+  - backup code 테이블은 `auth_mfa_backup_code`
+  - backup code는 plain 값이나 복호화 가능한 ciphertext 없이 `SHA-256` hash만 저장한다
   - challenge row는 `user_id` 기준 1행만 유지해 user별 현재 pending state만 덮어쓴다
 - 거절 기준:
   - wrong TOTP code, 만료 challenge, 사용 완료 challenge는 `401 mfa challenge failed`
+  - wrong backup code, 이미 `USED|SUPERSEDED` 된 backup code도 `401 mfa challenge failed`
   - challenge 시도 횟수가 상한에 도달하면 상태를 `FAILED`로 바꾸고 같은 challenge는 더 이상 성공하지 못한다
   - pending enrollment가 없거나 이미 만료된 enrollment verify는 `400`
 

--- a/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeChallengeVerifyCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeChallengeVerifyCommand.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** backup code 기반 MFA challenge confirm 요청 최소 입력값입니다. */
+public record BackupCodeChallengeVerifyCommand(String challengeId, String backupCode) {
+
+  public BackupCodeChallengeVerifyCommand {
+    if (challengeId == null || challengeId.isBlank()) {
+      throw new IllegalArgumentException("challengeId is required");
+    }
+    if (backupCode == null || backupCode.isBlank()) {
+      throw new IllegalArgumentException("backupCode is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeGenerateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeGenerateCommand.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** backup code 재발급 전 현재 TOTP code 재검증에 필요한 입력값입니다. */
+public record BackupCodeGenerateCommand(long userId, String totpCode) {
+
+  public BackupCodeGenerateCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (totpCode == null || !totpCode.matches("\\d{6}")) {
+      throw new IllegalArgumentException("totpCode must be 6 digits");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeIssueCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeIssueCommand.java
@@ -1,0 +1,19 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 새 backup code row 저장 최소 입력값입니다. */
+public record BackupCodeIssueCommand(long userId, String codeHash, Instant createdAt) {
+
+  public BackupCodeIssueCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (codeHash == null || codeHash.isBlank()) {
+      throw new IllegalArgumentException("codeHash is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeIssueResult.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeIssueResult.java
@@ -1,0 +1,19 @@
+package com.aquilabank.domain.auth.model;
+
+import java.util.List;
+
+/** 발급 직후 1회 노출할 plain backup code 목록 응답입니다. */
+public record BackupCodeIssueResult(List<String> backupCodes, int codeCount) {
+
+  public BackupCodeIssueResult {
+    if (backupCodes == null || backupCodes.isEmpty()) {
+      throw new IllegalArgumentException("backupCodes must not be empty");
+    }
+    if (codeCount <= 0) {
+      throw new IllegalArgumentException("codeCount must be positive");
+    }
+    if (backupCodes.size() != codeCount) {
+      throw new IllegalArgumentException("backupCodes size must match codeCount");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeRecord.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeRecord.java
@@ -1,0 +1,31 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** backup code exact lookup과 상태 전이에 필요한 최소 row 모델입니다. */
+public record BackupCodeRecord(
+    long codeId,
+    long userId,
+    String codeHash,
+    BackupCodeStatus codeStatus,
+    Instant usedAt,
+    Instant createdAt) {
+
+  public BackupCodeRecord {
+    if (codeId <= 0) {
+      throw new IllegalArgumentException("codeId must be positive");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (codeHash == null || codeHash.isBlank()) {
+      throw new IllegalArgumentException("codeHash is required");
+    }
+    if (codeStatus == null) {
+      throw new IllegalArgumentException("codeStatus is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeStatus.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.auth.model;
+
+public enum BackupCodeStatus {
+  ACTIVE,
+  USED,
+  SUPERSEDED
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeUseCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/BackupCodeUseCommand.java
@@ -1,0 +1,16 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 검증 성공한 backup code를 즉시 소진 처리할 때 씁니다. */
+public record BackupCodeUseCommand(long codeId, Instant usedAt) {
+
+  public BackupCodeUseCommand {
+    if (codeId <= 0) {
+      throw new IllegalArgumentException("codeId must be positive");
+    }
+    if (usedAt == null) {
+      throw new IllegalArgumentException("usedAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/GeneratedBackupCode.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/GeneratedBackupCode.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** 발급 응답용 plain backup code와 저장용 hash를 함께 담습니다. */
+public record GeneratedBackupCode(String plainCode, String codeHash) {
+
+  public GeneratedBackupCode {
+    if (plainCode == null || plainCode.isBlank()) {
+      throw new IllegalArgumentException("plainCode is required");
+    }
+    if (codeHash == null || codeHash.isBlank()) {
+      throw new IllegalArgumentException("codeHash is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/BackupCodeLoadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/BackupCodeLoadPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.BackupCodeRecord;
+import java.util.Optional;
+
+/** backup code exact lookup은 user 범위와 hash를 같이 고정해 작은 row만 읽습니다. */
+public interface BackupCodeLoadPort {
+
+  Optional<BackupCodeRecord> findActiveByUserIdAndCodeHashForUpdate(long userId, String codeHash);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/BackupCodeSecretPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/BackupCodeSecretPort.java
@@ -1,0 +1,12 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.GeneratedBackupCode;
+import java.util.List;
+
+/** backup code 생성과 hash 계산을 security adapter로 분리합니다. */
+public interface BackupCodeSecretPort {
+
+  List<GeneratedBackupCode> generate(int count);
+
+  String hash(String plainCode);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/BackupCodeWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/BackupCodeWritePort.java
@@ -1,0 +1,15 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.BackupCodeIssueCommand;
+import com.aquilabank.domain.auth.model.BackupCodeUseCommand;
+import java.time.Instant;
+
+/** backup code 발급, 재발급 supersede, 1회 사용 전이를 write port로 분리합니다. */
+public interface BackupCodeWritePort {
+
+  void supersedeActiveByUserId(long userId, Instant supersededAt);
+
+  void issue(BackupCodeIssueCommand command);
+
+  void markUsed(BackupCodeUseCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyService.java
@@ -1,0 +1,167 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.AuthSessionClientMetadata;
+import com.aquilabank.domain.auth.model.BackupCodeChallengeVerifyCommand;
+import com.aquilabank.domain.auth.model.BackupCodeRecord;
+import com.aquilabank.domain.auth.model.BackupCodeUseCommand;
+import com.aquilabank.domain.auth.model.IssuedAccessToken;
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.TotpCredential;
+import com.aquilabank.domain.auth.model.TotpCredentialStatus;
+import com.aquilabank.domain.auth.model.TotpLoginChallenge;
+import com.aquilabank.domain.auth.model.TotpLoginChallengeStatus;
+import com.aquilabank.domain.auth.model.TotpLoginChallengeUpdateCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
+import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
+import com.aquilabank.domain.auth.port.BackupCodeWritePort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
+import com.aquilabank.domain.auth.port.TotpLoginChallengeLoadPort;
+import com.aquilabank.domain.auth.port.TotpLoginChallengeWritePort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** backup code도 TOTP와 같은 one-time challenge row를 재사용해 최종 로그인으로 승격합니다. */
+public final class BackupCodeChallengeVerifyService implements BackupCodeChallengeVerifyUseCase {
+
+  private final TotpLoginChallengeLoadPort totpLoginChallengeLoadPort;
+  private final TotpLoginChallengeWritePort totpLoginChallengeWritePort;
+  private final TotpCredentialLoadPort totpCredentialLoadPort;
+  private final BackupCodeLoadPort backupCodeLoadPort;
+  private final BackupCodeWritePort backupCodeWritePort;
+  private final BackupCodeSecretPort backupCodeSecretPort;
+  private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
+  private final RefreshTokenSecretPort refreshTokenSecretPort;
+  private final AuthTokenIssuePort authTokenIssuePort;
+  private final RefreshTokenPolicy refreshTokenPolicy;
+  private final int challengeMaxAttempts;
+  private final Clock clock;
+
+  public BackupCodeChallengeVerifyService(
+      TotpLoginChallengeLoadPort totpLoginChallengeLoadPort,
+      TotpLoginChallengeWritePort totpLoginChallengeWritePort,
+      TotpCredentialLoadPort totpCredentialLoadPort,
+      BackupCodeLoadPort backupCodeLoadPort,
+      BackupCodeWritePort backupCodeWritePort,
+      BackupCodeSecretPort backupCodeSecretPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      RefreshTokenSecretPort refreshTokenSecretPort,
+      AuthTokenIssuePort authTokenIssuePort,
+      RefreshTokenPolicy refreshTokenPolicy,
+      int challengeMaxAttempts,
+      Clock clock) {
+    this.totpLoginChallengeLoadPort = totpLoginChallengeLoadPort;
+    this.totpLoginChallengeWritePort = totpLoginChallengeWritePort;
+    this.totpCredentialLoadPort = totpCredentialLoadPort;
+    this.backupCodeLoadPort = backupCodeLoadPort;
+    this.backupCodeWritePort = backupCodeWritePort;
+    this.backupCodeSecretPort = backupCodeSecretPort;
+    this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
+    this.refreshTokenSecretPort = refreshTokenSecretPort;
+    this.authTokenIssuePort = authTokenIssuePort;
+    this.refreshTokenPolicy = refreshTokenPolicy;
+    this.challengeMaxAttempts = challengeMaxAttempts;
+    this.clock = clock;
+  }
+
+  @Override
+  public LoginResult verify(BackupCodeChallengeVerifyCommand command) {
+    Instant now = Instant.now(clock);
+    TotpLoginChallenge challenge =
+        totpLoginChallengeLoadPort
+            .findByChallengeIdForUpdate(command.challengeId())
+            .orElseThrow(this::invalidChallenge);
+
+    if (challenge.challengeStatus() != TotpLoginChallengeStatus.PENDING) {
+      throw invalidChallenge();
+    }
+    if (!challenge.expiresAt().isAfter(now)) {
+      updateChallenge(challenge, TotpLoginChallengeStatus.EXPIRED, challenge.attemptCount(), now);
+      throw invalidChallenge();
+    }
+    if (challenge.userStatus() != UserStatus.ACTIVE) {
+      updateChallenge(challenge, TotpLoginChallengeStatus.FAILED, challenge.attemptCount(), now);
+      throw invalidChallenge();
+    }
+
+    TotpCredential credential =
+        totpCredentialLoadPort
+            .findCredentialByUserIdForUpdate(challenge.userId())
+            .orElseThrow(this::invalidChallenge);
+    if (credential.credentialStatus() != TotpCredentialStatus.ACTIVE) {
+      updateChallenge(challenge, TotpLoginChallengeStatus.FAILED, challenge.attemptCount(), now);
+      throw invalidChallenge();
+    }
+
+    BackupCodeRecord backupCode = loadBackupCode(challenge.userId(), command.backupCode());
+    if (backupCode == null) {
+      handleWrongCode(challenge, now);
+      throw invalidChallenge();
+    }
+
+    updateChallenge(challenge, TotpLoginChallengeStatus.VERIFIED, challenge.attemptCount(), now);
+    backupCodeWritePort.markUsed(new BackupCodeUseCommand(backupCode.codeId(), now));
+    return issueTokenPair(challenge, now);
+  }
+
+  private BackupCodeRecord loadBackupCode(long userId, String backupCode) {
+    try {
+      String codeHash = backupCodeSecretPort.hash(backupCode);
+      return backupCodeLoadPort
+          .findActiveByUserIdAndCodeHashForUpdate(userId, codeHash)
+          .orElse(null);
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+  }
+
+  private void handleWrongCode(TotpLoginChallenge challenge, Instant now) {
+    int nextAttemptCount = challenge.attemptCount() + 1;
+    TotpLoginChallengeStatus nextStatus =
+        nextAttemptCount >= challengeMaxAttempts
+            ? TotpLoginChallengeStatus.FAILED
+            : TotpLoginChallengeStatus.PENDING;
+    updateChallenge(challenge, nextStatus, nextAttemptCount, now);
+  }
+
+  private LoginResult issueTokenPair(TotpLoginChallenge challenge, Instant now) {
+    String refreshToken = refreshTokenSecretPort.createToken();
+    Instant refreshExpiresAt = now.plus(refreshTokenPolicy.ttl());
+    refreshTokenSessionWritePort.create(
+        new RefreshTokenSessionCreateCommand(
+            challenge.userId(),
+            refreshTokenSecretPort.hash(refreshToken),
+            refreshExpiresAt,
+            now,
+            new AuthSessionClientMetadata(challenge.deviceName(), challenge.ipAddress())));
+    IssuedAccessToken issuedAccessToken =
+        authTokenIssuePort.issue(challenge.userId(), challenge.loginId(), now);
+    return LoginResult.success(
+        issuedAccessToken.accessToken(),
+        refreshToken,
+        issuedAccessToken.tokenType(),
+        issuedAccessToken.expiresAt(),
+        refreshExpiresAt,
+        issuedAccessToken.userId());
+  }
+
+  private void updateChallenge(
+      TotpLoginChallenge challenge,
+      TotpLoginChallengeStatus nextStatus,
+      int attemptCount,
+      Instant updatedAt) {
+    totpLoginChallengeWritePort.update(
+        new TotpLoginChallengeUpdateCommand(
+            challenge.userId(), challenge.challengeId(), nextStatus, attemptCount, updatedAt));
+  }
+
+  private InvalidCredentialsException invalidChallenge() {
+    return new InvalidCredentialsException("mfa challenge failed");
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.BackupCodeChallengeVerifyCommand;
+import com.aquilabank.domain.auth.model.LoginResult;
+
+/** backup code로 MFA challenge를 검증해 최종 token pair를 발급하는 진입점입니다. */
+public interface BackupCodeChallengeVerifyUseCase {
+
+  LoginResult verify(BackupCodeChallengeVerifyCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeGenerateService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeGenerateService.java
@@ -1,0 +1,88 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.BackupCodeGenerateCommand;
+import com.aquilabank.domain.auth.model.BackupCodeIssueCommand;
+import com.aquilabank.domain.auth.model.BackupCodeIssueResult;
+import com.aquilabank.domain.auth.model.GeneratedBackupCode;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.TotpCredential;
+import com.aquilabank.domain.auth.model.TotpCredentialStatus;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
+import com.aquilabank.domain.auth.port.BackupCodeWritePort;
+import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
+import com.aquilabank.domain.auth.port.TotpSecretPort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+/** backup code 묶음 교체는 현재 TOTP 재검증 뒤 같은 tx 안에서만 허용합니다. */
+public final class BackupCodeGenerateService implements BackupCodeGenerateUseCase {
+
+  private final UserCredentialLoadPort userCredentialLoadPort;
+  private final TotpCredentialLoadPort totpCredentialLoadPort;
+  private final TotpSecretPort totpSecretPort;
+  private final BackupCodeSecretPort backupCodeSecretPort;
+  private final BackupCodeWritePort backupCodeWritePort;
+  private final int backupCodeCount;
+  private final Clock clock;
+
+  public BackupCodeGenerateService(
+      UserCredentialLoadPort userCredentialLoadPort,
+      TotpCredentialLoadPort totpCredentialLoadPort,
+      TotpSecretPort totpSecretPort,
+      BackupCodeSecretPort backupCodeSecretPort,
+      BackupCodeWritePort backupCodeWritePort,
+      int backupCodeCount,
+      Clock clock) {
+    this.userCredentialLoadPort = userCredentialLoadPort;
+    this.totpCredentialLoadPort = totpCredentialLoadPort;
+    this.totpSecretPort = totpSecretPort;
+    this.backupCodeSecretPort = backupCodeSecretPort;
+    this.backupCodeWritePort = backupCodeWritePort;
+    this.backupCodeCount = backupCodeCount;
+    this.clock = clock;
+  }
+
+  @Override
+  public BackupCodeIssueResult issue(BackupCodeGenerateCommand command) {
+    Instant now = Instant.now(clock);
+    loadActiveUser(command.userId());
+    TotpCredential credential =
+        totpCredentialLoadPort
+            .findCredentialByUserIdForUpdate(command.userId())
+            .orElseThrow(this::invalidIssue);
+    if (credential.credentialStatus() != TotpCredentialStatus.ACTIVE) {
+      throw invalidIssue();
+    }
+    if (!totpSecretPort.matches(
+        credential.secretCiphertext(), credential.secretNonce(), command.totpCode(), now)) {
+      throw invalidIssue();
+    }
+
+    List<GeneratedBackupCode> generatedItems = backupCodeSecretPort.generate(backupCodeCount);
+    // 재발급 race에서도 active 묶음이 한 세트만 남도록 이전 code를 먼저 supersede 합니다.
+    backupCodeWritePort.supersedeActiveByUserId(command.userId(), now);
+    for (GeneratedBackupCode item : generatedItems) {
+      backupCodeWritePort.issue(new BackupCodeIssueCommand(command.userId(), item.codeHash(), now));
+    }
+    return new BackupCodeIssueResult(
+        generatedItems.stream().map(GeneratedBackupCode::plainCode).toList(),
+        generatedItems.size());
+  }
+
+  private LoginUser loadActiveUser(long userId) {
+    LoginUser user =
+        userCredentialLoadPort.findByUserIdForUpdate(userId).orElseThrow(this::invalidIssue);
+    if (user.status() != UserStatus.ACTIVE) {
+      throw invalidIssue();
+    }
+    return user;
+  }
+
+  private InvalidCredentialsException invalidIssue() {
+    return new InvalidCredentialsException("backup code issue failed");
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeGenerateUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeGenerateUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.BackupCodeGenerateCommand;
+import com.aquilabank.domain.auth.model.BackupCodeIssueResult;
+
+/** 현재 TOTP 재검증 뒤 backup code 묶음을 재발급하는 진입점입니다. */
+public interface BackupCodeGenerateUseCase {
+
+  BackupCodeIssueResult issue(BackupCodeGenerateCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpDisableService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpDisableService.java
@@ -6,6 +6,7 @@ import com.aquilabank.domain.auth.model.TotpCredential;
 import com.aquilabank.domain.auth.model.TotpCredentialStatus;
 import com.aquilabank.domain.auth.model.TotpDisableCommand;
 import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.BackupCodeWritePort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
 import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
 import com.aquilabank.domain.auth.port.TotpCredentialWritePort;
@@ -21,6 +22,7 @@ public final class TotpDisableService implements TotpDisableUseCase {
   private final TotpCredentialLoadPort totpCredentialLoadPort;
   private final TotpCredentialWritePort totpCredentialWritePort;
   private final TotpSecretPort totpSecretPort;
+  private final BackupCodeWritePort backupCodeWritePort;
   private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
   private final Clock clock;
 
@@ -29,12 +31,14 @@ public final class TotpDisableService implements TotpDisableUseCase {
       TotpCredentialLoadPort totpCredentialLoadPort,
       TotpCredentialWritePort totpCredentialWritePort,
       TotpSecretPort totpSecretPort,
+      BackupCodeWritePort backupCodeWritePort,
       RefreshTokenSessionWritePort refreshTokenSessionWritePort,
       Clock clock) {
     this.userCredentialLoadPort = userCredentialLoadPort;
     this.totpCredentialLoadPort = totpCredentialLoadPort;
     this.totpCredentialWritePort = totpCredentialWritePort;
     this.totpSecretPort = totpSecretPort;
+    this.backupCodeWritePort = backupCodeWritePort;
     this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
     this.clock = clock;
   }
@@ -56,6 +60,7 @@ public final class TotpDisableService implements TotpDisableUseCase {
     }
 
     totpCredentialWritePort.deleteByUserId(command.userId());
+    backupCodeWritePort.supersedeActiveByUserId(command.userId(), now);
     refreshTokenSessionWritePort.revokeActiveSessionsByUserId(command.userId(), now);
   }
 

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -9,6 +9,8 @@ import com.aquilabank.domain.auth.port.AccountStatusAccessPort;
 import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
+import com.aquilabank.domain.auth.port.BackupCodeWritePort;
 import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
@@ -43,6 +45,8 @@ import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryService;
 import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryUseCase;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryService;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.BackupCodeGenerateService;
+import com.aquilabank.domain.auth.usecase.BackupCodeGenerateUseCase;
 import com.aquilabank.domain.auth.usecase.LoginService;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutService;
@@ -315,6 +319,35 @@ public class AuthConfiguration {
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
     return command ->
         transactionTemplate.executeWithoutResult(status -> totpDisableService.disable(command));
+  }
+
+  @Bean
+  BackupCodeGenerateUseCase backupCodeGenerateUseCase(
+      UserCredentialLoadPort userCredentialLoadPort,
+      TotpCredentialLoadPort totpCredentialLoadPort,
+      TotpSecretPort totpSecretPort,
+      BackupCodeSecretPort backupCodeSecretPort,
+      BackupCodeWritePort backupCodeWritePort,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    BackupCodeGenerateService backupCodeGenerateService =
+        new BackupCodeGenerateService(
+            userCredentialLoadPort,
+            totpCredentialLoadPort,
+            totpSecretPort,
+            backupCodeSecretPort,
+            backupCodeWritePort,
+            10,
+            authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command -> {
+      com.aquilabank.domain.auth.model.BackupCodeIssueResult result =
+          transactionTemplate.execute(status -> backupCodeGenerateService.issue(command));
+      if (result == null) {
+        throw new IllegalStateException("backup code issue transaction returned null result");
+      }
+      return result;
+    };
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -9,6 +9,7 @@ import com.aquilabank.domain.auth.port.AccountStatusAccessPort;
 import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
 import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
 import com.aquilabank.domain.auth.port.BackupCodeWritePort;
 import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
@@ -45,6 +46,8 @@ import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryService;
 import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryUseCase;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryService;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.BackupCodeChallengeVerifyService;
+import com.aquilabank.domain.auth.usecase.BackupCodeChallengeVerifyUseCase;
 import com.aquilabank.domain.auth.usecase.BackupCodeGenerateService;
 import com.aquilabank.domain.auth.usecase.BackupCodeGenerateUseCase;
 import com.aquilabank.domain.auth.usecase.LoginService;
@@ -305,6 +308,7 @@ public class AuthConfiguration {
       TotpCredentialLoadPort totpCredentialLoadPort,
       TotpCredentialWritePort totpCredentialWritePort,
       TotpSecretPort totpSecretPort,
+      BackupCodeWritePort backupCodeWritePort,
       RefreshTokenSessionWritePort refreshTokenSessionWritePort,
       Clock authClock,
       PlatformTransactionManager platformTransactionManager) {
@@ -314,6 +318,7 @@ public class AuthConfiguration {
             totpCredentialLoadPort,
             totpCredentialWritePort,
             totpSecretPort,
+            backupCodeWritePort,
             refreshTokenSessionWritePort,
             authClock);
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
@@ -347,6 +352,61 @@ public class AuthConfiguration {
         throw new IllegalStateException("backup code issue transaction returned null result");
       }
       return result;
+    };
+  }
+
+  @Bean
+  BackupCodeChallengeVerifyUseCase backupCodeChallengeVerifyUseCase(
+      TotpLoginChallengeLoadPort totpLoginChallengeLoadPort,
+      TotpLoginChallengeWritePort totpLoginChallengeWritePort,
+      TotpCredentialLoadPort totpCredentialLoadPort,
+      BackupCodeLoadPort backupCodeLoadPort,
+      BackupCodeWritePort backupCodeWritePort,
+      BackupCodeSecretPort backupCodeSecretPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      RefreshTokenSecretPort refreshTokenSecretPort,
+      AuthTokenIssuePort authTokenIssuePort,
+      RefreshTokenPolicy refreshTokenPolicy,
+      SecurityTotpProperties securityTotpProperties,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    BackupCodeChallengeVerifyService backupCodeChallengeVerifyService =
+        new BackupCodeChallengeVerifyService(
+            totpLoginChallengeLoadPort,
+            totpLoginChallengeWritePort,
+            totpCredentialLoadPort,
+            backupCodeLoadPort,
+            backupCodeWritePort,
+            backupCodeSecretPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            authTokenIssuePort,
+            refreshTokenPolicy,
+            securityTotpProperties.challengeMaxAttempts(),
+            authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command -> {
+      LoginTransactionResult transactionResult =
+          transactionTemplate.execute(
+              status -> {
+                try {
+                  return LoginTransactionResult.success(
+                      backupCodeChallengeVerifyService.verify(command));
+                } catch (InvalidCredentialsException ex) {
+                  return LoginTransactionResult.failure(ex);
+                }
+              });
+      if (transactionResult == null) {
+        throw new IllegalStateException("backup code challenge verify transaction result is null");
+      }
+      if (transactionResult.exception() != null) {
+        throw transactionResult.exception();
+      }
+      if (transactionResult.result() == null) {
+        throw new IllegalStateException(
+            "backup code challenge verify transaction returned null result");
+      }
+      return transactionResult.result();
     };
   }
 

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -479,7 +479,7 @@ public class JdbcAuthRepository
         rs.getLong("user_id"),
         rs.getString("code_hash"),
         BackupCodeStatus.valueOf(rs.getString("code_status")),
-        toInstant(rs.getTimestamp("used_at")),
+        toNullableInstant(rs.getTimestamp("used_at")),
         toInstant(rs.getTimestamp("created_at")));
   }
 

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -9,6 +9,8 @@ import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.BackupCodeRecord;
+import com.aquilabank.domain.auth.model.BackupCodeStatus;
 import com.aquilabank.domain.auth.model.LoginUser;
 import com.aquilabank.domain.auth.model.MembershipRole;
 import com.aquilabank.domain.auth.model.MembershipStatus;
@@ -25,6 +27,7 @@ import com.aquilabank.domain.auth.port.AccountAccessPort;
 import com.aquilabank.domain.auth.port.AccountStatusAccessPort;
 import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
+import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
 import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
 import com.aquilabank.domain.auth.port.TotpLoginChallengeLoadPort;
@@ -45,6 +48,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class JdbcAuthRepository
     implements UserCredentialLoadPort,
+        BackupCodeLoadPort,
         RefreshTokenSessionLoadPort,
         TotpCredentialLoadPort,
         TotpLoginChallengeLoadPort,
@@ -194,6 +198,30 @@ public class JdbcAuthRepository
             """,
             new MapSqlParameterSource().addValue("challengeId", challengeId),
             (rs, rowNum) -> mapTotpLoginChallenge(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<BackupCodeRecord> findActiveByUserIdAndCodeHashForUpdate(
+      long userId, String codeHash) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT id,
+                   user_id,
+                   code_hash,
+                   code_status,
+                   used_at,
+                   created_at
+            FROM auth_mfa_backup_code
+            WHERE user_id = :userId
+              AND code_hash = :codeHash
+              AND code_status = 'ACTIVE'
+            FOR UPDATE
+            """,
+            new MapSqlParameterSource().addValue("userId", userId).addValue("codeHash", codeHash),
+            (rs, rowNum) -> mapBackupCodeRecord(rs))
         .stream()
         .findFirst();
   }
@@ -443,6 +471,16 @@ public class JdbcAuthRepository
         toInstant(rs.getTimestamp("expires_at")),
         rs.getString("device_name"),
         rs.getString("ip_address"));
+  }
+
+  private BackupCodeRecord mapBackupCodeRecord(ResultSet rs) throws SQLException {
+    return new BackupCodeRecord(
+        rs.getLong("id"),
+        rs.getLong("user_id"),
+        rs.getString("code_hash"),
+        BackupCodeStatus.valueOf(rs.getString("code_status")),
+        toInstant(rs.getTimestamp("used_at")),
+        toInstant(rs.getTimestamp("created_at")));
   }
 
   private RefreshTokenSession mapRefreshTokenSession(ResultSet rs) throws SQLException {

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -7,6 +7,8 @@ import com.aquilabank.domain.auth.model.AuthStatusChangeAuditEntry;
 import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
 import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.BackupCodeIssueCommand;
+import com.aquilabank.domain.auth.model.BackupCodeUseCommand;
 import com.aquilabank.domain.auth.model.LoginFailureUpdateCommand;
 import com.aquilabank.domain.auth.model.LoginSuccessUpdateCommand;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenIssueCommand;
@@ -28,6 +30,7 @@ import com.aquilabank.domain.auth.model.UserBootstrapResult;
 import com.aquilabank.domain.auth.model.UserBootstrapWriteCommand;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
+import com.aquilabank.domain.auth.port.BackupCodeWritePort;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
 import com.aquilabank.domain.auth.port.PasswordRecoveryTokenWritePort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionCleanupPort;
@@ -54,6 +57,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcAuthWriteRepository
     implements UserBootstrapPort,
         LoginAttemptUpdatePort,
+        BackupCodeWritePort,
         PasswordRecoveryTokenWritePort,
         UserCredentialUpdatePort,
         RefreshTokenSessionCleanupPort,
@@ -68,6 +72,71 @@ public class JdbcAuthWriteRepository
 
   public JdbcAuthWriteRepository(NamedParameterJdbcTemplate jdbcTemplate) {
     this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional
+  public void supersedeActiveByUserId(long userId, Instant supersededAt) {
+    jdbcTemplate.update(
+        """
+        UPDATE auth_mfa_backup_code
+        SET code_status = 'SUPERSEDED',
+            updated_at = :supersededAt
+        WHERE user_id = :userId
+          AND code_status = 'ACTIVE'
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("supersededAt", Timestamp.from(supersededAt)));
+  }
+
+  @Override
+  @Transactional
+  public void issue(BackupCodeIssueCommand command) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO auth_mfa_backup_code (
+            user_id,
+            code_hash,
+            code_status,
+            used_at,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :codeHash,
+            'ACTIVE',
+            NULL,
+            :createdAt,
+            :createdAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", command.userId())
+            .addValue("codeHash", command.codeHash())
+            .addValue("createdAt", Timestamp.from(command.createdAt())));
+  }
+
+  @Override
+  @Transactional
+  public void markUsed(BackupCodeUseCommand command) {
+    int updated =
+        jdbcTemplate.update(
+            """
+            UPDATE auth_mfa_backup_code
+            SET code_status = 'USED',
+                used_at = :usedAt,
+                updated_at = :usedAt
+            WHERE id = :codeId
+              AND code_status = 'ACTIVE'
+            """,
+            new MapSqlParameterSource()
+                .addValue("codeId", command.codeId())
+                .addValue("usedAt", Timestamp.from(command.usedAt())));
+    if (updated != 1) {
+      throw new IllegalStateException("backup code is not active");
+    }
   }
 
   @Override

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.security;
 
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
 import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
@@ -181,6 +182,11 @@ public class SecurityConfiguration {
   @Bean
   RefreshTokenSecretPort refreshTokenSecretPort() {
     return new Sha256RefreshTokenManager();
+  }
+
+  @Bean
+  BackupCodeSecretPort backupCodeSecretPort() {
+    return new Sha256BackupCodeManager();
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -80,6 +80,8 @@ public class SecurityConfiguration {
                     .permitAll()
                     .requestMatchers("/api/v1/auth/mfa/totp/challenge/verify")
                     .permitAll()
+                    .requestMatchers("/api/v1/auth/mfa/backup-codes/challenge/verify")
+                    .permitAll()
                     // 내부 운영 API는 public JWT resolver에서 제외하고 전용 service JWT로만 검증합니다.
                     .requestMatchers("/internal/api/v1/accounts/bootstrap")
                     .permitAll()

--- a/back/src/main/java/com/aquilabank/global/security/Sha256BackupCodeManager.java
+++ b/back/src/main/java/com/aquilabank/global/security/Sha256BackupCodeManager.java
@@ -1,0 +1,97 @@
+package com.aquilabank.global.security;
+
+import com.aquilabank.domain.auth.model.GeneratedBackupCode;
+import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Set;
+
+/** backup code는 1회성 수단이라 복호화 없이 사람이 읽기 쉬운 값과 hash만 만듭니다. */
+public class Sha256BackupCodeManager implements BackupCodeSecretPort {
+
+  private static final String ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  private static final int CODE_LENGTH = 8;
+  private static final int SEGMENT_LENGTH = 4;
+
+  private final SecureRandom secureRandom = new SecureRandom();
+
+  @Override
+  public List<GeneratedBackupCode> generate(int count) {
+    if (count <= 0) {
+      throw new IllegalArgumentException("count must be positive");
+    }
+
+    List<GeneratedBackupCode> items = new ArrayList<>(count);
+    Set<String> seen = new HashSet<>(count);
+    while (items.size() < count) {
+      String normalized = generateNormalizedCode();
+      if (!seen.add(normalized)) {
+        continue;
+      }
+      items.add(new GeneratedBackupCode(format(normalized), sha256Hex(normalized)));
+    }
+    return items;
+  }
+
+  @Override
+  public String hash(String plainCode) {
+    return sha256Hex(normalize(plainCode));
+  }
+
+  private String generateNormalizedCode() {
+    StringBuilder builder = new StringBuilder(CODE_LENGTH);
+    for (int index = 0; index < CODE_LENGTH; index++) {
+      builder.append(ALPHABET.charAt(secureRandom.nextInt(ALPHABET.length())));
+    }
+    return builder.toString();
+  }
+
+  private String format(String normalized) {
+    return normalized.substring(0, SEGMENT_LENGTH) + "-" + normalized.substring(SEGMENT_LENGTH);
+  }
+
+  private String normalize(String plainCode) {
+    if (plainCode == null || plainCode.isBlank()) {
+      throw new IllegalArgumentException("plainCode is required");
+    }
+
+    StringBuilder builder = new StringBuilder(CODE_LENGTH);
+    for (int index = 0; index < plainCode.length(); index++) {
+      char current = plainCode.charAt(index);
+      if (current == '-' || Character.isWhitespace(current)) {
+        continue;
+      }
+      builder.append(Character.toUpperCase(current));
+    }
+
+    String normalized = builder.toString();
+    if (normalized.length() != CODE_LENGTH) {
+      throw new IllegalArgumentException("plainCode must be 8 characters");
+    }
+    // 입력 formatting 차이로 hash가 달라지지 않게 hyphen/대소문자를 제거한 뒤 검증합니다.
+    for (int index = 0; index < normalized.length(); index++) {
+      if (ALPHABET.indexOf(normalized.charAt(index)) < 0) {
+        throw new IllegalArgumentException("plainCode contains unsupported characters");
+      }
+    }
+    return normalized;
+  }
+
+  private String sha256Hex(String value) {
+    return HexFormat.of().formatHex(sha256(value.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  private byte[] sha256(byte[] value) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(value);
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -5,6 +5,8 @@ import com.aquilabank.domain.auth.model.AuthSessionListQuery;
 import com.aquilabank.domain.auth.model.AuthSessionRevokeAllCommand;
 import com.aquilabank.domain.auth.model.AuthSessionRevokeCommand;
 import com.aquilabank.domain.auth.model.AuthSessionSummary;
+import com.aquilabank.domain.auth.model.BackupCodeGenerateCommand;
+import com.aquilabank.domain.auth.model.BackupCodeIssueResult;
 import com.aquilabank.domain.auth.model.LoginCommand;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.model.LogoutCommand;
@@ -22,6 +24,7 @@ import com.aquilabank.domain.auth.model.TotpEnrollmentVerifyResult;
 import com.aquilabank.domain.auth.usecase.AuthSessionListUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionRevokeAllUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionRevokeUseCase;
+import com.aquilabank.domain.auth.usecase.BackupCodeGenerateUseCase;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutUseCase;
 import com.aquilabank.domain.auth.usecase.PasswordRecoveryConfirmUseCase;
@@ -75,6 +78,7 @@ public class LoginController {
   private final TotpEnrollmentUseCase totpEnrollmentUseCase;
   private final TotpChallengeVerifyUseCase totpChallengeVerifyUseCase;
   private final TotpDisableUseCase totpDisableUseCase;
+  private final BackupCodeGenerateUseCase backupCodeGenerateUseCase;
   private final LogoutUseCase logoutUseCase;
   private final PasswordResetUseCase passwordResetUseCase;
   private final PasswordRecoveryRequestUseCase passwordRecoveryRequestUseCase;
@@ -91,6 +95,7 @@ public class LoginController {
       TotpEnrollmentUseCase totpEnrollmentUseCase,
       TotpChallengeVerifyUseCase totpChallengeVerifyUseCase,
       TotpDisableUseCase totpDisableUseCase,
+      BackupCodeGenerateUseCase backupCodeGenerateUseCase,
       LogoutUseCase logoutUseCase,
       PasswordResetUseCase passwordResetUseCase,
       PasswordRecoveryRequestUseCase passwordRecoveryRequestUseCase,
@@ -105,6 +110,7 @@ public class LoginController {
     this.totpEnrollmentUseCase = totpEnrollmentUseCase;
     this.totpChallengeVerifyUseCase = totpChallengeVerifyUseCase;
     this.totpDisableUseCase = totpDisableUseCase;
+    this.backupCodeGenerateUseCase = backupCodeGenerateUseCase;
     this.logoutUseCase = logoutUseCase;
     this.passwordResetUseCase = passwordResetUseCase;
     this.passwordRecoveryRequestUseCase = passwordRecoveryRequestUseCase;
@@ -160,6 +166,17 @@ public class LoginController {
     AuthenticatedUserPrincipal userPrincipal = requireUserPrincipal(principal);
     totpDisableUseCase.disable(new TotpDisableCommand(userPrincipal.userId(), request.totpCode()));
     return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/mfa/backup-codes")
+  public BackupCodeIssueResponse issueBackupCodes(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @Valid @RequestBody TotpCodeRequest request) {
+    AuthenticatedUserPrincipal userPrincipal = requireUserPrincipal(principal);
+    BackupCodeIssueResult result =
+        backupCodeGenerateUseCase.issue(
+            new BackupCodeGenerateCommand(userPrincipal.userId(), request.totpCode()));
+    return BackupCodeIssueResponse.from(result);
   }
 
   @GetMapping("/sessions")
@@ -317,6 +334,14 @@ public class LoginController {
     private static TotpEnrollmentVerifyResponse from(TotpEnrollmentVerifyResult result) {
       return new TotpEnrollmentVerifyResponse(
           result.credentialStatus().name(), result.verifiedAt());
+    }
+  }
+
+  /** backup code 발급 응답 */
+  public record BackupCodeIssueResponse(int codeCount, List<String> backupCodes) {
+
+    private static BackupCodeIssueResponse from(BackupCodeIssueResult result) {
+      return new BackupCodeIssueResponse(result.codeCount(), result.backupCodes());
     }
   }
 

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -5,6 +5,7 @@ import com.aquilabank.domain.auth.model.AuthSessionListQuery;
 import com.aquilabank.domain.auth.model.AuthSessionRevokeAllCommand;
 import com.aquilabank.domain.auth.model.AuthSessionRevokeCommand;
 import com.aquilabank.domain.auth.model.AuthSessionSummary;
+import com.aquilabank.domain.auth.model.BackupCodeChallengeVerifyCommand;
 import com.aquilabank.domain.auth.model.BackupCodeGenerateCommand;
 import com.aquilabank.domain.auth.model.BackupCodeIssueResult;
 import com.aquilabank.domain.auth.model.LoginCommand;
@@ -24,6 +25,7 @@ import com.aquilabank.domain.auth.model.TotpEnrollmentVerifyResult;
 import com.aquilabank.domain.auth.usecase.AuthSessionListUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionRevokeAllUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionRevokeUseCase;
+import com.aquilabank.domain.auth.usecase.BackupCodeChallengeVerifyUseCase;
 import com.aquilabank.domain.auth.usecase.BackupCodeGenerateUseCase;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutUseCase;
@@ -79,6 +81,7 @@ public class LoginController {
   private final TotpChallengeVerifyUseCase totpChallengeVerifyUseCase;
   private final TotpDisableUseCase totpDisableUseCase;
   private final BackupCodeGenerateUseCase backupCodeGenerateUseCase;
+  private final BackupCodeChallengeVerifyUseCase backupCodeChallengeVerifyUseCase;
   private final LogoutUseCase logoutUseCase;
   private final PasswordResetUseCase passwordResetUseCase;
   private final PasswordRecoveryRequestUseCase passwordRecoveryRequestUseCase;
@@ -96,6 +99,7 @@ public class LoginController {
       TotpChallengeVerifyUseCase totpChallengeVerifyUseCase,
       TotpDisableUseCase totpDisableUseCase,
       BackupCodeGenerateUseCase backupCodeGenerateUseCase,
+      BackupCodeChallengeVerifyUseCase backupCodeChallengeVerifyUseCase,
       LogoutUseCase logoutUseCase,
       PasswordResetUseCase passwordResetUseCase,
       PasswordRecoveryRequestUseCase passwordRecoveryRequestUseCase,
@@ -111,6 +115,7 @@ public class LoginController {
     this.totpChallengeVerifyUseCase = totpChallengeVerifyUseCase;
     this.totpDisableUseCase = totpDisableUseCase;
     this.backupCodeGenerateUseCase = backupCodeGenerateUseCase;
+    this.backupCodeChallengeVerifyUseCase = backupCodeChallengeVerifyUseCase;
     this.logoutUseCase = logoutUseCase;
     this.passwordResetUseCase = passwordResetUseCase;
     this.passwordRecoveryRequestUseCase = passwordRecoveryRequestUseCase;
@@ -177,6 +182,15 @@ public class LoginController {
         backupCodeGenerateUseCase.issue(
             new BackupCodeGenerateCommand(userPrincipal.userId(), request.totpCode()));
     return BackupCodeIssueResponse.from(result);
+  }
+
+  @PostMapping("/mfa/backup-codes/challenge/verify")
+  public LoginResponse verifyBackupCodeChallenge(
+      @Valid @RequestBody BackupCodeChallengeVerifyRequest request) {
+    LoginResult result =
+        backupCodeChallengeVerifyUseCase.verify(
+            new BackupCodeChallengeVerifyCommand(request.challengeId(), request.backupCode()));
+    return LoginResponse.from(result);
   }
 
   @GetMapping("/sessions")
@@ -289,6 +303,11 @@ public class LoginController {
   public record TotpChallengeVerifyRequest(
       @NotBlank(message = "challengeId is required") @Size(max = 64, message = "challengeId must be 64 characters or less") String challengeId,
       @NotBlank(message = "totpCode is required") @Pattern(regexp = "\\d{6}", message = "totpCode must be 6 digits") String totpCode) {}
+
+  /** backup code challenge verify 요청 body */
+  public record BackupCodeChallengeVerifyRequest(
+      @NotBlank(message = "challengeId is required") @Size(max = 64, message = "challengeId must be 64 characters or less") String challengeId,
+      @NotBlank(message = "backupCode is required") @Size(max = 16, message = "backupCode must be 16 characters or less") String backupCode) {}
 
   /** access/refresh token 발급 응답 */
   public record LoginResponse(

--- a/back/src/main/resources/db/migration/V22__add_auth_mfa_backup_code.sql
+++ b/back/src/main/resources/db/migration/V22__add_auth_mfa_backup_code.sql
@@ -1,0 +1,16 @@
+CREATE TABLE auth_mfa_backup_code (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    code_hash VARCHAR(64) NOT NULL,
+    code_status VARCHAR(16) NOT NULL
+        CHECK (code_status IN ('ACTIVE', 'USED', 'SUPERSEDED')),
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_auth_mfa_backup_code_hash UNIQUE (code_hash),
+    CONSTRAINT fk_auth_mfa_backup_code_user
+        FOREIGN KEY (user_id) REFERENCES bank_user (id)
+);
+
+CREATE INDEX idx_auth_mfa_backup_code_user_status
+    ON auth_mfa_backup_code (user_id ASC, code_status ASC, id ASC);

--- a/back/src/test/java/com/aquilabank/domain/auth/model/BackupCodeRecordTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/model/BackupCodeRecordTest.java
@@ -1,0 +1,42 @@
+package com.aquilabank.domain.auth.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class BackupCodeRecordTest {
+
+  @Test
+  void createsValidBackupCodeRecord() {
+    BackupCodeRecord record =
+        new BackupCodeRecord(
+            1L,
+            7L,
+            "a".repeat(64),
+            BackupCodeStatus.ACTIVE,
+            null,
+            Instant.parse("2026-04-20T09:30:00Z"));
+
+    assertThat(record.userId()).isEqualTo(7L);
+    assertThat(record.codeStatus()).isEqualTo(BackupCodeStatus.ACTIVE);
+  }
+
+  @Test
+  void rejectsInvalidIdentifiersAndBlankHash() {
+    Instant createdAt = Instant.parse("2026-04-20T09:30:00Z");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new BackupCodeRecord(0L, 7L, "a".repeat(64), BackupCodeStatus.ACTIVE, null, createdAt));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new BackupCodeRecord(1L, 0L, "a".repeat(64), BackupCodeStatus.ACTIVE, null, createdAt));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new BackupCodeRecord(1L, 7L, " ", BackupCodeStatus.ACTIVE, null, createdAt));
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyServiceTest.java
@@ -1,0 +1,169 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.BackupCodeChallengeVerifyCommand;
+import com.aquilabank.domain.auth.model.BackupCodeRecord;
+import com.aquilabank.domain.auth.model.BackupCodeStatus;
+import com.aquilabank.domain.auth.model.IssuedAccessToken;
+import com.aquilabank.domain.auth.model.LoginResultStatus;
+import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
+import com.aquilabank.domain.auth.model.TotpCredential;
+import com.aquilabank.domain.auth.model.TotpCredentialStatus;
+import com.aquilabank.domain.auth.model.TotpLoginChallenge;
+import com.aquilabank.domain.auth.model.TotpLoginChallengeStatus;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
+import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
+import com.aquilabank.domain.auth.port.BackupCodeWritePort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
+import com.aquilabank.domain.auth.port.TotpLoginChallengeLoadPort;
+import com.aquilabank.domain.auth.port.TotpLoginChallengeWritePort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class BackupCodeChallengeVerifyServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-20T10:30:00Z");
+
+  @Test
+  void issuesTokenPairAndMarksBackupCodeUsedWhenChallengeMatches() {
+    TotpLoginChallengeLoadPort totpLoginChallengeLoadPort =
+        Mockito.mock(TotpLoginChallengeLoadPort.class);
+    TotpLoginChallengeWritePort totpLoginChallengeWritePort =
+        Mockito.mock(TotpLoginChallengeWritePort.class);
+    TotpCredentialLoadPort totpCredentialLoadPort = Mockito.mock(TotpCredentialLoadPort.class);
+    BackupCodeLoadPort backupCodeLoadPort = Mockito.mock(BackupCodeLoadPort.class);
+    BackupCodeWritePort backupCodeWritePort = Mockito.mock(BackupCodeWritePort.class);
+    BackupCodeSecretPort backupCodeSecretPort = Mockito.mock(BackupCodeSecretPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(totpLoginChallengeLoadPort.findByChallengeIdForUpdate("challenge-1"))
+        .thenReturn(Optional.of(activeChallenge()));
+    when(totpCredentialLoadPort.findCredentialByUserIdForUpdate(7L))
+        .thenReturn(Optional.of(activeCredential()));
+    when(backupCodeSecretPort.hash("ABCD-EFGH")).thenReturn("backup-hash");
+    when(backupCodeLoadPort.findActiveByUserIdAndCodeHashForUpdate(7L, "backup-hash"))
+        .thenReturn(Optional.of(activeBackupCode()));
+    when(refreshTokenSecretPort.createToken()).thenReturn("refresh-token");
+    when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("refresh-hash");
+    when(authTokenIssuePort.issue(7L, "alice", NOW))
+        .thenReturn(new IssuedAccessToken("access-token", "Bearer", NOW.plusSeconds(900), 7L));
+
+    BackupCodeChallengeVerifyService service =
+        new BackupCodeChallengeVerifyService(
+            totpLoginChallengeLoadPort,
+            totpLoginChallengeWritePort,
+            totpCredentialLoadPort,
+            backupCodeLoadPort,
+            backupCodeWritePort,
+            backupCodeSecretPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            5,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    var result = service.verify(new BackupCodeChallengeVerifyCommand("challenge-1", "ABCD-EFGH"));
+
+    assertEquals(LoginResultStatus.SUCCESS, result.status());
+    assertEquals("access-token", result.accessToken());
+    verify(totpLoginChallengeWritePort).update(any());
+    verify(backupCodeWritePort).markUsed(any());
+    verify(refreshTokenSessionWritePort).create(any());
+  }
+
+  @Test
+  void incrementsAttemptCountWhenBackupCodeIsWrong() {
+    TotpLoginChallengeLoadPort totpLoginChallengeLoadPort =
+        Mockito.mock(TotpLoginChallengeLoadPort.class);
+    TotpLoginChallengeWritePort totpLoginChallengeWritePort =
+        Mockito.mock(TotpLoginChallengeWritePort.class);
+    TotpCredentialLoadPort totpCredentialLoadPort = Mockito.mock(TotpCredentialLoadPort.class);
+    BackupCodeLoadPort backupCodeLoadPort = Mockito.mock(BackupCodeLoadPort.class);
+    BackupCodeWritePort backupCodeWritePort = Mockito.mock(BackupCodeWritePort.class);
+    BackupCodeSecretPort backupCodeSecretPort = Mockito.mock(BackupCodeSecretPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(totpLoginChallengeLoadPort.findByChallengeIdForUpdate("challenge-1"))
+        .thenReturn(Optional.of(activeChallenge()));
+    when(totpCredentialLoadPort.findCredentialByUserIdForUpdate(7L))
+        .thenReturn(Optional.of(activeCredential()));
+    when(backupCodeSecretPort.hash("WRONG-CODE")).thenReturn("wrong-hash");
+    when(backupCodeLoadPort.findActiveByUserIdAndCodeHashForUpdate(7L, "wrong-hash"))
+        .thenReturn(Optional.empty());
+
+    BackupCodeChallengeVerifyService service =
+        new BackupCodeChallengeVerifyService(
+            totpLoginChallengeLoadPort,
+            totpLoginChallengeWritePort,
+            totpCredentialLoadPort,
+            backupCodeLoadPort,
+            backupCodeWritePort,
+            backupCodeSecretPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            5,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () -> service.verify(new BackupCodeChallengeVerifyCommand("challenge-1", "WRONG-CODE")));
+
+    verify(totpLoginChallengeWritePort).update(any());
+    verify(backupCodeWritePort, never()).markUsed(any());
+    verify(refreshTokenSessionWritePort, never()).create(any());
+  }
+
+  private TotpLoginChallenge activeChallenge() {
+    return new TotpLoginChallenge(
+        7L,
+        "alice",
+        UserStatus.ACTIVE,
+        "challenge-1",
+        TotpLoginChallengeStatus.PENDING,
+        0,
+        NOW.plus(Duration.ofMinutes(5)),
+        "Windows / Edge",
+        "192.0.2.77");
+  }
+
+  private TotpCredential activeCredential() {
+    return new TotpCredential(
+        7L,
+        TotpCredentialStatus.ACTIVE,
+        "cipher",
+        "nonce",
+        null,
+        NOW.minus(Duration.ofMinutes(10)),
+        null);
+  }
+
+  private BackupCodeRecord activeBackupCode() {
+    return new BackupCodeRecord(
+        31L, 7L, "backup-hash", BackupCodeStatus.ACTIVE, null, NOW.minus(Duration.ofMinutes(3)));
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/BackupCodeGenerateServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/BackupCodeGenerateServiceTest.java
@@ -1,0 +1,119 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.BackupCodeGenerateCommand;
+import com.aquilabank.domain.auth.model.GeneratedBackupCode;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.TotpCredential;
+import com.aquilabank.domain.auth.model.TotpCredentialStatus;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
+import com.aquilabank.domain.auth.port.BackupCodeWritePort;
+import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
+import com.aquilabank.domain.auth.port.TotpSecretPort;
+import com.aquilabank.domain.auth.port.UserCredentialLoadPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class BackupCodeGenerateServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-20T10:00:00Z");
+
+  @Test
+  void issuesFreshBackupCodesAfterTotpReverification() {
+    UserCredentialLoadPort userCredentialLoadPort = Mockito.mock(UserCredentialLoadPort.class);
+    TotpCredentialLoadPort totpCredentialLoadPort = Mockito.mock(TotpCredentialLoadPort.class);
+    TotpSecretPort totpSecretPort = Mockito.mock(TotpSecretPort.class);
+    BackupCodeSecretPort backupCodeSecretPort = Mockito.mock(BackupCodeSecretPort.class);
+    BackupCodeWritePort backupCodeWritePort = Mockito.mock(BackupCodeWritePort.class);
+
+    when(userCredentialLoadPort.findByUserIdForUpdate(7L)).thenReturn(Optional.of(activeUser()));
+    when(totpCredentialLoadPort.findCredentialByUserIdForUpdate(7L))
+        .thenReturn(Optional.of(activeCredential()));
+    when(totpSecretPort.matches("cipher", "nonce", "123456", NOW)).thenReturn(true);
+    when(backupCodeSecretPort.generate(3))
+        .thenReturn(
+            List.of(
+                new GeneratedBackupCode("ABCD-EFGH", "hash-1"),
+                new GeneratedBackupCode("JKLM-NPQR", "hash-2"),
+                new GeneratedBackupCode("STUV-WXYZ", "hash-3")));
+
+    BackupCodeGenerateService service =
+        new BackupCodeGenerateService(
+            userCredentialLoadPort,
+            totpCredentialLoadPort,
+            totpSecretPort,
+            backupCodeSecretPort,
+            backupCodeWritePort,
+            3,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    var result = service.issue(new BackupCodeGenerateCommand(7L, "123456"));
+
+    assertEquals(3, result.codeCount());
+    assertEquals(List.of("ABCD-EFGH", "JKLM-NPQR", "STUV-WXYZ"), result.backupCodes());
+    verify(backupCodeWritePort).supersedeActiveByUserId(7L, NOW);
+    verify(backupCodeWritePort, times(3)).issue(any());
+  }
+
+  @Test
+  void rejectsWrongTotpCodeWithoutMutatingBackupCodes() {
+    UserCredentialLoadPort userCredentialLoadPort = Mockito.mock(UserCredentialLoadPort.class);
+    TotpCredentialLoadPort totpCredentialLoadPort = Mockito.mock(TotpCredentialLoadPort.class);
+    TotpSecretPort totpSecretPort = Mockito.mock(TotpSecretPort.class);
+    BackupCodeSecretPort backupCodeSecretPort = Mockito.mock(BackupCodeSecretPort.class);
+    BackupCodeWritePort backupCodeWritePort = Mockito.mock(BackupCodeWritePort.class);
+
+    when(userCredentialLoadPort.findByUserIdForUpdate(7L)).thenReturn(Optional.of(activeUser()));
+    when(totpCredentialLoadPort.findCredentialByUserIdForUpdate(7L))
+        .thenReturn(Optional.of(activeCredential()));
+    when(totpSecretPort.matches("cipher", "nonce", "123456", NOW)).thenReturn(false);
+
+    BackupCodeGenerateService service =
+        new BackupCodeGenerateService(
+            userCredentialLoadPort,
+            totpCredentialLoadPort,
+            totpSecretPort,
+            backupCodeSecretPort,
+            backupCodeWritePort,
+            3,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () -> service.issue(new BackupCodeGenerateCommand(7L, "123456")));
+
+    verify(backupCodeWritePort, never()).supersedeActiveByUserId(anyLong(), any(Instant.class));
+    verify(backupCodeWritePort, never()).issue(any());
+  }
+
+  private LoginUser activeUser() {
+    return new LoginUser(7L, "alice", "encoded-password", UserStatus.ACTIVE, 0, null, null, null);
+  }
+
+  private TotpCredential activeCredential() {
+    return new TotpCredential(
+        7L,
+        TotpCredentialStatus.ACTIVE,
+        "cipher",
+        "nonce",
+        null,
+        NOW.minus(Duration.ofMinutes(10)),
+        NOW.minus(Duration.ofMinutes(1)));
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/TotpDisableServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/TotpDisableServiceTest.java
@@ -13,6 +13,7 @@ import com.aquilabank.domain.auth.model.TotpCredential;
 import com.aquilabank.domain.auth.model.TotpCredentialStatus;
 import com.aquilabank.domain.auth.model.TotpDisableCommand;
 import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.BackupCodeWritePort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
 import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
 import com.aquilabank.domain.auth.port.TotpCredentialWritePort;
@@ -36,6 +37,7 @@ class TotpDisableServiceTest {
     TotpCredentialLoadPort totpCredentialLoadPort = Mockito.mock(TotpCredentialLoadPort.class);
     TotpCredentialWritePort totpCredentialWritePort = Mockito.mock(TotpCredentialWritePort.class);
     TotpSecretPort totpSecretPort = Mockito.mock(TotpSecretPort.class);
+    BackupCodeWritePort backupCodeWritePort = Mockito.mock(BackupCodeWritePort.class);
     RefreshTokenSessionWritePort refreshTokenSessionWritePort =
         Mockito.mock(RefreshTokenSessionWritePort.class);
 
@@ -50,12 +52,14 @@ class TotpDisableServiceTest {
             totpCredentialLoadPort,
             totpCredentialWritePort,
             totpSecretPort,
+            backupCodeWritePort,
             refreshTokenSessionWritePort,
             Clock.fixed(NOW, ZoneOffset.UTC));
 
     service.disable(new TotpDisableCommand(7L, "123456"));
 
     verify(totpCredentialWritePort).deleteByUserId(7L);
+    verify(backupCodeWritePort).supersedeActiveByUserId(7L, NOW);
     verify(refreshTokenSessionWritePort).revokeActiveSessionsByUserId(7L, NOW);
   }
 
@@ -65,6 +69,7 @@ class TotpDisableServiceTest {
     TotpCredentialLoadPort totpCredentialLoadPort = Mockito.mock(TotpCredentialLoadPort.class);
     TotpCredentialWritePort totpCredentialWritePort = Mockito.mock(TotpCredentialWritePort.class);
     TotpSecretPort totpSecretPort = Mockito.mock(TotpSecretPort.class);
+    BackupCodeWritePort backupCodeWritePort = Mockito.mock(BackupCodeWritePort.class);
     RefreshTokenSessionWritePort refreshTokenSessionWritePort =
         Mockito.mock(RefreshTokenSessionWritePort.class);
 
@@ -79,6 +84,7 @@ class TotpDisableServiceTest {
             totpCredentialLoadPort,
             totpCredentialWritePort,
             totpSecretPort,
+            backupCodeWritePort,
             refreshTokenSessionWritePort,
             Clock.fixed(NOW, ZoneOffset.UTC));
 
@@ -87,6 +93,7 @@ class TotpDisableServiceTest {
         () -> service.disable(new TotpDisableCommand(7L, "123456")));
 
     verify(totpCredentialWritePort, never()).deleteByUserId(anyLong());
+    verify(backupCodeWritePort, never()).supersedeActiveByUserId(anyLong(), any(Instant.class));
     verify(refreshTokenSessionWritePort, never())
         .revokeActiveSessionsByUserId(anyLong(), any(Instant.class));
   }

--- a/back/src/test/java/com/aquilabank/global/security/Sha256BackupCodeManagerTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/Sha256BackupCodeManagerTest.java
@@ -1,0 +1,50 @@
+package com.aquilabank.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.aquilabank.domain.auth.model.GeneratedBackupCode;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class Sha256BackupCodeManagerTest {
+
+  @Test
+  void generatesUniqueReadableBackupCodesWithDeterministicHashes() {
+    Sha256BackupCodeManager manager = new Sha256BackupCodeManager();
+
+    List<GeneratedBackupCode> backupCodes = manager.generate(10);
+
+    assertThat(backupCodes).hasSize(10);
+    assertThat(backupCodes.stream().map(GeneratedBackupCode::plainCode).collect(Collectors.toSet()))
+        .hasSize(10);
+    assertThat(backupCodes.stream().map(GeneratedBackupCode::codeHash).collect(Collectors.toSet()))
+        .hasSize(10);
+    assertThat(backupCodes)
+        .allSatisfy(
+            item -> {
+              assertThat(item.plainCode()).matches("[A-Z2-9]{4}-[A-Z2-9]{4}");
+              assertThat(item.codeHash()).hasSize(64);
+              assertThat(item.codeHash()).isEqualTo(manager.hash(item.plainCode()));
+            });
+  }
+
+  @Test
+  void hashNormalizesCaseAndHyphen() {
+    Sha256BackupCodeManager manager = new Sha256BackupCodeManager();
+
+    String firstHash = manager.hash("abcd-efgh");
+    String secondHash = manager.hash("ABCDEFGH");
+
+    assertThat(firstHash).isEqualTo(secondHash);
+  }
+
+  @Test
+  void rejectsBlankCodeAndNonPositiveCount() {
+    Sha256BackupCodeManager manager = new Sha256BackupCodeManager();
+
+    assertThrows(IllegalArgumentException.class, () -> manager.generate(0));
+    assertThrows(IllegalArgumentException.class, () -> manager.hash(" "));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
@@ -1483,6 +1484,97 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void backupCodeIssueAndChallengeVerifyConsumeCode() throws Exception {
+    TokenPairResponseView initialSession =
+        loginResult("alice", "password123!", "backup-code-login-001", WINDOWS_CHROME);
+    TotpEnrollmentStartResponseView enrollment =
+        startTotpEnrollment(initialSession.accessToken(), "backup-code-start-001");
+    verifyTotpEnrollment(
+        initialSession.accessToken(),
+        currentTotpCode(enrollment.secretKey()),
+        "backup-code-enroll-verify-001");
+
+    BackupCodeIssueResponseView issued =
+        issueBackupCodes(
+            initialSession.accessToken(),
+            currentTotpCode(enrollment.secretKey()),
+            "backup-code-issue-001");
+
+    assertEquals(10, issued.codeCount());
+    assertEquals(10, issued.backupCodes().size());
+    assertEquals(10, countBackupCodesByStatus(userId, "ACTIVE"));
+    assertEquals(0, countBackupCodeRowsMatchingPlainValue(issued.backupCodes().get(0)));
+
+    LoginChallengeResponseView challenge =
+        loginChallenge("alice", "password123!", "backup-code-login-002", WINDOWS_EDGE);
+
+    TokenPairResponseView verifiedSession =
+        verifyBackupCodeChallenge(
+            challenge.challengeId(),
+            issued.backupCodes().get(0),
+            "backup-code-challenge-verify-001",
+            IPHONE_SAFARI);
+    RefreshTokenSessionView challengeSession =
+        loadRefreshTokenSession(verifiedSession.refreshToken());
+    TotpLoginChallengeView verifiedChallenge = loadTotpLoginChallenge(challenge.challengeId());
+
+    assertEquals("SUCCESS", verifiedSession.status());
+    assertEquals("Windows / Edge", challengeSession.deviceName());
+    assertEquals("192.0.2.77", challengeSession.ipAddress());
+    assertEquals("VERIFIED", verifiedChallenge.challengeStatus());
+    assertEquals(9, countBackupCodesByStatus(userId, "ACTIVE"));
+    assertEquals(1, countBackupCodesByStatus(userId, "USED"));
+
+    verifyBackupCodeChallengeExpectUnauthorized(
+        challenge.challengeId(), issued.backupCodes().get(0), "backup-code-reuse-001");
+  }
+
+  @Test
+  void backupCodeReissueSupersedesPreviousSet() throws Exception {
+    TokenPairResponseView initialSession =
+        loginResult("alice", "password123!", "backup-reissue-login-001", WINDOWS_CHROME);
+    TotpEnrollmentStartResponseView enrollment =
+        startTotpEnrollment(initialSession.accessToken(), "backup-reissue-start-001");
+    verifyTotpEnrollment(
+        initialSession.accessToken(),
+        currentTotpCode(enrollment.secretKey()),
+        "backup-reissue-enroll-verify-001");
+
+    BackupCodeIssueResponseView firstIssued =
+        issueBackupCodes(
+            initialSession.accessToken(),
+            currentTotpCode(enrollment.secretKey()),
+            "backup-reissue-issue-001");
+    BackupCodeIssueResponseView secondIssued =
+        issueBackupCodes(
+            initialSession.accessToken(),
+            currentTotpCode(enrollment.secretKey()),
+            "backup-reissue-issue-002");
+
+    assertEquals(10, countBackupCodesByStatus(userId, "ACTIVE"));
+    assertEquals(10, countBackupCodesByStatus(userId, "SUPERSEDED"));
+
+    LoginChallengeResponseView failedChallenge =
+        loginChallenge("alice", "password123!", "backup-reissue-login-002", WINDOWS_EDGE);
+    verifyBackupCodeChallengeExpectUnauthorized(
+        failedChallenge.challengeId(),
+        firstIssued.backupCodes().get(0),
+        "backup-reissue-old-code-001");
+
+    LoginChallengeResponseView successChallenge =
+        loginChallenge("alice", "password123!", "backup-reissue-login-003", WINDOWS_CHROME);
+    verifyBackupCodeChallenge(
+        successChallenge.challengeId(),
+        secondIssued.backupCodes().get(0),
+        "backup-reissue-new-code-001",
+        WINDOWS_EDGE);
+
+    assertEquals(9, countBackupCodesByStatus(userId, "ACTIVE"));
+    assertEquals(1, countBackupCodesByStatus(userId, "USED"));
+    assertEquals(10, countBackupCodesByStatus(userId, "SUPERSEDED"));
+  }
+
+  @Test
   void totpChallengeStopsAfterMaxAttempts() throws Exception {
     TokenPairResponseView initialSession =
         loginResult("alice", "password123!", "totp-limit-login-001", WINDOWS_CHROME);
@@ -1521,6 +1613,10 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         initialSession.accessToken(),
         currentTotpCode(enrollment.secretKey()),
         "totp-disable-verify-001");
+    issueBackupCodes(
+        initialSession.accessToken(),
+        currentTotpCode(enrollment.secretKey()),
+        "totp-disable-backup-issue-001");
 
     disableTotp(
         initialSession.accessToken(),
@@ -1528,6 +1624,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         "totp-disable-request-001");
 
     assertEquals(0, countTotpCredentialRows(userId));
+    assertEquals(0, countBackupCodesByStatus(userId, "ACTIVE"));
+    assertEquals(10, countBackupCodesByStatus(userId, "SUPERSEDED"));
     assertEquals(0, countActiveRefreshSessions(userId));
 
     loginResult("alice", "password123!", "totp-disable-login-002", WINDOWS_EDGE);
@@ -1711,6 +1809,37 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(jsonPath("$.message").value("mfa challenge failed"));
   }
 
+  private BackupCodeIssueResponseView issueBackupCodes(
+      String accessToken, String totpCode, String requestId) throws Exception {
+    MvcResult result =
+        performIssueBackupCodes(accessToken, totpCode, requestId)
+            .andExpect(status().isOk())
+            .andReturn();
+    JsonNode body = objectMapper.readTree(result.getResponse().getContentAsByteArray());
+    List<String> backupCodes = new java.util.ArrayList<>();
+    for (JsonNode item : body.get("backupCodes")) {
+      backupCodes.add(item.asText());
+    }
+    return new BackupCodeIssueResponseView(body.get("codeCount").asInt(), backupCodes);
+  }
+
+  private TokenPairResponseView verifyBackupCodeChallenge(
+      String challengeId, String backupCode, String requestId, RequestClientMetadata clientMetadata)
+      throws Exception {
+    MvcResult result =
+        performVerifyBackupCodeChallenge(challengeId, backupCode, requestId, clientMetadata)
+            .andReturn();
+    assertEquals(200, result.getResponse().getStatus(), result.getResponse().getContentAsString());
+    return readTokenPair(result);
+  }
+
+  private void verifyBackupCodeChallengeExpectUnauthorized(
+      String challengeId, String backupCode, String requestId) throws Exception {
+    performVerifyBackupCodeChallenge(challengeId, backupCode, requestId, null)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("mfa challenge failed"));
+  }
+
   private void disableTotp(String accessToken, String totpCode, String requestId) throws Exception {
     performDisableTotp(accessToken, totpCode, requestId).andExpect(status().isNoContent());
   }
@@ -1788,6 +1917,46 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
     if (requestId != null && !requestId.isBlank()) {
       requestBuilder.header("X-Request-Id", requestId);
     }
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performIssueBackupCodes(
+      String accessToken, String totpCode, String requestId) throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        post("/api/v1/auth/mfa/backup-codes")
+            .header("Authorization", "Bearer " + accessToken)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "totpCode": "%s"
+                }
+                """
+                    .formatted(totpCode));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performVerifyBackupCodeChallenge(
+      String challengeId, String backupCode, String requestId, RequestClientMetadata clientMetadata)
+      throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        post("/api/v1/auth/mfa/backup-codes/challenge/verify")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "challengeId": "%s",
+                  "backupCode": "%s"
+                }
+                """
+                    .formatted(challengeId, backupCode));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    applyClientMetadata(requestBuilder, clientMetadata);
     return mockMvc.perform(requestBuilder);
   }
 
@@ -2298,6 +2467,36 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .orElseThrow(() -> new AssertionError("totp login challenge is not found"));
   }
 
+  private int countBackupCodesByStatus(long userId, String codeStatus) {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM auth_mfa_backup_code
+            WHERE user_id = :userId
+              AND code_status = :codeStatus
+            """,
+            new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
+                .addValue("userId", userId)
+                .addValue("codeStatus", codeStatus),
+            Integer.class);
+    return count == null ? 0 : count;
+  }
+
+  private int countBackupCodeRowsMatchingPlainValue(String plainCode) {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM auth_mfa_backup_code
+            WHERE code_hash = :plainCode
+            """,
+            new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
+                .addValue("plainCode", plainCode),
+            Integer.class);
+    return count == null ? 0 : count;
+  }
+
   private int countActiveRefreshSessions(long userId) {
     Integer count =
         jdbcTemplate.queryForObject(
@@ -2426,6 +2625,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
       String status, String secretKey, String otpauthUri, Instant expiresAt) {}
 
   private record TotpEnrollmentVerifyResponseView(String status, Instant verifiedAt) {}
+
+  private record BackupCodeIssueResponseView(int codeCount, List<String> backupCodes) {}
 
   private record TotpCredentialView(
       String credentialStatus,

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerBackupCodeChallengeTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerBackupCodeChallengeTest.java
@@ -7,8 +7,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.aquilabank.domain.auth.model.BackupCodeGenerateCommand;
-import com.aquilabank.domain.auth.model.BackupCodeIssueResult;
+import com.aquilabank.domain.auth.model.BackupCodeChallengeVerifyCommand;
+import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.usecase.AuthSessionListUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionRevokeAllUseCase;
 import com.aquilabank.domain.auth.usecase.AuthSessionRevokeUseCase;
@@ -23,28 +23,23 @@ import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
 import com.aquilabank.domain.auth.usecase.TotpChallengeVerifyUseCase;
 import com.aquilabank.domain.auth.usecase.TotpDisableUseCase;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
-import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.security.LoginThrottleGuard;
 import com.aquilabank.global.web.ApiExceptionHandler;
-import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
-import java.util.List;
-import org.junit.jupiter.api.AfterEach;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-class LoginControllerBackupCodeTest {
+class LoginControllerBackupCodeChallengeTest {
 
-  private BackupCodeGenerateUseCase backupCodeGenerateUseCase;
+  private BackupCodeChallengeVerifyUseCase backupCodeChallengeVerifyUseCase;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
-    backupCodeGenerateUseCase = mock(BackupCodeGenerateUseCase.class);
+    backupCodeChallengeVerifyUseCase = mock(BackupCodeChallengeVerifyUseCase.class);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new LoginController(
@@ -56,8 +51,8 @@ class LoginControllerBackupCodeTest {
                     mock(TotpEnrollmentUseCase.class),
                     mock(TotpChallengeVerifyUseCase.class),
                     mock(TotpDisableUseCase.class),
-                    backupCodeGenerateUseCase,
-                    mock(BackupCodeChallengeVerifyUseCase.class),
+                    mock(BackupCodeGenerateUseCase.class),
+                    backupCodeChallengeVerifyUseCase,
                     mock(LogoutUseCase.class),
                     mock(PasswordResetUseCase.class),
                     mock(PasswordRecoveryRequestUseCase.class),
@@ -65,40 +60,39 @@ class LoginControllerBackupCodeTest {
                     mock(AuthSessionMetadataResolver.class),
                     mock(LoginThrottleGuard.class)))
             .setControllerAdvice(new ApiExceptionHandler())
-            .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .build();
   }
 
-  @AfterEach
-  void tearDown() {
-    SecurityContextHolder.clearContext();
-  }
-
   @Test
-  void issuesBackupCodesForAuthenticatedUser() throws Exception {
-    SecurityContextHolder.getContext()
-        .setAuthentication(
-            UsernamePasswordAuthenticationToken.authenticated(
-                new AuthenticatedUserPrincipal(7L, "alice"), null, List.of()));
-    when(backupCodeGenerateUseCase.issue(
+  void verifiesBackupCodeChallengeAndReturnsTokenPair() throws Exception {
+    when(backupCodeChallengeVerifyUseCase.verify(
             argThat(
-                (BackupCodeGenerateCommand command) ->
-                    command.userId() == 7L && "123456".equals(command.totpCode()))))
-        .thenReturn(new BackupCodeIssueResult(List.of("ABCD-EFGH", "JKLM-NPQR"), 2));
+                (BackupCodeChallengeVerifyCommand command) ->
+                    "challenge-1".equals(command.challengeId())
+                        && "ABCD-EFGH".equals(command.backupCode()))))
+        .thenReturn(
+            LoginResult.success(
+                "access-token",
+                "refresh-token",
+                "Bearer",
+                Instant.parse("2026-04-20T11:00:00Z"),
+                Instant.parse("2026-05-04T10:30:00Z"),
+                7L));
 
     mockMvc
         .perform(
-            post("/api/v1/auth/mfa/backup-codes")
+            post("/api/v1/auth/mfa/backup-codes/challenge/verify")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
                     {
-                      "totpCode": "123456"
+                      "challengeId": "challenge-1",
+                      "backupCode": "ABCD-EFGH"
                     }
                     """))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.codeCount").value(2))
-        .andExpect(jsonPath("$.backupCodes[0]").value("ABCD-EFGH"))
-        .andExpect(jsonPath("$.backupCodes[1]").value("JKLM-NPQR"));
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.accessToken").value("access-token"))
+        .andExpect(jsonPath("$.refreshToken").value("refresh-token"));
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerBackupCodeTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerBackupCodeTest.java
@@ -1,0 +1,102 @@
+package com.aquilabank.global.web.auth;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.auth.model.BackupCodeGenerateCommand;
+import com.aquilabank.domain.auth.model.BackupCodeIssueResult;
+import com.aquilabank.domain.auth.usecase.AuthSessionListUseCase;
+import com.aquilabank.domain.auth.usecase.AuthSessionRevokeAllUseCase;
+import com.aquilabank.domain.auth.usecase.AuthSessionRevokeUseCase;
+import com.aquilabank.domain.auth.usecase.BackupCodeGenerateUseCase;
+import com.aquilabank.domain.auth.usecase.LoginUseCase;
+import com.aquilabank.domain.auth.usecase.LogoutUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryConfirmUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordRecoveryRequestUseCase;
+import com.aquilabank.domain.auth.usecase.PasswordResetUseCase;
+import com.aquilabank.domain.auth.usecase.RefreshTokenUseCase;
+import com.aquilabank.domain.auth.usecase.TotpChallengeVerifyUseCase;
+import com.aquilabank.domain.auth.usecase.TotpDisableUseCase;
+import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import com.aquilabank.global.security.LoginThrottleGuard;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class LoginControllerBackupCodeTest {
+
+  private BackupCodeGenerateUseCase backupCodeGenerateUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    backupCodeGenerateUseCase = mock(BackupCodeGenerateUseCase.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new LoginController(
+                    mock(LoginUseCase.class),
+                    mock(AuthSessionListUseCase.class),
+                    mock(AuthSessionRevokeUseCase.class),
+                    mock(AuthSessionRevokeAllUseCase.class),
+                    mock(RefreshTokenUseCase.class),
+                    mock(TotpEnrollmentUseCase.class),
+                    mock(TotpChallengeVerifyUseCase.class),
+                    mock(TotpDisableUseCase.class),
+                    backupCodeGenerateUseCase,
+                    mock(LogoutUseCase.class),
+                    mock(PasswordResetUseCase.class),
+                    mock(PasswordRecoveryRequestUseCase.class),
+                    mock(PasswordRecoveryConfirmUseCase.class),
+                    mock(AuthSessionMetadataResolver.class),
+                    mock(LoginThrottleGuard.class)))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
+            .build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void issuesBackupCodesForAuthenticatedUser() throws Exception {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            UsernamePasswordAuthenticationToken.authenticated(
+                new AuthenticatedUserPrincipal(7L, "alice"), null, List.of()));
+    when(backupCodeGenerateUseCase.issue(
+            argThat(
+                (BackupCodeGenerateCommand command) ->
+                    command.userId() == 7L && "123456".equals(command.totpCode()))))
+        .thenReturn(new BackupCodeIssueResult(List.of("ABCD-EFGH", "JKLM-NPQR"), 2));
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/mfa/backup-codes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "totpCode": "123456"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.codeCount").value(2))
+        .andExpect(jsonPath("$.backupCodes[0]").value("ABCD-EFGH"))
+        .andExpect(jsonPath("$.backupCodes[1]").value("JKLM-NPQR"));
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #152

## 🌿 Base Branch
- `main`

## 📝 Summary
- TOTP MFA에 backup code 발급/재발급 기능을 추가했습니다.
- 로그인 challenge 검증 경로에서 backup code를 1회성 대체 수단으로 사용할 수 있게 확장했습니다.
- TOTP 비활성화 시 활성 backup code를 함께 폐기하고, README와 통합 검증을 반영했습니다.

## 🛠 Changes
- `auth_mfa_backup_code` 테이블, SHA-256 기반 code hash 저장, 활성/사용/대체 상태 모델 추가
- 인증 사용자 + 현재 TOTP 재검증을 요구하는 `POST /api/v1/auth/mfa/backup-codes` 추가
- `POST /api/v1/auth/mfa/backup-codes/challenge/verify` 추가, 성공 시 backup code 1회 사용 처리
- TOTP disable 시 활성 backup code 일괄 supersede 처리
- 서비스/컨트롤러/통합 테스트 및 README 문서 반영

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth-mfa-backup-codes ./back/gradlew -p back test --tests '*BackupCodeGenerateServiceTest' --tests '*LoginControllerBackupCodeTest'`
- `tools/test/with-resource-lock.sh back-gradle-auth-mfa-backup-codes ./back/gradlew -p back test --tests '*BackupCodeChallengeVerifyServiceTest' --tests '*LoginControllerBackupCodeChallengeTest' --tests '*TotpDisableServiceTest'`
- `tools/test/with-resource-lock.sh back-gradle-auth-mfa-backup-codes ./back/gradlew -p back test --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check --no-daemon`

## 📸 Screenshot / API Example
```json
POST /api/v1/auth/mfa/backup-codes
{"code":"123456"}

200 OK
{
  "backupCodes": ["ABCD-EFGH", "JKLM-NPQR", "STUV-WXYZ", "..."]
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: backup code 상태 전이(`ACTIVE`/`USED`/`SUPERSEDED`)와 challenge attempt 증가 흐름이 인증 실패 처리와 엮여 있어 회귀 시 MFA 로그인 실패율이 올라갈 수 있습니다.
- 롤백 방법: PR revert 후 `auth_mfa_backup_code` 사용 경로를 제거하고 기존 TOTP-only challenge 흐름으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?