### PR TITLE
[Feat] auth current session 식별 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -432,6 +432,7 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
   - raw refresh token은 응답으로만 한 번 내려가고 DB에는 `SHA-256 token_hash`만 저장
   - raw binding token도 cookie로만 한 번 내려가고 DB에는 `SHA-256 device_binding_hash`만 저장
   - 저장 테이블은 `auth_refresh_token_session`
+  - access token JWT는 `user_id`와 함께 현재 refresh token session의 `session_id` claim도 포함한다
   - login/refresh 시 session row에 `device_name`, `ip_address`를 함께 저장
   - `device_name`은 request `User-Agent`를 경량 규칙으로 정리한 `OS / Browser` 값 우선 사용
   - `ip_address`는 `X-Forwarded-For` 첫 값, `Forwarded for=`, `X-Real-IP`, `remoteAddr` 순서로 해석
@@ -447,7 +448,9 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
   - 현재 JWT user만 호출 가능하고 bootstrap account principal은 `403`
   - query parameter `size`는 기본 `20`, 최대 `50`
   - 응답은 현재 user의 `ACTIVE` 이면서 아직 만료되지 않은 session만 `expires_at DESC, id DESC` 순서로 반환
-  - item 필드는 `sessionId`, `sessionStatus`, `expiresAt`, `lastUsedAt`, `createdAt`, `deviceName`, `ipAddress`
+  - item 필드는 `sessionId`, `sessionStatus`, `expiresAt`, `lastUsedAt`, `createdAt`, `deviceName`, `ipAddress`, `currentSession`
+  - `currentSession=true` 기준은 현재 access token의 `session_id` claim과 item `sessionId` 일치 여부다
+  - deploy 직후 TTL 내에 남는 구 access token처럼 `session_id` claim이 없으면 인증은 유지하고 `currentSession`은 전부 `false`다
 - 세션 종료 기준:
   - `DELETE /api/v1/auth/sessions/{sessionId}`는 현재 user 소유의 `ACTIVE` session 하나만 `REVOKED`로 바꾼다.
   - `DELETE /api/v1/auth/sessions`는 현재 user의 `ACTIVE` session 전체를 `REVOKED`로 바꾸고 `ab_refresh_device` cookie도 clear 한다.

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AuthTokenIssuePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AuthTokenIssuePort.java
@@ -6,5 +6,5 @@ import java.time.Instant;
 /** 인증 완료 user 정보로 JWT access token만 발급하는 port */
 public interface AuthTokenIssuePort {
 
-  IssuedAccessToken issue(long userId, String subject, Instant issuedAt);
+  IssuedAccessToken issue(long userId, String subject, long sessionId, Instant issuedAt);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyService.java
@@ -157,16 +157,17 @@ public final class BackupCodeChallengeVerifyService implements BackupCodeChallen
     Instant refreshExpiresAt = now.plus(refreshTokenPolicy.ttl());
     // refresh token 단독 탈취 재사용을 막기 위해 device binding hash를 session에 함께 저장합니다.
     String rememberDeviceToken = issueRememberDevice(challenge, now, rememberDevice);
-    refreshTokenSessionWritePort.create(
-        new RefreshTokenSessionCreateCommand(
-            challenge.userId(),
-            refreshTokenHash,
-            refreshDeviceBindingHash,
-            refreshExpiresAt,
-            now,
-            new AuthSessionClientMetadata(challenge.deviceName(), challenge.ipAddress())));
+    long sessionId =
+        refreshTokenSessionWritePort.create(
+            new RefreshTokenSessionCreateCommand(
+                challenge.userId(),
+                refreshTokenHash,
+                refreshDeviceBindingHash,
+                refreshExpiresAt,
+                now,
+                new AuthSessionClientMetadata(challenge.deviceName(), challenge.ipAddress())));
     IssuedAccessToken issuedAccessToken =
-        authTokenIssuePort.issue(challenge.userId(), challenge.loginId(), now);
+        authTokenIssuePort.issue(challenge.userId(), challenge.loginId(), sessionId, now);
     return LoginResult.success(
         issuedAccessToken.accessToken(),
         refreshToken,

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/LoginService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/LoginService.java
@@ -292,15 +292,16 @@ public final class LoginService implements LoginUseCase {
         refreshDeviceBindingSecretPort.hash(refreshDeviceBindingToken);
     Instant refreshExpiresAt = now.plus(refreshTokenPolicy.ttl());
     // refresh token 단독 탈취 재사용을 막기 위해 device binding hash를 session에 함께 저장합니다.
-    refreshTokenSessionWritePort.create(
-        new RefreshTokenSessionCreateCommand(
-            userId,
-            refreshTokenHash,
-            refreshDeviceBindingHash,
-            refreshExpiresAt,
-            now,
-            sessionClientMetadata));
-    IssuedAccessToken issuedAccessToken = authTokenIssuePort.issue(userId, loginId, now);
+    long sessionId =
+        refreshTokenSessionWritePort.create(
+            new RefreshTokenSessionCreateCommand(
+                userId,
+                refreshTokenHash,
+                refreshDeviceBindingHash,
+                refreshExpiresAt,
+                now,
+                sessionClientMetadata));
+    IssuedAccessToken issuedAccessToken = authTokenIssuePort.issue(userId, loginId, sessionId, now);
     return LoginResult.success(
         issuedAccessToken.accessToken(),
         refreshToken,

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenService.java
@@ -93,7 +93,7 @@ public final class RefreshTokenService implements RefreshTokenUseCase {
         new RefreshTokenSessionRotateCommand(session.sessionId(), newSessionId, now));
 
     IssuedAccessToken issuedAccessToken =
-        authTokenIssuePort.issue(session.userId(), session.loginId(), now);
+        authTokenIssuePort.issue(session.userId(), session.loginId(), newSessionId, now);
     return LoginResult.success(
         issuedAccessToken.accessToken(),
         nextRefreshToken,

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpChallengeVerifyService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpChallengeVerifyService.java
@@ -135,16 +135,17 @@ public final class TotpChallengeVerifyService implements TotpChallengeVerifyUseC
     Instant refreshExpiresAt = now.plus(refreshTokenPolicy.ttl());
     // refresh token 단독 탈취 재사용을 막기 위해 device binding hash를 session에 함께 저장합니다.
     String rememberDeviceToken = issueRememberDevice(challenge, now, rememberDevice);
-    refreshTokenSessionWritePort.create(
-        new com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand(
-            challenge.userId(),
-            refreshTokenHash,
-            refreshDeviceBindingHash,
-            refreshExpiresAt,
-            now,
-            new AuthSessionClientMetadata(challenge.deviceName(), challenge.ipAddress())));
+    long sessionId =
+        refreshTokenSessionWritePort.create(
+            new com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand(
+                challenge.userId(),
+                refreshTokenHash,
+                refreshDeviceBindingHash,
+                refreshExpiresAt,
+                now,
+                new AuthSessionClientMetadata(challenge.deviceName(), challenge.ipAddress())));
     IssuedAccessToken issuedAccessToken =
-        authTokenIssuePort.issue(challenge.userId(), challenge.loginId(), now);
+        authTokenIssuePort.issue(challenge.userId(), challenge.loginId(), sessionId, now);
     return LoginResult.success(
         issuedAccessToken.accessToken(),
         refreshToken,

--- a/back/src/main/java/com/aquilabank/global/security/AuthenticatedUserPrincipal.java
+++ b/back/src/main/java/com/aquilabank/global/security/AuthenticatedUserPrincipal.java
@@ -1,8 +1,12 @@
 package com.aquilabank.global.security;
 
 /** 실제 bearer JWT가 해석한 user 중심 principal */
-public record AuthenticatedUserPrincipal(long userId, String subject)
+public record AuthenticatedUserPrincipal(long userId, String subject, Long currentSessionId)
     implements AuthenticatedRequestPrincipal {
+
+  public AuthenticatedUserPrincipal(long userId, String subject) {
+    this(userId, subject, null);
+  }
 
   public AuthenticatedUserPrincipal {
     if (userId <= 0) {
@@ -10,6 +14,9 @@ public record AuthenticatedUserPrincipal(long userId, String subject)
     }
     if (subject == null || subject.isBlank()) {
       throw new IllegalArgumentException("subject is required");
+    }
+    if (currentSessionId != null && currentSessionId <= 0) {
+      throw new IllegalArgumentException("currentSessionId must be positive");
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/security/HmacAccessTokenIssuer.java
+++ b/back/src/main/java/com/aquilabank/global/security/HmacAccessTokenIssuer.java
@@ -16,6 +16,9 @@ import javax.crypto.spec.SecretKeySpec;
 /** resource server 검증과 같은 shared secret으로 access token을 발급합니다. */
 public class HmacAccessTokenIssuer implements AuthTokenIssuePort {
 
+  private static final String USER_ID_CLAIM = "user_id";
+  private static final String SESSION_ID_CLAIM = "session_id";
+
   private final SecretKeySpec secretKeySpec;
   private final String issuer;
   private final long accessTokenTtlSeconds;
@@ -28,7 +31,10 @@ public class HmacAccessTokenIssuer implements AuthTokenIssuePort {
   }
 
   @Override
-  public IssuedAccessToken issue(long userId, String subject, Instant issuedAt) {
+  public IssuedAccessToken issue(long userId, String subject, long sessionId, Instant issuedAt) {
+    if (sessionId <= 0) {
+      throw new IllegalArgumentException("sessionId must be positive");
+    }
     Instant expiresAt = issuedAt.plusSeconds(accessTokenTtlSeconds);
 
     JWTClaimsSet.Builder claims =
@@ -36,7 +42,8 @@ public class HmacAccessTokenIssuer implements AuthTokenIssuePort {
             .subject(subject)
             .issueTime(Date.from(issuedAt))
             .expirationTime(Date.from(expiresAt))
-            .claim("user_id", userId);
+            .claim(USER_ID_CLAIM, userId)
+            .claim(SESSION_ID_CLAIM, sessionId);
     if (issuer != null && !issuer.isBlank()) {
       claims.issuer(issuer);
     }

--- a/back/src/main/java/com/aquilabank/global/security/JwtUserAuthenticationConverter.java
+++ b/back/src/main/java/com/aquilabank/global/security/JwtUserAuthenticationConverter.java
@@ -13,6 +13,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 public class JwtUserAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
   private static final String USER_ID_CLAIM = "user_id";
+  private static final String SESSION_ID_CLAIM = "session_id";
 
   @Override
   public AbstractAuthenticationToken convert(Jwt jwt) {
@@ -20,9 +21,10 @@ public class JwtUserAuthenticationConverter implements Converter<Jwt, AbstractAu
     if (userId == null || userId.longValue() <= 0) {
       throw new IllegalArgumentException("user_id claim must be a positive number");
     }
+    Long currentSessionId = extractCurrentSessionId(jwt);
     Collection<GrantedAuthority> authorities = extractAuthorities(jwt);
     AuthenticatedUserPrincipal principal =
-        new AuthenticatedUserPrincipal(userId.longValue(), jwt.getSubject());
+        new AuthenticatedUserPrincipal(userId.longValue(), jwt.getSubject(), currentSessionId);
     return new JwtAuthenticationToken(jwt, authorities, jwt.getSubject()) {
       @Override
       public Object getPrincipal() {
@@ -40,5 +42,17 @@ public class JwtUserAuthenticationConverter implements Converter<Jwt, AbstractAu
           .toList();
     }
     return List.of();
+  }
+
+  private Long extractCurrentSessionId(Jwt jwt) {
+    Number sessionId = jwt.getClaim(SESSION_ID_CLAIM);
+    if (sessionId == null) {
+      // deploy 직후 짧게 남는 구 token까지 허용해 강제 재로그인을 피합니다.
+      return null;
+    }
+    if (sessionId.longValue() <= 0) {
+      throw new IllegalArgumentException("session_id claim must be a positive number");
+    }
+    return sessionId.longValue();
   }
 }

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -215,9 +215,10 @@ public class LoginController {
       @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
       @RequestParam(defaultValue = "20")
           @Min(value = 1, message = "size must be at least 1") @Max(value = 50, message = "size must be 50 or less") int size) {
+    AuthenticatedUserPrincipal userPrincipal = requireUserPrincipal(principal);
     AuthSessionList result =
-        authSessionListUseCase.get(new AuthSessionListQuery(resolveUserId(principal), size));
-    return AuthSessionListResponse.from(result);
+        authSessionListUseCase.get(new AuthSessionListQuery(userPrincipal.userId(), size));
+    return AuthSessionListResponse.from(result, userPrincipal.currentSessionId());
   }
 
   @DeleteMapping("/sessions/{sessionId}")
@@ -393,9 +394,11 @@ public class LoginController {
   /** 현재 user refresh token session 목록 응답 */
   public record AuthSessionListResponse(List<AuthSessionItemResponse> items) {
 
-    private static AuthSessionListResponse from(AuthSessionList result) {
+    private static AuthSessionListResponse from(AuthSessionList result, Long currentSessionId) {
       return new AuthSessionListResponse(
-          result.items().stream().map(AuthSessionItemResponse::from).toList());
+          result.items().stream()
+              .map(summary -> AuthSessionItemResponse.from(summary, currentSessionId))
+              .toList());
     }
   }
 
@@ -407,9 +410,10 @@ public class LoginController {
       Instant lastUsedAt,
       Instant createdAt,
       String deviceName,
-      String ipAddress) {
+      String ipAddress,
+      boolean currentSession) {
 
-    private static AuthSessionItemResponse from(AuthSessionSummary summary) {
+    private static AuthSessionItemResponse from(AuthSessionSummary summary, Long currentSessionId) {
       return new AuthSessionItemResponse(
           summary.sessionId(),
           summary.sessionStatus().name(),
@@ -417,7 +421,8 @@ public class LoginController {
           summary.lastUsedAt(),
           summary.createdAt(),
           summary.deviceName(),
-          summary.ipAddress());
+          summary.ipAddress(),
+          currentSessionId != null && summary.sessionId() == currentSessionId);
     }
   }
 

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/BackupCodeChallengeVerifyServiceTest.java
@@ -75,7 +75,8 @@ class BackupCodeChallengeVerifyServiceTest {
     when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("refresh-hash");
     when(refreshDeviceBindingSecretPort.createToken()).thenReturn("binding-token");
     when(refreshDeviceBindingSecretPort.hash("binding-token")).thenReturn("binding-hash");
-    when(authTokenIssuePort.issue(7L, "alice", NOW))
+    when(refreshTokenSessionWritePort.create(any())).thenReturn(51L);
+    when(authTokenIssuePort.issue(7L, "alice", 51L, NOW))
         .thenReturn(new IssuedAccessToken("access-token", "Bearer", NOW.plusSeconds(900), 7L));
 
     BackupCodeChallengeVerifyService service =
@@ -106,6 +107,7 @@ class BackupCodeChallengeVerifyServiceTest {
     verify(totpLoginChallengeWritePort).update(any());
     verify(backupCodeWritePort).markUsed(any());
     verify(refreshTokenSessionWritePort).create(any());
+    verify(authTokenIssuePort).issue(7L, "alice", 51L, NOW);
     verify(rememberDeviceWritePort, never()).issue(any());
   }
 
@@ -200,7 +202,8 @@ class BackupCodeChallengeVerifyServiceTest {
     when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("refresh-hash");
     when(refreshDeviceBindingSecretPort.createToken()).thenReturn("binding-token");
     when(refreshDeviceBindingSecretPort.hash("binding-token")).thenReturn("binding-hash");
-    when(authTokenIssuePort.issue(7L, "alice", NOW))
+    when(refreshTokenSessionWritePort.create(any())).thenReturn(52L);
+    when(authTokenIssuePort.issue(7L, "alice", 52L, NOW))
         .thenReturn(new IssuedAccessToken("access-token", "Bearer", NOW.plusSeconds(900), 7L));
 
     BackupCodeChallengeVerifyService service =
@@ -227,6 +230,7 @@ class BackupCodeChallengeVerifyServiceTest {
 
     assertEquals("binding-token", result.refreshDeviceBindingToken());
     assertEquals("remember-device-token", result.rememberDeviceToken());
+    verify(authTokenIssuePort).issue(7L, "alice", 52L, NOW);
     verify(rememberDeviceWritePort).issue(any());
   }
 

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/LoginServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/LoginServiceTest.java
@@ -104,7 +104,7 @@ class LoginServiceTest {
     verify(loginAttemptUpdatePort, never()).recordLoginSuccess(Mockito.any());
     verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
     verify(authTokenIssuePort, never())
-        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
+        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(), Mockito.any());
     verify(userCredentialLoadPort).findByLoginIdForUpdate(eq("missing-user"));
     verifyNoInteractions(
         totpCredentialLoadPort,
@@ -247,7 +247,8 @@ class LoginServiceTest {
     when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("refresh-hash");
     when(refreshDeviceBindingSecretPort.createToken()).thenReturn("binding-token");
     when(refreshDeviceBindingSecretPort.hash("binding-token")).thenReturn("binding-hash");
-    when(authTokenIssuePort.issue(7L, "alice", Instant.parse("2026-04-17T00:00:00Z")))
+    when(refreshTokenSessionWritePort.create(any())).thenReturn(31L);
+    when(authTokenIssuePort.issue(7L, "alice", 31L, Instant.parse("2026-04-17T00:00:00Z")))
         .thenReturn(
             new com.aquilabank.domain.auth.model.IssuedAccessToken(
                 "access-token", "Bearer", Instant.parse("2026-04-17T00:15:00Z"), 7L));
@@ -287,6 +288,7 @@ class LoginServiceTest {
         "next-remember-device-token", result.rememberDeviceToken());
     verify(rememberDeviceWritePort).rotate(any());
     verify(refreshTokenSessionWritePort).create(any());
+    verify(authTokenIssuePort).issue(7L, "alice", 31L, Instant.parse("2026-04-17T00:00:00Z"));
     verify(totpLoginChallengeWritePort, never()).upsert(any());
   }
 
@@ -321,7 +323,8 @@ class LoginServiceTest {
     when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("refresh-hash");
     when(refreshDeviceBindingSecretPort.createToken()).thenReturn("binding-token");
     when(refreshDeviceBindingSecretPort.hash("binding-token")).thenReturn("binding-hash");
-    when(authTokenIssuePort.issue(7L, "alice", Instant.parse("2026-04-17T00:00:00Z")))
+    when(refreshTokenSessionWritePort.create(any())).thenReturn(32L);
+    when(authTokenIssuePort.issue(7L, "alice", 32L, Instant.parse("2026-04-17T00:00:00Z")))
         .thenReturn(
             new com.aquilabank.domain.auth.model.IssuedAccessToken(
                 "access-token", "Bearer", Instant.parse("2026-04-17T00:15:00Z"), 7L));
@@ -364,5 +367,6 @@ class LoginServiceTest {
                     Instant.parse("2026-05-01T00:00:00Z"),
                     Instant.parse("2026-04-17T00:00:00Z"),
                     SESSION_CLIENT_METADATA)));
+    verify(authTokenIssuePort).issue(7L, "alice", 32L, Instant.parse("2026-04-17T00:00:00Z"));
   }
 }

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenServiceTest.java
@@ -58,7 +58,7 @@ class RefreshTokenServiceTest {
     when(refreshDeviceBindingSecretPort.hash("next-binding-token")).thenReturn("next-binding-hash");
     when(refreshTokenSessionWritePort.create(any(RefreshTokenSessionCreateCommand.class)))
         .thenReturn(33L);
-    when(authTokenIssuePort.issue(7L, "alice", NOW))
+    when(authTokenIssuePort.issue(7L, "alice", 33L, NOW))
         .thenReturn(new IssuedAccessToken("access-token", "Bearer", NOW.plusSeconds(900), 7L));
 
     RefreshTokenService refreshTokenService =
@@ -93,6 +93,7 @@ class RefreshTokenServiceTest {
                 SESSION_CLIENT_METADATA));
     verify(refreshTokenSessionWritePort)
         .rotate(new RefreshTokenSessionRotateCommand(11L, 33L, NOW));
+    verify(authTokenIssuePort).issue(7L, "alice", 33L, NOW);
   }
 
   @Test
@@ -143,7 +144,7 @@ class RefreshTokenServiceTest {
     verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
     verify(refreshTokenSessionWritePort, never()).rotate(Mockito.any());
     verify(authTokenIssuePort, never())
-        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
+        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(), Mockito.any());
   }
 
   @Test
@@ -194,7 +195,7 @@ class RefreshTokenServiceTest {
     verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
     verify(refreshTokenSessionWritePort, never()).rotate(Mockito.any());
     verify(authTokenIssuePort, never())
-        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.any());
+        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(), Mockito.any());
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/TotpChallengeVerifyServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/TotpChallengeVerifyServiceTest.java
@@ -69,7 +69,8 @@ class TotpChallengeVerifyServiceTest {
     when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("refresh-hash");
     when(refreshDeviceBindingSecretPort.createToken()).thenReturn("binding-token");
     when(refreshDeviceBindingSecretPort.hash("binding-token")).thenReturn("binding-hash");
-    when(authTokenIssuePort.issue(7L, "alice", NOW))
+    when(refreshTokenSessionWritePort.create(any())).thenReturn(41L);
+    when(authTokenIssuePort.issue(7L, "alice", 41L, NOW))
         .thenReturn(new IssuedAccessToken("access-token", "Bearer", NOW.plusSeconds(900), 7L));
 
     TotpChallengeVerifyService service =
@@ -98,6 +99,7 @@ class TotpChallengeVerifyServiceTest {
     verify(totpLoginChallengeWritePort).update(any());
     verify(totpCredentialWritePort).touchLastUsed(any());
     verify(refreshTokenSessionWritePort).create(any());
+    verify(authTokenIssuePort).issue(7L, "alice", 41L, NOW);
     verify(rememberDeviceWritePort, never()).issue(any());
   }
 
@@ -182,7 +184,8 @@ class TotpChallengeVerifyServiceTest {
     when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("refresh-hash");
     when(refreshDeviceBindingSecretPort.createToken()).thenReturn("binding-token");
     when(refreshDeviceBindingSecretPort.hash("binding-token")).thenReturn("binding-hash");
-    when(authTokenIssuePort.issue(7L, "alice", NOW))
+    when(refreshTokenSessionWritePort.create(any())).thenReturn(42L);
+    when(authTokenIssuePort.issue(7L, "alice", 42L, NOW))
         .thenReturn(new IssuedAccessToken("access-token", "Bearer", NOW.plusSeconds(900), 7L));
 
     TotpChallengeVerifyService service =
@@ -207,6 +210,7 @@ class TotpChallengeVerifyServiceTest {
 
     assertEquals("binding-token", result.refreshDeviceBindingToken());
     assertEquals("remember-device-token", result.rememberDeviceToken());
+    verify(authTokenIssuePort).issue(7L, "alice", 42L, NOW);
     verify(rememberDeviceWritePort).issue(any());
   }
 

--- a/back/src/test/java/com/aquilabank/global/security/JwtUserAuthenticationConverterTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/JwtUserAuthenticationConverterTest.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
@@ -21,7 +22,8 @@ class JwtUserAuthenticationConverterTest {
             Instant.now(),
             Instant.now().plusSeconds(300),
             Map.of("alg", "HS256"),
-            Map.of("sub", "alice", "user_id", 123L, "scope", "transactions:read"));
+            Map.of(
+                "sub", "alice", "user_id", 123L, "session_id", 456L, "scope", "transactions:read"));
 
     JwtAuthenticationToken authentication = (JwtAuthenticationToken) converter.convert(jwt);
     AuthenticatedUserPrincipal principal =
@@ -29,9 +31,29 @@ class JwtUserAuthenticationConverterTest {
 
     assertEquals(123L, principal.userId());
     assertEquals("alice", principal.subject());
+    assertEquals(456L, principal.currentSessionId());
     assertEquals(
         "SCOPE_transactions:read",
         authentication.getAuthorities().iterator().next().getAuthority());
+  }
+
+  @Test
+  void allowsLegacyJwtWithoutSessionIdClaim() {
+    Jwt jwt =
+        new Jwt(
+            "token",
+            Instant.now(),
+            Instant.now().plusSeconds(300),
+            Map.of("alg", "HS256"),
+            Map.of("sub", "alice", "user_id", 123L));
+
+    JwtAuthenticationToken authentication = (JwtAuthenticationToken) converter.convert(jwt);
+    AuthenticatedUserPrincipal principal =
+        (AuthenticatedUserPrincipal) authentication.getPrincipal();
+
+    assertEquals(123L, principal.userId());
+    assertEquals("alice", principal.subject());
+    assertNull(principal.currentSessionId());
   }
 
   @Test
@@ -43,6 +65,19 @@ class JwtUserAuthenticationConverterTest {
             Instant.now().plusSeconds(300),
             Map.of("alg", "HS256"),
             Map.of("sub", "alice"));
+
+    assertThrows(IllegalArgumentException.class, () -> converter.convert(jwt));
+  }
+
+  @Test
+  void rejectsNonPositiveSessionIdClaim() {
+    Jwt jwt =
+        new Jwt(
+            "token",
+            Instant.now(),
+            Instant.now().plusSeconds(300),
+            Map.of("alg", "HS256"),
+            Map.of("sub", "alice", "user_id", 123L, "session_id", 0L));
 
     assertThrows(IllegalArgumentException.class, () -> converter.convert(jwt));
   }

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -22,10 +22,18 @@ import com.aquilabank.standard.util.Base32Codec;
 import com.aquilabank.support.PostgresContainerTestSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import jakarta.servlet.http.Cookie;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +72,7 @@ import org.springframework.web.context.WebApplicationContext;
 class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSupport {
 
   private static final String AUTH_ADMIN_SUBJECT = "ops-admin";
+  private static final String TEST_SECRET = "test-local-jwt-secret-test-local-jwt-secret";
   private static final String REFRESH_DEVICE_COOKIE_NAME = "ab_refresh_device";
   private static final String REMEMBER_DEVICE_COOKIE_NAME = "ab_mfa_remember_device";
   private static final RequestClientMetadata WINDOWS_CHROME =
@@ -778,16 +787,67 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.items.length()").value(3))
         .andExpect(jsonPath("$.items[0].sessionId").value(newestSessionId))
+        .andExpect(jsonPath("$.items[0].currentSession").value(true))
         .andExpect(jsonPath("$.items[0].sessionStatus").value("ACTIVE"))
         .andExpect(jsonPath("$.items[0].deviceName").value(WINDOWS_EDGE.expectedDeviceName()))
         .andExpect(jsonPath("$.items[0].ipAddress").value(WINDOWS_EDGE.expectedIpAddress()))
         .andExpect(jsonPath("$.items[1].sessionId").value(middleSessionId))
+        .andExpect(jsonPath("$.items[1].currentSession").value(false))
         .andExpect(jsonPath("$.items[1].deviceName").value(IPHONE_SAFARI.expectedDeviceName()))
         .andExpect(jsonPath("$.items[1].ipAddress").value(IPHONE_SAFARI.expectedIpAddress()))
         .andExpect(jsonPath("$.items[2].sessionId").value(oldestSessionId))
+        .andExpect(jsonPath("$.items[2].currentSession").value(false))
         .andExpect(jsonPath("$.items[2].deviceName").value(WINDOWS_CHROME.expectedDeviceName()))
         .andExpect(jsonPath("$.items[2].ipAddress").value(WINDOWS_CHROME.expectedIpAddress()))
         .andExpect(jsonPath("$.items[0].createdAt").isString());
+  }
+
+  @Test
+  void authSessionListMarksRefreshedSessionAsCurrent() throws Exception {
+    TokenPairResponseView oldest =
+        loginResult("alice", "password123!", "session-current-refresh-login-001", WINDOWS_CHROME);
+    TokenPairResponseView current =
+        loginResult("alice", "password123!", "session-current-refresh-login-002", WINDOWS_EDGE);
+    TokenPairResponseView refreshed =
+        refresh(current.refreshToken(), "session-current-refresh-refresh-001", IPHONE_SAFARI);
+
+    long refreshedSessionId = loadRefreshTokenSessionId(refreshed.refreshToken());
+    long oldestSessionId = loadRefreshTokenSessionId(oldest.refreshToken());
+
+    mockMvc
+        .perform(
+            get("/api/v1/auth/sessions")
+                .header("Authorization", "Bearer " + refreshed.accessToken())
+                .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].sessionId").value(refreshedSessionId))
+        .andExpect(jsonPath("$.items[0].currentSession").value(true))
+        .andExpect(jsonPath("$.items[1].sessionId").value(oldestSessionId))
+        .andExpect(jsonPath("$.items[1].currentSession").value(false));
+  }
+
+  @Test
+  void authSessionListAllowsLegacyJwtWithoutSessionIdAndMarksNoCurrentSession() throws Exception {
+    TokenPairResponseView oldest =
+        loginResult("alice", "password123!", "session-legacy-login-001", WINDOWS_CHROME);
+    TokenPairResponseView newest =
+        loginResult("alice", "password123!", "session-legacy-login-002", WINDOWS_EDGE);
+    long newestSessionId = loadRefreshTokenSessionId(newest.refreshToken());
+    long oldestSessionId = loadRefreshTokenSessionId(oldest.refreshToken());
+    String legacyAccessToken = issueLegacyAccessToken("alice", userId);
+
+    mockMvc
+        .perform(
+            get("/api/v1/auth/sessions")
+                .header("Authorization", "Bearer " + legacyAccessToken)
+                .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].sessionId").value(newestSessionId))
+        .andExpect(jsonPath("$.items[0].currentSession").value(false))
+        .andExpect(jsonPath("$.items[1].sessionId").value(oldestSessionId))
+        .andExpect(jsonPath("$.items[1].currentSession").value(false));
   }
 
   @Test
@@ -2578,6 +2638,22 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
 
   private String internalServiceAuthorization(String subject, InternalServiceScope scope) {
     return "Bearer " + internalServiceTokenIssuer.issue(subject, java.util.Set.of(scope));
+  }
+
+  private String issueLegacyAccessToken(String subject, long userId) throws Exception {
+    Instant issuedAt = Instant.now();
+    JWTClaimsSet claimsSet =
+        new JWTClaimsSet.Builder()
+            .subject(subject)
+            .issueTime(Date.from(issuedAt))
+            .expirationTime(Date.from(issuedAt.plusSeconds(900)))
+            .claim("user_id", userId)
+            .build();
+    SignedJWT signedJwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(), claimsSet);
+    signedJwt.sign(new MACSigner(TEST_SECRET.getBytes(StandardCharsets.UTF_8)));
+    return signedJwt.serialize();
   }
 
   private LoginProtectionState loadLoginProtectionState(long userId) {


### PR DESCRIPTION
## 🔗 Related Issue
- close #158

## 🌿 Base Branch
- `main`

## 📝 Summary
- auth access token에 현재 refresh token session의 `session_id` claim을 넣어 현재 세션을 식별할 수 있게 했습니다.
- `GET /api/v1/auth/sessions` 응답에 `currentSession`을 추가하고, 구 access token은 TTL 동안 계속 허용하도록 backward compatibility를 유지했습니다.

## 🛠 Changes
- `AuthTokenIssuePort`와 access token issuer가 `session_id` claim을 발급하도록 확장했습니다.
- login/refresh/TOTP challenge/backup code challenge의 token pair 발급 경로가 session id를 issuer에 전달하도록 맞췄습니다.
- `AuthenticatedUserPrincipal`이 optional `currentSessionId`를 들고, JWT converter가 `session_id`를 읽되 구 token은 nullable로 허용하도록 변경했습니다.
- auth session 목록 응답 item에 `currentSession`을 추가하고 integration/unit 테스트, README를 갱신했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-auth-current-session ./back/gradlew -p back test --tests '*LoginServiceTest' --tests '*RefreshTokenServiceTest' --tests '*TotpChallengeVerifyServiceTest' --tests '*BackupCodeChallengeVerifyServiceTest' --tests '*JwtUserAuthenticationConverterTest' --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `./back/gradlew -p back spotlessApply`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- login/refresh/legacy JWT 경로에서 `currentSession` 응답이 기대값대로 나오는 integration 테스트 확인

## 📸 Screenshot / API Example
- API example:
```json
{
  "items": [
    {
      "sessionId": 123,
      "sessionStatus": "ACTIVE",
      "expiresAt": "2026-04-20T13:00:00Z",
      "lastUsedAt": "2026-04-20T12:55:00Z",
      "createdAt": "2026-04-20T12:00:00Z",
      "deviceName": "Windows / Edge",
      "ipAddress": "192.0.2.77",
      "currentSession": true
    }
  ]
}
```

## ⚠️ Risk & Rollback
- 예상 리스크:
  - deploy 직후 TTL 내 구 access token은 `session_id`가 없어 `currentSession`이 전부 `false`로 보일 수 있습니다.
  - 새 token 발급 경로에서 `session_id` 전달이 빠지면 현재 세션 표시가 틀어질 수 있습니다.
- 롤백 방법:
  - 이 PR revert로 `session_id` claim과 `currentSession` 응답 필드를 함께 원복합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [ ] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?