### PR TITLE
[Feat] notification 검색/필터 API 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -234,6 +234,22 @@ tools/test/with-resource-lock.sh back-gradle-check \
 - 오래된 inbox row를 지울 때 연결된 `notification_user_read_state`도 FK cascade로 함께 정리해 read state orphan과 unread 회귀를 막습니다.
 - 기본 설정은 `NOTIFICATION_INBOX_CLEANUP_ENABLED=true`, `NOTIFICATION_INBOX_CLEANUP_RETENTION_DAYS=90`, `NOTIFICATION_INBOX_CLEANUP_BATCH_SIZE=500`, `NOTIFICATION_INBOX_CLEANUP_FIXED_DELAY_MS=300000` 입니다.
 
+## Notification Search API
+
+- endpoint:
+  - `GET /api/v1/notifications/search`
+- query param:
+  - `limit`, `cursor`
+  - `readStatus=ALL|UNREAD|READ` 기본값 `ALL`
+  - `eventType` exact match
+  - `from`, `to`는 ISO-8601 UTC instant 두 값이 함께 와야 합니다.
+- 계약:
+  - 기존 `GET /api/v1/notifications` 목록 API는 그대로 유지하고, 검색은 별도 endpoint로 분리합니다.
+  - `from/to`를 생략하면 최근 31일 window를 자동 적용하고, 응답 `appliedFrom`, `appliedTo`에 실제 window를 반환합니다.
+  - 다음 page는 `cursor`만 보내도 같은 `appliedFrom/appliedTo`를 재사용합니다.
+  - 검색 cursor는 `readStatus`, `eventType`, `appliedFrom`, `appliedTo` fingerprint를 포함하므로 요청 필터가 달라지면 `400`을 반환합니다.
+  - `from > to` 또는 31일 초과 window는 허용하지 않습니다.
+
 ## Notification Bulk Actions
 
 - endpoint:

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationReadStatusFilter.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationReadStatusFilter.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.notification.model;
+
+public enum NotificationReadStatusFilter {
+  ALL,
+  UNREAD,
+  READ
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchCursor.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchCursor.java
@@ -19,6 +19,9 @@ public record NotificationSearchCursor(
     if (appliedFrom.isAfter(appliedTo)) {
       throw new IllegalArgumentException("appliedFrom must be before or equal to appliedTo");
     }
+    if (createdAt.isBefore(appliedFrom) || createdAt.isAfter(appliedTo)) {
+      throw new IllegalArgumentException("createdAt must be within applied window");
+    }
     if (filterFingerprint == null || filterFingerprint.isBlank()) {
       throw new IllegalArgumentException("filterFingerprint is required");
     }

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchCursor.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchCursor.java
@@ -1,0 +1,26 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** 검색 cursor는 필터 window까지 함께 고정해야 page 간 의미가 유지된다 */
+public record NotificationSearchCursor(
+    Instant createdAt, long id, Instant appliedFrom, Instant appliedTo, String filterFingerprint) {
+
+  public NotificationSearchCursor {
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+    if (id <= 0) {
+      throw new IllegalArgumentException("id must be positive");
+    }
+    if (appliedFrom == null || appliedTo == null) {
+      throw new IllegalArgumentException("applied window is required");
+    }
+    if (appliedFrom.isAfter(appliedTo)) {
+      throw new IllegalArgumentException("appliedFrom must be before or equal to appliedTo");
+    }
+    if (filterFingerprint == null || filterFingerprint.isBlank()) {
+      throw new IllegalArgumentException("filterFingerprint is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchQuery.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchQuery.java
@@ -1,0 +1,28 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** 검색 전용 query는 기본 window와 필터를 한 번에 고정한다 */
+public record NotificationSearchQuery(
+    int limit,
+    NotificationSearchCursor cursor,
+    NotificationReadStatusFilter readStatus,
+    String eventType,
+    Instant appliedFrom,
+    Instant appliedTo) {
+
+  public NotificationSearchQuery {
+    if (limit < 1 || limit > 100) {
+      throw new IllegalArgumentException("limit must be between 1 and 100");
+    }
+    if (readStatus == null) {
+      throw new IllegalArgumentException("readStatus is required");
+    }
+    if (appliedFrom == null || appliedTo == null) {
+      throw new IllegalArgumentException("applied window is required");
+    }
+    if (appliedFrom.isAfter(appliedTo)) {
+      throw new IllegalArgumentException("appliedFrom must be before or equal to appliedTo");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchSlice.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchSlice.java
@@ -1,0 +1,17 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+import java.util.List;
+
+public record NotificationSearchSlice(
+    List<NotificationSummary> items,
+    NotificationSearchCursor nextCursor,
+    boolean hasNext,
+    int limit,
+    Instant appliedFrom,
+    Instant appliedTo) {
+
+  public NotificationSearchSlice {
+    items = List.copyOf(items);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchSlice.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchSlice.java
@@ -25,5 +25,10 @@ public record NotificationSearchSlice(
     if (!hasNext && nextCursor != null) {
       throw new IllegalArgumentException("nextCursor must be null when hasNext is false");
     }
+    if (nextCursor != null
+        && (!nextCursor.appliedFrom().equals(appliedFrom)
+            || !nextCursor.appliedTo().equals(appliedTo))) {
+      throw new IllegalArgumentException("nextCursor window must match slice window");
+    }
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchSlice.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationSearchSlice.java
@@ -13,5 +13,17 @@ public record NotificationSearchSlice(
 
   public NotificationSearchSlice {
     items = List.copyOf(items);
+    if (limit < 1 || limit > 100) {
+      throw new IllegalArgumentException("limit must be between 1 and 100");
+    }
+    if (appliedFrom == null || appliedTo == null) {
+      throw new IllegalArgumentException("applied window is required");
+    }
+    if (appliedFrom.isAfter(appliedTo)) {
+      throw new IllegalArgumentException("appliedFrom must be before or equal to appliedTo");
+    }
+    if (!hasNext && nextCursor != null) {
+      throw new IllegalArgumentException("nextCursor must be null when hasNext is false");
+    }
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxSearchPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationInboxSearchPort.java
@@ -1,0 +1,12 @@
+package com.aquilabank.domain.notification.port;
+
+import com.aquilabank.domain.notification.model.NotificationSearchQuery;
+import com.aquilabank.domain.notification.model.NotificationSearchSlice;
+
+/** 검색 전용 inbox 조회는 기존 목록 API와 분리된 조건/window 계약을 사용합니다. */
+public interface NotificationInboxSearchPort {
+
+  NotificationSearchSlice searchByUserId(long userId, NotificationSearchQuery query);
+
+  NotificationSearchSlice searchByAccountId(long accountId, NotificationSearchQuery query);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationSearchService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationSearchService.java
@@ -1,0 +1,37 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.NotificationSearchQuery;
+import com.aquilabank.domain.notification.model.NotificationSearchSlice;
+import com.aquilabank.domain.notification.port.NotificationInboxSearchPort;
+
+/** controller 는 principal 별 검색 주체만 고르고 실제 search 는 port 로 위임합니다. */
+public final class NotificationSearchService implements NotificationSearchUseCase {
+
+  private final NotificationInboxSearchPort notificationInboxSearchPort;
+
+  public NotificationSearchService(NotificationInboxSearchPort notificationInboxSearchPort) {
+    this.notificationInboxSearchPort = notificationInboxSearchPort;
+  }
+
+  @Override
+  public NotificationSearchSlice searchForUser(long userId, NotificationSearchQuery query) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (query == null) {
+      throw new IllegalArgumentException("query is required");
+    }
+    return notificationInboxSearchPort.searchByUserId(userId, query);
+  }
+
+  @Override
+  public NotificationSearchSlice searchForAccount(long accountId, NotificationSearchQuery query) {
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (query == null) {
+      throw new IllegalArgumentException("query is required");
+    }
+    return notificationInboxSearchPort.searchByAccountId(accountId, query);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationSearchUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationSearchUseCase.java
@@ -1,0 +1,11 @@
+package com.aquilabank.domain.notification.usecase;
+
+import com.aquilabank.domain.notification.model.NotificationSearchQuery;
+import com.aquilabank.domain.notification.model.NotificationSearchSlice;
+
+public interface NotificationSearchUseCase {
+
+  NotificationSearchSlice searchForUser(long userId, NotificationSearchQuery query);
+
+  NotificationSearchSlice searchForAccount(long accountId, NotificationSearchQuery query);
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationConfiguration.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.config;
 
 import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
+import com.aquilabank.domain.notification.port.NotificationInboxSearchPort;
 import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
 import com.aquilabank.domain.notification.usecase.NotificationBulkActionService;
 import com.aquilabank.domain.notification.usecase.NotificationBulkActionUseCase;
@@ -8,7 +9,10 @@ import com.aquilabank.domain.notification.usecase.NotificationQueryService;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadService;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import com.aquilabank.domain.notification.usecase.NotificationSearchService;
+import com.aquilabank.domain.notification.usecase.NotificationSearchUseCase;
 import com.aquilabank.global.notification.NotificationSseFanoutInstanceId;
+import java.time.Clock;
 import java.util.UUID;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -20,9 +24,20 @@ import org.springframework.context.annotation.Configuration;
 public class NotificationConfiguration {
 
   @Bean
+  Clock notificationSearchClock() {
+    return Clock.systemUTC();
+  }
+
+  @Bean
   NotificationQueryUseCase notificationQueryUseCase(
       NotificationInboxReadPort notificationInboxReadPort) {
     return new NotificationQueryService(notificationInboxReadPort);
+  }
+
+  @Bean
+  NotificationSearchUseCase notificationSearchUseCase(
+      NotificationInboxSearchPort notificationInboxSearchPort) {
+    return new NotificationSearchService(notificationInboxSearchPort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -3,12 +3,17 @@ package com.aquilabank.global.persistence.notification;
 import com.aquilabank.domain.notification.model.NotificationCursor;
 import com.aquilabank.domain.notification.model.NotificationInboxEntry;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationReadStatusFilter;
 import com.aquilabank.domain.notification.model.NotificationReplayQuery;
+import com.aquilabank.domain.notification.model.NotificationSearchCursor;
+import com.aquilabank.domain.notification.model.NotificationSearchQuery;
+import com.aquilabank.domain.notification.model.NotificationSearchSlice;
 import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.domain.notification.model.NotificationSummary;
 import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
 import com.aquilabank.domain.notification.port.NotificationInboxCleanupPort;
 import com.aquilabank.domain.notification.port.NotificationInboxReadPort;
+import com.aquilabank.domain.notification.port.NotificationInboxSearchPort;
 import com.aquilabank.domain.notification.port.NotificationInboxWritePort;
 import com.aquilabank.global.notification.NotificationInboxInsertedEvent;
 import java.sql.ResultSet;
@@ -31,6 +36,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @Repository
 public class JdbcNotificationInboxRepository
     implements NotificationInboxReadPort,
+        NotificationInboxSearchPort,
         NotificationInboxWritePort,
         NotificationInboxAppendPort,
         NotificationInboxCleanupPort {
@@ -65,6 +71,18 @@ public class JdbcNotificationInboxRepository
             ? fetchByAccountIdFirstPage(accountId, query)
             : fetchByAccountIdNextPage(accountId, query);
     return toSlice(rows, query.limit());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public NotificationSearchSlice searchByUserId(long userId, NotificationSearchQuery query) {
+    return toSearchSlice(fetchSearchByUserId(userId, query), query);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public NotificationSearchSlice searchByAccountId(long accountId, NotificationSearchQuery query) {
+    return toSearchSlice(fetchSearchByAccountId(accountId, query), query);
   }
 
   @Override
@@ -360,6 +378,16 @@ public class JdbcNotificationInboxRepository
     return new NotificationSlice(items, nextCursor, hasNext, limit);
   }
 
+  private NotificationSearchSlice toSearchSlice(
+      List<NotificationSummary> rows, NotificationSearchQuery query) {
+    boolean hasNext = rows.size() > query.limit();
+    List<NotificationSummary> items =
+        hasNext ? new ArrayList<>(rows.subList(0, query.limit())) : rows;
+    NotificationSearchCursor nextCursor = hasNext ? toSearchCursor(items.getLast(), query) : null;
+    return new NotificationSearchSlice(
+        items, nextCursor, hasNext, query.limit(), query.appliedFrom(), query.appliedTo());
+  }
+
   private static NotificationSummary mapRow(ResultSet rs) throws SQLException {
     return new NotificationSummary(
         rs.getLong("id"),
@@ -373,6 +401,16 @@ public class JdbcNotificationInboxRepository
 
   private static NotificationCursor toCursor(NotificationSummary item) {
     return new NotificationCursor(item.createdAt(), item.id());
+  }
+
+  private NotificationSearchCursor toSearchCursor(
+      NotificationSummary item, NotificationSearchQuery query) {
+    return new NotificationSearchCursor(
+        item.createdAt(),
+        item.id(),
+        query.appliedFrom(),
+        query.appliedTo(),
+        searchFingerprint(query));
   }
 
   private static Instant nullableInstant(ResultSet rs, String columnName) throws SQLException {
@@ -553,5 +591,177 @@ public class JdbcNotificationInboxRepository
             .addValue("cursorCreatedAt", Timestamp.from(query.cursor().createdAt()))
             .addValue("cursorId", query.cursor().id()),
         ROW_MAPPER);
+  }
+
+  private List<NotificationSummary> fetchSearchByAccountId(
+      long accountId, NotificationSearchQuery query) {
+    String normalizedEventType = normalizeEventType(query.eventType());
+    StringBuilder sql =
+        new StringBuilder(
+            """
+            SELECT id,
+                   account_id,
+                   event_type,
+                   title,
+                   message,
+                   created_at,
+                   read_at
+            FROM notification_inbox
+            WHERE account_id = :accountId
+              AND archived_at IS NULL
+              AND created_at >= :appliedFrom
+              AND created_at <= :appliedTo
+            """);
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("appliedFrom", Timestamp.from(query.appliedFrom()))
+            .addValue("appliedTo", Timestamp.from(query.appliedTo()))
+            .addValue("limitPlusOne", query.limit() + 1);
+    if (normalizedEventType != null) {
+      sql.append(
+          """
+              AND event_type = :eventType
+          """);
+      params.addValue("eventType", normalizedEventType);
+    }
+    appendAccountReadStatusFilter(sql, query.readStatus());
+    appendCursorFilter(sql, params, query.cursor(), "created_at", "id");
+    sql.append(
+        """
+            ORDER BY created_at DESC, id DESC
+            LIMIT :limitPlusOne
+        """);
+    return jdbcTemplate.query(sql.toString(), params, ROW_MAPPER);
+  }
+
+  private List<NotificationSummary> fetchSearchByUserId(
+      long userId, NotificationSearchQuery query) {
+    String normalizedEventType = normalizeEventType(query.eventType());
+    StringBuilder sql =
+        new StringBuilder(
+            """
+            SELECT n.id,
+                   n.account_id,
+                   n.event_type,
+                   n.title,
+                   n.message,
+                   n.created_at,
+                   r.read_at
+            FROM notification_inbox n
+            JOIN user_account_membership m
+              ON m.account_id = n.account_id
+            JOIN bank_user u
+              ON u.id = m.user_id
+            LEFT JOIN notification_user_read_state r
+              ON r.user_id = :userId
+             AND r.notification_id = n.id
+            WHERE m.user_id = :userId
+              AND m.membership_status = 'ACTIVE'
+              AND u.user_status = 'ACTIVE'
+              AND n.archived_at IS NULL
+              AND r.archived_at IS NULL
+              AND r.deleted_at IS NULL
+              AND n.created_at >= :appliedFrom
+              AND n.created_at <= :appliedTo
+            """);
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("appliedFrom", Timestamp.from(query.appliedFrom()))
+            .addValue("appliedTo", Timestamp.from(query.appliedTo()))
+            .addValue("limitPlusOne", query.limit() + 1);
+    if (normalizedEventType != null) {
+      sql.append(
+          """
+              AND n.event_type = :eventType
+          """);
+      params.addValue("eventType", normalizedEventType);
+    }
+    appendUserReadStatusFilter(sql, query.readStatus());
+    appendCursorFilter(sql, params, query.cursor(), "n.created_at", "n.id");
+    sql.append(
+        """
+            ORDER BY n.created_at DESC, n.id DESC
+            LIMIT :limitPlusOne
+        """);
+    return jdbcTemplate.query(sql.toString(), params, ROW_MAPPER);
+  }
+
+  private void appendAccountReadStatusFilter(
+      StringBuilder sql, NotificationReadStatusFilter readStatus) {
+    if (readStatus == NotificationReadStatusFilter.UNREAD) {
+      sql.append(
+          """
+              AND read_at IS NULL
+          """);
+      return;
+    }
+    if (readStatus == NotificationReadStatusFilter.READ) {
+      sql.append(
+          """
+              AND read_at IS NOT NULL
+          """);
+    }
+  }
+
+  private void appendUserReadStatusFilter(
+      StringBuilder sql, NotificationReadStatusFilter readStatus) {
+    if (readStatus == NotificationReadStatusFilter.UNREAD) {
+      sql.append(
+          """
+              AND r.read_at IS NULL
+          """);
+      return;
+    }
+    if (readStatus == NotificationReadStatusFilter.READ) {
+      sql.append(
+          """
+              AND r.read_at IS NOT NULL
+          """);
+    }
+  }
+
+  private void appendCursorFilter(
+      StringBuilder sql,
+      MapSqlParameterSource params,
+      NotificationSearchCursor cursor,
+      String createdAtColumn,
+      String idColumn) {
+    if (cursor == null) {
+      return;
+    }
+    sql.append("AND (")
+        .append(createdAtColumn)
+        .append(" < :cursorCreatedAt OR (")
+        .append(createdAtColumn)
+        .append(" = :cursorCreatedAt AND ")
+        .append(idColumn)
+        .append(
+            """
+             < :cursorId))
+            """);
+    params
+        .addValue("cursorCreatedAt", Timestamp.from(cursor.createdAt()))
+        .addValue("cursorId", cursor.id());
+  }
+
+  private String normalizeEventType(String eventType) {
+    if (eventType == null) {
+      return null;
+    }
+    String normalized = eventType.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  private String searchFingerprint(NotificationSearchQuery query) {
+    String normalizedEventType = normalizeEventType(query.eventType());
+    return query.readStatus()
+        + "|"
+        + (normalizedEventType == null ? "" : normalizedEventType)
+        + "|"
+        + query.appliedFrom()
+        + "|"
+        + query.appliedTo();
   }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -76,12 +76,14 @@ public class JdbcNotificationInboxRepository
   @Override
   @Transactional(readOnly = true)
   public NotificationSearchSlice searchByUserId(long userId, NotificationSearchQuery query) {
+    validateSearchCursor(query);
     return toSearchSlice(fetchSearchByUserId(userId, query), query);
   }
 
   @Override
   @Transactional(readOnly = true)
   public NotificationSearchSlice searchByAccountId(long accountId, NotificationSearchQuery query) {
+    validateSearchCursor(query);
     return toSearchSlice(fetchSearchByAccountId(accountId, query), query);
   }
 
@@ -411,6 +413,20 @@ public class JdbcNotificationInboxRepository
         query.appliedFrom(),
         query.appliedTo(),
         searchFingerprint(query));
+  }
+
+  private void validateSearchCursor(NotificationSearchQuery query) {
+    NotificationSearchCursor cursor = query.cursor();
+    if (cursor == null) {
+      return;
+    }
+    if (!cursor.appliedFrom().equals(query.appliedFrom())
+        || !cursor.appliedTo().equals(query.appliedTo())) {
+      throw new IllegalArgumentException("search cursor window must match query");
+    }
+    if (!cursor.filterFingerprint().equals(searchFingerprint(query))) {
+      throw new IllegalArgumentException("search cursor fingerprint must match query");
+    }
   }
 
   private static Instant nullableInstant(ResultSet rs, String columnName) throws SQLException {

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
@@ -95,18 +95,22 @@ public class NotificationController {
       @RequestParam(required = false) String eventType,
       @RequestParam(required = false) String from,
       @RequestParam(required = false) String to) {
-    NotificationSearchCursor decodedCursor =
-        cursor == null || cursor.isBlank() ? null : NotificationSearchCursorCodec.decode(cursor);
-    NotificationSearchWindow appliedWindow = resolveSearchWindow(decodedCursor, from, to);
-    NotificationSearchQuery query =
-        new NotificationSearchQuery(
-            limit,
-            decodedCursor,
-            parseReadStatus(readStatus),
-            normalizeEventType(eventType),
-            appliedWindow.appliedFrom(),
-            appliedWindow.appliedTo());
-    return NotificationSearchResponse.from(resolveSearchNotifications(principal, query));
+    try {
+      NotificationSearchCursor decodedCursor =
+          cursor == null || cursor.isBlank() ? null : NotificationSearchCursorCodec.decode(cursor);
+      NotificationSearchWindow appliedWindow = resolveSearchWindow(decodedCursor, from, to);
+      NotificationSearchQuery query =
+          new NotificationSearchQuery(
+              limit,
+              decodedCursor,
+              parseReadStatus(readStatus),
+              normalizeEventType(eventType),
+              appliedWindow.appliedFrom(),
+              appliedWindow.appliedTo());
+      return NotificationSearchResponse.from(resolveSearchNotifications(principal, query));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
   }
 
   @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
@@ -306,8 +310,7 @@ public class NotificationController {
         return validateSearchWindow(cursor.appliedFrom(), cursor.appliedTo());
       }
       Instant appliedTo = Instant.now(notificationSearchClock);
-      return validateSearchWindow(
-          appliedTo.minusSeconds(SEARCH_WINDOW_SECONDS), appliedTo);
+      return validateSearchWindow(appliedTo.minusSeconds(SEARCH_WINDOW_SECONDS), appliedTo);
     }
     Instant appliedFrom = parseInstant(from, "from");
     Instant appliedTo = parseInstant(to, "to");
@@ -316,7 +319,7 @@ public class NotificationController {
 
   private NotificationReadStatusFilter parseReadStatus(String rawReadStatus) {
     try {
-      return NotificationReadStatusFilter.valueOf(rawReadStatus.toUpperCase(Locale.ROOT));
+      return NotificationReadStatusFilter.valueOf(rawReadStatus.trim().toUpperCase(Locale.ROOT));
     } catch (RuntimeException ex) {
       throw new IllegalArgumentException("readStatus is invalid", ex);
     }
@@ -344,7 +347,7 @@ public class NotificationController {
     if (eventType == null || eventType.isBlank()) {
       return null;
     }
-    return eventType;
+    return eventType.trim();
   }
 
   /** bulk action body 는 작은 id 목록만 허용해 notification inbox SQL 범위를 고정합니다. */

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
@@ -3,9 +3,13 @@ package com.aquilabank.global.web.notification;
 import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
 import com.aquilabank.domain.notification.model.NotificationCursor;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationReadStatusFilter;
+import com.aquilabank.domain.notification.model.NotificationSearchCursor;
+import com.aquilabank.domain.notification.model.NotificationSearchQuery;
 import com.aquilabank.domain.notification.usecase.NotificationBulkActionUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import com.aquilabank.domain.notification.usecase.NotificationSearchUseCase;
 import com.aquilabank.global.notification.NotificationSseBroker;
 import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
@@ -15,7 +19,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -39,20 +47,28 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/v1/notifications")
 public class NotificationController {
 
+  private static final long SEARCH_WINDOW_SECONDS = 31L * 24 * 60 * 60;
+
   private final NotificationQueryUseCase notificationQueryUseCase;
   private final NotificationReadUseCase notificationReadUseCase;
   private final NotificationBulkActionUseCase notificationBulkActionUseCase;
+  private final NotificationSearchUseCase notificationSearchUseCase;
   private final NotificationSseBroker notificationSseBroker;
+  private final Clock notificationSearchClock;
 
   public NotificationController(
       NotificationQueryUseCase notificationQueryUseCase,
       NotificationReadUseCase notificationReadUseCase,
       NotificationBulkActionUseCase notificationBulkActionUseCase,
-      NotificationSseBroker notificationSseBroker) {
+      NotificationSearchUseCase notificationSearchUseCase,
+      NotificationSseBroker notificationSseBroker,
+      @Qualifier("notificationSearchClock") Clock notificationSearchClock) {
     this.notificationQueryUseCase = notificationQueryUseCase;
     this.notificationReadUseCase = notificationReadUseCase;
     this.notificationBulkActionUseCase = notificationBulkActionUseCase;
+    this.notificationSearchUseCase = notificationSearchUseCase;
     this.notificationSseBroker = notificationSseBroker;
+    this.notificationSearchClock = notificationSearchClock;
   }
 
   @GetMapping
@@ -68,6 +84,29 @@ public class NotificationController {
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }
+  }
+
+  @GetMapping("/search")
+  public NotificationSearchResponse searchNotifications(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @RequestParam(defaultValue = "20") int limit,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(defaultValue = "ALL") String readStatus,
+      @RequestParam(required = false) String eventType,
+      @RequestParam(required = false) String from,
+      @RequestParam(required = false) String to) {
+    NotificationSearchCursor decodedCursor =
+        cursor == null || cursor.isBlank() ? null : NotificationSearchCursorCodec.decode(cursor);
+    NotificationSearchWindow appliedWindow = resolveSearchWindow(decodedCursor, from, to);
+    NotificationSearchQuery query =
+        new NotificationSearchQuery(
+            limit,
+            decodedCursor,
+            parseReadStatus(readStatus),
+            normalizeEventType(eventType),
+            appliedWindow.appliedFrom(),
+            appliedWindow.appliedTo());
+    return NotificationSearchResponse.from(resolveSearchNotifications(principal, query));
   }
 
   @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
@@ -164,6 +203,18 @@ public class NotificationController {
     throw new IllegalArgumentException("unsupported principal type");
   }
 
+  private com.aquilabank.domain.notification.model.NotificationSearchSlice
+      resolveSearchNotifications(
+          AuthenticatedRequestPrincipal principal, NotificationSearchQuery query) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      return notificationSearchUseCase.searchForUser(userPrincipal.userId(), query);
+    }
+    if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      return notificationSearchUseCase.searchForAccount(accountPrincipal.accountId(), query);
+    }
+    throw new IllegalArgumentException("unsupported principal type");
+  }
+
   private void dispatchMarkAsRead(AuthenticatedRequestPrincipal principal, long notificationId) {
     if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
       notificationReadUseCase.markAsReadForUser(userPrincipal.userId(), notificationId);
@@ -242,8 +293,59 @@ public class NotificationController {
     }
   }
 
+  /** cursor 재사용 시 같은 window를 유지해야 다음 page 의미가 고정됩니다. */
+  private NotificationSearchWindow resolveSearchWindow(
+      NotificationSearchCursor cursor, String from, String to) {
+    boolean hasFrom = from != null && !from.isBlank();
+    boolean hasTo = to != null && !to.isBlank();
+    if (hasFrom != hasTo) {
+      throw new IllegalArgumentException("from and to must be provided together");
+    }
+    if (!hasFrom) {
+      if (cursor != null) {
+        return new NotificationSearchWindow(cursor.appliedFrom(), cursor.appliedTo());
+      }
+      Instant appliedTo = Instant.now(notificationSearchClock);
+      return new NotificationSearchWindow(appliedTo.minusSeconds(SEARCH_WINDOW_SECONDS), appliedTo);
+    }
+    Instant appliedFrom = parseInstant(from, "from");
+    Instant appliedTo = parseInstant(to, "to");
+    if (appliedFrom.isAfter(appliedTo)) {
+      throw new IllegalArgumentException("from must be before or equal to to");
+    }
+    if (appliedFrom.plusSeconds(SEARCH_WINDOW_SECONDS).isBefore(appliedTo)) {
+      throw new IllegalArgumentException("search window must be 31 days or less");
+    }
+    return new NotificationSearchWindow(appliedFrom, appliedTo);
+  }
+
+  private NotificationReadStatusFilter parseReadStatus(String rawReadStatus) {
+    try {
+      return NotificationReadStatusFilter.valueOf(rawReadStatus.toUpperCase(Locale.ROOT));
+    } catch (RuntimeException ex) {
+      throw new IllegalArgumentException("readStatus is invalid", ex);
+    }
+  }
+
+  private Instant parseInstant(String rawValue, String fieldName) {
+    try {
+      return Instant.parse(rawValue);
+    } catch (RuntimeException ex) {
+      throw new IllegalArgumentException(fieldName + " must be a valid ISO-8601 instant", ex);
+    }
+  }
+
+  private String normalizeEventType(String eventType) {
+    if (eventType == null || eventType.isBlank()) {
+      return null;
+    }
+    return eventType;
+  }
+
   /** bulk action body 는 작은 id 목록만 허용해 notification inbox SQL 범위를 고정합니다. */
   public record NotificationBulkActionRequest(
       @NotEmpty(message = "notificationIds must not be empty") @Size(max = 100, message = "notificationIds size must be 100 or less") List<@Positive(message = "notificationIds must contain only positive values") Long>
               notificationIds) {}
+
+  private record NotificationSearchWindow(Instant appliedFrom, Instant appliedTo) {}
 }

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
@@ -303,20 +303,15 @@ public class NotificationController {
     }
     if (!hasFrom) {
       if (cursor != null) {
-        return new NotificationSearchWindow(cursor.appliedFrom(), cursor.appliedTo());
+        return validateSearchWindow(cursor.appliedFrom(), cursor.appliedTo());
       }
       Instant appliedTo = Instant.now(notificationSearchClock);
-      return new NotificationSearchWindow(appliedTo.minusSeconds(SEARCH_WINDOW_SECONDS), appliedTo);
+      return validateSearchWindow(
+          appliedTo.minusSeconds(SEARCH_WINDOW_SECONDS), appliedTo);
     }
     Instant appliedFrom = parseInstant(from, "from");
     Instant appliedTo = parseInstant(to, "to");
-    if (appliedFrom.isAfter(appliedTo)) {
-      throw new IllegalArgumentException("from must be before or equal to to");
-    }
-    if (appliedFrom.plusSeconds(SEARCH_WINDOW_SECONDS).isBefore(appliedTo)) {
-      throw new IllegalArgumentException("search window must be 31 days or less");
-    }
-    return new NotificationSearchWindow(appliedFrom, appliedTo);
+    return validateSearchWindow(appliedFrom, appliedTo);
   }
 
   private NotificationReadStatusFilter parseReadStatus(String rawReadStatus) {
@@ -333,6 +328,16 @@ public class NotificationController {
     } catch (RuntimeException ex) {
       throw new IllegalArgumentException(fieldName + " must be a valid ISO-8601 instant", ex);
     }
+  }
+
+  private NotificationSearchWindow validateSearchWindow(Instant appliedFrom, Instant appliedTo) {
+    if (appliedFrom.isAfter(appliedTo)) {
+      throw new IllegalArgumentException("from must be before or equal to to");
+    }
+    if (appliedFrom.plusSeconds(SEARCH_WINDOW_SECONDS).isBefore(appliedTo)) {
+      throw new IllegalArgumentException("search window must be 31 days or less");
+    }
+    return new NotificationSearchWindow(appliedFrom, appliedTo);
   }
 
   private String normalizeEventType(String eventType) {

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationSearchCursorCodec.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationSearchCursorCodec.java
@@ -1,0 +1,51 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.NotificationSearchCursor;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+/** 검색 cursor는 query string transport용으로만 Base64-url 인코딩한다 */
+public final class NotificationSearchCursorCodec {
+
+  private static final String DELIMITER = "|";
+
+  private NotificationSearchCursorCodec() {}
+
+  public static String encode(NotificationSearchCursor cursor) {
+    String payload =
+        cursor.createdAt()
+            + DELIMITER
+            + cursor.id()
+            + DELIMITER
+            + cursor.appliedFrom()
+            + DELIMITER
+            + cursor.appliedTo()
+            + DELIMITER
+            + cursor.filterFingerprint();
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static NotificationSearchCursor decode(String rawCursor) {
+    try {
+      String decoded =
+          new String(
+              Base64.getUrlDecoder().decode(rawCursor.getBytes(StandardCharsets.UTF_8)),
+              StandardCharsets.UTF_8);
+      String[] tokens = decoded.split("\\|", 5);
+      if (tokens.length != 5) {
+        throw new IllegalArgumentException("cursor format is invalid");
+      }
+      return new NotificationSearchCursor(
+          Instant.parse(tokens[0]),
+          Long.parseLong(tokens[1]),
+          Instant.parse(tokens[2]),
+          Instant.parse(tokens[3]),
+          tokens[4]);
+    } catch (RuntimeException ex) {
+      throw new IllegalArgumentException("cursor format is invalid", ex);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationSearchResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationSearchResponse.java
@@ -1,0 +1,28 @@
+package com.aquilabank.global.web.notification;
+
+import com.aquilabank.domain.notification.model.NotificationSearchSlice;
+import java.time.Instant;
+import java.util.List;
+
+public record NotificationSearchResponse(
+    List<NotificationQueryResponse.NotificationItemResponse> items,
+    String nextCursor,
+    boolean hasNext,
+    int limit,
+    Instant appliedFrom,
+    Instant appliedTo) {
+
+  public static NotificationSearchResponse from(NotificationSearchSlice slice) {
+    return new NotificationSearchResponse(
+        slice.items().stream()
+            .map(NotificationQueryResponse.NotificationItemResponse::from)
+            .toList(),
+        slice.nextCursor() == null
+            ? null
+            : NotificationSearchCursorCodec.encode(slice.nextCursor()),
+        slice.hasNext(),
+        slice.limit(),
+        slice.appliedFrom(),
+        slice.appliedTo());
+  }
+}

--- a/back/src/main/resources/db/migration/V25__add_notification_search_index.sql
+++ b/back/src/main/resources/db/migration/V25__add_notification_search_index.sql
@@ -1,0 +1,6 @@
+CREATE INDEX idx_notification_inbox_account_event_type_cursor
+    ON notification_inbox (account_id, event_type, created_at DESC, id DESC)
+    WHERE archived_at IS NULL;
+
+COMMENT ON INDEX idx_notification_inbox_account_event_type_cursor IS
+    'notification search account path용. account_id + event_type exact filter 뒤 created_at DESC, id DESC keyset 정렬 유지';

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -294,6 +294,21 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
     assertThat(slice.nextCursor().appliedTo()).isEqualTo(appliedTo);
     assertThat(slice.nextCursor().filterFingerprint())
         .isEqualTo("UNREAD|TransferBooked|2026-04-17T00:00:00Z|2026-04-17T00:01:00Z");
+
+    NotificationSearchSlice nextSlice =
+        repository.searchByAccountId(
+            accountId[0],
+            new NotificationSearchQuery(
+                2,
+                slice.nextCursor(),
+                NotificationReadStatusFilter.UNREAD,
+                "TransferBooked",
+                appliedFrom,
+                appliedTo));
+
+    assertThat(nextSlice.items()).extracting("title").containsExactly("match-1");
+    assertThat(nextSlice.hasNext()).isFalse();
+    assertThat(nextSlice.nextCursor()).isNull();
   }
 
   @Test
@@ -385,6 +400,36 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
     assertThat(slice.nextCursor()).isNull();
     assertThat(slice.appliedFrom()).isEqualTo(appliedFrom);
     assertThat(slice.appliedTo()).isEqualTo(appliedTo);
+
+    NotificationSearchSlice readSlice =
+        repository.searchByUserId(
+            userId[0],
+            new NotificationSearchQuery(
+                10,
+                null,
+                NotificationReadStatusFilter.READ,
+                "TransferBooked",
+                appliedFrom,
+                appliedTo));
+
+    assertThat(readSlice.items()).extracting("title").containsExactly("visible-read");
+    assertThat(readSlice.items())
+        .extracting("readAt")
+        .containsExactly(appliedFrom.plusSeconds(21));
+
+    NotificationSearchSlice unreadSlice =
+        repository.searchByUserId(
+            userId[0],
+            new NotificationSearchQuery(
+                10,
+                null,
+                NotificationReadStatusFilter.UNREAD,
+                "TransferBooked",
+                appliedFrom,
+                appliedTo));
+
+    assertThat(unreadSlice.items()).extracting("title").containsExactly("visible-unread");
+    assertThat(unreadSlice.items()).extracting("readAt").containsExactly((Instant) null);
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.aquilabank.domain.notification.model.NotificationInboxEntry;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationReadStatusFilter;
+import com.aquilabank.domain.notification.model.NotificationSearchQuery;
+import com.aquilabank.domain.notification.model.NotificationSearchSlice;
 import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.support.PostgresContainerTestSupport;
 import java.sql.Timestamp;
@@ -192,6 +195,194 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
         .isTrue();
     assertThat(repository.markAsReadByAccountId(accountId[0], 99999L, base.plusSeconds(50)))
         .isFalse();
+  }
+
+  @Test
+  void searchesAccountNotificationsByEventTypeReadStatusAndWindow() {
+    long[] accountId = new long[1];
+    long[] matchingIds = new long[3];
+    Instant appliedFrom = Instant.parse("2026-04-17T00:00:00Z");
+    Instant appliedTo = Instant.parse("2026-04-17T00:01:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          accountId[0] = insertAccount("search account");
+          insertNotification(
+              accountId[0],
+              "evt-search-account-read",
+              "TransferBooked",
+              "read",
+              "read",
+              appliedFrom.plusSeconds(5),
+              appliedFrom.plusSeconds(5));
+          insertNotification(
+              accountId[0],
+              "evt-search-account-other-type",
+              "TransferReversed",
+              "other-type",
+              "other-type",
+              null,
+              appliedFrom.plusSeconds(10));
+          insertArchivedNotification(
+              accountId[0],
+              "evt-search-account-archived",
+              "TransferBooked",
+              "archived",
+              "archived",
+              appliedFrom.plusSeconds(15),
+              appliedFrom.plusSeconds(15));
+          insertNotification(
+              accountId[0],
+              "evt-search-account-outside-window",
+              "TransferBooked",
+              "outside-window",
+              "outside-window",
+              null,
+              appliedFrom.minusSeconds(1));
+          matchingIds[0] =
+              insertNotification(
+                  accountId[0],
+                  "evt-search-account-match-1",
+                  "TransferBooked",
+                  "match-1",
+                  "match-1",
+                  null,
+                  appliedFrom.plusSeconds(20));
+          matchingIds[1] =
+              insertNotification(
+                  accountId[0],
+                  "evt-search-account-match-2",
+                  "TransferBooked",
+                  "match-2",
+                  "match-2",
+                  null,
+                  appliedFrom.plusSeconds(30));
+          matchingIds[2] =
+              insertNotification(
+                  accountId[0],
+                  "evt-search-account-match-3",
+                  "TransferBooked",
+                  "match-3",
+                  "match-3",
+                  null,
+                  appliedFrom.plusSeconds(40));
+        });
+
+    NotificationSearchSlice slice =
+        repository.searchByAccountId(
+            accountId[0],
+            new NotificationSearchQuery(
+                2,
+                null,
+                NotificationReadStatusFilter.UNREAD,
+                "TransferBooked",
+                appliedFrom,
+                appliedTo));
+
+    assertThat(slice.items()).extracting("title").containsExactly("match-3", "match-2");
+    assertThat(slice.items()).extracting("id").containsExactly(matchingIds[2], matchingIds[1]);
+    assertThat(slice.hasNext()).isTrue();
+    assertThat(slice.limit()).isEqualTo(2);
+    assertThat(slice.appliedFrom()).isEqualTo(appliedFrom);
+    assertThat(slice.appliedTo()).isEqualTo(appliedTo);
+    assertThat(slice.nextCursor()).isNotNull();
+    assertThat(slice.nextCursor().createdAt()).isEqualTo(appliedFrom.plusSeconds(30));
+    assertThat(slice.nextCursor().id()).isEqualTo(matchingIds[1]);
+    assertThat(slice.nextCursor().appliedFrom()).isEqualTo(appliedFrom);
+    assertThat(slice.nextCursor().appliedTo()).isEqualTo(appliedTo);
+    assertThat(slice.nextCursor().filterFingerprint())
+        .isEqualTo("UNREAD|TransferBooked|2026-04-17T00:00:00Z|2026-04-17T00:01:00Z");
+  }
+
+  @Test
+  void searchesUserNotificationsWithoutLeakingArchivedDeletedOrRevokedRows() {
+    long[] userId = new long[1];
+    long[] accountIds = new long[2];
+    Instant appliedFrom = Instant.parse("2026-04-17T00:00:00Z");
+    Instant appliedTo = Instant.parse("2026-04-17T00:01:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("user-search-scope");
+          accountIds[0] = insertAccount("active search account");
+          accountIds[1] = insertAccount("revoked search account");
+          insertMembership(userId[0], accountIds[0], "OWNER", "ACTIVE");
+          insertMembership(userId[0], accountIds[1], "VIEWER", "REVOKED");
+
+          long visibleUnreadId =
+              insertNotification(
+                  accountIds[0],
+                  "evt-search-user-visible-unread",
+                  "TransferBooked",
+                  "visible-unread",
+                  "visible-unread",
+                  null,
+                  appliedFrom.plusSeconds(10));
+          long visibleReadId =
+              insertNotification(
+                  accountIds[0],
+                  "evt-search-user-visible-read",
+                  "TransferBooked",
+                  "visible-read",
+                  "visible-read",
+                  null,
+                  appliedFrom.plusSeconds(20));
+          long archivedStateId =
+              insertNotification(
+                  accountIds[0],
+                  "evt-search-user-archived",
+                  "TransferBooked",
+                  "archived-state",
+                  "archived-state",
+                  null,
+                  appliedFrom.plusSeconds(30));
+          long deletedStateId =
+              insertNotification(
+                  accountIds[0],
+                  "evt-search-user-deleted",
+                  "TransferBooked",
+                  "deleted-state",
+                  "deleted-state",
+                  null,
+                  appliedFrom.plusSeconds(40));
+          insertNotification(
+              accountIds[1],
+              "evt-search-user-revoked",
+              "TransferBooked",
+              "revoked-membership",
+              "revoked-membership",
+              null,
+              appliedFrom.plusSeconds(50));
+
+          insertUserNotificationState(userId[0], visibleUnreadId, null, null, null);
+          insertUserNotificationState(
+              userId[0], visibleReadId, appliedFrom.plusSeconds(21), null, null);
+          insertUserNotificationState(
+              userId[0], archivedStateId, null, appliedFrom.plusSeconds(31), null);
+          insertUserNotificationState(
+              userId[0], deletedStateId, null, null, appliedFrom.plusSeconds(41));
+        });
+
+    NotificationSearchSlice slice =
+        repository.searchByUserId(
+            userId[0],
+            new NotificationSearchQuery(
+                10,
+                null,
+                NotificationReadStatusFilter.ALL,
+                "TransferBooked",
+                appliedFrom,
+                appliedTo));
+
+    assertThat(slice.items()).extracting("title").containsExactly("visible-read", "visible-unread");
+    assertThat(slice.items()).extracting("accountId").containsExactly(accountIds[0], accountIds[0]);
+    assertThat(slice.items())
+        .extracting("readAt")
+        .containsExactly(appliedFrom.plusSeconds(21), null);
+    assertThat(slice.hasNext()).isFalse();
+    assertThat(slice.nextCursor()).isNull();
+    assertThat(slice.appliedFrom()).isEqualTo(appliedFrom);
+    assertThat(slice.appliedTo()).isEqualTo(appliedTo);
   }
 
   @Test
@@ -503,24 +694,81 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
     return notificationId;
   }
 
+  private long insertArchivedNotification(
+      long accountId,
+      String eventKey,
+      String eventType,
+      String title,
+      String message,
+      Instant archivedAt,
+      Instant createdAt) {
+    Long notificationId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO notification_inbox (
+                account_id,
+                event_key,
+                event_type,
+                title,
+                message,
+                archived_at,
+                created_at
+            )
+            VALUES (
+                :accountId,
+                :eventKey,
+                :eventType,
+                :title,
+                :message,
+                :archivedAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("eventKey", eventKey)
+                .addValue("eventType", eventType)
+                .addValue("title", title)
+                .addValue("message", message)
+                .addValue("archivedAt", Timestamp.from(archivedAt))
+                .addValue("createdAt", Timestamp.from(createdAt)),
+            Long.class);
+    if (notificationId == null) {
+      throw new IllegalStateException("notification_inbox insert did not return id");
+    }
+    return notificationId;
+  }
+
   private void insertUserReadState(long userId, long notificationId, Instant readAt) {
+    insertUserNotificationState(userId, notificationId, readAt, null, null);
+  }
+
+  private void insertUserNotificationState(
+      long userId, long notificationId, Instant readAt, Instant archivedAt, Instant deletedAt) {
     jdbcTemplate.update(
         """
         INSERT INTO notification_user_read_state (
             user_id,
             notification_id,
-            read_at
+            read_at,
+            archived_at,
+            deleted_at
         )
         VALUES (
             :userId,
             :notificationId,
-            :readAt
+            :readAt,
+            :archivedAt,
+            :deletedAt
         )
         """,
         new MapSqlParameterSource()
             .addValue("userId", userId)
             .addValue("notificationId", notificationId)
-            .addValue("readAt", Timestamp.from(readAt)));
+            .addValue("readAt", readAt == null ? null : Timestamp.from(readAt))
+            .addValue("archivedAt", archivedAt == null ? null : Timestamp.from(archivedAt))
+            .addValue("deletedAt", deletedAt == null ? null : Timestamp.from(deletedAt)));
   }
 
   private long totalNotifications() {

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.aquilabank.global.persistence.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.aquilabank.domain.notification.model.NotificationInboxEntry;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
 import com.aquilabank.domain.notification.model.NotificationReadStatusFilter;
+import com.aquilabank.domain.notification.model.NotificationSearchCursor;
 import com.aquilabank.domain.notification.model.NotificationSearchQuery;
 import com.aquilabank.domain.notification.model.NotificationSearchSlice;
 import com.aquilabank.domain.notification.model.NotificationSlice;
@@ -383,6 +385,95 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
     assertThat(slice.nextCursor()).isNull();
     assertThat(slice.appliedFrom()).isEqualTo(appliedFrom);
     assertThat(slice.appliedTo()).isEqualTo(appliedTo);
+  }
+
+  @Test
+  void rejectsAccountSearchWhenCursorWindowDoesNotMatchQuery() {
+    long[] accountId = new long[1];
+    Instant appliedFrom = Instant.parse("2026-04-17T00:00:00Z");
+    Instant appliedTo = Instant.parse("2026-04-17T00:01:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          accountId[0] = insertAccount("search account mismatch");
+          insertNotification(
+              accountId[0],
+              "evt-search-account-mismatch",
+              "TransferBooked",
+              "match",
+              "match",
+              null,
+              appliedFrom.plusSeconds(10));
+        });
+
+    NotificationSearchCursor cursor =
+        new NotificationSearchCursor(
+            appliedFrom.plusSeconds(10),
+            1L,
+            appliedFrom.minusSeconds(10),
+            appliedTo.plusSeconds(10),
+            "ALL|TransferBooked|2026-04-16T23:59:50Z|2026-04-17T00:01:10Z");
+
+    assertThatThrownBy(
+            () ->
+                repository.searchByAccountId(
+                    accountId[0],
+                    new NotificationSearchQuery(
+                        10,
+                        cursor,
+                        NotificationReadStatusFilter.ALL,
+                        "TransferBooked",
+                        appliedFrom,
+                        appliedTo)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("search cursor window must match query");
+  }
+
+  @Test
+  void rejectsUserSearchWhenCursorFingerprintDoesNotMatchQuery() {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    long[] notificationId = new long[1];
+    Instant appliedFrom = Instant.parse("2026-04-17T00:00:00Z");
+    Instant appliedTo = Instant.parse("2026-04-17T00:01:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("user-search-fingerprint");
+          accountId[0] = insertAccount("active search fingerprint account");
+          insertMembership(userId[0], accountId[0], "OWNER", "ACTIVE");
+          notificationId[0] =
+              insertNotification(
+                  accountId[0],
+                  "evt-search-user-fingerprint",
+                  "TransferBooked",
+                  "visible",
+                  "visible",
+                  null,
+                  appliedFrom.plusSeconds(10));
+        });
+
+    NotificationSearchCursor cursor =
+        new NotificationSearchCursor(
+            appliedFrom.plusSeconds(10),
+            notificationId[0],
+            appliedFrom,
+            appliedTo,
+            "READ|TransferBooked|2026-04-17T00:00:00Z|2026-04-17T00:01:00Z");
+
+    assertThatThrownBy(
+            () ->
+                repository.searchByUserId(
+                    userId[0],
+                    new NotificationSearchQuery(
+                        10,
+                        cursor,
+                        NotificationReadStatusFilter.ALL,
+                        "TransferBooked",
+                        appliedFrom,
+                        appliedTo)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("search cursor fingerprint must match query");
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -413,9 +413,7 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
                 appliedTo));
 
     assertThat(readSlice.items()).extracting("title").containsExactly("visible-read");
-    assertThat(readSlice.items())
-        .extracting("readAt")
-        .containsExactly(appliedFrom.plusSeconds(21));
+    assertThat(readSlice.items()).extracting("readAt").containsExactly(appliedFrom.plusSeconds(21));
 
     NotificationSearchSlice unreadSlice =
         repository.searchByUserId(

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
@@ -584,6 +584,83 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
         .andExpect(jsonPath("$.message").value("readStatus is invalid"));
   }
 
+  @Test
+  void continuesSearchNextPageWithCursorOnlyUsingSameWindow() throws Exception {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    Instant from = Instant.parse("2026-04-01T00:00:00Z");
+    Instant to = Instant.parse("2026-04-30T23:59:59Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("cursor-window-user");
+          accountId[0] = insertAccount("cursor window account");
+          insertMembership(userId[0], accountId[0], "OWNER", "ACTIVE");
+          insertNotification(
+              accountId[0],
+              "evt-window-1",
+              "TransferBooked",
+              "첫 페이지 A",
+              "A",
+              null,
+              Instant.parse("2026-04-21T10:00:00Z"));
+          insertNotification(
+              accountId[0],
+              "evt-window-2",
+              "TransferBooked",
+              "첫 페이지 B",
+              "B",
+              null,
+              Instant.parse("2026-04-21T09:00:00Z"));
+          insertNotification(
+              accountId[0],
+              "evt-window-3",
+              "TransferBooked",
+              "둘째 페이지",
+              "C",
+              null,
+              Instant.parse("2026-04-21T08:00:00Z"));
+        });
+
+    String token = issueToken("cursor-window-subject", userId[0]);
+
+    MvcResult pageOne =
+        mockMvc
+            .perform(
+                get("/api/v1/notifications/search")
+                    .header("Authorization", "Bearer " + token)
+                    .param("limit", "2")
+                    .param("from", from.toString())
+                    .param("to", to.toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items.length()").value(2))
+            .andExpect(jsonPath("$.items[0].title").value("첫 페이지 A"))
+            .andExpect(jsonPath("$.items[1].title").value("첫 페이지 B"))
+            .andExpect(jsonPath("$.appliedFrom").value(from.toString()))
+            .andExpect(jsonPath("$.appliedTo").value(to.toString()))
+            .andExpect(jsonPath("$.hasNext").value(true))
+            .andReturn();
+
+    String cursor =
+        OBJECT_MAPPER
+            .readTree(pageOne.getResponse().getContentAsString())
+            .get("nextCursor")
+            .asText();
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("Authorization", "Bearer " + token)
+                .param("limit", "2")
+                .param("cursor", cursor))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].title").value("둘째 페이지"))
+        .andExpect(jsonPath("$.appliedFrom").value(from.toString()))
+        .andExpect(jsonPath("$.appliedTo").value(to.toString()))
+        .andExpect(jsonPath("$.hasNext").value(false));
+  }
+
   private long insertUser(String loginId) {
     Long userId =
         jdbcTemplate.queryForObject(

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
@@ -557,6 +557,33 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
         .andExpect(status().isBadRequest());
   }
 
+  @Test
+  void rejectsSearchWhenReadStatusIsInvalid() throws Exception {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    Instant from = Instant.parse("2026-04-01T00:00:00Z");
+    Instant to = Instant.parse("2026-04-30T23:59:59Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("invalid-status-user");
+          accountId[0] = insertAccount("invalid status account");
+          insertMembership(userId[0], accountId[0], "OWNER", "ACTIVE");
+        });
+
+    String token = issueToken("invalid-status-user-subject", userId[0]);
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("Authorization", "Bearer " + token)
+                .param("readStatus", "BROKEN")
+                .param("from", from.toString())
+                .param("to", to.toString()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("readStatus is invalid"));
+  }
+
   private long insertUser(String loginId) {
     Long userId =
         jdbcTemplate.queryForObject(

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.aquilabank.support.PostgresContainerTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -26,6 +27,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.context.WebApplicationContext;
@@ -37,6 +39,7 @@ import org.springframework.web.context.WebApplicationContext;
 class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
 
   private static final String TEST_SECRET = "test-local-jwt-secret-test-local-jwt-secret";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Autowired private WebApplicationContext context;
 
@@ -400,6 +403,158 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
         .perform(get("/api/v1/notifications/unread-count").header("X-Account-Id", accountId[0]))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.unreadCount").value(0));
+  }
+
+  @Test
+  void searchesNotificationsForJwtUserWithExplicitFilters() throws Exception {
+    long[] userId = new long[1];
+    long[] accountIds = new long[2];
+    long[] notificationIds = new long[4];
+    Instant from = Instant.parse("2026-04-01T00:00:00Z");
+    Instant to = Instant.parse("2026-04-30T23:59:59Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("search-user");
+          accountIds[0] = insertAccount("search account");
+          accountIds[1] = insertAccount("search hidden account");
+          insertMembership(userId[0], accountIds[0], "OWNER", "ACTIVE");
+          insertMembership(userId[0], accountIds[1], "OWNER", "REVOKED");
+          notificationIds[0] =
+              insertNotification(
+                  accountIds[0],
+                  "evt-search-1",
+                  "TransferBooked",
+                  "읽지 않은 검색 알림",
+                  "A",
+                  null,
+                  Instant.parse("2026-04-18T10:00:00Z"));
+          notificationIds[1] =
+              insertNotification(
+                  accountIds[0],
+                  "evt-search-2",
+                  "TransferBooked",
+                  "읽은 검색 알림",
+                  "B",
+                  null,
+                  Instant.parse("2026-04-19T10:00:00Z"));
+          notificationIds[2] =
+              insertNotification(
+                  accountIds[0],
+                  "evt-search-3",
+                  "CardApproved",
+                  "다른 eventType",
+                  "C",
+                  null,
+                  Instant.parse("2026-04-20T10:00:00Z"));
+          notificationIds[3] =
+              insertNotification(
+                  accountIds[1],
+                  "evt-search-4",
+                  "TransferBooked",
+                  "권한 없는 알림",
+                  "D",
+                  null,
+                  Instant.parse("2026-04-21T10:00:00Z"));
+        });
+
+    String token = issueToken("search-user-subject", userId[0]);
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/" + notificationIds[1] + "/read")
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("Authorization", "Bearer " + token)
+                .param("readStatus", "UNREAD")
+                .param("eventType", "TransferBooked")
+                .param("from", from.toString())
+                .param("to", to.toString()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].title").value("읽지 않은 검색 알림"))
+        .andExpect(jsonPath("$.items[0].eventType").value("TransferBooked"))
+        .andExpect(jsonPath("$.items[0].read").value(false))
+        .andExpect(jsonPath("$.appliedFrom").value(from.toString()))
+        .andExpect(jsonPath("$.appliedTo").value(to.toString()));
+  }
+
+  @Test
+  void rejectsSearchCursorWhenRequestedFiltersDoNotMatch() throws Exception {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    Instant from = Instant.parse("2026-04-01T00:00:00Z");
+    Instant to = Instant.parse("2026-04-30T23:59:59Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("cursor-user");
+          accountId[0] = insertAccount("cursor account");
+          insertMembership(userId[0], accountId[0], "OWNER", "ACTIVE");
+          insertNotification(
+              accountId[0],
+              "evt-cursor-1",
+              "TransferBooked",
+              "첫 페이지 알림 A",
+              "A",
+              null,
+              Instant.parse("2026-04-21T10:00:00Z"));
+          insertNotification(
+              accountId[0],
+              "evt-cursor-2",
+              "TransferBooked",
+              "첫 페이지 알림 B",
+              "B",
+              null,
+              Instant.parse("2026-04-21T09:00:00Z"));
+          insertNotification(
+              accountId[0],
+              "evt-cursor-3",
+              "TransferBooked",
+              "둘째 페이지 알림",
+              "C",
+              null,
+              Instant.parse("2026-04-21T08:00:00Z"));
+        });
+
+    String token = issueToken("cursor-user-subject", userId[0]);
+
+    MvcResult pageOne =
+        mockMvc
+            .perform(
+                get("/api/v1/notifications/search")
+                    .header("Authorization", "Bearer " + token)
+                    .param("limit", "2")
+                    .param("readStatus", "ALL")
+                    .param("eventType", "TransferBooked")
+                    .param("from", from.toString())
+                    .param("to", to.toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items.length()").value(2))
+            .andExpect(jsonPath("$.hasNext").value(true))
+            .andReturn();
+
+    String cursor =
+        OBJECT_MAPPER
+            .readTree(pageOne.getResponse().getContentAsString())
+            .get("nextCursor")
+            .asText();
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("Authorization", "Bearer " + token)
+                .param("limit", "2")
+                .param("cursor", cursor)
+                .param("readStatus", "UNREAD")
+                .param("eventType", "TransferBooked")
+                .param("from", from.toString())
+                .param("to", to.toString()))
+        .andExpect(status().isBadRequest());
   }
 
   private long insertUser(String loginId) {

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -256,6 +256,137 @@ class NotificationControllerTest {
   }
 
   @Test
+  void rejectsMalformedSearchCursor() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("cursor", "broken"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("cursor format is invalid"))
+        .andExpect(jsonPath("$.path").value("/api/v1/notifications/search"));
+  }
+
+  @Test
+  void rejectsSearchWhenFromIsInvalidIsoInstant() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("from", "broken")
+                .param("to", "2026-04-21T12:00:00Z"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("from must be a valid ISO-8601 instant"))
+        .andExpect(jsonPath("$.path").value("/api/v1/notifications/search"));
+  }
+
+  @Test
+  void rejectsSearchWhenToIsInvalidIsoInstant() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "broken"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("to must be a valid ISO-8601 instant"))
+        .andExpect(jsonPath("$.path").value("/api/v1/notifications/search"));
+  }
+
+  @Test
+  void rejectsSearchWhenFromIsAfterTo() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("from", "2026-04-21T12:00:01Z")
+                .param("to", "2026-04-21T12:00:00Z"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("from must be before or equal to to"))
+        .andExpect(jsonPath("$.path").value("/api/v1/notifications/search"));
+  }
+
+  @Test
+  void rejectsSearchWhenExplicitRangeExceedsThirtyOneDays() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("from", "2026-03-01T00:00:00Z")
+                .param("to", "2026-04-21T12:00:00Z"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("search window must be 31 days or less"))
+        .andExpect(jsonPath("$.path").value("/api/v1/notifications/search"));
+  }
+
+  @Test
+  void reusesCursorWindowWhenOnlyCursorIsProvided() throws Exception {
+    NotificationSearchCursor cursor =
+        new NotificationSearchCursor(
+            Instant.parse("2026-04-20T10:00:00Z"),
+            20L,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            Instant.parse("2026-04-21T12:00:00Z"),
+            "ALL|TransferBooked|2026-04-01T00:00:00Z|2026-04-21T12:00:00Z");
+    when(notificationSearchUseCase.searchForAccount(eq(101L), any(NotificationSearchQuery.class)))
+        .thenReturn(
+            new NotificationSearchSlice(
+                List.of(), null, false, 20, cursor.appliedFrom(), cursor.appliedTo()));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("cursor", NotificationSearchCursorCodec.encode(cursor)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.appliedFrom").value(cursor.appliedFrom().toString()))
+        .andExpect(jsonPath("$.appliedTo").value(cursor.appliedTo().toString()));
+
+    verify(notificationSearchUseCase)
+        .searchForAccount(
+            eq(101L),
+            eq(
+                new NotificationSearchQuery(
+                    20,
+                    cursor,
+                    NotificationReadStatusFilter.ALL,
+                    null,
+                    cursor.appliedFrom(),
+                    cursor.appliedTo())));
+  }
+
+  @Test
+  void trimsReadStatusAndEventTypeBeforeSearchQueryResolution() throws Exception {
+    Instant appliedFrom = Instant.parse("2026-04-01T00:00:00Z");
+    Instant appliedTo = Instant.parse("2026-04-21T12:00:00Z");
+    when(notificationSearchUseCase.searchForAccount(eq(101L), any(NotificationSearchQuery.class)))
+        .thenReturn(
+            new NotificationSearchSlice(List.of(), null, false, 20, appliedFrom, appliedTo));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("readStatus", " UNREAD ")
+                .param("eventType", " TransferBooked ")
+                .param("from", appliedFrom.toString())
+                .param("to", appliedTo.toString()))
+        .andExpect(status().isOk());
+
+    verify(notificationSearchUseCase)
+        .searchForAccount(
+            eq(101L),
+            eq(
+                new NotificationSearchQuery(
+                    20,
+                    null,
+                    NotificationReadStatusFilter.UNREAD,
+                    "TransferBooked",
+                    appliedFrom,
+                    appliedTo)));
+  }
+
+  @Test
   void rejectsSearchWhenReusedCursorWindowExceedsThirtyOneDays() throws Exception {
     NotificationSearchCursor cursor =
         new NotificationSearchCursor(

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -19,6 +19,7 @@ import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
 import com.aquilabank.domain.notification.model.NotificationCursor;
 import com.aquilabank.domain.notification.model.NotificationListQuery;
 import com.aquilabank.domain.notification.model.NotificationReadStatusFilter;
+import com.aquilabank.domain.notification.model.NotificationSearchCursor;
 import com.aquilabank.domain.notification.model.NotificationSearchQuery;
 import com.aquilabank.domain.notification.model.NotificationSearchSlice;
 import com.aquilabank.domain.notification.model.NotificationSlice;
@@ -241,6 +242,36 @@ class NotificationControllerTest {
                 .param("from", "2026-04-01T00:00:00Z"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("from and to must be provided together"));
+  }
+
+  @Test
+  void rejectsSearchWhenReadStatusIsInvalid() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("readStatus", "BROKEN"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("readStatus is invalid"));
+  }
+
+  @Test
+  void rejectsSearchWhenReusedCursorWindowExceedsThirtyOneDays() throws Exception {
+    NotificationSearchCursor cursor =
+        new NotificationSearchCursor(
+            Instant.parse("2026-04-21T10:00:00Z"),
+            41L,
+            Instant.parse("2026-03-01T00:00:00Z"),
+            Instant.parse("2026-04-21T12:00:00Z"),
+            "ALL||2026-03-01T00:00:00Z|2026-04-21T12:00:00Z");
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("cursor", NotificationSearchCursorCodec.encode(cursor)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("search window must be 31 days or less"));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -17,17 +17,24 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
 import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
 import com.aquilabank.domain.notification.model.NotificationCursor;
+import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationReadStatusFilter;
+import com.aquilabank.domain.notification.model.NotificationSearchQuery;
+import com.aquilabank.domain.notification.model.NotificationSearchSlice;
 import com.aquilabank.domain.notification.model.NotificationSlice;
 import com.aquilabank.domain.notification.model.NotificationSummary;
 import com.aquilabank.domain.notification.usecase.NotificationBulkActionUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.domain.notification.usecase.NotificationReadUseCase;
+import com.aquilabank.domain.notification.usecase.NotificationSearchUseCase;
 import com.aquilabank.global.notification.NotificationSseBroker;
 import com.aquilabank.global.notification.NotificationSseOverloadException;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +47,7 @@ class NotificationControllerTest {
   private NotificationQueryUseCase notificationQueryUseCase;
   private NotificationReadUseCase notificationReadUseCase;
   private NotificationBulkActionUseCase notificationBulkActionUseCase;
+  private NotificationSearchUseCase notificationSearchUseCase;
   private NotificationSseBroker notificationSseBroker;
   private MockMvc mockMvc;
 
@@ -48,14 +56,19 @@ class NotificationControllerTest {
     notificationQueryUseCase = mock(NotificationQueryUseCase.class);
     notificationReadUseCase = mock(NotificationReadUseCase.class);
     notificationBulkActionUseCase = mock(NotificationBulkActionUseCase.class);
+    notificationSearchUseCase = mock(NotificationSearchUseCase.class);
     notificationSseBroker = mock(NotificationSseBroker.class);
+    Clock notificationSearchClock =
+        Clock.fixed(Instant.parse("2026-04-21T12:00:00Z"), ZoneOffset.UTC);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new NotificationController(
                     notificationQueryUseCase,
                     notificationReadUseCase,
                     notificationBulkActionUseCase,
-                    notificationSseBroker))
+                    notificationSearchUseCase,
+                    notificationSseBroker,
+                    notificationSearchClock))
             .setControllerAdvice(new ApiExceptionHandler())
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
@@ -179,6 +192,71 @@ class NotificationControllerTest {
         .perform(
             get("/api/v1/notifications").header("X-Account-Id", "101").param("cursor", "broken"))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void searchesNotificationsForAccountWithDefaultWindow() throws Exception {
+    Instant appliedTo = Instant.parse("2026-04-21T12:00:00Z");
+    Instant appliedFrom = appliedTo.minusSeconds(31L * 24 * 60 * 60);
+    when(notificationSearchUseCase.searchForAccount(eq(101L), any(NotificationSearchQuery.class)))
+        .thenReturn(
+            new NotificationSearchSlice(
+                List.of(
+                    new NotificationSummary(
+                        20L,
+                        101L,
+                        "TransferBooked",
+                        "검색 알림",
+                        "검색 본문",
+                        Instant.parse("2026-04-20T10:00:00Z"),
+                        null)),
+                null,
+                false,
+                20,
+                appliedFrom,
+                appliedTo));
+
+    mockMvc
+        .perform(get("/api/v1/notifications/search").header("X-Account-Id", "101"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].notificationId").value(20L))
+        .andExpect(jsonPath("$.appliedFrom").value(appliedFrom.toString()))
+        .andExpect(jsonPath("$.appliedTo").value(appliedTo.toString()))
+        .andExpect(jsonPath("$.hasNext").value(false));
+
+    verify(notificationSearchUseCase)
+        .searchForAccount(
+            eq(101L),
+            eq(
+                new NotificationSearchQuery(
+                    20, null, NotificationReadStatusFilter.ALL, null, appliedFrom, appliedTo)));
+  }
+
+  @Test
+  void rejectsSearchWhenOnlyFromIsProvided() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", "101")
+                .param("from", "2026-04-01T00:00:00Z"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("from and to must be provided together"));
+  }
+
+  @Test
+  void keepsExistingNotificationListPathUnchanged() throws Exception {
+    when(notificationQueryUseCase.getNotificationsForAccount(anyLong(), any()))
+        .thenReturn(new NotificationSlice(List.of(), null, false, 20));
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("X-Account-Id", "101"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(0))
+        .andExpect(jsonPath("$.limit").value(20))
+        .andExpect(jsonPath("$.nextCursor").isEmpty());
+
+    verify(notificationQueryUseCase)
+        .getNotificationsForAccount(eq(101L), eq(new NotificationListQuery(20, null)));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationSearchCursorCodecTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationSearchCursorCodecTest.java
@@ -1,0 +1,33 @@
+package com.aquilabank.global.web.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.aquilabank.domain.notification.model.NotificationSearchCursor;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class NotificationSearchCursorCodecTest {
+
+  @Test
+  void encodesAndDecodesSearchCursor() {
+    NotificationSearchCursor cursor =
+        new NotificationSearchCursor(
+            Instant.parse("2026-04-21T09:00:00Z"),
+            41L,
+            Instant.parse("2026-03-21T00:00:00Z"),
+            Instant.parse("2026-04-21T00:00:00Z"),
+            "UNREAD|TransferBooked|2026-03-21T00:00:00Z|2026-04-21T00:00:00Z");
+
+    String encoded = NotificationSearchCursorCodec.encode(cursor);
+
+    assertThat(NotificationSearchCursorCodec.decode(encoded)).isEqualTo(cursor);
+  }
+
+  @Test
+  void rejectsBrokenCursorPayload() {
+    assertThatThrownBy(() -> NotificationSearchCursorCodec.decode("broken"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("cursor format is invalid");
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationSearchCursorCodecTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationSearchCursorCodecTest.java
@@ -78,6 +78,37 @@ class NotificationSearchCursorCodecTest {
   }
 
   @Test
+  void rejectsSearchSliceWhenNextCursorWindowDiffers() {
+    NotificationSearchCursor nextCursor =
+        new NotificationSearchCursor(
+            Instant.parse("2026-04-20T00:00:00Z"),
+            41L,
+            Instant.parse("2026-03-20T00:00:00Z"),
+            Instant.parse("2026-04-20T00:00:00Z"),
+            "UNREAD|TransferBooked|2026-03-20T00:00:00Z|2026-04-20T00:00:00Z");
+
+    assertThatThrownBy(
+            () ->
+                new NotificationSearchSlice(
+                    List.of(
+                        new NotificationSummary(
+                            10L,
+                            101L,
+                            "TransferBooked",
+                            "입금 완료",
+                            "급여가 입금되었습니다.",
+                            Instant.parse("2026-04-20T00:10:00Z"),
+                            null)),
+                    nextCursor,
+                    true,
+                    20,
+                    Instant.parse("2026-03-21T00:00:00Z"),
+                    Instant.parse("2026-04-21T00:00:00Z")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("nextCursor window must match slice window");
+  }
+
+  @Test
   void mapsSearchResponseWithNextCursorAndWindow() {
     NotificationSearchCursor nextCursor =
         new NotificationSearchCursor(

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationSearchCursorCodecTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationSearchCursorCodecTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.aquilabank.domain.notification.model.NotificationSearchCursor;
+import com.aquilabank.domain.notification.model.NotificationSearchSlice;
+import com.aquilabank.domain.notification.model.NotificationSummary;
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class NotificationSearchCursorCodecTest {
@@ -13,7 +16,7 @@ class NotificationSearchCursorCodecTest {
   void encodesAndDecodesSearchCursor() {
     NotificationSearchCursor cursor =
         new NotificationSearchCursor(
-            Instant.parse("2026-04-21T09:00:00Z"),
+            Instant.parse("2026-04-20T09:00:00Z"),
             41L,
             Instant.parse("2026-03-21T00:00:00Z"),
             Instant.parse("2026-04-21T00:00:00Z"),
@@ -29,5 +32,87 @@ class NotificationSearchCursorCodecTest {
     assertThatThrownBy(() -> NotificationSearchCursorCodec.decode("broken"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("cursor format is invalid");
+  }
+
+  @Test
+  void rejectsCursorOutsideAppliedWindow() {
+    assertThatThrownBy(
+            () ->
+                new NotificationSearchCursor(
+                    Instant.parse("2026-03-20T23:59:59Z"),
+                    41L,
+                    Instant.parse("2026-03-21T00:00:00Z"),
+                    Instant.parse("2026-04-21T00:00:00Z"),
+                    "UNREAD|TransferBooked|2026-03-21T00:00:00Z|2026-04-21T00:00:00Z"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void rejectsSearchSliceWithClosedResultAndNextCursor() {
+    NotificationSearchCursor nextCursor =
+        new NotificationSearchCursor(
+            Instant.parse("2026-04-20T09:00:00Z"),
+            41L,
+            Instant.parse("2026-03-21T00:00:00Z"),
+            Instant.parse("2026-04-21T00:00:00Z"),
+            "UNREAD|TransferBooked|2026-03-21T00:00:00Z|2026-04-21T00:00:00Z");
+
+    assertThatThrownBy(
+            () ->
+                new NotificationSearchSlice(
+                    List.of(
+                        new NotificationSummary(
+                            10L,
+                            101L,
+                            "TransferBooked",
+                            "입금 완료",
+                            "급여가 입금되었습니다.",
+                            Instant.parse("2026-04-21T00:10:00Z"),
+                            null)),
+                    nextCursor,
+                    false,
+                    20,
+                    Instant.parse("2026-03-21T00:00:00Z"),
+                    Instant.parse("2026-04-21T00:00:00Z")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void mapsSearchResponseWithNextCursorAndWindow() {
+    NotificationSearchCursor nextCursor =
+        new NotificationSearchCursor(
+            Instant.parse("2026-04-20T09:00:00Z"),
+            41L,
+            Instant.parse("2026-03-21T00:00:00Z"),
+            Instant.parse("2026-04-21T00:00:00Z"),
+            "UNREAD|TransferBooked|2026-03-21T00:00:00Z|2026-04-21T00:00:00Z");
+    NotificationSearchSlice slice =
+        new NotificationSearchSlice(
+            List.of(
+                new NotificationSummary(
+                    10L,
+                    101L,
+                    "TransferBooked",
+                    "입금 완료",
+                    "급여가 입금되었습니다.",
+                    Instant.parse("2026-04-21T00:10:00Z"),
+                    null)),
+            nextCursor,
+            true,
+            20,
+            Instant.parse("2026-03-21T00:00:00Z"),
+            Instant.parse("2026-04-21T00:00:00Z"));
+
+    NotificationSearchResponse response = NotificationSearchResponse.from(slice);
+
+    assertThat(response.items()).hasSize(1);
+    assertThat(response.items().get(0).notificationId()).isEqualTo(10L);
+    assertThat(response.items().get(0).accountId()).isEqualTo(101L);
+    assertThat(response.items().get(0).title()).isEqualTo("입금 완료");
+    assertThat(response.hasNext()).isTrue();
+    assertThat(response.limit()).isEqualTo(20);
+    assertThat(response.appliedFrom()).isEqualTo(Instant.parse("2026-03-21T00:00:00Z"));
+    assertThat(response.appliedTo()).isEqualTo(Instant.parse("2026-04-21T00:00:00Z"));
+    assertThat(response.nextCursor()).isEqualTo(NotificationSearchCursorCodec.encode(nextCursor));
   }
 }

--- a/docs/superpowers/specs/2026-04-21-notification-search-filters-design.md
+++ b/docs/superpowers/specs/2026-04-21-notification-search-filters-design.md
@@ -1,0 +1,349 @@
+# Notification Search Filters Design
+
+**Issue:** `#160`
+**Branch:** `feat/notification-search-filters`
+
+## Goal
+
+기존 `GET /api/v1/notifications` 최소 cursor 목록 API를 유지하면서, 검색/필터 목적의 읽기 경로를 별도로 추가한다.
+이번 범위는 실무에서 가장 흔하게 쓰는 `readStatus`, `eventType`, `from/to` 필터만 지원하고, `created_at DESC, id DESC` keyset 정렬과 `t3.micro` 운영 제약을 함께 지킨다.
+
+## Non-Goals
+
+- 기존 `GET /api/v1/notifications` 계약 변경
+- unread count, SSE, bulk read/archive/delete 계약 변경
+- 제목/본문 free-text 검색
+- Elasticsearch, Redis, 별도 검색 엔진 도입
+- notification write/consumer/outbox 경로 변경
+
+## Current State
+
+- 현재 목록 API는 `limit + cursor`만 받는 최소 keyset page 계약이다.
+- `NotificationListQuery`는 `limit`, `cursor`만 들고 있다.
+- `JdbcNotificationInboxRepository`는 account principal과 JWT user principal을 분리해 읽는다.
+- 정렬은 `created_at DESC, id DESC` 고정이고, account 쪽은 partial index `idx_notification_inbox_account_visible_cursor`를 사용한다.
+- JWT user 쪽은 membership + `notification_user_read_state` left join으로 per-user read/archive/delete 상태를 반영한다.
+
+## Decision Summary
+
+1. 기존 목록 API는 그대로 둔다.
+2. 검색/필터는 별도 endpoint `GET /api/v1/notifications/search`로 추가한다.
+3. 검색 전용 domain model, use case, read port, JDBC SQL을 기존 목록 경로와 분리한다.
+4. 이번 필터는 `readStatus`, `eventType`, `from`, `to`까지만 허용한다.
+5. 검색 정렬과 page 방식은 기존과 동일하게 `created_at DESC, id DESC` keyset을 유지한다.
+6. free-text 검색은 후속 이슈로 남긴다.
+
+## API Contract
+
+### Endpoint
+
+- `GET /api/v1/notifications/search`
+
+### Query Parameters
+
+- `limit`
+  - optional
+  - default `20`
+  - min `1`, max `100`
+- `cursor`
+  - optional
+  - search 전용 opaque cursor
+- `readStatus`
+  - optional
+  - `ALL | UNREAD | READ`
+  - default `ALL`
+- `eventType`
+  - optional
+  - exact match
+- `from`
+  - optional
+  - ISO-8601 UTC instant
+- `to`
+  - optional
+  - ISO-8601 UTC instant
+
+### Time Window Policy
+
+- `from`, `to`는 둘 다 오거나 둘 다 없어야 한다.
+- 둘 다 전달되면 `from <= to` 여야 하고, `to - from <= 31일` 이어야 한다.
+- 둘 다 없으면 서버가 최근 31일 window를 적용한다.
+- 암묵 기본 window를 안정적으로 이어가기 위해 response에 `appliedFrom`, `appliedTo`를 함께 반환한다.
+- cursor가 있는 후속 page에서 `from/to`를 다시 주지 않으면, cursor에 저장된 `appliedFrom`, `appliedTo`를 같은 검색 window로 재사용한다.
+
+### Response
+
+검색 전용 response를 따로 둔다.
+
+```json
+{
+  "items": [
+    {
+      "notificationId": 123,
+      "accountId": 10,
+      "eventType": "TransferBooked",
+      "title": "급여 입금",
+      "message": "4월 급여가 입금되었습니다.",
+      "read": false,
+      "createdAt": "2026-04-21T09:00:00Z",
+      "readAt": null
+    }
+  ],
+  "nextCursor": "opaque",
+  "hasNext": true,
+  "limit": 20,
+  "appliedFrom": "2026-03-21T00:00:00Z",
+  "appliedTo": "2026-04-21T00:00:00Z"
+}
+```
+
+### Error Policy
+
+- `400`
+  - 잘못된 `limit`
+  - 잘못된 `readStatus`
+  - `from`만 있거나 `to`만 있는 경우
+  - `from > to`
+  - 기간 31일 초과
+  - cursor decode 실패
+  - cursor 안의 filter fingerprint와 현재 요청 필터 조합 불일치
+- `401`
+  - 인증 없음
+- `200`
+  - 결과가 없어도 정상 응답, `items=[]`
+
+## Search Query Model
+
+### New Domain Types
+
+- `NotificationSearchQuery`
+  - `limit`
+  - `cursor`
+  - `readStatus`
+  - `eventType`
+  - `from`
+  - `to`
+- `NotificationReadStatusFilter`
+  - `ALL`
+  - `UNREAD`
+  - `READ`
+- `NotificationSearchCursor`
+  - `createdAt`
+  - `id`
+  - `filterFingerprint`
+- `NotificationSearchSlice`
+  - `items`
+  - `nextCursor`
+  - `hasNext`
+  - `limit`
+  - `appliedFrom`
+  - `appliedTo`
+
+### Why Separate the Query Model
+
+- 기존 `NotificationListQuery`는 최소 목록 page 계약만 표현한다.
+- 검색 조건까지 같은 타입에 얹으면 기존 목록 API와 검색 API의 수명주기가 섞인다.
+- 별도 query/slice를 두면 이후 text search, facet, 별도 read model 도입 시 검색 경로만 따로 바꿀 수 있다.
+
+## Controller Strategy
+
+- 기존 `NotificationController`에 새 `GET /search` handler를 추가한다.
+- 기존 `GET /api/v1/notifications` handler는 그대로 둔다.
+- principal 해석은 현재 패턴을 유지한다.
+  - `AuthenticatedUserPrincipal` -> user 검색
+  - `AuthenticatedAccountPrincipal` -> account 검색
+- 검색 response는 기존 `NotificationQueryResponse`와 분리된 `NotificationSearchResponse`로 변환한다.
+  - 이유: `appliedFrom`, `appliedTo` 같은 검색 전용 metadata가 필요하다.
+
+## Cursor Strategy
+
+### Ordering
+
+- 정렬은 항상 `created_at DESC, id DESC`
+- page 2부터는 기존과 동일한 keyset 조건 사용
+
+```sql
+(
+  created_at < :cursorCreatedAt
+  OR (created_at = :cursorCreatedAt AND id < :cursorId)
+)
+```
+
+### Filter Fingerprint
+
+- 검색 cursor는 현재 필터 조합을 fingerprint로 함께 저장한다.
+- fingerprint 대상:
+  - `readStatus`
+  - `eventType`
+  - `appliedFrom`
+  - `appliedTo`
+- 다음 page 요청에서 현재 query의 normalized filter와 cursor fingerprint가 다르면 `400`
+
+### Why This Matters
+
+- 검색 중간에 필터를 바꾸면 keyset 의미가 깨진다.
+- 목록 API보다 검색 API가 drift 위험이 크므로, cursor에서 조기 차단하는 편이 안전하다.
+- `appliedFrom/appliedTo`를 fingerprint에 포함해야 암묵 기본 31일 window도 page 간 동일하게 유지된다.
+
+## Persistence Strategy
+
+### Port Split
+
+- 기존 `NotificationInboxReadPort`는 목록/리플레이/unread count 용도로 유지한다.
+- 검색 전용 port를 추가한다.
+  - 예: `NotificationInboxSearchPort`
+
+### Use Case Split
+
+- 기존 `NotificationQueryUseCase`는 목록/리플레이/unread count 유지
+- 검색 전용 use case 추가
+  - 예: `NotificationSearchUseCase`
+  - 예: `NotificationSearchService`
+
+### JDBC Adapter Split
+
+- 기존 `JdbcNotificationInboxRepository` 안에 검색 메서드를 추가해도 되지만, 검색 SQL을 목록 SQL과 논리적으로 분리한다.
+- 메서드 예시:
+  - `searchByUserId(long userId, NotificationSearchQuery query)`
+  - `searchByAccountId(long accountId, NotificationSearchQuery query)`
+
+## SQL Strategy
+
+### Account Principal Search
+
+기본 조건:
+
+- `account_id = :accountId`
+- `archived_at IS NULL`
+- `created_at BETWEEN :from AND :to`
+
+선택 조건:
+
+- `event_type = :eventType`
+- `read_at IS NULL` or `read_at IS NOT NULL`
+
+정렬/제한:
+
+- `ORDER BY created_at DESC, id DESC`
+- `LIMIT :limitPlusOne`
+
+### JWT User Search
+
+기본 조건:
+
+- membership active
+- user active
+- `n.archived_at IS NULL`
+- `r.archived_at IS NULL`
+- `r.deleted_at IS NULL`
+- `n.created_at BETWEEN :from AND :to`
+
+선택 조건:
+
+- `n.event_type = :eventType`
+- `r.read_at IS NULL` for `UNREAD`
+- `r.read_at IS NOT NULL` for `READ`
+
+### Why No Text Search Yet
+
+- `title/message ILIKE`는 현재 schema와 index로는 planner drift 위험이 크다.
+- `t3.micro` 기준에서 text search까지 같이 열면 이번 PR의 목적이 “검색 경로 분리”에서 “새 검색 엔진 흉내”로 커진다.
+- 먼저 structured filters와 전용 cursor를 분리하는 것이 실무적으로 안전하다.
+
+## Index Strategy
+
+### Keep Existing Indexes
+
+- `idx_notification_inbox_account_visible_cursor`
+- `idx_notification_inbox_account_visible_unread`
+
+### Add One Search-Focused Index
+
+우선 1개만 추가한다.
+
+- `idx_notification_inbox_account_event_type_cursor`
+  - `(account_id, event_type, created_at DESC, id DESC)`
+  - `WHERE archived_at IS NULL`
+
+### Why Only One New Index
+
+- `eventType`는 선택도가 높고 실무 필터 빈도도 높다.
+- `readStatus`는 `read_at IS NULL/IS NOT NULL`로 갈라지지만, 이번 PR에서 index를 여러 개 더 만들면 write 비용과 review 범위가 커진다.
+- 검색 전용 경로를 먼저 안정화한 뒤, 필요하면 `READ` 쪽 보조 index를 후속으로 여는 편이 낫다.
+
+## Validation Rules
+
+- `limit`: `1..100`
+- `readStatus`: enum only
+- `eventType`: blank면 null로 정규화
+- `from/to`
+  - partial 금지
+  - `from > to` 금지
+  - 최대 31일
+- cursor:
+  - broken payload 금지
+  - filter mismatch 금지
+
+## Backward Compatibility
+
+- 기존 목록 API response shape 유지
+- 기존 목록 cursor 유지
+- unread count 유지
+- single/bulk read/archive/delete 유지
+- SSE 유지
+
+즉, 이번 변경은 검색 전용 surface 추가이지 기존 notification inbox API 재설계가 아니다.
+
+## Test Strategy
+
+### Domain / Unit
+
+- `NotificationSearchQuery` 검증
+- `NotificationReadStatusFilter` 기본값/파싱
+- `from/to` 31일 제한
+- search cursor fingerprint 생성/비교
+
+### Controller
+
+- `GET /api/v1/notifications/search` 정상 응답
+- invalid `readStatus` -> `400`
+- partial `from/to` -> `400`
+- 31일 초과 -> `400`
+- broken cursor -> `400`
+- cursor/filter mismatch -> `400`
+
+### JDBC Integration
+
+account principal:
+
+- 기본 search first page
+- `UNREAD`
+- `READ`
+- `eventType`
+- 기간 필터
+- cursor next page
+
+JWT user principal:
+
+- membership active 범위만 조회
+- per-user read state 반영
+- shared account에서 사용자별 `READ/UNREAD` 분리
+
+### API Integration
+
+- 기존 `GET /api/v1/notifications` 회귀 없음
+- 새 `/search`가 검색 조건대로 결과를 반환
+- 같은 cursor를 다른 filter와 재사용하면 `400`
+- unread count/read 처리 계약 회귀 없음
+
+## Operational Notes
+
+- 검색 endpoint는 fail-fast validation으로 넓은 조회를 초기에 차단한다.
+- 검색 쿼리는 `limit + 1` 방식으로 `hasNext`를 계산한다.
+- 검색 API와 기존 목록 API를 분리해, 이후 text search나 별도 검색 projection이 필요해지면 검색 경로만 교체할 수 있게 한다.
+
+## Follow-Up Candidates
+
+- title/message free-text 검색
+- 인기 filter 기준 추가 index 최적화
+- eventType별 facet count
+- 별도 notification_search_projection 도입 검토


### PR DESCRIPTION
## 🔗 Related Issue
- close #160

## 🌿 Base Branch
- `main`

## 📝 Summary
- `GET /api/v1/notifications/search` 검색 endpoint를 추가해 `readStatus`, `eventType`, `from/to` structured filter를 지원합니다.
- 기본 31일 window와 search cursor fingerprint를 도입해 bounded query/keyset semantics를 유지합니다.
- account/JWT user read path를 유지한 상태로 JDBC query, index, tests, README를 함께 정리했습니다.

## 🛠 Changes
- search 전용 domain model/use case/port/cursor codec/response/controller wiring을 추가했습니다.
- `JdbcNotificationInboxRepository`에 account/user 검색 SQL과 cursor fingerprint 검증을 추가하고, `V25__add_notification_search_index.sql` partial index를 추가했습니다.
- controller/repository/integration tests와 README search API 문서를 추가했습니다.
- API 계약 변경: `GET /api/v1/notifications/search` 신규 추가
- 스키마 변경: `idx_notification_inbox_account_event_type_cursor` partial index 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back spotlessApply`
- `tools/test/with-resource-lock.sh back-gradle-notification-search ./back/gradlew -p back test --tests '*NotificationSearchCursorCodecTest' --tests '*NotificationControllerTest' --tests '*JdbcNotificationInboxRepositoryIntegrationTest' --tests '*NotificationApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- `GET /api/v1/notifications/search?readStatus=UNREAD&eventType=TransferBooked&from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z`
- 응답 필드: `items`, `nextCursor`, `hasNext`, `limit`, `appliedFrom`, `appliedTo`

## ⚠️ Risk & Rollback
- 예상 리스크:
  - search cursor는 filter fingerprint 불일치 시 `400`을 반환하므로, 클라이언트는 page 2부터 필터를 바꾸지 않아야 합니다.
  - `V25` index는 additive migration이라 planner 개선 목적만 갖고 기존 목록 API 계약은 건드리지 않습니다.
- 롤백 방법:
  - 애플리케이션은 이 PR revert SHA로 되돌립니다.
  - DB index는 additive라 남겨도 기능상 문제 없고, 필요하면 `DROP INDEX CONCURRENTLY idx_notification_inbox_account_event_type_cursor;`로 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`완성 기능`, N/A)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?