### PR TITLE
[Feat] 송금 부분 reversal 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -335,6 +335,7 @@ bash tools/test/check-nginx-sse-proxy.sh
   - `POST /api/v1/transfers/{transactionReference}/reversal`
 - reversal 요청 필드:
   - `sourceAccountId`
+  - `amountMinor` (선택, 없으면 남은 reversal 가능 금액 전체)
   - `reversalReason`: `CANCEL` | `CORRECTION`
   - `summary`
 - reversal 응답 필드:
@@ -353,10 +354,12 @@ bash tools/test/check-nginx-sse-proxy.sh
   - 원본 `transaction_read_model` 상태는 `REVERSED` 로 전이하고 reversal read model row 2건을 추가
   - outbox는 `TransferReversed` event를 별도 적재
 - 충돌 기준:
-  - 같은 원본 transfer를 다시 reversal 하면 `409 transfer is already reversed`
+  - 누적 reversal 금액이 원본 금액을 넘으면 `409 reversal amount exceeds remaining amount`
+  - 이미 전액 reversal 된 원본 transfer를 다시 reversal 하면 `409 transfer is already reversed`
   - reversal 시 target 계좌 잔액이 부족하면 `409 reversal target balance is not enough`
 - 운영 주의:
-  - 이번 범위는 full reversal만 지원하고 partial reversal은 제외
+  - partial reversal은 원본 ledger row를 수정하지 않고 reversal ledger row를 누적 append 한다
+  - 원본 read model 상태는 부분 reversal 후 `PARTIALLY_REVERSED`, 전액 누적 reversal 후 `REVERSED` 로 전이한다
   - notification inbox consumer는 `TransferBooked`, `TransferReversed` fan-out을 모두 처리하고 DLQ/ops 집계는 두 topic 합산 기준으로 본다
 
 ## Public Login Protection

--- a/back/src/main/java/com/aquilabank/domain/ledger/model/TransferReversalCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/model/TransferReversalCommand.java
@@ -4,6 +4,7 @@ package com.aquilabank.domain.ledger.model;
 public record TransferReversalCommand(
     String originalTransactionReference,
     long sourceAccountId,
+    Long amountMinor,
     TransferReversalReason reversalReason,
     String summary,
     String idempotencyKey) {
@@ -17,6 +18,9 @@ public record TransferReversalCommand(
     }
     if (sourceAccountId <= 0) {
       throw new IllegalArgumentException("sourceAccountId must be positive");
+    }
+    if (amountMinor != null && amountMinor <= 0) {
+      throw new IllegalArgumentException("amountMinor must be positive");
     }
     if (reversalReason == null) {
       throw new IllegalArgumentException("reversalReason is required");
@@ -33,6 +37,8 @@ public record TransferReversalCommand(
     return originalTransactionReference
         + "|"
         + sourceAccountId
+        + "|"
+        + amountMinor
         + "|"
         + reversalReason
         + "|"

--- a/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionStatus.java
@@ -4,5 +4,6 @@ package com.aquilabank.domain.transaction.model;
 public enum TransactionStatus {
   PENDING,
   BOOKED,
+  PARTIALLY_REVERSED,
   REVERSED
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferWriteRepository.java
@@ -176,7 +176,16 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
     OriginalTransferRecord original =
         loadOriginalTransferForUpdate(
             command.originalTransactionReference(), command.sourceAccountId());
-    ensureNotAlreadyReversed(command.originalTransactionReference());
+    long alreadyReversedAmount =
+        loadExistingReversalAmountForUpdate(original.transactionReference());
+    long remainingAmount = original.amountMinor() - alreadyReversedAmount;
+    if (remainingAmount <= 0) {
+      throw new CommandConflictException("transfer is already reversed");
+    }
+    long reversalAmount = command.amountMinor() == null ? remainingAmount : command.amountMinor();
+    if (reversalAmount > remainingAmount) {
+      throw new CommandConflictException("reversal amount exceeds remaining amount");
+    }
 
     LockedBalanceSnapshot source = loadBalanceSnapshot(original.sourceAccountId());
     LockedBalanceSnapshot target = loadBalanceSnapshot(original.targetAccountId());
@@ -184,18 +193,22 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
         || !target.currencyCode().equals(original.currencyCode())) {
       throw new CurrencyMismatchException("currency does not match original transfer");
     }
-    if (target.availableBalanceMinor() < original.amountMinor()) {
+    if (target.availableBalanceMinor() < reversalAmount) {
       throw new InsufficientBalanceException("reversal target balance is not enough");
     }
 
     Instant bookedAt = now;
     String reversalTransactionReference = "TRX-" + UUID.randomUUID();
-    long sourceBalanceAfter = source.availableBalanceMinor() + original.amountMinor();
-    long targetBalanceAfter = target.availableBalanceMinor() - original.amountMinor();
+    long sourceBalanceAfter = source.availableBalanceMinor() + reversalAmount;
+    long targetBalanceAfter = target.availableBalanceMinor() - reversalAmount;
+    long totalReversedAmount = alreadyReversedAmount + reversalAmount;
+    String originalStatus =
+        totalReversedAmount == original.amountMinor() ? "REVERSED" : "PARTIALLY_REVERSED";
     String reversalMetadata =
         toJson(
             Map.of(
                 "originalTransactionReference", original.transactionReference(),
+                "reversalAmountMinor", reversalAmount,
                 "reversalReason", command.reversalReason().name()));
 
     long sourceReversalEntryId =
@@ -203,7 +216,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
             original.sourceAccountId(),
             reversalTransactionReference,
             "CREDIT",
-            original.amountMinor(),
+            reversalAmount,
             original.currencyCode(),
             command.summary(),
             bookedAt,
@@ -213,7 +226,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
             original.targetAccountId(),
             reversalTransactionReference,
             "DEBIT",
-            original.amountMinor(),
+            reversalAmount,
             original.currencyCode(),
             command.summary(),
             bookedAt,
@@ -224,14 +237,14 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
     updateBalanceSnapshot(
         original.targetAccountId(), targetReversalEntryId, targetBalanceAfter, bookedAt);
 
-    markTransactionReadModelReversed(original.transactionReference());
+    markTransactionReadModelStatus(original.transactionReference(), originalStatus);
     insertTransactionReadModel(
         sourceReversalEntryId,
         original.sourceAccountId(),
         reversalTransactionReference,
         "CREDIT",
         "BOOKED",
-        original.amountMinor(),
+        reversalAmount,
         sourceBalanceAfter,
         original.currencyCode(),
         command.summary(),
@@ -243,15 +256,17 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
         reversalTransactionReference,
         "DEBIT",
         "BOOKED",
-        original.amountMinor(),
+        reversalAmount,
         targetBalanceAfter,
         original.currencyCode(),
         command.summary(),
         "ACCOUNT-" + original.sourceAccountId(),
         bookedAt);
 
-    insertTransferReversal(original, reversalTransactionReference, command, bookedAt);
-    insertReversalOutboxEvent(original, reversalTransactionReference, command, bookedAt);
+    insertTransferReversal(
+        original, reversalTransactionReference, reversalAmount, command, bookedAt);
+    insertReversalOutboxEvent(
+        original, reversalTransactionReference, reversalAmount, command, bookedAt);
 
     TransferReversalResult result =
         new TransferReversalResult(
@@ -259,11 +274,11 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
             reversalTransactionReference,
             original.sourceAccountId(),
             original.targetAccountId(),
-            original.amountMinor(),
+            reversalAmount,
             original.currencyCode(),
             sourceBalanceAfter,
             bookedAt,
-            "REVERSED");
+            originalStatus);
     completeIdempotency(command.idempotencyKey(), result, bookedAt);
     return result;
   }
@@ -565,12 +580,13 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
   private void insertReversalOutboxEvent(
       OriginalTransferRecord original,
       String reversalTransactionReference,
+      long reversalAmount,
       TransferReversalCommand command,
       Instant bookedAt) {
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("aggregateId", reversalTransactionReference)
-            .addValue("eventKey", "transfer-reversed:" + original.transactionReference())
+            .addValue("eventKey", "transfer-reversed:" + reversalTransactionReference)
             .addValue(
                 "payload",
                 toJson(
@@ -579,7 +595,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
                         "reversalTransactionReference", reversalTransactionReference,
                         "sourceAccountId", original.sourceAccountId(),
                         "targetAccountId", original.targetAccountId(),
-                        "amountMinor", original.amountMinor(),
+                        "amountMinor", reversalAmount,
                         "currencyCode", original.currencyCode(),
                         "reversalReason", command.reversalReason().name(),
                         "bookedAt", bookedAt.toString())))
@@ -616,6 +632,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
   private void insertTransferReversal(
       OriginalTransferRecord original,
       String reversalTransactionReference,
+      long reversalAmount,
       TransferReversalCommand command,
       Instant createdAt) {
     try {
@@ -649,7 +666,7 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
               .addValue("reversalTransactionReference", reversalTransactionReference)
               .addValue("sourceAccountId", original.sourceAccountId())
               .addValue("targetAccountId", original.targetAccountId())
-              .addValue("amountMinor", original.amountMinor())
+              .addValue("amountMinor", reversalAmount)
               .addValue("currencyCode", original.currencyCode())
               .addValue("reversalReason", command.reversalReason().name())
               .addValue("summary", command.summary())
@@ -659,25 +676,21 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
     }
   }
 
-  private void ensureNotAlreadyReversed(String originalTransactionReference) {
-    boolean exists =
-        jdbcTemplate
-            .query(
-                """
-                SELECT 1
-                FROM transfer_reversal
-                WHERE original_transaction_reference = :originalTransactionReference
-                FOR UPDATE
-                """,
-                new MapSqlParameterSource()
-                    .addValue("originalTransactionReference", originalTransactionReference),
-                (rs, rowNum) -> rs.getInt(1))
-            .stream()
-            .findFirst()
-            .isPresent();
-    if (exists) {
-      throw new CommandConflictException("transfer is already reversed");
-    }
+  private long loadExistingReversalAmountForUpdate(String originalTransactionReference) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT amount_minor
+            FROM transfer_reversal
+            WHERE original_transaction_reference = :originalTransactionReference
+            FOR UPDATE
+            """,
+            new MapSqlParameterSource()
+                .addValue("originalTransactionReference", originalTransactionReference),
+            (rs, rowNum) -> rs.getLong("amount_minor"))
+        .stream()
+        .mapToLong(Long::longValue)
+        .sum();
   }
 
   private OriginalTransferRecord loadOriginalTransferForUpdate(
@@ -737,15 +750,18 @@ public class JdbcTransferWriteRepository implements TransferWritePort, TransferR
         debit.currencyCode());
   }
 
-  private void markTransactionReadModelReversed(String transactionReference) {
+  private void markTransactionReadModelStatus(
+      String transactionReference, String transactionStatus) {
     int updated =
         jdbcTemplate.update(
             """
             UPDATE transaction_read_model
-            SET transaction_status = 'REVERSED'
+            SET transaction_status = :transactionStatus
             WHERE transaction_reference = :transactionReference
             """,
-            new MapSqlParameterSource().addValue("transactionReference", transactionReference));
+            new MapSqlParameterSource()
+                .addValue("transactionReference", transactionReference)
+                .addValue("transactionStatus", transactionStatus));
     if (updated != 2) {
       throw new IllegalStateException("original transaction read model update failed");
     }

--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
@@ -78,6 +78,7 @@ public class TransferCommandController {
             new TransferReversalCommand(
                 transactionReference,
                 sourceAccountId,
+                request.amountMinor(),
                 request.reversalReason(),
                 request.summary(),
                 idempotencyKey));
@@ -98,6 +99,7 @@ public class TransferCommandController {
   /** 송금 reversal 요청 body */
   public record TransferReversalRequest(
       @Positive(message = "sourceAccountId must be positive") long sourceAccountId,
+      @Positive(message = "amountMinor must be positive") Long amountMinor,
       @NotNull(message = "reversalReason is required") TransferReversalReason reversalReason,
       @NotBlank(message = "summary is required") @Size(max = 120, message = "summary must be 120 characters or less") String summary) {}
 

--- a/back/src/main/resources/db/migration/V27__add_transfer_partial_reversal.sql
+++ b/back/src/main/resources/db/migration/V27__add_transfer_partial_reversal.sql
@@ -1,0 +1,15 @@
+ALTER TABLE transaction_read_model
+    DROP CONSTRAINT transaction_read_model_transaction_status_check;
+
+ALTER TABLE transaction_read_model
+    ALTER COLUMN transaction_status TYPE VARCHAR(24);
+
+ALTER TABLE transaction_read_model
+    ADD CONSTRAINT transaction_read_model_transaction_status_check
+        CHECK (transaction_status IN ('PENDING', 'BOOKED', 'PARTIALLY_REVERSED', 'REVERSED'));
+
+ALTER TABLE transfer_reversal
+    DROP CONSTRAINT uq_transfer_reversal_original_reference;
+
+CREATE INDEX idx_transfer_reversal_original_created_at
+    ON transfer_reversal (original_transaction_reference, created_at DESC, id DESC);

--- a/back/src/test/java/com/aquilabank/domain/ledger/model/TransferReversalCommandTest.java
+++ b/back/src/test/java/com/aquilabank/domain/ledger/model/TransferReversalCommandTest.java
@@ -1,0 +1,40 @@
+package com.aquilabank.domain.ledger.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TransferReversalCommandTest {
+
+  @Test
+  void acceptsMissingAmountForFullRemainingReversal() {
+    TransferReversalCommand command =
+        new TransferReversalCommand(
+            "TRX-1", 101L, null, TransferReversalReason.CANCEL, "cancel all", "rev-1");
+
+    assertThat(command.amountMinor()).isNull();
+  }
+
+  @Test
+  void rejectsNonPositivePartialAmount() {
+    assertThatThrownBy(
+            () ->
+                new TransferReversalCommand(
+                    "TRX-1", 101L, 0L, TransferReversalReason.CANCEL, "bad", "rev-1"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("amountMinor must be positive");
+  }
+
+  @Test
+  void includesAmountInFingerprint() {
+    TransferReversalCommand first =
+        new TransferReversalCommand(
+            "TRX-1", 101L, 500L, TransferReversalReason.CANCEL, "partial", "rev-1");
+    TransferReversalCommand second =
+        new TransferReversalCommand(
+            "TRX-1", 101L, 700L, TransferReversalReason.CANCEL, "partial", "rev-1");
+
+    assertThat(first.fingerprint()).isNotEqualTo(second.fingerprint());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
@@ -174,6 +174,125 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
   }
 
   @Test
+  void partiallyReversesTransferAndKeepsOriginalPartiallyReversed() throws Exception {
+    TransferResponseView booked =
+        invokeTransfer("transfer-partial-001", targetAccountId, 1_500L, "rent");
+
+    TransferReversalResponseView reversed =
+        invokeReversal(
+            booked.transactionReference(),
+            "reversal-partial-001",
+            500L,
+            "CORRECTION",
+            "partial rent");
+
+    assertEquals(booked.transactionReference(), reversed.originalTransactionReference());
+    assertEquals(500L, reversed.amountMinor());
+    assertEquals(9_000L, reversed.availableBalanceAfterMinor());
+    assertEquals("PARTIALLY_REVERSED", reversed.status());
+    assertEquals(2L, countRows("ledger_entry", booked.transactionReference()));
+    assertEquals(2L, countRows("ledger_entry", reversed.reversalTransactionReference()));
+    assertEquals(2L, countRows("transaction_read_model", reversed.reversalTransactionReference()));
+    assertEquals(2L, transactionStatusCount(booked.transactionReference(), "PARTIALLY_REVERSED"));
+    assertEquals(9_000L, balanceOf(sourceAccountId));
+    assertEquals(1_000L, balanceOf(targetAccountId));
+    assertEquals(1L, transferReversalCount(booked.transactionReference()));
+
+    Map<String, Object> outboxState = outboxState(reversed.reversalTransactionReference());
+    assertEquals("TransferReversed", outboxState.get("event_type"));
+    assertEquals(
+        500,
+        objectMapper
+            .readTree(String.valueOf(outboxState.get("payload")))
+            .get("amountMinor")
+            .asInt());
+  }
+
+  @Test
+  void completesOriginalStatusWhenPartialReversalsReachOriginalAmount() throws Exception {
+    TransferResponseView booked =
+        invokeTransfer("transfer-partial-002", targetAccountId, 1_500L, "rent");
+
+    TransferReversalResponseView first =
+        invokeReversal(
+            booked.transactionReference(),
+            "reversal-partial-002",
+            500L,
+            "CORRECTION",
+            "partial rent");
+    TransferReversalResponseView second =
+        invokeReversal(
+            booked.transactionReference(),
+            "reversal-partial-003",
+            1_000L,
+            "CANCEL",
+            "remaining rent");
+
+    assertEquals("PARTIALLY_REVERSED", first.status());
+    assertEquals("REVERSED", second.status());
+    assertEquals(2L, transactionStatusCount(booked.transactionReference(), "REVERSED"));
+    assertEquals(10_000L, balanceOf(sourceAccountId));
+    assertEquals(0L, balanceOf(targetAccountId));
+    assertEquals(2L, transferReversalCount(booked.transactionReference()));
+  }
+
+  @Test
+  void rejectsPartialReversalWhenAmountExceedsRemainingAmount() throws Exception {
+    TransferResponseView booked =
+        invokeTransfer("transfer-partial-003", targetAccountId, 1_500L, "rent");
+    invokeReversal(
+        booked.transactionReference(), "reversal-partial-004", 1_000L, "CORRECTION", "part");
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers/%s/reversal".formatted(booked.transactionReference()))
+                    .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", "reversal-partial-005-request")
+                    .header("Idempotency-Key", "reversal-partial-005")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "amountMinor": 600,
+                          "reversalReason": "CANCEL",
+                          "summary": "too much"
+                        }
+                        """
+                            .formatted(sourceAccountId)))
+            .andReturn();
+
+    assertEquals(409, result.getResponse().getStatus(), result.getResponse().getContentAsString());
+    assertEquals(
+        "reversal amount exceeds remaining amount",
+        objectMapper
+            .readTree(result.getResponse().getContentAsByteArray())
+            .get("message")
+            .asText());
+    assertEquals(1L, transferReversalCount(booked.transactionReference()));
+    assertEquals(9_500L, balanceOf(sourceAccountId));
+    assertEquals(500L, balanceOf(targetAccountId));
+  }
+
+  @Test
+  void reversesRemainingAmountWhenAmountIsOmittedAfterPartialReversal() throws Exception {
+    TransferResponseView booked =
+        invokeTransfer("transfer-partial-004", targetAccountId, 1_500L, "rent");
+    invokeReversal(
+        booked.transactionReference(), "reversal-partial-006", 500L, "CORRECTION", "part");
+
+    TransferReversalResponseView second =
+        invokeReversal(booked.transactionReference(), "reversal-partial-007", "CANCEL", "rest");
+
+    assertEquals(1_000L, second.amountMinor());
+    assertEquals("REVERSED", second.status());
+    assertEquals(10_000L, balanceOf(sourceAccountId));
+    assertEquals(0L, balanceOf(targetAccountId));
+    assertEquals(2L, transferReversalCount(booked.transactionReference()));
+  }
+
+  @Test
   void rejectsDuplicateReversalForSameOriginalTransfer() throws Exception {
     TransferResponseView booked =
         invokeTransfer("transfer-005", targetAccountId, 1_200L, "tuition");
@@ -406,6 +525,42 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
         result.getResponse().getHeader("X-Request-Id"));
   }
 
+  private TransferReversalResponseView invokeReversal(
+      String originalTransactionReference,
+      String idempotencyKey,
+      long amountMinor,
+      String reversalReason,
+      String summary)
+      throws Exception {
+    String requestId = idempotencyKey + "-request";
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers/%s/reversal".formatted(originalTransactionReference))
+                    .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", requestId)
+                    .header("Idempotency-Key", idempotencyKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "amountMinor": %d,
+                          "reversalReason": "%s",
+                          "summary": "%s"
+                        }
+                        """
+                            .formatted(sourceAccountId, amountMinor, reversalReason, summary)))
+            .andReturn();
+
+    assertEquals(200, result.getResponse().getStatus(), result.getResponse().getContentAsString());
+
+    return new TransferReversalResponseView(
+        objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(), TransferReversalResponseBody.class),
+        result.getResponse().getHeader("X-Request-Id"));
+  }
+
   private void updateBalance(long accountId, long availableBalanceMinor) {
     jdbcTemplate.update(
         """
@@ -590,6 +745,14 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
 
     private long availableBalanceAfterMinor() {
       return body.availableBalanceAfterMinor();
+    }
+
+    private long amountMinor() {
+      return body.amountMinor();
+    }
+
+    private String status() {
+      return body.status();
     }
   }
 

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -117,6 +117,7 @@ class TransferCommandControllerTest {
                     """
                     {
                       "sourceAccountId": 101,
+                      "amountMinor": 700,
                       "reversalReason": "CANCEL",
                       "summary": "cancel transfer"
                     }
@@ -127,7 +128,11 @@ class TransferCommandControllerTest {
         .andExpect(jsonPath("$.availableBalanceAfterMinor").value(10000));
 
     verify(transferReversalUseCase)
-        .reverse(argThat(command -> "reversal-001".equals(command.idempotencyKey())));
+        .reverse(
+            argThat(
+                command ->
+                    "reversal-001".equals(command.idempotencyKey())
+                        && Long.valueOf(700L).equals(command.amountMinor())));
   }
 
   @Test

--- a/docs/superpowers/specs/2026-04-21-transfer-partial-reversal-design.md
+++ b/docs/superpowers/specs/2026-04-21-transfer-partial-reversal-design.md
@@ -1,0 +1,126 @@
+# Transfer Partial Reversal Design
+
+**Issue:** `#164`
+**Branch:** `feat/transfer-partial-reversal`
+
+## Goal
+
+기존 full reversal 경로를 확장해 원본 송금 금액 중 일부만 reversal 할 수 있게 한다.
+원본 ledger row는 수정하지 않고 reversal ledger entry를 누적 append 하며, snapshot/read model/outbox/idempotency는 기존 write transaction 경계 안에서 함께 처리한다.
+
+## Non-Goals
+
+- bulk reversal
+- 운영 승인 workflow
+- frontend 송금 UI
+- notification consumer 신규 fan-out 변경
+- reversal 이후 자동 재송금
+- 외부 저장소나 분산 lock 도입
+
+## Decision Summary
+
+1. 기존 endpoint `POST /api/v1/transfers/{transactionReference}/reversal`를 유지한다.
+2. request body에 선택 필드 `amountMinor`를 추가한다.
+3. `amountMinor`가 없으면 남은 reversal 가능 금액 전액을 reversal한다.
+4. `amountMinor`가 있으면 `0 < amountMinor <= 남은 reversal 가능 금액`만 허용한다.
+5. 원본 1건에 여러 `transfer_reversal` row를 허용한다.
+6. 원본 read model 상태는 누적 금액에 따라 `PARTIALLY_REVERSED` 또는 `REVERSED`로 전이한다.
+7. reversal outbox payload에는 실제 reversal 금액을 넣는다.
+
+## API Contract
+
+### Request
+
+```json
+{
+  "sourceAccountId": 101,
+  "amountMinor": 500,
+  "reversalReason": "CORRECTION",
+  "summary": "partial correction"
+}
+```
+
+- `amountMinor`
+  - optional
+  - null이면 남은 reversal 가능 금액 전체
+  - 양수만 허용
+
+### Response
+
+기존 response shape를 유지하고 `amountMinor`는 실제 reversal 금액을 반환한다.
+
+```json
+{
+  "originalTransactionReference": "TRX-1",
+  "reversalTransactionReference": "TRX-2",
+  "sourceAccountId": 101,
+  "targetAccountId": 202,
+  "amountMinor": 500,
+  "currencyCode": "KRW",
+  "availableBalanceAfterMinor": 9500,
+  "bookedAt": "2026-04-21T00:00:00Z",
+  "status": "PARTIALLY_REVERSED"
+}
+```
+
+## Data Model
+
+### Migration
+
+- `transaction_read_model.transaction_status` check constraint에 `PARTIALLY_REVERSED` 추가
+- `transfer_reversal.original_transaction_reference` unique 제약 제거
+- `transfer_reversal`에 `(original_transaction_reference, created_at DESC, id DESC)` index 추가
+
+### Remaining Amount
+
+```
+remaining = original.amount_minor - SUM(transfer_reversal.amount_minor WHERE original_transaction_reference = ?)
+```
+
+계산은 original ledger rows와 `transfer_reversal` rows를 같은 DB transaction 안에서 `FOR UPDATE`로 잠근 뒤 수행한다.
+
+## Write Flow
+
+1. idempotency key insert 또는 재사용
+2. original transfer ledger row 2건 lock
+3. original transfer의 기존 reversal rows lock
+4. remaining amount 계산
+5. requested amount 결정
+6. target/source snapshot lock
+7. target 잔액 검증
+8. reversal ledger entry 2건 append
+9. snapshot 2건 update
+10. original read model 상태를 `PARTIALLY_REVERSED` 또는 `REVERSED`로 update
+11. reversal read model row 2건 insert
+12. transfer_reversal row insert
+13. TransferReversed outbox insert
+14. idempotency complete
+
+## Error Policy
+
+- `400`
+  - `amountMinor <= 0`
+  - request validation 실패
+- `404`
+  - sourceAccountId와 original transaction이 맞지 않음
+- `409`
+  - idempotency key가 다른 request fingerprint로 재사용됨
+  - same command in progress
+  - target balance 부족
+  - requested amount가 remaining amount를 초과함
+
+## Tests
+
+- domain command test: null amount는 허용, non-positive amount는 거부, fingerprint에 amount 포함
+- controller test: amountMinor가 use case command로 전달됨
+- API integration test:
+  - partial reversal 후 ledger/read model/outbox/snapshot 검증
+  - 두 번째 partial reversal로 전액 도달 시 `REVERSED` 전이
+  - remaining 초과 reversal은 `409`
+  - 기존 full reversal request는 남은 전액 reversal 유지
+
+## Risks
+
+- 기존 unique 제약 제거 시 중복 full reversal 차단이 누적 금액 검증으로 완전히 대체되어야 한다.
+- original read model 상태가 `BOOKED -> PARTIALLY_REVERSED -> REVERSED`로 전이되어 transaction 조회 필터와 detail 응답이 새 상태를 허용해야 한다.
+- notification consumer는 기존 `TransferReversed` 이벤트를 계속 처리하되 부분/전체 의미를 amount 기준으로만 구분한다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #164

## 🌿 Base Branch
- `main`

## 📝 Summary
- 송금 reversal API에 선택적 `amountMinor`를 추가해 부분 reversal을 지원합니다.
- 원본 ledger row는 유지하고 reversal ledger/read model/outbox row를 누적 append하며, 원본 read model 상태는 `PARTIALLY_REVERSED` 또는 `REVERSED`로 전이합니다.

## 🛠 Changes
- `TransferReversalCommand`에 optional `amountMinor` 추가
- `transaction_read_model.transaction_status`에 `PARTIALLY_REVERSED` 추가
- `transfer_reversal` 원본 unique 제약 제거 및 원본별 다건 reversal index 추가
- JDBC reversal write path를 remaining amount 기반으로 변경
- controller/API 통합 테스트와 README 기준 업데이트

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-transfer-partial-domain ./back/gradlew -p back test --tests '*TransferReversalCommandTest'`
- `tools/test/with-resource-lock.sh back-gradle-transfer-partial-api ./back/gradlew -p back test --tests '*TransferCommandControllerTest' --tests '*TransferCommandApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-transfer-partial-check ./back/gradlew -p back check`
- pre-commit hook: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
```json
{
  "sourceAccountId": 101,
  "amountMinor": 500,
  "reversalReason": "CORRECTION",
  "summary": "partial correction"
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: `transfer_reversal` 원본 unique 제약 제거로 기존 중복 차단은 누적 금액 검증이 담당합니다.
- 롤백 방법: PR revert. 이미 migration이 배포된 경우 후속 rollback migration으로 `PARTIALLY_REVERSED` row 상태 정리와 제약 복구가 필요합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
