### PR TITLE
[Feat] external IdP/OIDC 로그인 연동 추가

### DIFF
--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-flyway")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.kafka:spring-kafka")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/back/src/main/java/com/aquilabank/domain/auth/model/ExternalOidcLoginCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/ExternalOidcLoginCommand.java
@@ -1,0 +1,24 @@
+package com.aquilabank.domain.auth.model;
+
+/** 외부 IdP 인증 결과를 내부 session 발급 입력으로 넘기는 command입니다. */
+public record ExternalOidcLoginCommand(
+    String providerId, String subject, AuthSessionClientMetadata sessionClientMetadata) {
+
+  public ExternalOidcLoginCommand {
+    if (providerId == null || providerId.isBlank()) {
+      throw new IllegalArgumentException("providerId is required");
+    }
+    if (providerId.length() > 64) {
+      throw new IllegalArgumentException("providerId must be 64 characters or less");
+    }
+    if (subject == null || subject.isBlank()) {
+      throw new IllegalArgumentException("subject is required");
+    }
+    if (subject.length() > 255) {
+      throw new IllegalArgumentException("subject must be 255 characters or less");
+    }
+    if (sessionClientMetadata == null) {
+      throw new IllegalArgumentException("sessionClientMetadata is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/ExternalIdentityUserLoadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/ExternalIdentityUserLoadPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.LoginUser;
+import java.util.Optional;
+
+/** 외부 provider subject에 명시 연결된 내부 user만 조회합니다. */
+public interface ExternalIdentityUserLoadPort {
+
+  Optional<LoginUser> findByProviderIdAndSubjectForUpdate(String providerId, String subject);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalOidcLoginService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalOidcLoginService.java
@@ -1,0 +1,120 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.ExternalOidcLoginCommand;
+import com.aquilabank.domain.auth.model.IssuedAccessToken;
+import com.aquilabank.domain.auth.model.LoginResetAuditEntry;
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.LoginSuccessUpdateCommand;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.ExternalIdentityUserLoadPort;
+import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
+import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
+import com.aquilabank.domain.auth.port.RefreshDeviceBindingSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** 외부 IdP 인증 완료 사용자를 내부 refresh session과 JWT로 교환합니다. */
+public final class ExternalOidcLoginService implements ExternalOidcLoginUseCase {
+
+  private final ExternalIdentityUserLoadPort externalIdentityUserLoadPort;
+  private final LoginAttemptUpdatePort loginAttemptUpdatePort;
+  private final LoginAttemptAuditPort loginAttemptAuditPort;
+  private final RefreshTokenSessionWritePort refreshTokenSessionWritePort;
+  private final RefreshTokenSecretPort refreshTokenSecretPort;
+  private final RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort;
+  private final AuthTokenIssuePort authTokenIssuePort;
+  private final RefreshTokenPolicy refreshTokenPolicy;
+  private final Clock clock;
+
+  public ExternalOidcLoginService(
+      ExternalIdentityUserLoadPort externalIdentityUserLoadPort,
+      LoginAttemptUpdatePort loginAttemptUpdatePort,
+      LoginAttemptAuditPort loginAttemptAuditPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      RefreshTokenSecretPort refreshTokenSecretPort,
+      RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort,
+      AuthTokenIssuePort authTokenIssuePort,
+      RefreshTokenPolicy refreshTokenPolicy,
+      Clock clock) {
+    this.externalIdentityUserLoadPort = externalIdentityUserLoadPort;
+    this.loginAttemptUpdatePort = loginAttemptUpdatePort;
+    this.loginAttemptAuditPort = loginAttemptAuditPort;
+    this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
+    this.refreshTokenSecretPort = refreshTokenSecretPort;
+    this.refreshDeviceBindingSecretPort = refreshDeviceBindingSecretPort;
+    this.authTokenIssuePort = authTokenIssuePort;
+    this.refreshTokenPolicy = refreshTokenPolicy;
+    this.clock = clock;
+  }
+
+  @Override
+  public LoginResult login(ExternalOidcLoginCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+
+    Instant now = Instant.now(clock);
+    // 외부 IdP 인증은 내부 권한 부여가 아니므로 명시 연결된 subject만 세션으로 교환합니다.
+    LoginUser user =
+        externalIdentityUserLoadPort
+            .findByProviderIdAndSubjectForUpdate(command.providerId(), command.subject())
+            .orElseThrow(() -> new InvalidCredentialsException("oidc login failed"));
+    if (user.status() != UserStatus.ACTIVE || isTemporarilyLocked(user, now)) {
+      throw new InvalidCredentialsException("oidc login failed");
+    }
+
+    loginAttemptUpdatePort.recordLoginSuccess(new LoginSuccessUpdateCommand(user.userId(), now));
+    if (shouldLogReset(user)) {
+      loginAttemptAuditPort.logReset(
+          new LoginResetAuditEntry(
+              user.loginId(), user.userId(), user.failedLoginCount(), user.loginLockedUntil()));
+    }
+    return issueTokenPair(user, command, now);
+  }
+
+  private boolean isTemporarilyLocked(LoginUser user, Instant now) {
+    return user.loginLockedUntil() != null && user.loginLockedUntil().isAfter(now);
+  }
+
+  private boolean shouldLogReset(LoginUser user) {
+    return user.failedLoginCount() > 0 || user.loginLockedUntil() != null;
+  }
+
+  private LoginResult issueTokenPair(
+      LoginUser user, ExternalOidcLoginCommand command, Instant now) {
+    String refreshToken = refreshTokenSecretPort.createToken();
+    String refreshTokenHash = refreshTokenSecretPort.hash(refreshToken);
+    String refreshDeviceBindingToken = refreshDeviceBindingSecretPort.createToken();
+    String refreshDeviceBindingHash =
+        refreshDeviceBindingSecretPort.hash(refreshDeviceBindingToken);
+    Instant refreshExpiresAt = now.plus(refreshTokenPolicy.ttl());
+    // 기존 refresh token 탈취 방어와 동일하게 device binding hash를 함께 저장합니다.
+    long sessionId =
+        refreshTokenSessionWritePort.create(
+            new RefreshTokenSessionCreateCommand(
+                user.userId(),
+                refreshTokenHash,
+                refreshDeviceBindingHash,
+                refreshExpiresAt,
+                now,
+                command.sessionClientMetadata()));
+    IssuedAccessToken issuedAccessToken =
+        authTokenIssuePort.issue(user.userId(), user.loginId(), sessionId, now);
+    return LoginResult.success(
+        issuedAccessToken.accessToken(),
+        refreshToken,
+        issuedAccessToken.tokenType(),
+        issuedAccessToken.expiresAt(),
+        refreshExpiresAt,
+        issuedAccessToken.userId(),
+        refreshDeviceBindingToken,
+        null);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalOidcLoginUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalOidcLoginUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.ExternalOidcLoginCommand;
+import com.aquilabank.domain.auth.model.LoginResult;
+
+public interface ExternalOidcLoginUseCase {
+
+  LoginResult login(ExternalOidcLoginCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -13,6 +13,7 @@ import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
 import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
 import com.aquilabank.domain.auth.port.BackupCodeWritePort;
+import com.aquilabank.domain.auth.port.ExternalIdentityUserLoadPort;
 import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
 import com.aquilabank.domain.auth.port.PasswordHashPort;
@@ -55,6 +56,8 @@ import com.aquilabank.domain.auth.usecase.BackupCodeChallengeVerifyService;
 import com.aquilabank.domain.auth.usecase.BackupCodeChallengeVerifyUseCase;
 import com.aquilabank.domain.auth.usecase.BackupCodeGenerateService;
 import com.aquilabank.domain.auth.usecase.BackupCodeGenerateUseCase;
+import com.aquilabank.domain.auth.usecase.ExternalOidcLoginService;
+import com.aquilabank.domain.auth.usecase.ExternalOidcLoginUseCase;
 import com.aquilabank.domain.auth.usecase.LoginService;
 import com.aquilabank.domain.auth.usecase.LoginUseCase;
 import com.aquilabank.domain.auth.usecase.LogoutService;
@@ -197,6 +200,53 @@ public class AuthConfiguration {
       }
       if (transactionResult.result() == null) {
         throw new IllegalStateException("login transaction returned null result");
+      }
+      return transactionResult.result();
+    };
+  }
+
+  @Bean
+  ExternalOidcLoginUseCase externalOidcLoginUseCase(
+      ExternalIdentityUserLoadPort externalIdentityUserLoadPort,
+      LoginAttemptUpdatePort loginAttemptUpdatePort,
+      LoginAttemptAuditPort loginAttemptAuditPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      RefreshTokenSecretPort refreshTokenSecretPort,
+      RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort,
+      AuthTokenIssuePort authTokenIssuePort,
+      RefreshTokenPolicy refreshTokenPolicy,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    ExternalOidcLoginService externalOidcLoginService =
+        new ExternalOidcLoginService(
+            externalIdentityUserLoadPort,
+            loginAttemptUpdatePort,
+            loginAttemptAuditPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            refreshDeviceBindingSecretPort,
+            authTokenIssuePort,
+            refreshTokenPolicy,
+            authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command -> {
+      LoginTransactionResult transactionResult =
+          transactionTemplate.execute(
+              status -> {
+                try {
+                  return LoginTransactionResult.success(externalOidcLoginService.login(command));
+                } catch (InvalidCredentialsException ex) {
+                  return LoginTransactionResult.failure(ex);
+                }
+              });
+      if (transactionResult == null) {
+        throw new IllegalStateException("external oidc login transaction result is null");
+      }
+      if (transactionResult.exception() != null) {
+        throw transactionResult.exception();
+      }
+      if (transactionResult.result() == null) {
+        throw new IllegalStateException("external oidc login transaction returned null result");
       }
       return transactionResult.result();
     };

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -30,6 +30,7 @@ import com.aquilabank.domain.auth.port.AccountStatusAccessPort;
 import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
+import com.aquilabank.domain.auth.port.ExternalIdentityUserLoadPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
 import com.aquilabank.domain.auth.port.RememberDeviceLoadPort;
 import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
@@ -59,6 +60,7 @@ public class JdbcAuthRepository
         AuthSessionQueryPort,
         AccountAccessPort,
         AccountStatusAccessPort,
+        ExternalIdentityUserLoadPort,
         UserQueryPort,
         UserAccountMembershipQueryPort,
         AuthStatusChangeAuditQueryPort {
@@ -132,6 +134,35 @@ public class JdbcAuthRepository
             FOR UPDATE
             """,
             new MapSqlParameterSource().addValue("userId", userId),
+            (rs, rowNum) -> mapLoginUser(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<LoginUser> findByProviderIdAndSubjectForUpdate(
+      String providerId, String subject) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT u.id,
+                   u.login_id,
+                   u.password_hash,
+                   u.user_status,
+                   u.failed_login_count,
+                   u.last_login_failed_at,
+                   u.login_locked_until,
+                   u.last_login_succeeded_at
+            FROM auth_external_identity e
+            JOIN bank_user u
+              ON u.id = e.user_id
+            WHERE e.provider_id = :providerId
+              AND e.subject = :subject
+            FOR UPDATE OF u
+            """,
+            new MapSqlParameterSource()
+                .addValue("providerId", providerId)
+                .addValue("subject", subject),
             (rs, rowNum) -> mapLoginUser(rs))
         .stream()
         .findFirst();

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -9,7 +9,9 @@ import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
 import com.aquilabank.domain.auth.port.RememberDeviceSecretPort;
 import com.aquilabank.global.web.InternalAuthStatusAuditRequestCachingFilter;
 import com.aquilabank.global.web.RequestIdFilter;
+import com.aquilabank.global.web.auth.OidcLoginAuthenticationSuccessHandler;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -23,6 +25,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -58,6 +61,8 @@ public class SecurityConfiguration {
       RequestIdFilter requestIdFilter,
       InternalAuthStatusAuditRequestCachingFilter internalAuthStatusAuditRequestCachingFilter,
       ObjectProvider<BootstrapHeaderAuthenticationFilter> bootstrapHeaderAuthenticationFilter,
+      ObjectProvider<ClientRegistrationRepository> clientRegistrationRepository,
+      ObjectProvider<OidcLoginAuthenticationSuccessHandler> oidcLoginAuthenticationSuccessHandler,
       JwtDecoder jwtDecoder,
       BearerTokenResolver publicApiBearerTokenResolver)
       throws Exception {
@@ -85,6 +90,8 @@ public class SecurityConfiguration {
                     .permitAll()
                     .requestMatchers("/api/v1/auth/mfa/backup-codes/challenge/verify")
                     .permitAll()
+                    .requestMatchers("/oauth2/authorization/**", "/login/oauth2/code/**")
+                    .permitAll()
                     // 내부 운영 API는 public JWT resolver에서 제외하고 전용 service JWT로만 검증합니다.
                     .requestMatchers("/internal/api/v1/accounts/bootstrap")
                     .permitAll()
@@ -110,6 +117,22 @@ public class SecurityConfiguration {
             exception ->
                 exception.authenticationEntryPoint(
                     new HttpStatusEntryPoint(org.springframework.http.HttpStatus.UNAUTHORIZED)));
+
+    OidcLoginAuthenticationSuccessHandler successHandler =
+        oidcLoginAuthenticationSuccessHandler.getIfAvailable();
+    if (successHandler != null && clientRegistrationRepository.getIfAvailable() != null) {
+      // OIDC authorization state만 session을 쓰고, API 인증은 기존 bearer JWT 경로를 유지합니다.
+      http.sessionManagement(
+              session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+          .oauth2Login(
+              oauth2 ->
+                  oauth2
+                      .successHandler(successHandler)
+                      .failureHandler(
+                          (request, response, exception) ->
+                              response.sendError(
+                                  HttpServletResponse.SC_UNAUTHORIZED, "oidc login failed")));
+    }
 
     http.addFilterBefore(requestIdFilter, AnonymousAuthenticationFilter.class);
     http.addFilterAfter(internalAuthStatusAuditRequestCachingFilter, RequestIdFilter.class);

--- a/back/src/main/java/com/aquilabank/global/web/auth/OidcLoginAuthenticationSuccessHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/OidcLoginAuthenticationSuccessHandler.java
@@ -1,0 +1,111 @@
+package com.aquilabank.global.web.auth;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.ExternalOidcLoginCommand;
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.usecase.ExternalOidcLoginUseCase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+/** OIDC 인증 성공을 내부 token session 발급 응답으로 교환합니다. */
+@Component
+public class OidcLoginAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final ExternalOidcLoginUseCase externalOidcLoginUseCase;
+  private final AuthSessionMetadataResolver authSessionMetadataResolver;
+  private final RefreshDeviceBindingCookieManager refreshDeviceBindingCookieManager;
+  private final ObjectMapper objectMapper;
+
+  public OidcLoginAuthenticationSuccessHandler(
+      ExternalOidcLoginUseCase externalOidcLoginUseCase,
+      AuthSessionMetadataResolver authSessionMetadataResolver,
+      RefreshDeviceBindingCookieManager refreshDeviceBindingCookieManager,
+      ObjectMapper objectMapper) {
+    this.externalOidcLoginUseCase = externalOidcLoginUseCase;
+    this.authSessionMetadataResolver = authSessionMetadataResolver;
+    this.refreshDeviceBindingCookieManager = refreshDeviceBindingCookieManager;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void onAuthenticationSuccess(
+      HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+      throws IOException, ServletException {
+    if (!(authentication instanceof OAuth2AuthenticationToken authenticationToken)
+        || !(authenticationToken.getPrincipal() instanceof OidcUser oidcUser)) {
+      writeUnauthorized(response);
+      return;
+    }
+
+    String subject = oidcUser.getSubject();
+    if (subject == null || subject.isBlank()) {
+      writeUnauthorized(response);
+      return;
+    }
+
+    try {
+      LoginResult result =
+          externalOidcLoginUseCase.login(
+              new ExternalOidcLoginCommand(
+                  authenticationToken.getAuthorizedClientRegistrationId(),
+                  subject,
+                  authSessionMetadataResolver.resolve(request)));
+      writeSuccess(response, result);
+    } catch (InvalidCredentialsException ex) {
+      writeUnauthorized(response);
+    }
+  }
+
+  private void writeSuccess(HttpServletResponse response, LoginResult result) throws IOException {
+    HttpHeaders headers = new HttpHeaders();
+    if (result.refreshDeviceBindingToken() != null) {
+      refreshDeviceBindingCookieManager.addBindingCookie(
+          headers, result.refreshDeviceBindingToken());
+    }
+    headers.forEach((name, values) -> values.forEach(value -> response.addHeader(name, value)));
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    objectMapper.writeValue(response.getOutputStream(), LoginResponse.from(result));
+  }
+
+  private void writeUnauthorized(HttpServletResponse response) throws IOException {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    objectMapper.writeValue(
+        response.getOutputStream(), new ErrorResponse("UNAUTHORIZED", "oidc login failed"));
+  }
+
+  private record LoginResponse(
+      String status,
+      String accessToken,
+      String refreshToken,
+      String tokenType,
+      Instant expiresAt,
+      Instant refreshExpiresAt,
+      Long userId) {
+
+    private static LoginResponse from(LoginResult result) {
+      return new LoginResponse(
+          result.status().name(),
+          result.accessToken(),
+          result.refreshToken(),
+          result.tokenType(),
+          result.expiresAt(),
+          result.refreshExpiresAt(),
+          result.userId());
+    }
+  }
+
+  private record ErrorResponse(String status, String message) {}
+}

--- a/back/src/main/resources/db/migration/V28__add_auth_external_identity.sql
+++ b/back/src/main/resources/db/migration/V28__add_auth_external_identity.sql
@@ -1,0 +1,14 @@
+CREATE TABLE auth_external_identity (
+    provider_id VARCHAR(64) NOT NULL,
+    subject VARCHAR(255) NOT NULL,
+    user_id BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (provider_id, subject),
+    CONSTRAINT uq_auth_external_identity_provider_user UNIQUE (provider_id, user_id),
+    CONSTRAINT fk_auth_external_identity_user
+        FOREIGN KEY (user_id) REFERENCES bank_user (id)
+);
+
+CREATE INDEX idx_auth_external_identity_user
+    ON auth_external_identity (user_id);

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/ExternalOidcLoginServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/ExternalOidcLoginServiceTest.java
@@ -1,0 +1,204 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.AuthSessionClientMetadata;
+import com.aquilabank.domain.auth.model.ExternalOidcLoginCommand;
+import com.aquilabank.domain.auth.model.IssuedAccessToken;
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.model.LoginResultStatus;
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
+import com.aquilabank.domain.auth.port.ExternalIdentityUserLoadPort;
+import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
+import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
+import com.aquilabank.domain.auth.port.RefreshDeviceBindingSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ExternalOidcLoginServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-21T00:00:00Z");
+  private static final AuthSessionClientMetadata SESSION_CLIENT_METADATA =
+      new AuthSessionClientMetadata("macOS / Safari", "203.0.113.20");
+
+  @Test
+  void issuesInternalTokenPairForLinkedActiveIdentity() {
+    ExternalIdentityUserLoadPort externalIdentityUserLoadPort =
+        Mockito.mock(ExternalIdentityUserLoadPort.class);
+    LoginAttemptUpdatePort loginAttemptUpdatePort = Mockito.mock(LoginAttemptUpdatePort.class);
+    LoginAttemptAuditPort loginAttemptAuditPort = Mockito.mock(LoginAttemptAuditPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort =
+        Mockito.mock(RefreshDeviceBindingSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(externalIdentityUserLoadPort.findByProviderIdAndSubjectForUpdate(
+            "google", "oidc-subject-1"))
+        .thenReturn(
+            Optional.of(
+                new LoginUser(
+                    7L, "alice", "hash", UserStatus.ACTIVE, 2, NOW.minusSeconds(60), null, null)));
+    when(refreshTokenSecretPort.createToken()).thenReturn("refresh-token");
+    when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("refresh-hash");
+    when(refreshDeviceBindingSecretPort.createToken()).thenReturn("binding-token");
+    when(refreshDeviceBindingSecretPort.hash("binding-token")).thenReturn("binding-hash");
+    when(refreshTokenSessionWritePort.create(
+            argThat(
+                command ->
+                    command.userId() == 7L
+                        && "refresh-hash".equals(command.tokenHash())
+                        && "binding-hash".equals(command.deviceBindingHash())
+                        && NOW.plus(Duration.ofDays(14)).equals(command.expiresAt())
+                        && SESSION_CLIENT_METADATA.equals(command.sessionClientMetadata()))))
+        .thenReturn(31L);
+    when(authTokenIssuePort.issue(7L, "alice", 31L, NOW))
+        .thenReturn(new IssuedAccessToken("access-token", "Bearer", NOW.plusSeconds(900), 7L));
+
+    ExternalOidcLoginService service =
+        new ExternalOidcLoginService(
+            externalIdentityUserLoadPort,
+            loginAttemptUpdatePort,
+            loginAttemptAuditPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            refreshDeviceBindingSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    LoginResult result =
+        service.login(
+            new ExternalOidcLoginCommand("google", "oidc-subject-1", SESSION_CLIENT_METADATA));
+
+    assertThat(result.status()).isEqualTo(LoginResultStatus.SUCCESS);
+    assertThat(result.accessToken()).isEqualTo("access-token");
+    assertThat(result.refreshToken()).isEqualTo("refresh-token");
+    assertThat(result.refreshDeviceBindingToken()).isEqualTo("binding-token");
+    assertThat(result.userId()).isEqualTo(7L);
+    verify(loginAttemptUpdatePort)
+        .recordLoginSuccess(
+            argThat(command -> command.userId() == 7L && NOW.equals(command.succeededAt())));
+    verify(loginAttemptAuditPort)
+        .logReset(
+            argThat(
+                entry ->
+                    "alice".equals(entry.loginId())
+                        && entry.userId() == 7L
+                        && entry.previousFailureCount() == 2));
+  }
+
+  @Test
+  void rejectsUnlinkedIdentityWithoutIssuingTokens() {
+    ExternalIdentityUserLoadPort externalIdentityUserLoadPort =
+        Mockito.mock(ExternalIdentityUserLoadPort.class);
+    LoginAttemptUpdatePort loginAttemptUpdatePort = Mockito.mock(LoginAttemptUpdatePort.class);
+    LoginAttemptAuditPort loginAttemptAuditPort = Mockito.mock(LoginAttemptAuditPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort =
+        Mockito.mock(RefreshDeviceBindingSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(externalIdentityUserLoadPort.findByProviderIdAndSubjectForUpdate(
+            "google", "unknown-subject"))
+        .thenReturn(Optional.empty());
+
+    ExternalOidcLoginService service =
+        new ExternalOidcLoginService(
+            externalIdentityUserLoadPort,
+            loginAttemptUpdatePort,
+            loginAttemptAuditPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            refreshDeviceBindingSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () ->
+            service.login(
+                new ExternalOidcLoginCommand(
+                    "google", "unknown-subject", SESSION_CLIENT_METADATA)));
+
+    verify(externalIdentityUserLoadPort)
+        .findByProviderIdAndSubjectForUpdate("google", "unknown-subject");
+    verifyNoInteractions(
+        loginAttemptUpdatePort,
+        loginAttemptAuditPort,
+        refreshTokenSessionWritePort,
+        refreshTokenSecretPort,
+        refreshDeviceBindingSecretPort,
+        authTokenIssuePort);
+  }
+
+  @Test
+  void rejectsInactiveOrTemporarilyLockedUser() {
+    ExternalIdentityUserLoadPort externalIdentityUserLoadPort =
+        Mockito.mock(ExternalIdentityUserLoadPort.class);
+    LoginAttemptUpdatePort loginAttemptUpdatePort = Mockito.mock(LoginAttemptUpdatePort.class);
+    LoginAttemptAuditPort loginAttemptAuditPort = Mockito.mock(LoginAttemptAuditPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort =
+        Mockito.mock(RefreshDeviceBindingSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(externalIdentityUserLoadPort.findByProviderIdAndSubjectForUpdate(
+            "google", "locked-subject"))
+        .thenReturn(
+            Optional.of(
+                new LoginUser(
+                    8L,
+                    "locked-user",
+                    "hash",
+                    UserStatus.ACTIVE,
+                    5,
+                    NOW.minusSeconds(30),
+                    NOW.plusSeconds(300),
+                    null)));
+
+    ExternalOidcLoginService service =
+        new ExternalOidcLoginService(
+            externalIdentityUserLoadPort,
+            loginAttemptUpdatePort,
+            loginAttemptAuditPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            refreshDeviceBindingSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () ->
+            service.login(
+                new ExternalOidcLoginCommand("google", "locked-subject", SESSION_CLIENT_METADATA)));
+
+    verify(loginAttemptUpdatePort, never()).recordLoginSuccess(Mockito.any());
+    verifyNoInteractions(refreshTokenSessionWritePort, refreshTokenSecretPort, authTokenIssuePort);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthExternalIdentityRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthExternalIdentityRepositoryIntegrationTest.java
@@ -1,0 +1,122 @@
+package com.aquilabank.global.persistence.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.auth.model.LoginUser;
+import com.aquilabank.domain.auth.model.UserStatus;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcAuthExternalIdentityRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcAuthRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void findsUserByProviderAndSubjectForUpdate() {
+    long[] userId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("alice", "ACTIVE");
+          insertExternalIdentity(userId[0], "google", "google-subject-1");
+        });
+
+    Optional<LoginUser> result =
+        repository.findByProviderIdAndSubjectForUpdate("google", "google-subject-1");
+
+    assertThat(result).isPresent();
+    assertThat(result.get().userId()).isEqualTo(userId[0]);
+    assertThat(result.get().loginId()).isEqualTo("alice");
+    assertThat(result.get().status()).isEqualTo(UserStatus.ACTIVE);
+  }
+
+  @Test
+  void returnsEmptyForUnlinkedSubject() {
+    commit(
+        transactionManager,
+        () -> {
+          long userId = insertUser("alice", "ACTIVE");
+          insertExternalIdentity(userId, "google", "google-subject-1");
+        });
+
+    Optional<LoginUser> result =
+        repository.findByProviderIdAndSubjectForUpdate("google", "unknown-subject");
+
+    assertThat(result).isEmpty();
+  }
+
+  private long insertUser(String loginId, String userStatus) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                :userStatus,
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("loginId", loginId)
+                .addValue("userStatus", userStatus),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private void insertExternalIdentity(long userId, String providerId, String subject) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO auth_external_identity (
+            provider_id,
+            subject,
+            user_id,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :providerId,
+            :subject,
+            :userId,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("providerId", providerId)
+            .addValue("subject", subject)
+            .addValue("userId", userId));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/security/OidcLoginSecurityIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/OidcLoginSecurityIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.aquilabank.global.security;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      "spring.security.oauth2.client.registration.google.provider=google",
+      "spring.security.oauth2.client.registration.google.client-id=test-client",
+      "spring.security.oauth2.client.registration.google.client-secret=test-secret",
+      "spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code",
+      "spring.security.oauth2.client.registration.google.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}",
+      "spring.security.oauth2.client.registration.google.scope=openid",
+      "spring.security.oauth2.client.provider.google.authorization-uri=https://idp.example/oauth2/v1/authorize",
+      "spring.security.oauth2.client.provider.google.token-uri=https://idp.example/oauth2/v1/token",
+      "spring.security.oauth2.client.provider.google.jwk-set-uri=https://idp.example/oauth2/v1/keys",
+      "spring.security.oauth2.client.provider.google.user-info-uri=https://idp.example/oauth2/v1/userinfo",
+      "spring.security.oauth2.client.provider.google.user-name-attribute=sub"
+    })
+class OidcLoginSecurityIntegrationTest {
+
+  @Autowired private WebApplicationContext context;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUpMockMvc() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void redirectsAuthorizationRequestToConfiguredOidcProvider() throws Exception {
+    mockMvc
+        .perform(get("/oauth2/authorization/google"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(
+            header().string("Location", containsString("https://idp.example/oauth2/v1/authorize")));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/OidcLoginAuthenticationSuccessHandlerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/OidcLoginAuthenticationSuccessHandlerTest.java
@@ -1,0 +1,97 @@
+package com.aquilabank.global.web.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.model.AuthSessionClientMetadata;
+import com.aquilabank.domain.auth.model.ExternalOidcLoginCommand;
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.domain.auth.usecase.ExternalOidcLoginUseCase;
+import com.aquilabank.global.security.SecurityJwtProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+class OidcLoginAuthenticationSuccessHandlerTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
+
+  @Test
+  void exchangesOidcSubjectForInternalTokenResponse() throws Exception {
+    ExternalOidcLoginUseCase externalOidcLoginUseCase = mock(ExternalOidcLoginUseCase.class);
+    AuthSessionMetadataResolver authSessionMetadataResolver =
+        mock(AuthSessionMetadataResolver.class);
+    RefreshDeviceBindingCookieManager refreshDeviceBindingCookieManager =
+        new RefreshDeviceBindingCookieManager(
+            new SecurityJwtProperties("secret", "issuer", 900L, 1_209_600L, "ab_refresh_device"));
+    OidcLoginAuthenticationSuccessHandler handler =
+        new OidcLoginAuthenticationSuccessHandler(
+            externalOidcLoginUseCase,
+            authSessionMetadataResolver,
+            refreshDeviceBindingCookieManager,
+            OBJECT_MAPPER);
+    AuthSessionClientMetadata metadata =
+        new AuthSessionClientMetadata("macOS / Safari", "203.0.113.20");
+    when(authSessionMetadataResolver.resolve(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(metadata);
+    when(externalOidcLoginUseCase.login(
+            argThat(
+                (ExternalOidcLoginCommand command) ->
+                    "google".equals(command.providerId())
+                        && "oidc-subject-1".equals(command.subject())
+                        && metadata.equals(command.sessionClientMetadata()))))
+        .thenReturn(
+            LoginResult.success(
+                "access-token",
+                "refresh-token",
+                "Bearer",
+                Instant.parse("2026-04-21T00:15:00Z"),
+                Instant.parse("2026-05-05T00:00:00Z"),
+                7L,
+                "binding-token",
+                null));
+
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/login/oauth2/code/google");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    handler.onAuthenticationSuccess(request, response, authentication("google", "oidc-subject-1"));
+
+    JsonNode body = OBJECT_MAPPER.readTree(response.getContentAsString());
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getContentType()).isEqualTo("application/json");
+    assertThat(body.get("status").asText()).isEqualTo("SUCCESS");
+    assertThat(body.get("accessToken").asText()).isEqualTo("access-token");
+    assertThat(body.get("refreshToken").asText()).isEqualTo("refresh-token");
+    assertThat(response.getHeader("Set-Cookie")).contains("ab_refresh_device=binding-token");
+    verify(externalOidcLoginUseCase)
+        .login(
+            argThat(
+                command ->
+                    "google".equals(command.providerId())
+                        && "oidc-subject-1".equals(command.subject())));
+  }
+
+  private OAuth2AuthenticationToken authentication(String registrationId, String subject) {
+    OidcIdToken idToken =
+        new OidcIdToken(
+            "id-token",
+            Instant.parse("2026-04-21T00:00:00Z"),
+            Instant.parse("2026-04-21T00:05:00Z"),
+            Map.of("sub", subject));
+    OidcUser user = new DefaultOidcUser(List.of(new SimpleGrantedAuthority("ROLE_USER")), idToken);
+    return new OAuth2AuthenticationToken(user, user.getAuthorities(), registrationId);
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #166

## 🌿 Base Branch
- main

## 📝 Summary
- 외부 IdP/OIDC 인증 성공 후 내부 JWT access token과 refresh token session을 발급하는 backend 연동 경로를 추가한다.
- 자동 프로비저닝 없이 auth_external_identity exact mapping이 있는 기존 사용자만 내부 세션으로 교환한다.

## 🛠 Changes
- auth_external_identity 매핑 테이블과 provider_id + subject 기반 user lookup 추가
- ExternalOidcLoginUseCase로 기존 refresh session/device binding/JWT 발급 규칙 재사용
- spring-boot-starter-oauth2-client 의존성 및 OAuth2 login success handler 추가
- /oauth2/authorization/**, /login/oauth2/code/** public 경로와 OIDC authorization state용 session 정책 반영
- domain/JDBC/web/security 테스트 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*ExternalOidc*'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*Oidc*'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back check`
- `git rev-list --count main..HEAD` => `2`

## 📸 Screenshot / API Example
- UI 변경 없음
- OIDC callback 성공 응답 예시:
```json
{
  "status": "SUCCESS",
  "accessToken": "<jwt>",
  "refreshToken": "<refresh-token>",
  "tokenType": "Bearer",
  "expiresAt": "2026-04-21T00:15:00Z",
  "refreshExpiresAt": "2026-05-05T00:00:00Z",
  "userId": 7
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: OAuth2 authorization state 보존을 위해 OIDC login flow에서만 session 사용이 생긴다. API bearer JWT 인증 경로는 기존대로 유지한다.
- 예상 리스크: 운영 IdP client 설정이 없으면 OAuth2 login filter는 활성화되지 않는다.
- 롤백 방법: PR revert 후 V28 migration 적용 전 환경은 코드 revert만, 적용 후 환경은 auth_external_identity 미사용 상태에서 revert migration 정책에 따라 테이블 제거를 별도 운영 승인으로 진행한다.

## ☑️ Checklist
- [x] base branch가 main인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?