### PR TITLE
[Feat] 외부 identity 매핑 internal admin API 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/exception/DuplicateExternalIdentityMappingException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/DuplicateExternalIdentityMappingException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.exception;
+
+/** 같은 provider subject 또는 provider user 매핑 중복을 막습니다. */
+public class DuplicateExternalIdentityMappingException extends RuntimeException {
+
+  public DuplicateExternalIdentityMappingException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/exception/ExternalIdentityAuditNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/ExternalIdentityAuditNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.exception;
+
+/** requestId 기준 external identity 감사 row가 없을 때 사용합니다. */
+public class ExternalIdentityAuditNotFoundException extends RuntimeException {
+
+  public ExternalIdentityAuditNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/exception/ExternalIdentityMappingNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/exception/ExternalIdentityMappingNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.exception;
+
+/** 삭제 대상 external identity 매핑이 없을 때 사용합니다. */
+public class ExternalIdentityMappingNotFoundException extends RuntimeException {
+
+  public ExternalIdentityMappingNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityAuditSummary.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityAuditSummary.java
@@ -1,0 +1,54 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** external identity 변경 감사 row를 requestId exact lookup으로 반환합니다. */
+public record ExternalIdentityAuditSummary(
+    String requestId,
+    String actorSubject,
+    ExternalIdentityChangeType changeType,
+    long userId,
+    String providerId,
+    String subjectHash,
+    AuthStatusChangeReason normalizedReason,
+    AuthStatusChangeOutcome outcome,
+    Instant createdAt) {
+
+  public ExternalIdentityAuditSummary {
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (changeType == null) {
+      throw new IllegalArgumentException("changeType is required");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (providerId == null || providerId.isBlank()) {
+      throw new IllegalArgumentException("providerId is required");
+    }
+    if (subjectHash == null || subjectHash.isBlank()) {
+      throw new IllegalArgumentException("subjectHash is required");
+    }
+    if (normalizedReason == null) {
+      throw new IllegalArgumentException("reason is required");
+    }
+    if (outcome == null) {
+      throw new IllegalArgumentException("outcome is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+
+  public AuthStatusChangeReasonCode reasonCode() {
+    return normalizedReason.reasonCode();
+  }
+
+  public String reasonDetail() {
+    return normalizedReason.reasonDetail();
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityChangeType.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityChangeType.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.auth.model;
+
+/** external identity 매핑 변경 종류입니다. */
+public enum ExternalIdentityChangeType {
+  LINK,
+  UNLINK
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityLinkCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityLinkCommand.java
@@ -1,0 +1,16 @@
+package com.aquilabank.domain.auth.model;
+
+/** internal admin이 외부 identity를 기존 user에 연결할 때 쓰는 command입니다. */
+public record ExternalIdentityLinkCommand(
+    long userId,
+    String providerId,
+    String subject,
+    AuthStatusChangeReason normalizedReason,
+    String actorSubject,
+    String requestId) {
+
+  public ExternalIdentityLinkCommand {
+    ExternalIdentityMappingValidator.validate(
+        userId, providerId, subject, normalizedReason, actorSubject, requestId);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityMapping.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityMapping.java
@@ -1,0 +1,32 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 외부 provider subject와 내부 user 연결 결과입니다. */
+public record ExternalIdentityMapping(
+    long userId, String providerId, String subject, Instant createdAt, Instant updatedAt) {
+
+  public ExternalIdentityMapping {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (providerId == null || providerId.isBlank()) {
+      throw new IllegalArgumentException("providerId is required");
+    }
+    if (providerId.length() > 64) {
+      throw new IllegalArgumentException("providerId must be 64 characters or less");
+    }
+    if (subject == null || subject.isBlank()) {
+      throw new IllegalArgumentException("subject is required");
+    }
+    if (subject.length() > 255) {
+      throw new IllegalArgumentException("subject must be 255 characters or less");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+    if (updatedAt == null) {
+      throw new IllegalArgumentException("updatedAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityMappingValidator.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityMappingValidator.java
@@ -1,0 +1,42 @@
+package com.aquilabank.domain.auth.model;
+
+final class ExternalIdentityMappingValidator {
+
+  private ExternalIdentityMappingValidator() {}
+
+  static void validate(
+      long userId,
+      String providerId,
+      String subject,
+      AuthStatusChangeReason normalizedReason,
+      String actorSubject,
+      String requestId) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (providerId == null || providerId.isBlank()) {
+      throw new IllegalArgumentException("providerId is required");
+    }
+    if (providerId.length() > 64) {
+      throw new IllegalArgumentException("providerId must be 64 characters or less");
+    }
+    if (subject == null || subject.isBlank()) {
+      throw new IllegalArgumentException("subject is required");
+    }
+    if (subject.length() > 255) {
+      throw new IllegalArgumentException("subject must be 255 characters or less");
+    }
+    if (normalizedReason == null) {
+      throw new IllegalArgumentException("reason is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (requestId.length() > 64) {
+      throw new IllegalArgumentException("requestId must be 64 characters or less");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityUnlinkCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/ExternalIdentityUnlinkCommand.java
@@ -1,0 +1,16 @@
+package com.aquilabank.domain.auth.model;
+
+/** internal admin이 외부 identity 연결을 해제할 때 쓰는 command입니다. */
+public record ExternalIdentityUnlinkCommand(
+    long userId,
+    String providerId,
+    String subject,
+    AuthStatusChangeReason normalizedReason,
+    String actorSubject,
+    String requestId) {
+
+  public ExternalIdentityUnlinkCommand {
+    ExternalIdentityMappingValidator.validate(
+        userId, providerId, subject, normalizedReason, actorSubject, requestId);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/ExternalIdentityAuditQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/ExternalIdentityAuditQueryPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.ExternalIdentityAuditSummary;
+import java.util.Optional;
+
+/** external identity 감사 row requestId exact lookup port입니다. */
+public interface ExternalIdentityAuditQueryPort {
+
+  Optional<ExternalIdentityAuditSummary> findByRequestId(String requestId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/ExternalIdentityMappingWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/ExternalIdentityMappingWritePort.java
@@ -1,0 +1,13 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.ExternalIdentityLinkCommand;
+import com.aquilabank.domain.auth.model.ExternalIdentityMapping;
+import com.aquilabank.domain.auth.model.ExternalIdentityUnlinkCommand;
+
+/** external identity 매핑 변경과 감사 기록을 같은 저장소 경로로 처리합니다. */
+public interface ExternalIdentityMappingWritePort {
+
+  ExternalIdentityMapping link(ExternalIdentityLinkCommand command);
+
+  ExternalIdentityMapping unlink(ExternalIdentityUnlinkCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityAuditQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityAuditQueryService.java
@@ -1,0 +1,27 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.ExternalIdentityAuditNotFoundException;
+import com.aquilabank.domain.auth.model.ExternalIdentityAuditSummary;
+import com.aquilabank.domain.auth.port.ExternalIdentityAuditQueryPort;
+
+public final class ExternalIdentityAuditQueryService implements ExternalIdentityAuditQueryUseCase {
+
+  private final ExternalIdentityAuditQueryPort externalIdentityAuditQueryPort;
+
+  public ExternalIdentityAuditQueryService(
+      ExternalIdentityAuditQueryPort externalIdentityAuditQueryPort) {
+    this.externalIdentityAuditQueryPort = externalIdentityAuditQueryPort;
+  }
+
+  @Override
+  public ExternalIdentityAuditSummary getByRequestId(String requestId) {
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    return externalIdentityAuditQueryPort
+        .findByRequestId(requestId)
+        .orElseThrow(
+            () ->
+                new ExternalIdentityAuditNotFoundException("external identity audit is not found"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityAuditQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityAuditQueryUseCase.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.ExternalIdentityAuditSummary;
+
+public interface ExternalIdentityAuditQueryUseCase {
+
+  ExternalIdentityAuditSummary getByRequestId(String requestId);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityMappingAdminService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityMappingAdminService.java
@@ -1,0 +1,33 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.ExternalIdentityLinkCommand;
+import com.aquilabank.domain.auth.model.ExternalIdentityMapping;
+import com.aquilabank.domain.auth.model.ExternalIdentityUnlinkCommand;
+import com.aquilabank.domain.auth.port.ExternalIdentityMappingWritePort;
+
+public final class ExternalIdentityMappingAdminService
+    implements ExternalIdentityMappingLinkUseCase, ExternalIdentityMappingUnlinkUseCase {
+
+  private final ExternalIdentityMappingWritePort externalIdentityMappingWritePort;
+
+  public ExternalIdentityMappingAdminService(
+      ExternalIdentityMappingWritePort externalIdentityMappingWritePort) {
+    this.externalIdentityMappingWritePort = externalIdentityMappingWritePort;
+  }
+
+  @Override
+  public ExternalIdentityMapping link(ExternalIdentityLinkCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+    return externalIdentityMappingWritePort.link(command);
+  }
+
+  @Override
+  public ExternalIdentityMapping unlink(ExternalIdentityUnlinkCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+    return externalIdentityMappingWritePort.unlink(command);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityMappingLinkUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityMappingLinkUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.ExternalIdentityLinkCommand;
+import com.aquilabank.domain.auth.model.ExternalIdentityMapping;
+
+public interface ExternalIdentityMappingLinkUseCase {
+
+  ExternalIdentityMapping link(ExternalIdentityLinkCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityMappingUnlinkUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/ExternalIdentityMappingUnlinkUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.ExternalIdentityMapping;
+import com.aquilabank.domain.auth.model.ExternalIdentityUnlinkCommand;
+
+public interface ExternalIdentityMappingUnlinkUseCase {
+
+  ExternalIdentityMapping unlink(ExternalIdentityUnlinkCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -13,6 +13,8 @@ import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
 import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
 import com.aquilabank.domain.auth.port.BackupCodeWritePort;
+import com.aquilabank.domain.auth.port.ExternalIdentityAuditQueryPort;
+import com.aquilabank.domain.auth.port.ExternalIdentityMappingWritePort;
 import com.aquilabank.domain.auth.port.ExternalIdentityUserLoadPort;
 import com.aquilabank.domain.auth.port.LoginAttemptAuditPort;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
@@ -56,6 +58,9 @@ import com.aquilabank.domain.auth.usecase.BackupCodeChallengeVerifyService;
 import com.aquilabank.domain.auth.usecase.BackupCodeChallengeVerifyUseCase;
 import com.aquilabank.domain.auth.usecase.BackupCodeGenerateService;
 import com.aquilabank.domain.auth.usecase.BackupCodeGenerateUseCase;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityAuditQueryService;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityAuditQueryUseCase;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityMappingAdminService;
 import com.aquilabank.domain.auth.usecase.ExternalOidcLoginService;
 import com.aquilabank.domain.auth.usecase.ExternalOidcLoginUseCase;
 import com.aquilabank.domain.auth.usecase.LoginService;
@@ -705,6 +710,18 @@ public class AuthConfiguration {
   AuthStatusChangeAuditQueryUseCase authStatusChangeAuditQueryUseCase(
       AuthStatusChangeAuditQueryPort authStatusChangeAuditQueryPort) {
     return new AuthStatusChangeAuditQueryService(authStatusChangeAuditQueryPort);
+  }
+
+  @Bean
+  ExternalIdentityMappingAdminService externalIdentityMappingAdminService(
+      ExternalIdentityMappingWritePort externalIdentityMappingWritePort) {
+    return new ExternalIdentityMappingAdminService(externalIdentityMappingWritePort);
+  }
+
+  @Bean
+  ExternalIdentityAuditQueryUseCase externalIdentityAuditQueryUseCase(
+      ExternalIdentityAuditQueryPort externalIdentityAuditQueryPort) {
+    return new ExternalIdentityAuditQueryService(externalIdentityAuditQueryPort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -1,7 +1,9 @@
 package com.aquilabank.global.persistence.auth;
 
 import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
+import com.aquilabank.domain.auth.exception.DuplicateExternalIdentityMappingException;
 import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
+import com.aquilabank.domain.auth.exception.ExternalIdentityMappingNotFoundException;
 import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditEntry;
 import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
@@ -9,6 +11,10 @@ import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
 import com.aquilabank.domain.auth.model.BackupCodeIssueCommand;
 import com.aquilabank.domain.auth.model.BackupCodeUseCommand;
+import com.aquilabank.domain.auth.model.ExternalIdentityChangeType;
+import com.aquilabank.domain.auth.model.ExternalIdentityLinkCommand;
+import com.aquilabank.domain.auth.model.ExternalIdentityMapping;
+import com.aquilabank.domain.auth.model.ExternalIdentityUnlinkCommand;
 import com.aquilabank.domain.auth.model.LoginFailureUpdateCommand;
 import com.aquilabank.domain.auth.model.LoginSuccessUpdateCommand;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenIssueCommand;
@@ -34,6 +40,7 @@ import com.aquilabank.domain.auth.model.UserBootstrapWriteCommand;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
 import com.aquilabank.domain.auth.port.BackupCodeWritePort;
+import com.aquilabank.domain.auth.port.ExternalIdentityMappingWritePort;
 import com.aquilabank.domain.auth.port.LoginAttemptUpdatePort;
 import com.aquilabank.domain.auth.port.PasswordRecoveryTokenWritePort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionCleanupPort;
@@ -46,10 +53,14 @@ import com.aquilabank.domain.auth.port.UserAccountMembershipUpsertPort;
 import com.aquilabank.domain.auth.port.UserBootstrapPort;
 import com.aquilabank.domain.auth.port.UserCredentialUpdatePort;
 import com.aquilabank.domain.auth.port.UserStatusUpdatePort;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.HexFormat;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -70,6 +81,7 @@ public class JdbcAuthWriteRepository
         TotpCredentialWritePort,
         TotpLoginChallengeWritePort,
         UserAccountMembershipUpsertPort,
+        ExternalIdentityMappingWritePort,
         UserStatusUpdatePort,
         UserAccountMembershipStatusUpdatePort {
 
@@ -77,6 +89,70 @@ public class JdbcAuthWriteRepository
 
   public JdbcAuthWriteRepository(NamedParameterJdbcTemplate jdbcTemplate) {
     this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional
+  public ExternalIdentityMapping link(ExternalIdentityLinkCommand command) {
+    assertUserExists(command.userId());
+    Instant now = Instant.now();
+    try {
+      ExternalIdentityMapping mapping =
+          jdbcTemplate
+              .query(
+                  """
+                  INSERT INTO auth_external_identity (
+                      provider_id,
+                      subject,
+                      user_id,
+                      created_at,
+                      updated_at
+                  )
+                  VALUES (
+                      :providerId,
+                      :subject,
+                      :userId,
+                      :now,
+                      :now
+                  )
+                  RETURNING user_id, provider_id, subject, created_at, updated_at
+                  """,
+                  new MapSqlParameterSource()
+                      .addValue("providerId", command.providerId())
+                      .addValue("subject", command.subject())
+                      .addValue("userId", command.userId())
+                      .addValue("now", Timestamp.from(now)),
+                  (rs, rowNum) -> mapExternalIdentityMapping(rs))
+              .stream()
+              .findFirst()
+              .orElseThrow(
+                  () -> new IllegalStateException("external identity insert returned null"));
+      insertExternalIdentityAudit(command, ExternalIdentityChangeType.LINK, now);
+      return mapping;
+    } catch (DuplicateKeyException ex) {
+      throw new DuplicateExternalIdentityMappingException(
+          "external identity mapping already exists");
+    }
+  }
+
+  @Override
+  @Transactional
+  public ExternalIdentityMapping unlink(ExternalIdentityUnlinkCommand command) {
+    ExternalIdentityMapping mapping = loadExternalIdentityMappingForUpdate(command);
+    int updated =
+        jdbcTemplate.update(
+            """
+            DELETE FROM auth_external_identity
+            WHERE user_id = :userId
+              AND provider_id = :providerId
+              AND subject = :subject
+            """,
+            externalIdentityParams(command));
+    if (updated != 1) {
+      throw new ExternalIdentityMappingNotFoundException("external identity mapping is not found");
+    }
+    insertExternalIdentityAudit(command, ExternalIdentityChangeType.UNLINK, Instant.now());
+    return mapping;
   }
 
   @Override
@@ -1019,6 +1095,131 @@ public class JdbcAuthWriteRepository
             .addValue("createdAt", Timestamp.from(entry.createdAt())));
   }
 
+  private ExternalIdentityMapping loadExternalIdentityMappingForUpdate(
+      ExternalIdentityUnlinkCommand command) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT user_id, provider_id, subject, created_at, updated_at
+            FROM auth_external_identity
+            WHERE user_id = :userId
+              AND provider_id = :providerId
+              AND subject = :subject
+            FOR UPDATE
+            """,
+            externalIdentityParams(command),
+            (rs, rowNum) -> mapExternalIdentityMapping(rs))
+        .stream()
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new ExternalIdentityMappingNotFoundException(
+                    "external identity mapping is not found"));
+  }
+
+  private void insertExternalIdentityAudit(
+      ExternalIdentityLinkCommand command, ExternalIdentityChangeType changeType, Instant now) {
+    insertExternalIdentityAudit(
+        command.userId(),
+        command.providerId(),
+        command.subject(),
+        command.requestId(),
+        command.actorSubject(),
+        command.normalizedReason().reasonCode().name(),
+        command.normalizedReason().reasonDetail(),
+        changeType,
+        now);
+  }
+
+  private void insertExternalIdentityAudit(
+      ExternalIdentityUnlinkCommand command, ExternalIdentityChangeType changeType, Instant now) {
+    insertExternalIdentityAudit(
+        command.userId(),
+        command.providerId(),
+        command.subject(),
+        command.requestId(),
+        command.actorSubject(),
+        command.normalizedReason().reasonCode().name(),
+        command.normalizedReason().reasonDetail(),
+        changeType,
+        now);
+  }
+
+  private void insertExternalIdentityAudit(
+      long userId,
+      String providerId,
+      String subject,
+      String requestId,
+      String actorSubject,
+      String reasonCode,
+      String reason,
+      ExternalIdentityChangeType changeType,
+      Instant now) {
+    // raw OIDC subject는 장기 식별자라 감사 row에는 hash만 남깁니다.
+    jdbcTemplate.update(
+        """
+        INSERT INTO auth_external_identity_audit (
+            request_id,
+            actor_subject,
+            change_type,
+            target_user_id,
+            provider_id,
+            subject_hash,
+            reason_code,
+            reason,
+            outcome,
+            created_at
+        )
+        VALUES (
+            :requestId,
+            :actorSubject,
+            :changeType,
+            :userId,
+            :providerId,
+            :subjectHash,
+            :reasonCode,
+            :reason,
+            'SUCCESS',
+            :createdAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("requestId", requestId)
+            .addValue("actorSubject", actorSubject)
+            .addValue("changeType", changeType.name())
+            .addValue("userId", userId)
+            .addValue("providerId", providerId)
+            .addValue("subjectHash", sha256(subject))
+            .addValue("reasonCode", reasonCode)
+            .addValue("reason", reason)
+            .addValue("createdAt", Timestamp.from(now)));
+  }
+
+  private MapSqlParameterSource externalIdentityParams(ExternalIdentityUnlinkCommand command) {
+    return new MapSqlParameterSource()
+        .addValue("userId", command.userId())
+        .addValue("providerId", command.providerId())
+        .addValue("subject", command.subject());
+  }
+
+  private ExternalIdentityMapping mapExternalIdentityMapping(ResultSet rs) throws SQLException {
+    return new ExternalIdentityMapping(
+        rs.getLong("user_id"),
+        rs.getString("provider_id"),
+        rs.getString("subject"),
+        toInstant(rs.getTimestamp("created_at")),
+        toInstant(rs.getTimestamp("updated_at")));
+  }
+
+  private String sha256(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+
   private void assertUserUpdated(int updated) {
     if (updated == 0) {
       throw new AuthUserNotFoundException("user is not found");
@@ -1027,6 +1228,10 @@ public class JdbcAuthWriteRepository
 
   private Timestamp toTimestamp(Instant value) {
     return value == null ? null : Timestamp.from(value);
+  }
+
+  private Instant toInstant(Timestamp value) {
+    return value == null ? null : value.toInstant();
   }
 
   private void assertUserExists(long userId) {

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcExternalIdentityAuditRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcExternalIdentityAuditRepository.java
@@ -1,0 +1,71 @@
+package com.aquilabank.global.persistence.auth;
+
+import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
+import com.aquilabank.domain.auth.model.ExternalIdentityAuditSummary;
+import com.aquilabank.domain.auth.model.ExternalIdentityChangeType;
+import com.aquilabank.domain.auth.port.ExternalIdentityAuditQueryPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Optional;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** external identity 감사 requestId exact lookup 전용 adapter입니다. */
+@Repository
+public class JdbcExternalIdentityAuditRepository implements ExternalIdentityAuditQueryPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcExternalIdentityAuditRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public Optional<ExternalIdentityAuditSummary> findByRequestId(String requestId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT request_id,
+                   actor_subject,
+                   change_type,
+                   target_user_id,
+                   provider_id,
+                   subject_hash,
+                   reason_code,
+                   reason,
+                   outcome,
+                   created_at
+            FROM auth_external_identity_audit
+            WHERE request_id = :requestId
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            new MapSqlParameterSource().addValue("requestId", requestId),
+            (rs, rowNum) -> mapAuditSummary(rs))
+        .stream()
+        .findFirst();
+  }
+
+  private ExternalIdentityAuditSummary mapAuditSummary(ResultSet rs) throws SQLException {
+    return new ExternalIdentityAuditSummary(
+        rs.getString("request_id"),
+        rs.getString("actor_subject"),
+        ExternalIdentityChangeType.valueOf(rs.getString("change_type")),
+        rs.getLong("target_user_id"),
+        rs.getString("provider_id"),
+        rs.getString("subject_hash"),
+        new AuthStatusChangeReason(
+            AuthStatusChangeReasonCode.valueOf(rs.getString("reason_code")),
+            rs.getString("reason")),
+        AuthStatusChangeOutcome.valueOf(rs.getString("outcome")),
+        toInstant(rs.getTimestamp("created_at")));
+  }
+
+  private Instant toInstant(java.sql.Timestamp value) {
+    return value == null ? null : value.toInstant();
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -5,7 +5,10 @@ import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
 import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
 import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
 import com.aquilabank.domain.auth.exception.AuthUserNotFoundException;
+import com.aquilabank.domain.auth.exception.DuplicateExternalIdentityMappingException;
 import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
+import com.aquilabank.domain.auth.exception.ExternalIdentityAuditNotFoundException;
+import com.aquilabank.domain.auth.exception.ExternalIdentityMappingNotFoundException;
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
 import com.aquilabank.domain.auth.exception.PasswordRecoveryTokenNotFoundException;
 import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
@@ -117,6 +120,8 @@ public class ApiExceptionHandler {
     TransferReversalNotFoundException.class,
     AuthStatusChangeAuditNotFoundException.class,
     AuthUserNotFoundException.class,
+    ExternalIdentityAuditNotFoundException.class,
+    ExternalIdentityMappingNotFoundException.class,
     PasswordRecoveryTokenNotFoundException.class,
     UserAccountMembershipNotFoundException.class,
     NotificationNotFoundException.class,
@@ -127,6 +132,7 @@ public class ApiExceptionHandler {
   }
 
   @ExceptionHandler({
+    DuplicateExternalIdentityMappingException.class,
     DuplicateLoginIdException.class,
     CommandConflictException.class,
     CurrencyMismatchException.class,

--- a/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthAdminController.java
@@ -4,12 +4,17 @@ import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReasonNormalizer;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.ExternalIdentityLinkCommand;
+import com.aquilabank.domain.auth.model.ExternalIdentityMapping;
+import com.aquilabank.domain.auth.model.ExternalIdentityUnlinkCommand;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenLookupView;
 import com.aquilabank.domain.auth.model.UserAccountMembershipStatusUpdateCommand;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.model.UserStatusUpdateCommand;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityMappingLinkUseCase;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityMappingUnlinkUseCase;
 import com.aquilabank.domain.auth.usecase.PasswordRecoveryTokenQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
@@ -27,8 +32,10 @@ import jakarta.validation.constraints.Size;
 import java.time.Instant;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,6 +54,8 @@ public class InternalAuthAdminController {
   private final UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase;
   private final UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase;
   private final PasswordRecoveryTokenQueryUseCase passwordRecoveryTokenQueryUseCase;
+  private final ExternalIdentityMappingLinkUseCase externalIdentityMappingLinkUseCase;
+  private final ExternalIdentityMappingUnlinkUseCase externalIdentityMappingUnlinkUseCase;
   private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
 
   public InternalAuthAdminController(
@@ -55,12 +64,16 @@ public class InternalAuthAdminController {
       UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase,
       UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase,
       PasswordRecoveryTokenQueryUseCase passwordRecoveryTokenQueryUseCase,
+      ExternalIdentityMappingLinkUseCase externalIdentityMappingLinkUseCase,
+      ExternalIdentityMappingUnlinkUseCase externalIdentityMappingUnlinkUseCase,
       InternalServiceRequestAuthorizer internalServiceRequestAuthorizer) {
     this.authUserQueryUseCase = authUserQueryUseCase;
     this.userStatusUpdateUseCase = userStatusUpdateUseCase;
     this.userAccountMembershipQueryUseCase = userAccountMembershipQueryUseCase;
     this.userAccountMembershipStatusUpdateUseCase = userAccountMembershipStatusUpdateUseCase;
     this.passwordRecoveryTokenQueryUseCase = passwordRecoveryTokenQueryUseCase;
+    this.externalIdentityMappingLinkUseCase = externalIdentityMappingLinkUseCase;
+    this.externalIdentityMappingUnlinkUseCase = externalIdentityMappingUnlinkUseCase;
     this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
   }
 
@@ -103,6 +116,44 @@ public class InternalAuthAdminController {
         httpServletRequest, InternalServiceScope.AUTH_ADMIN);
     return PasswordRecoveryTokenResponse.from(
         passwordRecoveryTokenQueryUseCase.getByHandoffRequestId(handoffRequestId));
+  }
+
+  @PostMapping("/users/{userId}/external-identities")
+  public ExternalIdentityMappingResponse linkExternalIdentity(
+      HttpServletRequest httpServletRequest,
+      @PathVariable @Positive(message = "userId must be positive") long userId,
+      @Valid @RequestBody ExternalIdentityMappingRequest request) {
+    InternalServiceTokenClaims claims =
+        internalServiceRequestAuthorizer.requireScope(
+            httpServletRequest, InternalServiceScope.AUTH_ADMIN);
+    return ExternalIdentityMappingResponse.from(
+        externalIdentityMappingLinkUseCase.link(
+            new ExternalIdentityLinkCommand(
+                userId,
+                request.providerId(),
+                request.subject(),
+                resolveReason(request.reasonCode(), request.reasonDetail(), null),
+                claims.subject(),
+                resolveRequestId(httpServletRequest))));
+  }
+
+  @DeleteMapping("/users/{userId}/external-identities")
+  public ExternalIdentityMappingResponse unlinkExternalIdentity(
+      HttpServletRequest httpServletRequest,
+      @PathVariable @Positive(message = "userId must be positive") long userId,
+      @Valid @RequestBody ExternalIdentityMappingRequest request) {
+    InternalServiceTokenClaims claims =
+        internalServiceRequestAuthorizer.requireScope(
+            httpServletRequest, InternalServiceScope.AUTH_ADMIN);
+    return ExternalIdentityMappingResponse.from(
+        externalIdentityMappingUnlinkUseCase.unlink(
+            new ExternalIdentityUnlinkCommand(
+                userId,
+                request.providerId(),
+                request.subject(),
+                resolveReason(request.reasonCode(), request.reasonDetail(), null),
+                claims.subject(),
+                resolveRequestId(httpServletRequest))));
   }
 
   @PutMapping("/users/{userId}/status")
@@ -168,6 +219,16 @@ public class InternalAuthAdminController {
               max = AuthStatusChangeReason.MAX_REASON_DETAIL_LENGTH,
               message = "reason must be 200 characters or less")
           String reason) {}
+
+  /** 내부 external identity 매핑 생성/삭제 요청 body */
+  public record ExternalIdentityMappingRequest(
+      @NotBlank(message = "providerId is required") @Size(max = 64, message = "providerId must be 64 characters or less") String providerId,
+      @NotBlank(message = "subject is required") @Size(max = 255, message = "subject must be 255 characters or less") String subject,
+      @NotNull(message = "reasonCode is required") AuthStatusChangeReasonCode reasonCode,
+      @NotBlank(message = "reasonDetail is required") @Size(
+              max = AuthStatusChangeReason.MAX_REASON_DETAIL_LENGTH,
+              message = "reasonDetail must be 200 characters or less")
+          String reasonDetail) {}
 
   private String resolveRequestId(HttpServletRequest httpServletRequest) {
     return RequestTraceContext.currentRequestId()
@@ -248,6 +309,20 @@ public class InternalAuthAdminController {
           view.expiresAt(),
           view.usedAt(),
           view.createdAt());
+    }
+  }
+
+  /** 내부 external identity 매핑 생성/삭제 응답 */
+  public record ExternalIdentityMappingResponse(
+      long userId, String providerId, String subject, Instant createdAt, Instant updatedAt) {
+
+    static ExternalIdentityMappingResponse from(ExternalIdentityMapping mapping) {
+      return new ExternalIdentityMappingResponse(
+          mapping.userId(),
+          mapping.providerId(),
+          mapping.subject(),
+          mapping.createdAt(),
+          mapping.updatedAt());
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthExternalIdentityAuditController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthExternalIdentityAuditController.java
@@ -1,0 +1,73 @@
+package com.aquilabank.global.web.auth;
+
+import com.aquilabank.domain.auth.model.ExternalIdentityAuditSummary;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityAuditQueryUseCase;
+import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
+import com.aquilabank.global.security.InternalServiceScope;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 내부 external identity 감사 requestId exact lookup만 노출합니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/auth/external-identity-audits")
+@ConditionalOnProperty(name = "security.auth-bootstrap-api.enabled", havingValue = "true")
+public class InternalAuthExternalIdentityAuditController {
+
+  private final ExternalIdentityAuditQueryUseCase externalIdentityAuditQueryUseCase;
+  private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
+
+  public InternalAuthExternalIdentityAuditController(
+      ExternalIdentityAuditQueryUseCase externalIdentityAuditQueryUseCase,
+      InternalServiceRequestAuthorizer internalServiceRequestAuthorizer) {
+    this.externalIdentityAuditQueryUseCase = externalIdentityAuditQueryUseCase;
+    this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
+  }
+
+  @GetMapping("/by-request-id")
+  public ExternalIdentityAuditResponse getByRequestId(
+      HttpServletRequest httpServletRequest,
+      @RequestParam @NotBlank(message = "requestId is required") String requestId) {
+    internalServiceRequestAuthorizer.requireScope(
+        httpServletRequest, InternalServiceScope.AUTH_ADMIN);
+    return ExternalIdentityAuditResponse.from(
+        externalIdentityAuditQueryUseCase.getByRequestId(requestId));
+  }
+
+  /** 내부 external identity audit exact lookup 응답 */
+  public record ExternalIdentityAuditResponse(
+      String requestId,
+      String actorSubject,
+      String changeType,
+      long userId,
+      String providerId,
+      String subjectHash,
+      String reasonCode,
+      String reasonDetail,
+      String reason,
+      String outcome,
+      Instant createdAt) {
+
+    static ExternalIdentityAuditResponse from(ExternalIdentityAuditSummary summary) {
+      return new ExternalIdentityAuditResponse(
+          summary.requestId(),
+          summary.actorSubject(),
+          summary.changeType().name(),
+          summary.userId(),
+          summary.providerId(),
+          summary.subjectHash(),
+          summary.reasonCode().name(),
+          summary.reasonDetail(),
+          summary.reasonDetail(),
+          summary.outcome().name(),
+          summary.createdAt());
+    }
+  }
+}

--- a/back/src/main/resources/db/migration/V29__add_auth_external_identity_audit.sql
+++ b/back/src/main/resources/db/migration/V29__add_auth_external_identity_audit.sql
@@ -1,0 +1,24 @@
+CREATE TABLE auth_external_identity_audit (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    request_id VARCHAR(64) NOT NULL,
+    actor_subject VARCHAR(120) NOT NULL,
+    change_type VARCHAR(16) NOT NULL CHECK (change_type IN ('LINK', 'UNLINK')),
+    target_user_id BIGINT NOT NULL,
+    provider_id VARCHAR(64) NOT NULL,
+    subject_hash CHAR(64) NOT NULL,
+    reason_code VARCHAR(32) NOT NULL CHECK (reason_code IN (
+        'FRAUD_REVIEW',
+        'USER_REQUEST',
+        'OPS_MANUAL',
+        'ACCOUNT_CLOSURE',
+        'LEGACY_FREE_TEXT'
+    )),
+    reason VARCHAR(200) NOT NULL,
+    outcome VARCHAR(16) NOT NULL CHECK (outcome IN ('SUCCESS')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_auth_external_identity_audit_user
+        FOREIGN KEY (target_user_id) REFERENCES bank_user (id)
+);
+
+CREATE INDEX idx_auth_external_identity_audit_request_id
+    ON auth_external_identity_audit (request_id);

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/ExternalIdentityMappingAdminServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/ExternalIdentityMappingAdminServiceTest.java
@@ -1,0 +1,125 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.ExternalIdentityAuditNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
+import com.aquilabank.domain.auth.model.ExternalIdentityAuditSummary;
+import com.aquilabank.domain.auth.model.ExternalIdentityChangeType;
+import com.aquilabank.domain.auth.model.ExternalIdentityLinkCommand;
+import com.aquilabank.domain.auth.model.ExternalIdentityMapping;
+import com.aquilabank.domain.auth.model.ExternalIdentityUnlinkCommand;
+import com.aquilabank.domain.auth.port.ExternalIdentityAuditQueryPort;
+import com.aquilabank.domain.auth.port.ExternalIdentityMappingWritePort;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ExternalIdentityMappingAdminServiceTest {
+
+  private static final AuthStatusChangeReason REASON =
+      new AuthStatusChangeReason(AuthStatusChangeReasonCode.OPS_MANUAL, "ops-approved");
+
+  @Test
+  void linksExternalIdentityThroughWritePort() {
+    ExternalIdentityMappingWritePort writePort =
+        Mockito.mock(ExternalIdentityMappingWritePort.class);
+    ExternalIdentityMappingAdminService service =
+        new ExternalIdentityMappingAdminService(writePort);
+    ExternalIdentityMapping mapping =
+        new ExternalIdentityMapping(
+            21L,
+            "google",
+            "oidc-subject-1",
+            Instant.parse("2026-04-21T00:00:00Z"),
+            Instant.parse("2026-04-21T00:00:00Z"));
+    when(writePort.link(argThat(command -> command.userId() == 21L))).thenReturn(mapping);
+
+    ExternalIdentityMapping result =
+        service.link(
+            new ExternalIdentityLinkCommand(
+                21L, "google", "oidc-subject-1", REASON, "ops-admin", "request-001"));
+
+    assertThat(result).isEqualTo(mapping);
+    verify(writePort)
+        .link(
+            argThat(
+                command ->
+                    command.userId() == 21L
+                        && command.providerId().equals("google")
+                        && command.subject().equals("oidc-subject-1")
+                        && command.normalizedReason().reasonCode()
+                            == AuthStatusChangeReasonCode.OPS_MANUAL
+                        && command.actorSubject().equals("ops-admin")
+                        && command.requestId().equals("request-001")));
+  }
+
+  @Test
+  void unlinksExternalIdentityThroughWritePort() {
+    ExternalIdentityMappingWritePort writePort =
+        Mockito.mock(ExternalIdentityMappingWritePort.class);
+    ExternalIdentityMappingAdminService service =
+        new ExternalIdentityMappingAdminService(writePort);
+    ExternalIdentityMapping mapping =
+        new ExternalIdentityMapping(
+            21L,
+            "google",
+            "oidc-subject-1",
+            Instant.parse("2026-04-20T00:00:00Z"),
+            Instant.parse("2026-04-21T00:00:00Z"));
+    when(writePort.unlink(argThat(command -> command.userId() == 21L))).thenReturn(mapping);
+
+    ExternalIdentityMapping result =
+        service.unlink(
+            new ExternalIdentityUnlinkCommand(
+                21L, "google", "oidc-subject-1", REASON, "ops-admin", "request-002"));
+
+    assertThat(result).isEqualTo(mapping);
+    verify(writePort)
+        .unlink(
+            argThat(
+                command ->
+                    command.userId() == 21L
+                        && command.providerId().equals("google")
+                        && command.subject().equals("oidc-subject-1")
+                        && command.requestId().equals("request-002")));
+  }
+
+  @Test
+  void getsExternalIdentityAuditByRequestId() {
+    ExternalIdentityAuditQueryPort queryPort = Mockito.mock(ExternalIdentityAuditQueryPort.class);
+    ExternalIdentityAuditQueryService service = new ExternalIdentityAuditQueryService(queryPort);
+    ExternalIdentityAuditSummary summary =
+        new ExternalIdentityAuditSummary(
+            "request-001",
+            "ops-admin",
+            ExternalIdentityChangeType.LINK,
+            21L,
+            "google",
+            "subject-hash",
+            REASON,
+            AuthStatusChangeOutcome.SUCCESS,
+            Instant.parse("2026-04-21T00:00:00Z"));
+    when(queryPort.findByRequestId("request-001")).thenReturn(Optional.of(summary));
+
+    assertThat(service.getByRequestId("request-001")).isEqualTo(summary);
+  }
+
+  @Test
+  void rejectsMissingExternalIdentityAudit() {
+    ExternalIdentityAuditQueryPort queryPort = Mockito.mock(ExternalIdentityAuditQueryPort.class);
+    ExternalIdentityAuditQueryService service = new ExternalIdentityAuditQueryService(queryPort);
+    when(queryPort.findByRequestId("missing-request")).thenReturn(Optional.empty());
+
+    assertThrows(
+        ExternalIdentityAuditNotFoundException.class,
+        () -> service.getByRequestId("missing-request"));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthExternalIdentityAdminRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthExternalIdentityAdminRepositoryIntegrationTest.java
@@ -1,0 +1,190 @@
+package com.aquilabank.global.persistence.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.aquilabank.domain.auth.exception.DuplicateExternalIdentityMappingException;
+import com.aquilabank.domain.auth.exception.ExternalIdentityMappingNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
+import com.aquilabank.domain.auth.model.ExternalIdentityAuditSummary;
+import com.aquilabank.domain.auth.model.ExternalIdentityChangeType;
+import com.aquilabank.domain.auth.model.ExternalIdentityLinkCommand;
+import com.aquilabank.domain.auth.model.ExternalIdentityMapping;
+import com.aquilabank.domain.auth.model.ExternalIdentityUnlinkCommand;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcAuthExternalIdentityAdminRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  private static final AuthStatusChangeReason REASON =
+      new AuthStatusChangeReason(AuthStatusChangeReasonCode.OPS_MANUAL, "ops-approved");
+
+  @Autowired private JdbcAuthWriteRepository writeRepository;
+
+  @Autowired private JdbcExternalIdentityAuditRepository queryRepository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void linksExternalIdentityAndWritesAuditWithSubjectHash() {
+    long userId = insertUser("alice");
+
+    ExternalIdentityMapping mapping =
+        writeRepository.link(
+            new ExternalIdentityLinkCommand(
+                userId, "google", "oidc-subject-1", REASON, "ops-admin", "request-link-001"));
+
+    assertThat(mapping.userId()).isEqualTo(userId);
+    assertThat(mapping.providerId()).isEqualTo("google");
+    assertThat(mapping.subject()).isEqualTo("oidc-subject-1");
+    assertThat(mapping.createdAt()).isNotNull();
+    assertThat(countMappings()).isEqualTo(1);
+
+    Optional<ExternalIdentityAuditSummary> audit =
+        queryRepository.findByRequestId("request-link-001");
+    assertThat(audit).isPresent();
+    assertThat(audit.get().changeType()).isEqualTo(ExternalIdentityChangeType.LINK);
+    assertThat(audit.get().providerId()).isEqualTo("google");
+    assertThat(audit.get().subjectHash()).hasSize(64);
+    assertThat(audit.get().subjectHash()).doesNotContain("oidc-subject-1");
+    assertThat(audit.get().outcome()).isEqualTo(AuthStatusChangeOutcome.SUCCESS);
+    assertThat(audit.get().reasonCode()).isEqualTo(AuthStatusChangeReasonCode.OPS_MANUAL);
+  }
+
+  @Test
+  void rejectsDuplicateProviderSubjectOrProviderUserMapping() {
+    long userId = insertUser("alice");
+    long otherUserId = insertUser("bob");
+    writeRepository.link(
+        new ExternalIdentityLinkCommand(
+            userId, "google", "oidc-subject-1", REASON, "ops-admin", "request-link-001"));
+
+    assertThatThrownBy(
+            () ->
+                writeRepository.link(
+                    new ExternalIdentityLinkCommand(
+                        otherUserId,
+                        "google",
+                        "oidc-subject-1",
+                        REASON,
+                        "ops-admin",
+                        "request-link-duplicate-subject")))
+        .isInstanceOf(DuplicateExternalIdentityMappingException.class);
+
+    assertThatThrownBy(
+            () ->
+                writeRepository.link(
+                    new ExternalIdentityLinkCommand(
+                        userId,
+                        "google",
+                        "oidc-subject-2",
+                        REASON,
+                        "ops-admin",
+                        "request-link-duplicate-user")))
+        .isInstanceOf(DuplicateExternalIdentityMappingException.class);
+  }
+
+  @Test
+  void unlinksExternalIdentityAndWritesAudit() {
+    long userId = insertUser("alice");
+    writeRepository.link(
+        new ExternalIdentityLinkCommand(
+            userId, "google", "oidc-subject-1", REASON, "ops-admin", "request-link-001"));
+
+    ExternalIdentityMapping mapping =
+        writeRepository.unlink(
+            new ExternalIdentityUnlinkCommand(
+                userId, "google", "oidc-subject-1", REASON, "ops-admin", "request-unlink-001"));
+
+    assertThat(mapping.userId()).isEqualTo(userId);
+    assertThat(mapping.subject()).isEqualTo("oidc-subject-1");
+    assertThat(countMappings()).isZero();
+
+    Optional<ExternalIdentityAuditSummary> audit =
+        queryRepository.findByRequestId("request-unlink-001");
+    assertThat(audit).isPresent();
+    assertThat(audit.get().changeType()).isEqualTo(ExternalIdentityChangeType.UNLINK);
+    assertThat(audit.get().userId()).isEqualTo(userId);
+  }
+
+  @Test
+  void rejectsUnlinkWhenMappingIsMissing() {
+    long userId = insertUser("alice");
+
+    assertThatThrownBy(
+            () ->
+                writeRepository.unlink(
+                    new ExternalIdentityUnlinkCommand(
+                        userId,
+                        "google",
+                        "missing-subject",
+                        REASON,
+                        "ops-admin",
+                        "request-unlink-missing")))
+        .isInstanceOf(ExternalIdentityMappingNotFoundException.class);
+  }
+
+  private long insertUser(String loginId) {
+    long[] userId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          Long id =
+              jdbcTemplate.queryForObject(
+                  """
+                  INSERT INTO bank_user (
+                      login_id,
+                      password_hash,
+                      display_name,
+                      user_status,
+                      created_at,
+                      updated_at
+                  )
+                  VALUES (
+                      :loginId,
+                      '$2a$10$abcdefghijklmnopqrstuv',
+                      :loginId,
+                      'ACTIVE',
+                      CURRENT_TIMESTAMP,
+                      CURRENT_TIMESTAMP
+                  )
+                  RETURNING id
+                  """,
+                  new MapSqlParameterSource().addValue("loginId", loginId),
+                  Long.class);
+          if (id == null) {
+            throw new IllegalStateException("bank_user insert did not return id");
+          }
+          userId[0] = id;
+        });
+    return userId[0];
+  }
+
+  private int countMappings() {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM auth_external_identity",
+            new MapSqlParameterSource(),
+            Integer.class);
+    return count == null ? 0 : count;
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -293,7 +293,8 @@ class InternalAuthAdminControllerTest {
                     """
                     {
                       "providerId": "google",
-                      "subject": "google-subject-001"
+                      "subject": "google-subject-001",
+                      "reasonDetail": "oidc onboarding"
                     }
                     """))
         .andExpect(status().isBadRequest())

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -5,13 +5,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.aquilabank.domain.auth.exception.DuplicateExternalIdentityMappingException;
 import com.aquilabank.domain.auth.exception.PasswordRecoveryTokenNotFoundException;
 import com.aquilabank.domain.auth.model.AuthUserSummary;
+import com.aquilabank.domain.auth.model.ExternalIdentityMapping;
 import com.aquilabank.domain.auth.model.MembershipRole;
 import com.aquilabank.domain.auth.model.MembershipStatus;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenLookupView;
@@ -19,6 +23,8 @@ import com.aquilabank.domain.auth.model.PasswordRecoveryTokenStatus;
 import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityMappingLinkUseCase;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityMappingUnlinkUseCase;
 import com.aquilabank.domain.auth.usecase.PasswordRecoveryTokenQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
@@ -42,6 +48,8 @@ class InternalAuthAdminControllerTest {
   private UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase;
   private UserAccountMembershipStatusUpdateUseCase userAccountMembershipStatusUpdateUseCase;
   private PasswordRecoveryTokenQueryUseCase passwordRecoveryTokenQueryUseCase;
+  private ExternalIdentityMappingLinkUseCase externalIdentityMappingLinkUseCase;
+  private ExternalIdentityMappingUnlinkUseCase externalIdentityMappingUnlinkUseCase;
   private MockMvc mockMvc;
 
   @BeforeEach
@@ -51,6 +59,8 @@ class InternalAuthAdminControllerTest {
     userAccountMembershipQueryUseCase = mock(UserAccountMembershipQueryUseCase.class);
     userAccountMembershipStatusUpdateUseCase = mock(UserAccountMembershipStatusUpdateUseCase.class);
     passwordRecoveryTokenQueryUseCase = mock(PasswordRecoveryTokenQueryUseCase.class);
+    externalIdentityMappingLinkUseCase = mock(ExternalIdentityMappingLinkUseCase.class);
+    externalIdentityMappingUnlinkUseCase = mock(ExternalIdentityMappingUnlinkUseCase.class);
 
     mockMvc =
         MockMvcBuilders.standaloneSetup(
@@ -60,6 +70,8 @@ class InternalAuthAdminControllerTest {
                     userAccountMembershipQueryUseCase,
                     userAccountMembershipStatusUpdateUseCase,
                     passwordRecoveryTokenQueryUseCase,
+                    externalIdentityMappingLinkUseCase,
+                    externalIdentityMappingUnlinkUseCase,
                     InternalServiceTokenTestSupport.authorizer()))
             .setControllerAdvice(new ApiExceptionHandler())
             .build();
@@ -177,6 +189,146 @@ class InternalAuthAdminControllerTest {
                 .param("requestId", "handoff-request-001"))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+
+  @Test
+  void linksAndUnlinksExternalIdentityMapping() throws Exception {
+    ExternalIdentityMapping mapping =
+        new ExternalIdentityMapping(
+            21L,
+            "google",
+            "google-subject-001",
+            Instant.parse("2026-04-20T11:00:00Z"),
+            Instant.parse("2026-04-20T11:00:00Z"));
+
+    when(externalIdentityMappingLinkUseCase.link(argThat(command -> command.userId() == 21L)))
+        .thenReturn(mapping);
+    when(externalIdentityMappingUnlinkUseCase.unlink(argThat(command -> command.userId() == 21L)))
+        .thenReturn(mapping);
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/auth/users/21/external-identities")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.AUTH_ADMIN))
+                .header(REQUEST_ID_HEADER, "external-identity-link-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "providerId": "google",
+                      "subject": "google-subject-001",
+                      "reasonCode": "OPS_MANUAL",
+                      "reasonDetail": "oidc onboarding"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(21))
+        .andExpect(jsonPath("$.providerId").value("google"))
+        .andExpect(jsonPath("$.subject").value("google-subject-001"))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-20T11:00:00Z"))
+        .andExpect(jsonPath("$.updatedAt").value("2026-04-20T11:00:00Z"));
+
+    mockMvc
+        .perform(
+            delete("/internal/api/v1/auth/users/21/external-identities")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.AUTH_ADMIN))
+                .header(REQUEST_ID_HEADER, "external-identity-unlink-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "providerId": "google",
+                      "subject": "google-subject-001",
+                      "reasonCode": "OPS_MANUAL",
+                      "reasonDetail": "oidc unlink"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(21))
+        .andExpect(jsonPath("$.providerId").value("google"))
+        .andExpect(jsonPath("$.subject").value("google-subject-001"));
+
+    verify(externalIdentityMappingLinkUseCase)
+        .link(
+            argThat(
+                command ->
+                    command.userId() == 21L
+                        && command.providerId().equals("google")
+                        && command.subject().equals("google-subject-001")
+                        && command.normalizedReason().reasonCode().name().equals("OPS_MANUAL")
+                        && command.normalizedReason().reasonDetail().equals("oidc onboarding")
+                        && command.actorSubject().equals(SUBJECT)
+                        && command.requestId().equals("external-identity-link-request")));
+    verify(externalIdentityMappingUnlinkUseCase)
+        .unlink(
+            argThat(
+                command ->
+                    command.userId() == 21L
+                        && command.providerId().equals("google")
+                        && command.subject().equals("google-subject-001")
+                        && command.normalizedReason().reasonCode().name().equals("OPS_MANUAL")
+                        && command.normalizedReason().reasonDetail().equals("oidc unlink")
+                        && command.actorSubject().equals(SUBJECT)
+                        && command.requestId().equals("external-identity-unlink-request")));
+  }
+
+  @Test
+  void rejectsMissingStructuredReasonForExternalIdentityMapping() throws Exception {
+    mockMvc
+        .perform(
+            post("/internal/api/v1/auth/users/21/external-identities")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.AUTH_ADMIN))
+                .header(REQUEST_ID_HEADER, "external-identity-missing-reason-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "providerId": "google",
+                      "subject": "google-subject-001"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("reasonCode is required"));
+
+    verifyNoInteractions(externalIdentityMappingLinkUseCase);
+  }
+
+  @Test
+  void rejectsDuplicateExternalIdentityMappingAsConflict() throws Exception {
+    when(externalIdentityMappingLinkUseCase.link(argThat(command -> command.userId() == 21L)))
+        .thenThrow(
+            new DuplicateExternalIdentityMappingException(
+                "external identity mapping already exists"));
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/auth/users/21/external-identities")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.AUTH_ADMIN))
+                .header(REQUEST_ID_HEADER, "external-identity-duplicate-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "providerId": "google",
+                      "subject": "google-subject-001",
+                      "reasonCode": "OPS_MANUAL",
+                      "reasonDetail": "duplicate check"
+                    }
+                    """))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.message").value("external identity mapping already exists"));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthExternalIdentityAuditControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthExternalIdentityAuditControllerTest.java
@@ -1,0 +1,106 @@
+package com.aquilabank.global.web.auth;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.auth.exception.ExternalIdentityAuditNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
+import com.aquilabank.domain.auth.model.ExternalIdentityAuditSummary;
+import com.aquilabank.domain.auth.model.ExternalIdentityChangeType;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityAuditQueryUseCase;
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenTestSupport;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class InternalAuthExternalIdentityAuditControllerTest {
+
+  private ExternalIdentityAuditQueryUseCase externalIdentityAuditQueryUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    externalIdentityAuditQueryUseCase = mock(ExternalIdentityAuditQueryUseCase.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new InternalAuthExternalIdentityAuditController(
+                    externalIdentityAuditQueryUseCase,
+                    InternalServiceTokenTestSupport.authorizer()))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void getsExternalIdentityAuditByRequestId() throws Exception {
+    when(externalIdentityAuditQueryUseCase.getByRequestId("external-identity-link-request"))
+        .thenReturn(
+            new ExternalIdentityAuditSummary(
+                "external-identity-link-request",
+                "ops-admin",
+                ExternalIdentityChangeType.LINK,
+                21L,
+                "google",
+                "0".repeat(64),
+                new AuthStatusChangeReason(
+                    AuthStatusChangeReasonCode.OPS_MANUAL, "oidc onboarding"),
+                AuthStatusChangeOutcome.SUCCESS,
+                Instant.parse("2026-04-20T11:00:00Z")));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/external-identity-audits/by-request-id")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        "ops-admin", InternalServiceScope.AUTH_ADMIN))
+                .param("requestId", "external-identity-link-request"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.requestId").value("external-identity-link-request"))
+        .andExpect(jsonPath("$.actorSubject").value("ops-admin"))
+        .andExpect(jsonPath("$.changeType").value("LINK"))
+        .andExpect(jsonPath("$.userId").value(21))
+        .andExpect(jsonPath("$.providerId").value("google"))
+        .andExpect(jsonPath("$.subjectHash").value("0".repeat(64)))
+        .andExpect(jsonPath("$.reasonCode").value("OPS_MANUAL"))
+        .andExpect(jsonPath("$.reasonDetail").value("oidc onboarding"))
+        .andExpect(jsonPath("$.reason").value("oidc onboarding"))
+        .andExpect(jsonPath("$.outcome").value("SUCCESS"))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-20T11:00:00Z"));
+  }
+
+  @Test
+  void returnsNotFoundWhenExternalIdentityAuditRequestIdDoesNotExist() throws Exception {
+    when(externalIdentityAuditQueryUseCase.getByRequestId("missing-request"))
+        .thenThrow(new ExternalIdentityAuditNotFoundException("audit record is not found"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/external-identity-audits/by-request-id")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        "ops-admin", InternalServiceScope.AUTH_ADMIN))
+                .param("requestId", "missing-request"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("audit record is not found"));
+  }
+
+  @Test
+  void rejectsMissingOrInvalidInternalServiceToken() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/external-identity-audits/by-request-id")
+                .param("requestId", "external-identity-link-request"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusFailureLoggingTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusFailureLoggingTest.java
@@ -8,6 +8,8 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.aquilabank.domain.auth.usecase.AuthUserQueryUseCase;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityMappingLinkUseCase;
+import com.aquilabank.domain.auth.usecase.ExternalIdentityMappingUnlinkUseCase;
 import com.aquilabank.domain.auth.usecase.PasswordRecoveryTokenQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipStatusUpdateUseCase;
@@ -45,6 +47,10 @@ class InternalAuthStatusFailureLoggingTest {
         Mockito.mock(UserAccountMembershipStatusUpdateUseCase.class);
     PasswordRecoveryTokenQueryUseCase passwordRecoveryTokenQueryUseCase =
         Mockito.mock(PasswordRecoveryTokenQueryUseCase.class);
+    ExternalIdentityMappingLinkUseCase externalIdentityMappingLinkUseCase =
+        Mockito.mock(ExternalIdentityMappingLinkUseCase.class);
+    ExternalIdentityMappingUnlinkUseCase externalIdentityMappingUnlinkUseCase =
+        Mockito.mock(ExternalIdentityMappingUnlinkUseCase.class);
     var authorizer = InternalServiceTokenTestSupport.authorizer();
 
     mockMvc =
@@ -55,6 +61,8 @@ class InternalAuthStatusFailureLoggingTest {
                     userAccountMembershipQueryUseCase,
                     userAccountMembershipStatusUpdateUseCase,
                     passwordRecoveryTokenQueryUseCase,
+                    externalIdentityMappingLinkUseCase,
+                    externalIdentityMappingUnlinkUseCase,
                     authorizer))
             .addInterceptors(new InternalServiceTokenAuthenticationInterceptor(authorizer))
             .addFilters(new RequestIdFilter(), new InternalAuthStatusAuditRequestCachingFilter())


### PR DESCRIPTION
## 🔗 Related Issue
- close #168

## 🌿 Base Branch
- `main`

## 📝 Summary
- 외부 IdP `providerId/subject`를 기존 내부 user에 연결/해제하는 internal auth admin API를 추가합니다.
- 변경 이력은 `auth_external_identity_audit`에 남기고, 감사 조회 응답은 raw subject 대신 SHA-256 `subjectHash`만 반환합니다.

## 🛠 Changes
- domain: external identity link/unlink command, mapping result, audit summary, use case/port, 충돌/미존재 예외 추가
- persistence: `auth_external_identity_audit` V29 migration, mapping create/delete와 audit insert, requestId exact lookup repository 추가
- web: `POST/DELETE /internal/api/v1/auth/users/{userId}/external-identities`, `GET /internal/api/v1/auth/external-identity-audits/by-request-id` 추가
- security/error: 기존 `AUTH_ADMIN` internal service token 보호 경계 재사용, duplicate conflict와 not found 예외 매핑 추가
- test: CI 환경별 validation field error 순서 차이를 제거하도록 missing reasonCode 테스트 입력을 단일 실패 조건으로 보정

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인 (`N/A`: controller/JDBC 통합 테스트로 API 계약 검증)
- [ ] 로그 / 메트릭 확인 (`N/A`: 신규 메트릭 없음)

### 실행한 검증
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests 'com.aquilabank.global.web.auth.InternalAuthAdminControllerTest.rejectsMissingStructuredReasonForExternalIdentityMapping'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*ExternalIdentity*' --tests '*InternalAuthAdminControllerTest'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back check`
- `git rev-list --count main..HEAD` => `4`

## 📸 Screenshot / API Example
```http
POST /internal/api/v1/auth/users/21/external-identities
Authorization: Bearer <internal-service-token-with-AUTH_ADMIN>
X-Request-Id: external-identity-link-request
Content-Type: application/json

{
  "providerId": "google",
  "subject": "google-subject-001",
  "reasonCode": "OPS_MANUAL",
  "reasonDetail": "oidc onboarding"
}
```

```json
{
  "requestId": "external-identity-link-request",
  "actorSubject": "ops-admin",
  "changeType": "LINK",
  "userId": 21,
  "providerId": "google",
  "subjectHash": "<sha256-hex>",
  "reasonCode": "OPS_MANUAL",
  "reasonDetail": "oidc onboarding",
  "outcome": "SUCCESS"
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: 잘못된 매핑 생성은 외부 IdP 로그인 권한 경계를 바꿀 수 있으므로 `AUTH_ADMIN`, requestId, structured reason을 필수로 유지합니다.
- 롤백 방법: PR revert. V29 감사 테이블은 기능 미사용 상태에서는 참조되지 않으며, 필요 시 별도 migration으로 정리합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`: 미완성 기능 아님)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (`N/A`: 신규 운영 문서/메트릭 없음)