### PR TITLE
[Feat] refresh token reuse 감지와 session family revoke 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionFamilyRevokeCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionFamilyRevokeCommand.java
@@ -1,0 +1,16 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** reuse 감지 시 같은 refresh token session family를 종료하는 write 모델입니다. */
+public record RefreshTokenSessionFamilyRevokeCommand(long reusedSessionId, Instant revokedAt) {
+
+  public RefreshTokenSessionFamilyRevokeCommand {
+    if (reusedSessionId <= 0) {
+      throw new IllegalArgumentException("reusedSessionId must be positive");
+    }
+    if (revokedAt == null) {
+      throw new IllegalArgumentException("revokedAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionWritePort.java
@@ -1,6 +1,7 @@
 package com.aquilabank.domain.auth.port;
 
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
 import java.time.Instant;
@@ -13,6 +14,8 @@ public interface RefreshTokenSessionWritePort {
   void rotate(RefreshTokenSessionRotateCommand command);
 
   void revoke(RefreshTokenSessionRevokeCommand command);
+
+  void revokeFamily(RefreshTokenSessionFamilyRevokeCommand command);
 
   void revokeActiveSessionsByUserId(long userId, Instant revokedAt);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenService.java
@@ -7,6 +7,7 @@ import com.aquilabank.domain.auth.model.RefreshTokenCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
 import com.aquilabank.domain.auth.model.RefreshTokenSession;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
 import com.aquilabank.domain.auth.model.UserStatus;
@@ -56,6 +57,11 @@ public final class RefreshTokenService implements RefreshTokenUseCase {
             .orElseThrow(() -> new InvalidCredentialsException("refresh failed"));
 
     if (session.sessionStatus() != RefreshTokenSessionStatus.ACTIVE) {
+      // ROTATED token 재사용은 탈취 가능성이 높아 descendant session까지 같은 transaction에서 종료합니다.
+      if (session.sessionStatus() == RefreshTokenSessionStatus.ROTATED) {
+        refreshTokenSessionWritePort.revokeFamily(
+            new RefreshTokenSessionFamilyRevokeCommand(session.sessionId(), now));
+      }
       throw new InvalidCredentialsException("refresh failed");
     }
     if (!session.expiresAt().isAfter(now)) {

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -278,12 +278,25 @@ public class AuthConfiguration {
             authClock);
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
     return command -> {
-      LoginResult result =
-          transactionTemplate.execute(status -> refreshTokenService.refresh(command));
-      if (result == null) {
+      LoginTransactionResult transactionResult =
+          transactionTemplate.execute(
+              status -> {
+                try {
+                  return LoginTransactionResult.success(refreshTokenService.refresh(command));
+                } catch (InvalidCredentialsException ex) {
+                  return LoginTransactionResult.failure(ex);
+                }
+              });
+      if (transactionResult == null) {
+        throw new IllegalStateException("refresh transaction result is null");
+      }
+      if (transactionResult.exception() != null) {
+        throw transactionResult.exception();
+      }
+      if (transactionResult.result() == null) {
         throw new IllegalStateException("refresh transaction returned null result");
       }
-      return result;
+      return transactionResult.result();
     };
   }
 

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -21,6 +21,7 @@ import com.aquilabank.domain.auth.model.PasswordRecoveryTokenIssueCommand;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenUseCommand;
 import com.aquilabank.domain.auth.model.PasswordResetWriteCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
 import com.aquilabank.domain.auth.model.RememberDeviceIssueCommand;
@@ -622,6 +623,62 @@ public class JdbcAuthWriteRepository
     if (updated != 1) {
       throw new IllegalStateException("refresh token session is not active");
     }
+  }
+
+  @Override
+  @Transactional
+  public void revokeFamily(RefreshTokenSessionFamilyRevokeCommand command) {
+    jdbcTemplate.update(
+        """
+        WITH RECURSIVE ancestors(id, replaced_by_session_id) AS (
+            SELECT id,
+                   replaced_by_session_id
+            FROM auth_refresh_token_session
+            WHERE id = :reusedSessionId
+
+            UNION ALL
+
+            SELECT parent.id,
+                   parent.replaced_by_session_id
+            FROM auth_refresh_token_session parent
+            JOIN ancestors child ON parent.replaced_by_session_id = child.id
+        ),
+        family_root(id) AS (
+            SELECT ancestor.id
+            FROM ancestors ancestor
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM auth_refresh_token_session parent
+                WHERE parent.replaced_by_session_id = ancestor.id
+            )
+            LIMIT 1
+        ),
+        family(id, replaced_by_session_id) AS (
+            SELECT session.id,
+                   session.replaced_by_session_id
+            FROM auth_refresh_token_session session
+            JOIN family_root root ON session.id = root.id
+
+            UNION ALL
+
+            SELECT child.id,
+                   child.replaced_by_session_id
+            FROM auth_refresh_token_session child
+            JOIN family parent ON parent.replaced_by_session_id = child.id
+        )
+        UPDATE auth_refresh_token_session target
+        SET session_status = 'REVOKED',
+            last_used_at = :revokedAt,
+            updated_at = :revokedAt
+        WHERE target.session_status = 'ACTIVE'
+          AND target.id IN (
+              SELECT id
+              FROM family
+          )
+        """,
+        new MapSqlParameterSource()
+            .addValue("reusedSessionId", command.reusedSessionId())
+            .addValue("revokedAt", Timestamp.from(command.revokedAt())));
   }
 
   @Override

--- a/back/src/main/resources/db/migration/V30__add_refresh_token_session_family_index.sql
+++ b/back/src/main/resources/db/migration/V30__add_refresh_token_session_family_index.sql
@@ -1,0 +1,4 @@
+-- session family revoke recursive CTE가 parent lookup을 index 경로로 타도록 보조합니다.
+CREATE INDEX idx_auth_refresh_token_session_replaced_by
+    ON auth_refresh_token_session (replaced_by_session_id)
+    WHERE replaced_by_session_id IS NOT NULL;

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenServiceTest.java
@@ -14,6 +14,7 @@ import com.aquilabank.domain.auth.model.RefreshTokenCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
 import com.aquilabank.domain.auth.model.RefreshTokenSession;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
 import com.aquilabank.domain.auth.model.UserStatus;
@@ -145,6 +146,109 @@ class RefreshTokenServiceTest {
     verify(refreshTokenSessionWritePort, never()).rotate(Mockito.any());
     verify(authTokenIssuePort, never())
         .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(), Mockito.any());
+  }
+
+  @Test
+  void detectsRotatedRefreshTokenReuseAndRevokesSessionFamily() {
+    RefreshTokenSessionLoadPort refreshTokenSessionLoadPort =
+        Mockito.mock(RefreshTokenSessionLoadPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort =
+        Mockito.mock(RefreshDeviceBindingSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("token-hash");
+    when(refreshTokenSessionLoadPort.findByTokenHashForUpdate("token-hash"))
+        .thenReturn(
+            Optional.of(
+                new RefreshTokenSession(
+                    11L,
+                    7L,
+                    "alice",
+                    UserStatus.ACTIVE,
+                    "token-hash",
+                    "binding-hash",
+                    RefreshTokenSessionStatus.ROTATED,
+                    NOW.plusSeconds(30),
+                    NOW.minusSeconds(10),
+                    NOW.minusSeconds(10),
+                    33L)));
+
+    RefreshTokenService refreshTokenService =
+        new RefreshTokenService(
+            refreshTokenSessionLoadPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            refreshDeviceBindingSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            CLOCK);
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () ->
+            refreshTokenService.refresh(
+                new RefreshTokenCommand(
+                    "refresh-token", "binding-token", SESSION_CLIENT_METADATA)));
+
+    verify(refreshTokenSessionWritePort)
+        .revokeFamily(new RefreshTokenSessionFamilyRevokeCommand(11L, NOW));
+    verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
+    verify(refreshTokenSessionWritePort, never()).rotate(Mockito.any());
+    verify(authTokenIssuePort, never())
+        .issue(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(), Mockito.any());
+  }
+
+  @Test
+  void rejectsRevokedRefreshTokenWithoutFamilyRevoke() {
+    RefreshTokenSessionLoadPort refreshTokenSessionLoadPort =
+        Mockito.mock(RefreshTokenSessionLoadPort.class);
+    RefreshTokenSessionWritePort refreshTokenSessionWritePort =
+        Mockito.mock(RefreshTokenSessionWritePort.class);
+    RefreshTokenSecretPort refreshTokenSecretPort = Mockito.mock(RefreshTokenSecretPort.class);
+    RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort =
+        Mockito.mock(RefreshDeviceBindingSecretPort.class);
+    AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+
+    when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("token-hash");
+    when(refreshTokenSessionLoadPort.findByTokenHashForUpdate("token-hash"))
+        .thenReturn(
+            Optional.of(
+                new RefreshTokenSession(
+                    11L,
+                    7L,
+                    "alice",
+                    UserStatus.ACTIVE,
+                    "token-hash",
+                    "binding-hash",
+                    RefreshTokenSessionStatus.REVOKED,
+                    NOW.plusSeconds(30),
+                    NOW.minusSeconds(10),
+                    null,
+                    null)));
+
+    RefreshTokenService refreshTokenService =
+        new RefreshTokenService(
+            refreshTokenSessionLoadPort,
+            refreshTokenSessionWritePort,
+            refreshTokenSecretPort,
+            refreshDeviceBindingSecretPort,
+            authTokenIssuePort,
+            new RefreshTokenPolicy(Duration.ofDays(14)),
+            CLOCK);
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () ->
+            refreshTokenService.refresh(
+                new RefreshTokenCommand(
+                    "refresh-token", "binding-token", SESSION_CLIENT_METADATA)));
+
+    verify(refreshTokenSessionWritePort, never()).revokeFamily(Mockito.any());
+    verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
+    verify(refreshTokenSessionWritePort, never()).rotate(Mockito.any());
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthRefreshTokenSessionFamilyRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthRefreshTokenSessionFamilyRepositoryIntegrationTest.java
@@ -1,0 +1,161 @@
+package com.aquilabank.global.persistence.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcAuthRefreshTokenSessionFamilyRepositoryIntegrationTest
+    extends PostgresContainerTestSupport {
+
+  private static final Instant NOW = Instant.parse("2026-04-21T01:00:00Z");
+
+  @Autowired private JdbcAuthWriteRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void revokesOnlyActiveDescendantSessionsInReusedTokenFamily() {
+    long[] middleSessionId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          long userId = insertUser("family-user");
+          long activeSessionId = insertSession(userId, "active-descendant", "ACTIVE", null);
+          middleSessionId[0] = insertSession(userId, "rotated-middle", "ROTATED", activeSessionId);
+          insertSession(userId, "rotated-root", "ROTATED", middleSessionId[0]);
+          insertSession(userId, "unrelated-active", "ACTIVE", null);
+        });
+
+    repository.revokeFamily(new RefreshTokenSessionFamilyRevokeCommand(middleSessionId[0], NOW));
+
+    Map<String, String> statuses = findStatusesByTokenHash();
+    assertThat(statuses)
+        .containsEntry("active-descendant", "REVOKED")
+        .containsEntry("rotated-middle", "ROTATED")
+        .containsEntry("rotated-root", "ROTATED")
+        .containsEntry("unrelated-active", "ACTIVE");
+    assertThat(findUpdatedAt("active-descendant")).isEqualTo(NOW);
+  }
+
+  private long insertUser(String loginId) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private long insertSession(
+      long userId, String tokenHash, String sessionStatus, Long replacedBySessionId) {
+    Long sessionId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO auth_refresh_token_session (
+                user_id,
+                token_hash,
+                session_status,
+                expires_at,
+                last_used_at,
+                rotated_at,
+                replaced_by_session_id,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :userId,
+                :tokenHash,
+                :sessionStatus,
+                :expiresAt,
+                :lastUsedAt,
+                :rotatedAt,
+                :replacedBySessionId,
+                :createdAt,
+                :updatedAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("userId", userId)
+                .addValue("tokenHash", tokenHash)
+                .addValue("sessionStatus", sessionStatus)
+                .addValue("expiresAt", Timestamp.from(NOW.plusSeconds(3600)))
+                .addValue("lastUsedAt", null)
+                .addValue("rotatedAt", "ROTATED".equals(sessionStatus) ? Timestamp.from(NOW) : null)
+                .addValue("replacedBySessionId", replacedBySessionId)
+                .addValue("createdAt", Timestamp.from(NOW.minusSeconds(60)))
+                .addValue("updatedAt", Timestamp.from(NOW.minusSeconds(60))),
+            Long.class);
+    if (sessionId == null) {
+      throw new IllegalStateException("refresh token session insert did not return id");
+    }
+    return sessionId;
+  }
+
+  private Map<String, String> findStatusesByTokenHash() {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT token_hash,
+                   session_status
+            FROM auth_refresh_token_session
+            """,
+            new MapSqlParameterSource(),
+            (rs, rowNum) -> Map.entry(rs.getString("token_hash"), rs.getString("session_status")))
+        .stream()
+        .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private Instant findUpdatedAt(String tokenHash) {
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT updated_at
+        FROM auth_refresh_token_session
+        WHERE token_hash = :tokenHash
+        """,
+        new MapSqlParameterSource().addValue("tokenHash", tokenHash),
+        (rs, rowNum) -> rs.getTimestamp("updated_at").toInstant());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -683,6 +683,11 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
     assertEquals(WINDOWS_EDGE.expectedIpAddress(), newSession.ipAddress());
 
     refreshExpectUnauthorized(loginResult.refreshToken(), "refresh-reuse-001");
+
+    RefreshTokenSessionView revokedDescendant = loadRefreshTokenSession(refreshed.refreshToken());
+    assertEquals("REVOKED", revokedDescendant.sessionStatus());
+    assertNotNull(revokedDescendant.lastUsedAt());
+    refreshExpectUnauthorized(refreshed.refreshToken(), "refresh-descendant-after-reuse-001");
   }
 
   @Test


### PR DESCRIPTION
## 🔗 Related Issue
- close #170

## 🌿 Base Branch
- `main`

## 📝 Summary
- refresh token rotation 이후 이미 ROTATED 된 token이 다시 제출되면 reuse attack으로 보고 generic 401을 유지합니다.
- reuse 감지 시 같은 session family의 ACTIVE descendant refresh token session을 같은 transaction에서 REVOKED로 전환합니다.

## 🛠 Changes
- domain: `RefreshTokenSessionFamilyRevokeCommand`와 `RefreshTokenSessionWritePort.revokeFamily` 계약 추가
- use case: ROTATED refresh token 재사용 감지 시 family revoke 호출 후 기존 `refresh failed` 응답 유지
- persistence: `replaced_by_session_id` lineage 기반 recursive CTE로 ACTIVE descendant만 revoke, parent lookup index V30 추가
- transaction: refresh 실패 응답을 유지하되 `InvalidCredentialsException`을 transaction 안에서 failure result로 바꿔 reuse revoke 변경이 rollback되지 않게 조정
- test: domain, JDBC integration, refresh API integration에서 reuse 후 descendant session revoke 검증

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인 (`N/A`: domain/JDBC/API 통합 테스트로 검증)
- [ ] 로그 / 메트릭 확인 (`N/A`: 신규 로그/메트릭 없음)

### 실행한 검증
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*RefreshTokenServiceTest' --tests '*JdbcAuthRefreshTokenSessionFamilyRepositoryIntegrationTest' --tests '*LoginAndAccountAccessApiIntegrationTest.refreshRotatesTokenAndRejectsReusedToken'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*RefreshTokenServiceTest' --tests '*JdbcAuthRefreshTokenSessionFamilyRepositoryIntegrationTest' --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back check`
- `git rev-list --count main..HEAD` => `2`

## 📸 Screenshot / API Example
```http
POST /api/v1/auth/refresh
Content-Type: application/json
Cookie: refreshDeviceBinding=<binding-token>

{
  "refreshToken": "<already-rotated-refresh-token>"
}
```

```json
{
  "status": 401,
  "message": "refresh failed"
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: family 범위가 잘못 계산되면 정상 descendant session이 남거나 unrelated session까지 revoke될 수 있습니다. recursive CTE는 `replaced_by_session_id` lineage 안의 ACTIVE session만 갱신하도록 제한했습니다.
- 롤백 방법: PR revert. V30 index는 기능 미사용 시 동작 영향이 없으며, 필요하면 후속 migration으로 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`: 미완성 기능 아님)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (`N/A`: 신규 운영 문서/메트릭 없음)