### PR TITLE
[Feat] 민감 mutation API current session active gate 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/auth/model/CurrentSessionActiveCheckCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/CurrentSessionActiveCheckCommand.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** 민감 mutation 실행 전 현재 access token의 session이 유효한지 확인하는 command입니다. */
+public record CurrentSessionActiveCheckCommand(long userId, long sessionId) {
+
+  public CurrentSessionActiveCheckCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (sessionId <= 0) {
+      throw new IllegalArgumentException("sessionId must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/CurrentSessionActivePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/CurrentSessionActivePort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.port;
+
+import java.time.Instant;
+
+/** current session gate가 사용할 refresh token session exact lookup port입니다. */
+public interface CurrentSessionActivePort {
+
+  boolean existsActiveSession(long userId, long sessionId, Instant now);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveService.java
@@ -1,0 +1,28 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveCheckCommand;
+import com.aquilabank.domain.auth.port.CurrentSessionActivePort;
+import java.time.Clock;
+import java.time.Instant;
+
+/** 민감 mutation은 access token의 현재 refresh session이 아직 ACTIVE일 때만 허용합니다. */
+public final class CurrentSessionActiveService implements CurrentSessionActiveUseCase {
+
+  private final CurrentSessionActivePort currentSessionActivePort;
+  private final Clock clock;
+
+  public CurrentSessionActiveService(
+      CurrentSessionActivePort currentSessionActivePort, Clock clock) {
+    this.currentSessionActivePort = currentSessionActivePort;
+    this.clock = clock;
+  }
+
+  @Override
+  public void requireActive(CurrentSessionActiveCheckCommand command) {
+    Instant now = Instant.now(clock);
+    if (!currentSessionActivePort.existsActiveSession(command.userId(), command.sessionId(), now)) {
+      throw new InvalidCredentialsException("current session is not active");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveUseCase.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.CurrentSessionActiveCheckCommand;
+
+public interface CurrentSessionActiveUseCase {
+
+  void requireActive(CurrentSessionActiveCheckCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -13,6 +13,7 @@ import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
 import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
 import com.aquilabank.domain.auth.port.BackupCodeWritePort;
+import com.aquilabank.domain.auth.port.CurrentSessionActivePort;
 import com.aquilabank.domain.auth.port.ExternalIdentityAuditQueryPort;
 import com.aquilabank.domain.auth.port.ExternalIdentityMappingWritePort;
 import com.aquilabank.domain.auth.port.ExternalIdentityUserLoadPort;
@@ -58,6 +59,8 @@ import com.aquilabank.domain.auth.usecase.BackupCodeChallengeVerifyService;
 import com.aquilabank.domain.auth.usecase.BackupCodeChallengeVerifyUseCase;
 import com.aquilabank.domain.auth.usecase.BackupCodeGenerateService;
 import com.aquilabank.domain.auth.usecase.BackupCodeGenerateUseCase;
+import com.aquilabank.domain.auth.usecase.CurrentSessionActiveService;
+import com.aquilabank.domain.auth.usecase.CurrentSessionActiveUseCase;
 import com.aquilabank.domain.auth.usecase.ExternalIdentityAuditQueryService;
 import com.aquilabank.domain.auth.usecase.ExternalIdentityAuditQueryUseCase;
 import com.aquilabank.domain.auth.usecase.ExternalIdentityMappingAdminService;
@@ -723,6 +726,12 @@ public class AuthConfiguration {
   AuthStatusChangeAuditQueryUseCase authStatusChangeAuditQueryUseCase(
       AuthStatusChangeAuditQueryPort authStatusChangeAuditQueryPort) {
     return new AuthStatusChangeAuditQueryService(authStatusChangeAuditQueryPort);
+  }
+
+  @Bean
+  CurrentSessionActiveUseCase currentSessionActiveUseCase(
+      CurrentSessionActivePort currentSessionActivePort, Clock authClock) {
+    return new CurrentSessionActiveService(currentSessionActivePort, authClock);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -30,6 +30,7 @@ import com.aquilabank.domain.auth.port.AccountStatusAccessPort;
 import com.aquilabank.domain.auth.port.AuthSessionQueryPort;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
+import com.aquilabank.domain.auth.port.CurrentSessionActivePort;
 import com.aquilabank.domain.auth.port.ExternalIdentityUserLoadPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
 import com.aquilabank.domain.auth.port.RememberDeviceLoadPort;
@@ -61,6 +62,7 @@ public class JdbcAuthRepository
         AccountAccessPort,
         AccountStatusAccessPort,
         ExternalIdentityUserLoadPort,
+        CurrentSessionActivePort,
         UserQueryPort,
         UserAccountMembershipQueryPort,
         AuthStatusChangeAuditQueryPort {
@@ -367,6 +369,28 @@ public class JdbcAuthRepository
             .addValue("now", Timestamp.from(now))
             .addValue("size", size),
         (rs, rowNum) -> mapAuthSessionSummary(rs));
+  }
+
+  @Override
+  public boolean existsActiveSession(long userId, long sessionId, Instant now) {
+    Boolean exists =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM auth_refresh_token_session
+                WHERE id = :sessionId
+                  AND user_id = :userId
+                  AND session_status = 'ACTIVE'
+                  AND expires_at > :now
+            )
+            """,
+            new MapSqlParameterSource()
+                .addValue("userId", userId)
+                .addValue("sessionId", sessionId)
+                .addValue("now", Timestamp.from(now)),
+            Boolean.class);
+    return Boolean.TRUE.equals(exists);
   }
 
   @Override

--- a/back/src/main/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptor.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptor.java
@@ -1,0 +1,89 @@
+package com.aquilabank.global.web.security;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveCheckCommand;
+import com.aquilabank.domain.auth.usecase.CurrentSessionActiveUseCase;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/** 민감 mutation에서 JWT session_id가 아직 ACTIVE인지 재확인합니다. */
+@Component
+public class CurrentSessionActiveInterceptor implements HandlerInterceptor {
+
+  private static final String CURRENT_SESSION_INACTIVE_MESSAGE = "current session is not active";
+  private static final List<SensitiveMutationPath> SENSITIVE_MUTATION_PATHS =
+      List.of(
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/transfers$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/transfers/[^/]+/reversal$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/auth/password-reset$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/auth/mfa/totp/enroll$")),
+          new SensitiveMutationPath(
+              "POST", Pattern.compile("^/api/v1/auth/mfa/totp/enroll/verify$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/auth/mfa/totp/disable$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/auth/mfa/backup-codes$")),
+          new SensitiveMutationPath("DELETE", Pattern.compile("^/api/v1/auth/sessions$")),
+          new SensitiveMutationPath("DELETE", Pattern.compile("^/api/v1/auth/sessions/[^/]+$")));
+
+  private final CurrentSessionActiveUseCase currentSessionActiveUseCase;
+
+  public CurrentSessionActiveInterceptor(CurrentSessionActiveUseCase currentSessionActiveUseCase) {
+    this.currentSessionActiveUseCase = currentSessionActiveUseCase;
+  }
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    if (!isSensitiveMutation(request)) {
+      return true;
+    }
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || !authentication.isAuthenticated()) {
+      return true;
+    }
+
+    Object principal = authentication.getPrincipal();
+    if (!(principal instanceof AuthenticatedUserPrincipal userPrincipal)) {
+      return true;
+    }
+
+    Long currentSessionId = userPrincipal.currentSessionId();
+    if (currentSessionId == null) {
+      // session_id 없는 구 access token은 read 호환만 허용하고 고위험 mutation은 재로그인 요구.
+      throw new InvalidCredentialsException(CURRENT_SESSION_INACTIVE_MESSAGE);
+    }
+
+    currentSessionActiveUseCase.requireActive(
+        new CurrentSessionActiveCheckCommand(userPrincipal.userId(), currentSessionId));
+    return true;
+  }
+
+  private boolean isSensitiveMutation(HttpServletRequest request) {
+    String method = request.getMethod();
+    String path = normalizedPath(request);
+    return SENSITIVE_MUTATION_PATHS.stream().anyMatch(item -> item.matches(method, path));
+  }
+
+  private String normalizedPath(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    String contextPath = request.getContextPath();
+    if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
+      path = path.substring(contextPath.length());
+    }
+    return path.isBlank() ? "/" : path;
+  }
+
+  private record SensitiveMutationPath(String method, Pattern pathPattern) {
+
+    private boolean matches(String requestMethod, String path) {
+      return method.equals(requestMethod) && pathPattern.matcher(path).matches();
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
@@ -15,14 +15,17 @@ public class WebMvcSecurityConfiguration implements WebMvcConfigurer {
       currentAuthenticatedPrincipalArgumentResolver;
   private final InternalServiceTokenAuthenticationInterceptor
       internalServiceTokenAuthenticationInterceptor;
+  private final CurrentSessionActiveInterceptor currentSessionActiveInterceptor;
 
   public WebMvcSecurityConfiguration(
       CurrentAuthenticatedPrincipalArgumentResolver currentAuthenticatedPrincipalArgumentResolver,
-      InternalServiceTokenAuthenticationInterceptor internalServiceTokenAuthenticationInterceptor) {
+      InternalServiceTokenAuthenticationInterceptor internalServiceTokenAuthenticationInterceptor,
+      CurrentSessionActiveInterceptor currentSessionActiveInterceptor) {
     this.currentAuthenticatedPrincipalArgumentResolver =
         currentAuthenticatedPrincipalArgumentResolver;
     this.internalServiceTokenAuthenticationInterceptor =
         internalServiceTokenAuthenticationInterceptor;
+    this.currentSessionActiveInterceptor = currentSessionActiveInterceptor;
   }
 
   @Override
@@ -32,6 +35,19 @@ public class WebMvcSecurityConfiguration implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
+    registry
+        .addInterceptor(currentSessionActiveInterceptor)
+        .addPathPatterns(
+            "/api/v1/transfers",
+            "/api/v1/transfers/*/reversal",
+            "/api/v1/auth/password-reset",
+            "/api/v1/auth/mfa/totp/enroll",
+            "/api/v1/auth/mfa/totp/enroll/verify",
+            "/api/v1/auth/mfa/totp/disable",
+            "/api/v1/auth/mfa/backup-codes",
+            "/api/v1/auth/sessions",
+            "/api/v1/auth/sessions/*");
+
     registry
         .addInterceptor(internalServiceTokenAuthenticationInterceptor)
         .addPathPatterns(

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveServiceTest.java
@@ -1,0 +1,45 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveCheckCommand;
+import com.aquilabank.domain.auth.port.CurrentSessionActivePort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class CurrentSessionActiveServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-21T01:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+  @Test
+  void allowsWhenCurrentSessionIsActiveForUser() {
+    CurrentSessionActivePort currentSessionActivePort = mock(CurrentSessionActivePort.class);
+    when(currentSessionActivePort.existsActiveSession(7L, 11L, NOW)).thenReturn(true);
+    CurrentSessionActiveService service =
+        new CurrentSessionActiveService(currentSessionActivePort, CLOCK);
+
+    assertDoesNotThrow(() -> service.requireActive(new CurrentSessionActiveCheckCommand(7L, 11L)));
+
+    verify(currentSessionActivePort).existsActiveSession(7L, 11L, NOW);
+  }
+
+  @Test
+  void rejectsWhenCurrentSessionIsNotActiveForUser() {
+    CurrentSessionActivePort currentSessionActivePort = mock(CurrentSessionActivePort.class);
+    when(currentSessionActivePort.existsActiveSession(7L, 11L, NOW)).thenReturn(false);
+    CurrentSessionActiveService service =
+        new CurrentSessionActiveService(currentSessionActivePort, CLOCK);
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () -> service.requireActive(new CurrentSessionActiveCheckCommand(7L, 11L)));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcCurrentSessionActiveRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcCurrentSessionActiveRepositoryIntegrationTest.java
@@ -1,0 +1,128 @@
+package com.aquilabank.global.persistence.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcCurrentSessionActiveRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  private static final Instant NOW = Instant.parse("2026-04-21T01:00:00Z");
+
+  @Autowired private JdbcAuthRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void findsOnlySameUserActiveUnexpiredSession() {
+    long[] userId = new long[1];
+    long[] otherUserId = new long[1];
+    long[] activeSessionId = new long[1];
+    long[] revokedSessionId = new long[1];
+    long[] expiredSessionId = new long[1];
+    long[] otherUserSessionId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("session-user");
+          otherUserId[0] = insertUser("other-session-user");
+          activeSessionId[0] =
+              insertSession(userId[0], "active-session", "ACTIVE", NOW.plusSeconds(60));
+          revokedSessionId[0] =
+              insertSession(userId[0], "revoked-session", "REVOKED", NOW.plusSeconds(60));
+          expiredSessionId[0] =
+              insertSession(userId[0], "expired-session", "ACTIVE", NOW.minusSeconds(1));
+          otherUserSessionId[0] =
+              insertSession(otherUserId[0], "other-active-session", "ACTIVE", NOW.plusSeconds(60));
+        });
+
+    assertThat(repository.existsActiveSession(userId[0], activeSessionId[0], NOW)).isTrue();
+    assertThat(repository.existsActiveSession(userId[0], revokedSessionId[0], NOW)).isFalse();
+    assertThat(repository.existsActiveSession(userId[0], expiredSessionId[0], NOW)).isFalse();
+    assertThat(repository.existsActiveSession(userId[0], otherUserSessionId[0], NOW)).isFalse();
+  }
+
+  private long insertUser(String loginId) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private long insertSession(
+      long userId, String tokenHash, String sessionStatus, Instant expiresAt) {
+    Long sessionId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO auth_refresh_token_session (
+                user_id,
+                token_hash,
+                session_status,
+                expires_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :userId,
+                :tokenHash,
+                :sessionStatus,
+                :expiresAt,
+                :createdAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("userId", userId)
+                .addValue("tokenHash", tokenHash)
+                .addValue("sessionStatus", sessionStatus)
+                .addValue("expiresAt", Timestamp.from(expiresAt))
+                .addValue("createdAt", Timestamp.from(NOW.minusSeconds(60))),
+            Long.class);
+    if (sessionId == null) {
+      throw new IllegalStateException("refresh token session insert did not return id");
+    }
+    return sessionId;
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -750,11 +750,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         loginResult("alice", "password123!", "password-reset-disabled-login-001");
     updateLegacyUserStatus(userId, "DISABLED", "fraud-review", "password-reset-disabled-ops-001");
 
-    passwordResetExpectUnauthorized(
-        currentSession.accessToken(),
-        "password123!",
-        "newPassword456!",
-        "password-reset-disabled-request-001");
+    passwordReset(
+            currentSession.accessToken(),
+            "password123!",
+            "newPassword456!",
+            "password-reset-disabled-request-001")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("current session is not active"));
   }
 
   @Test
@@ -994,6 +996,93 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
     refreshExpectUnauthorized(middle.refreshToken(), "session-revoke-all-refresh-002");
     refreshExpectUnauthorized(newest.refreshToken(), "session-revoke-all-refresh-003");
     refresh(bob.refreshToken(), "session-revoke-all-refresh-004");
+  }
+
+  @Test
+  void sensitiveMutationsRejectRevokedCurrentSessionAccessToken() throws Exception {
+    TokenPairResponseView loginResult =
+        loginResult("alice", "password123!", "current-session-gate-login-001");
+    long currentSessionId = loadRefreshTokenSessionId(loginResult.refreshToken());
+
+    revokeSession(loginResult.accessToken(), currentSessionId, "current-session-gate-revoke-001")
+        .andExpect(status().isNoContent());
+
+    passwordReset(
+            loginResult.accessToken(),
+            "password123!",
+            "newPassword456!",
+            "current-session-gate-password-reset-001")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("current session is not active"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Authorization", "Bearer " + loginResult.accessToken())
+                .header("Idempotency-Key", "current-session-gate-transfer-001")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": 500,
+                      "currencyCode": "KRW",
+                      "summary": "revoked-session-blocked"
+                    }
+                    """
+                        .formatted(allowedSourceAccountId, targetAccountId)))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("current session is not active"));
+
+    performStartTotpEnrollment(loginResult.accessToken(), "current-session-gate-totp-enroll-001")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("current session is not active"));
+
+    revokeAllSessions(loginResult.accessToken(), "current-session-gate-revoke-all-001")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("current session is not active"));
+  }
+
+  @Test
+  void sensitiveMutationsRejectLegacyJwtWithoutSessionId() throws Exception {
+    loginResult("alice", "password123!", "current-session-gate-legacy-login-001");
+    String legacyAccessToken = issueLegacyAccessToken("alice", userId);
+
+    passwordReset(
+            legacyAccessToken,
+            "password123!",
+            "newPassword456!",
+            "current-session-gate-legacy-password-reset-001")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("current session is not active"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Authorization", "Bearer " + legacyAccessToken)
+                .header("Idempotency-Key", "current-session-gate-legacy-transfer-001")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": 500,
+                      "currencyCode": "KRW",
+                      "summary": "legacy-session-blocked"
+                    }
+                    """
+                        .formatted(allowedSourceAccountId, targetAccountId)))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("current session is not active"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/auth/sessions")
+                .header("Authorization", "Bearer " + legacyAccessToken)
+                .param("size", "10"))
+        .andExpect(status().isOk());
   }
 
   @Test
@@ -1321,8 +1410,8 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     }
                     """
                         .formatted(allowedSourceAccountId, targetAccountId)))
-        .andExpect(status().isForbidden())
-        .andExpect(jsonPath("$.message").value("account access is denied"));
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("current session is not active"));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptorTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptorTest.java
@@ -1,0 +1,119 @@
+package com.aquilabank.global.web.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveCheckCommand;
+import com.aquilabank.domain.auth.usecase.CurrentSessionActiveUseCase;
+import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class CurrentSessionActiveInterceptorTest {
+
+  private CurrentSessionActiveUseCase currentSessionActiveUseCase;
+  private CurrentSessionActiveInterceptor interceptor;
+
+  @BeforeEach
+  void setUp() {
+    currentSessionActiveUseCase = mock(CurrentSessionActiveUseCase.class);
+    interceptor = new CurrentSessionActiveInterceptor(currentSessionActiveUseCase);
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void checksActiveSessionForSensitiveUserMutations() throws Exception {
+    authenticate(new AuthenticatedUserPrincipal(7L, "alice", 11L));
+
+    List<RequestPath> items =
+        List.of(
+            new RequestPath("POST", "/api/v1/transfers"),
+            new RequestPath("POST", "/api/v1/transfers/TRX-1/reversal"),
+            new RequestPath("POST", "/api/v1/auth/password-reset"),
+            new RequestPath("POST", "/api/v1/auth/mfa/totp/enroll"),
+            new RequestPath("POST", "/api/v1/auth/mfa/totp/enroll/verify"),
+            new RequestPath("POST", "/api/v1/auth/mfa/totp/disable"),
+            new RequestPath("POST", "/api/v1/auth/mfa/backup-codes"),
+            new RequestPath("DELETE", "/api/v1/auth/sessions"),
+            new RequestPath("DELETE", "/api/v1/auth/sessions/11"));
+
+    for (RequestPath item : items) {
+      assertTrue(interceptor.preHandle(request(item.method(), item.path()), response(), null));
+    }
+
+    verify(currentSessionActiveUseCase, times(items.size()))
+        .requireActive(new CurrentSessionActiveCheckCommand(7L, 11L));
+  }
+
+  @Test
+  void rejectsSensitiveMutationWhenJwtHasNoSessionId() {
+    authenticate(new AuthenticatedUserPrincipal(7L, "alice"));
+
+    InvalidCredentialsException exception =
+        assertThrows(
+            InvalidCredentialsException.class,
+            () ->
+                interceptor.preHandle(
+                    request("POST", "/api/v1/auth/password-reset"), response(), null));
+
+    assertEquals("current session is not active", exception.getMessage());
+    verifyNoInteractions(currentSessionActiveUseCase);
+  }
+
+  @Test
+  void skipsNonSensitiveAuthPathsForLegacyJwt() throws Exception {
+    authenticate(new AuthenticatedUserPrincipal(7L, "alice"));
+
+    assertTrue(interceptor.preHandle(request("GET", "/api/v1/auth/sessions"), response(), null));
+    assertTrue(interceptor.preHandle(request("POST", "/api/v1/auth/logout"), response(), null));
+    assertTrue(
+        interceptor.preHandle(
+            request("POST", "/api/v1/auth/mfa/totp/challenge/verify"), response(), null));
+
+    verifyNoInteractions(currentSessionActiveUseCase);
+  }
+
+  @Test
+  void skipsBootstrapPrincipalForExistingControllerAuthorization() throws Exception {
+    authenticate(new AuthenticatedAccountPrincipal(101L, "bootstrap-account"));
+
+    assertTrue(interceptor.preHandle(request("POST", "/api/v1/transfers"), response(), null));
+    assertTrue(
+        interceptor.preHandle(request("POST", "/api/v1/auth/password-reset"), response(), null));
+
+    verifyNoInteractions(currentSessionActiveUseCase);
+  }
+
+  private MockHttpServletRequest request(String method, String path) {
+    return new MockHttpServletRequest(method, path);
+  }
+
+  private MockHttpServletResponse response() {
+    return new MockHttpServletResponse();
+  }
+
+  private void authenticate(Object principal) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            UsernamePasswordAuthenticationToken.authenticated(principal, null, List.of()));
+  }
+
+  private record RequestPath(String method, String path) {}
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #172

## 🌿 Base Branch
- `main`

## 📝 Summary
- refresh token session이 revoke/expire된 뒤에도 남은 access token으로 고위험 mutation을 실행하지 못하게 current session active gate를 추가합니다.
- gate는 transfer/password/MFA/session revoke mutation에만 적용하고 login, refresh, logout, password recovery, MFA challenge verify, read path는 제외합니다.

## 🛠 Changes
- current session active domain port/use case와 JDBC exact lookup을 추가했습니다.
- Web MVC interceptor에서 보호 대상 method/path만 선별해 JWT `session_id`가 같은 user의 ACTIVE 미만료 session인지 확인합니다.
- revoked current session access token과 legacy `session_id` 없는 token이 민감 mutation에서 401로 막히는 auth/transfer 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*CurrentSessionActive*' --tests '*LoginAndAccountAccessApiIntegrationTest' --tests '*Transfer*ControllerTest'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back check`
- pre-commit hook: `./back/gradlew -p back check`
- `git rev-list --count main..HEAD` = `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 민감 mutation마다 session exact lookup이 추가됩니다. 대상 path를 고위험 mutation으로 제한해 부하 범위를 줄였습니다.
- 예상 리스크: `session_id` 없는 legacy access token은 read 호환은 유지하지만 민감 mutation에서는 재로그인이 필요합니다.
- 롤백 방법: 이 PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A