### PR TITLE
[Feat] transfer limit/risk policy 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/ledger/exception/TransferLimitExceededException.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/exception/TransferLimitExceededException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.ledger.exception;
+
+/** 송금 한도 초과는 write side effect 없이 거절해야 하는 risk policy 위반입니다. */
+public class TransferLimitExceededException extends RuntimeException {
+
+  public TransferLimitExceededException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/model/TransferLimitPolicy.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/model/TransferLimitPolicy.java
@@ -1,0 +1,17 @@
+package com.aquilabank.domain.ledger.model;
+
+public record TransferLimitPolicy(long singleTransferLimitMinor, long dailyTransferLimitMinor) {
+
+  public TransferLimitPolicy {
+    if (singleTransferLimitMinor <= 0) {
+      throw new IllegalArgumentException("singleTransferLimitMinor must be positive");
+    }
+    if (dailyTransferLimitMinor <= 0) {
+      throw new IllegalArgumentException("dailyTransferLimitMinor must be positive");
+    }
+    if (dailyTransferLimitMinor < singleTransferLimitMinor) {
+      throw new IllegalArgumentException(
+          "dailyTransferLimitMinor must be greater than or equal to singleTransferLimitMinor");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/port/TransferLimitUsageReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/port/TransferLimitUsageReadPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.ledger.port;
+
+import java.time.Instant;
+
+public interface TransferLimitUsageReadPort {
+
+  long sumBookedDebitAmountMinor(
+      long sourceAccountId, String currencyCode, Instant fromInclusive, Instant toExclusive);
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferCommandService.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferCommandService.java
@@ -3,18 +3,24 @@ package com.aquilabank.domain.ledger.usecase;
 import com.aquilabank.domain.ledger.model.TransferCommand;
 import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.port.TransferWritePort;
+import java.util.Objects;
 
-/** 송금 명령을 write port로 위임하는 기본 use case 구현 */
+/** 송금 명령을 한도 policy 검증 후 write port로 위임하는 use case 구현 */
 public final class TransferCommandService implements TransferCommandUseCase {
 
+  private final TransferLimitPolicyUseCase limitPolicyUseCase;
   private final TransferWritePort transferWritePort;
 
-  public TransferCommandService(TransferWritePort transferWritePort) {
-    this.transferWritePort = transferWritePort;
+  public TransferCommandService(
+      TransferLimitPolicyUseCase limitPolicyUseCase, TransferWritePort transferWritePort) {
+    this.limitPolicyUseCase = Objects.requireNonNull(limitPolicyUseCase, "limitPolicyUseCase");
+    this.transferWritePort = Objects.requireNonNull(transferWritePort, "transferWritePort");
   }
 
   @Override
   public TransferResult transfer(TransferCommand command) {
+    // 한도 초과는 command_idempotency insert 전 차단해 실패 side effect를 남기지 않습니다.
+    limitPolicyUseCase.validate(command);
     // 실제 ledger 반영 책임은 write port 구현으로 위임
     return transferWritePort.transfer(command);
   }

--- a/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyService.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyService.java
@@ -1,0 +1,48 @@
+package com.aquilabank.domain.ledger.usecase;
+
+import com.aquilabank.domain.ledger.exception.TransferLimitExceededException;
+import com.aquilabank.domain.ledger.model.TransferCommand;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Objects;
+
+/** source 계좌 기준 risk limit을 command write 전에 검증합니다. */
+public final class TransferLimitPolicyService implements TransferLimitPolicyUseCase {
+
+  private final TransferLimitUsageReadPort usageReadPort;
+  private final Clock clock;
+  private final ZoneId businessZoneId;
+  private final TransferLimitPolicy policy;
+
+  public TransferLimitPolicyService(
+      TransferLimitUsageReadPort usageReadPort,
+      Clock clock,
+      ZoneId businessZoneId,
+      TransferLimitPolicy policy) {
+    this.usageReadPort = Objects.requireNonNull(usageReadPort, "usageReadPort");
+    this.clock = Objects.requireNonNull(clock, "clock");
+    this.businessZoneId = Objects.requireNonNull(businessZoneId, "businessZoneId");
+    this.policy = Objects.requireNonNull(policy, "policy");
+  }
+
+  @Override
+  public void validate(TransferCommand command) {
+    if (command.amountMinor() > policy.singleTransferLimitMinor()) {
+      throw new TransferLimitExceededException("single transfer limit exceeded");
+    }
+    Instant now = clock.instant();
+    LocalDate businessDate = LocalDate.ofInstant(now, businessZoneId);
+    Instant fromInclusive = businessDate.atStartOfDay(businessZoneId).toInstant();
+    Instant toExclusive = businessDate.plusDays(1).atStartOfDay(businessZoneId).toInstant();
+    long dailyUsed =
+        usageReadPort.sumBookedDebitAmountMinor(
+            command.sourceAccountId(), command.currencyCode(), fromInclusive, toExclusive);
+    if (dailyUsed + command.amountMinor() > policy.dailyTransferLimitMinor()) {
+      throw new TransferLimitExceededException("daily transfer limit exceeded");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyUseCase.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.ledger.usecase;
+
+import com.aquilabank.domain.ledger.model.TransferCommand;
+
+public interface TransferLimitPolicyUseCase {
+
+  void validate(TransferCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/TransferCommandConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/TransferCommandConfiguration.java
@@ -4,6 +4,7 @@ import com.aquilabank.domain.ledger.port.TransferReversalWritePort;
 import com.aquilabank.domain.ledger.port.TransferWritePort;
 import com.aquilabank.domain.ledger.usecase.TransferCommandService;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
+import com.aquilabank.domain.ledger.usecase.TransferLimitPolicyUseCase;
 import com.aquilabank.domain.ledger.usecase.TransferReversalCommandService;
 import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
 import org.springframework.context.annotation.Bean;
@@ -14,9 +15,10 @@ import org.springframework.context.annotation.Configuration;
 public class TransferCommandConfiguration {
 
   @Bean
-  TransferCommandUseCase transferCommandUseCase(TransferWritePort transferWritePort) {
+  TransferCommandUseCase transferCommandUseCase(
+      TransferLimitPolicyUseCase transferLimitPolicyUseCase, TransferWritePort transferWritePort) {
     // 쓰기 path도 configuration에서만 adapter를 조립하고 domain service는 순수하게 유지합니다.
-    return new TransferCommandService(transferWritePort);
+    return new TransferCommandService(transferLimitPolicyUseCase, transferWritePort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/config/TransferLimitPolicyConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/TransferLimitPolicyConfiguration.java
@@ -1,0 +1,28 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
+import com.aquilabank.domain.ledger.usecase.TransferLimitPolicyService;
+import com.aquilabank.domain.ledger.usecase.TransferLimitPolicyUseCase;
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** transfer command 진입 전에 적용할 계좌 단위 한도 정책을 조립합니다. */
+@Configuration
+@EnableConfigurationProperties(TransferLimitPolicyProperties.class)
+public class TransferLimitPolicyConfiguration {
+
+  @Bean
+  TransferLimitPolicyUseCase transferLimitPolicyUseCase(
+      TransferLimitUsageReadPort usageReadPort, TransferLimitPolicyProperties properties) {
+    return new TransferLimitPolicyService(
+        usageReadPort,
+        Clock.systemUTC(),
+        ZoneId.of(properties.businessZoneId()),
+        new TransferLimitPolicy(
+            properties.singleTransferLimitMinor(), properties.dailyTransferLimitMinor()));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/config/TransferLimitPolicyProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/TransferLimitPolicyProperties.java
@@ -1,0 +1,29 @@
+package com.aquilabank.global.config;
+
+import java.time.ZoneId;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** 송금 risk policy 기본 한도 설정 */
+@ConfigurationProperties(prefix = "ledger.transfer-limit")
+public record TransferLimitPolicyProperties(
+    long singleTransferLimitMinor, long dailyTransferLimitMinor, String businessZoneId) {
+
+  public TransferLimitPolicyProperties {
+    if (singleTransferLimitMinor <= 0) {
+      throw new IllegalArgumentException(
+          "ledger.transfer-limit.single-transfer-limit-minor must be positive");
+    }
+    if (dailyTransferLimitMinor <= 0) {
+      throw new IllegalArgumentException(
+          "ledger.transfer-limit.daily-transfer-limit-minor must be positive");
+    }
+    if (dailyTransferLimitMinor < singleTransferLimitMinor) {
+      throw new IllegalArgumentException(
+          "ledger.transfer-limit.daily-transfer-limit-minor must be greater than or equal to single-transfer-limit-minor");
+    }
+    if (businessZoneId == null || businessZoneId.isBlank()) {
+      throw new IllegalArgumentException("ledger.transfer-limit.business-zone-id is required");
+    }
+    ZoneId.of(businessZoneId);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferLimitUsageRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferLimitUsageRepository.java
@@ -1,0 +1,43 @@
+package com.aquilabank.global.persistence.ledger;
+
+import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** source 계좌의 당일 BOOKED DEBIT 합계만 읽어 daily limit 검증 비용을 제한합니다. */
+@Repository
+public class JdbcTransferLimitUsageRepository implements TransferLimitUsageReadPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcTransferLimitUsageRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public long sumBookedDebitAmountMinor(
+      long sourceAccountId, String currencyCode, Instant fromInclusive, Instant toExclusive) {
+    Long total =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COALESCE(SUM(amount_minor), 0)::bigint
+            FROM ledger_entry
+            WHERE account_id = :sourceAccountId
+              AND currency_code = :currencyCode
+              AND direction = 'DEBIT'
+              AND entry_status = 'BOOKED'
+              AND booked_at >= :fromInclusive
+              AND booked_at < :toExclusive
+            """,
+            new MapSqlParameterSource()
+                .addValue("sourceAccountId", sourceAccountId)
+                .addValue("currencyCode", currencyCode)
+                .addValue("fromInclusive", Timestamp.from(fromInclusive))
+                .addValue("toExclusive", Timestamp.from(toExclusive)),
+            Long.class);
+    return total == null ? 0L : total;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -19,6 +19,7 @@ import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
 import com.aquilabank.domain.ledger.exception.LedgerSnapshotOpenDriftNotFoundException;
 import com.aquilabank.domain.ledger.exception.SnapshotNotFoundException;
 import com.aquilabank.domain.ledger.exception.TransferAccountStatusBlockedException;
+import com.aquilabank.domain.ledger.exception.TransferLimitExceededException;
 import com.aquilabank.domain.ledger.exception.TransferReversalNotFoundException;
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
 import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
@@ -105,7 +106,8 @@ public class ApiExceptionHandler {
 
   @ExceptionHandler({
     AccountAccessDeniedException.class,
-    TransferAccountStatusBlockedException.class
+    TransferAccountStatusBlockedException.class,
+    TransferLimitExceededException.class
   })
   ResponseEntity<ApiErrorResponse> handleForbidden(
       RuntimeException ex, HttpServletRequest request) {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -125,6 +125,10 @@ auth:
       retention-days: ${AUTH_REFRESH_TOKEN_SESSION_CLEANUP_RETENTION_DAYS:30}
 
 ledger:
+  transfer-limit:
+    single-transfer-limit-minor: ${LEDGER_TRANSFER_LIMIT_SINGLE_TRANSFER_LIMIT_MINOR:10000000}
+    daily-transfer-limit-minor: ${LEDGER_TRANSFER_LIMIT_DAILY_TRANSFER_LIMIT_MINOR:50000000}
+    business-zone-id: ${LEDGER_TRANSFER_LIMIT_BUSINESS_ZONE_ID:Asia/Seoul}
   command-idempotency:
     cleanup:
       enabled: ${LEDGER_COMMAND_IDEMPOTENCY_CLEANUP_ENABLED:true}

--- a/back/src/main/resources/db/migration/V33__add_transfer_limit_lookup_index.sql
+++ b/back/src/main/resources/db/migration/V33__add_transfer_limit_lookup_index.sql
@@ -1,0 +1,4 @@
+-- daily transfer limit은 source 계좌의 BOOKED DEBIT 당일 합계만 조회합니다.
+CREATE INDEX idx_ledger_entry_transfer_limit_daily
+    ON ledger_entry (account_id, currency_code, booked_at)
+    WHERE direction = 'DEBIT' AND entry_status = 'BOOKED';

--- a/back/src/test/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyServiceTest.java
@@ -1,0 +1,83 @@
+package com.aquilabank.domain.ledger.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.ledger.exception.TransferLimitExceededException;
+import com.aquilabank.domain.ledger.model.TransferCommand;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TransferLimitPolicyServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-21T01:00:00Z");
+  private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+  private final TransferLimitUsageReadPort usageReadPort =
+      Mockito.mock(TransferLimitUsageReadPort.class);
+
+  @Test
+  void rejectsWhenSingleTransferLimitIsExceededWithoutUsageLookup() {
+    TransferLimitPolicyService service =
+        new TransferLimitPolicyService(
+            usageReadPort,
+            Clock.fixed(NOW, ZoneOffset.UTC),
+            SEOUL,
+            new TransferLimitPolicy(1_000L, 10_000L));
+
+    assertThatThrownBy(() -> service.validate(command(1_001L)))
+        .isInstanceOf(TransferLimitExceededException.class)
+        .hasMessage("single transfer limit exceeded");
+    verifyNoInteractions(usageReadPort);
+  }
+
+  @Test
+  void rejectsWhenDailyOutgoingLimitWouldBeExceededForSourceAccountDay() {
+    TransferLimitPolicyService service =
+        new TransferLimitPolicyService(
+            usageReadPort,
+            Clock.fixed(NOW, ZoneOffset.UTC),
+            SEOUL,
+            new TransferLimitPolicy(1_000L, 5_000L));
+    Instant expectedFrom = Instant.parse("2026-04-20T15:00:00Z");
+    Instant expectedTo = Instant.parse("2026-04-21T15:00:00Z");
+    when(usageReadPort.sumBookedDebitAmountMinor(101L, "KRW", expectedFrom, expectedTo))
+        .thenReturn(4_500L);
+
+    assertThatThrownBy(() -> service.validate(command(600L)))
+        .isInstanceOf(TransferLimitExceededException.class)
+        .hasMessage("daily transfer limit exceeded");
+    verify(usageReadPort).sumBookedDebitAmountMinor(101L, "KRW", expectedFrom, expectedTo);
+  }
+
+  @Test
+  void allowsWhenSingleAndDailyLimitsAreNotExceeded() {
+    TransferLimitPolicyService service =
+        new TransferLimitPolicyService(
+            usageReadPort,
+            Clock.fixed(NOW, ZoneOffset.UTC),
+            SEOUL,
+            new TransferLimitPolicy(1_000L, 5_000L));
+    Instant expectedFrom = Instant.parse("2026-04-20T15:00:00Z");
+    Instant expectedTo = Instant.parse("2026-04-21T15:00:00Z");
+    when(usageReadPort.sumBookedDebitAmountMinor(101L, "KRW", expectedFrom, expectedTo))
+        .thenReturn(4_400L);
+
+    assertThatCode(() -> service.validate(command(600L))).doesNotThrowAnyException();
+    verify(usageReadPort).sumBookedDebitAmountMinor(101L, "KRW", expectedFrom, expectedTo);
+  }
+
+  private TransferCommand command(long amountMinor) {
+    return new TransferCommand(
+        101L, 202L, amountMinor, "KRW", "policy test", "transfer-limit-test");
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/TransferLimitPolicyConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/TransferLimitPolicyConfigurationTest.java
@@ -1,0 +1,56 @@
+package com.aquilabank.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
+import com.aquilabank.domain.ledger.usecase.TransferLimitPolicyUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class TransferLimitPolicyConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(TransferLimitPolicyConfiguration.class)
+          .withBean(TransferLimitUsageReadPort.class, () -> mock(TransferLimitUsageReadPort.class))
+          .withPropertyValues(
+              "ledger.transfer-limit.single-transfer-limit-minor=1000000",
+              "ledger.transfer-limit.daily-transfer-limit-minor=5000000",
+              "ledger.transfer-limit.business-zone-id=Asia/Seoul");
+
+  @Test
+  void createsTransferLimitPolicyUseCase() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasSingleBean(TransferLimitPolicyUseCase.class);
+          assertThat(context).hasSingleBean(TransferLimitPolicyProperties.class);
+        });
+  }
+
+  @Test
+  void rejectsNonPositiveSingleLimit() {
+    contextRunner
+        .withPropertyValues("ledger.transfer-limit.single-transfer-limit-minor=0")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .hasRootCauseMessage(
+                      "ledger.transfer-limit.single-transfer-limit-minor must be positive");
+            });
+  }
+
+  @Test
+  void rejectsDailyLimitSmallerThanSingleLimit() {
+    contextRunner
+        .withPropertyValues("ledger.transfer-limit.daily-transfer-limit-minor=999999")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .hasRootCauseMessage(
+                      "ledger.transfer-limit.daily-transfer-limit-minor must be greater than or equal to single-transfer-limit-minor");
+            });
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/ledger/JdbcTransferLimitUsageRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/ledger/JdbcTransferLimitUsageRepositoryIntegrationTest.java
@@ -1,0 +1,136 @@
+package com.aquilabank.global.persistence.ledger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcTransferLimitUsageRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  private static final Instant DAY_START = Instant.parse("2026-04-20T15:00:00Z");
+  private static final Instant DAY_END = Instant.parse("2026-04-21T15:00:00Z");
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @Autowired private JdbcTransferLimitUsageRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void sumsOnlyBookedDebitLedgerEntriesForSourceAccountCurrencyAndDayWindow() {
+    long[] sourceAccountId = new long[1];
+    long[] otherAccountId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          sourceAccountId[0] = insertAccount("source");
+          otherAccountId[0] = insertAccount("other");
+          insertLedger(sourceAccountId[0], "DEBIT", "BOOKED", 1_000L, "KRW", DAY_START);
+          insertLedger(
+              sourceAccountId[0], "DEBIT", "BOOKED", 2_000L, "KRW", DAY_END.minusSeconds(1));
+          insertLedger(
+              sourceAccountId[0], "CREDIT", "BOOKED", 9_000L, "KRW", DAY_START.plusSeconds(1));
+          insertLedger(
+              sourceAccountId[0], "DEBIT", "PENDING", 8_000L, "KRW", DAY_START.plusSeconds(2));
+          insertLedger(
+              sourceAccountId[0], "DEBIT", "BOOKED", 7_000L, "USD", DAY_START.plusSeconds(3));
+          insertLedger(
+              sourceAccountId[0], "DEBIT", "BOOKED", 6_000L, "KRW", DAY_START.minusSeconds(1));
+          insertLedger(sourceAccountId[0], "DEBIT", "BOOKED", 5_000L, "KRW", DAY_END);
+          insertLedger(
+              otherAccountId[0], "DEBIT", "BOOKED", 4_000L, "KRW", DAY_START.plusSeconds(4));
+        });
+
+    long total =
+        repository.sumBookedDebitAmountMinor(sourceAccountId[0], "KRW", DAY_START, DAY_END);
+
+    assertThat(total).isEqualTo(3_000L);
+  }
+
+  private long insertAccount(String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW'
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertLedger(
+      long accountId,
+      String direction,
+      String entryStatus,
+      long amountMinor,
+      String currencyCode,
+      Instant bookedAt) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO ledger_entry (
+            account_id,
+            transaction_reference,
+            entry_reference,
+            direction,
+            entry_status,
+            amount_minor,
+            currency_code,
+            booked_at,
+            metadata,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :accountId,
+            'TRX-' || gen_random_uuid(),
+            'ENT-' || gen_random_uuid(),
+            :direction,
+            :entryStatus,
+            :amountMinor,
+            :currencyCode,
+            :bookedAt,
+            '{}'::jsonb,
+            :bookedAt,
+            :bookedAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("direction", direction)
+            .addValue("entryStatus", entryStatus)
+            .addValue("amountMinor", amountMinor)
+            .addValue("currencyCode", currencyCode)
+            .addValue("bookedAt", Timestamp.from(bookedAt)));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandApiIntegrationTest.java
@@ -29,7 +29,13 @@ import org.springframework.web.context.WebApplicationContext;
 @ActiveProfiles("test")
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+    properties = {
+      "spring.flyway.enabled=true",
+      "management.health.db.enabled=true",
+      "ledger.transfer-limit.single-transfer-limit-minor=2000",
+      "ledger.transfer-limit.daily-transfer-limit-minor=3000",
+      "ledger.transfer-limit.business-zone-id=Asia/Seoul"
+    })
 class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
 
   @Autowired private WebApplicationContext context;
@@ -136,6 +142,51 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
     assertEquals(0L, totalCount("command_idempotency"));
     assertEquals(100L, balanceOf(sourceAccountId));
     assertEquals(0L, balanceOf(targetAccountId));
+  }
+
+  @Test
+  void rejectsTransferWhenSingleLimitIsExceededWithoutWriteSideEffects() throws Exception {
+    long ledgerCountBefore = totalCount("ledger_entry");
+    long transactionCountBefore = totalCount("transaction_read_model");
+    long outboxCountBefore = totalCount("outbox_event");
+    long idempotencyCountBefore = totalCount("command_idempotency");
+    long sourceBalanceBefore = balanceOf(sourceAccountId);
+    long targetBalanceBefore = balanceOf(targetAccountId);
+
+    MvcResult result =
+        invokeTransferRaw("transfer-limit-single-001", targetAccountId, 2_001L, "single limit");
+
+    assertTransferLimitExceeded(result, "single transfer limit exceeded");
+    assertEquals(ledgerCountBefore, totalCount("ledger_entry"));
+    assertEquals(transactionCountBefore, totalCount("transaction_read_model"));
+    assertEquals(outboxCountBefore, totalCount("outbox_event"));
+    assertEquals(idempotencyCountBefore, totalCount("command_idempotency"));
+    assertEquals(0L, idempotencyCount("transfer-limit-single-001"));
+    assertEquals(sourceBalanceBefore, balanceOf(sourceAccountId));
+    assertEquals(targetBalanceBefore, balanceOf(targetAccountId));
+  }
+
+  @Test
+  void rejectsTransferWhenDailyLimitIsExceededWithoutWriteSideEffects() throws Exception {
+    invokeTransfer("transfer-limit-daily-001", targetAccountId, 2_000L, "daily base");
+    long ledgerCountBefore = totalCount("ledger_entry");
+    long transactionCountBefore = totalCount("transaction_read_model");
+    long outboxCountBefore = totalCount("outbox_event");
+    long idempotencyCountBefore = totalCount("command_idempotency");
+    long sourceBalanceBefore = balanceOf(sourceAccountId);
+    long targetBalanceBefore = balanceOf(targetAccountId);
+
+    MvcResult result =
+        invokeTransferRaw("transfer-limit-daily-002", targetAccountId, 1_100L, "daily limit");
+
+    assertTransferLimitExceeded(result, "daily transfer limit exceeded");
+    assertEquals(ledgerCountBefore, totalCount("ledger_entry"));
+    assertEquals(transactionCountBefore, totalCount("transaction_read_model"));
+    assertEquals(outboxCountBefore, totalCount("outbox_event"));
+    assertEquals(idempotencyCountBefore, totalCount("command_idempotency"));
+    assertEquals(0L, idempotencyCount("transfer-limit-daily-002"));
+    assertEquals(sourceBalanceBefore, balanceOf(sourceAccountId));
+    assertEquals(targetBalanceBefore, balanceOf(targetAccountId));
   }
 
   @Test
@@ -629,27 +680,7 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
   private TransferResponseView invokeTransfer(
       String idempotencyKey, long targetAccountId, long amountMinor, String summary)
       throws Exception {
-    String requestId = idempotencyKey + "-request";
-    MvcResult result =
-        mockMvc
-            .perform(
-                post("/api/v1/transfers")
-                    .header("X-Account-Id", String.valueOf(sourceAccountId))
-                    .header("X-Request-Id", requestId)
-                    .header("Idempotency-Key", idempotencyKey)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(
-                        """
-                        {
-                          "sourceAccountId": %d,
-                          "targetAccountId": %d,
-                          "amountMinor": %d,
-                          "currencyCode": "KRW",
-                          "summary": "%s"
-                        }
-                        """
-                            .formatted(sourceAccountId, targetAccountId, amountMinor, summary)))
-            .andReturn();
+    MvcResult result = invokeTransferRaw(idempotencyKey, targetAccountId, amountMinor, summary);
 
     assertEquals(200, result.getResponse().getStatus(), result.getResponse().getContentAsString());
 
@@ -657,6 +688,31 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
         objectMapper.readValue(
             result.getResponse().getContentAsByteArray(), TransferResponseBody.class),
         result.getResponse().getHeader("X-Request-Id"));
+  }
+
+  private MvcResult invokeTransferRaw(
+      String idempotencyKey, long targetAccountId, long amountMinor, String summary)
+      throws Exception {
+    String requestId = idempotencyKey + "-request";
+    return mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("X-Account-Id", String.valueOf(sourceAccountId))
+                .header("X-Request-Id", requestId)
+                .header("Idempotency-Key", idempotencyKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": %d,
+                      "targetAccountId": %d,
+                      "amountMinor": %d,
+                      "currencyCode": "KRW",
+                      "summary": "%s"
+                    }
+                    """
+                        .formatted(sourceAccountId, targetAccountId, amountMinor, summary)))
+        .andReturn();
   }
 
   private TransferReversalResponseView invokeReversal(
@@ -785,6 +841,16 @@ class TransferCommandApiIntegrationTest extends PostgresContainerTestSupport {
     assertEquals(403, result.getResponse().getStatus(), result.getResponse().getContentAsString());
     assertEquals(
         "account access is denied",
+        objectMapper
+            .readTree(result.getResponse().getContentAsByteArray())
+            .get("message")
+            .asText());
+  }
+
+  private void assertTransferLimitExceeded(MvcResult result, String message) throws Exception {
+    assertEquals(403, result.getResponse().getStatus(), result.getResponse().getContentAsString());
+    assertEquals(
+        message,
         objectMapper
             .readTree(result.getResponse().getContentAsByteArray())
             .get("message")


### PR DESCRIPTION
## 🔗 Related Issue
- close #180

## 🌿 Base Branch
- `main`

## 📝 Summary
- 송금 write path에 source 계좌 기준 1회/일별 한도 policy를 추가합니다.
- 한도 초과 요청은 command idempotency insert 전에 403으로 거절되어 ledger/read model/outbox/balance side effect를 남기지 않습니다.

## 🛠 Changes
- `ledger.transfer-limit.*` 설정과 domain policy/use case/JDBC usage read port 추가
- source 계좌의 당일 `BOOKED` `DEBIT` 합계를 읽는 bounded index 추가
- 송금 use case에 limit gate 연결 및 403 예외 매핑 추가
- 1회/일별 한도 초과 API integration test와 side-effect 부재 검증 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*TransferLimit*'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*TransferCommandApiIntegrationTest'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*TransferLimit*' --tests '*TransferCommandApiIntegrationTest'`
- pre-commit hook: `./back/gradlew -p back check`
- `git rev-list --count main..HEAD` = `2`, brief `commit_plan` = `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 설정값을 낮게 배포하면 정상 송금이 403으로 거절될 수 있습니다.
- 롤백 방법: 이 PR revert 또는 `LEDGER_TRANSFER_LIMIT_*` 값을 운영 한도에 맞게 상향 조정합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
