### PR TITLE
[Feat] ledger audit lookup internal API 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/ledger/exception/LedgerAuditEntryNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/exception/LedgerAuditEntryNotFoundException.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.ledger.exception;
+
+/** 내부 ledger audit lookup에서 entryReference 단건을 찾지 못한 상태 */
+public class LedgerAuditEntryNotFoundException extends RuntimeException {
+
+  public LedgerAuditEntryNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/model/LedgerAuditEntry.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/model/LedgerAuditEntry.java
@@ -1,0 +1,18 @@
+package com.aquilabank.domain.ledger.model;
+
+import java.time.Instant;
+
+public record LedgerAuditEntry(
+    long id,
+    long accountId,
+    String transactionReference,
+    String entryReference,
+    String direction,
+    String entryStatus,
+    long amountMinor,
+    String currencyCode,
+    Instant bookedAt,
+    Instant occurredAt,
+    String description,
+    String traceId,
+    Instant createdAt) {}

--- a/back/src/main/java/com/aquilabank/domain/ledger/port/LedgerAuditLookupPort.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/port/LedgerAuditLookupPort.java
@@ -1,0 +1,15 @@
+package com.aquilabank.domain.ledger.port;
+
+import com.aquilabank.domain.ledger.model.LedgerAuditEntry;
+import java.util.List;
+import java.util.Optional;
+
+public interface LedgerAuditLookupPort {
+
+  List<LedgerAuditEntry> findByRequestId(String requestId, long afterEntryId, int limit);
+
+  List<LedgerAuditEntry> findByTransactionReference(
+      String transactionReference, long afterEntryId, int limit);
+
+  Optional<LedgerAuditEntry> findByEntryReference(String entryReference);
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/usecase/LedgerAuditLookupService.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/usecase/LedgerAuditLookupService.java
@@ -1,0 +1,55 @@
+package com.aquilabank.domain.ledger.usecase;
+
+import com.aquilabank.domain.ledger.exception.LedgerAuditEntryNotFoundException;
+import com.aquilabank.domain.ledger.model.LedgerAuditEntry;
+import com.aquilabank.domain.ledger.port.LedgerAuditLookupPort;
+import java.util.List;
+import java.util.Objects;
+
+public final class LedgerAuditLookupService implements LedgerAuditLookupUseCase {
+
+  private final LedgerAuditLookupPort lookupPort;
+
+  public LedgerAuditLookupService(LedgerAuditLookupPort lookupPort) {
+    this.lookupPort = Objects.requireNonNull(lookupPort, "lookupPort");
+  }
+
+  @Override
+  public List<LedgerAuditEntry> findByRequestId(String requestId, long afterEntryId, int limit) {
+    validateRequired(requestId, "requestId");
+    validateCursor(afterEntryId, limit);
+    return lookupPort.findByRequestId(requestId, afterEntryId, limit);
+  }
+
+  @Override
+  public List<LedgerAuditEntry> findByTransactionReference(
+      String transactionReference, long afterEntryId, int limit) {
+    validateRequired(transactionReference, "transactionReference");
+    validateCursor(afterEntryId, limit);
+    return lookupPort.findByTransactionReference(transactionReference, afterEntryId, limit);
+  }
+
+  @Override
+  public LedgerAuditEntry getByEntryReference(String entryReference) {
+    validateRequired(entryReference, "entryReference");
+    return lookupPort
+        .findByEntryReference(entryReference)
+        .orElseThrow(
+            () -> new LedgerAuditEntryNotFoundException("ledger audit entry is not found"));
+  }
+
+  private void validateRequired(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " is required");
+    }
+  }
+
+  private void validateCursor(long afterEntryId, int limit) {
+    if (afterEntryId < 0) {
+      throw new IllegalArgumentException("afterEntryId must not be negative");
+    }
+    if (limit <= 0) {
+      throw new IllegalArgumentException("limit must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/usecase/LedgerAuditLookupUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/usecase/LedgerAuditLookupUseCase.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.ledger.usecase;
+
+import com.aquilabank.domain.ledger.model.LedgerAuditEntry;
+import java.util.List;
+
+public interface LedgerAuditLookupUseCase {
+
+  List<LedgerAuditEntry> findByRequestId(String requestId, long afterEntryId, int limit);
+
+  List<LedgerAuditEntry> findByTransactionReference(
+      String transactionReference, long afterEntryId, int limit);
+
+  LedgerAuditEntry getByEntryReference(String entryReference);
+}

--- a/back/src/main/java/com/aquilabank/global/config/LedgerAuditLookupConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/LedgerAuditLookupConfiguration.java
@@ -1,0 +1,17 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.ledger.port.LedgerAuditLookupPort;
+import com.aquilabank.domain.ledger.usecase.LedgerAuditLookupService;
+import com.aquilabank.domain.ledger.usecase.LedgerAuditLookupUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** ledger audit lookup use case와 read adapter를 조립합니다. */
+@Configuration
+public class LedgerAuditLookupConfiguration {
+
+  @Bean
+  LedgerAuditLookupUseCase ledgerAuditLookupUseCase(LedgerAuditLookupPort lookupPort) {
+    return new LedgerAuditLookupService(lookupPort);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcLedgerAuditLookupRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcLedgerAuditLookupRepository.java
@@ -1,0 +1,136 @@
+package com.aquilabank.global.persistence.ledger;
+
+import com.aquilabank.domain.ledger.model.LedgerAuditEntry;
+import com.aquilabank.domain.ledger.port.LedgerAuditLookupPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** ledger_entry 원본 감사 추적을 index 기반 bounded lookup으로 제한합니다. */
+@Repository
+public class JdbcLedgerAuditLookupRepository implements LedgerAuditLookupPort {
+
+  private static final RowMapper<LedgerAuditEntry> ROW_MAPPER =
+      (rs, rowNum) -> mapLedgerAuditEntry(rs);
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcLedgerAuditLookupRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<LedgerAuditEntry> findByRequestId(String requestId, long afterEntryId, int limit) {
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               account_id,
+               transaction_reference,
+               entry_reference,
+               direction,
+               entry_status,
+               amount_minor,
+               currency_code,
+               booked_at,
+               occurred_at,
+               description,
+               trace_id,
+               created_at
+        FROM ledger_entry
+        WHERE trace_id = :requestId
+          AND id > :afterEntryId
+        ORDER BY id ASC
+        LIMIT :limit
+        """,
+        new MapSqlParameterSource()
+            .addValue("requestId", requestId)
+            .addValue("afterEntryId", afterEntryId)
+            .addValue("limit", limit),
+        ROW_MAPPER);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<LedgerAuditEntry> findByTransactionReference(
+      String transactionReference, long afterEntryId, int limit) {
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               account_id,
+               transaction_reference,
+               entry_reference,
+               direction,
+               entry_status,
+               amount_minor,
+               currency_code,
+               booked_at,
+               occurred_at,
+               description,
+               trace_id,
+               created_at
+        FROM ledger_entry
+        WHERE transaction_reference = :transactionReference
+          AND id > :afterEntryId
+        ORDER BY id ASC
+        LIMIT :limit
+        """,
+        new MapSqlParameterSource()
+            .addValue("transactionReference", transactionReference)
+            .addValue("afterEntryId", afterEntryId)
+            .addValue("limit", limit),
+        ROW_MAPPER);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<LedgerAuditEntry> findByEntryReference(String entryReference) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT id,
+                   account_id,
+                   transaction_reference,
+                   entry_reference,
+                   direction,
+                   entry_status,
+                   amount_minor,
+                   currency_code,
+                   booked_at,
+                   occurred_at,
+                   description,
+                   trace_id,
+                   created_at
+            FROM ledger_entry
+            WHERE entry_reference = :entryReference
+            """,
+            new MapSqlParameterSource().addValue("entryReference", entryReference),
+            ROW_MAPPER)
+        .stream()
+        .findFirst();
+  }
+
+  private static LedgerAuditEntry mapLedgerAuditEntry(ResultSet rs) throws SQLException {
+    return new LedgerAuditEntry(
+        rs.getLong("id"),
+        rs.getLong("account_id"),
+        rs.getString("transaction_reference"),
+        rs.getString("entry_reference"),
+        rs.getString("direction"),
+        rs.getString("entry_status"),
+        rs.getLong("amount_minor"),
+        rs.getString("currency_code"),
+        rs.getObject("booked_at", OffsetDateTime.class).toInstant(),
+        rs.getObject("occurred_at", OffsetDateTime.class).toInstant(),
+        rs.getString("description"),
+        rs.getString("trace_id"),
+        rs.getObject("created_at", OffsetDateTime.class).toInstant());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -16,6 +16,7 @@ import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
+import com.aquilabank.domain.ledger.exception.LedgerAuditEntryNotFoundException;
 import com.aquilabank.domain.ledger.exception.LedgerSnapshotOpenDriftNotFoundException;
 import com.aquilabank.domain.ledger.exception.SnapshotNotFoundException;
 import com.aquilabank.domain.ledger.exception.TransferAccountStatusBlockedException;
@@ -127,6 +128,7 @@ public class ApiExceptionHandler {
     AuthUserNotFoundException.class,
     ExternalIdentityAuditNotFoundException.class,
     ExternalIdentityMappingNotFoundException.class,
+    LedgerAuditEntryNotFoundException.class,
     PasswordRecoveryTokenNotFoundException.class,
     UserAccountMembershipNotFoundException.class,
     NotificationNotFoundException.class,

--- a/back/src/main/java/com/aquilabank/global/web/ledger/LedgerAuditEntryListResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/LedgerAuditEntryListResponse.java
@@ -1,0 +1,26 @@
+package com.aquilabank.global.web.ledger;
+
+import com.aquilabank.domain.ledger.model.LedgerAuditEntry;
+import java.util.List;
+
+public record LedgerAuditEntryListResponse(
+    String lookupType,
+    String lookupValue,
+    long afterEntryId,
+    int limit,
+    long nextAfterEntryId,
+    List<LedgerAuditEntryResponse> items) {
+
+  static LedgerAuditEntryListResponse from(
+      String lookupType,
+      String lookupValue,
+      long afterEntryId,
+      int limit,
+      List<LedgerAuditEntry> items) {
+    List<LedgerAuditEntryResponse> responses =
+        items.stream().map(LedgerAuditEntryResponse::from).toList();
+    long nextAfterEntryId = items.isEmpty() ? afterEntryId : items.getLast().id();
+    return new LedgerAuditEntryListResponse(
+        lookupType, lookupValue, afterEntryId, limit, nextAfterEntryId, responses);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ledger/LedgerAuditEntryResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/LedgerAuditEntryResponse.java
@@ -1,0 +1,37 @@
+package com.aquilabank.global.web.ledger;
+
+import com.aquilabank.domain.ledger.model.LedgerAuditEntry;
+import java.time.Instant;
+
+public record LedgerAuditEntryResponse(
+    long id,
+    long accountId,
+    String transactionReference,
+    String entryReference,
+    String direction,
+    String entryStatus,
+    long amountMinor,
+    String currencyCode,
+    Instant bookedAt,
+    Instant occurredAt,
+    String description,
+    String traceId,
+    Instant createdAt) {
+
+  static LedgerAuditEntryResponse from(LedgerAuditEntry item) {
+    return new LedgerAuditEntryResponse(
+        item.id(),
+        item.accountId(),
+        item.transactionReference(),
+        item.entryReference(),
+        item.direction(),
+        item.entryStatus(),
+        item.amountMinor(),
+        item.currencyCode(),
+        item.bookedAt(),
+        item.occurredAt(),
+        item.description(),
+        item.traceId(),
+        item.createdAt());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ledger/LedgerAuditLookupController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/LedgerAuditLookupController.java
@@ -1,0 +1,80 @@
+package com.aquilabank.global.web.ledger;
+
+import com.aquilabank.domain.ledger.usecase.LedgerAuditLookupUseCase;
+import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
+import com.aquilabank.global.security.InternalServiceScope;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** ledger 원본 추적 API는 내부 운영 token과 bounded cursor 조회로만 허용합니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/ledger/audit")
+public class LedgerAuditLookupController {
+
+  private static final int DEFAULT_LIMIT = 50;
+  private static final int MAX_LIMIT = 100;
+
+  private final LedgerAuditLookupUseCase lookupUseCase;
+  private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
+
+  public LedgerAuditLookupController(
+      LedgerAuditLookupUseCase lookupUseCase,
+      InternalServiceRequestAuthorizer internalServiceRequestAuthorizer) {
+    this.lookupUseCase = lookupUseCase;
+    this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
+  }
+
+  @GetMapping("/request-ids/{requestId}/entries")
+  public LedgerAuditEntryListResponse findByRequestId(
+      HttpServletRequest request,
+      @PathVariable String requestId,
+      @RequestParam(required = false, defaultValue = "0")
+          @PositiveOrZero(message = "afterEntryId must not be negative") long afterEntryId,
+      @RequestParam(required = false) @Positive(message = "limit must be positive") Integer limit) {
+    internalServiceRequestAuthorizer.requireScope(request, InternalServiceScope.LEDGER_OPS);
+    int resolvedLimit = resolveLimit(limit);
+    return LedgerAuditEntryListResponse.from(
+        "REQUEST_ID",
+        requestId,
+        afterEntryId,
+        resolvedLimit,
+        lookupUseCase.findByRequestId(requestId, afterEntryId, resolvedLimit));
+  }
+
+  @GetMapping("/transactions/{transactionReference}/entries")
+  public LedgerAuditEntryListResponse findByTransactionReference(
+      HttpServletRequest request,
+      @PathVariable String transactionReference,
+      @RequestParam(required = false, defaultValue = "0")
+          @PositiveOrZero(message = "afterEntryId must not be negative") long afterEntryId,
+      @RequestParam(required = false) @Positive(message = "limit must be positive") Integer limit) {
+    internalServiceRequestAuthorizer.requireScope(request, InternalServiceScope.LEDGER_OPS);
+    int resolvedLimit = resolveLimit(limit);
+    return LedgerAuditEntryListResponse.from(
+        "TRANSACTION_REFERENCE",
+        transactionReference,
+        afterEntryId,
+        resolvedLimit,
+        lookupUseCase.findByTransactionReference(
+            transactionReference, afterEntryId, resolvedLimit));
+  }
+
+  @GetMapping("/entries/{entryReference}")
+  public LedgerAuditEntryResponse findByEntryReference(
+      HttpServletRequest request, @PathVariable String entryReference) {
+    internalServiceRequestAuthorizer.requireScope(request, InternalServiceScope.LEDGER_OPS);
+    return LedgerAuditEntryResponse.from(lookupUseCase.getByEntryReference(entryReference));
+  }
+
+  private int resolveLimit(Integer limit) {
+    return limit == null ? DEFAULT_LIMIT : Math.min(limit, MAX_LIMIT);
+  }
+}

--- a/back/src/main/resources/db/migration/V34__add_ledger_audit_lookup_index.sql
+++ b/back/src/main/resources/db/migration/V34__add_ledger_audit_lookup_index.sql
@@ -1,0 +1,4 @@
+-- requestId audit lookup은 trace_id + id cursor로 작은 batch만 추적합니다.
+CREATE INDEX idx_ledger_entry_trace_id_id
+    ON ledger_entry (trace_id, id)
+    WHERE trace_id IS NOT NULL;

--- a/back/src/test/java/com/aquilabank/domain/ledger/usecase/LedgerAuditLookupServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/ledger/usecase/LedgerAuditLookupServiceTest.java
@@ -1,0 +1,89 @@
+package com.aquilabank.domain.ledger.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.ledger.exception.LedgerAuditEntryNotFoundException;
+import com.aquilabank.domain.ledger.model.LedgerAuditEntry;
+import com.aquilabank.domain.ledger.port.LedgerAuditLookupPort;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class LedgerAuditLookupServiceTest {
+
+  private static final LedgerAuditEntry ENTRY =
+      new LedgerAuditEntry(
+          10L,
+          101L,
+          "TRX-audit-001",
+          "ENT-audit-001",
+          "DEBIT",
+          "BOOKED",
+          1_000L,
+          "KRW",
+          Instant.parse("2026-04-21T00:00:00Z"),
+          Instant.parse("2026-04-21T00:00:00Z"),
+          "audit transfer",
+          "audit-request-001",
+          Instant.parse("2026-04-21T00:00:00Z"));
+
+  private final LedgerAuditLookupPort lookupPort = Mockito.mock(LedgerAuditLookupPort.class);
+  private final LedgerAuditLookupService service = new LedgerAuditLookupService(lookupPort);
+
+  @Test
+  void delegatesRequestIdLookupWithBoundedCursorArguments() {
+    when(lookupPort.findByRequestId("audit-request-001", 5L, 20)).thenReturn(List.of(ENTRY));
+
+    List<LedgerAuditEntry> result = service.findByRequestId("audit-request-001", 5L, 20);
+
+    assertThat(result).containsExactly(ENTRY);
+    verify(lookupPort).findByRequestId("audit-request-001", 5L, 20);
+  }
+
+  @Test
+  void delegatesTransactionReferenceLookupWithBoundedCursorArguments() {
+    when(lookupPort.findByTransactionReference("TRX-audit-001", 0L, 10)).thenReturn(List.of(ENTRY));
+
+    List<LedgerAuditEntry> result = service.findByTransactionReference("TRX-audit-001", 0L, 10);
+
+    assertThat(result).containsExactly(ENTRY);
+    verify(lookupPort).findByTransactionReference("TRX-audit-001", 0L, 10);
+  }
+
+  @Test
+  void returnsEntryReferenceLookupResult() {
+    when(lookupPort.findByEntryReference("ENT-audit-001")).thenReturn(Optional.of(ENTRY));
+
+    LedgerAuditEntry result = service.getByEntryReference("ENT-audit-001");
+
+    assertThat(result).isEqualTo(ENTRY);
+    verify(lookupPort).findByEntryReference("ENT-audit-001");
+  }
+
+  @Test
+  void rejectsInvalidLookupArguments() {
+    assertThatThrownBy(() -> service.findByRequestId(" ", 0L, 10))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("requestId is required");
+    assertThatThrownBy(() -> service.findByRequestId("audit-request-001", -1L, 10))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("afterEntryId must not be negative");
+    assertThatThrownBy(() -> service.findByRequestId("audit-request-001", 0L, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("limit must be positive");
+  }
+
+  @Test
+  void throwsWhenEntryReferenceDoesNotExist() {
+    when(lookupPort.findByEntryReference("ENT-missing")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getByEntryReference("ENT-missing"))
+        .isInstanceOf(LedgerAuditEntryNotFoundException.class)
+        .hasMessage("ledger audit entry is not found");
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/ledger/JdbcLedgerAuditLookupRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/ledger/JdbcLedgerAuditLookupRepositoryIntegrationTest.java
@@ -1,0 +1,208 @@
+package com.aquilabank.global.persistence.ledger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.ledger.model.LedgerAuditEntry;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcLedgerAuditLookupRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  private static final Instant BASE = Instant.parse("2026-04-21T00:00:00Z");
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @Autowired private JdbcLedgerAuditLookupRepository repository;
+
+  private long firstEntryId;
+  private long secondEntryId;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+    commit(
+        transactionManager,
+        () -> {
+          long accountId = insertAccount("audit account");
+          firstEntryId =
+              insertLedgerEntry(
+                  accountId,
+                  "TRX-audit-001",
+                  "ENT-audit-001",
+                  "DEBIT",
+                  "BOOKED",
+                  1_000L,
+                  "audit request first",
+                  "audit-request-001",
+                  BASE);
+          secondEntryId =
+              insertLedgerEntry(
+                  accountId,
+                  "TRX-audit-001",
+                  "ENT-audit-002",
+                  "CREDIT",
+                  "BOOKED",
+                  1_000L,
+                  "audit request second",
+                  "audit-request-001",
+                  BASE.plusSeconds(1));
+          insertLedgerEntry(
+              accountId,
+              "TRX-audit-002",
+              "ENT-audit-003",
+              "DEBIT",
+              "BOOKED",
+              500L,
+              "other request",
+              "audit-request-002",
+              BASE.plusSeconds(2));
+        });
+  }
+
+  @Test
+  void findsByRequestIdWithIdCursorAndLimit() {
+    List<LedgerAuditEntry> items = repository.findByRequestId("audit-request-001", firstEntryId, 1);
+
+    assertThat(items).hasSize(1);
+    LedgerAuditEntry item = items.getFirst();
+    assertThat(item.id()).isEqualTo(secondEntryId);
+    assertThat(item.entryReference()).isEqualTo("ENT-audit-002");
+    assertThat(item.traceId()).isEqualTo("audit-request-001");
+  }
+
+  @Test
+  void findsByTransactionReferenceWithIdOrdering() {
+    List<LedgerAuditEntry> items = repository.findByTransactionReference("TRX-audit-001", 0L, 10);
+
+    assertThat(items).extracting(LedgerAuditEntry::id).containsExactly(firstEntryId, secondEntryId);
+    assertThat(items)
+        .extracting(LedgerAuditEntry::transactionReference)
+        .containsOnly("TRX-audit-001");
+  }
+
+  @Test
+  void findsSingleEntryByEntryReference() {
+    Optional<LedgerAuditEntry> item = repository.findByEntryReference("ENT-audit-001");
+
+    assertThat(item).isPresent();
+    assertThat(item.get().id()).isEqualTo(firstEntryId);
+    assertThat(item.get().description()).isEqualTo("audit request first");
+    assertThat(item.get().traceId()).isEqualTo("audit-request-001");
+  }
+
+  @Test
+  void returnsEmptyWhenEntryReferenceIsMissing() {
+    assertThat(repository.findByEntryReference("ENT-missing")).isEmpty();
+  }
+
+  private long insertAccount(String displayName) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                :now,
+                :now
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("displayName", displayName)
+                .addValue("now", Timestamp.from(BASE)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return id;
+  }
+
+  private long insertLedgerEntry(
+      long accountId,
+      String transactionReference,
+      String entryReference,
+      String direction,
+      String entryStatus,
+      long amountMinor,
+      String description,
+      String traceId,
+      Instant bookedAt) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO ledger_entry (
+                account_id,
+                transaction_reference,
+                entry_reference,
+                direction,
+                entry_status,
+                amount_minor,
+                currency_code,
+                booked_at,
+                occurred_at,
+                description,
+                trace_id,
+                metadata,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountId,
+                :transactionReference,
+                :entryReference,
+                :direction,
+                :entryStatus,
+                :amountMinor,
+                'KRW',
+                :bookedAt,
+                :bookedAt,
+                :description,
+                :traceId,
+                '{}'::jsonb,
+                :bookedAt,
+                :bookedAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("transactionReference", transactionReference)
+                .addValue("entryReference", entryReference)
+                .addValue("direction", direction)
+                .addValue("entryStatus", entryStatus)
+                .addValue("amountMinor", amountMinor)
+                .addValue("description", description)
+                .addValue("traceId", traceId)
+                .addValue("bookedAt", Timestamp.from(bookedAt)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("ledger_entry insert did not return id");
+    }
+    return id;
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/ledger/LedgerAuditLookupApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/LedgerAuditLookupApiIntegrationTest.java
@@ -1,0 +1,264 @@
+package com.aquilabank.global.web.ledger;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenIssuer;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class LedgerAuditLookupApiIntegrationTest extends PostgresContainerTestSupport {
+
+  private static final Instant BASE = Instant.parse("2026-04-21T00:00:00Z");
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @Autowired private InternalServiceTokenIssuer internalServiceTokenIssuer;
+
+  private MockMvc mockMvc;
+  private long firstEntryId;
+  private long secondEntryId;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    commit(
+        transactionManager,
+        () -> {
+          long accountId = insertAccount("audit api account");
+          firstEntryId =
+              insertLedgerEntry(
+                  accountId,
+                  "TRX-audit-api-001",
+                  "ENT-audit-api-001",
+                  "DEBIT",
+                  "BOOKED",
+                  1_000L,
+                  "audit api first",
+                  "audit-api-request-001",
+                  BASE);
+          secondEntryId =
+              insertLedgerEntry(
+                  accountId,
+                  "TRX-audit-api-001",
+                  "ENT-audit-api-002",
+                  "CREDIT",
+                  "BOOKED",
+                  1_000L,
+                  "audit api second",
+                  "audit-api-request-001",
+                  BASE.plusSeconds(1));
+          insertLedgerEntry(
+              accountId,
+              "TRX-audit-api-002",
+              "ENT-audit-api-003",
+              "DEBIT",
+              "BOOKED",
+              500L,
+              "audit api other",
+              "audit-api-request-002",
+              BASE.plusSeconds(2));
+        });
+  }
+
+  @Test
+  void findsLedgerEntriesByRequestIdWithLimitCap() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/ledger/audit/request-ids/audit-api-request-001/entries")
+                .header("Authorization", ledgerOpsAuthorization())
+                .param("limit", "500"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.lookupType").value("REQUEST_ID"))
+        .andExpect(jsonPath("$.lookupValue").value("audit-api-request-001"))
+        .andExpect(jsonPath("$.afterEntryId").value(0))
+        .andExpect(jsonPath("$.limit").value(100))
+        .andExpect(jsonPath("$.nextAfterEntryId").value(secondEntryId))
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].id").value(firstEntryId))
+        .andExpect(jsonPath("$.items[0].entryReference").value("ENT-audit-api-001"))
+        .andExpect(jsonPath("$.items[0].metadata").doesNotExist());
+  }
+
+  @Test
+  void findsLedgerEntriesByTransactionReferenceWithCursor() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/ledger/audit/transactions/TRX-audit-api-001/entries")
+                .header("Authorization", ledgerOpsAuthorization())
+                .param("afterEntryId", String.valueOf(firstEntryId))
+                .param("limit", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.lookupType").value("TRANSACTION_REFERENCE"))
+        .andExpect(jsonPath("$.lookupValue").value("TRX-audit-api-001"))
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].id").value(secondEntryId))
+        .andExpect(jsonPath("$.items[0].transactionReference").value("TRX-audit-api-001"));
+  }
+
+  @Test
+  void findsLedgerEntryByEntryReference() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/ledger/audit/entries/ENT-audit-api-001")
+                .header("Authorization", ledgerOpsAuthorization()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(firstEntryId))
+        .andExpect(jsonPath("$.entryReference").value("ENT-audit-api-001"))
+        .andExpect(jsonPath("$.transactionReference").value("TRX-audit-api-001"))
+        .andExpect(jsonPath("$.traceId").value("audit-api-request-001"))
+        .andExpect(jsonPath("$.metadata").doesNotExist());
+  }
+
+  @Test
+  void returnsNotFoundWhenEntryReferenceIsMissing() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/ledger/audit/entries/ENT-audit-api-missing")
+                .header("Authorization", ledgerOpsAuthorization()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("ledger audit entry is not found"));
+  }
+
+  @Test
+  void rejectsWithoutLedgerOpsScope() throws Exception {
+    mockMvc
+        .perform(
+            get("/internal/api/v1/ledger/audit/request-ids/audit-api-request-001/entries")
+                .header("Authorization", accountAdminAuthorization()))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+
+  private long insertAccount(String displayName) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                :now,
+                :now
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("displayName", displayName)
+                .addValue("now", Timestamp.from(BASE)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return id;
+  }
+
+  private long insertLedgerEntry(
+      long accountId,
+      String transactionReference,
+      String entryReference,
+      String direction,
+      String entryStatus,
+      long amountMinor,
+      String description,
+      String traceId,
+      Instant bookedAt) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO ledger_entry (
+                account_id,
+                transaction_reference,
+                entry_reference,
+                direction,
+                entry_status,
+                amount_minor,
+                currency_code,
+                booked_at,
+                occurred_at,
+                description,
+                trace_id,
+                metadata,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountId,
+                :transactionReference,
+                :entryReference,
+                :direction,
+                :entryStatus,
+                :amountMinor,
+                'KRW',
+                :bookedAt,
+                :bookedAt,
+                :description,
+                :traceId,
+                '{}'::jsonb,
+                :bookedAt,
+                :bookedAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("transactionReference", transactionReference)
+                .addValue("entryReference", entryReference)
+                .addValue("direction", direction)
+                .addValue("entryStatus", entryStatus)
+                .addValue("amountMinor", amountMinor)
+                .addValue("description", description)
+                .addValue("traceId", traceId)
+                .addValue("bookedAt", Timestamp.from(bookedAt)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("ledger_entry insert did not return id");
+    }
+    return id;
+  }
+
+  private String ledgerOpsAuthorization() {
+    return "Bearer "
+        + internalServiceTokenIssuer.issue(
+            "ledger-ops", java.util.Set.of(InternalServiceScope.LEDGER_OPS));
+  }
+
+  private String accountAdminAuthorization() {
+    return "Bearer "
+        + internalServiceTokenIssuer.issue(
+            "account-admin", java.util.Set.of(InternalServiceScope.ACCOUNT_ADMIN));
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #181

## 🌿 Base Branch
- `main`

## 📝 Summary
- 내부 운영자가 `requestId`, `transactionReference`, `entryReference` 기준으로 `ledger_entry`를 추적하는 LEDGER_OPS API를 추가합니다.
- 목록 조회는 id cursor와 limit 상한으로 bounded 처리하고, 응답은 감사 추적 필드 중심으로 제한합니다.

## 🛠 Changes
- ledger audit lookup domain model/use case/read port/JDBC adapter 추가
- `trace_id, id` 기반 requestId lookup index migration 추가
- `/internal/api/v1/ledger/audit/**` 내부 API 및 응답 DTO 추가
- LEDGER_OPS scope 권한, request/transaction/entry 조회, entryReference 404 integration test 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*LedgerAuditLookup*'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back check`
- pre-commit hook: `./back/gradlew -p back check`
- `git rev-list --count main..HEAD` = `2`, brief `commit_plan` = `2`

## 📸 Screenshot / API Example
- `GET /internal/api/v1/ledger/audit/request-ids/{requestId}/entries?afterEntryId=0&limit=50`
- `GET /internal/api/v1/ledger/audit/transactions/{transactionReference}/entries?afterEntryId=0&limit=50`
- `GET /internal/api/v1/ledger/audit/entries/{entryReference}`

## ⚠️ Risk & Rollback
- 예상 리스크: 이 PR은 `V34__add_ledger_audit_lookup_index.sql`을 사용하므로 `V33`을 포함한 #180 merge 이후 반영하는 순서가 안전합니다.
- 롤백 방법: 이 PR revert. API는 내부 LEDGER_OPS token으로만 접근 가능하며 schema rollback은 index drop migration 또는 revert 배포로 처리합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
