### PR TITLE
[Perf] notification unread projection 및 preference 반영

### DIFF
--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -41,6 +41,8 @@ public class JdbcNotificationInboxRepository
         NotificationInboxAppendPort,
         NotificationInboxCleanupPort {
 
+  private static final String ACCOUNT_SCOPE = "ACCOUNT";
+  private static final String USER_SCOPE = "USER";
   private static final RowMapper<NotificationSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
@@ -154,46 +156,13 @@ public class JdbcNotificationInboxRepository
   @Override
   @Transactional(readOnly = true)
   public long countUnreadByUserId(long userId) {
-    Long count =
-        jdbcTemplate.queryForObject(
-            """
-            SELECT COUNT(*)
-            FROM notification_inbox n
-            JOIN user_account_membership m
-              ON m.account_id = n.account_id
-            JOIN bank_user u
-              ON u.id = m.user_id
-            LEFT JOIN notification_user_read_state r
-              ON r.user_id = :userId
-             AND r.notification_id = n.id
-            WHERE m.user_id = :userId
-              AND m.membership_status = 'ACTIVE'
-              AND u.user_status = 'ACTIVE'
-              AND n.archived_at IS NULL
-              AND r.read_at IS NULL
-              AND r.archived_at IS NULL
-              AND r.deleted_at IS NULL
-            """,
-            new MapSqlParameterSource().addValue("userId", userId),
-            Long.class);
-    return count == null ? 0L : count;
+    return unreadProjectionCount(USER_SCOPE, userId);
   }
 
   @Override
   @Transactional(readOnly = true)
   public long countUnreadByAccountId(long accountId) {
-    Long count =
-        jdbcTemplate.queryForObject(
-            """
-            SELECT COUNT(*)
-            FROM notification_inbox
-            WHERE account_id = :accountId
-              AND archived_at IS NULL
-              AND read_at IS NULL
-            """,
-            new MapSqlParameterSource().addValue("accountId", accountId),
-            Long.class);
-    return count == null ? 0L : count;
+    return unreadProjectionCount(ACCOUNT_SCOPE, accountId);
   }
 
   @Override
@@ -211,68 +180,60 @@ public class JdbcNotificationInboxRepository
   @Override
   @Transactional
   public int markAllAsReadByUserId(long userId, List<Long> notificationIds, Instant readAt) {
-    return upsertUserNotificationState(userId, notificationIds, readAt, null, null);
+    ProjectionUpdateCount count = markUserNotificationsAsRead(userId, notificationIds, readAt);
+    decrementUnreadProjection(USER_SCOPE, userId, count.unreadDelta());
+    return count.matchedCount();
   }
 
   @Override
   @Transactional
   public int markAllAsReadByAccountId(long accountId, List<Long> notificationIds, Instant readAt) {
-    return jdbcTemplate.update(
-        """
-        UPDATE notification_inbox
-        SET read_at = COALESCE(read_at, :readAt)
-        WHERE account_id = :accountId
-          AND archived_at IS NULL
-          AND id IN (:notificationIds)
-        """,
-        new MapSqlParameterSource()
-            .addValue("accountId", accountId)
-            .addValue("notificationIds", notificationIds)
-            .addValue("readAt", Timestamp.from(readAt)));
+    ProjectionUpdateCount count =
+        markAccountNotificationsAsRead(accountId, notificationIds, readAt);
+    decrementUnreadProjection(ACCOUNT_SCOPE, accountId, count.unreadDelta());
+    return count.matchedCount();
   }
 
   @Override
   @Transactional
   public int archiveByUserId(long userId, List<Long> notificationIds, Instant archivedAt) {
-    return upsertUserNotificationState(userId, notificationIds, null, archivedAt, null);
+    ProjectionUpdateCount count =
+        hideUserNotifications(userId, notificationIds, archivedAt, "archived_at");
+    decrementUnreadProjection(USER_SCOPE, userId, count.unreadDelta());
+    return count.matchedCount();
   }
 
   @Override
   @Transactional
   public int archiveByAccountId(long accountId, List<Long> notificationIds, Instant archivedAt) {
-    return jdbcTemplate.update(
-        """
-        UPDATE notification_inbox
-        SET archived_at = COALESCE(archived_at, :archivedAt)
-        WHERE account_id = :accountId
-          AND archived_at IS NULL
-          AND id IN (:notificationIds)
-        """,
-        new MapSqlParameterSource()
-            .addValue("accountId", accountId)
-            .addValue("notificationIds", notificationIds)
-            .addValue("archivedAt", Timestamp.from(archivedAt)));
+    List<ProjectionDelta> userDeltas =
+        findVisibleUnreadUserDeltasForAccountNotifications(accountId, notificationIds);
+    ProjectionUpdateCount count =
+        archiveAccountNotifications(accountId, notificationIds, archivedAt);
+    decrementUnreadProjection(ACCOUNT_SCOPE, accountId, count.unreadDelta());
+    decrementUserUnreadProjections(userDeltas);
+    return count.matchedCount();
   }
 
   @Override
   @Transactional
   public int deleteByUserId(long userId, List<Long> notificationIds, Instant deletedAt) {
     // JWT user delete 는 shared inbox row 삭제 대신 per-user deleted_at 으로 숨겨 다른 공동 사용자 inbox를 보존합니다.
-    return upsertUserNotificationState(userId, notificationIds, null, null, deletedAt);
+    ProjectionUpdateCount count =
+        hideUserNotifications(userId, notificationIds, deletedAt, "deleted_at");
+    decrementUnreadProjection(USER_SCOPE, userId, count.unreadDelta());
+    return count.matchedCount();
   }
 
   @Override
   @Transactional
   public int deleteByAccountId(long accountId, List<Long> notificationIds) {
-    return jdbcTemplate.update(
-        """
-        DELETE FROM notification_inbox
-        WHERE account_id = :accountId
-          AND id IN (:notificationIds)
-        """,
-        new MapSqlParameterSource()
-            .addValue("accountId", accountId)
-            .addValue("notificationIds", notificationIds));
+    List<ProjectionDelta> userDeltas =
+        findVisibleUnreadUserDeltasForAccountNotifications(accountId, notificationIds);
+    ProjectionUpdateCount count = deleteAccountNotifications(accountId, notificationIds);
+    decrementUnreadProjection(ACCOUNT_SCOPE, accountId, count.unreadDelta());
+    decrementUserUnreadProjections(userDeltas);
+    return count.matchedCount();
   }
 
   @Override
@@ -321,6 +282,7 @@ public class JdbcNotificationInboxRepository
                   .addValue("createdAt", Timestamp.from(item.createdAt())),
               ROW_MAPPER));
     }
+    applyUnreadProjectionForInsertedNotifications(insertedItems);
     publishInsertedNotifications(insertedItems);
   }
 
@@ -434,18 +396,156 @@ public class JdbcNotificationInboxRepository
     return value == null ? null : value.toInstant();
   }
 
-  private Timestamp nullableTimestamp(Instant value) {
-    return value == null ? null : Timestamp.from(value);
+  private long unreadProjectionCount(String scopeType, long scopeId) {
+    List<Long> rows =
+        jdbcTemplate.query(
+            """
+            SELECT unread_count
+            FROM notification_unread_count_projection
+            WHERE scope_type = :scopeType
+              AND scope_id = :scopeId
+            """,
+            new MapSqlParameterSource()
+                .addValue("scopeType", scopeType)
+                .addValue("scopeId", scopeId),
+            (rs, rowNum) -> rs.getLong("unread_count"));
+    return rows.isEmpty() ? 0L : rows.getFirst();
   }
 
-  // JWT user 경로는 shared inbox 원본 row를 건드리지 않고 user별 상태만 upsert 해야 공동 사용자 간 정리 동작이 섞이지 않습니다.
-  private int upsertUserNotificationState(
-      long userId,
-      List<Long> notificationIds,
-      Instant readAt,
-      Instant archivedAt,
-      Instant deletedAt) {
-    return jdbcTemplate.update(
+  private void applyUnreadProjectionForInsertedNotifications(List<NotificationSummary> items) {
+    for (NotificationSummary item : items) {
+      incrementUnreadProjection(ACCOUNT_SCOPE, item.accountId(), 1L);
+      hideInsertedNotificationForDisabledUsers(item);
+      incrementUserProjectionForEnabledUsers(item);
+    }
+  }
+
+  private void hideInsertedNotificationForDisabledUsers(NotificationSummary item) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_user_read_state (
+            user_id,
+            notification_id,
+            read_at,
+            archived_at,
+            deleted_at
+        )
+        SELECT m.user_id,
+               :notificationId,
+               NULL,
+               NULL,
+               :deletedAt
+        FROM user_account_membership m
+        JOIN bank_user u
+          ON u.id = m.user_id
+        JOIN notification_preference p
+          ON p.user_id = m.user_id
+         AND p.category = 'TRANSACTIONAL'
+         AND p.channel = 'IN_APP'
+         AND p.enabled = FALSE
+        WHERE m.account_id = :accountId
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+        ON CONFLICT (user_id, notification_id)
+        DO UPDATE
+        SET deleted_at = COALESCE(notification_user_read_state.deleted_at, EXCLUDED.deleted_at)
+        """,
+        new MapSqlParameterSource()
+            .addValue("notificationId", item.id())
+            .addValue("accountId", item.accountId())
+            .addValue("deletedAt", Timestamp.from(item.createdAt())));
+  }
+
+  private void incrementUserProjectionForEnabledUsers(NotificationSummary item) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_unread_count_projection (
+            scope_type,
+            scope_id,
+            unread_count,
+            updated_at
+        )
+        SELECT :scopeType,
+               m.user_id,
+               1,
+               CURRENT_TIMESTAMP
+        FROM user_account_membership m
+        JOIN bank_user u
+          ON u.id = m.user_id
+        LEFT JOIN notification_preference p
+          ON p.user_id = m.user_id
+         AND p.category = 'TRANSACTIONAL'
+         AND p.channel = 'IN_APP'
+        WHERE m.account_id = :accountId
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+          AND COALESCE(p.enabled, TRUE) = TRUE
+        ON CONFLICT (scope_type, scope_id)
+        DO UPDATE
+        SET unread_count = notification_unread_count_projection.unread_count + EXCLUDED.unread_count,
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        new MapSqlParameterSource()
+            .addValue("scopeType", USER_SCOPE)
+            .addValue("accountId", item.accountId()));
+  }
+
+  private void incrementUnreadProjection(String scopeType, long scopeId, long delta) {
+    if (delta <= 0) {
+      return;
+    }
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_unread_count_projection (
+            scope_type,
+            scope_id,
+            unread_count,
+            updated_at
+        )
+        VALUES (
+            :scopeType,
+            :scopeId,
+            :delta,
+            CURRENT_TIMESTAMP
+        )
+        ON CONFLICT (scope_type, scope_id)
+        DO UPDATE
+        SET unread_count = notification_unread_count_projection.unread_count + EXCLUDED.unread_count,
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        new MapSqlParameterSource()
+            .addValue("scopeType", scopeType)
+            .addValue("scopeId", scopeId)
+            .addValue("delta", delta));
+  }
+
+  private void decrementUnreadProjection(String scopeType, long scopeId, long delta) {
+    if (delta <= 0) {
+      return;
+    }
+    jdbcTemplate.update(
+        """
+        UPDATE notification_unread_count_projection
+        SET unread_count = GREATEST(unread_count - :delta, 0),
+            updated_at = CURRENT_TIMESTAMP
+        WHERE scope_type = :scopeType
+          AND scope_id = :scopeId
+        """,
+        new MapSqlParameterSource()
+            .addValue("scopeType", scopeType)
+            .addValue("scopeId", scopeId)
+            .addValue("delta", delta));
+  }
+
+  private void decrementUserUnreadProjections(List<ProjectionDelta> deltas) {
+    for (ProjectionDelta delta : deltas) {
+      decrementUnreadProjection(USER_SCOPE, delta.scopeId(), delta.unreadCount());
+    }
+  }
+
+  private ProjectionUpdateCount markUserNotificationsAsRead(
+      long userId, List<Long> notificationIds, Instant readAt) {
+    return jdbcTemplate.queryForObject(
         """
         WITH accessible_notification AS (
             SELECT n.id
@@ -459,29 +559,268 @@ public class JdbcNotificationInboxRepository
               AND u.user_status = 'ACTIVE'
               AND n.archived_at IS NULL
               AND n.id IN (:notificationIds)
+        ),
+        changed_unread AS (
+            INSERT INTO notification_user_read_state (
+                user_id,
+                notification_id,
+                read_at,
+                archived_at,
+                deleted_at
+            )
+            SELECT :userId, id, :readAt, NULL, NULL
+            FROM accessible_notification
+            ON CONFLICT (user_id, notification_id)
+            DO UPDATE
+            SET read_at = COALESCE(notification_user_read_state.read_at, EXCLUDED.read_at)
+            WHERE notification_user_read_state.read_at IS NULL
+              AND notification_user_read_state.archived_at IS NULL
+              AND notification_user_read_state.deleted_at IS NULL
+            RETURNING notification_id
         )
-        INSERT INTO notification_user_read_state (
-            user_id,
-            notification_id,
-            read_at,
-            archived_at,
-            deleted_at
-        )
-        SELECT :userId, id, :readAt, :archivedAt, :deletedAt
-        FROM accessible_notification
-        ON CONFLICT (user_id, notification_id)
-        DO UPDATE
-        SET read_at = COALESCE(notification_user_read_state.read_at, EXCLUDED.read_at),
-            archived_at = COALESCE(notification_user_read_state.archived_at, EXCLUDED.archived_at),
-            deleted_at = COALESCE(notification_user_read_state.deleted_at, EXCLUDED.deleted_at)
+        SELECT (SELECT COUNT(*) FROM accessible_notification) AS matched_count,
+               (SELECT COUNT(*) FROM changed_unread) AS unread_delta
         """,
         new MapSqlParameterSource()
             .addValue("userId", userId)
             .addValue("notificationIds", notificationIds)
-            .addValue("readAt", nullableTimestamp(readAt))
-            .addValue("archivedAt", nullableTimestamp(archivedAt))
-            .addValue("deletedAt", nullableTimestamp(deletedAt)));
+            .addValue("readAt", Timestamp.from(readAt)),
+        (rs, rowNum) ->
+            new ProjectionUpdateCount(rs.getInt("matched_count"), rs.getInt("unread_delta")));
   }
+
+  private ProjectionUpdateCount hideUserNotifications(
+      long userId, List<Long> notificationIds, Instant hiddenAt, String hiddenColumn) {
+    ProjectionUpdateCount count =
+        jdbcTemplate.queryForObject(
+            """
+            WITH accessible_notification AS (
+                SELECT n.id
+                FROM notification_inbox n
+                JOIN user_account_membership m
+                  ON m.account_id = n.account_id
+                JOIN bank_user u
+                  ON u.id = m.user_id
+                WHERE m.user_id = :userId
+                  AND m.membership_status = 'ACTIVE'
+                  AND u.user_status = 'ACTIVE'
+                  AND n.archived_at IS NULL
+                  AND n.id IN (:notificationIds)
+            ),
+            changed_unread AS (
+                INSERT INTO notification_user_read_state (
+                    user_id,
+                    notification_id,
+                    read_at,
+                    archived_at,
+                    deleted_at
+                )
+                SELECT :userId, id, NULL, %s, %s
+                FROM accessible_notification
+                ON CONFLICT (user_id, notification_id)
+                DO UPDATE
+                SET %s = COALESCE(notification_user_read_state.%s, EXCLUDED.%s)
+                WHERE notification_user_read_state.read_at IS NULL
+                  AND notification_user_read_state.archived_at IS NULL
+                  AND notification_user_read_state.deleted_at IS NULL
+                RETURNING notification_id
+            )
+            SELECT (SELECT COUNT(*) FROM accessible_notification) AS matched_count,
+                   (SELECT COUNT(*) FROM changed_unread) AS unread_delta
+            """
+                .formatted(
+                    hiddenColumnValue("archived_at", hiddenColumn),
+                    hiddenColumnValue("deleted_at", hiddenColumn),
+                    hiddenColumn,
+                    hiddenColumn,
+                    hiddenColumn),
+            new MapSqlParameterSource()
+                .addValue("userId", userId)
+                .addValue("notificationIds", notificationIds)
+                .addValue("hiddenAt", Timestamp.from(hiddenAt)),
+            (rs, rowNum) ->
+                new ProjectionUpdateCount(rs.getInt("matched_count"), rs.getInt("unread_delta")));
+    hideReadUserNotifications(userId, notificationIds, hiddenAt, hiddenColumn);
+    return count;
+  }
+
+  private void hideReadUserNotifications(
+      long userId, List<Long> notificationIds, Instant hiddenAt, String hiddenColumn) {
+    jdbcTemplate.queryForObject(
+        """
+            WITH accessible_notification AS (
+                SELECT n.id
+                FROM notification_inbox n
+                JOIN user_account_membership m
+                  ON m.account_id = n.account_id
+                JOIN bank_user u
+                  ON u.id = m.user_id
+                WHERE m.user_id = :userId
+                  AND m.membership_status = 'ACTIVE'
+                  AND u.user_status = 'ACTIVE'
+                  AND n.archived_at IS NULL
+                  AND n.id IN (:notificationIds)
+            ),
+            changed_read AS (
+                INSERT INTO notification_user_read_state (
+                    user_id,
+                    notification_id,
+                    read_at,
+                    archived_at,
+                    deleted_at
+                )
+                SELECT :userId, id, NULL, %s, %s
+                FROM accessible_notification
+                ON CONFLICT (user_id, notification_id)
+                DO UPDATE
+                SET %s = COALESCE(notification_user_read_state.%s, EXCLUDED.%s)
+                WHERE notification_user_read_state.read_at IS NOT NULL
+                  AND notification_user_read_state.archived_at IS NULL
+                  AND notification_user_read_state.deleted_at IS NULL
+                RETURNING notification_id
+            )
+            SELECT COUNT(*)
+            FROM changed_read
+            """
+            .formatted(
+                hiddenColumnValue("archived_at", hiddenColumn),
+                hiddenColumnValue("deleted_at", hiddenColumn),
+                hiddenColumn,
+                hiddenColumn,
+                hiddenColumn),
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("notificationIds", notificationIds)
+            .addValue("hiddenAt", Timestamp.from(hiddenAt)),
+        Integer.class);
+  }
+
+  private String hiddenColumnValue(String columnName, String hiddenColumn) {
+    return columnName.equals(hiddenColumn) ? ":hiddenAt" : "NULL";
+  }
+
+  private ProjectionUpdateCount markAccountNotificationsAsRead(
+      long accountId, List<Long> notificationIds, Instant readAt) {
+    return jdbcTemplate.queryForObject(
+        """
+        WITH accessible_notification AS (
+            SELECT id,
+                   read_at
+            FROM notification_inbox
+            WHERE account_id = :accountId
+              AND archived_at IS NULL
+              AND id IN (:notificationIds)
+            FOR UPDATE
+        ),
+        updated_notification AS (
+            UPDATE notification_inbox n
+            SET read_at = COALESCE(n.read_at, :readAt)
+            FROM accessible_notification a
+            WHERE n.id = a.id
+            RETURNING a.read_at AS previous_read_at
+        )
+        SELECT COUNT(*) AS matched_count,
+               COUNT(*) FILTER (WHERE previous_read_at IS NULL) AS unread_delta
+        FROM updated_notification
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("notificationIds", notificationIds)
+            .addValue("readAt", Timestamp.from(readAt)),
+        (rs, rowNum) ->
+            new ProjectionUpdateCount(rs.getInt("matched_count"), rs.getInt("unread_delta")));
+  }
+
+  private ProjectionUpdateCount archiveAccountNotifications(
+      long accountId, List<Long> notificationIds, Instant archivedAt) {
+    return jdbcTemplate.queryForObject(
+        """
+        WITH accessible_notification AS (
+            SELECT id,
+                   read_at
+            FROM notification_inbox
+            WHERE account_id = :accountId
+              AND archived_at IS NULL
+              AND id IN (:notificationIds)
+            FOR UPDATE
+        ),
+        updated_notification AS (
+            UPDATE notification_inbox n
+            SET archived_at = COALESCE(n.archived_at, :archivedAt)
+            FROM accessible_notification a
+            WHERE n.id = a.id
+            RETURNING a.read_at AS previous_read_at
+        )
+        SELECT COUNT(*) AS matched_count,
+               COUNT(*) FILTER (WHERE previous_read_at IS NULL) AS unread_delta
+        FROM updated_notification
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("notificationIds", notificationIds)
+            .addValue("archivedAt", Timestamp.from(archivedAt)),
+        (rs, rowNum) ->
+            new ProjectionUpdateCount(rs.getInt("matched_count"), rs.getInt("unread_delta")));
+  }
+
+  private ProjectionUpdateCount deleteAccountNotifications(
+      long accountId, List<Long> notificationIds) {
+    return jdbcTemplate.queryForObject(
+        """
+        WITH deleted_notification AS (
+            DELETE FROM notification_inbox
+            WHERE account_id = :accountId
+              AND id IN (:notificationIds)
+            RETURNING read_at,
+                      archived_at
+        )
+        SELECT COUNT(*) AS matched_count,
+               COUNT(*) FILTER (
+                   WHERE read_at IS NULL
+                     AND archived_at IS NULL
+               ) AS unread_delta
+        FROM deleted_notification
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("notificationIds", notificationIds),
+        (rs, rowNum) ->
+            new ProjectionUpdateCount(rs.getInt("matched_count"), rs.getInt("unread_delta")));
+  }
+
+  private List<ProjectionDelta> findVisibleUnreadUserDeltasForAccountNotifications(
+      long accountId, List<Long> notificationIds) {
+    return jdbcTemplate.query(
+        """
+        SELECT m.user_id AS scope_id,
+               COUNT(*) AS unread_count
+        FROM notification_inbox n
+        JOIN user_account_membership m
+          ON m.account_id = n.account_id
+        JOIN bank_user u
+          ON u.id = m.user_id
+        LEFT JOIN notification_user_read_state r
+          ON r.user_id = m.user_id
+         AND r.notification_id = n.id
+        WHERE n.account_id = :accountId
+          AND n.archived_at IS NULL
+          AND n.id IN (:notificationIds)
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+          AND r.read_at IS NULL
+          AND r.archived_at IS NULL
+          AND r.deleted_at IS NULL
+        GROUP BY m.user_id
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("notificationIds", notificationIds),
+        (rs, rowNum) -> new ProjectionDelta(rs.getLong("scope_id"), rs.getLong("unread_count")));
+  }
+
+  private record ProjectionUpdateCount(int matchedCount, long unreadDelta) {}
+
+  private record ProjectionDelta(long scopeId, long unreadCount) {}
 
   private List<NotificationSummary> fetchByUserIdFirstPage(
       long userId, NotificationListQuery query) {

--- a/back/src/main/resources/db/migration/V35__add_notification_unread_count_projection.sql
+++ b/back/src/main/resources/db/migration/V35__add_notification_unread_count_projection.sql
@@ -1,0 +1,15 @@
+-- unread count API는 대규모 inbox에서 COUNT/JOIN 반복 대신 scope별 counter row만 조회합니다.
+CREATE TABLE notification_unread_count_projection (
+    scope_type VARCHAR(16) NOT NULL,
+    scope_id BIGINT NOT NULL,
+    unread_count BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (scope_type, scope_id),
+    CONSTRAINT chk_notification_unread_projection_scope
+        CHECK (scope_type IN ('USER', 'ACCOUNT')),
+    CONSTRAINT chk_notification_unread_projection_count
+        CHECK (unread_count >= 0)
+);
+
+COMMENT ON TABLE notification_unread_count_projection IS
+    'notification unread count 단건 조회용 projection. USER/ACCOUNT scope별 counter만 유지합니다.';

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -637,6 +637,158 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
   }
 
   @Test
+  void appendsNotificationsAndUpdatesUnreadProjectionOnlyForInsertedRows() {
+    long[] userIds = new long[3];
+    long[] accountId = new long[1];
+    Instant createdAt = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userIds[0] = insertUser("projection-user-a");
+          userIds[1] = insertUser("projection-user-b");
+          userIds[2] = insertUser("projection-user-revoked");
+          accountId[0] = insertAccount("projection account");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
+          insertMembership(userIds[2], accountId[0], "VIEWER", "REVOKED");
+          repository.appendAllIfAbsent(
+              List.of(
+                  new NotificationInboxEntry(
+                      accountId[0],
+                      "transfer-booked:TRX-PROJECTION:ACCOUNT-" + accountId[0],
+                      "TransferBooked",
+                      "이체 완료",
+                      "1500 KRW 입금 · projection",
+                      createdAt)));
+          repository.appendAllIfAbsent(
+              List.of(
+                  new NotificationInboxEntry(
+                      accountId[0],
+                      "transfer-booked:TRX-PROJECTION:ACCOUNT-" + accountId[0],
+                      "TransferBooked",
+                      "이체 완료",
+                      "1500 KRW 입금 · projection",
+                      createdAt)));
+        });
+
+    assertThat(repository.countUnreadByAccountId(accountId[0])).isEqualTo(1L);
+    assertThat(repository.countUnreadByUserId(userIds[0])).isEqualTo(1L);
+    assertThat(repository.countUnreadByUserId(userIds[1])).isEqualTo(1L);
+    assertThat(repository.countUnreadByUserId(userIds[2])).isZero();
+    assertThat(projectionCount("ACCOUNT", accountId[0])).isEqualTo(1L);
+    assertThat(projectionCount("USER", userIds[0])).isEqualTo(1L);
+    assertThat(projectionCount("USER", userIds[1])).isEqualTo(1L);
+    assertThat(projectionCount("USER", userIds[2])).isZero();
+  }
+
+  @Test
+  void updatesUnreadProjectionWhenNotificationsBecomeReadArchivedOrDeleted() {
+    long[] userIds = new long[2];
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[3];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userIds[0] = insertUser("projection-state-a");
+          userIds[1] = insertUser("projection-state-b");
+          accountId[0] = insertAccount("projection state account");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
+          repository.appendAllIfAbsent(
+              List.of(
+                  new NotificationInboxEntry(
+                      accountId[0], "evt-projection-state-1", "TransferBooked", "A", "A", base),
+                  new NotificationInboxEntry(
+                      accountId[0],
+                      "evt-projection-state-2",
+                      "TransferBooked",
+                      "B",
+                      "B",
+                      base.plusSeconds(5)),
+                  new NotificationInboxEntry(
+                      accountId[0],
+                      "evt-projection-state-3",
+                      "TransferBooked",
+                      "C",
+                      "C",
+                      base.plusSeconds(10))));
+          notificationIds[0] = findNotificationIdByEventKey("evt-projection-state-1");
+          notificationIds[1] = findNotificationIdByEventKey("evt-projection-state-2");
+          notificationIds[2] = findNotificationIdByEventKey("evt-projection-state-3");
+        });
+
+    assertThat(projectionCount("ACCOUNT", accountId[0])).isEqualTo(3L);
+    assertThat(projectionCount("USER", userIds[0])).isEqualTo(3L);
+    assertThat(projectionCount("USER", userIds[1])).isEqualTo(3L);
+
+    assertThat(repository.markAsReadByUserId(userIds[0], notificationIds[0], base.plusSeconds(20)))
+        .isTrue();
+    assertThat(projectionCount("USER", userIds[0])).isEqualTo(2L);
+    assertThat(repository.markAsReadByUserId(userIds[0], notificationIds[0], base.plusSeconds(21)))
+        .isTrue();
+    assertThat(projectionCount("USER", userIds[0])).isEqualTo(2L);
+
+    assertThat(
+            repository.archiveByUserId(
+                userIds[0], List.of(notificationIds[1]), base.plusSeconds(30)))
+        .isEqualTo(1);
+    assertThat(projectionCount("USER", userIds[0])).isEqualTo(1L);
+    assertThat(projectionCount("USER", userIds[1])).isEqualTo(3L);
+
+    assertThat(
+            repository.archiveByAccountId(
+                accountId[0], List.of(notificationIds[2]), base.plusSeconds(40)))
+        .isEqualTo(1);
+    assertThat(projectionCount("ACCOUNT", accountId[0])).isEqualTo(2L);
+    assertThat(projectionCount("USER", userIds[0])).isEqualTo(0L);
+    assertThat(projectionCount("USER", userIds[1])).isEqualTo(2L);
+
+    assertThat(repository.deleteByAccountId(accountId[0], List.of(notificationIds[0])))
+        .isEqualTo(1);
+    assertThat(projectionCount("ACCOUNT", accountId[0])).isEqualTo(1L);
+    assertThat(projectionCount("USER", userIds[0])).isEqualTo(0L);
+    assertThat(projectionCount("USER", userIds[1])).isEqualTo(1L);
+  }
+
+  @Test
+  void suppressesInAppNotificationForUsersWithDisabledTransactionalPreference() {
+    long[] userIds = new long[2];
+    long[] accountId = new long[1];
+    Instant createdAt = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userIds[0] = insertUser("preference-enabled-user");
+          userIds[1] = insertUser("preference-disabled-user");
+          accountId[0] = insertAccount("preference account");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
+          insertPreference(userIds[1], "TRANSACTIONAL", "IN_APP", false);
+          repository.appendAllIfAbsent(
+              List.of(
+                  new NotificationInboxEntry(
+                      accountId[0],
+                      "evt-preference-disabled",
+                      "TransferBooked",
+                      "이체 완료",
+                      "1500 KRW 입금 · preference",
+                      createdAt)));
+        });
+
+    assertThat(repository.fetchByUserId(userIds[0], new NotificationListQuery(10, null)).items())
+        .extracting("title")
+        .containsExactly("이체 완료");
+    assertThat(repository.fetchByUserId(userIds[1], new NotificationListQuery(10, null)).items())
+        .isEmpty();
+    assertThat(repository.countUnreadByUserId(userIds[0])).isEqualTo(1L);
+    assertThat(repository.countUnreadByUserId(userIds[1])).isZero();
+    assertThat(projectionCount("USER", userIds[0])).isEqualTo(1L);
+    assertThat(projectionCount("USER", userIds[1])).isZero();
+    assertThat(hiddenStateCount(userIds[1])).isEqualTo(1L);
+  }
+
+  @Test
   void deletesExpiredNotificationsInBatchesAndCascadesUserReadState() {
     long[] userId = new long[1];
     long[] accountId = new long[1];
@@ -825,6 +977,7 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
     if (notificationId == null) {
       throw new IllegalStateException("notification_inbox insert did not return id");
     }
+    seedUnreadProjectionForInsertedNotification(accountId, notificationId, readAt);
     return notificationId;
   }
 
@@ -903,6 +1056,161 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
             .addValue("readAt", readAt == null ? null : Timestamp.from(readAt))
             .addValue("archivedAt", archivedAt == null ? null : Timestamp.from(archivedAt))
             .addValue("deletedAt", deletedAt == null ? null : Timestamp.from(deletedAt)));
+    if (readAt != null || archivedAt != null || deletedAt != null) {
+      decrementTestProjection("USER", userId, 1L);
+    }
+  }
+
+  private void seedUnreadProjectionForInsertedNotification(
+      long accountId, long notificationId, Instant readAt) {
+    if (readAt == null) {
+      incrementTestProjection("ACCOUNT", accountId, 1L);
+    }
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_unread_count_projection (
+            scope_type,
+            scope_id,
+            unread_count,
+            updated_at
+        )
+        SELECT 'USER',
+               m.user_id,
+               1,
+               CURRENT_TIMESTAMP
+        FROM user_account_membership m
+        JOIN bank_user u
+          ON u.id = m.user_id
+        LEFT JOIN notification_preference p
+          ON p.user_id = m.user_id
+         AND p.category = 'TRANSACTIONAL'
+         AND p.channel = 'IN_APP'
+        WHERE m.account_id = :accountId
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+          AND COALESCE(p.enabled, TRUE) = TRUE
+        ON CONFLICT (scope_type, scope_id)
+        DO UPDATE
+        SET unread_count = notification_unread_count_projection.unread_count + EXCLUDED.unread_count,
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("notificationId", notificationId));
+  }
+
+  private void incrementTestProjection(String scopeType, long scopeId, long delta) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_unread_count_projection (
+            scope_type,
+            scope_id,
+            unread_count,
+            updated_at
+        )
+        VALUES (
+            :scopeType,
+            :scopeId,
+            :delta,
+            CURRENT_TIMESTAMP
+        )
+        ON CONFLICT (scope_type, scope_id)
+        DO UPDATE
+        SET unread_count = notification_unread_count_projection.unread_count + EXCLUDED.unread_count,
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        new MapSqlParameterSource()
+            .addValue("scopeType", scopeType)
+            .addValue("scopeId", scopeId)
+            .addValue("delta", delta));
+  }
+
+  private void decrementTestProjection(String scopeType, long scopeId, long delta) {
+    jdbcTemplate.update(
+        """
+        UPDATE notification_unread_count_projection
+        SET unread_count = GREATEST(unread_count - :delta, 0),
+            updated_at = CURRENT_TIMESTAMP
+        WHERE scope_type = :scopeType
+          AND scope_id = :scopeId
+        """,
+        new MapSqlParameterSource()
+            .addValue("scopeType", scopeType)
+            .addValue("scopeId", scopeId)
+            .addValue("delta", delta));
+  }
+
+  private void insertPreference(long userId, String category, String channel, boolean enabled) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_preference (
+            user_id,
+            category,
+            channel,
+            enabled,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :category,
+            :channel,
+            :enabled,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("category", category)
+            .addValue("channel", channel)
+            .addValue("enabled", enabled));
+  }
+
+  private long findNotificationIdByEventKey(String eventKey) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT id
+            FROM notification_inbox
+            WHERE event_key = :eventKey
+            """,
+            new MapSqlParameterSource().addValue("eventKey", eventKey),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("notification_inbox row was not found");
+    }
+    return id;
+  }
+
+  private long projectionCount(String scopeType, long scopeId) {
+    List<Long> rows =
+        jdbcTemplate.query(
+            """
+            SELECT unread_count
+            FROM notification_unread_count_projection
+            WHERE scope_type = :scopeType
+              AND scope_id = :scopeId
+            """,
+            new MapSqlParameterSource()
+                .addValue("scopeType", scopeType)
+                .addValue("scopeId", scopeId),
+            (rs, rowNum) -> rs.getLong("unread_count"));
+    return rows.isEmpty() ? 0L : rows.getFirst();
+  }
+
+  private long hiddenStateCount(long userId) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM notification_user_read_state
+            WHERE user_id = :userId
+              AND deleted_at IS NOT NULL
+            """,
+            new MapSqlParameterSource().addValue("userId", userId),
+            Long.class);
+    return count == null ? 0L : count;
   }
 
   private long totalNotifications() {

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.aquilabank.domain.notification.model.NotificationInboxEntry;
+import com.aquilabank.global.persistence.notification.JdbcNotificationInboxRepository;
 import com.aquilabank.support.PostgresContainerTestSupport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
@@ -44,6 +46,8 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
   @Autowired private WebApplicationContext context;
 
   @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private JdbcNotificationInboxRepository notificationInboxRepository;
 
   @Autowired private PlatformTransactionManager transactionManager;
 
@@ -256,6 +260,60 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
         .andExpect(
             jsonPath("$.items[?(@.category=='SECURITY' && @.channel=='SMS')].enabled")
                 .value(org.hamcrest.Matchers.contains(true)));
+  }
+
+  @Test
+  void hidesInAppNotificationsForJwtUserWithDisabledTransactionalPreference() throws Exception {
+    long[] userIds = new long[2];
+    long[] accountId = new long[1];
+    Instant createdAt = Instant.parse("2026-04-17T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userIds[0] = insertUser("api-pref-enabled-user");
+          userIds[1] = insertUser("api-pref-disabled-user");
+          accountId[0] = insertAccount("api preference account");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
+          insertPreference(userIds[1], "TRANSACTIONAL", "IN_APP", false);
+          notificationInboxRepository.appendAllIfAbsent(
+              java.util.List.of(
+                  new NotificationInboxEntry(
+                      accountId[0],
+                      "evt-api-preference-disabled",
+                      "TransferBooked",
+                      "이체 완료",
+                      "1500 KRW 입금 · preference",
+                      createdAt)));
+        });
+
+    String enabledToken = issueToken("api-pref-enabled-subject", userIds[0]);
+    String disabledToken = issueToken("api-pref-disabled-subject", userIds[1]);
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + enabledToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].title").value("이체 완료"));
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + disabledToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(0));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count")
+                .header("Authorization", "Bearer " + enabledToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(1));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count")
+                .header("Authorization", "Bearer " + disabledToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(0));
   }
 
   @Test
@@ -862,7 +920,96 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
     if (notificationId == null) {
       throw new IllegalStateException("notification_inbox insert did not return id");
     }
+    seedUnreadProjectionForInsertedNotification(accountId, readAt);
     return notificationId;
+  }
+
+  private void seedUnreadProjectionForInsertedNotification(long accountId, Instant readAt) {
+    if (readAt == null) {
+      incrementTestProjection("ACCOUNT", accountId, 1L);
+    }
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_unread_count_projection (
+            scope_type,
+            scope_id,
+            unread_count,
+            updated_at
+        )
+        SELECT 'USER',
+               m.user_id,
+               1,
+               CURRENT_TIMESTAMP
+        FROM user_account_membership m
+        JOIN bank_user u
+          ON u.id = m.user_id
+        LEFT JOIN notification_preference p
+          ON p.user_id = m.user_id
+         AND p.category = 'TRANSACTIONAL'
+         AND p.channel = 'IN_APP'
+        WHERE m.account_id = :accountId
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+          AND COALESCE(p.enabled, TRUE) = TRUE
+        ON CONFLICT (scope_type, scope_id)
+        DO UPDATE
+        SET unread_count = notification_unread_count_projection.unread_count + EXCLUDED.unread_count,
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        new MapSqlParameterSource().addValue("accountId", accountId));
+  }
+
+  private void incrementTestProjection(String scopeType, long scopeId, long delta) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_unread_count_projection (
+            scope_type,
+            scope_id,
+            unread_count,
+            updated_at
+        )
+        VALUES (
+            :scopeType,
+            :scopeId,
+            :delta,
+            CURRENT_TIMESTAMP
+        )
+        ON CONFLICT (scope_type, scope_id)
+        DO UPDATE
+        SET unread_count = notification_unread_count_projection.unread_count + EXCLUDED.unread_count,
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        new MapSqlParameterSource()
+            .addValue("scopeType", scopeType)
+            .addValue("scopeId", scopeId)
+            .addValue("delta", delta));
+  }
+
+  private void insertPreference(long userId, String category, String channel, boolean enabled) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_preference (
+            user_id,
+            category,
+            channel,
+            enabled,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :category,
+            :channel,
+            :enabled,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("category", category)
+            .addValue("channel", channel)
+            .addValue("enabled", enabled));
   }
 
   private String issueToken(String subject, long userId) throws JOSEException {

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -45,6 +45,7 @@ public abstract class PostgresContainerTestSupport {
                         """
                         TRUNCATE TABLE
                             auth_status_change_audit,
+                            notification_unread_count_projection,
                             notification_preference,
                             notification_user_read_state,
                             notification_inbox,


### PR DESCRIPTION
## 🔗 Related Issue
- close #184

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification unread count를 count query 대신 `notification_unread_count_projection` 단건 조회로 전환했습니다.
- inbox append/read/archive/delete 경로에서 projection을 같은 transaction 안에서 증감합니다.
- `TRANSACTIONAL/IN_APP=false` user는 새 transfer notification이 목록과 unread count에 노출되지 않게 했습니다.

## 🛠 Changes
- `notification_unread_count_projection` migration 추가
- `JdbcNotificationInboxRepository` unread count read path를 projection 조회로 변경
- inbox append, user/account read, archive, delete 시 projection 증감 처리
- IN_APP disabled user에 대해 `notification_user_read_state.deleted_at` 숨김 state 기록
- repository/API integration test로 projection 및 preference 억제 계약 검증

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-test ./back/gradlew -p back test --tests '*JdbcNotificationInboxRepositoryIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-test ./back/gradlew -p back test --tests '*NotificationApiIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-notification ./back/gradlew -p back test --tests '*Notification*'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: migration은 새 projection table을 만들지만 과거 notification row backfill은 포함하지 않습니다. 배포 직후 기존 unread count 보정이 필요하면 별도 backfill/reconcile 작업이 필요합니다.
- 예상 리스크: preference 억제는 append 시점부터 적용되며, 이미 적재된 과거 notification에는 retroactive 적용하지 않습니다.
- 롤백 방법: PR revert 후 projection table migration 영향을 별도 rollback migration으로 정리합니다. API 응답 계약은 변경하지 않았습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
