### PR TITLE
[Feat] notification EMAIL/SMS channel outbox 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliveryStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliveryStatus.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.notification.model;
+
+public enum NotificationChannelDeliveryStatus {
+  PENDING,
+  SENDING,
+  SENT,
+  FAILED
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelOutboxEntry.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelOutboxEntry.java
@@ -1,0 +1,51 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** EMAIL/SMS provider worker가 가져갈 durable delivery outbox 적재 모델 */
+public record NotificationChannelOutboxEntry(
+    long notificationId,
+    long userId,
+    long accountId,
+    NotificationPreferenceCategory category,
+    NotificationPreferenceChannel channel,
+    String eventType,
+    String eventKey,
+    String payload,
+    Instant availableAt,
+    Instant createdAt) {
+
+  public NotificationChannelOutboxEntry {
+    if (notificationId <= 0) {
+      throw new IllegalArgumentException("notificationId must be positive");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (category == null) {
+      throw new IllegalArgumentException("category must not be null");
+    }
+    if (channel != NotificationPreferenceChannel.EMAIL
+        && channel != NotificationPreferenceChannel.SMS) {
+      throw new IllegalArgumentException("channel must be EMAIL or SMS");
+    }
+    if (eventType == null || eventType.isBlank() || eventType.length() > 60) {
+      throw new IllegalArgumentException("eventType must be between 1 and 60 characters");
+    }
+    if (eventKey == null || eventKey.isBlank() || eventKey.length() > 160) {
+      throw new IllegalArgumentException("eventKey must be between 1 and 160 characters");
+    }
+    if (payload == null || payload.isBlank()) {
+      throw new IllegalArgumentException("payload must not be blank");
+    }
+    if (availableAt == null) {
+      throw new IllegalArgumentException("availableAt must not be null");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt must not be null");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelOutboxItem.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelOutboxItem.java
@@ -1,0 +1,22 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** channel delivery queue 조회/claim 전 단계에서 사용하는 outbox row snapshot */
+public record NotificationChannelOutboxItem(
+    long id,
+    long notificationId,
+    long userId,
+    long accountId,
+    NotificationPreferenceCategory category,
+    NotificationPreferenceChannel channel,
+    String eventType,
+    String eventKey,
+    String payload,
+    NotificationChannelDeliveryStatus deliveryStatus,
+    Instant availableAt,
+    Instant sentAt,
+    int retryCount,
+    String lastError,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationChannelOutboxAppendPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationChannelOutboxAppendPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.notification.port;
+
+import com.aquilabank.domain.notification.model.NotificationChannelOutboxEntry;
+import java.util.List;
+
+public interface NotificationChannelOutboxAppendPort {
+
+  int appendAllIfAbsent(List<NotificationChannelOutboxEntry> items);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationChannelOutboxReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationChannelOutboxReadPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.notification.port;
+
+import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
+import java.time.Instant;
+import java.util.List;
+
+public interface NotificationChannelOutboxReadPort {
+
+  List<NotificationChannelOutboxItem> findPending(int limit, Instant now);
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationChannelOutboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationChannelOutboxRepository.java
@@ -1,0 +1,171 @@
+package com.aquilabank.global.persistence.notification;
+
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
+import com.aquilabank.domain.notification.model.NotificationChannelOutboxEntry;
+import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
+import com.aquilabank.domain.notification.model.NotificationPreferenceCategory;
+import com.aquilabank.domain.notification.model.NotificationPreferenceChannel;
+import com.aquilabank.domain.notification.port.NotificationChannelOutboxAppendPort;
+import com.aquilabank.domain.notification.port.NotificationChannelOutboxReadPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** EMAIL/SMS 외부 channel delivery outbox를 PostgreSQL durable queue로 관리합니다. */
+@Repository
+public class JdbcNotificationChannelOutboxRepository
+    implements NotificationChannelOutboxAppendPort, NotificationChannelOutboxReadPort {
+
+  private static final RowMapper<NotificationChannelOutboxItem> ROW_MAPPER =
+      (rs, rowNum) -> mapRow(rs);
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcNotificationChannelOutboxRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional
+  public int appendAllIfAbsent(List<NotificationChannelOutboxEntry> items) {
+    List<NotificationChannelOutboxEntry> entries = List.copyOf(items);
+    if (entries.isEmpty()) {
+      throw new IllegalArgumentException("items must not be empty");
+    }
+    int insertedCount = 0;
+    for (NotificationChannelOutboxEntry item : entries) {
+      insertedCount += appendIfAbsent(item);
+    }
+    return insertedCount;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<NotificationChannelOutboxItem> findPending(int limit, Instant now) {
+    if (limit <= 0) {
+      throw new IllegalArgumentException("limit must be positive");
+    }
+    if (now == null) {
+      throw new IllegalArgumentException("now must not be null");
+    }
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               notification_id,
+               user_id,
+               account_id,
+               category,
+               channel,
+               event_type,
+               event_key,
+               payload::text AS payload,
+               delivery_status,
+               available_at,
+               sent_at,
+               retry_count,
+               last_error,
+               created_at,
+               updated_at
+        FROM notification_channel_outbox
+        WHERE delivery_status IN ('PENDING', 'FAILED')
+          AND available_at <= :now
+        ORDER BY available_at ASC, id ASC
+        LIMIT :limit
+        """,
+        new MapSqlParameterSource().addValue("limit", limit).addValue("now", Timestamp.from(now)),
+        ROW_MAPPER);
+  }
+
+  private int appendIfAbsent(NotificationChannelOutboxEntry item) {
+    Integer inserted =
+        jdbcTemplate.queryForObject(
+            """
+            WITH inserted AS (
+                INSERT INTO notification_channel_outbox (
+                    notification_id,
+                    user_id,
+                    account_id,
+                    category,
+                    channel,
+                    event_type,
+                    event_key,
+                    payload,
+                    delivery_status,
+                    available_at,
+                    retry_count,
+                    created_at,
+                    updated_at
+                )
+                VALUES (
+                    :notificationId,
+                    :userId,
+                    :accountId,
+                    :category,
+                    :channel,
+                    :eventType,
+                    :eventKey,
+                    CAST(:payload AS jsonb),
+                    'PENDING',
+                    :availableAt,
+                    0,
+                    :createdAt,
+                    :createdAt
+                )
+                ON CONFLICT (event_key, user_id, channel) DO NOTHING
+                RETURNING id
+            )
+            SELECT COUNT(*)
+            FROM inserted
+            """,
+            new MapSqlParameterSource()
+                .addValue("notificationId", item.notificationId())
+                .addValue("userId", item.userId())
+                .addValue("accountId", item.accountId())
+                .addValue("category", item.category().name())
+                .addValue("channel", item.channel().name())
+                .addValue("eventType", item.eventType())
+                .addValue("eventKey", item.eventKey())
+                .addValue("payload", item.payload())
+                .addValue("availableAt", Timestamp.from(item.availableAt()))
+                .addValue("createdAt", Timestamp.from(item.createdAt())),
+            Integer.class);
+    return inserted == null ? 0 : inserted;
+  }
+
+  private static NotificationChannelOutboxItem mapRow(ResultSet rs) throws SQLException {
+    return new NotificationChannelOutboxItem(
+        rs.getLong("id"),
+        rs.getLong("notification_id"),
+        rs.getLong("user_id"),
+        rs.getLong("account_id"),
+        NotificationPreferenceCategory.valueOf(rs.getString("category")),
+        NotificationPreferenceChannel.valueOf(rs.getString("channel")),
+        rs.getString("event_type"),
+        rs.getString("event_key"),
+        rs.getString("payload"),
+        NotificationChannelDeliveryStatus.valueOf(rs.getString("delivery_status")),
+        instant(rs, "available_at"),
+        nullableInstant(rs, "sent_at"),
+        rs.getInt("retry_count"),
+        rs.getString("last_error"),
+        instant(rs, "created_at"),
+        instant(rs, "updated_at"));
+  }
+
+  private static Instant instant(ResultSet rs, String columnName) throws SQLException {
+    return rs.getObject(columnName, OffsetDateTime.class).toInstant();
+  }
+
+  private static Instant nullableInstant(ResultSet rs, String columnName) throws SQLException {
+    OffsetDateTime value = rs.getObject(columnName, OffsetDateTime.class);
+    return value == null ? null : value.toInstant();
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -283,6 +283,7 @@ public class JdbcNotificationInboxRepository
               ROW_MAPPER));
     }
     applyUnreadProjectionForInsertedNotifications(insertedItems);
+    appendChannelOutboxForInsertedNotifications(insertedItems);
     publishInsertedNotifications(insertedItems);
   }
 
@@ -418,6 +419,78 @@ public class JdbcNotificationInboxRepository
       hideInsertedNotificationForDisabledUsers(item);
       incrementUserProjectionForEnabledUsers(item);
     }
+  }
+
+  private void appendChannelOutboxForInsertedNotifications(List<NotificationSummary> items) {
+    for (NotificationSummary item : items) {
+      appendChannelOutboxForInsertedNotification(item);
+    }
+  }
+
+  private void appendChannelOutboxForInsertedNotification(NotificationSummary item) {
+    // 현재 inbox ingest source는 transfer event라 외부 channel preference도 TRANSACTIONAL 기준으로 평가합니다.
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_channel_outbox (
+            notification_id,
+            user_id,
+            account_id,
+            category,
+            channel,
+            event_type,
+            event_key,
+            payload,
+            delivery_status,
+            available_at,
+            retry_count,
+            created_at,
+            updated_at
+        )
+        SELECT n.id,
+               m.user_id,
+               n.account_id,
+               'TRANSACTIONAL',
+               channel_item.channel,
+               n.event_type,
+               n.event_key,
+               jsonb_build_object(
+                   'notificationId', n.id,
+                   'userId', m.user_id,
+                   'accountId', n.account_id,
+                   'category', 'TRANSACTIONAL',
+                   'channel', channel_item.channel,
+                   'eventType', n.event_type,
+                   'eventKey', n.event_key,
+                   'title', n.title,
+                   'message', n.message,
+                   'createdAt', n.created_at
+               ),
+               'PENDING',
+               n.created_at,
+               0,
+               n.created_at,
+               n.created_at
+        FROM notification_inbox n
+        JOIN user_account_membership m
+          ON m.account_id = n.account_id
+        JOIN bank_user u
+          ON u.id = m.user_id
+        JOIN (
+            VALUES ('EMAIL'::varchar, TRUE),
+                   ('SMS'::varchar, FALSE)
+        ) AS channel_item(channel, default_enabled)
+          ON TRUE
+        LEFT JOIN notification_preference p
+          ON p.user_id = m.user_id
+         AND p.category = 'TRANSACTIONAL'
+         AND p.channel = channel_item.channel
+        WHERE n.id = :notificationId
+          AND m.membership_status = 'ACTIVE'
+          AND u.user_status = 'ACTIVE'
+          AND COALESCE(p.enabled, channel_item.default_enabled) = TRUE
+        ON CONFLICT (event_key, user_id, channel) DO NOTHING
+        """,
+        new MapSqlParameterSource().addValue("notificationId", item.id()));
   }
 
   private void hideInsertedNotificationForDisabledUsers(NotificationSummary item) {

--- a/back/src/main/resources/db/migration/V36__add_notification_channel_outbox.sql
+++ b/back/src/main/resources/db/migration/V36__add_notification_channel_outbox.sql
@@ -1,0 +1,48 @@
+-- 외부 channel delivery는 Kafka domain event outbox와 retry 상태를 분리합니다.
+CREATE TABLE notification_channel_outbox (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    notification_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    account_id BIGINT NOT NULL,
+    category VARCHAR(32) NOT NULL,
+    channel VARCHAR(16) NOT NULL,
+    event_type VARCHAR(60) NOT NULL,
+    event_key VARCHAR(160) NOT NULL,
+    payload JSONB NOT NULL,
+    delivery_status VARCHAR(16) NOT NULL DEFAULT 'PENDING',
+    available_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sent_at TIMESTAMPTZ,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_error VARCHAR(300),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_notification_channel_outbox_notification
+        FOREIGN KEY (notification_id) REFERENCES notification_inbox (id) ON DELETE CASCADE,
+    CONSTRAINT fk_notification_channel_outbox_user
+        FOREIGN KEY (user_id) REFERENCES bank_user (id) ON DELETE CASCADE,
+    CONSTRAINT fk_notification_channel_outbox_account
+        FOREIGN KEY (account_id) REFERENCES bank_account (id),
+    CONSTRAINT uq_notification_channel_outbox_event_user_channel
+        UNIQUE (event_key, user_id, channel),
+    CONSTRAINT chk_notification_channel_outbox_category
+        CHECK (category IN ('TRANSACTIONAL', 'SECURITY', 'MARKETING')),
+    CONSTRAINT chk_notification_channel_outbox_channel
+        CHECK (channel IN ('EMAIL', 'SMS')),
+    CONSTRAINT chk_notification_channel_outbox_status
+        CHECK (delivery_status IN ('PENDING', 'SENDING', 'SENT', 'FAILED')),
+    CONSTRAINT chk_notification_channel_outbox_retry_count
+        CHECK (retry_count >= 0)
+);
+
+CREATE INDEX idx_notification_channel_outbox_queue
+    ON notification_channel_outbox (delivery_status, available_at, id)
+    WHERE delivery_status IN ('PENDING', 'FAILED');
+
+CREATE INDEX idx_notification_channel_outbox_notification
+    ON notification_channel_outbox (notification_id);
+
+COMMENT ON TABLE notification_channel_outbox IS
+    'notification EMAIL/SMS provider 발송 대상 queue. inbox ingest 재시도는 event_key/user/channel unique key로 중복 방지합니다.';
+
+COMMENT ON INDEX idx_notification_channel_outbox_queue IS
+    'provider worker가 PENDING/FAILED row를 available_at 순서로 작은 batch claim할 때 사용하는 queue index입니다.';

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationChannelOutboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationChannelOutboxRepositoryIntegrationTest.java
@@ -1,0 +1,216 @@
+package com.aquilabank.global.persistence.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
+import com.aquilabank.domain.notification.model.NotificationChannelOutboxEntry;
+import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
+import com.aquilabank.domain.notification.model.NotificationPreferenceCategory;
+import com.aquilabank.domain.notification.model.NotificationPreferenceChannel;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcNotificationChannelOutboxRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void appendsPendingRowsIdempotentlyAndReadsOnlyAvailableItems() {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[2];
+    Instant base = Instant.parse("2026-04-22T00:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("channel-outbox-user");
+          accountId[0] = insertAccount("channel outbox account");
+          notificationIds[0] =
+              insertNotification(
+                  accountId[0],
+                  "evt-channel-outbox-ready",
+                  "TransferBooked",
+                  "이체 완료",
+                  "1000 KRW 입금",
+                  base);
+          notificationIds[1] =
+              insertNotification(
+                  accountId[0],
+                  "evt-channel-outbox-future",
+                  "TransferBooked",
+                  "이체 완료",
+                  "2000 KRW 입금",
+                  base.plusSeconds(1));
+        });
+
+    NotificationChannelOutboxEntry readyItem =
+        new NotificationChannelOutboxEntry(
+            notificationIds[0],
+            userId[0],
+            accountId[0],
+            NotificationPreferenceCategory.TRANSACTIONAL,
+            NotificationPreferenceChannel.EMAIL,
+            "TransferBooked",
+            "evt-channel-outbox-ready",
+            "{\"kind\":\"transfer\",\"amount\":\"1000\"}",
+            base.minusSeconds(5),
+            base);
+    NotificationChannelOutboxEntry futureItem =
+        new NotificationChannelOutboxEntry(
+            notificationIds[1],
+            userId[0],
+            accountId[0],
+            NotificationPreferenceCategory.TRANSACTIONAL,
+            NotificationPreferenceChannel.SMS,
+            "TransferBooked",
+            "evt-channel-outbox-future",
+            "{\"kind\":\"transfer\",\"amount\":\"2000\"}",
+            base.plusSeconds(60),
+            base.plusSeconds(1));
+
+    assertThat(repository.appendAllIfAbsent(List.of(readyItem, readyItem, futureItem)))
+        .isEqualTo(2);
+    assertThat(repository.appendAllIfAbsent(List.of(readyItem))).isZero();
+
+    List<NotificationChannelOutboxItem> availableItems = repository.findPending(10, base);
+
+    assertThat(availableItems).hasSize(1);
+    NotificationChannelOutboxItem item = availableItems.getFirst();
+    assertThat(item.notificationId()).isEqualTo(notificationIds[0]);
+    assertThat(item.userId()).isEqualTo(userId[0]);
+    assertThat(item.accountId()).isEqualTo(accountId[0]);
+    assertThat(item.category()).isEqualTo(NotificationPreferenceCategory.TRANSACTIONAL);
+    assertThat(item.channel()).isEqualTo(NotificationPreferenceChannel.EMAIL);
+    assertThat(item.deliveryStatus()).isEqualTo(NotificationChannelDeliveryStatus.PENDING);
+    assertThat(item.retryCount()).isZero();
+    assertThat(item.payload()).contains("\"amount\"");
+    assertThat(item.availableAt()).isEqualTo(base.minusSeconds(5));
+
+    assertThat(repository.findPending(10, base.plusSeconds(120)))
+        .extracting(NotificationChannelOutboxItem::eventKey)
+        .containsExactly("evt-channel-outbox-ready", "evt-channel-outbox-future");
+  }
+
+  private long insertUser(String loginId) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private long insertAccount(String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private long insertNotification(
+      long accountId,
+      String eventKey,
+      String eventType,
+      String title,
+      String message,
+      Instant createdAt) {
+    Long notificationId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO notification_inbox (
+                account_id,
+                event_key,
+                event_type,
+                title,
+                message,
+                created_at
+            )
+            VALUES (
+                :accountId,
+                :eventKey,
+                :eventType,
+                :title,
+                :message,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("eventKey", eventKey)
+                .addValue("eventType", eventType)
+                .addValue("title", title)
+                .addValue("message", message)
+                .addValue("createdAt", Timestamp.from(createdAt)),
+            Long.class);
+    if (notificationId == null) {
+      throw new IllegalStateException("notification_inbox insert did not return id");
+    }
+    return notificationId;
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryIntegrationTest.java
@@ -789,6 +789,47 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
   }
 
   @Test
+  void appendsEmailSmsChannelOutboxUsingTransactionalPreferences() {
+    long[] userIds = new long[3];
+    long[] accountId = new long[1];
+    Instant createdAt = Instant.parse("2026-04-22T00:00:00Z");
+    String eventKey = "evt-channel-preference";
+    String eventType = "TransferBooked";
+    String title = "이체 완료";
+    String message = "1500 KRW 입금 · channel preference";
+    commit(
+        transactionManager,
+        () -> {
+          userIds[0] = insertUser("channel-default-email-user");
+          userIds[1] = insertUser("channel-email-disabled-user");
+          userIds[2] = insertUser("channel-sms-enabled-user");
+          accountId[0] = insertAccount("channel preference account");
+          insertMembership(userIds[0], accountId[0], "OWNER", "ACTIVE");
+          insertMembership(userIds[1], accountId[0], "VIEWER", "ACTIVE");
+          insertMembership(userIds[2], accountId[0], "VIEWER", "ACTIVE");
+          insertPreference(userIds[1], "TRANSACTIONAL", "EMAIL", false);
+          insertPreference(userIds[2], "TRANSACTIONAL", "EMAIL", false);
+          insertPreference(userIds[2], "TRANSACTIONAL", "SMS", true);
+          NotificationInboxEntry accountItem =
+              new NotificationInboxEntry(
+                  accountId[0], eventKey, eventType, title, message, createdAt);
+          repository.appendAllIfAbsent(List.of(accountItem));
+          repository.appendAllIfAbsent(List.of(accountItem));
+        });
+
+    assertThat(findChannelOutboxRows(eventKey))
+        .containsExactlyInAnyOrder(
+            new ChannelOutboxRow(userIds[0], "EMAIL", eventKey),
+            new ChannelOutboxRow(userIds[2], "SMS", eventKey));
+    assertThat(channelOutboxCount(eventKey)).isEqualTo(2L);
+    assertThat(findChannelOutboxPayloads(eventKey))
+        .allSatisfy(
+            payload ->
+                assertThat(payload)
+                    .contains("\"eventType\"", "\"title\"", "\"message\"", "\"accountId\""));
+  }
+
+  @Test
   void deletesExpiredNotificationsInBatchesAndCascadesUserReadState() {
     long[] userId = new long[1];
     long[] accountId = new long[1];
@@ -1213,6 +1254,47 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
     return count == null ? 0L : count;
   }
 
+  private List<ChannelOutboxRow> findChannelOutboxRows(String eventKey) {
+    return jdbcTemplate.query(
+        """
+        SELECT user_id,
+               channel,
+               event_key
+        FROM notification_channel_outbox
+        WHERE event_key = :eventKey
+        ORDER BY user_id ASC, channel ASC
+        """,
+        new MapSqlParameterSource().addValue("eventKey", eventKey),
+        (rs, rowNum) ->
+            new ChannelOutboxRow(
+                rs.getLong("user_id"), rs.getString("channel"), rs.getString("event_key")));
+  }
+
+  private List<String> findChannelOutboxPayloads(String eventKey) {
+    return jdbcTemplate.queryForList(
+        """
+        SELECT payload::text
+        FROM notification_channel_outbox
+        WHERE event_key = :eventKey
+        ORDER BY user_id ASC, channel ASC
+        """,
+        new MapSqlParameterSource().addValue("eventKey", eventKey),
+        String.class);
+  }
+
+  private long channelOutboxCount(String eventKey) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM notification_channel_outbox
+            WHERE event_key = :eventKey
+            """,
+            new MapSqlParameterSource().addValue("eventKey", eventKey),
+            Long.class);
+    return count == null ? 0L : count;
+  }
+
   private long totalNotifications() {
     Long count =
         jdbcTemplate.queryForObject(
@@ -1250,4 +1332,6 @@ class JdbcNotificationInboxRepositoryIntegrationTest extends PostgresContainerTe
             Long.class);
     return count == null ? 0L : count;
   }
+
+  private record ChannelOutboxRow(long userId, String channel, String eventKey) {}
 }

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -45,6 +45,7 @@ public abstract class PostgresContainerTestSupport {
                         """
                         TRUNCATE TABLE
                             auth_status_change_audit,
+                            notification_channel_outbox,
                             notification_unread_count_projection,
                             notification_preference,
                             notification_user_read_state,


### PR DESCRIPTION
## 🔗 Related Issue
- close #186

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification inbox ingest 이후 EMAIL/SMS 외부 채널 발송 대상을 별도 durable outbox에 적재합니다.
- preference 기본값과 명시 설정을 반영해 TRANSACTIONAL/EMAIL 기본 enabled, TRANSACTIONAL/SMS 기본 disabled 계약을 적용합니다.
- 외부 provider 발송 worker는 이번 PR 범위에서 제외하고 queue 적재까지만 처리합니다.

## 🛠 Changes
- `notification_channel_outbox` table, queue index, 중복 방지 unique key를 추가했습니다.
- channel outbox domain model/port와 JDBC repository를 추가했습니다.
- `JdbcNotificationInboxRepository.appendAllIfAbsent`에서 inserted notification만 대상으로 EMAIL/SMS preference 기반 outbox row를 생성합니다.
- repository/inbox integration test로 idempotent insert, pending 조회, default/disabled/enabled preference 동작을 검증했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-channel-tests ./back/gradlew -p back test --tests '*JdbcNotificationChannelOutboxRepositoryIntegrationTest' --tests '*JdbcNotificationInboxRepositoryIntegrationTest'` → BUILD SUCCESSFUL
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check` → BUILD SUCCESSFUL
- `git rev-list --count main..HEAD` → 2, brief commit_plan 2개와 일치

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: inbox ingest transaction에 EMAIL/SMS channel outbox insert가 추가되어 active membership 수와 enabled channel 수만큼 write cost가 증가합니다.
- 예상 리스크: provider worker가 아직 없으므로 실제 EMAIL/SMS 발송은 후속 PR 전까지 수행되지 않습니다.
- 롤백 방법: PR revert로 ingest write 경로를 제거합니다. 추가 schema는 남아도 기존 API/consumer 동작에는 영향이 없습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A - 외부 발송 worker는 범위 밖이며 새 queue row만 적재합니다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A - API/권한 변경 없음.
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A - provider worker/monitoring은 후속 작업 범위.
