### PR TITLE
[Chore] notification DLQ redrive audit history 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveAuditEntry.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveAuditEntry.java
@@ -1,0 +1,63 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** DLQ redrive 시도별 운영 추적을 위한 audit write 모델 */
+public record NotificationDlqRedriveAuditEntry(
+    String actor,
+    String requestId,
+    String sourceTopic,
+    int sourcePartition,
+    long sourceOffset,
+    String eventKey,
+    String targetTopic,
+    Integer targetPartition,
+    Long targetOffset,
+    NotificationDlqRedriveOutcome outcome,
+    String errorMessage,
+    Instant redrivenAt) {
+
+  public NotificationDlqRedriveAuditEntry {
+    validateRequiredText(actor, "actor", 120);
+    validateRequiredText(requestId, "requestId", 120);
+    validateRequiredText(sourceTopic, "sourceTopic", 160);
+    validateOptionalText(eventKey, "eventKey", 160);
+    validateOptionalText(targetTopic, "targetTopic", 160);
+    if (sourcePartition < 0) {
+      throw new IllegalArgumentException("sourcePartition must not be negative");
+    }
+    if (sourceOffset < 0) {
+      throw new IllegalArgumentException("sourceOffset must not be negative");
+    }
+    if (targetPartition != null && targetPartition < 0) {
+      throw new IllegalArgumentException("targetPartition must not be negative");
+    }
+    if (targetOffset != null && targetOffset < 0) {
+      throw new IllegalArgumentException("targetOffset must not be negative");
+    }
+    if (outcome == null) {
+      throw new IllegalArgumentException("outcome must not be null");
+    }
+    if (outcome == NotificationDlqRedriveOutcome.SUCCESS
+        && (targetTopic == null || targetPartition == null || targetOffset == null)) {
+      throw new IllegalArgumentException("success audit must include target offset");
+    }
+    if (redrivenAt == null) {
+      throw new IllegalArgumentException("redrivenAt must not be null");
+    }
+  }
+
+  private static void validateRequiredText(String value, String name, int maxLength) {
+    if (value == null || value.isBlank() || value.length() > maxLength) {
+      throw new IllegalArgumentException(
+          "%s must be between 1 and %d characters".formatted(name, maxLength));
+    }
+  }
+
+  private static void validateOptionalText(String value, String name, int maxLength) {
+    if (value != null && (value.isBlank() || value.length() > maxLength)) {
+      throw new IllegalArgumentException(
+          "%s must be between 1 and %d characters".formatted(name, maxLength));
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveAuditItem.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveAuditItem.java
@@ -1,0 +1,20 @@
+package com.aquilabank.domain.notification.model;
+
+import java.time.Instant;
+
+/** DLQ redrive audit history 조회용 row snapshot */
+public record NotificationDlqRedriveAuditItem(
+    long id,
+    String actor,
+    String requestId,
+    String sourceTopic,
+    int sourcePartition,
+    long sourceOffset,
+    String eventKey,
+    String targetTopic,
+    Integer targetPartition,
+    Long targetOffset,
+    NotificationDlqRedriveOutcome outcome,
+    String errorMessage,
+    Instant redrivenAt,
+    Instant createdAt) {}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveCommand.java
@@ -1,0 +1,20 @@
+package com.aquilabank.domain.notification.model;
+
+/** DLQ redrive 실행자와 request trace를 함께 전달하는 command */
+public record NotificationDlqRedriveCommand(
+    NotificationDlqRedriveTarget target, String actor, String requestId) {
+
+  public NotificationDlqRedriveCommand {
+    if (target == null) {
+      throw new IllegalArgumentException("target is required");
+    }
+    validateText(actor, "actor");
+    validateText(requestId, "requestId");
+  }
+
+  private static void validateText(String value, String name) {
+    if (value == null || value.isBlank() || value.length() > 120) {
+      throw new IllegalArgumentException("%s must be between 1 and 120 characters".formatted(name));
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveOutcome.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationDlqRedriveOutcome.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.notification.model;
+
+public enum NotificationDlqRedriveOutcome {
+  SUCCESS,
+  NOT_FOUND,
+  FAILED
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationDlqRedriveAuditPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationDlqRedriveAuditPort.java
@@ -1,0 +1,13 @@
+package com.aquilabank.domain.notification.port;
+
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveAuditEntry;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveAuditItem;
+import java.util.List;
+
+public interface NotificationDlqRedriveAuditPort {
+
+  void append(NotificationDlqRedriveAuditEntry item);
+
+  List<NotificationDlqRedriveAuditItem> findBySource(
+      String sourceTopic, int sourcePartition, long sourceOffset);
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationOpsRecoveryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationOpsRecoveryPort.java
@@ -1,10 +1,10 @@
 package com.aquilabank.domain.notification.port;
 
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveCommand;
 import com.aquilabank.domain.notification.model.NotificationDlqRedriveResult;
-import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
 
 /** notification DLQ redrive 는 Kafka adapter 가 source record 조회와 재발행을 맡습니다. */
 public interface NotificationOpsRecoveryPort {
 
-  NotificationDlqRedriveResult redrive(NotificationDlqRedriveTarget target);
+  NotificationDlqRedriveResult redrive(NotificationDlqRedriveCommand command);
 }

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationOpsRecoveryService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationOpsRecoveryService.java
@@ -1,5 +1,6 @@
 package com.aquilabank.domain.notification.usecase;
 
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveCommand;
 import com.aquilabank.domain.notification.model.NotificationDlqRedriveResult;
 import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
 import com.aquilabank.domain.notification.port.NotificationOpsRecoveryPort;
@@ -21,6 +22,14 @@ public final class NotificationOpsRecoveryService implements NotificationOpsReco
     if (target == null) {
       throw new IllegalArgumentException("target is required");
     }
-    return notificationOpsRecoveryPort.redrive(target);
+    return redrive(new NotificationDlqRedriveCommand(target, "system", "unknown"));
+  }
+
+  @Override
+  public NotificationDlqRedriveResult redrive(NotificationDlqRedriveCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+    return notificationOpsRecoveryPort.redrive(command);
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationOpsRecoveryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationOpsRecoveryUseCase.java
@@ -1,9 +1,12 @@
 package com.aquilabank.domain.notification.usecase;
 
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveCommand;
 import com.aquilabank.domain.notification.model.NotificationDlqRedriveResult;
 import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
 
 public interface NotificationOpsRecoveryUseCase {
 
   NotificationDlqRedriveResult redrive(NotificationDlqRedriveTarget target);
+
+  NotificationDlqRedriveResult redrive(NotificationDlqRedriveCommand command);
 }

--- a/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationInboxConsumerConfiguration.java
@@ -1,5 +1,6 @@
 package com.aquilabank.global.config;
 
+import com.aquilabank.domain.notification.port.NotificationDlqRedriveAuditPort;
 import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
 import com.aquilabank.domain.notification.port.NotificationOpsReadPort;
 import com.aquilabank.domain.notification.port.NotificationOpsRecoveryPort;
@@ -149,9 +150,10 @@ public class NotificationInboxConsumerConfiguration {
   @ConditionalOnBean(name = "notificationInboxDlqKafkaTemplate")
   NotificationOpsRecoveryPort notificationOpsRecoveryPort(
       NotificationInboxConsumerProperties properties,
-      @Qualifier("notificationInboxDlqKafkaTemplate") KafkaTemplate<String, String> notificationInboxDlqKafkaTemplate) {
+      @Qualifier("notificationInboxDlqKafkaTemplate") KafkaTemplate<String, String> notificationInboxDlqKafkaTemplate,
+      NotificationDlqRedriveAuditPort notificationDlqRedriveAuditPort) {
     return new KafkaNotificationOpsRecoveryRepository(
-        properties, notificationInboxDlqKafkaTemplate);
+        properties, notificationInboxDlqKafkaTemplate, notificationDlqRedriveAuditPort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/notification/KafkaNotificationOpsRecoveryRepository.java
+++ b/back/src/main/java/com/aquilabank/global/notification/KafkaNotificationOpsRecoveryRepository.java
@@ -1,8 +1,12 @@
 package com.aquilabank.global.notification;
 
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveAuditEntry;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveCommand;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveOutcome;
 import com.aquilabank.domain.notification.model.NotificationDlqRedriveResult;
 import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
+import com.aquilabank.domain.notification.port.NotificationDlqRedriveAuditPort;
 import com.aquilabank.domain.notification.port.NotificationOpsRecoveryPort;
 import com.aquilabank.global.config.NotificationInboxConsumerProperties;
 import java.nio.ByteBuffer;
@@ -21,12 +25,16 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.KafkaHeaders;
 
 /** preview 좌표 기준 exact seek 만 허용해 DLQ redrive 범위를 넓히지 않습니다. */
 public final class KafkaNotificationOpsRecoveryRepository implements NotificationOpsRecoveryPort {
 
+  private static final Logger log =
+      LoggerFactory.getLogger(KafkaNotificationOpsRecoveryRepository.class);
   private static final Duration READ_TIMEOUT = Duration.ofSeconds(2);
   private static final Duration POLL_INTERVAL = Duration.ofMillis(200);
   private static final String REDRIVE_SOURCE_TOPIC_HEADER = "notification-redrive-source-topic";
@@ -36,18 +44,73 @@ public final class KafkaNotificationOpsRecoveryRepository implements Notificatio
 
   private final NotificationInboxConsumerProperties properties;
   private final KafkaTemplate<String, String> kafkaTemplate;
+  private final NotificationDlqRedriveAuditPort auditPort;
 
   public KafkaNotificationOpsRecoveryRepository(
-      NotificationInboxConsumerProperties properties, KafkaTemplate<String, String> kafkaTemplate) {
+      NotificationInboxConsumerProperties properties,
+      KafkaTemplate<String, String> kafkaTemplate,
+      NotificationDlqRedriveAuditPort auditPort) {
     this.properties = properties;
     this.kafkaTemplate = kafkaTemplate;
+    this.auditPort = auditPort;
   }
 
   @Override
-  public NotificationDlqRedriveResult redrive(NotificationDlqRedriveTarget target) {
-    ConsumerRecord<String, String> sourceRecord = findDlqRecord(target);
-    String originalTopic = requiredHeaderValue(sourceRecord, KafkaHeaders.DLT_ORIGINAL_TOPIC);
-    Integer originalPartition = headerInteger(sourceRecord, KafkaHeaders.DLT_ORIGINAL_PARTITION);
+  public NotificationDlqRedriveResult redrive(NotificationDlqRedriveCommand command) {
+    NotificationDlqRedriveTarget target = command.target();
+    ConsumerRecord<String, String> sourceRecord;
+    try {
+      sourceRecord = findDlqRecord(target);
+    } catch (NotificationNotFoundException ex) {
+      appendAudit(
+          command,
+          properties.dlq().topic(),
+          target.partition(),
+          target.offset(),
+          null,
+          null,
+          null,
+          null,
+          NotificationDlqRedriveOutcome.NOT_FOUND,
+          ex.getMessage(),
+          Instant.now());
+      throw ex;
+    } catch (RuntimeException ex) {
+      appendAudit(
+          command,
+          properties.dlq().topic(),
+          target.partition(),
+          target.offset(),
+          null,
+          null,
+          null,
+          null,
+          NotificationDlqRedriveOutcome.FAILED,
+          ex.getMessage(),
+          Instant.now());
+      throw ex;
+    }
+
+    String originalTopic;
+    Integer originalPartition;
+    try {
+      originalTopic = requiredHeaderValue(sourceRecord, KafkaHeaders.DLT_ORIGINAL_TOPIC);
+      originalPartition = headerInteger(sourceRecord, KafkaHeaders.DLT_ORIGINAL_PARTITION);
+    } catch (RuntimeException ex) {
+      appendAudit(
+          command,
+          sourceRecord.topic(),
+          sourceRecord.partition(),
+          sourceRecord.offset(),
+          sourceRecord.key(),
+          null,
+          null,
+          null,
+          NotificationDlqRedriveOutcome.FAILED,
+          ex.getMessage(),
+          Instant.now());
+      throw ex;
+    }
 
     ProducerRecord<String, String> redriveRecord =
         new ProducerRecord<>(
@@ -56,7 +119,19 @@ public final class KafkaNotificationOpsRecoveryRepository implements Notificatio
 
     try {
       var sendResult = kafkaTemplate.send(redriveRecord).get(5, TimeUnit.SECONDS);
-      return new NotificationDlqRedriveResult(
+      Instant redrivenAt = Instant.now();
+      NotificationDlqRedriveResult result =
+          new NotificationDlqRedriveResult(
+              sourceRecord.topic(),
+              sourceRecord.partition(),
+              sourceRecord.offset(),
+              sourceRecord.key(),
+              originalTopic,
+              sendResult.getRecordMetadata().partition(),
+              sendResult.getRecordMetadata().offset(),
+              redrivenAt);
+      appendAudit(
+          command,
           sourceRecord.topic(),
           sourceRecord.partition(),
           sourceRecord.offset(),
@@ -64,12 +139,77 @@ public final class KafkaNotificationOpsRecoveryRepository implements Notificatio
           originalTopic,
           sendResult.getRecordMetadata().partition(),
           sendResult.getRecordMetadata().offset(),
-          Instant.now());
+          NotificationDlqRedriveOutcome.SUCCESS,
+          null,
+          redrivenAt);
+      return result;
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
+      appendAudit(
+          command,
+          sourceRecord.topic(),
+          sourceRecord.partition(),
+          sourceRecord.offset(),
+          sourceRecord.key(),
+          originalTopic,
+          originalPartition,
+          null,
+          NotificationDlqRedriveOutcome.FAILED,
+          "notification DLQ redrive interrupted",
+          Instant.now());
       throw new IllegalStateException("notification DLQ redrive interrupted", ex);
     } catch (Exception ex) {
+      appendAudit(
+          command,
+          sourceRecord.topic(),
+          sourceRecord.partition(),
+          sourceRecord.offset(),
+          sourceRecord.key(),
+          originalTopic,
+          originalPartition,
+          null,
+          NotificationDlqRedriveOutcome.FAILED,
+          ex.getMessage(),
+          Instant.now());
       throw new IllegalStateException("notification DLQ redrive publish failed", ex);
+    }
+  }
+
+  private void appendAudit(
+      NotificationDlqRedriveCommand command,
+      String sourceTopic,
+      int sourcePartition,
+      long sourceOffset,
+      String eventKey,
+      String targetTopic,
+      Integer targetPartition,
+      Long targetOffset,
+      NotificationDlqRedriveOutcome outcome,
+      String errorMessage,
+      Instant redrivenAt) {
+    try {
+      auditPort.append(
+          new NotificationDlqRedriveAuditEntry(
+              command.actor(),
+              command.requestId(),
+              sourceTopic,
+              sourcePartition,
+              sourceOffset,
+              eventKey,
+              targetTopic,
+              targetPartition,
+              targetOffset,
+              outcome,
+              errorMessage,
+              redrivenAt));
+    } catch (RuntimeException auditEx) {
+      log.warn(
+          "notification DLQ redrive audit append failed. sourceTopic={} partition={} offset={} outcome={}",
+          sourceTopic,
+          sourcePartition,
+          sourceOffset,
+          outcome,
+          auditEx);
     }
   }
 

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationDlqRedriveAuditRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationDlqRedriveAuditRepository.java
@@ -1,0 +1,137 @@
+package com.aquilabank.global.persistence.notification;
+
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveAuditEntry;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveAuditItem;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveOutcome;
+import com.aquilabank.domain.notification.port.NotificationDlqRedriveAuditPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** DLQ redrive 운영 이력을 source offset 기준으로 누적 저장합니다. */
+@Repository
+public class JdbcNotificationDlqRedriveAuditRepository implements NotificationDlqRedriveAuditPort {
+
+  private static final RowMapper<NotificationDlqRedriveAuditItem> ROW_MAPPER =
+      (rs, rowNum) -> mapRow(rs);
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcNotificationDlqRedriveAuditRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional
+  public void append(NotificationDlqRedriveAuditEntry item) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_dlq_redrive_audit (
+            actor,
+            request_id,
+            source_topic,
+            source_partition,
+            source_offset,
+            event_key,
+            target_topic,
+            target_partition,
+            target_offset,
+            outcome,
+            error_message,
+            redriven_at,
+            created_at
+        )
+        VALUES (
+            :actor,
+            :requestId,
+            :sourceTopic,
+            :sourcePartition,
+            :sourceOffset,
+            :eventKey,
+            :targetTopic,
+            :targetPartition,
+            :targetOffset,
+            :outcome,
+            :errorMessage,
+            :redrivenAt,
+            CURRENT_TIMESTAMP
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("actor", item.actor())
+            .addValue("requestId", item.requestId())
+            .addValue("sourceTopic", item.sourceTopic())
+            .addValue("sourcePartition", item.sourcePartition())
+            .addValue("sourceOffset", item.sourceOffset())
+            .addValue("eventKey", item.eventKey())
+            .addValue("targetTopic", item.targetTopic())
+            .addValue("targetPartition", item.targetPartition())
+            .addValue("targetOffset", item.targetOffset())
+            .addValue("outcome", item.outcome().name())
+            .addValue("errorMessage", item.errorMessage())
+            .addValue("redrivenAt", Timestamp.from(item.redrivenAt())));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<NotificationDlqRedriveAuditItem> findBySource(
+      String sourceTopic, int sourcePartition, long sourceOffset) {
+    return jdbcTemplate.query(
+        """
+        SELECT id,
+               actor,
+               request_id,
+               source_topic,
+               source_partition,
+               source_offset,
+               event_key,
+               target_topic,
+               target_partition,
+               target_offset,
+               outcome,
+               error_message,
+               redriven_at,
+               created_at
+        FROM notification_dlq_redrive_audit
+        WHERE source_topic = :sourceTopic
+          AND source_partition = :sourcePartition
+          AND source_offset = :sourceOffset
+        ORDER BY id ASC
+        """,
+        new MapSqlParameterSource()
+            .addValue("sourceTopic", sourceTopic)
+            .addValue("sourcePartition", sourcePartition)
+            .addValue("sourceOffset", sourceOffset),
+        ROW_MAPPER);
+  }
+
+  private static NotificationDlqRedriveAuditItem mapRow(ResultSet rs) throws SQLException {
+    return new NotificationDlqRedriveAuditItem(
+        rs.getLong("id"),
+        rs.getString("actor"),
+        rs.getString("request_id"),
+        rs.getString("source_topic"),
+        rs.getInt("source_partition"),
+        rs.getLong("source_offset"),
+        rs.getString("event_key"),
+        rs.getString("target_topic"),
+        rs.getObject("target_partition", Integer.class),
+        rs.getObject("target_offset", Long.class),
+        NotificationDlqRedriveOutcome.valueOf(rs.getString("outcome")),
+        rs.getString("error_message"),
+        instant(rs, "redriven_at"),
+        instant(rs, "created_at"));
+  }
+
+  private static Instant instant(ResultSet rs, String columnName) throws SQLException {
+    return rs.getObject(columnName, OffsetDateTime.class).toInstant();
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationDlqRedriveRequest.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationDlqRedriveRequest.java
@@ -1,5 +1,6 @@
 package com.aquilabank.global.web.notification;
 
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveCommand;
 import com.aquilabank.domain.notification.model.NotificationDlqRedriveTarget;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -11,5 +12,9 @@ public record NotificationDlqRedriveRequest(
 
   NotificationDlqRedriveTarget toTarget() {
     return new NotificationDlqRedriveTarget(partition, offset);
+  }
+
+  NotificationDlqRedriveCommand toCommand(String actor, String requestId) {
+    return new NotificationDlqRedriveCommand(toTarget(), actor, requestId);
   }
 }

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationOpsController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationOpsController.java
@@ -5,6 +5,8 @@ import com.aquilabank.domain.notification.usecase.NotificationOpsRecoveryUseCase
 import com.aquilabank.global.config.NotificationInboxConsumerProperties;
 import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenClaims;
+import com.aquilabank.global.web.RequestTraceContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
@@ -60,8 +62,22 @@ public class NotificationOpsController {
   @PostMapping("/dlq-events/redrive")
   public NotificationDlqRedriveResponse redriveDlqEvent(
       HttpServletRequest request, @Valid @RequestBody NotificationDlqRedriveRequest body) {
-    internalServiceRequestAuthorizer.requireScope(request, InternalServiceScope.OUTBOX_OPS);
+    InternalServiceTokenClaims claims =
+        internalServiceRequestAuthorizer.requireScope(request, InternalServiceScope.OUTBOX_OPS);
     return NotificationDlqRedriveResponse.from(
-        notificationOpsRecoveryUseCase.redrive(body.toTarget()));
+        notificationOpsRecoveryUseCase.redrive(
+            body.toCommand(claims.subject(), resolveRequestId(request))));
+  }
+
+  private String resolveRequestId(HttpServletRequest request) {
+    return RequestTraceContext.currentRequestId()
+        .or(
+            () -> {
+              String header = request.getHeader(RequestTraceContext.REQUEST_ID_HEADER);
+              return header == null || header.isBlank()
+                  ? java.util.Optional.empty()
+                  : java.util.Optional.of(header);
+            })
+        .orElse("unknown");
   }
 }

--- a/back/src/main/resources/db/migration/V37__add_notification_dlq_redrive_audit.sql
+++ b/back/src/main/resources/db/migration/V37__add_notification_dlq_redrive_audit.sql
@@ -1,0 +1,53 @@
+-- DLQ redrive는 운영 복구 행위라 source/target offset과 outcome을 영구 audit으로 남깁니다.
+CREATE TABLE notification_dlq_redrive_audit (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    actor VARCHAR(120) NOT NULL,
+    request_id VARCHAR(120) NOT NULL,
+    source_topic VARCHAR(160) NOT NULL,
+    source_partition INTEGER NOT NULL,
+    source_offset BIGINT NOT NULL,
+    event_key VARCHAR(160),
+    target_topic VARCHAR(160),
+    target_partition INTEGER,
+    target_offset BIGINT,
+    outcome VARCHAR(16) NOT NULL,
+    error_message TEXT,
+    redriven_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_notification_dlq_redrive_audit_source_partition
+        CHECK (source_partition >= 0),
+    CONSTRAINT chk_notification_dlq_redrive_audit_source_offset
+        CHECK (source_offset >= 0),
+    CONSTRAINT chk_notification_dlq_redrive_audit_target_partition
+        CHECK (target_partition IS NULL OR target_partition >= 0),
+    CONSTRAINT chk_notification_dlq_redrive_audit_target_offset
+        CHECK (target_offset IS NULL OR target_offset >= 0),
+    CONSTRAINT chk_notification_dlq_redrive_audit_outcome
+        CHECK (outcome IN ('SUCCESS', 'NOT_FOUND', 'FAILED')),
+    CONSTRAINT chk_notification_dlq_redrive_audit_success_target
+        CHECK (
+            outcome <> 'SUCCESS'
+            OR (
+                target_topic IS NOT NULL
+                AND target_partition IS NOT NULL
+                AND target_offset IS NOT NULL
+            )
+        )
+);
+
+CREATE INDEX idx_notification_dlq_redrive_audit_source
+    ON notification_dlq_redrive_audit (
+        source_topic,
+        source_partition,
+        source_offset,
+        id
+    );
+
+CREATE INDEX idx_notification_dlq_redrive_audit_created
+    ON notification_dlq_redrive_audit (created_at DESC, id DESC);
+
+COMMENT ON TABLE notification_dlq_redrive_audit IS
+    'notification DLQ redrive 운영 이력. 같은 source offset 반복 redrive도 outcome별로 누적합니다.';
+
+COMMENT ON INDEX idx_notification_dlq_redrive_audit_source IS
+    'DLQ preview 좌표 기준으로 redrive audit history를 확인하는 lookup index입니다.';

--- a/back/src/test/java/com/aquilabank/global/config/NotificationInboxConsumerConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/NotificationInboxConsumerConfigurationTest.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import com.aquilabank.domain.notification.port.NotificationDlqRedriveAuditPort;
 import com.aquilabank.domain.notification.port.NotificationInboxAppendPort;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,9 @@ class NotificationInboxConsumerConfigurationTest {
           .withUserConfiguration(NotificationInboxConsumerConfiguration.class)
           .withBean(
               NotificationInboxAppendPort.class, () -> mock(NotificationInboxAppendPort.class))
+          .withBean(
+              NotificationDlqRedriveAuditPort.class,
+              () -> mock(NotificationDlqRedriveAuditPort.class))
           .withBean(ObjectMapper.class, ObjectMapper::new);
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationDlqRedriveAuditRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationDlqRedriveAuditRepositoryIntegrationTest.java
@@ -1,0 +1,85 @@
+package com.aquilabank.global.persistence.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveAuditEntry;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveAuditItem;
+import com.aquilabank.domain.notification.model.NotificationDlqRedriveOutcome;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcNotificationDlqRedriveAuditRepositoryIntegrationTest
+    extends PostgresContainerTestSupport {
+
+  private static final String SOURCE_TOPIC = "bank.transfer.booked.dlq.v1";
+  private static final String TARGET_TOPIC = "bank.transfer.booked.v1";
+
+  @Autowired private JdbcNotificationDlqRedriveAuditRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void appendsAuditRowsForRepeatedSourceOffsetAttempts() {
+    Instant base = Instant.parse("2026-04-22T03:00:00Z");
+    repository.append(
+        new NotificationDlqRedriveAuditEntry(
+            "outbox-ops",
+            "redrive-request-1",
+            SOURCE_TOPIC,
+            0,
+            42L,
+            "transfer-booked:redrive-audit",
+            TARGET_TOPIC,
+            0,
+            12L,
+            NotificationDlqRedriveOutcome.SUCCESS,
+            null,
+            base));
+    repository.append(
+        new NotificationDlqRedriveAuditEntry(
+            "outbox-ops",
+            "redrive-request-2",
+            SOURCE_TOPIC,
+            0,
+            42L,
+            null,
+            null,
+            null,
+            null,
+            NotificationDlqRedriveOutcome.NOT_FOUND,
+            "notification DLQ record is not found: partition=0 offset=42",
+            base.plusSeconds(1)));
+
+    List<NotificationDlqRedriveAuditItem> items = repository.findBySource(SOURCE_TOPIC, 0, 42L);
+
+    assertThat(items).hasSize(2);
+    assertThat(items)
+        .extracting(NotificationDlqRedriveAuditItem::outcome)
+        .containsExactly(
+            NotificationDlqRedriveOutcome.SUCCESS, NotificationDlqRedriveOutcome.NOT_FOUND);
+    assertThat(items.getFirst().actor()).isEqualTo("outbox-ops");
+    assertThat(items.getFirst().requestId()).isEqualTo("redrive-request-1");
+    assertThat(items.getFirst().eventKey()).isEqualTo("transfer-booked:redrive-audit");
+    assertThat(items.getFirst().targetTopic()).isEqualTo(TARGET_TOPIC);
+    assertThat(items.getFirst().targetPartition()).isEqualTo(0);
+    assertThat(items.getFirst().targetOffset()).isEqualTo(12L);
+    assertThat(items.getLast().targetTopic()).isNull();
+    assertThat(items.getLast().targetPartition()).isNull();
+    assertThat(items.getLast().targetOffset()).isNull();
+    assertThat(items.getLast().errorMessage()).contains("not found");
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationOpsApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationOpsApiIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.aquilabank.global.web.notification;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.test.context.ActiveProfiles;
@@ -58,6 +62,8 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
   @Qualifier("notificationInboxDlqKafkaTemplate") private KafkaTemplate<String, String> kafkaTemplate;
 
   @Autowired private NotificationOpsQueryUseCase notificationOpsQueryUseCase;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
 
   @Autowired private ObjectMapper objectMapper;
 
@@ -115,6 +121,7 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
   @Test
   void redrivesNotificationDlqRecordWithInternalServiceToken() throws Exception {
     String eventKey = "transfer-booked:REDRIVE-" + System.currentTimeMillis();
+    String requestId = "notification-redrive-audit-success";
     ProducerRecord<String, String> record =
         validDlqRecord(eventKey, "{\"transactionReference\":\"redrive\"}");
     var sendResult = kafkaTemplate.send(record).get(5, TimeUnit.SECONDS);
@@ -123,6 +130,7 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
         .perform(
             post("/internal/api/v1/outbox/notification/dlq-events/redrive")
                 .header("Authorization", outboxOpsAuthorization())
+                .header("X-Request-Id", requestId)
                 .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
                 .content(
                     objectMapper.writeValueAsString(
@@ -135,6 +143,22 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
         .andExpect(jsonPath("$.targetTopic").value(TRANSFER_BOOKED_TOPIC))
         .andExpect(jsonPath("$.targetPartition").value(0))
         .andExpect(jsonPath("$.targetOffset", greaterThanOrEqualTo(0)));
+
+    assertThat(
+            findRedriveAuditRows(
+                TRANSFER_BOOKED_DLQ_TOPIC,
+                sendResult.getRecordMetadata().partition(),
+                sendResult.getRecordMetadata().offset()))
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.actor()).isEqualTo("outbox-ops");
+              assertThat(item.requestId()).isEqualTo(requestId);
+              assertThat(item.eventKey()).isEqualTo(eventKey);
+              assertThat(item.targetTopic()).isEqualTo(TRANSFER_BOOKED_TOPIC);
+              assertThat(item.targetOffset()).isNotNull();
+              assertThat(item.outcome()).isEqualTo("SUCCESS");
+            });
   }
 
   @Test
@@ -153,6 +177,7 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
   @Test
   void returnsBadRequestWhenDlqOriginalTopicHeaderIsMissing() throws Exception {
     String eventKey = "transfer-booked:REDRIVE-MISSING-" + System.currentTimeMillis();
+    String requestId = "notification-redrive-audit-failed";
     ProducerRecord<String, String> record =
         new ProducerRecord<>(TRANSFER_BOOKED_DLQ_TOPIC, eventKey, "{\"broken\":true}");
     var sendResult = kafkaTemplate.send(record).get(5, TimeUnit.SECONDS);
@@ -161,6 +186,7 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
         .perform(
             post("/internal/api/v1/outbox/notification/dlq-events/redrive")
                 .header("Authorization", outboxOpsAuthorization())
+                .header("X-Request-Id", requestId)
                 .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
                 .content(
                     objectMapper.writeValueAsString(
@@ -170,21 +196,58 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
         .andExpect(status().isBadRequest())
         .andExpect(
             jsonPath("$.message").value("notification DLQ record original topic is missing"));
+
+    assertThat(
+            findRedriveAuditRows(
+                TRANSFER_BOOKED_DLQ_TOPIC,
+                sendResult.getRecordMetadata().partition(),
+                sendResult.getRecordMetadata().offset()))
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.actor()).isEqualTo("outbox-ops");
+              assertThat(item.requestId()).isEqualTo(requestId);
+              assertThat(item.eventKey()).isEqualTo(eventKey);
+              assertThat(item.targetTopic()).isNull();
+              assertThat(item.targetOffset()).isNull();
+              assertThat(item.outcome()).isEqualTo("FAILED");
+              assertThat(item.errorMessage()).contains("original topic is missing");
+            });
   }
 
   @Test
   void returnsNotFoundWhenDlqRecordDoesNotExist() throws Exception {
+    long missingOffset = 9_000_000_000L + System.currentTimeMillis();
+    String requestId = "notification-redrive-audit-not-found";
+
     mockMvc
         .perform(
             post("/internal/api/v1/outbox/notification/dlq-events/redrive")
                 .header("Authorization", outboxOpsAuthorization())
+                .header("X-Request-Id", requestId)
                 .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
                 .content(
-                    objectMapper.writeValueAsString(new NotificationDlqRedriveRequest(0, 9999L))))
+                    objectMapper.writeValueAsString(
+                        new NotificationDlqRedriveRequest(0, missingOffset))))
         .andExpect(status().isNotFound())
         .andExpect(
             jsonPath("$.message")
-                .value("notification DLQ record is not found: partition=0 offset=9999"));
+                .value(
+                    "notification DLQ record is not found: partition=0 offset=%d"
+                        .formatted(missingOffset)));
+
+    assertThat(findRedriveAuditRows(TRANSFER_BOOKED_DLQ_TOPIC, 0, missingOffset))
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.actor()).isEqualTo("outbox-ops");
+              assertThat(item.requestId()).isEqualTo(requestId);
+              assertThat(item.eventKey()).isNull();
+              assertThat(item.targetTopic()).isNull();
+              assertThat(item.targetOffset()).isNull();
+              assertThat(item.outcome()).isEqualTo("NOT_FOUND");
+              assertThat(item.errorMessage()).contains("not found");
+            });
   }
 
   @Test
@@ -244,4 +307,45 @@ class NotificationOpsApiIntegrationTest extends PostgresKafkaContainerTestSuppor
         + internalServiceTokenIssuer.issue(
             "outbox-ops", java.util.Set.of(InternalServiceScope.OUTBOX_OPS));
   }
+
+  private List<RedriveAuditRow> findRedriveAuditRows(
+      String sourceTopic, int sourcePartition, long sourceOffset) {
+    return jdbcTemplate.query(
+        """
+        SELECT actor,
+               request_id,
+               event_key,
+               target_topic,
+               target_offset,
+               outcome,
+               error_message
+        FROM notification_dlq_redrive_audit
+        WHERE source_topic = :sourceTopic
+          AND source_partition = :sourcePartition
+          AND source_offset = :sourceOffset
+        ORDER BY id ASC
+        """,
+        new MapSqlParameterSource()
+            .addValue("sourceTopic", sourceTopic)
+            .addValue("sourcePartition", sourcePartition)
+            .addValue("sourceOffset", sourceOffset),
+        (rs, rowNum) ->
+            new RedriveAuditRow(
+                rs.getString("actor"),
+                rs.getString("request_id"),
+                rs.getString("event_key"),
+                rs.getString("target_topic"),
+                rs.getObject("target_offset", Long.class),
+                rs.getString("outcome"),
+                rs.getString("error_message")));
+  }
+
+  private record RedriveAuditRow(
+      String actor,
+      String requestId,
+      String eventKey,
+      String targetTopic,
+      Long targetOffset,
+      String outcome,
+      String errorMessage) {}
 }

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -45,6 +45,7 @@ public abstract class PostgresContainerTestSupport {
                         """
                         TRUNCATE TABLE
                             auth_status_change_audit,
+                            notification_dlq_redrive_audit,
                             notification_channel_outbox,
                             notification_unread_count_projection,
                             notification_preference,


### PR DESCRIPTION
## 🔗 Related Issue
- close #188

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification DLQ redrive 시도마다 actor/requestId/source offset/target offset/outcome을 DB audit history로 저장합니다.
- 성공, source 미발견, redrive 실패 계열 결과를 모두 audit row로 남기고 기존 redrive API 성공 응답 계약은 유지합니다.
- #187이 V36 migration을 사용하므로 이 PR은 V37 migration을 사용하며 #187 이후 merge하는 순서가 안전합니다.

## 🛠 Changes
- `notification_dlq_redrive_audit` table과 source lookup/created_at index를 추가했습니다.
- DLQ redrive audit domain model/port와 JDBC repository를 추가했습니다.
- internal redrive API에서 internal service token subject와 `X-Request-Id`를 command로 전달합니다.
- Kafka redrive repository에서 SUCCESS, NOT_FOUND, FAILED outcome audit을 저장합니다.
- repository/API/Kafka/config integration test로 audit 저장과 기존 redrive 동작을 검증했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-redrive-verify ./back/gradlew -p back test --tests '*JdbcNotificationDlqRedriveAuditRepositoryIntegrationTest' --tests '*NotificationDlqIntegrationTest' --tests '*NotificationOpsApiIntegrationTest' --tests '*NotificationInboxConsumerConfigurationTest'` → BUILD SUCCESSFUL
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check` → BUILD SUCCESSFUL
- `git rev-list --count main..HEAD` → 2, brief commit_plan 2개와 일치

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: #187보다 먼저 merge되면 migration version 순서가 운영 배포에서 꼬일 수 있습니다. #187 merge 후 이 PR을 merge해야 합니다.
- 예상 리스크: audit insert 실패는 redrive 결과를 막지 않도록 warning만 남깁니다.
- 롤백 방법: PR revert로 redrive audit write 경로를 제거합니다. 추가 schema는 남아도 기존 redrive API 동작에는 영향이 없습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A - ops audit 저장 경로만 추가합니다.
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A - audit table 추가 외 runbook 변경 없음.
