### PR TITLE
[Perf] transaction_read_model archive retention 경로 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/transaction/port/TransactionReadModelRetentionCleanupPort.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/port/TransactionReadModelRetentionCleanupPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.transaction.port;
+
+import java.time.Instant;
+
+/** hot read model retention 처리를 persistence adapter로 위임합니다. */
+public interface TransactionReadModelRetentionCleanupPort {
+
+  int archiveExpiredReadModels(Instant cutoff, int batchSize, Instant archivedAt);
+}

--- a/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionReadModelRetentionCleanupService.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionReadModelRetentionCleanupService.java
@@ -1,0 +1,41 @@
+package com.aquilabank.domain.transaction.usecase;
+
+import com.aquilabank.domain.transaction.port.TransactionReadModelRetentionCleanupPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/** retention 기준과 batch 크기를 domain에서 고정해 scheduler/adapter drift를 막습니다. */
+public final class TransactionReadModelRetentionCleanupService
+    implements TransactionReadModelRetentionCleanupUseCase {
+
+  private final TransactionReadModelRetentionCleanupPort cleanupPort;
+  private final Clock clock;
+  private final Duration retention;
+  private final int batchSize;
+
+  public TransactionReadModelRetentionCleanupService(
+      TransactionReadModelRetentionCleanupPort cleanupPort,
+      Clock clock,
+      Duration retention,
+      int batchSize) {
+    this.cleanupPort = Objects.requireNonNull(cleanupPort, "cleanupPort");
+    this.clock = Objects.requireNonNull(clock, "clock");
+    this.retention = Objects.requireNonNull(retention, "retention");
+    if (retention.isZero() || retention.isNegative()) {
+      throw new IllegalArgumentException("retention must be positive");
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("batchSize must be positive");
+    }
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public int archiveExpiredReadModels() {
+    Instant archivedAt = clock.instant();
+    Instant cutoff = archivedAt.minus(retention);
+    return cleanupPort.archiveExpiredReadModels(cutoff, batchSize, archivedAt);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionReadModelRetentionCleanupUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionReadModelRetentionCleanupUseCase.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.transaction.usecase;
+
+/** transaction read model hot table retention batch 진입점 */
+public interface TransactionReadModelRetentionCleanupUseCase {
+
+  int archiveExpiredReadModels();
+}

--- a/back/src/main/java/com/aquilabank/global/config/TransactionReadModelCleanupConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/TransactionReadModelCleanupConfiguration.java
@@ -1,0 +1,29 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.transaction.port.TransactionReadModelRetentionCleanupPort;
+import com.aquilabank.domain.transaction.usecase.TransactionReadModelRetentionCleanupService;
+import com.aquilabank.domain.transaction.usecase.TransactionReadModelRetentionCleanupUseCase;
+import java.time.Clock;
+import java.time.Duration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/** transaction read model retention cleanup use case와 runtime 설정을 조립합니다. */
+@Configuration
+@EnableScheduling
+@EnableConfigurationProperties(TransactionReadModelCleanupProperties.class)
+public class TransactionReadModelCleanupConfiguration {
+
+  @Bean
+  TransactionReadModelRetentionCleanupUseCase transactionReadModelRetentionCleanupUseCase(
+      TransactionReadModelRetentionCleanupPort cleanupPort,
+      TransactionReadModelCleanupProperties cleanupProperties) {
+    return new TransactionReadModelRetentionCleanupService(
+        cleanupPort,
+        Clock.systemUTC(),
+        Duration.ofDays(cleanupProperties.retentionDays()),
+        cleanupProperties.batchSize());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/config/TransactionReadModelCleanupProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/TransactionReadModelCleanupProperties.java
@@ -1,0 +1,28 @@
+package com.aquilabank.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** transaction read model hot table retention batch 런타임 기준 */
+@ConfigurationProperties(prefix = "transaction.read-model.cleanup")
+public record TransactionReadModelCleanupProperties(
+    boolean enabled, long fixedDelayMs, long initialDelayMs, int batchSize, long retentionDays) {
+
+  public TransactionReadModelCleanupProperties {
+    if (fixedDelayMs <= 0) {
+      throw new IllegalArgumentException(
+          "transaction.read-model.cleanup.fixed-delay-ms must be positive");
+    }
+    if (initialDelayMs < 0) {
+      throw new IllegalArgumentException(
+          "transaction.read-model.cleanup.initial-delay-ms must not be negative");
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException(
+          "transaction.read-model.cleanup.batch-size must be positive");
+    }
+    if (retentionDays <= 0) {
+      throw new IllegalArgumentException(
+          "transaction.read-model.cleanup.retention-days must be positive");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadModelRetentionCleanupRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadModelRetentionCleanupRepository.java
@@ -1,0 +1,111 @@
+package com.aquilabank.global.persistence.transaction;
+
+import com.aquilabank.domain.transaction.port.TransactionReadModelRetentionCleanupPort;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** transaction read model hot table retention을 작은 batch archive로 처리하는 JDBC adapter */
+@Repository
+public class JdbcTransactionReadModelRetentionCleanupRepository
+    implements TransactionReadModelRetentionCleanupPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcTransactionReadModelRetentionCleanupRepository(
+      NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional
+  public int archiveExpiredReadModels(Instant cutoff, int batchSize, Instant archivedAt) {
+    // archive insert 성공이 확인된 row만 hot table에서 제거해 projection 유실 가능성을 막습니다.
+    Integer archived =
+        jdbcTemplate.queryForObject(
+            """
+            WITH expired AS (
+                SELECT id,
+                       ledger_entry_id,
+                       account_id,
+                       transaction_reference,
+                       direction,
+                       transaction_status,
+                       amount_minor,
+                       balance_after_minor,
+                       currency_code,
+                       summary,
+                       counterparty_masked_name,
+                       booked_at,
+                       created_at
+                FROM transaction_read_model
+                WHERE booked_at < :cutoff
+                FOR UPDATE SKIP LOCKED
+                LIMIT :batchSize
+            ),
+            archived AS (
+                INSERT INTO transaction_read_model_archive (
+                    id,
+                    ledger_entry_id,
+                    account_id,
+                    transaction_reference,
+                    direction,
+                    transaction_status,
+                    amount_minor,
+                    balance_after_minor,
+                    currency_code,
+                    summary,
+                    counterparty_masked_name,
+                    booked_at,
+                    created_at,
+                    archived_at
+                )
+                SELECT id,
+                       ledger_entry_id,
+                       account_id,
+                       transaction_reference,
+                       direction,
+                       transaction_status,
+                       amount_minor,
+                       balance_after_minor,
+                       currency_code,
+                       summary,
+                       counterparty_masked_name,
+                       booked_at,
+                       created_at,
+                       :archivedAt
+                FROM expired
+                ON CONFLICT DO NOTHING
+                RETURNING ledger_entry_id
+            ),
+            safe_to_delete AS (
+                SELECT ledger_entry_id
+                FROM archived
+                UNION
+                SELECT e.ledger_entry_id
+                FROM expired e
+                JOIN transaction_read_model_archive a
+                  ON a.ledger_entry_id = e.ledger_entry_id
+            ),
+            deleted AS (
+                DELETE FROM transaction_read_model t
+                USING expired e
+                JOIN safe_to_delete s
+                  ON s.ledger_entry_id = e.ledger_entry_id
+                WHERE t.id = e.id
+                RETURNING t.id
+            )
+            SELECT COUNT(*)
+            FROM deleted
+            """,
+            new MapSqlParameterSource()
+                .addValue("cutoff", Timestamp.from(cutoff))
+                .addValue("batchSize", batchSize)
+                .addValue("archivedAt", Timestamp.from(archivedAt)),
+            Integer.class);
+    return archived == null ? 0 : archived;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/transaction/TransactionReadModelRetentionCleanupPoller.java
+++ b/back/src/main/java/com/aquilabank/global/transaction/TransactionReadModelRetentionCleanupPoller.java
@@ -1,0 +1,34 @@
+package com.aquilabank.global.transaction;
+
+import com.aquilabank.domain.transaction.usecase.TransactionReadModelRetentionCleanupUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** 오래된 transaction read model row를 archive table로 옮겨 hot index 비용을 제한합니다. */
+@Component
+@ConditionalOnProperty(name = "transaction.read-model.cleanup.enabled", havingValue = "true")
+public class TransactionReadModelRetentionCleanupPoller {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(TransactionReadModelRetentionCleanupPoller.class);
+
+  private final TransactionReadModelRetentionCleanupUseCase cleanupUseCase;
+
+  public TransactionReadModelRetentionCleanupPoller(
+      TransactionReadModelRetentionCleanupUseCase cleanupUseCase) {
+    this.cleanupUseCase = cleanupUseCase;
+  }
+
+  @Scheduled(
+      fixedDelayString = "${transaction.read-model.cleanup.fixed-delay-ms:300000}",
+      initialDelayString = "${transaction.read-model.cleanup.initial-delay-ms:60000}")
+  void archiveExpiredReadModels() {
+    int archived = cleanupUseCase.archiveExpiredReadModels();
+    if (archived > 0) {
+      log.info("archived {} expired transaction read model row(s)", archived);
+    }
+  }
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -149,6 +149,15 @@ ledger:
     drift-list-limit: ${LEDGER_SNAPSHOT_RECONCILIATION_DRIFT_LIST_LIMIT:50}
     recovery-reason-max-length: ${LEDGER_SNAPSHOT_RECONCILIATION_RECOVERY_REASON_MAX_LENGTH:200}
 
+transaction:
+  read-model:
+    cleanup:
+      enabled: ${TRANSACTION_READ_MODEL_CLEANUP_ENABLED:false}
+      fixed-delay-ms: ${TRANSACTION_READ_MODEL_CLEANUP_FIXED_DELAY_MS:300000}
+      initial-delay-ms: ${TRANSACTION_READ_MODEL_CLEANUP_INITIAL_DELAY_MS:60000}
+      batch-size: ${TRANSACTION_READ_MODEL_CLEANUP_BATCH_SIZE:500}
+      retention-days: ${TRANSACTION_READ_MODEL_CLEANUP_RETENTION_DAYS:365}
+
 notification:
   sse:
     connection-timeout-ms: ${NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS:1800000}

--- a/back/src/main/resources/db/migration/V38__add_transaction_read_model_archive_retention.sql
+++ b/back/src/main/resources/db/migration/V38__add_transaction_read_model_archive_retention.sql
@@ -1,0 +1,43 @@
+-- hot transaction_read_model 은 최근 조회용으로 작게 유지하고, 오래된 projection 은 archive table 로 이동합니다.
+CREATE TABLE transaction_read_model_archive (
+    id BIGINT PRIMARY KEY,
+    ledger_entry_id BIGINT NOT NULL,
+    account_id BIGINT NOT NULL,
+    transaction_reference VARCHAR(64) NOT NULL,
+    direction VARCHAR(8) NOT NULL CHECK (direction IN ('DEBIT', 'CREDIT')),
+    transaction_status VARCHAR(16) NOT NULL
+        CHECK (transaction_status IN ('PENDING', 'BOOKED', 'PARTIALLY_REVERSED', 'REVERSED')),
+    amount_minor BIGINT NOT NULL CHECK (amount_minor > 0),
+    balance_after_minor BIGINT NOT NULL,
+    currency_code VARCHAR(3) NOT NULL CHECK (currency_code ~ '^[A-Z]{3}$'),
+    summary VARCHAR(120),
+    counterparty_masked_name VARCHAR(80),
+    booked_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    archived_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT uq_transaction_read_model_archive_ledger_entry UNIQUE (ledger_entry_id),
+    CONSTRAINT fk_transaction_read_model_archive_ledger_entry
+        FOREIGN KEY (ledger_entry_id) REFERENCES ledger_entry (id)
+);
+
+CREATE INDEX idx_transaction_read_model_cleanup_cursor
+    ON transaction_read_model USING BRIN (booked_at)
+    WITH (pages_per_range = 32);
+
+CREATE INDEX idx_transaction_read_model_archive_account_cursor
+    ON transaction_read_model_archive (account_id, booked_at DESC, id DESC);
+
+CREATE INDEX idx_transaction_read_model_archive_account_status_cursor
+    ON transaction_read_model_archive (account_id, transaction_status, booked_at DESC, id DESC);
+
+COMMENT ON TABLE transaction_read_model_archive IS
+    'transaction_read_model hot table retention 대상 projection 보관. ledger_entry 원장은 삭제하지 않음';
+
+COMMENT ON INDEX idx_transaction_read_model_cleanup_cursor IS
+    'transaction read model retention batch용. account-scoped 조회 btree와 경쟁하지 않는 cutoff BRIN 보조 index';
+
+COMMENT ON INDEX idx_transaction_read_model_archive_account_cursor IS
+    'archive projection account-scoped timeline 재조회/복구용. hot read model과 같은 keyset 정렬 유지';
+
+COMMENT ON INDEX idx_transaction_read_model_archive_account_status_cursor IS
+    'archive projection status filter 재조회/복구용. account_id + status 뒤 keyset 정렬 유지';

--- a/back/src/test/java/com/aquilabank/domain/transaction/usecase/TransactionReadModelRetentionCleanupServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/transaction/usecase/TransactionReadModelRetentionCleanupServiceTest.java
@@ -1,0 +1,36 @@
+package com.aquilabank.domain.transaction.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.transaction.port.TransactionReadModelRetentionCleanupPort;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class TransactionReadModelRetentionCleanupServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-22T00:00:00Z");
+
+  private final TransactionReadModelRetentionCleanupPort cleanupPort =
+      mock(TransactionReadModelRetentionCleanupPort.class);
+
+  @Test
+  void archivesExpiredReadModelsUsingConfiguredRetentionAndBatchSize() {
+    Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    when(cleanupPort.archiveExpiredReadModels(NOW.minus(Duration.ofDays(365)), 500, NOW))
+        .thenReturn(3);
+    TransactionReadModelRetentionCleanupService service =
+        new TransactionReadModelRetentionCleanupService(
+            cleanupPort, clock, Duration.ofDays(365), 500);
+
+    int archived = service.archiveExpiredReadModels();
+
+    assertThat(archived).isEqualTo(3);
+    verify(cleanupPort).archiveExpiredReadModels(NOW.minus(Duration.ofDays(365)), 500, NOW);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadModelRetentionCleanupRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadModelRetentionCleanupRepositoryIntegrationTest.java
@@ -1,0 +1,232 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcTransactionReadModelRetentionCleanupRepositoryIntegrationTest
+    extends PostgresContainerTestSupport {
+
+  private static final Instant BASE = Instant.parse("2026-04-22T00:00:00Z");
+
+  @Autowired private JdbcTransactionReadModelRetentionCleanupRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void archivesExpiredReadModelsInSmallBatchesWithoutDeletingLedgerSource() {
+    Instant cutoff = BASE.minusSeconds(60);
+    Instant archivedAt = BASE.plusSeconds(10);
+    long[] accountId = new long[1];
+
+    commit(
+        transactionManager,
+        () -> {
+          accountId[0] = insertAccount("retention account");
+          insertTransaction(accountId[0], "retention-old-1", cutoff.minusSeconds(20));
+          insertTransaction(accountId[0], "retention-old-2", cutoff.minusSeconds(10));
+          insertTransaction(accountId[0], "retention-fresh", cutoff.plusSeconds(10));
+        });
+
+    int firstArchived = repository.archiveExpiredReadModels(cutoff, 1, archivedAt);
+
+    assertThat(firstArchived).isEqualTo(1);
+    assertThat(findHotReferences()).hasSize(2).contains("retention-fresh");
+    assertThat(findArchiveReferences())
+        .hasSize(1)
+        .allSatisfy(reference -> assertThat(reference).startsWith("retention-old-"));
+    assertThat(totalLedgerEntries()).isEqualTo(3L);
+
+    int secondArchived = repository.archiveExpiredReadModels(cutoff, 10, archivedAt);
+
+    assertThat(secondArchived).isEqualTo(1);
+    assertThat(findHotReferences()).containsExactly("retention-fresh");
+    assertThat(findArchiveReferences()).containsExactly("retention-old-1", "retention-old-2");
+    assertThat(totalLedgerEntries()).isEqualTo(3L);
+
+    int thirdArchived = repository.archiveExpiredReadModels(cutoff, 10, archivedAt);
+
+    assertThat(thirdArchived).isZero();
+    assertThat(findHotReferences()).containsExactly("retention-fresh");
+    assertThat(findArchiveReferences()).containsExactly("retention-old-1", "retention-old-2");
+    assertThat(totalLedgerEntries()).isEqualTo(3L);
+  }
+
+  private long insertAccount(String displayName) {
+    String accountNumber =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0')
+            """,
+            new MapSqlParameterSource(),
+            String.class);
+    if (accountNumber == null) {
+      throw new IllegalStateException("account number is not generated");
+    }
+
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountNumber,
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                :createdAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountNumber", accountNumber)
+                .addValue("displayName", displayName)
+                .addValue("createdAt", Timestamp.from(BASE)),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertTransaction(long accountId, String reference, Instant bookedAt) {
+    Long ledgerEntryId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO ledger_entry (
+                account_id,
+                transaction_reference,
+                entry_reference,
+                direction,
+                entry_status,
+                amount_minor,
+                currency_code,
+                booked_at,
+                occurred_at,
+                description,
+                metadata,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountId,
+                :reference,
+                :reference || '-entry',
+                'CREDIT',
+                'BOOKED',
+                1700,
+                'KRW',
+                :bookedAt,
+                :bookedAt,
+                :reference,
+                '{}'::jsonb,
+                :bookedAt,
+                :bookedAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("reference", reference)
+                .addValue("bookedAt", Timestamp.from(bookedAt)),
+            Long.class);
+    if (ledgerEntryId == null) {
+      throw new IllegalStateException("ledger entry insert did not return id");
+    }
+
+    jdbcTemplate.update(
+        """
+        INSERT INTO transaction_read_model (
+            ledger_entry_id,
+            account_id,
+            transaction_reference,
+            direction,
+            transaction_status,
+            amount_minor,
+            balance_after_minor,
+            currency_code,
+            summary,
+            counterparty_masked_name,
+            booked_at,
+            created_at
+        )
+        VALUES (
+            :ledgerEntryId,
+            :accountId,
+            :reference,
+            'CREDIT',
+            'BOOKED',
+            1700,
+            1001700,
+            'KRW',
+            :reference,
+            'ATM',
+            :bookedAt,
+            :bookedAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("ledgerEntryId", ledgerEntryId)
+            .addValue("accountId", accountId)
+            .addValue("reference", reference)
+            .addValue("bookedAt", Timestamp.from(bookedAt)));
+  }
+
+  private List<String> findHotReferences() {
+    return jdbcTemplate.query(
+        """
+        SELECT transaction_reference
+        FROM transaction_read_model
+        ORDER BY booked_at ASC, id ASC
+        """,
+        new MapSqlParameterSource(),
+        (rs, rowNum) -> rs.getString("transaction_reference"));
+  }
+
+  private List<String> findArchiveReferences() {
+    return jdbcTemplate.query(
+        """
+        SELECT transaction_reference
+        FROM transaction_read_model_archive
+        ORDER BY booked_at ASC, id ASC
+        """,
+        new MapSqlParameterSource(),
+        (rs, rowNum) -> rs.getString("transaction_reference"));
+  }
+
+  private long totalLedgerEntries() {
+    Long count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM ledger_entry", new MapSqlParameterSource(), Long.class);
+    return count == null ? 0L : count;
+  }
+}

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -51,6 +51,7 @@ public abstract class PostgresContainerTestSupport {
                             notification_preference,
                             notification_user_read_state,
                             notification_inbox,
+                            transaction_read_model_archive,
                             transaction_read_model,
                             ledger_entry,
                             command_idempotency,

--- a/tools/test/run-transaction-read-model-retention.sh
+++ b/tools/test/run-transaction-read-model-retention.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[transaction-retention] fixture: cutoff 이전 read model 2 rows + fresh row 1 row"
+echo "[transaction-retention] expectation: expired rows move to transaction_read_model_archive; ledger_entry remains"
+echo "[transaction-retention] index guard: cleanup BRIN must not replace account-scoped keyset btree plans"
+echo "[transaction-retention] runtime default: TRANSACTION_READ_MODEL_CLEANUP_ENABLED=false"
+
+tools/test/with-resource-lock.sh back-gradle-transaction-retention ./back/gradlew -p back test \
+  --tests '*TransactionReadModelRetentionCleanupServiceTest' \
+  --tests '*JdbcTransactionReadModelRetentionCleanupRepositoryIntegrationTest' \
+  --tests '*JdbcTransactionReadRepositoryPartitionFitIntegrationTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #191

## 🌿 Base Branch
- `main`

## 📝 Summary
- `transaction_read_model` hot table의 오래된 projection을 archive table로 이동하는 retention 경로를 추가합니다.
- `ledger_entry` 원장은 유지하고, cleanup은 기본 비활성화 상태에서 작은 batch로만 실행되게 했습니다.
- cleanup 보조 index는 BRIN으로 두어 기존 account-scoped keyset btree plan과 경쟁하지 않게 했습니다.

## 🛠 Changes
- `transaction_read_model_archive` table과 archive 조회/복구용 index를 추가했습니다.
- transaction read model retention domain port/use case, JDBC adapter, scheduler 설정을 추가했습니다.
- `tools/test/run-transaction-read-model-retention.sh`로 retention 동작과 partition-fit index 회귀를 함께 검증합니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-transaction-retention ./back/gradlew -p back test --tests '*TransactionReadModelRetentionCleanupServiceTest' --tests '*JdbcTransactionReadModelRetentionCleanupRepositoryIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-transaction-retention ./back/gradlew -p back test --tests '*TransactionReadModelRetentionCleanupServiceTest' --tests '*JdbcTransactionReadModelRetentionCleanupRepositoryIntegrationTest' --tests '*JdbcTransactionReadRepositoryPartitionFitIntegrationTest'`
- `./back/gradlew -p back check` (pre-commit hook)
- `tools/test/run-transaction-read-model-retention.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: retention 기간을 짧게 설정하면 hot read model의 과거 조회 window가 archive table로 이동합니다. 이번 PR은 archive 조회 API를 추가하지 않습니다.
- 롤백 방법: `TRANSACTION_READ_MODEL_CLEANUP_ENABLED=false`로 poller를 비활성화하고, 필요하면 migration revert PR로 archive table/index를 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
