### PR TITLE
[Perf] transaction latency p95 histogram/SLO alert 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -186,6 +186,7 @@ set +a
   - outbox metric은 기본 wiring만 있으면 항상 export 됩니다.
   - notification consumer lag/DLQ metric은 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true` 와 DLQ topic 설정이 있어야 export 됩니다.
   - transaction latency timer는 `GET /api/v1/transactions` query path가 한 번이라도 호출되면 `query_shape` tag 기준으로 누적됩니다.
+  - transaction latency histogram bucket은 p95 SLO alert용으로 `50ms, 80ms, 120ms, 150ms, 180ms, 350ms, 750ms, 1s, 3s` 경계를 export 합니다.
 - transaction `query_shape` 기준:
   - `first_page`
   - `cursor`
@@ -194,9 +195,16 @@ set +a
   - `amount_first`, `amount_cursor`
   - `mixed_first`, `mixed_cursor`
   - `reference_exact`
+- transaction p95 SLO 기준:
+  - `reference_exact`: `80ms`
+  - `first_page`: `120ms`
+  - `cursor`, `status_first`, `status_cursor`, `direction_first`, `direction_cursor`: `150ms`
+  - `amount_first`, `amount_cursor`, `mixed_first`, `mixed_cursor`: `180ms`
 - 운영 메모:
   - outbox/notification gauge는 scrape 한 번에 같은 summary를 여러 번 다시 조회하지 않게 `5초` cache 안에서 재사용합니다.
   - SSE session metric은 현재 app instance 메모리의 active session 수만 보여주므로 multi-instance 전체 합계는 Prometheus 쿼리에서 합산합니다.
+  - p95 alert는 `query_shape`별 5분 rate가 충분할 때만 평가해 low traffic 노이즈를 줄입니다.
+  - histogram bucket/alert rollback은 `management.metrics.distribution.*.aquila.transaction.query.latency`와 `AquilaTransactionQueryLatencyP95SloHigh` rule 제거로 수행합니다.
   - baseline 자산은 `ops/prometheus/` 아래에 두고 dashboard import, alert rule apply, tuning 가이드는 `ops/prometheus/README.md`를 기준으로 봅니다.
 - baseline 파일:
   - dashboard: `ops/prometheus/grafana/aquila-bank-overview.json`

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -62,6 +62,11 @@ management:
       probes:
         enabled: true
       show-details: never
+  metrics:
+    distribution:
+      slo:
+        # p95 SLO alert가 쓰는 경계만 고정해 query_shape/outcome별 bucket 수를 제한합니다.
+        aquila.transaction.query.latency: 50ms,80ms,120ms,150ms,180ms,350ms,750ms,1s,3s
 
 logging:
   pattern:

--- a/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
@@ -156,6 +156,12 @@ class PrometheusMetricsIntegrationTest extends PostgresKafkaContainerTestSupport
       assertThat(body)
           .containsPattern(
               "aquila_transaction_query_latency_seconds_count\\{[^\\n]*outcome=\"success\"[^\\n]*query_shape=\"first_page\"[^\\n]*\\}\\s+1");
+      assertThat(body)
+          .containsPattern(
+              "aquila_transaction_query_latency_seconds_bucket\\{(?=[^\\n]*le=\"0\\.12\")(?=[^\\n]*outcome=\"success\")(?=[^\\n]*query_shape=\"first_page\")[^\\n]*\\}\\s+1");
+      assertThat(body)
+          .containsPattern(
+              "aquila_transaction_query_latency_seconds_bucket\\{(?=[^\\n]*le=\"0\\.75\")(?=[^\\n]*outcome=\"success\")(?=[^\\n]*query_shape=\"first_page\")[^\\n]*\\}\\s+1");
     } finally {
       emitter.complete();
     }

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -18,12 +18,13 @@
   - notification consumer lag / DLQ count
   - SSE total session, account/user/total trend, reject/drop trend
   - transaction query rate by `query_shape`
-  - transaction 평균 latency by `query_shape`
+  - transaction p95 latency by `query_shape`
 - datasource 기준:
   - Grafana datasource variable 이름은 `datasource`입니다.
   - import 직후 Prometheus datasource를 한 번 선택하면 모든 panel이 그 값을 재사용합니다.
 - query 기준:
-  - transaction latency는 histogram percentile이 아니라 `sum(rate(..._sum)) / sum(rate(..._count))` 평균값을 사용합니다.
+  - transaction stat latency는 `sum(rate(..._sum)) / sum(rate(..._count))` 평균값을 유지합니다.
+  - transaction shape별 latency는 `aquila_transaction_query_latency_seconds_bucket`의 `histogram_quantile(0.95, ...)`를 사용합니다.
   - notification lag panel은 topic label이 있을 때 topic별로 분리해 보여줍니다.
   - SSE reject/drop metric은 앱 재시작 전까지 누적되는 gauge 성격이므로 절대값 trend로만 봅니다.
 
@@ -52,6 +53,7 @@
   - DLQ count `> 0`
   - SSE total session `> 56`
 - transaction baseline:
+  - success query p95 SLO: reference_exact `80ms`, first_page `120ms`, cursor/status/direction `150ms`, amount/mixed `180ms`
   - success query 평균 latency `> 750ms`
 
 ## Alert Rule Apply
@@ -89,6 +91,7 @@ bash tools/ops/validate-prometheus-assets.sh
 
 - outbox/notification threshold는 현재 README와 actuator health 기본값을 기준으로 둔 값입니다.
 - `AquilaNotificationSseSessionPressureHigh`의 `56`은 기본 `NOTIFICATION_SSE_MAX_TOTAL_SESSIONS=64`의 `87.5%` baseline입니다.
-- transaction latency `750ms`는 query mix가 가벼운 환경을 전제로 한 출발값입니다. 실제 production에서는 `query_shape`, account volume, DB latency 분포를 보고 조정합니다.
+- transaction p95 SLO는 baseline fixture 기준 회귀 감지선입니다. 실제 production에서는 `query_shape`, account volume, DB latency 분포를 보고 threshold와 `for` 시간을 같이 조정합니다.
+- transaction 평균 latency `750ms` alert는 p95 SLO보다 느슨한 coarse guard로 남겨 둡니다.
 - notification lag/DLQ alert는 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true`가 아니면 metric 자체가 export되지 않을 수 있습니다.
 - multi-instance SSE 합계는 Grafana/Prometheus 쿼리에서 인스턴스 합산으로 해석하고, 단일 instance alert는 node별 pressure 확인 용도로만 씁니다.

--- a/ops/prometheus/grafana/aquila-bank-overview.json
+++ b/ops/prometheus/grafana/aquila-bank-overview.json
@@ -551,12 +551,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (query_shape) (rate(aquila_transaction_query_latency_seconds_sum{outcome=\"success\"}[5m])) / clamp_min(sum by (query_shape) (rate(aquila_transaction_query_latency_seconds_count{outcome=\"success\"}[5m])), 0.001)",
-          "legendFormat": "{{query_shape}} avg_latency",
+          "expr": "histogram_quantile(0.95, sum by (le, query_shape) (rate(aquila_transaction_query_latency_seconds_bucket{outcome=\"success\"}[5m])))",
+          "legendFormat": "{{query_shape}} p95_latency",
           "refId": "A"
         }
       ],
-      "title": "Transaction Avg Latency by Shape",
+      "title": "Transaction P95 Latency by Shape",
       "type": "timeseries"
     }
   ],

--- a/ops/prometheus/rules/aquila-bank-alerts.yml
+++ b/ops/prometheus/rules/aquila-bank-alerts.yml
@@ -101,6 +101,61 @@ groups:
   - name: aquila-bank-transaction
     interval: 30s
     rules:
+      - alert: AquilaTransactionQueryLatencyP95SloHigh
+        expr: |
+          (
+            (
+              histogram_quantile(
+                0.95,
+                sum by (le, query_shape) (
+                  rate(aquila_transaction_query_latency_seconds_bucket{outcome="success",query_shape="reference_exact"}[5m])
+                )
+              ) > 0.08
+            )
+            or
+            (
+              histogram_quantile(
+                0.95,
+                sum by (le, query_shape) (
+                  rate(aquila_transaction_query_latency_seconds_bucket{outcome="success",query_shape="first_page"}[5m])
+                )
+              ) > 0.12
+            )
+            or
+            (
+              histogram_quantile(
+                0.95,
+                sum by (le, query_shape) (
+                  rate(aquila_transaction_query_latency_seconds_bucket{outcome="success",query_shape=~"cursor|status_first|status_cursor|direction_first|direction_cursor"}[5m])
+                )
+              ) > 0.15
+            )
+            or
+            (
+              histogram_quantile(
+                0.95,
+                sum by (le, query_shape) (
+                  rate(aquila_transaction_query_latency_seconds_bucket{outcome="success",query_shape=~"amount_first|amount_cursor|mixed_first|mixed_cursor"}[5m])
+                )
+              ) > 0.18
+            )
+          )
+          and on (query_shape)
+          sum by (query_shape) (
+            rate(aquila_transaction_query_latency_seconds_count{outcome="success"}[5m])
+          ) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: transaction
+          baseline: "true"
+          slo: "p95"
+        annotations:
+          summary: "Aquila Bank transaction query p95 SLO is high"
+          description: "transaction query p95 latency가 query_shape별 baseline SLO를 5분 이상 초과했습니다. histogram bucket과 query volume을 같이 확인합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
       - alert: AquilaTransactionQueryLatencyHigh
         expr: |
           (

--- a/tools/ops/validate-prometheus-assets.sh
+++ b/tools/ops/validate-prometheus-assets.sh
@@ -33,6 +33,14 @@ data["groups"].each do |group|
     abort("expr missing in #{group["name"]}/#{rule["alert"]}") if rule["expr"].to_s.empty?
   end
 end
+
+transaction_rules = data["groups"].find { |group| group["name"] == "aquila-bank-transaction" }&.fetch("rules", [])
+p95_rule = transaction_rules.find { |rule| rule["alert"] == "AquilaTransactionQueryLatencyP95SloHigh" }
+abort("transaction p95 SLO alert missing") unless p95_rule
+expr = p95_rule["expr"].to_s
+abort("transaction p95 SLO alert must use histogram_quantile(0.95)") unless expr.match?(/histogram_quantile\s*\(\s*0\.95/)
+abort("transaction p95 SLO alert must read histogram buckets") unless expr.include?("aquila_transaction_query_latency_seconds_bucket")
+abort("transaction p95 SLO alert must keep query_shape labels") unless expr.include?("query_shape")
 ' "${RULES_FILE}"
 
 echo "Prometheus dashboard and alert rule baseline look valid."


### PR DESCRIPTION
## 🔗 Related Issue
- close #198

## 🌿 Base Branch
- `main`

## 📝 Summary
- `GET /api/v1/transactions` latency timer에 Prometheus histogram SLO bucket을 고정했습니다.
- query_shape별 p95 SLO alert와 Grafana p95 panel 기준을 추가했습니다.

## 🛠 Changes
- `aquila.transaction.query.latency` SLO bucket 설정 추가
- `AquilaTransactionQueryLatencyP95SloHigh` Prometheus alert rule 추가
- Prometheus asset validation script가 p95 histogram alert를 검증하도록 보강
- Prometheus metrics 통합 테스트에서 bucket export 확인
- README/ops 문서에 p95 SLO와 rollback 기준 기록

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/ops/validate-prometheus-assets.sh`
- `tools/test/with-resource-lock.sh back-prometheus-metrics ./back/gradlew -p back test --tests '*PrometheusMetricsIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- commit hook: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: p95 threshold가 초기 production traffic 분포와 맞지 않으면 alert noise가 발생할 수 있습니다.
- 롤백 방법: `management.metrics.distribution.slo.aquila.transaction.query.latency` 설정과 `AquilaTransactionQueryLatencyP95SloHigh` alert rule을 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
