### PR TITLE
[Perf] notification user inbox EXPLAIN baseline 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -233,6 +233,13 @@ tools/test/with-resource-lock.sh back-gradle-check \
 - notification inbox retention cleanup은 `notification_inbox.created_at` 기준으로만 동작해 account/user 경로의 read 의미를 따로 해석하지 않습니다.
 - 오래된 inbox row를 지울 때 연결된 `notification_user_read_state`도 FK cascade로 함께 정리해 read state orphan과 unread 회귀를 막습니다.
 - 기본 설정은 `NOTIFICATION_INBOX_CLEANUP_ENABLED=true`, `NOTIFICATION_INBOX_CLEANUP_RETENTION_DAYS=90`, `NOTIFICATION_INBOX_CLEANUP_BATCH_SIZE=500`, `NOTIFICATION_INBOX_CLEANUP_FIXED_DELAY_MS=300000` 입니다.
+- JWT user inbox list는 active account별 bounded LATERAL query로 `idx_notification_inbox_account_visible_cursor` partial index를 재사용합니다.
+- user inbox EXPLAIN baseline은 active membership/user visibility와 per-user hidden state를 포함한 first/cursor page에서 `notification_inbox` full scan 회귀를 차단합니다.
+- 실행:
+  ```bash
+  tools/test/with-resource-lock.sh back-notification-user-inbox-baseline \
+    tools/test/run-notification-user-inbox-explain-baseline.sh
+  ```
 
 ## Notification Search API
 

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -897,76 +897,16 @@ public class JdbcNotificationInboxRepository
 
   private List<NotificationSummary> fetchByUserIdFirstPage(
       long userId, NotificationListQuery query) {
-    return jdbcTemplate.query(
-        """
-        SELECT n.id,
-               n.account_id,
-               n.event_type,
-               n.title,
-               n.message,
-               n.created_at,
-               r.read_at
-        FROM notification_inbox n
-        JOIN user_account_membership m
-          ON m.account_id = n.account_id
-        JOIN bank_user u
-          ON u.id = m.user_id
-        LEFT JOIN notification_user_read_state r
-          ON r.user_id = :userId
-         AND r.notification_id = n.id
-        WHERE m.user_id = :userId
-          AND m.membership_status = 'ACTIVE'
-          AND u.user_status = 'ACTIVE'
-          AND n.archived_at IS NULL
-          AND r.archived_at IS NULL
-          AND r.deleted_at IS NULL
-        ORDER BY n.created_at DESC, n.id DESC
-        LIMIT :limitPlusOne
-        """,
-        new MapSqlParameterSource()
-            .addValue("userId", userId)
-            .addValue("limitPlusOne", query.limit() + 1),
-        ROW_MAPPER);
+    NotificationUserInboxQueryStatement statement =
+        NotificationUserInboxQueryStatement.from(userId, query);
+    return jdbcTemplate.query(statement.sql(), statement.params(), ROW_MAPPER);
   }
 
   private List<NotificationSummary> fetchByUserIdNextPage(
       long userId, NotificationListQuery query) {
-    return jdbcTemplate.query(
-        """
-        SELECT n.id,
-               n.account_id,
-               n.event_type,
-               n.title,
-               n.message,
-               n.created_at,
-               r.read_at
-        FROM notification_inbox n
-        JOIN user_account_membership m
-          ON m.account_id = n.account_id
-        JOIN bank_user u
-          ON u.id = m.user_id
-        LEFT JOIN notification_user_read_state r
-          ON r.user_id = :userId
-         AND r.notification_id = n.id
-        WHERE m.user_id = :userId
-          AND m.membership_status = 'ACTIVE'
-          AND u.user_status = 'ACTIVE'
-          AND n.archived_at IS NULL
-          AND r.archived_at IS NULL
-          AND r.deleted_at IS NULL
-          AND (
-                n.created_at < :cursorCreatedAt
-             OR (n.created_at = :cursorCreatedAt AND n.id < :cursorId)
-              )
-        ORDER BY n.created_at DESC, n.id DESC
-        LIMIT :limitPlusOne
-        """,
-        new MapSqlParameterSource()
-            .addValue("userId", userId)
-            .addValue("limitPlusOne", query.limit() + 1)
-            .addValue("cursorCreatedAt", Timestamp.from(query.cursor().createdAt()))
-            .addValue("cursorId", query.cursor().id()),
-        ROW_MAPPER);
+    NotificationUserInboxQueryStatement statement =
+        NotificationUserInboxQueryStatement.from(userId, query);
+    return jdbcTemplate.query(statement.sql(), statement.params(), ROW_MAPPER);
   }
 
   private List<NotificationSummary> fetchByAccountIdFirstPage(

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/NotificationUserInboxQueryStatement.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/NotificationUserInboxQueryStatement.java
@@ -1,0 +1,75 @@
+package com.aquilabank.global.persistence.notification;
+
+import com.aquilabank.domain.notification.model.NotificationListQuery;
+import java.sql.Timestamp;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+/** JWT user inbox list를 active account별 keyset query로 잘라 inbox 전체 scan/sort를 막습니다. */
+record NotificationUserInboxQueryStatement(String sql, MapSqlParameterSource params) {
+
+  static NotificationUserInboxQueryStatement from(long userId, NotificationListQuery query) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("limitPlusOne", query.limit() + 1);
+    String cursorPredicate = "";
+    if (query.cursor() != null) {
+      cursorPredicate =
+          """
+              AND (
+                    n.created_at < :cursorCreatedAt
+                 OR (n.created_at = :cursorCreatedAt AND n.id < :cursorId)
+                  )
+          """;
+      params
+          .addValue("cursorCreatedAt", Timestamp.from(query.cursor().createdAt()))
+          .addValue("cursorId", query.cursor().id());
+    }
+
+    return new NotificationUserInboxQueryStatement(
+        """
+        WITH active_account AS (
+            SELECT m.account_id
+            FROM user_account_membership m
+            JOIN bank_user u
+              ON u.id = m.user_id
+            WHERE m.user_id = :userId
+              AND m.membership_status = 'ACTIVE'
+              AND u.user_status = 'ACTIVE'
+        )
+        SELECT item.id,
+               item.account_id,
+               item.event_type,
+               item.title,
+               item.message,
+               item.created_at,
+               item.read_at
+        FROM active_account a
+        JOIN LATERAL (
+            SELECT n.id,
+                   n.account_id,
+                   n.event_type,
+                   n.title,
+                   n.message,
+                   n.created_at,
+                   r.read_at
+            FROM notification_inbox n
+            LEFT JOIN notification_user_read_state r
+              ON r.user_id = :userId
+             AND r.notification_id = n.id
+            WHERE n.account_id = a.account_id
+              AND n.archived_at IS NULL
+              AND r.archived_at IS NULL
+              AND r.deleted_at IS NULL
+        %s
+            ORDER BY n.created_at DESC, n.id DESC
+            LIMIT :limitPlusOne
+        ) item
+          ON TRUE
+        ORDER BY item.created_at DESC, item.id DESC
+        LIMIT :limitPlusOne
+        """
+            .formatted(cursorPredicate),
+        params);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryUserExplainBaselineIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepositoryUserExplainBaselineIntegrationTest.java
@@ -1,0 +1,284 @@
+package com.aquilabank.global.persistence.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.notification.model.NotificationListQuery;
+import com.aquilabank.domain.notification.model.NotificationSlice;
+import com.aquilabank.support.NotificationExplainPlan;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcNotificationInboxRepositoryUserExplainBaselineIntegrationTest
+    extends PostgresContainerTestSupport {
+
+  private static final Instant BASE = Instant.parse("2026-04-18T00:00:00Z");
+  private static final int PAGE_SIZE = 50;
+  private static final int ROWS_PER_ACCOUNT = 5_000;
+  private static final int NOISE_ACCOUNT_COUNT = 24;
+  private static final Object SEED_LOCK = new Object();
+  private static BaselineWindow sharedBaselineWindow;
+
+  @Autowired private JdbcNotificationInboxRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  private BaselineWindow baselineWindow;
+
+  @BeforeEach
+  void setUpDatabase() {
+    if (sharedBaselineWindow != null) {
+      baselineWindow = sharedBaselineWindow;
+      return;
+    }
+
+    synchronized (SEED_LOCK) {
+      if (sharedBaselineWindow == null) {
+        resetBankingTables(jdbcTemplate);
+        // baseline seed는 bulk insert/analyze가 포함되어 기본 transaction timeout보다 넉넉히 둡니다.
+        commit(transactionManager, 30, () -> sharedBaselineWindow = seedBaseline());
+      }
+      baselineWindow = sharedBaselineWindow;
+    }
+  }
+
+  @Test
+  void userFirstPageUsesVisibleCursorIndexWithoutInboxSeqScan() {
+    NotificationListQuery query = new NotificationListQuery(PAGE_SIZE, null);
+
+    NotificationSlice slice = repository.fetchByUserId(baselineWindow.userId(), query);
+    NotificationExplainPlan plan = explain(baselineWindow.userId(), query);
+
+    assertThat(slice.items()).hasSize(PAGE_SIZE);
+    assertThat(slice.hasNext()).isTrue();
+    assertThat(plan.rootNodeType()).isEqualTo("Limit");
+    assertThat(plan.seqScanRelations()).doesNotContain("notification_inbox");
+    assertThat(plan.indexNames()).contains("idx_notification_inbox_account_visible_cursor");
+  }
+
+  @Test
+  void userCursorPageKeepsVisibleCursorIndexWithoutInboxSeqScan() {
+    NotificationListQuery firstPageQuery = new NotificationListQuery(PAGE_SIZE, null);
+    NotificationSlice firstPage = repository.fetchByUserId(baselineWindow.userId(), firstPageQuery);
+    NotificationListQuery cursorQuery =
+        new NotificationListQuery(PAGE_SIZE, firstPage.nextCursor());
+
+    NotificationSlice slice = repository.fetchByUserId(baselineWindow.userId(), cursorQuery);
+    NotificationExplainPlan plan = explain(baselineWindow.userId(), cursorQuery);
+
+    assertThat(firstPage.nextCursor()).isNotNull();
+    assertThat(slice.items()).hasSize(PAGE_SIZE);
+    assertThat(slice.items().getFirst().createdAt())
+        .isBeforeOrEqualTo(firstPage.items().getLast().createdAt());
+    assertThat(plan.seqScanRelations()).doesNotContain("notification_inbox");
+    assertThat(plan.indexNames()).contains("idx_notification_inbox_account_visible_cursor");
+  }
+
+  private BaselineWindow seedBaseline() {
+    long userId = insertUser("user-inbox-baseline");
+    List<Long> targetAccountIds = new ArrayList<>();
+    for (int i = 1; i <= 3; i++) {
+      long accountId = insertAccount("baseline target " + i);
+      targetAccountIds.add(accountId);
+      insertMembership(userId, accountId, "VIEWER", "ACTIVE");
+      insertNotifications(accountId, "target-" + i, ROWS_PER_ACCOUNT);
+    }
+    long revokedAccountId = insertAccount("baseline revoked");
+    insertMembership(userId, revokedAccountId, "VIEWER", "REVOKED");
+    insertNotifications(revokedAccountId, "revoked", ROWS_PER_ACCOUNT);
+
+    for (int i = 1; i <= NOISE_ACCOUNT_COUNT; i++) {
+      long noiseUserId = insertUser("noise-user-inbox-" + i);
+      long noiseAccountId = insertAccount("noise inbox " + i);
+      insertMembership(noiseUserId, noiseAccountId, "OWNER", "ACTIVE");
+      insertNotifications(noiseAccountId, "noise-" + i, ROWS_PER_ACCOUNT);
+    }
+
+    hideEveryNthTargetNotification(userId, targetAccountIds, 47);
+    analyzeTables();
+    return new BaselineWindow(userId);
+  }
+
+  private NotificationExplainPlan explain(long userId, NotificationListQuery query) {
+    NotificationUserInboxQueryStatement statement =
+        NotificationUserInboxQueryStatement.from(userId, query);
+    String explainJson =
+        jdbcTemplate.queryForObject(
+            "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)\n" + statement.sql(),
+            statement.params(),
+            (rs, rowNum) -> rs.getString(1));
+    if (explainJson == null) {
+      throw new IllegalStateException("EXPLAIN did not return JSON");
+    }
+    return NotificationExplainPlan.fromJson(objectMapper, explainJson);
+  }
+
+  private long insertUser(String loginId) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private long insertAccount(String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertMembership(long userId, long accountId, String role, String status) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO user_account_membership (
+            user_id,
+            account_id,
+            membership_role,
+            membership_status,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :userId,
+            :accountId,
+            :role,
+            :status,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("accountId", accountId)
+            .addValue("role", role)
+            .addValue("status", status));
+  }
+
+  private void insertNotifications(long accountId, String prefix, int count) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_inbox (
+            account_id,
+            event_key,
+            event_type,
+            title,
+            message,
+            archived_at,
+            created_at
+        )
+        SELECT :accountId,
+               :prefix || '-' || gs::text,
+               CASE WHEN gs % 7 = 0 THEN 'TransferReversed' ELSE 'TransferBooked' END,
+               'title ' || gs::text,
+               'message ' || gs::text,
+               CASE WHEN gs % 113 = 0 THEN CAST(:base AS timestamptz) ELSE NULL::timestamptz END,
+               CAST(:base AS timestamptz) - (gs * INTERVAL '1 second')
+        FROM generate_series(1, :count) gs
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("prefix", prefix)
+            .addValue("count", count)
+            .addValue("base", Timestamp.from(BASE)));
+  }
+
+  private void hideEveryNthTargetNotification(
+      long userId, List<Long> targetAccountIds, int modulo) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_user_read_state (
+            user_id,
+            notification_id,
+            read_at,
+            archived_at,
+            deleted_at
+        )
+        SELECT :userId,
+               n.id,
+               NULL,
+               NULL,
+               :deletedAt
+        FROM notification_inbox n
+        WHERE n.account_id IN (:accountIds)
+          AND n.id % :modulo = 0
+        ON CONFLICT (user_id, notification_id) DO NOTHING
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("accountIds", targetAccountIds)
+            .addValue("modulo", modulo)
+            .addValue("deletedAt", Timestamp.from(BASE)));
+  }
+
+  private void analyzeTables() {
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE bank_user");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE user_account_membership");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE notification_inbox");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE notification_user_read_state");
+  }
+
+  private record BaselineWindow(long userId) {}
+}

--- a/back/src/test/java/com/aquilabank/support/NotificationExplainPlan.java
+++ b/back/src/test/java/com/aquilabank/support/NotificationExplainPlan.java
@@ -1,0 +1,65 @@
+package com.aquilabank.support;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/** PostgreSQL EXPLAIN JSON에서 notification baseline 비교용 핵심 정보만 추립니다. */
+public record NotificationExplainPlan(
+    String rootNodeType,
+    Set<String> nodeTypes,
+    Set<String> indexNames,
+    Set<String> seqScanRelations) {
+
+  public static NotificationExplainPlan fromJson(ObjectMapper objectMapper, String planJson) {
+    try {
+      JsonNode rootArray = objectMapper.readTree(planJson);
+      JsonNode rootPlan = rootArray.path(0).path("Plan");
+      if (rootPlan.isMissingNode()) {
+        throw new IllegalArgumentException("EXPLAIN JSON root plan is missing");
+      }
+
+      LinkedHashSet<String> nodeTypes = new LinkedHashSet<>();
+      LinkedHashSet<String> indexNames = new LinkedHashSet<>();
+      LinkedHashSet<String> seqScanRelations = new LinkedHashSet<>();
+      collect(rootPlan, nodeTypes, indexNames, seqScanRelations);
+      return new NotificationExplainPlan(
+          rootPlan.path("Node Type").asText(), nodeTypes, indexNames, seqScanRelations);
+    } catch (IOException ex) {
+      throw new IllegalArgumentException("EXPLAIN JSON parse failed", ex);
+    }
+  }
+
+  public boolean hasNodeType(String nodeType) {
+    return nodeTypes.contains(nodeType);
+  }
+
+  public boolean usesIndex(String indexName) {
+    return indexNames.contains(indexName);
+  }
+
+  private static void collect(
+      JsonNode node, Set<String> nodeTypes, Set<String> indexNames, Set<String> seqScanRelations) {
+    String nodeType = node.path("Node Type").asText(null);
+    if (nodeType != null) {
+      nodeTypes.add(nodeType);
+    }
+    if ("Seq Scan".equals(nodeType)) {
+      String relationName = node.path("Relation Name").asText(null);
+      if (relationName != null) {
+        seqScanRelations.add(relationName);
+      }
+    }
+
+    String indexName = node.path("Index Name").asText(null);
+    if (indexName != null) {
+      indexNames.add(indexName);
+    }
+
+    for (JsonNode child : node.path("Plans")) {
+      collect(child, nodeTypes, indexNames, seqScanRelations);
+    }
+  }
+}

--- a/tools/test/run-notification-user-inbox-explain-baseline.sh
+++ b/tools/test/run-notification-user-inbox-explain-baseline.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[notification-user-inbox-baseline] fixture: target user 3x5000 rows + revoked 5000 rows + noise 24x5000 rows"
+echo "[notification-user-inbox-baseline] expectation: user first/cursor page uses idx_notification_inbox_account_visible_cursor without notification_inbox Seq Scan"
+echo "[notification-user-inbox-baseline] path: JWT user visibility = active membership + active user + per-user hidden state"
+
+./back/gradlew -p back test \
+  --tests '*JdbcNotificationInboxRepositoryUserExplainBaselineIntegrationTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #199

## 🌿 Base Branch
- `main`

## 📝 Summary
- JWT user notification inbox list query를 active account별 bounded LATERAL keyset 조회로 조정했습니다.
- user first/cursor page EXPLAIN baseline을 추가해 `notification_inbox` full scan 회귀를 차단합니다.

## 🛠 Changes
- user inbox list SQL을 `NotificationUserInboxQueryStatement`로 분리
- 기존 `idx_notification_inbox_account_visible_cursor`를 재사용하는 bounded query shape 적용
- Testcontainers PostgreSQL EXPLAIN baseline 테스트 추가
- baseline 실행 스크립트와 README 실행 기준 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-notification-user-inbox-baseline tools/test/run-notification-user-inbox-explain-baseline.sh`
- `tools/test/with-resource-lock.sh back-notification-inbox-repository ./back/gradlew -p back test --tests '*JdbcNotificationInboxRepositoryIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- commit hook: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: active account 수가 매우 많은 user는 final merge/sort 대상이 account 수에 비례해 증가할 수 있습니다. 기존 전체 inbox scan/sort보다 bounded path로 제한됩니다.
- 롤백 방법: `JdbcNotificationInboxRepository`의 user list query를 이전 join query로 되돌리고 baseline 테스트/스크립트를 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
