### PR TITLE
[Perf] notification SSE fan-out 부하와 장애 주입 검증 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -314,6 +314,15 @@ tools/test/with-resource-lock.sh back-gradle-check \
   - `aquila_notification_sse_sessions{principal_type="account|user|total"}`
   - `aquila_notification_sse_subscription_rejected_count{reason="session_limit"}`
   - `aquila_notification_sse_session_dropped_count{reason="pending_overflow"}`
+- 부하/장애 주입 검증:
+  - account 2개 session, user 2개 session, live event 25건을 같은 broker publish path로 보내 누락과 순서를 확인합니다.
+  - emitter send 실패는 해당 session만 제거하고 같은 batch의 healthy session 전파를 유지해야 합니다.
+  - replay pending overflow는 `pending_overflow` drop metric 증가와 session 제거로 해석합니다.
+  - 실행:
+    ```bash
+    tools/test/with-resource-lock.sh back-notification-sse-fanout-load-fault \
+      tools/test/run-notification-sse-fanout-load-fault.sh
+    ```
 
 ### Nginx Reverse Proxy Baseline
 

--- a/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
+++ b/back/src/main/java/com/aquilabank/global/notification/NotificationSseBroker.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -39,6 +40,7 @@ public class NotificationSseBroker {
   private final NotificationSseProperties notificationSseProperties;
   private final NotificationSseTargetResolver notificationSseTargetResolver;
   private final NotificationQueryUseCase notificationQueryUseCase;
+  private final LongFunction<SseEmitter> sseEmitterFactory;
   private final Map<Long, Map<String, NotificationSseSession>> accountSessions =
       new ConcurrentHashMap<>();
   private final Map<Long, Map<String, NotificationSseSession>> userSessions =
@@ -47,13 +49,27 @@ public class NotificationSseBroker {
   private final AtomicLong rejectedSubscriptionCount = new AtomicLong();
   private final AtomicLong backpressureDropCount = new AtomicLong();
 
+  @Autowired
   public NotificationSseBroker(
       NotificationSseProperties notificationSseProperties,
       NotificationSseTargetResolver notificationSseTargetResolver,
       NotificationQueryUseCase notificationQueryUseCase) {
+    this(
+        notificationSseProperties,
+        notificationSseTargetResolver,
+        notificationQueryUseCase,
+        SseEmitter::new);
+  }
+
+  NotificationSseBroker(
+      NotificationSseProperties notificationSseProperties,
+      NotificationSseTargetResolver notificationSseTargetResolver,
+      NotificationQueryUseCase notificationQueryUseCase,
+      LongFunction<SseEmitter> sseEmitterFactory) {
     this.notificationSseProperties = notificationSseProperties;
     this.notificationSseTargetResolver = notificationSseTargetResolver;
     this.notificationQueryUseCase = notificationQueryUseCase;
+    this.sseEmitterFactory = sseEmitterFactory;
   }
 
   public SseEmitter subscribeAccount(long accountId, String subject) {
@@ -157,7 +173,7 @@ public class NotificationSseBroker {
     String sessionId = UUID.randomUUID().toString();
     boolean registered = false;
     try {
-      SseEmitter emitter = new SseEmitter(notificationSseProperties.connectionTimeoutMs());
+      SseEmitter emitter = sseEmitterFactory.apply(notificationSseProperties.connectionTimeoutMs());
       NotificationSseSession session =
           new NotificationSseSession(sessionId, subject, emitter, lastEventId);
       if (!registerSession(sessionsByPrincipalId, principalId, session, maxPrincipalSessions)) {

--- a/back/src/test/java/com/aquilabank/global/notification/NotificationSseBrokerTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/NotificationSseBrokerTest.java
@@ -12,15 +12,24 @@ import com.aquilabank.domain.notification.model.NotificationReplayQuery;
 import com.aquilabank.domain.notification.model.NotificationSummary;
 import com.aquilabank.domain.notification.usecase.NotificationQueryUseCase;
 import com.aquilabank.global.config.NotificationSseProperties;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
+import java.util.function.LongFunction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter.DataWithMediaType;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
 
 class NotificationSseBrokerTest {
 
@@ -51,6 +60,62 @@ class NotificationSseBrokerTest {
         .hasMessage("notification SSE stream is temporarily overloaded");
     assertThat(notificationSseBroker.rejectedSubscriptionCount()).isEqualTo(1L);
     firstEmitter.complete();
+  }
+
+  @Test
+  void fansOutNotificationsToAccountAndActiveUserSessionsUnderLoad() throws Exception {
+    when(notificationSseTargetResolver.findActiveUserIdsByAccountId(101L))
+        .thenReturn(List.of(201L, 202L));
+    RecordingSseEmitterFactory emitterFactory = new RecordingSseEmitterFactory();
+    NotificationSseBroker notificationSseBroker = createBroker(8, 4, 8, emitterFactory);
+    notificationSseBroker.subscribeAccount(101L, "account-a");
+    notificationSseBroker.subscribeAccount(101L, "account-b");
+    notificationSseBroker.subscribeUser(201L, "user-a");
+    notificationSseBroker.subscribeUser(202L, "user-b");
+    List<NotificationSummary> items = new ArrayList<>();
+    List<Long> expectedIds = new ArrayList<>();
+    for (long index = 0; index < 25; index++) {
+      long notificationId = 1_000L + index;
+      items.add(notification(notificationId, 101L, "load-" + index));
+      expectedIds.add(notificationId);
+    }
+
+    notificationSseBroker.publishInsertedItems(items);
+
+    List<RecordingSseEmitter> emitters = emitterFactory.emitters();
+    awaitCondition(
+        () ->
+            emitters.stream()
+                .allMatch(emitter -> emitter.notificationIds().size() == expectedIds.size()),
+        Duration.ofSeconds(2));
+    assertThat(emitters).hasSize(4);
+    assertThat(emitters)
+        .allSatisfy(
+            emitter ->
+                assertThat(emitter.notificationIds()).containsExactlyElementsOf(expectedIds));
+    assertThat(notificationSseBroker.totalSessionCount()).isEqualTo(4);
+    assertThat(notificationSseBroker.backpressureDropCount()).isZero();
+  }
+
+  @Test
+  void isolatesEmitterFailureDuringFanoutBatch() throws Exception {
+    RecordingSseEmitterFactory emitterFactory = new RecordingSseEmitterFactory(true, false);
+    NotificationSseBroker notificationSseBroker = createBroker(4, 2, 4, emitterFactory);
+    notificationSseBroker.subscribeAccount(101L, "broken-account-session");
+    notificationSseBroker.subscribeAccount(101L, "healthy-account-session");
+    List<NotificationSummary> items =
+        List.of(notification(11L, 101L, "one"), notification(12L, 101L, "two"));
+
+    notificationSseBroker.publishInsertedItems(items);
+
+    RecordingSseEmitter brokenEmitter = emitterFactory.emitter(0);
+    RecordingSseEmitter healthyEmitter = emitterFactory.emitter(1);
+    awaitCondition(() -> healthyEmitter.notificationIds().size() == 2, Duration.ofSeconds(2));
+    awaitCondition(() -> notificationSseBroker.totalSessionCount() == 1, Duration.ofSeconds(2));
+    assertThat(healthyEmitter.notificationIds()).containsExactly(11L, 12L);
+    assertThat(brokenEmitter.completedCount()).isEqualTo(1);
+    assertThat(notificationSseBroker.accountSessionCount()).isEqualTo(1);
+    assertThat(notificationSseBroker.backpressureDropCount()).isZero();
   }
 
   @Test
@@ -124,6 +189,15 @@ class NotificationSseBrokerTest {
 
   private NotificationSseBroker createBroker(
       int maxTotalSessions, int maxUserSessions, int maxPendingEventsPerSession) {
+    return createBroker(
+        maxTotalSessions, maxUserSessions, maxPendingEventsPerSession, SseEmitter::new);
+  }
+
+  private NotificationSseBroker createBroker(
+      int maxTotalSessions,
+      int maxUserSessions,
+      int maxPendingEventsPerSession,
+      LongFunction<SseEmitter> emitterFactory) {
     return new NotificationSseBroker(
         new NotificationSseProperties(
             60_000L,
@@ -137,7 +211,8 @@ class NotificationSseBrokerTest {
             1_000L,
             2_000L),
         notificationSseTargetResolver,
-        notificationQueryUseCase);
+        notificationQueryUseCase,
+        emitterFactory);
   }
 
   private NotificationSummary notification(long id, long accountId, String suffix) {
@@ -160,5 +235,96 @@ class NotificationSseBrokerTest {
       Thread.sleep(20L);
     }
     assertThat(condition.getAsBoolean()).isTrue();
+  }
+
+  private static final class RecordingSseEmitterFactory implements LongFunction<SseEmitter> {
+
+    private final Queue<Boolean> failurePlan = new ArrayDeque<>();
+    private final List<RecordingSseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    private RecordingSseEmitterFactory(boolean... failNotificationEvents) {
+      for (boolean failNotificationEvent : failNotificationEvents) {
+        failurePlan.add(failNotificationEvent);
+      }
+    }
+
+    @Override
+    public SseEmitter apply(long timeoutMs) {
+      Boolean failNotificationEvent = failurePlan.poll();
+      RecordingSseEmitter emitter =
+          new RecordingSseEmitter(timeoutMs, Boolean.TRUE.equals(failNotificationEvent));
+      emitters.add(emitter);
+      return emitter;
+    }
+
+    private List<RecordingSseEmitter> emitters() {
+      return List.copyOf(emitters);
+    }
+
+    private RecordingSseEmitter emitter(int index) {
+      return emitters.get(index);
+    }
+  }
+
+  private static final class RecordingSseEmitter extends SseEmitter {
+
+    private final boolean failNotificationEvents;
+    private final List<RecordedSseEvent> events = new CopyOnWriteArrayList<>();
+    private final AtomicInteger completedCount = new AtomicInteger();
+
+    private RecordingSseEmitter(long timeoutMs, boolean failNotificationEvents) {
+      super(timeoutMs);
+      this.failNotificationEvents = failNotificationEvents;
+    }
+
+    @Override
+    public void send(SseEventBuilder builder) throws IOException {
+      RecordedSseEvent event = RecordedSseEvent.from(builder);
+      if (failNotificationEvents && "notification".equals(event.name())) {
+        throw new IOException("injected SSE send failure");
+      }
+      events.add(event);
+    }
+
+    @Override
+    public void complete() {
+      completedCount.incrementAndGet();
+      super.complete();
+    }
+
+    private List<Long> notificationIds() {
+      return events.stream()
+          .filter(event -> "notification".equals(event.name()))
+          .map(event -> Long.parseLong(event.id()))
+          .toList();
+    }
+
+    private int completedCount() {
+      return completedCount.get();
+    }
+  }
+
+  private record RecordedSseEvent(String name, String id, Object data) {
+
+    private static RecordedSseEvent from(SseEventBuilder builder) {
+      String name = null;
+      String id = null;
+      Object data = null;
+      for (DataWithMediaType item : builder.build()) {
+        Object value = item.getData();
+        if (value instanceof String text) {
+          for (String line : text.split("\\n")) {
+            if (line.startsWith("event:")) {
+              name = line.substring("event:".length());
+            } else if (line.startsWith("id:")) {
+              id = line.substring("id:".length());
+            }
+          }
+        } else {
+          data = value;
+        }
+      }
+      return new RecordedSseEvent(name, id, data);
+    }
   }
 }

--- a/tools/test/run-notification-sse-fanout-load-fault.sh
+++ b/tools/test/run-notification-sse-fanout-load-fault.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[notification-sse-fanout] fixture: account 2 sessions + user 2 sessions + 25 live events"
+echo "[notification-sse-fanout] fault: one injected emitter send failure must not block healthy sessions"
+echo "[notification-sse-fanout] backpressure: replay pending overflow drops only the slow session"
+
+./back/gradlew -p back test \
+  --tests '*NotificationSseBrokerTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #202

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification SSE broker의 account/user fan-out 부하와 emitter 장애 격리를 단위 테스트로 고정합니다.
- replay pending overflow 검증을 전용 스크립트와 README 운영 기준에 연결합니다.

## 🛠 Changes
- `NotificationSseBroker`에 production 기본값 `SseEmitter::new`를 유지하는 emitter factory seam 추가
- account/user 4개 session x 25 live event fan-out 순서/누락 검증 추가
- emitter send 실패가 해당 session만 닫고 healthy session 전파를 유지하는 장애 주입 테스트 추가
- `tools/test/run-notification-sse-fanout-load-fault.sh` 및 README 검증 명령 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-notification-sse-fanout-load-fault tools/test/run-notification-sse-fanout-load-fault.sh`
- `tools/test/with-resource-lock.sh back-context-smoke ./back/gradlew -p back test --tests '*AquilaBankApplicationTests' --tests '*NotificationSseBrokerTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit hook: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: test seam constructor가 Spring autowire 후보에 섞일 수 있어 production constructor에 `@Autowired`를 명시했습니다.
- 롤백 방법: `NotificationSseBrokerTest` 추가 케이스, emitter factory seam, 검증 스크립트/README 변경을 revert 합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
