### PR TITLE
[Perf] account list keyset pagination 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -34,6 +34,23 @@ com.aquilabank
 - `redis`는 분산 login throttling 이 필요할 때만 opt-in 으로 사용합니다.
 - Redis 경로는 login throttling counter 에만 쓰고, SSE fan-out 은 계속 PostgreSQL `LISTEN/NOTIFY` 를 사용합니다.
 
+## Account List Pagination
+
+`GET /api/v1/accounts` 는 JWT 사용자 요청에서 기존 무파라미터 전체 목록 응답을 유지하면서, `limit` 또는 `cursor` 가 들어오면 account_id 기준 keyset page로 조회합니다.
+
+- 기본 page size: `50`
+- 최대 page size: `100`
+- cursor: 응답의 `nextCursor` 값을 그대로 다음 요청의 `cursor` 에 전달
+- 정렬: `membership.account_id ASC`
+- index: `idx_user_account_membership_user_status_account_cursor`
+
+재현 명령:
+
+```bash
+tools/test/with-resource-lock.sh back-account-list-keyset \
+  tools/test/run-account-list-keyset-pagination.sh
+```
+
 ## Stack
 
 - Java 21

--- a/back/src/main/java/com/aquilabank/domain/account/model/AccountSummaryList.java
+++ b/back/src/main/java/com/aquilabank/domain/account/model/AccountSummaryList.java
@@ -3,12 +3,19 @@ package com.aquilabank.domain.account.model;
 import java.util.List;
 
 /** 내 계좌 목록 조회 결과를 한 번에 묶는 최소 응답 모델 */
-public record AccountSummaryList(List<AccountSummary> items) {
+public record AccountSummaryList(List<AccountSummary> items, Long nextCursorAccountId) {
+
+  public AccountSummaryList(List<AccountSummary> items) {
+    this(items, null);
+  }
 
   public AccountSummaryList {
     items = List.copyOf(items);
     if (items.stream().anyMatch(java.util.Objects::isNull)) {
       throw new IllegalArgumentException("items must not contain null");
+    }
+    if (nextCursorAccountId != null && nextCursorAccountId <= 0) {
+      throw new IllegalArgumentException("nextCursorAccountId must be positive");
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/account/port/AccountListReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/account/port/AccountListReadPort.java
@@ -6,4 +6,6 @@ import com.aquilabank.domain.account.model.AccountSummaryList;
 public interface AccountListReadPort {
 
   AccountSummaryList findByUserId(long userId);
+
+  AccountSummaryList findByUserId(long userId, int limit, Long afterAccountId);
 }

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountListQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountListQueryService.java
@@ -6,6 +6,8 @@ import com.aquilabank.domain.account.port.AccountListReadPort;
 /** 내 계좌 목록 조회 입력 검증과 저장소 위임을 묶습니다. */
 public final class AccountListQueryService implements AccountListQueryUseCase {
 
+  private static final int MAX_LIMIT = 100;
+
   private final AccountListReadPort accountListReadPort;
 
   public AccountListQueryService(AccountListReadPort accountListReadPort) {
@@ -14,9 +16,25 @@ public final class AccountListQueryService implements AccountListQueryUseCase {
 
   @Override
   public AccountSummaryList getByUserId(long userId) {
+    validateUserId(userId);
+    return accountListReadPort.findByUserId(userId);
+  }
+
+  @Override
+  public AccountSummaryList getByUserId(long userId, int limit, Long afterAccountId) {
+    validateUserId(userId);
+    if (limit < 1 || limit > MAX_LIMIT) {
+      throw new IllegalArgumentException("limit must be between 1 and 100");
+    }
+    if (afterAccountId != null && afterAccountId <= 0) {
+      throw new IllegalArgumentException("cursor accountId must be positive");
+    }
+    return accountListReadPort.findByUserId(userId, limit, afterAccountId);
+  }
+
+  private void validateUserId(long userId) {
     if (userId <= 0) {
       throw new IllegalArgumentException("userId must be positive");
     }
-    return accountListReadPort.findByUserId(userId);
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountListQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountListQueryUseCase.java
@@ -6,4 +6,6 @@ import com.aquilabank.domain.account.model.AccountSummaryList;
 public interface AccountListQueryUseCase {
 
   AccountSummaryList getByUserId(long userId);
+
+  AccountSummaryList getByUserId(long userId, int limit, Long afterAccountId);
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountListRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountListRepository.java
@@ -7,6 +7,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.List;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -52,6 +53,51 @@ public class JdbcAccountListRepository implements AccountListReadPort {
             """,
             new MapSqlParameterSource().addValue("userId", userId),
             (rs, rowNum) -> mapAccountSummary(rs)));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public AccountSummaryList findByUserId(long userId, int limit, Long afterAccountId) {
+    int fetchSize = limit + 1;
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("limit", fetchSize)
+            .addValue("afterAccountId", afterAccountId == null ? 0L : afterAccountId);
+    List<AccountSummary> items =
+        jdbcTemplate.query(
+            """
+            SELECT account.id,
+                   account.account_number,
+                   account.display_name,
+                   account.account_status,
+                   account.currency_code AS account_currency_code,
+                   snapshot.available_balance_minor,
+                   snapshot.pending_balance_minor,
+                   snapshot.currency_code AS snapshot_currency_code,
+                   account.created_at,
+                   snapshot.updated_at
+            FROM user_account_membership membership
+            JOIN bank_user bank_user
+              ON bank_user.id = membership.user_id
+            JOIN bank_account account
+              ON account.id = membership.account_id
+            JOIN account_balance_snapshot snapshot
+              ON snapshot.account_id = account.id
+            WHERE membership.user_id = :userId
+              AND membership.membership_status = 'ACTIVE'
+              AND membership.account_id > :afterAccountId
+              AND bank_user.user_status = 'ACTIVE'
+            ORDER BY membership.account_id ASC
+            LIMIT :limit
+            """,
+            params,
+            (rs, rowNum) -> mapAccountSummary(rs));
+    if (items.size() <= limit) {
+      return new AccountSummaryList(items);
+    }
+    List<AccountSummary> pageItems = items.subList(0, limit);
+    return new AccountSummaryList(pageItems, pageItems.getLast().accountId());
   }
 
   private AccountSummary mapAccountSummary(ResultSet rs) throws SQLException {

--- a/back/src/main/java/com/aquilabank/global/web/account/AccountListController.java
+++ b/back/src/main/java/com/aquilabank/global/web/account/AccountListController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -22,6 +23,8 @@ import org.springframework.web.server.ResponseStatusException;
 @RestController
 @RequestMapping("/api/v1/accounts")
 public class AccountListController {
+
+  private static final int DEFAULT_PAGE_LIMIT = 50;
 
   private final AccountListQueryUseCase accountListQueryUseCase;
   private final AccountSummaryQueryUseCase accountSummaryQueryUseCase;
@@ -35,16 +38,25 @@ public class AccountListController {
 
   @GetMapping
   public AccountListResponse getAccounts(
-      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal) {
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @RequestParam(required = false) Integer limit,
+      @RequestParam(required = false) String cursor) {
     try {
-      return AccountListResponse.from(resolveAccountSummaryList(principal));
+      return AccountListResponse.from(resolveAccountSummaryList(principal, limit, cursor));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }
   }
 
-  private AccountSummaryList resolveAccountSummaryList(AuthenticatedRequestPrincipal principal) {
+  private AccountSummaryList resolveAccountSummaryList(
+      AuthenticatedRequestPrincipal principal, Integer limit, String cursor) {
     if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      if (limit != null || hasCursor(cursor)) {
+        int resolvedLimit = limit == null ? DEFAULT_PAGE_LIMIT : limit;
+        Long afterAccountId = hasCursor(cursor) ? AccountListCursorCodec.decode(cursor) : null;
+        return accountListQueryUseCase.getByUserId(
+            userPrincipal.userId(), resolvedLimit, afterAccountId);
+      }
       return accountListQueryUseCase.getByUserId(userPrincipal.userId());
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
@@ -55,12 +67,19 @@ public class AccountListController {
     throw new IllegalArgumentException("unsupported principal type");
   }
 
+  private boolean hasCursor(String cursor) {
+    return cursor != null && !cursor.isBlank();
+  }
+
   /** 고객 계좌 목록 응답 */
-  public record AccountListResponse(List<AccountItemResponse> items) {
+  public record AccountListResponse(List<AccountItemResponse> items, String nextCursor) {
 
     static AccountListResponse from(AccountSummaryList summaryList) {
       return new AccountListResponse(
-          summaryList.items().stream().map(AccountItemResponse::from).toList());
+          summaryList.items().stream().map(AccountItemResponse::from).toList(),
+          summaryList.nextCursorAccountId() == null
+              ? null
+              : AccountListCursorCodec.encode(summaryList.nextCursorAccountId()));
     }
   }
 

--- a/back/src/main/java/com/aquilabank/global/web/account/AccountListCursorCodec.java
+++ b/back/src/main/java/com/aquilabank/global/web/account/AccountListCursorCodec.java
@@ -1,0 +1,29 @@
+package com.aquilabank.global.web.account;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/** account list cursor는 account_id keyset 값을 HTTP transport에서 opaque하게 숨깁니다. */
+final class AccountListCursorCodec {
+
+  private AccountListCursorCodec() {}
+
+  static String encode(long accountId) {
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(Long.toString(accountId).getBytes(StandardCharsets.UTF_8));
+  }
+
+  static long decode(String cursor) {
+    try {
+      String decoded = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+      long accountId = Long.parseLong(decoded);
+      if (accountId <= 0) {
+        throw new IllegalArgumentException("cursor format is invalid");
+      }
+      return accountId;
+    } catch (RuntimeException ex) {
+      throw new IllegalArgumentException("cursor format is invalid", ex);
+    }
+  }
+}

--- a/back/src/main/resources/db/migration/V40__add_account_list_keyset_index.sql
+++ b/back/src/main/resources/db/migration/V40__add_account_list_keyset_index.sql
@@ -1,0 +1,6 @@
+-- JWT 사용자 계좌 목록은 user/status 범위 안에서 account_id keyset 으로 다음 page를 읽습니다.
+CREATE INDEX idx_user_account_membership_user_status_account_cursor
+    ON user_account_membership (user_id, membership_status, account_id);
+
+COMMENT ON INDEX idx_user_account_membership_user_status_account_cursor
+    IS 'GET /api/v1/accounts JWT user keyset pagination: user_id + ACTIVE status + account_id cursor';

--- a/back/src/test/java/com/aquilabank/global/persistence/account/JdbcAccountListRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/account/JdbcAccountListRepositoryIntegrationTest.java
@@ -1,0 +1,254 @@
+package com.aquilabank.global.persistence.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.account.model.AccountSummaryList;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcAccountListRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcAccountListRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void returnsAccountListByAccountIdKeysetPage() {
+    long[] userId = new long[1];
+    long[] accountIds = new long[5];
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("account-list-user", "ACTIVE");
+          for (int index = 0; index < accountIds.length; index++) {
+            accountIds[index] = insertAccount("account-" + index);
+            insertSnapshot(accountIds[index]);
+            insertMembership(userId[0], accountIds[index], index == 2 ? "REVOKED" : "ACTIVE");
+          }
+        });
+
+    AccountSummaryList firstPage = repository.findByUserId(userId[0], 2, null);
+    AccountSummaryList secondPage =
+        repository.findByUserId(userId[0], 2, firstPage.nextCursorAccountId());
+
+    assertThat(firstPage.items())
+        .extracting(item -> item.accountId())
+        .containsExactly(accountIds[0], accountIds[1]);
+    assertThat(firstPage.nextCursorAccountId()).isEqualTo(accountIds[1]);
+    assertThat(secondPage.items())
+        .extracting(item -> item.accountId())
+        .containsExactly(accountIds[3], accountIds[4]);
+    assertThat(secondPage.nextCursorAccountId()).isNull();
+  }
+
+  @Test
+  void accountListKeysetPlanUsesUserStatusAccountCursorIndex() {
+    long[] userId = new long[1];
+    commit(transactionManager, () -> userId[0] = insertUser("account-list-plan-user", "ACTIVE"));
+    bulkInsertAccountsAndMemberships(userId[0], 5_000);
+
+    List<String> plan =
+        jdbcTemplate.queryForList(
+            """
+            EXPLAIN
+            SELECT account.id,
+                   account.account_number,
+                   account.display_name,
+                   account.account_status,
+                   account.currency_code AS account_currency_code,
+                   snapshot.available_balance_minor,
+                   snapshot.pending_balance_minor,
+                   snapshot.currency_code AS snapshot_currency_code,
+                   account.created_at,
+                   snapshot.updated_at
+            FROM user_account_membership membership
+            JOIN bank_user bank_user
+              ON bank_user.id = membership.user_id
+            JOIN bank_account account
+              ON account.id = membership.account_id
+            JOIN account_balance_snapshot snapshot
+              ON snapshot.account_id = account.id
+            WHERE membership.user_id = :userId
+              AND membership.membership_status = 'ACTIVE'
+              AND membership.account_id > :afterAccountId
+              AND bank_user.user_status = 'ACTIVE'
+            ORDER BY membership.account_id ASC
+            LIMIT :limit
+            """,
+            new MapSqlParameterSource()
+                .addValue("userId", userId[0])
+                .addValue("afterAccountId", 2_000L)
+                .addValue("limit", 51),
+            String.class);
+
+    String joinedPlan = String.join("\n", plan);
+    assertThat(joinedPlan).contains("idx_user_account_membership_user_status_account_cursor");
+    assertThat(joinedPlan).doesNotContain("Seq Scan on user_account_membership");
+  }
+
+  private long insertUser(String loginId, String status) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                :status,
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId).addValue("status", status),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private long insertAccount(String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertSnapshot(long accountId) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO account_balance_snapshot (
+            account_id,
+            available_balance_minor,
+            pending_balance_minor,
+            currency_code,
+            updated_at
+        )
+        VALUES (:accountId, 0, 0, 'KRW', CURRENT_TIMESTAMP)
+        """,
+        new MapSqlParameterSource().addValue("accountId", accountId));
+  }
+
+  private void insertMembership(long userId, long accountId, String status) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO user_account_membership (
+            user_id,
+            account_id,
+            membership_role,
+            membership_status,
+            created_at,
+            updated_at
+        )
+        VALUES (:userId, :accountId, 'OWNER', :status, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        """,
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("accountId", accountId)
+            .addValue("status", status));
+  }
+
+  private void bulkInsertAccountsAndMemberships(long userId, int count) {
+    jdbcTemplate.update(
+        """
+        WITH inserted_accounts AS (
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            SELECT '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                   'bulk-account-' || series.id,
+                   'ACTIVE',
+                   'KRW',
+                   CURRENT_TIMESTAMP,
+                   CURRENT_TIMESTAMP
+            FROM generate_series(1, :count) AS series(id)
+            RETURNING id
+        ),
+        inserted_snapshots AS (
+            INSERT INTO account_balance_snapshot (
+                account_id,
+                available_balance_minor,
+                pending_balance_minor,
+                currency_code,
+                updated_at
+            )
+            SELECT id, 0, 0, 'KRW', CURRENT_TIMESTAMP
+            FROM inserted_accounts
+            RETURNING account_id
+        )
+        INSERT INTO user_account_membership (
+            user_id,
+            account_id,
+            membership_role,
+            membership_status,
+            created_at,
+            updated_at
+        )
+        SELECT :userId,
+               account_id,
+               'OWNER',
+               'ACTIVE',
+               CURRENT_TIMESTAMP,
+               CURRENT_TIMESTAMP
+        FROM inserted_snapshots
+        """,
+        new MapSqlParameterSource().addValue("userId", userId).addValue("count", count));
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE user_account_membership");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE bank_account");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE account_balance_snapshot");
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/security/AccountListJwtSecurityIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/AccountListJwtSecurityIntegrationTest.java
@@ -19,6 +19,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -88,6 +89,47 @@ class AccountListJwtSecurityIntegrationTest {
   }
 
   @Test
+  void acceptsBearerJwtAndReturnsKeysetAccountPage() throws Exception {
+    when(accountListReadPort.findByUserId(55L, 2, 555L))
+        .thenReturn(
+            new AccountSummaryList(
+                List.of(
+                    new AccountSummary(
+                        777L,
+                        "100000000000002",
+                        "saving account",
+                        "ACTIVE",
+                        "KRW",
+                        20_000L,
+                        0L,
+                        Instant.parse("2026-04-16T10:00:00Z"),
+                        Instant.parse("2026-04-16T10:05:00Z")),
+                    new AccountSummary(
+                        888L,
+                        "100000000000003",
+                        "investment account",
+                        "ACTIVE",
+                        "KRW",
+                        30_000L,
+                        0L,
+                        Instant.parse("2026-04-16T11:00:00Z"),
+                        Instant.parse("2026-04-16T11:05:00Z"))),
+                888L));
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts")
+                .header("Authorization", "Bearer " + issueToken("user-55", 55L))
+                .param("limit", "2")
+                .param("cursor", encodeCursor(555L)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].accountId").value(777L))
+        .andExpect(jsonPath("$.items[1].accountId").value(888L))
+        .andExpect(jsonPath("$.nextCursor").value(encodeCursor(888L)));
+  }
+
+  @Test
   void rejectsRequestWithoutJwtOrBootstrapHeader() throws Exception {
     mockMvc.perform(get("/api/v1/accounts")).andExpect(status().isUnauthorized());
   }
@@ -107,5 +149,11 @@ class AccountListJwtSecurityIntegrationTest {
             new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(), claimsSet);
     signedJwt.sign(new MACSigner(TEST_SECRET.getBytes(StandardCharsets.UTF_8)));
     return signedJwt.serialize();
+  }
+
+  private String encodeCursor(long accountId) {
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(Long.toString(accountId).getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/tools/test/run-account-list-keyset-pagination.sh
+++ b/tools/test/run-account-list-keyset-pagination.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[account-list-keyset] fixture: JWT user account list keyset page + 5000 membership EXPLAIN baseline"
+echo "[account-list-keyset] expectation: user_id/status/account_id cursor index without membership Seq Scan"
+
+./back/gradlew -p back test \
+  --tests '*AccountListJwtSecurityIntegrationTest' \
+  --tests '*JdbcAccountListRepositoryIntegrationTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #207

## 🌿 Base Branch
- `main`

## 📝 Summary
- JWT 사용자 `GET /api/v1/accounts`에 `limit/cursor` 기반 account_id keyset pagination을 추가했습니다.
- 기존 무파라미터 전체 목록 응답은 유지하고, cursor는 HTTP adapter에서만 Base64 URL-safe 값으로 인코딩합니다.

## 🛠 Changes
- account list usecase/read port에 paged 조회 계약 추가
- JDBC repository에 `limit + 1` keyset query와 `nextCursorAccountId` 산출 추가
- `user_account_membership(user_id, membership_status, account_id)` cursor index 마이그레이션 추가
- JWT 보안 통합 테스트와 5천 membership EXPLAIN baseline 추가
- 재현 스크립트와 README 문서 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-account-list-keyset tools/test/run-account-list-keyset-pagination.sh`
- `tools/test/with-resource-lock.sh back-spotless ./back/gradlew -p back spotlessApply`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
```http
GET /api/v1/accounts?limit=2&cursor=NTU1
```

```json
{
  "items": [
    {
      "accountId": 777
    }
  ],
  "nextCursor": "Nzc3"
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: 응답에 `nextCursor` nullable field가 추가됩니다. 기존 `items` 계약과 무파라미터 조회 경로는 유지했습니다.
- 롤백 방법: 이 PR revert 후 Flyway index migration은 운영 정책에 따라 별도 `DROP INDEX CONCURRENTLY` migration으로 정리합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
