### PR TITLE
[Feat] bootstrap bulk import API 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -52,6 +52,23 @@ tools/test/with-resource-lock.sh back-account-list-keyset \
   tools/test/run-account-list-keyset-pagination.sh
 ```
 
+## Bootstrap Bulk Import
+
+내부 운영/테스트 도구는 `POST /internal/api/v1/bootstrap/bulk-import` 로 작은 bootstrap batch를 한 transaction에서 가져올 수 있습니다.
+
+- required scopes: `internal:account-bootstrap`, `internal:auth-bootstrap`
+- section order: `accounts` -> `users` -> `memberships`
+- max section size: 각 `50`개
+- membership은 같은 요청의 `userRef`, `accountRef`를 참조합니다.
+- 중간 실패 시 같은 요청의 account/user/membership 변경은 rollback 됩니다.
+
+재현 명령:
+
+```bash
+tools/test/with-resource-lock.sh back-bootstrap-bulk-import \
+  tools/test/run-bootstrap-bulk-import-api.sh
+```
+
 ## Stack
 
 - Java 21

--- a/back/src/main/java/com/aquilabank/domain/bootstrap/model/BootstrapBulkImportCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/bootstrap/model/BootstrapBulkImportCommand.java
@@ -1,0 +1,112 @@
+package com.aquilabank.domain.bootstrap.model;
+
+import com.aquilabank.domain.auth.model.MembershipRole;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** 내부 bootstrap bulk import 입력을 작은 batch와 request-local ref로 제한합니다. */
+public record BootstrapBulkImportCommand(
+    List<AccountItem> accounts, List<UserItem> users, List<MembershipItem> memberships) {
+
+  public static final int MAX_ITEMS_PER_SECTION = 50;
+
+  public BootstrapBulkImportCommand {
+    accounts = accounts == null ? List.of() : List.copyOf(accounts);
+    users = users == null ? List.of() : List.copyOf(users);
+    memberships = memberships == null ? List.of() : List.copyOf(memberships);
+    validateSize("accounts", accounts);
+    validateSize("users", users);
+    validateSize("memberships", memberships);
+    validateNoNull("accounts", accounts);
+    validateNoNull("users", users);
+    validateNoNull("memberships", memberships);
+    validateRefs(accounts, users, memberships);
+  }
+
+  private static void validateSize(String name, List<?> items) {
+    if (items.size() > MAX_ITEMS_PER_SECTION) {
+      throw new IllegalArgumentException(name + " must contain 50 items or less");
+    }
+  }
+
+  private static void validateNoNull(String name, List<?> items) {
+    if (items.stream().anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException(name + " must not contain null");
+    }
+  }
+
+  private static void validateRefs(
+      List<AccountItem> accounts, List<UserItem> users, List<MembershipItem> memberships) {
+    Set<String> accountRefs =
+        collectUniqueRefs(
+            "account clientRef", accounts.stream().map(AccountItem::clientRef).toList());
+    Set<String> userRefs =
+        collectUniqueRefs("user clientRef", users.stream().map(UserItem::clientRef).toList());
+    for (MembershipItem item : memberships) {
+      if (!userRefs.contains(item.userRef())) {
+        throw new IllegalArgumentException("membership userRef is not found: " + item.userRef());
+      }
+      if (!accountRefs.contains(item.accountRef())) {
+        throw new IllegalArgumentException(
+            "membership accountRef is not found: " + item.accountRef());
+      }
+    }
+  }
+
+  private static Set<String> collectUniqueRefs(String name, List<String> refs) {
+    Set<String> result = new HashSet<>();
+    for (String ref : refs) {
+      if (!result.add(ref)) {
+        throw new IllegalArgumentException(name + " must be unique: " + ref);
+      }
+    }
+    return result;
+  }
+
+  public record AccountItem(
+      String clientRef, String displayName, String currencyCode, long initialBalanceMinor) {
+
+    public AccountItem {
+      clientRef = normalizeRef(clientRef, "account clientRef");
+    }
+  }
+
+  public record UserItem(String clientRef, String loginId, String password, String displayName) {
+
+    public UserItem {
+      clientRef = normalizeRef(clientRef, "user clientRef");
+    }
+  }
+
+  public record MembershipItem(
+      String userRef,
+      String accountRef,
+      MembershipRole membershipRole,
+      MembershipStatus membershipStatus) {
+
+    public MembershipItem {
+      userRef = normalizeRef(userRef, "membership userRef");
+      accountRef = normalizeRef(accountRef, "membership accountRef");
+      if (membershipRole == null) {
+        throw new IllegalArgumentException("membershipRole is required");
+      }
+      if (membershipStatus == null) {
+        throw new IllegalArgumentException("membershipStatus is required");
+      }
+    }
+  }
+
+  private static String normalizeRef(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " is required");
+    }
+    String normalized = value.trim();
+    if (normalized.length() > 64) {
+      throw new IllegalArgumentException(name + " must be 64 characters or less");
+    }
+    return normalized;
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/bootstrap/model/BootstrapBulkImportResult.java
+++ b/back/src/main/java/com/aquilabank/domain/bootstrap/model/BootstrapBulkImportResult.java
@@ -1,0 +1,71 @@
+package com.aquilabank.domain.bootstrap.model;
+
+import com.aquilabank.domain.account.model.AccountBootstrapResult;
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserBootstrapResult;
+import java.util.List;
+
+/** bulk import 결과는 request-local ref와 생성된 식별자를 함께 반환합니다. */
+public record BootstrapBulkImportResult(
+    List<AccountItem> accounts,
+    List<UserItem> users,
+    List<MembershipItem> memberships,
+    Summary summary) {
+
+  public BootstrapBulkImportResult {
+    accounts = accounts == null ? List.of() : List.copyOf(accounts);
+    users = users == null ? List.of() : List.copyOf(users);
+    memberships = memberships == null ? List.of() : List.copyOf(memberships);
+    summary =
+        summary == null ? new Summary(accounts.size(), users.size(), memberships.size()) : summary;
+  }
+
+  public record AccountItem(String clientRef, AccountBootstrapResult account) {
+
+    public AccountItem {
+      if (clientRef == null || clientRef.isBlank()) {
+        throw new IllegalArgumentException("clientRef is required");
+      }
+      if (account == null) {
+        throw new IllegalArgumentException("account is required");
+      }
+    }
+  }
+
+  public record UserItem(String clientRef, UserBootstrapResult user) {
+
+    public UserItem {
+      if (clientRef == null || clientRef.isBlank()) {
+        throw new IllegalArgumentException("clientRef is required");
+      }
+      if (user == null) {
+        throw new IllegalArgumentException("user is required");
+      }
+    }
+  }
+
+  public record MembershipItem(
+      String userRef, String accountRef, UserAccountMembership membership) {
+
+    public MembershipItem {
+      if (userRef == null || userRef.isBlank()) {
+        throw new IllegalArgumentException("userRef is required");
+      }
+      if (accountRef == null || accountRef.isBlank()) {
+        throw new IllegalArgumentException("accountRef is required");
+      }
+      if (membership == null) {
+        throw new IllegalArgumentException("membership is required");
+      }
+    }
+  }
+
+  public record Summary(int accountCount, int userCount, int membershipCount) {
+
+    public Summary {
+      if (accountCount < 0 || userCount < 0 || membershipCount < 0) {
+        throw new IllegalArgumentException("summary counts must not be negative");
+      }
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/bootstrap/usecase/BootstrapBulkImportService.java
+++ b/back/src/main/java/com/aquilabank/domain/bootstrap/usecase/BootstrapBulkImportService.java
@@ -1,0 +1,86 @@
+package com.aquilabank.domain.bootstrap.usecase;
+
+import com.aquilabank.domain.account.model.AccountBootstrapCommand;
+import com.aquilabank.domain.account.model.AccountBootstrapResult;
+import com.aquilabank.domain.account.usecase.AccountBootstrapUseCase;
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserAccountMembershipUpsertCommand;
+import com.aquilabank.domain.auth.model.UserBootstrapCommand;
+import com.aquilabank.domain.auth.model.UserBootstrapResult;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipUpsertUseCase;
+import com.aquilabank.domain.auth.usecase.UserBootstrapUseCase;
+import com.aquilabank.domain.bootstrap.model.BootstrapBulkImportCommand;
+import com.aquilabank.domain.bootstrap.model.BootstrapBulkImportResult;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** 단건 bootstrap use case를 순서대로 묶어 같은 정합성 규칙을 재사용합니다. */
+public final class BootstrapBulkImportService implements BootstrapBulkImportUseCase {
+
+  private final AccountBootstrapUseCase accountBootstrapUseCase;
+  private final UserBootstrapUseCase userBootstrapUseCase;
+  private final UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase;
+
+  public BootstrapBulkImportService(
+      AccountBootstrapUseCase accountBootstrapUseCase,
+      UserBootstrapUseCase userBootstrapUseCase,
+      UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase) {
+    this.accountBootstrapUseCase =
+        Objects.requireNonNull(accountBootstrapUseCase, "accountBootstrapUseCase");
+    this.userBootstrapUseCase =
+        Objects.requireNonNull(userBootstrapUseCase, "userBootstrapUseCase");
+    this.userAccountMembershipUpsertUseCase =
+        Objects.requireNonNull(
+            userAccountMembershipUpsertUseCase, "userAccountMembershipUpsertUseCase");
+  }
+
+  @Override
+  public BootstrapBulkImportResult importItems(BootstrapBulkImportCommand command) {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
+
+    Map<String, AccountBootstrapResult> accountsByRef = new LinkedHashMap<>();
+    Map<String, UserBootstrapResult> usersByRef = new LinkedHashMap<>();
+    List<BootstrapBulkImportResult.AccountItem> accountResults = new ArrayList<>();
+    List<BootstrapBulkImportResult.UserItem> userResults = new ArrayList<>();
+    List<BootstrapBulkImportResult.MembershipItem> membershipResults = new ArrayList<>();
+
+    for (BootstrapBulkImportCommand.AccountItem item : command.accounts()) {
+      AccountBootstrapResult account =
+          accountBootstrapUseCase.bootstrap(
+              new AccountBootstrapCommand(
+                  item.displayName(), item.currencyCode(), item.initialBalanceMinor()));
+      accountsByRef.put(item.clientRef(), account);
+      accountResults.add(new BootstrapBulkImportResult.AccountItem(item.clientRef(), account));
+    }
+
+    for (BootstrapBulkImportCommand.UserItem item : command.users()) {
+      UserBootstrapResult user =
+          userBootstrapUseCase.bootstrap(
+              new UserBootstrapCommand(item.loginId(), item.password(), item.displayName()));
+      usersByRef.put(item.clientRef(), user);
+      userResults.add(new BootstrapBulkImportResult.UserItem(item.clientRef(), user));
+    }
+
+    for (BootstrapBulkImportCommand.MembershipItem item : command.memberships()) {
+      UserBootstrapResult user = usersByRef.get(item.userRef());
+      AccountBootstrapResult account = accountsByRef.get(item.accountRef());
+      UserAccountMembership membership =
+          userAccountMembershipUpsertUseCase.upsert(
+              new UserAccountMembershipUpsertCommand(
+                  user.userId(),
+                  account.accountId(),
+                  item.membershipRole(),
+                  item.membershipStatus()));
+      membershipResults.add(
+          new BootstrapBulkImportResult.MembershipItem(
+              item.userRef(), item.accountRef(), membership));
+    }
+
+    return new BootstrapBulkImportResult(accountResults, userResults, membershipResults, null);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/bootstrap/usecase/BootstrapBulkImportUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/bootstrap/usecase/BootstrapBulkImportUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.bootstrap.usecase;
+
+import com.aquilabank.domain.bootstrap.model.BootstrapBulkImportCommand;
+import com.aquilabank.domain.bootstrap.model.BootstrapBulkImportResult;
+
+/** 내부 bootstrap bulk import 진입점 */
+public interface BootstrapBulkImportUseCase {
+
+  BootstrapBulkImportResult importItems(BootstrapBulkImportCommand command);
+}

--- a/back/src/main/java/com/aquilabank/global/config/BootstrapBulkImportConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/BootstrapBulkImportConfiguration.java
@@ -1,0 +1,29 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.account.usecase.AccountBootstrapUseCase;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipUpsertUseCase;
+import com.aquilabank.domain.auth.usecase.UserBootstrapUseCase;
+import com.aquilabank.domain.bootstrap.usecase.BootstrapBulkImportService;
+import com.aquilabank.domain.bootstrap.usecase.BootstrapBulkImportUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/** bulk import는 요청 하나를 같은 DB transaction으로 묶어 중간 실패 partial write를 막습니다. */
+@Configuration
+public class BootstrapBulkImportConfiguration {
+
+  @Bean
+  BootstrapBulkImportUseCase bootstrapBulkImportUseCase(
+      AccountBootstrapUseCase accountBootstrapUseCase,
+      UserBootstrapUseCase userBootstrapUseCase,
+      UserAccountMembershipUpsertUseCase userAccountMembershipUpsertUseCase,
+      PlatformTransactionManager platformTransactionManager) {
+    BootstrapBulkImportService service =
+        new BootstrapBulkImportService(
+            accountBootstrapUseCase, userBootstrapUseCase, userAccountMembershipUpsertUseCase);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command -> transactionTemplate.execute(status -> service.importItems(command));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -99,6 +99,8 @@ public class SecurityConfiguration {
                     .permitAll()
                     .requestMatchers("/internal/api/v1/accounts/*/status")
                     .permitAll()
+                    .requestMatchers("/internal/api/v1/bootstrap/bulk-import")
+                    .permitAll()
                     .requestMatchers("/internal/api/v1/outbox/**")
                     .permitAll()
                     .requestMatchers("/internal/api/v1/ledger/**")

--- a/back/src/main/java/com/aquilabank/global/web/bootstrap/BootstrapBulkImportController.java
+++ b/back/src/main/java/com/aquilabank/global/web/bootstrap/BootstrapBulkImportController.java
@@ -1,0 +1,216 @@
+package com.aquilabank.global.web.bootstrap;
+
+import com.aquilabank.domain.account.model.AccountBootstrapResult;
+import com.aquilabank.domain.auth.model.MembershipRole;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.UserAccountMembership;
+import com.aquilabank.domain.auth.model.UserBootstrapResult;
+import com.aquilabank.domain.bootstrap.model.BootstrapBulkImportCommand;
+import com.aquilabank.domain.bootstrap.model.BootstrapBulkImportResult;
+import com.aquilabank.domain.bootstrap.usecase.BootstrapBulkImportUseCase;
+import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
+import com.aquilabank.global.security.InternalServiceScope;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 내부 bootstrap bulk import를 작고 동기적인 운영 API로 노출합니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/bootstrap/bulk-import")
+@ConditionalOnProperty(
+    name = {"security.account-bootstrap-api.enabled", "security.auth-bootstrap-api.enabled"},
+    havingValue = "true")
+public class BootstrapBulkImportController {
+
+  private final BootstrapBulkImportUseCase bootstrapBulkImportUseCase;
+  private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
+
+  public BootstrapBulkImportController(
+      BootstrapBulkImportUseCase bootstrapBulkImportUseCase,
+      InternalServiceRequestAuthorizer internalServiceRequestAuthorizer) {
+    this.bootstrapBulkImportUseCase = bootstrapBulkImportUseCase;
+    this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
+  }
+
+  @PostMapping
+  public BootstrapBulkImportResponse importItems(
+      HttpServletRequest httpServletRequest,
+      @Valid @RequestBody BootstrapBulkImportRequest request) {
+    internalServiceRequestAuthorizer.requireScope(
+        httpServletRequest, InternalServiceScope.ACCOUNT_BOOTSTRAP);
+    internalServiceRequestAuthorizer.requireScope(
+        httpServletRequest, InternalServiceScope.AUTH_BOOTSTRAP);
+
+    return BootstrapBulkImportResponse.from(
+        bootstrapBulkImportUseCase.importItems(request.toCommand()));
+  }
+
+  /** bulk import 요청 body */
+  public record BootstrapBulkImportRequest(
+      @Size(
+              max = BootstrapBulkImportCommand.MAX_ITEMS_PER_SECTION,
+              message = "accounts must contain 50 items or less")
+          List<@Valid AccountImportRequest> accounts,
+      @Size(
+              max = BootstrapBulkImportCommand.MAX_ITEMS_PER_SECTION,
+              message = "users must contain 50 items or less")
+          List<@Valid UserImportRequest> users,
+      @Size(
+              max = BootstrapBulkImportCommand.MAX_ITEMS_PER_SECTION,
+              message = "memberships must contain 50 items or less")
+          List<@Valid MembershipImportRequest> memberships) {
+
+    BootstrapBulkImportCommand toCommand() {
+      return new BootstrapBulkImportCommand(
+          accounts == null
+              ? List.of()
+              : accounts.stream().map(AccountImportRequest::toCommand).toList(),
+          users == null ? List.of() : users.stream().map(UserImportRequest::toCommand).toList(),
+          memberships == null
+              ? List.of()
+              : memberships.stream().map(MembershipImportRequest::toCommand).toList());
+    }
+  }
+
+  /** bulk account item */
+  public record AccountImportRequest(
+      @NotBlank(message = "clientRef is required") @Size(max = 64, message = "clientRef must be 64 characters or less") String clientRef,
+      @NotBlank(message = "displayName is required") @Size(max = 80, message = "displayName must be 80 characters or less") String displayName,
+      @NotBlank(message = "currencyCode is required") @Pattern(
+              regexp = "^[A-Z]{3}$",
+              message = "currencyCode must be a 3-letter uppercase code")
+          String currencyCode,
+      @PositiveOrZero(message = "initialBalanceMinor must be zero or positive") long initialBalanceMinor) {
+
+    BootstrapBulkImportCommand.AccountItem toCommand() {
+      return new BootstrapBulkImportCommand.AccountItem(
+          clientRef, displayName, currencyCode, initialBalanceMinor);
+    }
+  }
+
+  /** bulk user item */
+  public record UserImportRequest(
+      @NotBlank(message = "clientRef is required") @Size(max = 64, message = "clientRef must be 64 characters or less") String clientRef,
+      @NotBlank(message = "loginId is required") @Size(max = 80, message = "loginId must be 80 characters or less") String loginId,
+      @NotBlank(message = "password is required") @Size(max = 120, message = "password must be 120 characters or less") String password,
+      @NotBlank(message = "displayName is required") @Size(max = 80, message = "displayName must be 80 characters or less") String displayName) {
+
+    BootstrapBulkImportCommand.UserItem toCommand() {
+      return new BootstrapBulkImportCommand.UserItem(clientRef, loginId, password, displayName);
+    }
+  }
+
+  /** bulk membership item */
+  public record MembershipImportRequest(
+      @NotBlank(message = "userRef is required") @Size(max = 64, message = "userRef must be 64 characters or less") String userRef,
+      @NotBlank(message = "accountRef is required") @Size(max = 64, message = "accountRef must be 64 characters or less") String accountRef,
+      @NotNull(message = "membershipRole is required") MembershipRole membershipRole,
+      @NotNull(message = "membershipStatus is required") MembershipStatus membershipStatus) {
+
+    BootstrapBulkImportCommand.MembershipItem toCommand() {
+      return new BootstrapBulkImportCommand.MembershipItem(
+          userRef, accountRef, membershipRole, membershipStatus);
+    }
+  }
+
+  /** bulk import 응답 */
+  public record BootstrapBulkImportResponse(
+      List<AccountImportResponse> accounts,
+      List<UserImportResponse> users,
+      List<MembershipImportResponse> memberships,
+      SummaryResponse summary) {
+
+    static BootstrapBulkImportResponse from(BootstrapBulkImportResult result) {
+      return new BootstrapBulkImportResponse(
+          result.accounts().stream().map(AccountImportResponse::from).toList(),
+          result.users().stream().map(UserImportResponse::from).toList(),
+          result.memberships().stream().map(MembershipImportResponse::from).toList(),
+          SummaryResponse.from(result.summary()));
+    }
+  }
+
+  public record AccountImportResponse(
+      String clientRef,
+      long accountId,
+      String accountNumber,
+      String displayName,
+      String currencyCode,
+      long availableBalanceMinor,
+      String accountStatus,
+      Instant createdAt) {
+
+    static AccountImportResponse from(BootstrapBulkImportResult.AccountItem item) {
+      AccountBootstrapResult account = item.account();
+      return new AccountImportResponse(
+          item.clientRef(),
+          account.accountId(),
+          account.accountNumber(),
+          account.displayName(),
+          account.currencyCode(),
+          account.availableBalanceMinor(),
+          account.accountStatus(),
+          account.createdAt());
+    }
+  }
+
+  public record UserImportResponse(
+      String clientRef,
+      long userId,
+      String loginId,
+      String displayName,
+      String userStatus,
+      Instant createdAt) {
+
+    static UserImportResponse from(BootstrapBulkImportResult.UserItem item) {
+      UserBootstrapResult user = item.user();
+      return new UserImportResponse(
+          item.clientRef(),
+          user.userId(),
+          user.loginId(),
+          user.displayName(),
+          user.status().name(),
+          user.createdAt());
+    }
+  }
+
+  public record MembershipImportResponse(
+      String userRef,
+      String accountRef,
+      long userId,
+      long accountId,
+      String membershipRole,
+      String membershipStatus) {
+
+    static MembershipImportResponse from(BootstrapBulkImportResult.MembershipItem item) {
+      UserAccountMembership membership = item.membership();
+      return new MembershipImportResponse(
+          item.userRef(),
+          item.accountRef(),
+          membership.userId(),
+          membership.accountId(),
+          membership.role().name(),
+          membership.status().name());
+    }
+  }
+
+  public record SummaryResponse(int accountCount, int userCount, int membershipCount) {
+
+    static SummaryResponse from(BootstrapBulkImportResult.Summary summary) {
+      return new SummaryResponse(
+          summary.accountCount(), summary.userCount(), summary.membershipCount());
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
@@ -54,6 +54,7 @@ public class WebMvcSecurityConfiguration implements WebMvcConfigurer {
             "/internal/api/v1/accounts/bootstrap",
             "/internal/api/v1/accounts/status-change-audits/**",
             "/internal/api/v1/accounts/*/status",
+            "/internal/api/v1/bootstrap/bulk-import",
             "/internal/api/v1/auth/**",
             "/internal/api/v1/ledger/**",
             "/internal/api/v1/outbox/**");

--- a/back/src/test/java/com/aquilabank/global/web/bootstrap/BootstrapBulkImportApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/bootstrap/BootstrapBulkImportApiIntegrationTest.java
@@ -1,0 +1,159 @@
+package com.aquilabank.global.web.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenTestSupport;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class BootstrapBulkImportApiIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void importsAccountsUsersAndMembershipsInOneInternalRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/internal/api/v1/bootstrap/bulk-import")
+                .header("Authorization", bootstrapImportAuthorization())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "accounts": [
+                        {
+                          "clientRef": "source",
+                          "displayName": "source account",
+                          "currencyCode": "KRW",
+                          "initialBalanceMinor": 10000
+                        },
+                        {
+                          "clientRef": "target",
+                          "displayName": "target account",
+                          "currencyCode": "KRW",
+                          "initialBalanceMinor": 0
+                        }
+                      ],
+                      "users": [
+                        {
+                          "clientRef": "alice",
+                          "loginId": "alice",
+                          "password": "password123!",
+                          "displayName": "Alice"
+                        }
+                      ],
+                      "memberships": [
+                        {
+                          "userRef": "alice",
+                          "accountRef": "source",
+                          "membershipRole": "OWNER",
+                          "membershipStatus": "ACTIVE"
+                        },
+                        {
+                          "userRef": "alice",
+                          "accountRef": "target",
+                          "membershipRole": "VIEWER",
+                          "membershipStatus": "ACTIVE"
+                        }
+                      ]
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.summary.accountCount").value(2))
+        .andExpect(jsonPath("$.summary.userCount").value(1))
+        .andExpect(jsonPath("$.summary.membershipCount").value(2))
+        .andExpect(jsonPath("$.accounts[0].clientRef").value("source"))
+        .andExpect(jsonPath("$.users[0].clientRef").value("alice"))
+        .andExpect(jsonPath("$.memberships[1].membershipRole").value("VIEWER"));
+
+    assertThat(countRows("bank_account")).isEqualTo(2);
+    assertThat(countRows("bank_user")).isEqualTo(1);
+    assertThat(countRows("user_account_membership")).isEqualTo(2);
+  }
+
+  @Test
+  void rollsBackWholeImportWhenAnyItemFails() throws Exception {
+    mockMvc
+        .perform(
+            post("/internal/api/v1/bootstrap/bulk-import")
+                .header("Authorization", bootstrapImportAuthorization())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "accounts": [
+                        {
+                          "clientRef": "source",
+                          "displayName": "source account",
+                          "currencyCode": "KRW",
+                          "initialBalanceMinor": 10000
+                        }
+                      ],
+                      "users": [
+                        {
+                          "clientRef": "alice-1",
+                          "loginId": "alice",
+                          "password": "password123!",
+                          "displayName": "Alice"
+                        },
+                        {
+                          "clientRef": "alice-2",
+                          "loginId": "alice",
+                          "password": "password123!",
+                          "displayName": "Alice duplicate"
+                        }
+                      ],
+                      "memberships": []
+                    }
+                    """))
+        .andExpect(status().isConflict());
+
+    assertThat(countRows("bank_account")).isZero();
+    assertThat(countRows("bank_user")).isZero();
+    assertThat(countRows("user_account_membership")).isZero();
+  }
+
+  private String bootstrapImportAuthorization() {
+    return InternalServiceTokenTestSupport.authorization(
+        "bootstrap-bulk-import-test",
+        InternalServiceScope.ACCOUNT_BOOTSTRAP,
+        InternalServiceScope.AUTH_BOOTSTRAP);
+  }
+
+  private int countRows(String tableName) {
+    Integer count =
+        jdbcTemplate
+            .getJdbcTemplate()
+            .queryForObject("SELECT COUNT(*) FROM " + tableName, Integer.class);
+    if (count == null) {
+      throw new IllegalStateException("count query returned null");
+    }
+    return count;
+  }
+}

--- a/tools/test/run-bootstrap-bulk-import-api.sh
+++ b/tools/test/run-bootstrap-bulk-import-api.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[bootstrap-bulk-import] fixture: 2 accounts + 1 user + 2 memberships"
+echo "[bootstrap-bulk-import] expectation: bounded internal bulk import and request-level rollback"
+
+./back/gradlew -p back test \
+  --tests '*BootstrapBulkImportApiIntegrationTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #210

## 🌿 Base Branch
- `main`

## 📝 Summary
- 내부 `POST /internal/api/v1/bootstrap/bulk-import` API를 추가했습니다.
- 단건 account/user/membership bootstrap use case를 재사용하고, 요청 하나를 같은 transaction으로 묶어 중간 실패 partial write를 막습니다.

## 🛠 Changes
- `BootstrapBulkImportUseCase`와 request-local ref 기반 command/result 모델 추가
- account -> user -> membership 순서의 bulk import service 추가
- 내부 service token scope `internal:account-bootstrap`, `internal:auth-bootstrap` 동시 요구
- section별 최대 50개 제한과 rollback 통합 테스트 추가
- README와 재현 스크립트 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-bootstrap-bulk-import tools/test/run-bootstrap-bulk-import-api.sh`
- `tools/test/with-resource-lock.sh back-spotless ./back/gradlew -p back spotlessApply`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
```http
POST /internal/api/v1/bootstrap/bulk-import
```

```json
{
  "accounts": [{"clientRef": "source", "displayName": "source account", "currencyCode": "KRW", "initialBalanceMinor": 10000}],
  "users": [{"clientRef": "alice", "loginId": "alice", "password": "password123!", "displayName": "Alice"}],
  "memberships": [{"userRef": "alice", "accountRef": "source", "membershipRole": "OWNER", "membershipStatus": "ACTIVE"}]
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: 내부 bootstrap surface가 늘어납니다. token scope를 두 개 모두 요구하고 section별 50개 제한으로 범위를 제한했습니다.
- 롤백 방법: PR revert. DB schema 변경은 없습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
