### PR TITLE
[Perf] password recovery request throttling 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -34,6 +34,14 @@ com.aquilabank
 - `redis`는 분산 login throttling 이 필요할 때만 opt-in 으로 사용합니다.
 - Redis 경로는 login throttling counter 에만 쓰고, SSE fan-out 은 계속 PostgreSQL `LISTEN/NOTIFY` 를 사용합니다.
 - local Redis는 compose `redis` profile로만 뜨며 기본 `postgres kafka` 경로에는 포함하지 않습니다.
+- 같은 counter/guard는 password recovery request entrypoint에도 적용되어 token write 전 burst를 차단합니다.
+
+재현 명령:
+
+```bash
+tools/test/with-resource-lock.sh back-password-recovery-throttling \
+  tools/test/run-password-recovery-throttling.sh
+```
 
 ## Account List Pagination
 

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottleGuard.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottleGuard.java
@@ -22,17 +22,27 @@ public class LoginThrottleGuard {
   }
 
   public void check(String ipAddress) {
+    check(ipAddress, LoginThrottleEntryPoint.LOGIN);
+  }
+
+  public void checkPasswordRecovery(String ipAddress) {
+    check(ipAddress, LoginThrottleEntryPoint.PASSWORD_RECOVERY);
+  }
+
+  private void check(String ipAddress, LoginThrottleEntryPoint entryPoint) {
     String normalizedIpAddress = normalizeIpAddress(ipAddress);
     LoginThrottleStore.ThrottleDecision decision = loginThrottleStore.check(normalizedIpAddress);
     if (decision.throttled()) {
       logThrottle(
+          entryPoint,
           decision.scope(),
           normalizedIpAddress,
           decision.retryAfterSeconds(),
           decision.maxAttempts(),
           decision.windowSeconds(),
           decision.trackedIpCount());
-      throw new LoginThrottledException(decision.scope(), decision.retryAfterSeconds());
+      throw new LoginThrottledException(
+          decision.scope(), decision.retryAfterSeconds(), entryPoint.message());
     }
   }
 
@@ -42,6 +52,7 @@ public class LoginThrottleGuard {
   }
 
   private void logThrottle(
+      LoginThrottleEntryPoint entryPoint,
       LoginThrottleScope scope,
       String ipAddress,
       long retryAfterSeconds,
@@ -49,7 +60,8 @@ public class LoginThrottleGuard {
       long windowSeconds,
       int trackedIpCount) {
     log.warn(
-        "auth login throttled requestId={} scope={} ipHash={} retryAfterSeconds={} maxAttempts={} windowSeconds={} trackedIpCount={} path={}",
+        "{} requestId={} scope={} ipHash={} retryAfterSeconds={} maxAttempts={} windowSeconds={} trackedIpCount={} path={}",
+        entryPoint.logMessage(),
         RequestTraceContext.currentRequestId().orElse("-"),
         scope.name(),
         hashIpAddress(ipAddress),
@@ -82,5 +94,26 @@ public class LoginThrottleGuard {
       return "unknown";
     }
     return ipAddress;
+  }
+
+  private enum LoginThrottleEntryPoint {
+    LOGIN("auth login throttled", "too many login attempts"),
+    PASSWORD_RECOVERY("auth password recovery throttled", "too many password recovery requests");
+
+    private final String logMessage;
+    private final String message;
+
+    LoginThrottleEntryPoint(String logMessage, String message) {
+      this.logMessage = logMessage;
+      this.message = message;
+    }
+
+    String logMessage() {
+      return logMessage;
+    }
+
+    String message() {
+      return message;
+    }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottledException.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottledException.java
@@ -1,15 +1,22 @@
 package com.aquilabank.global.security;
 
-/** login entrypoint throttling 결과를 공통 API error response로 전달합니다. */
+/** 공개 auth entrypoint throttling 결과를 공통 API error response로 전달합니다. */
 public final class LoginThrottledException extends RuntimeException {
 
   private final LoginThrottleScope scope;
   private final long retryAfterSeconds;
 
   public LoginThrottledException(LoginThrottleScope scope, long retryAfterSeconds) {
-    super("too many login attempts");
+    this(scope, retryAfterSeconds, "too many login attempts");
+  }
+
+  public LoginThrottledException(LoginThrottleScope scope, long retryAfterSeconds, String message) {
+    super(message);
     if (retryAfterSeconds <= 0) {
       throw new IllegalArgumentException("retryAfterSeconds must be positive");
+    }
+    if (message == null || message.isBlank()) {
+      throw new IllegalArgumentException("message is required");
     }
     this.scope = scope;
     this.retryAfterSeconds = retryAfterSeconds;

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -275,7 +275,9 @@ public class LoginController {
 
   @PostMapping("/password-recovery/request")
   public ResponseEntity<Void> requestPasswordRecovery(
-      @Valid @RequestBody PasswordRecoveryRequest request) {
+      HttpServletRequest httpServletRequest, @Valid @RequestBody PasswordRecoveryRequest request) {
+    var sessionClientMetadata = authSessionMetadataResolver.resolve(httpServletRequest);
+    loginThrottleGuard.checkPasswordRecovery(sessionClientMetadata.ipAddress());
     PasswordRecoveryRequestResult result =
         passwordRecoveryRequestUseCase.request(
             new PasswordRecoveryRequestCommand(request.loginId()));

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginThrottlingIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginThrottlingIntegrationTest.java
@@ -134,6 +134,23 @@ class LoginThrottlingIntegrationTest extends PostgresContainerTestSupport {
     assertNotNull(token);
   }
 
+  @Test
+  void throttlesRepeatedPasswordRecoveryRequestBurstFromSameIp(CapturedOutput output)
+      throws Exception {
+    RequestClientMetadata sharedIp = clientMetadata("203.0.113.220");
+
+    passwordRecoveryExpectNoContent("alice", "recovery-ip-throttle-001", sharedIp);
+    passwordRecoveryExpectNoContent("alice", "recovery-ip-throttle-002", sharedIp);
+
+    passwordRecoveryExpectTooManyRequests("alice", "recovery-ip-throttle-003", sharedIp);
+    assertTrue(output.getOut().contains("auth password recovery throttled"));
+    assertTrue(output.getOut().contains("scope=IP"));
+
+    Thread.sleep(1200L);
+
+    passwordRecoveryExpectNoContent("alice", "recovery-ip-throttle-004", sharedIp);
+  }
+
   private String login(
       String loginId, String password, String requestId, RequestClientMetadata clientMetadata)
       throws Exception {
@@ -164,6 +181,21 @@ class LoginThrottlingIntegrationTest extends PostgresContainerTestSupport {
         .andExpect(header().string("Retry-After", "1"));
   }
 
+  private void passwordRecoveryExpectNoContent(
+      String loginId, String requestId, RequestClientMetadata clientMetadata) throws Exception {
+    performPasswordRecovery(loginId, requestId, clientMetadata)
+        .andExpect(status().isNoContent())
+        .andExpect(header().exists("X-Password-Recovery-Request-Id"));
+  }
+
+  private void passwordRecoveryExpectTooManyRequests(
+      String loginId, String requestId, RequestClientMetadata clientMetadata) throws Exception {
+    performPasswordRecovery(loginId, requestId, clientMetadata)
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.message").value("too many password recovery requests"))
+        .andExpect(header().string("Retry-After", "1"));
+  }
+
   private org.springframework.test.web.servlet.ResultActions performLogin(
       String loginId, String password, String requestId, RequestClientMetadata clientMetadata)
       throws Exception {
@@ -178,6 +210,26 @@ class LoginThrottlingIntegrationTest extends PostgresContainerTestSupport {
                 }
                 """
                     .formatted(loginId, password));
+    if (requestId != null && !requestId.isBlank()) {
+      requestBuilder.header("X-Request-Id", requestId);
+    }
+    requestBuilder.header("User-Agent", clientMetadata.userAgent());
+    requestBuilder.header("X-Forwarded-For", clientMetadata.forwardedFor());
+    return mockMvc.perform(requestBuilder);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performPasswordRecovery(
+      String loginId, String requestId, RequestClientMetadata clientMetadata) throws Exception {
+    MockHttpServletRequestBuilder requestBuilder =
+        post("/api/v1/auth/password-recovery/request")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                  "loginId": "%s"
+                }
+                """
+                    .formatted(loginId));
     if (requestId != null && !requestId.isBlank()) {
       requestBuilder.header("X-Request-Id", requestId);
     }

--- a/tools/test/run-password-recovery-throttling.sh
+++ b/tools/test/run-password-recovery-throttling.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[password-recovery-throttling] fixture: memory throttling threshold 2 per IP / 1s window"
+echo "[password-recovery-throttling] expectation: recovery request burst returns 429 before token write"
+
+./back/gradlew -p back test \
+  --tests '*LoginThrottlingIntegrationTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #212

## 🌿 Base Branch
- `main`

## 📝 Summary
- `POST /api/v1/auth/password-recovery/request`에 기존 auth throttling guard를 적용했습니다.
- token generation/write 전에 IP/global burst를 차단하고, recovery 전용 429 메시지와 로그를 분리했습니다.

## 🛠 Changes
- `LoginThrottleGuard`에 password recovery entrypoint check 추가
- `LoginThrottledException`의 메시지를 entrypoint별로 지정 가능하게 확장
- password recovery request controller에서 client IP 기반 throttle check 수행
- recovery request 2회 허용 후 3회 429 및 window 회복 통합 테스트 추가
- 재현 스크립트와 README 문서 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-password-recovery-throttling tools/test/run-password-recovery-throttling.sh`
- `tools/test/with-resource-lock.sh back-spotless ./back/gradlew -p back spotlessApply`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
```http
POST /api/v1/auth/password-recovery/request
```

throttled response:

```json
{
  "status": 429,
  "message": "too many password recovery requests"
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: login throttling counter를 recovery request와 공유하므로 같은 IP의 auth burst가 하나의 공개 auth entrypoint budget을 사용합니다. token write 전 차단이 목적이라 의도된 trade-off입니다.
- 롤백 방법: PR revert. DB schema 변경은 없습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
