### PR TITLE
[Chore] current session active gate 감사 이벤트와 alert 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -232,10 +232,12 @@ set +a
   - `aquila_notification_consumer_lag_count`
   - `aquila_notification_consumer_dlq_count`
   - `aquila_notification_sse_sessions{principal_type="account|user|total"}`
+  - `aquila_auth_current_session_gate_reject_count_total{reason_code="MISSING_SESSION_ID|INACTIVE_OR_MISMATCHED_SESSION"}`
   - `aquila_transaction_query_latency_seconds`
 - 활성화 조건:
   - outbox metric은 기본 wiring만 있으면 항상 export 됩니다.
   - notification consumer lag/DLQ metric은 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true` 와 DLQ topic 설정이 있어야 export 됩니다.
+  - current session gate reject counter는 민감 mutation에서 legacy JWT `session_id` 누락 또는 inactive/mismatch session 차단이 발생하면 증가합니다.
   - transaction latency timer는 `GET /api/v1/transactions` query path가 한 번이라도 호출되면 `query_shape` tag 기준으로 누적됩니다.
   - transaction latency histogram bucket은 p95 SLO alert용으로 `50ms, 80ms, 120ms, 150ms, 180ms, 350ms, 750ms, 1s, 3s` 경계를 export 합니다.
 - transaction `query_shape` 기준:
@@ -254,7 +256,10 @@ set +a
 - 운영 메모:
   - outbox/notification gauge는 scrape 한 번에 같은 summary를 여러 번 다시 조회하지 않게 `5초` cache 안에서 재사용합니다.
   - SSE session metric은 현재 app instance 메모리의 active session 수만 보여주므로 multi-instance 전체 합계는 Prometheus 쿼리에서 합산합니다.
+  - current session gate reject metric label은 `reason_code`만 사용하고, `requestId`, `userId`, `sessionId`, `path`는 structured audit log에서만 확인합니다.
+  - `AquilaCurrentSessionActiveGateRejectDetected` alert는 장애 확정이 아니라 security investigation 시작점입니다. 같은 시간대 `requestId`로 `auth current session gate rejected` log를 조회하고, `reasonCode`, `userId`, `sessionId`, `method`, `path`를 확인합니다.
   - p95 alert는 `query_shape`별 5분 rate가 충분할 때만 평가해 low traffic 노이즈를 줄입니다.
+  - current session gate alert rollback은 `AquilaCurrentSessionActiveGateRejectDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행하고, API 응답 계약은 그대로 유지합니다.
   - histogram bucket/alert rollback은 `management.metrics.distribution.*.aquila.transaction.query.latency`와 `AquilaTransactionQueryLatencyP95SloHigh` rule 제거로 수행합니다.
   - baseline 자산은 `ops/prometheus/` 아래에 두고 dashboard import, alert rule apply, tuning 가이드는 `ops/prometheus/README.md`를 기준으로 봅니다.
 - baseline 파일:

--- a/back/src/main/java/com/aquilabank/domain/auth/model/CurrentSessionActiveAuditEvent.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/CurrentSessionActiveAuditEvent.java
@@ -1,0 +1,36 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/** current session gate 차단 원인을 응답 대신 운영 audit surface로 남기는 이벤트입니다. */
+public record CurrentSessionActiveAuditEvent(
+    String requestId,
+    long userId,
+    Long sessionId,
+    String method,
+    String path,
+    CurrentSessionActiveRejectReason reasonCode,
+    Instant occurredAt) {
+
+  public CurrentSessionActiveAuditEvent {
+    requestId = requireText(requestId, "requestId");
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (sessionId != null && sessionId <= 0) {
+      throw new IllegalArgumentException("sessionId must be positive");
+    }
+    method = requireText(method, "method");
+    path = requireText(path, "path");
+    Objects.requireNonNull(reasonCode, "reasonCode must not be null");
+    Objects.requireNonNull(occurredAt, "occurredAt must not be null");
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value;
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/CurrentSessionActiveCheckCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/CurrentSessionActiveCheckCommand.java
@@ -1,7 +1,8 @@
 package com.aquilabank.domain.auth.model;
 
 /** 민감 mutation 실행 전 현재 access token의 session이 유효한지 확인하는 command입니다. */
-public record CurrentSessionActiveCheckCommand(long userId, long sessionId) {
+public record CurrentSessionActiveCheckCommand(
+    long userId, long sessionId, String requestId, String method, String path) {
 
   public CurrentSessionActiveCheckCommand {
     if (userId <= 0) {
@@ -10,5 +11,15 @@ public record CurrentSessionActiveCheckCommand(long userId, long sessionId) {
     if (sessionId <= 0) {
       throw new IllegalArgumentException("sessionId must be positive");
     }
+    requestId = requireText(requestId, "requestId");
+    method = requireText(method, "method");
+    path = requireText(path, "path");
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value;
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/model/CurrentSessionActiveRejectReason.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/CurrentSessionActiveRejectReason.java
@@ -1,0 +1,6 @@
+package com.aquilabank.domain.auth.model;
+
+public enum CurrentSessionActiveRejectReason {
+  MISSING_SESSION_ID,
+  INACTIVE_OR_MISMATCHED_SESSION
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/CurrentSessionActiveAuditPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/CurrentSessionActiveAuditPort.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.CurrentSessionActiveAuditEvent;
+
+public interface CurrentSessionActiveAuditPort {
+
+  void record(CurrentSessionActiveAuditEvent event);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveService.java
@@ -1,7 +1,10 @@
 package com.aquilabank.domain.auth.usecase;
 
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveAuditEvent;
 import com.aquilabank.domain.auth.model.CurrentSessionActiveCheckCommand;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveRejectReason;
+import com.aquilabank.domain.auth.port.CurrentSessionActiveAuditPort;
 import com.aquilabank.domain.auth.port.CurrentSessionActivePort;
 import java.time.Clock;
 import java.time.Instant;
@@ -10,11 +13,15 @@ import java.time.Instant;
 public final class CurrentSessionActiveService implements CurrentSessionActiveUseCase {
 
   private final CurrentSessionActivePort currentSessionActivePort;
+  private final CurrentSessionActiveAuditPort currentSessionActiveAuditPort;
   private final Clock clock;
 
   public CurrentSessionActiveService(
-      CurrentSessionActivePort currentSessionActivePort, Clock clock) {
+      CurrentSessionActivePort currentSessionActivePort,
+      CurrentSessionActiveAuditPort currentSessionActiveAuditPort,
+      Clock clock) {
     this.currentSessionActivePort = currentSessionActivePort;
+    this.currentSessionActiveAuditPort = currentSessionActiveAuditPort;
     this.clock = clock;
   }
 
@@ -22,6 +29,15 @@ public final class CurrentSessionActiveService implements CurrentSessionActiveUs
   public void requireActive(CurrentSessionActiveCheckCommand command) {
     Instant now = Instant.now(clock);
     if (!currentSessionActivePort.existsActiveSession(command.userId(), command.sessionId(), now)) {
+      currentSessionActiveAuditPort.record(
+          new CurrentSessionActiveAuditEvent(
+              command.requestId(),
+              command.userId(),
+              command.sessionId(),
+              command.method(),
+              command.path(),
+              CurrentSessionActiveRejectReason.INACTIVE_OR_MISMATCHED_SESSION,
+              now));
       throw new InvalidCredentialsException("current session is not active");
     }
   }

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -13,6 +13,7 @@ import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.BackupCodeLoadPort;
 import com.aquilabank.domain.auth.port.BackupCodeSecretPort;
 import com.aquilabank.domain.auth.port.BackupCodeWritePort;
+import com.aquilabank.domain.auth.port.CurrentSessionActiveAuditPort;
 import com.aquilabank.domain.auth.port.CurrentSessionActivePort;
 import com.aquilabank.domain.auth.port.ExternalIdentityAuditQueryPort;
 import com.aquilabank.domain.auth.port.ExternalIdentityMappingWritePort;
@@ -733,8 +734,11 @@ public class AuthConfiguration {
 
   @Bean
   CurrentSessionActiveUseCase currentSessionActiveUseCase(
-      CurrentSessionActivePort currentSessionActivePort, Clock authClock) {
-    return new CurrentSessionActiveService(currentSessionActivePort, authClock);
+      CurrentSessionActivePort currentSessionActivePort,
+      CurrentSessionActiveAuditPort currentSessionActiveAuditPort,
+      Clock authClock) {
+    return new CurrentSessionActiveService(
+        currentSessionActivePort, currentSessionActiveAuditPort, authClock);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/security/CurrentSessionActiveAuditEventPublisher.java
+++ b/back/src/main/java/com/aquilabank/global/security/CurrentSessionActiveAuditEventPublisher.java
@@ -1,0 +1,29 @@
+package com.aquilabank.global.security;
+
+import com.aquilabank.domain.auth.model.CurrentSessionActiveAuditEvent;
+import com.aquilabank.domain.auth.port.CurrentSessionActiveAuditPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** 상세 차단 사유는 응답 대신 structured audit log에만 남깁니다. */
+@Component
+public final class CurrentSessionActiveAuditEventPublisher
+    implements CurrentSessionActiveAuditPort {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(CurrentSessionActiveAuditEventPublisher.class);
+
+  @Override
+  public void record(CurrentSessionActiveAuditEvent event) {
+    log.warn(
+        "auth current session gate rejected requestId={} userId={} sessionId={} method={} path={} reasonCode={} occurredAt={}",
+        event.requestId(),
+        event.userId(),
+        event.sessionId() == null ? "-" : event.sessionId(),
+        event.method(),
+        event.path(),
+        event.reasonCode().name(),
+        event.occurredAt());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/CurrentSessionActiveAuditEventPublisher.java
+++ b/back/src/main/java/com/aquilabank/global/security/CurrentSessionActiveAuditEventPublisher.java
@@ -1,7 +1,12 @@
 package com.aquilabank.global.security;
 
 import com.aquilabank.domain.auth.model.CurrentSessionActiveAuditEvent;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveRejectReason;
 import com.aquilabank.domain.auth.port.CurrentSessionActiveAuditPort;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.EnumMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -13,9 +18,25 @@ public final class CurrentSessionActiveAuditEventPublisher
 
   private static final Logger log =
       LoggerFactory.getLogger(CurrentSessionActiveAuditEventPublisher.class);
+  private static final String REJECT_COUNTER_NAME = "aquila.auth.current_session_gate.reject.count";
+
+  private final Map<CurrentSessionActiveRejectReason, Counter> rejectCounters;
+
+  public CurrentSessionActiveAuditEventPublisher(MeterRegistry meterRegistry) {
+    this.rejectCounters = new EnumMap<>(CurrentSessionActiveRejectReason.class);
+    for (CurrentSessionActiveRejectReason reason : CurrentSessionActiveRejectReason.values()) {
+      rejectCounters.put(
+          reason,
+          Counter.builder(REJECT_COUNTER_NAME)
+              .tag("reason_code", reason.name())
+              .description("current session active gate rejected request count")
+              .register(meterRegistry));
+    }
+  }
 
   @Override
   public void record(CurrentSessionActiveAuditEvent event) {
+    rejectCounters.get(event.reasonCode()).increment();
     log.warn(
         "auth current session gate rejected requestId={} userId={} sessionId={} method={} path={} reasonCode={} occurredAt={}",
         event.requestId(),

--- a/back/src/main/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptor.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptor.java
@@ -1,11 +1,16 @@
 package com.aquilabank.global.web.security;
 
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveAuditEvent;
 import com.aquilabank.domain.auth.model.CurrentSessionActiveCheckCommand;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveRejectReason;
+import com.aquilabank.domain.auth.port.CurrentSessionActiveAuditPort;
 import com.aquilabank.domain.auth.usecase.CurrentSessionActiveUseCase;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import com.aquilabank.global.web.RequestTraceContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Instant;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.springframework.security.core.Authentication;
@@ -32,15 +37,21 @@ public class CurrentSessionActiveInterceptor implements HandlerInterceptor {
           new SensitiveMutationPath("DELETE", Pattern.compile("^/api/v1/auth/sessions/[^/]+$")));
 
   private final CurrentSessionActiveUseCase currentSessionActiveUseCase;
+  private final CurrentSessionActiveAuditPort currentSessionActiveAuditPort;
 
-  public CurrentSessionActiveInterceptor(CurrentSessionActiveUseCase currentSessionActiveUseCase) {
+  public CurrentSessionActiveInterceptor(
+      CurrentSessionActiveUseCase currentSessionActiveUseCase,
+      CurrentSessionActiveAuditPort currentSessionActiveAuditPort) {
     this.currentSessionActiveUseCase = currentSessionActiveUseCase;
+    this.currentSessionActiveAuditPort = currentSessionActiveAuditPort;
   }
 
   @Override
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
-    if (!isSensitiveMutation(request)) {
+    String method = request.getMethod();
+    String path = normalizedPath(request);
+    if (!isSensitiveMutation(method, path)) {
       return true;
     }
 
@@ -57,18 +68,30 @@ public class CurrentSessionActiveInterceptor implements HandlerInterceptor {
     Long currentSessionId = userPrincipal.currentSessionId();
     if (currentSessionId == null) {
       // session_id 없는 구 access token은 read 호환만 허용하고 고위험 mutation은 재로그인 요구.
+      currentSessionActiveAuditPort.record(
+          new CurrentSessionActiveAuditEvent(
+              requestId(),
+              userPrincipal.userId(),
+              null,
+              method,
+              path,
+              CurrentSessionActiveRejectReason.MISSING_SESSION_ID,
+              Instant.now()));
       throw new InvalidCredentialsException(CURRENT_SESSION_INACTIVE_MESSAGE);
     }
 
     currentSessionActiveUseCase.requireActive(
-        new CurrentSessionActiveCheckCommand(userPrincipal.userId(), currentSessionId));
+        new CurrentSessionActiveCheckCommand(
+            userPrincipal.userId(), currentSessionId, requestId(), method, path));
     return true;
   }
 
-  private boolean isSensitiveMutation(HttpServletRequest request) {
-    String method = request.getMethod();
-    String path = normalizedPath(request);
+  private boolean isSensitiveMutation(String method, String path) {
     return SENSITIVE_MUTATION_PATHS.stream().anyMatch(item -> item.matches(method, path));
+  }
+
+  private String requestId() {
+    return RequestTraceContext.currentRequestId().orElse("-");
   }
 
   private String normalizedPath(HttpServletRequest request) {

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/CurrentSessionActiveServiceTest.java
@@ -4,15 +4,21 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveAuditEvent;
 import com.aquilabank.domain.auth.model.CurrentSessionActiveCheckCommand;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveRejectReason;
+import com.aquilabank.domain.auth.port.CurrentSessionActiveAuditPort;
 import com.aquilabank.domain.auth.port.CurrentSessionActivePort;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class CurrentSessionActiveServiceTest {
 
@@ -22,24 +28,51 @@ class CurrentSessionActiveServiceTest {
   @Test
   void allowsWhenCurrentSessionIsActiveForUser() {
     CurrentSessionActivePort currentSessionActivePort = mock(CurrentSessionActivePort.class);
+    CurrentSessionActiveAuditPort currentSessionActiveAuditPort =
+        mock(CurrentSessionActiveAuditPort.class);
     when(currentSessionActivePort.existsActiveSession(7L, 11L, NOW)).thenReturn(true);
     CurrentSessionActiveService service =
-        new CurrentSessionActiveService(currentSessionActivePort, CLOCK);
+        new CurrentSessionActiveService(
+            currentSessionActivePort, currentSessionActiveAuditPort, CLOCK);
 
-    assertDoesNotThrow(() -> service.requireActive(new CurrentSessionActiveCheckCommand(7L, 11L)));
+    assertDoesNotThrow(
+        () ->
+            service.requireActive(
+                new CurrentSessionActiveCheckCommand(
+                    7L, 11L, "req-1", "POST", "/api/v1/transfers")));
 
     verify(currentSessionActivePort).existsActiveSession(7L, 11L, NOW);
+    verifyNoInteractions(currentSessionActiveAuditPort);
   }
 
   @Test
-  void rejectsWhenCurrentSessionIsNotActiveForUser() {
+  void recordsAuditEventWhenCurrentSessionIsNotActiveForUser() {
     CurrentSessionActivePort currentSessionActivePort = mock(CurrentSessionActivePort.class);
+    CurrentSessionActiveAuditPort currentSessionActiveAuditPort =
+        mock(CurrentSessionActiveAuditPort.class);
     when(currentSessionActivePort.existsActiveSession(7L, 11L, NOW)).thenReturn(false);
     CurrentSessionActiveService service =
-        new CurrentSessionActiveService(currentSessionActivePort, CLOCK);
+        new CurrentSessionActiveService(
+            currentSessionActivePort, currentSessionActiveAuditPort, CLOCK);
 
     assertThrows(
         InvalidCredentialsException.class,
-        () -> service.requireActive(new CurrentSessionActiveCheckCommand(7L, 11L)));
+        () ->
+            service.requireActive(
+                new CurrentSessionActiveCheckCommand(
+                    7L, 11L, "req-1", "POST", "/api/v1/transfers")));
+
+    ArgumentCaptor<CurrentSessionActiveAuditEvent> eventCaptor =
+        ArgumentCaptor.forClass(CurrentSessionActiveAuditEvent.class);
+    verify(currentSessionActiveAuditPort).record(eventCaptor.capture());
+    CurrentSessionActiveAuditEvent event = eventCaptor.getValue();
+    Assertions.assertEquals("req-1", event.requestId());
+    Assertions.assertEquals(7L, event.userId());
+    Assertions.assertEquals(11L, event.sessionId());
+    Assertions.assertEquals("POST", event.method());
+    Assertions.assertEquals("/api/v1/transfers", event.path());
+    Assertions.assertEquals(
+        CurrentSessionActiveRejectReason.INACTIVE_OR_MISMATCHED_SESSION, event.reasonCode());
+    Assertions.assertEquals(NOW, event.occurredAt());
   }
 }

--- a/back/src/test/java/com/aquilabank/global/security/CurrentSessionActiveAuditEventPublisherTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/CurrentSessionActiveAuditEventPublisherTest.java
@@ -1,0 +1,37 @@
+package com.aquilabank.global.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.aquilabank.domain.auth.model.CurrentSessionActiveAuditEvent;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveRejectReason;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class CurrentSessionActiveAuditEventPublisherTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-22T01:00:00Z");
+  private static final String METRIC_NAME = "aquila.auth.current_session_gate.reject.count";
+
+  @Test
+  void incrementsRejectCounterByReasonCodeOnly() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    CurrentSessionActiveAuditEventPublisher publisher =
+        new CurrentSessionActiveAuditEventPublisher(registry);
+
+    publisher.record(event(CurrentSessionActiveRejectReason.MISSING_SESSION_ID, null));
+    publisher.record(event(CurrentSessionActiveRejectReason.MISSING_SESSION_ID, null));
+    publisher.record(event(CurrentSessionActiveRejectReason.INACTIVE_OR_MISMATCHED_SESSION, 11L));
+
+    assertEquals(2.0, registry.counter(METRIC_NAME, "reason_code", "MISSING_SESSION_ID").count());
+    assertEquals(
+        1.0,
+        registry.counter(METRIC_NAME, "reason_code", "INACTIVE_OR_MISMATCHED_SESSION").count());
+  }
+
+  private CurrentSessionActiveAuditEvent event(
+      CurrentSessionActiveRejectReason reasonCode, Long sessionId) {
+    return new CurrentSessionActiveAuditEvent(
+        "req-1", 7L, sessionId, "POST", "/api/v1/auth/password-reset", reasonCode, NOW);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptorTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptorTest.java
@@ -9,14 +9,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveAuditEvent;
 import com.aquilabank.domain.auth.model.CurrentSessionActiveCheckCommand;
+import com.aquilabank.domain.auth.model.CurrentSessionActiveRejectReason;
+import com.aquilabank.domain.auth.port.CurrentSessionActiveAuditPort;
 import com.aquilabank.domain.auth.usecase.CurrentSessionActiveUseCase;
 import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import com.aquilabank.global.web.RequestTraceContext;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -25,22 +30,28 @@ import org.springframework.security.core.context.SecurityContextHolder;
 class CurrentSessionActiveInterceptorTest {
 
   private CurrentSessionActiveUseCase currentSessionActiveUseCase;
+  private CurrentSessionActiveAuditPort currentSessionActiveAuditPort;
   private CurrentSessionActiveInterceptor interceptor;
 
   @BeforeEach
   void setUp() {
     currentSessionActiveUseCase = mock(CurrentSessionActiveUseCase.class);
-    interceptor = new CurrentSessionActiveInterceptor(currentSessionActiveUseCase);
+    currentSessionActiveAuditPort = mock(CurrentSessionActiveAuditPort.class);
+    interceptor =
+        new CurrentSessionActiveInterceptor(
+            currentSessionActiveUseCase, currentSessionActiveAuditPort);
   }
 
   @AfterEach
   void clearSecurityContext() {
     SecurityContextHolder.clearContext();
+    RequestTraceContext.clear();
   }
 
   @Test
   void checksActiveSessionForSensitiveUserMutations() throws Exception {
     authenticate(new AuthenticatedUserPrincipal(7L, "alice", 11L));
+    RequestTraceContext.set("req-active");
 
     List<RequestPath> items =
         List.of(
@@ -58,13 +69,27 @@ class CurrentSessionActiveInterceptorTest {
       assertTrue(interceptor.preHandle(request(item.method(), item.path()), response(), null));
     }
 
-    verify(currentSessionActiveUseCase, times(items.size()))
-        .requireActive(new CurrentSessionActiveCheckCommand(7L, 11L));
+    ArgumentCaptor<CurrentSessionActiveCheckCommand> commandCaptor =
+        ArgumentCaptor.forClass(CurrentSessionActiveCheckCommand.class);
+    verify(currentSessionActiveUseCase, times(items.size())).requireActive(commandCaptor.capture());
+    List<CurrentSessionActiveCheckCommand> commands = commandCaptor.getAllValues();
+    assertEquals(items.size(), commands.size());
+    for (int i = 0; i < items.size(); i++) {
+      CurrentSessionActiveCheckCommand command = commands.get(i);
+      RequestPath item = items.get(i);
+      assertEquals(7L, command.userId());
+      assertEquals(11L, command.sessionId());
+      assertEquals("req-active", command.requestId());
+      assertEquals(item.method(), command.method());
+      assertEquals(item.path(), command.path());
+    }
+    verifyNoInteractions(currentSessionActiveAuditPort);
   }
 
   @Test
-  void rejectsSensitiveMutationWhenJwtHasNoSessionId() {
+  void recordsAuditEventWhenSensitiveMutationJwtHasNoSessionId() {
     authenticate(new AuthenticatedUserPrincipal(7L, "alice"));
+    RequestTraceContext.set("req-missing");
 
     InvalidCredentialsException exception =
         assertThrows(
@@ -75,6 +100,17 @@ class CurrentSessionActiveInterceptorTest {
 
     assertEquals("current session is not active", exception.getMessage());
     verifyNoInteractions(currentSessionActiveUseCase);
+    ArgumentCaptor<CurrentSessionActiveAuditEvent> eventCaptor =
+        ArgumentCaptor.forClass(CurrentSessionActiveAuditEvent.class);
+    verify(currentSessionActiveAuditPort).record(eventCaptor.capture());
+    CurrentSessionActiveAuditEvent event = eventCaptor.getValue();
+    assertEquals("req-missing", event.requestId());
+    assertEquals(7L, event.userId());
+    assertEquals(null, event.sessionId());
+    assertEquals("POST", event.method());
+    assertEquals("/api/v1/auth/password-reset", event.path());
+    assertEquals(CurrentSessionActiveRejectReason.MISSING_SESSION_ID, event.reasonCode());
+    assertTrue(event.occurredAt() != null);
   }
 
   @Test
@@ -88,6 +124,7 @@ class CurrentSessionActiveInterceptorTest {
             request("POST", "/api/v1/auth/mfa/totp/challenge/verify"), response(), null));
 
     verifyNoInteractions(currentSessionActiveUseCase);
+    verifyNoInteractions(currentSessionActiveAuditPort);
   }
 
   @Test
@@ -99,6 +136,7 @@ class CurrentSessionActiveInterceptorTest {
         interceptor.preHandle(request("POST", "/api/v1/auth/password-reset"), response(), null));
 
     verifyNoInteractions(currentSessionActiveUseCase);
+    verifyNoInteractions(currentSessionActiveAuditPort);
   }
 
   private MockHttpServletRequest request(String method, String path) {

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -52,6 +52,8 @@
   - consumer lag `> 100`
   - DLQ count `> 0`
   - SSE total session `> 56`
+- auth baseline:
+  - current session active gate reject rate `> 0` for `5m`
 - transaction baseline:
   - success query p95 SLO: reference_exact `80ms`, first_page `120ms`, cursor/status/direction `150ms`, amount/mixed `180ms`
   - success query 평균 latency `> 750ms`
@@ -95,3 +97,4 @@ bash tools/ops/validate-prometheus-assets.sh
 - transaction 평균 latency `750ms` alert는 p95 SLO보다 느슨한 coarse guard로 남겨 둡니다.
 - notification lag/DLQ alert는 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true`가 아니면 metric 자체가 export되지 않을 수 있습니다.
 - multi-instance SSE 합계는 Grafana/Prometheus 쿼리에서 인스턴스 합산으로 해석하고, 단일 instance alert는 node별 pressure 확인 용도로만 씁니다.
+- `AquilaCurrentSessionActiveGateRejectDetected`는 `reason_code`만 집계합니다. `requestId`, `userId`, `sessionId`, `path`는 cardinality 때문에 alert label로 올리지 않고 app structured log에서 drill-down합니다.

--- a/ops/prometheus/rules/aquila-bank-alerts.yml
+++ b/ops/prometheus/rules/aquila-bank-alerts.yml
@@ -98,6 +98,22 @@ groups:
           description: "SSE total session이 10분 이상 56을 초과했습니다. 기본 max-total-sessions=64 기준 87.5% 사용률 baseline입니다."
           runbook_path: "back/README.md#prometheus-metrics"
 
+  - name: aquila-bank-auth
+    interval: 30s
+    rules:
+      - alert: AquilaCurrentSessionActiveGateRejectDetected
+        expr: sum(rate(aquila_auth_current_session_gate_reject_count_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: auth
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank current session active gate rejects detected"
+          description: "민감 mutation에서 current session active gate 차단이 5분 이상 발생했습니다. requestId 기준 structured audit log를 먼저 확인합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
   - name: aquila-bank-transaction
     interval: 30s
     rules:


### PR DESCRIPTION
## 🔗 Related Issue
- close #218

## 🌿 Base Branch
- `main`

## 📝 Summary
- 민감 mutation에서 current session active gate가 차단한 요청을 domain audit event와 structured log로 기록합니다.
- `reason_code` 기준 Prometheus counter와 alert rule을 추가하고, 운영 문서에 조사/rollback 기준을 정리합니다.

## 🛠 Changes
- `CurrentSessionActiveAuditEvent`, `CurrentSessionActiveAuditPort`, `CurrentSessionActiveRejectReason` 추가
- legacy JWT `session_id` 누락과 inactive/mismatch session 차단을 서로 다른 `reasonCode`로 기록
- `aquila.auth.current_session_gate.reject.count` counter와 `AquilaCurrentSessionActiveGateRejectDetected` alert 추가
- README와 Prometheus baseline 문서에 metric, alert 의미, drill-down 기준, rollback 기준 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh current-session-active-alerting ./back/gradlew -p back test --tests '*CurrentSessionActiveServiceTest' --tests '*CurrentSessionActiveInterceptorTest' --tests '*CurrentSessionActiveAuditEventPublisherTest'`
- `bash tools/ops/validate-prometheus-assets.sh`
- `tools/test/with-resource-lock.sh current-session-active-alerting ./back/gradlew -p back check`
- `git rev-list --count main..HEAD` -> `3`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 차단 이벤트가 반복되는 환경에서는 warning alert noise가 생길 수 있습니다. API 응답은 기존 generic `401` 계약을 유지합니다.
- 롤백 방법: PR revert 또는 `AquilaCurrentSessionActiveGateRejectDetected` rule 제거/threshold 조정으로 처리합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
