### PR TITLE
[Chore] refresh token reuse 감지 audit/event와 alert 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -233,11 +233,13 @@ set +a
   - `aquila_notification_consumer_dlq_count`
   - `aquila_notification_sse_sessions{principal_type="account|user|total"}`
   - `aquila_auth_current_session_gate_reject_count_total{reason_code="MISSING_SESSION_ID|INACTIVE_OR_MISMATCHED_SESSION"}`
+  - `aquila_auth_refresh_token_reuse_detected_count_total{reason_code="ROTATED_TOKEN_REUSE"}`
   - `aquila_transaction_query_latency_seconds`
 - 활성화 조건:
   - outbox metric은 기본 wiring만 있으면 항상 export 됩니다.
   - notification consumer lag/DLQ metric은 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true` 와 DLQ topic 설정이 있어야 export 됩니다.
   - current session gate reject counter는 민감 mutation에서 legacy JWT `session_id` 누락 또는 inactive/mismatch session 차단이 발생하면 증가합니다.
+  - refresh token reuse metric은 `ROTATED` refresh token 재사용 감지와 family revoke가 발생하면 증가합니다.
   - transaction latency timer는 `GET /api/v1/transactions` query path가 한 번이라도 호출되면 `query_shape` tag 기준으로 누적됩니다.
   - transaction latency histogram bucket은 p95 SLO alert용으로 `50ms, 80ms, 120ms, 150ms, 180ms, 350ms, 750ms, 1s, 3s` 경계를 export 합니다.
 - transaction `query_shape` 기준:
@@ -258,8 +260,11 @@ set +a
   - SSE session metric은 현재 app instance 메모리의 active session 수만 보여주므로 multi-instance 전체 합계는 Prometheus 쿼리에서 합산합니다.
   - current session gate reject metric label은 `reason_code`만 사용하고, `requestId`, `userId`, `sessionId`, `path`는 structured audit log에서만 확인합니다.
   - `AquilaCurrentSessionActiveGateRejectDetected` alert는 장애 확정이 아니라 security investigation 시작점입니다. 같은 시간대 `requestId`로 `auth current session gate rejected` log를 조회하고, `reasonCode`, `userId`, `sessionId`, `method`, `path`를 확인합니다.
-  - p95 alert는 `query_shape`별 5분 rate가 충분할 때만 평가해 low traffic 노이즈를 줄입니다.
   - current session gate alert rollback은 `AquilaCurrentSessionActiveGateRejectDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행하고, API 응답 계약은 그대로 유지합니다.
+  - refresh token reuse metric label은 `reason_code`만 사용하고, `requestId`, `userId`, `reusedSessionId`, `familyRootId`는 structured audit log에서만 확인합니다.
+  - `AquilaRefreshTokenReuseDetected` alert는 공격성 재사용 후보입니다. 같은 시간대 `requestId`로 `auth refresh token reuse detected` log를 조회하고 `reusedSessionId`, `familyRootId`, `revokedCount`를 먼저 확인합니다.
+  - p95 alert는 `query_shape`별 5분 rate가 충분할 때만 평가해 low traffic 노이즈를 줄입니다.
+  - refresh token reuse alert rollback은 `AquilaRefreshTokenReuseDetected` rule 제거 또는 notification routing 비활성화로 수행하고, refresh API 응답 계약은 그대로 유지합니다.
   - histogram bucket/alert rollback은 `management.metrics.distribution.*.aquila.transaction.query.latency`와 `AquilaTransactionQueryLatencyP95SloHigh` rule 제거로 수행합니다.
   - baseline 자산은 `ops/prometheus/` 아래에 두고 dashboard import, alert rule apply, tuning 가이드는 `ops/prometheus/README.md`를 기준으로 봅니다.
 - baseline 파일:

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenCommand.java
@@ -4,10 +4,18 @@ package com.aquilabank.domain.auth.model;
 public record RefreshTokenCommand(
     String refreshToken,
     String refreshDeviceBindingToken,
-    AuthSessionClientMetadata sessionClientMetadata) {
+    AuthSessionClientMetadata sessionClientMetadata,
+    String requestId) {
 
   public RefreshTokenCommand(String refreshToken, AuthSessionClientMetadata sessionClientMetadata) {
-    this(refreshToken, null, sessionClientMetadata);
+    this(refreshToken, null, sessionClientMetadata, "-");
+  }
+
+  public RefreshTokenCommand(
+      String refreshToken,
+      String refreshDeviceBindingToken,
+      AuthSessionClientMetadata sessionClientMetadata) {
+    this(refreshToken, refreshDeviceBindingToken, sessionClientMetadata, "-");
   }
 
   public RefreshTokenCommand {
@@ -19,6 +27,9 @@ public record RefreshTokenCommand(
     }
     if (sessionClientMetadata == null) {
       throw new IllegalArgumentException("sessionClientMetadata is required");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      requestId = "-";
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenReuseAuditEvent.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenReuseAuditEvent.java
@@ -1,0 +1,48 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/** refresh token reuse 감지 상세는 응답 대신 운영 audit surface로만 남깁니다. */
+public record RefreshTokenReuseAuditEvent(
+    String requestId,
+    long userId,
+    long reusedSessionId,
+    long familyRootId,
+    Long replacedBySessionId,
+    int revokedCount,
+    String deviceName,
+    String ipAddress,
+    RefreshTokenReuseReason reasonCode,
+    Instant occurredAt) {
+
+  public RefreshTokenReuseAuditEvent {
+    requestId = requireText(requestId, "requestId");
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (reusedSessionId <= 0) {
+      throw new IllegalArgumentException("reusedSessionId must be positive");
+    }
+    if (familyRootId <= 0) {
+      throw new IllegalArgumentException("familyRootId must be positive");
+    }
+    if (replacedBySessionId != null && replacedBySessionId <= 0) {
+      throw new IllegalArgumentException("replacedBySessionId must be positive");
+    }
+    if (revokedCount < 0) {
+      throw new IllegalArgumentException("revokedCount must not be negative");
+    }
+    deviceName = requireText(deviceName, "deviceName");
+    ipAddress = requireText(ipAddress, "ipAddress");
+    Objects.requireNonNull(reasonCode, "reasonCode must not be null");
+    Objects.requireNonNull(occurredAt, "occurredAt must not be null");
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value;
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenReuseReason.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenReuseReason.java
@@ -1,0 +1,5 @@
+package com.aquilabank.domain.auth.model;
+
+public enum RefreshTokenReuseReason {
+  ROTATED_TOKEN_REUSE
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionFamilyRevokeResult.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/RefreshTokenSessionFamilyRevokeResult.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+/** reuse 감지 후 bounded session family revoke 결과입니다. */
+public record RefreshTokenSessionFamilyRevokeResult(long familyRootId, int revokedCount) {
+
+  public RefreshTokenSessionFamilyRevokeResult {
+    if (familyRootId <= 0) {
+      throw new IllegalArgumentException("familyRootId must be positive");
+    }
+    if (revokedCount < 0) {
+      throw new IllegalArgumentException("revokedCount must not be negative");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenReuseAuditPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenReuseAuditPort.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.port;
+
+import com.aquilabank.domain.auth.model.RefreshTokenReuseAuditEvent;
+
+public interface RefreshTokenReuseAuditPort {
+
+  void record(RefreshTokenReuseAuditEvent event);
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionWritePort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/RefreshTokenSessionWritePort.java
@@ -2,6 +2,7 @@ package com.aquilabank.domain.auth.port;
 
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeResult;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
 import java.time.Instant;
@@ -15,7 +16,8 @@ public interface RefreshTokenSessionWritePort {
 
   void revoke(RefreshTokenSessionRevokeCommand command);
 
-  void revokeFamily(RefreshTokenSessionFamilyRevokeCommand command);
+  RefreshTokenSessionFamilyRevokeResult revokeFamily(
+      RefreshTokenSessionFamilyRevokeCommand command);
 
   void revokeActiveSessionsByUserId(long userId, Instant revokedAt);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/RefreshTokenService.java
@@ -5,14 +5,18 @@ import com.aquilabank.domain.auth.model.IssuedAccessToken;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.model.RefreshTokenCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
+import com.aquilabank.domain.auth.model.RefreshTokenReuseAuditEvent;
+import com.aquilabank.domain.auth.model.RefreshTokenReuseReason;
 import com.aquilabank.domain.auth.model.RefreshTokenSession;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeResult;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.RefreshDeviceBindingSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenReuseAuditPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
@@ -27,6 +31,7 @@ public final class RefreshTokenService implements RefreshTokenUseCase {
   private final RefreshTokenSecretPort refreshTokenSecretPort;
   private final RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort;
   private final AuthTokenIssuePort authTokenIssuePort;
+  private final RefreshTokenReuseAuditPort refreshTokenReuseAuditPort;
   private final RefreshTokenPolicy refreshTokenPolicy;
   private final Clock clock;
 
@@ -38,11 +43,32 @@ public final class RefreshTokenService implements RefreshTokenUseCase {
       AuthTokenIssuePort authTokenIssuePort,
       RefreshTokenPolicy refreshTokenPolicy,
       Clock clock) {
+    this(
+        refreshTokenSessionLoadPort,
+        refreshTokenSessionWritePort,
+        refreshTokenSecretPort,
+        refreshDeviceBindingSecretPort,
+        authTokenIssuePort,
+        event -> {},
+        refreshTokenPolicy,
+        clock);
+  }
+
+  public RefreshTokenService(
+      RefreshTokenSessionLoadPort refreshTokenSessionLoadPort,
+      RefreshTokenSessionWritePort refreshTokenSessionWritePort,
+      RefreshTokenSecretPort refreshTokenSecretPort,
+      RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort,
+      AuthTokenIssuePort authTokenIssuePort,
+      RefreshTokenReuseAuditPort refreshTokenReuseAuditPort,
+      RefreshTokenPolicy refreshTokenPolicy,
+      Clock clock) {
     this.refreshTokenSessionLoadPort = refreshTokenSessionLoadPort;
     this.refreshTokenSessionWritePort = refreshTokenSessionWritePort;
     this.refreshTokenSecretPort = refreshTokenSecretPort;
     this.refreshDeviceBindingSecretPort = refreshDeviceBindingSecretPort;
     this.authTokenIssuePort = authTokenIssuePort;
+    this.refreshTokenReuseAuditPort = refreshTokenReuseAuditPort;
     this.refreshTokenPolicy = refreshTokenPolicy;
     this.clock = clock;
   }
@@ -59,8 +85,21 @@ public final class RefreshTokenService implements RefreshTokenUseCase {
     if (session.sessionStatus() != RefreshTokenSessionStatus.ACTIVE) {
       // ROTATED token 재사용은 탈취 가능성이 높아 descendant session까지 같은 transaction에서 종료합니다.
       if (session.sessionStatus() == RefreshTokenSessionStatus.ROTATED) {
-        refreshTokenSessionWritePort.revokeFamily(
-            new RefreshTokenSessionFamilyRevokeCommand(session.sessionId(), now));
+        RefreshTokenSessionFamilyRevokeResult revokeResult =
+            refreshTokenSessionWritePort.revokeFamily(
+                new RefreshTokenSessionFamilyRevokeCommand(session.sessionId(), now));
+        refreshTokenReuseAuditPort.record(
+            new RefreshTokenReuseAuditEvent(
+                command.requestId(),
+                session.userId(),
+                session.sessionId(),
+                revokeResult.familyRootId(),
+                session.replacedBySessionId(),
+                revokeResult.revokedCount(),
+                command.sessionClientMetadata().deviceName(),
+                command.sessionClientMetadata().ipAddress(),
+                RefreshTokenReuseReason.ROTATED_TOKEN_REUSE,
+                now));
       }
       throw new InvalidCredentialsException("refresh failed");
     }

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -26,6 +26,7 @@ import com.aquilabank.domain.auth.port.PasswordRecoverySecretPort;
 import com.aquilabank.domain.auth.port.PasswordRecoveryTokenLoadPort;
 import com.aquilabank.domain.auth.port.PasswordRecoveryTokenQueryPort;
 import com.aquilabank.domain.auth.port.RefreshDeviceBindingSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenReuseAuditPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
@@ -269,6 +270,7 @@ public class AuthConfiguration {
       RefreshTokenSecretPort refreshTokenSecretPort,
       RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort,
       AuthTokenIssuePort authTokenIssuePort,
+      RefreshTokenReuseAuditPort refreshTokenReuseAuditPort,
       RefreshTokenPolicy refreshTokenPolicy,
       Clock authClock,
       PlatformTransactionManager platformTransactionManager) {
@@ -279,6 +281,7 @@ public class AuthConfiguration {
             refreshTokenSecretPort,
             refreshDeviceBindingSecretPort,
             authTokenIssuePort,
+            refreshTokenReuseAuditPort,
             refreshTokenPolicy,
             authClock);
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthWriteRepository.java
@@ -22,6 +22,7 @@ import com.aquilabank.domain.auth.model.PasswordRecoveryTokenUseCommand;
 import com.aquilabank.domain.auth.model.PasswordResetWriteCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeResult;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRevokeCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
 import com.aquilabank.domain.auth.model.RememberDeviceIssueCommand;
@@ -629,9 +630,11 @@ public class JdbcAuthWriteRepository
 
   @Override
   @Transactional
-  public void revokeFamily(RefreshTokenSessionFamilyRevokeCommand command) {
-    jdbcTemplate.update(
-        """
+  public RefreshTokenSessionFamilyRevokeResult revokeFamily(
+      RefreshTokenSessionFamilyRevokeCommand command) {
+    RefreshTokenSessionFamilyRevokeResult result =
+        jdbcTemplate.queryForObject(
+            """
         WITH RECURSIVE ancestors(id, replaced_by_session_id) AS (
             SELECT id,
                    replaced_by_session_id
@@ -667,7 +670,8 @@ public class JdbcAuthWriteRepository
                    child.replaced_by_session_id
             FROM auth_refresh_token_session child
             JOIN family parent ON parent.replaced_by_session_id = child.id
-        )
+        ),
+        updated AS (
         UPDATE auth_refresh_token_session target
         SET session_status = 'REVOKED',
             last_used_at = :revokedAt,
@@ -677,10 +681,22 @@ public class JdbcAuthWriteRepository
               SELECT id
               FROM family
           )
+        RETURNING target.id
+        )
+        SELECT (SELECT id FROM family_root) AS family_root_id,
+               COUNT(updated.id) AS revoked_count
+        FROM updated
         """,
-        new MapSqlParameterSource()
-            .addValue("reusedSessionId", command.reusedSessionId())
-            .addValue("revokedAt", Timestamp.from(command.revokedAt())));
+            new MapSqlParameterSource()
+                .addValue("reusedSessionId", command.reusedSessionId())
+                .addValue("revokedAt", Timestamp.from(command.revokedAt())),
+            (rs, rowNum) ->
+                new RefreshTokenSessionFamilyRevokeResult(
+                    rs.getLong("family_root_id"), rs.getInt("revoked_count")));
+    if (result == null) {
+      throw new IllegalStateException("refresh token session family revoke returned null result");
+    }
+    return result;
   }
 
   @Override

--- a/back/src/main/java/com/aquilabank/global/security/RefreshTokenReuseAuditEventPublisher.java
+++ b/back/src/main/java/com/aquilabank/global/security/RefreshTokenReuseAuditEventPublisher.java
@@ -1,7 +1,12 @@
 package com.aquilabank.global.security;
 
 import com.aquilabank.domain.auth.model.RefreshTokenReuseAuditEvent;
+import com.aquilabank.domain.auth.model.RefreshTokenReuseReason;
 import com.aquilabank.domain.auth.port.RefreshTokenReuseAuditPort;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.EnumMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -12,9 +17,25 @@ public final class RefreshTokenReuseAuditEventPublisher implements RefreshTokenR
 
   private static final Logger log =
       LoggerFactory.getLogger(RefreshTokenReuseAuditEventPublisher.class);
+  private static final String REUSE_COUNTER_NAME = "aquila.auth.refresh_token_reuse.detected.count";
+
+  private final Map<RefreshTokenReuseReason, Counter> reuseCounters;
+
+  public RefreshTokenReuseAuditEventPublisher(MeterRegistry meterRegistry) {
+    this.reuseCounters = new EnumMap<>(RefreshTokenReuseReason.class);
+    for (RefreshTokenReuseReason reason : RefreshTokenReuseReason.values()) {
+      reuseCounters.put(
+          reason,
+          Counter.builder(REUSE_COUNTER_NAME)
+              .tag("reason_code", reason.name())
+              .description("refresh token reuse detected count")
+              .register(meterRegistry));
+    }
+  }
 
   @Override
   public void record(RefreshTokenReuseAuditEvent event) {
+    reuseCounters.get(event.reasonCode()).increment();
     log.warn(
         "auth refresh token reuse detected requestId={} userId={} reusedSessionId={} familyRootId={} replacedBySessionId={} revokedCount={} deviceName={} ipAddress={} reasonCode={} occurredAt={}",
         event.requestId(),

--- a/back/src/main/java/com/aquilabank/global/security/RefreshTokenReuseAuditEventPublisher.java
+++ b/back/src/main/java/com/aquilabank/global/security/RefreshTokenReuseAuditEventPublisher.java
@@ -1,0 +1,31 @@
+package com.aquilabank.global.security;
+
+import com.aquilabank.domain.auth.model.RefreshTokenReuseAuditEvent;
+import com.aquilabank.domain.auth.port.RefreshTokenReuseAuditPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** refresh token reuse 상세는 응답 대신 structured audit log에만 남깁니다. */
+@Component
+public final class RefreshTokenReuseAuditEventPublisher implements RefreshTokenReuseAuditPort {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(RefreshTokenReuseAuditEventPublisher.class);
+
+  @Override
+  public void record(RefreshTokenReuseAuditEvent event) {
+    log.warn(
+        "auth refresh token reuse detected requestId={} userId={} reusedSessionId={} familyRootId={} replacedBySessionId={} revokedCount={} deviceName={} ipAddress={} reasonCode={} occurredAt={}",
+        event.requestId(),
+        event.userId(),
+        event.reusedSessionId(),
+        event.familyRootId(),
+        event.replacedBySessionId() == null ? "-" : event.replacedBySessionId(),
+        event.revokedCount(),
+        event.deviceName(),
+        event.ipAddress(),
+        event.reasonCode().name(),
+        event.occurredAt());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -40,6 +40,7 @@ import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.security.LoginThrottleGuard;
+import com.aquilabank.global.web.RequestTraceContext;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -246,7 +247,8 @@ public class LoginController {
             new RefreshTokenCommand(
                 request.refreshToken(),
                 refreshDeviceBindingCookieManager.resolve(httpServletRequest),
-                authSessionMetadataResolver.resolve(httpServletRequest)));
+                authSessionMetadataResolver.resolve(httpServletRequest),
+                RequestTraceContext.currentRequestId().orElse("-")));
     return loginResponse(result, false);
   }
 

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/RefreshTokenServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
@@ -12,14 +13,18 @@ import com.aquilabank.domain.auth.model.AuthSessionClientMetadata;
 import com.aquilabank.domain.auth.model.IssuedAccessToken;
 import com.aquilabank.domain.auth.model.RefreshTokenCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenPolicy;
+import com.aquilabank.domain.auth.model.RefreshTokenReuseAuditEvent;
+import com.aquilabank.domain.auth.model.RefreshTokenReuseReason;
 import com.aquilabank.domain.auth.model.RefreshTokenSession;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionCreateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeResult;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionRotateCommand;
 import com.aquilabank.domain.auth.model.RefreshTokenSessionStatus;
 import com.aquilabank.domain.auth.model.UserStatus;
 import com.aquilabank.domain.auth.port.AuthTokenIssuePort;
 import com.aquilabank.domain.auth.port.RefreshDeviceBindingSecretPort;
+import com.aquilabank.domain.auth.port.RefreshTokenReuseAuditPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSecretPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionLoadPort;
 import com.aquilabank.domain.auth.port.RefreshTokenSessionWritePort;
@@ -29,6 +34,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 class RefreshTokenServiceTest {
@@ -158,6 +164,8 @@ class RefreshTokenServiceTest {
     RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort =
         Mockito.mock(RefreshDeviceBindingSecretPort.class);
     AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+    RefreshTokenReuseAuditPort refreshTokenReuseAuditPort =
+        Mockito.mock(RefreshTokenReuseAuditPort.class);
 
     when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("token-hash");
     when(refreshTokenSessionLoadPort.findByTokenHashForUpdate("token-hash"))
@@ -175,6 +183,9 @@ class RefreshTokenServiceTest {
                     NOW.minusSeconds(10),
                     NOW.minusSeconds(10),
                     33L)));
+    when(refreshTokenSessionWritePort.revokeFamily(
+            new RefreshTokenSessionFamilyRevokeCommand(11L, NOW)))
+        .thenReturn(new RefreshTokenSessionFamilyRevokeResult(3L, 1));
 
     RefreshTokenService refreshTokenService =
         new RefreshTokenService(
@@ -183,6 +194,7 @@ class RefreshTokenServiceTest {
             refreshTokenSecretPort,
             refreshDeviceBindingSecretPort,
             authTokenIssuePort,
+            refreshTokenReuseAuditPort,
             new RefreshTokenPolicy(Duration.ofDays(14)),
             CLOCK);
 
@@ -191,10 +203,24 @@ class RefreshTokenServiceTest {
         () ->
             refreshTokenService.refresh(
                 new RefreshTokenCommand(
-                    "refresh-token", "binding-token", SESSION_CLIENT_METADATA)));
+                    "refresh-token", "binding-token", SESSION_CLIENT_METADATA, "req-reuse")));
 
     verify(refreshTokenSessionWritePort)
         .revokeFamily(new RefreshTokenSessionFamilyRevokeCommand(11L, NOW));
+    ArgumentCaptor<RefreshTokenReuseAuditEvent> eventCaptor =
+        ArgumentCaptor.forClass(RefreshTokenReuseAuditEvent.class);
+    verify(refreshTokenReuseAuditPort).record(eventCaptor.capture());
+    RefreshTokenReuseAuditEvent event = eventCaptor.getValue();
+    assertEquals("req-reuse", event.requestId());
+    assertEquals(7L, event.userId());
+    assertEquals(11L, event.reusedSessionId());
+    assertEquals(3L, event.familyRootId());
+    assertEquals(33L, event.replacedBySessionId());
+    assertEquals(1, event.revokedCount());
+    assertEquals(SESSION_CLIENT_METADATA.deviceName(), event.deviceName());
+    assertEquals(SESSION_CLIENT_METADATA.ipAddress(), event.ipAddress());
+    assertEquals(RefreshTokenReuseReason.ROTATED_TOKEN_REUSE, event.reasonCode());
+    assertEquals(NOW, event.occurredAt());
     verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
     verify(refreshTokenSessionWritePort, never()).rotate(Mockito.any());
     verify(authTokenIssuePort, never())
@@ -211,6 +237,8 @@ class RefreshTokenServiceTest {
     RefreshDeviceBindingSecretPort refreshDeviceBindingSecretPort =
         Mockito.mock(RefreshDeviceBindingSecretPort.class);
     AuthTokenIssuePort authTokenIssuePort = Mockito.mock(AuthTokenIssuePort.class);
+    RefreshTokenReuseAuditPort refreshTokenReuseAuditPort =
+        Mockito.mock(RefreshTokenReuseAuditPort.class);
 
     when(refreshTokenSecretPort.hash("refresh-token")).thenReturn("token-hash");
     when(refreshTokenSessionLoadPort.findByTokenHashForUpdate("token-hash"))
@@ -236,6 +264,7 @@ class RefreshTokenServiceTest {
             refreshTokenSecretPort,
             refreshDeviceBindingSecretPort,
             authTokenIssuePort,
+            refreshTokenReuseAuditPort,
             new RefreshTokenPolicy(Duration.ofDays(14)),
             CLOCK);
 
@@ -249,6 +278,7 @@ class RefreshTokenServiceTest {
     verify(refreshTokenSessionWritePort, never()).revokeFamily(Mockito.any());
     verify(refreshTokenSessionWritePort, never()).create(Mockito.any());
     verify(refreshTokenSessionWritePort, never()).rotate(Mockito.any());
+    verifyNoInteractions(refreshTokenReuseAuditPort);
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthRefreshTokenSessionFamilyRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthRefreshTokenSessionFamilyRepositoryIntegrationTest.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.persistence.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeCommand;
+import com.aquilabank.domain.auth.model.RefreshTokenSessionFamilyRevokeResult;
 import com.aquilabank.support.PostgresContainerTestSupport;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -37,19 +38,24 @@ class JdbcAuthRefreshTokenSessionFamilyRepositoryIntegrationTest
   @Test
   void revokesOnlyActiveDescendantSessionsInReusedTokenFamily() {
     long[] middleSessionId = new long[1];
+    long[] rootSessionId = new long[1];
     commit(
         transactionManager,
         () -> {
           long userId = insertUser("family-user");
           long activeSessionId = insertSession(userId, "active-descendant", "ACTIVE", null);
           middleSessionId[0] = insertSession(userId, "rotated-middle", "ROTATED", activeSessionId);
-          insertSession(userId, "rotated-root", "ROTATED", middleSessionId[0]);
+          rootSessionId[0] = insertSession(userId, "rotated-root", "ROTATED", middleSessionId[0]);
           insertSession(userId, "unrelated-active", "ACTIVE", null);
         });
 
-    repository.revokeFamily(new RefreshTokenSessionFamilyRevokeCommand(middleSessionId[0], NOW));
+    RefreshTokenSessionFamilyRevokeResult result =
+        repository.revokeFamily(
+            new RefreshTokenSessionFamilyRevokeCommand(middleSessionId[0], NOW));
 
     Map<String, String> statuses = findStatusesByTokenHash();
+    assertThat(result.familyRootId()).isEqualTo(rootSessionId[0]);
+    assertThat(result.revokedCount()).isEqualTo(1);
     assertThat(statuses)
         .containsEntry("active-descendant", "REVOKED")
         .containsEntry("rotated-middle", "ROTATED")

--- a/back/src/test/java/com/aquilabank/global/security/RefreshTokenReuseAuditEventPublisherTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/RefreshTokenReuseAuditEventPublisherTest.java
@@ -1,0 +1,41 @@
+package com.aquilabank.global.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.aquilabank.domain.auth.model.RefreshTokenReuseAuditEvent;
+import com.aquilabank.domain.auth.model.RefreshTokenReuseReason;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenReuseAuditEventPublisherTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-22T02:00:00Z");
+  private static final String METRIC_NAME = "aquila.auth.refresh_token_reuse.detected.count";
+
+  @Test
+  void incrementsReuseCounterByReasonCodeOnly() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    RefreshTokenReuseAuditEventPublisher publisher =
+        new RefreshTokenReuseAuditEventPublisher(registry);
+
+    publisher.record(event());
+    publisher.record(event());
+
+    assertEquals(2.0, registry.counter(METRIC_NAME, "reason_code", "ROTATED_TOKEN_REUSE").count());
+  }
+
+  private RefreshTokenReuseAuditEvent event() {
+    return new RefreshTokenReuseAuditEvent(
+        "req-1",
+        7L,
+        11L,
+        3L,
+        33L,
+        1,
+        "Windows / Chrome",
+        "203.0.113.10",
+        RefreshTokenReuseReason.ROTATED_TOKEN_REUSE,
+        NOW);
+  }
+}

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -54,6 +54,7 @@
   - SSE total session `> 56`
 - auth baseline:
   - current session active gate reject rate `> 0` for `5m`
+  - refresh token reuse detected rate `> 0` for `1m`
 - transaction baseline:
   - success query p95 SLO: reference_exact `80ms`, first_page `120ms`, cursor/status/direction `150ms`, amount/mixed `180ms`
   - success query 평균 latency `> 750ms`
@@ -98,3 +99,4 @@ bash tools/ops/validate-prometheus-assets.sh
 - notification lag/DLQ alert는 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true`가 아니면 metric 자체가 export되지 않을 수 있습니다.
 - multi-instance SSE 합계는 Grafana/Prometheus 쿼리에서 인스턴스 합산으로 해석하고, 단일 instance alert는 node별 pressure 확인 용도로만 씁니다.
 - `AquilaCurrentSessionActiveGateRejectDetected`는 `reason_code`만 집계합니다. `requestId`, `userId`, `sessionId`, `path`는 cardinality 때문에 alert label로 올리지 않고 app structured log에서 drill-down합니다.
+- `AquilaRefreshTokenReuseDetected`는 공격성 재사용 후보라 critical baseline입니다. `requestId`, `userId`, `reusedSessionId`, `familyRootId`는 cardinality 때문에 alert label로 올리지 않고 app structured log에서 drill-down합니다.

--- a/ops/prometheus/rules/aquila-bank-alerts.yml
+++ b/ops/prometheus/rules/aquila-bank-alerts.yml
@@ -114,6 +114,19 @@ groups:
           description: "민감 mutation에서 current session active gate 차단이 5분 이상 발생했습니다. requestId 기준 structured audit log를 먼저 확인합니다."
           runbook_path: "back/README.md#prometheus-metrics"
 
+      - alert: AquilaRefreshTokenReuseDetected
+        expr: sum(rate(aquila_auth_refresh_token_reuse_detected_count_total[5m])) > 0
+        for: 1m
+        labels:
+          severity: critical
+          service: aquila-bank
+          domain: auth
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank refresh token reuse detected"
+          description: "refresh token reuse 감지가 발생했습니다. requestId 기준 structured audit log와 revokedCount를 즉시 확인합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
   - name: aquila-bank-transaction
     interval: 30s
     rules:


### PR DESCRIPTION
## 🔗 Related Issue
- close #219

## 🌿 Base Branch
- `main`

## 📝 Summary
- `ROTATED` refresh token 재사용 감지 시 family revoke 결과를 audit event와 structured log로 기록합니다.
- `reason_code` 기준 Prometheus counter/alert를 추가하고, 운영 문서에 조사/rollback 기준을 정리합니다.

## 🛠 Changes
- `RefreshTokenReuseAuditEvent`, `RefreshTokenReuseAuditPort`, `RefreshTokenReuseReason` 추가
- `revokeFamily()`가 `familyRootId`, `revokedCount`를 반환하도록 변경
- refresh request `requestId`를 domain command로 전달해 reuse audit에 포함
- `aquila.auth.refresh_token_reuse.detected.count` counter와 `AquilaRefreshTokenReuseDetected` alert 추가
- README와 Prometheus baseline 문서에 metric, alert 의미, drill-down 기준, rollback 기준 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh refresh-token-reuse-alerting ./back/gradlew -p back test --tests '*RefreshTokenServiceTest' --tests '*JdbcAuthRefreshTokenSessionFamilyRepositoryIntegrationTest' --tests '*RefreshTokenReuseAuditEventPublisherTest'`
- `bash tools/ops/validate-prometheus-assets.sh`
- `tools/test/with-resource-lock.sh refresh-token-reuse-alerting ./back/gradlew -p back check`
- `git rev-list --count main..HEAD` -> `3`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: alert는 reuse 감지 즉시 critical baseline으로 울리므로 운영 routing에 따라 noise가 커질 수 있습니다. public refresh 응답은 기존 generic `401 refresh failed`를 유지합니다.
- 롤백 방법: PR revert 또는 `AquilaRefreshTokenReuseDetected` rule 제거/routing 비활성화로 처리합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
