### PR TITLE
[Chore] 내부 auth 409 reason code 표준화

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -856,8 +856,9 @@ requestId drill-down:
 #### 409 운영 기준
 
 - 현재 known 상태:
-  - 내부 auth status update 경로에서 `409` 대표 error 문구는 아직 고정돼 있지 않습니다.
-  - 현재 runbook에서는 `httpStatus=409`와 같은 `actorSubject`/`path` 반복 패턴을 먼저 수집하고, 세부 error 분류는 후속 구현 이슈로 남깁니다.
+  - 내부 auth 409 응답은 기존 `message`를 유지하면서 분기용 `reasonCode`를 함께 반환합니다.
+  - 현재 표준 code는 `DUPLICATE_LOGIN_ID`, `DUPLICATE_EXTERNAL_IDENTITY_MAPPING`, `STATUS_TRANSITION_CONFLICT`입니다.
+  - `STATUS_TRANSITION_CONFLICT`는 상태 전이 불가 예외가 추가될 때 쓰는 예약 code이며, 현재 대표 실사용 code는 중복 loginId와 external identity mapping 중복입니다.
 - 수집 패턴:
 
 ```text
@@ -872,6 +873,20 @@ requestId drill-down:
   - 같은 대상에 대한 중복 상태 변경 시도
   - caller 재시도 정책 또는 수동 재실행 충돌
   - 상태 전이 전후 확인이 필요한 경쟁 조건 후보
+- 응답 예시:
+
+```json
+{
+  "status": 409,
+  "error": "Conflict",
+  "reasonCode": "DUPLICATE_EXTERNAL_IDENTITY_MAPPING",
+  "message": "external identity mapping already exists"
+}
+```
+
+- rollback:
+  - PR revert 시 `reasonCode` 필드만 사라지고 기존 `message` 기반 fallback은 유지됩니다.
+  - 운영 스크립트는 배포 전환 기간 동안 `reasonCode` 우선, 없으면 `message` fallback 순서로 분기합니다.
 
 #### 500 운영 기준
 
@@ -913,6 +928,7 @@ requestId 우선 drill-down:
 
 - 기본 처리:
   - 단발 `409`는 warning 전송보다 중복 호출, caller retry, 상태 전이 충돌 후보를 먼저 분리합니다.
+  - 응답 `reasonCode`를 우선 확인하고, 필드가 없으면 구버전 응답으로 보고 `message` fallback을 사용합니다.
 - 제외 조건:
   - 같은 actor의 단발 중복 호출이고, 인접 시간대에 성공 감사 row가 확인되는 경우
   - 수동 재실행이나 caller retry가 이미 적용된 상태로 보이는 경우

--- a/back/src/main/java/com/aquilabank/domain/auth/model/InternalAuthConflictReasonCode.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/InternalAuthConflictReasonCode.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.auth.model;
+
+/** 내부 auth 409 응답 분기 기준을 free-text message에서 분리합니다. */
+public enum InternalAuthConflictReasonCode {
+  DUPLICATE_LOGIN_ID,
+  DUPLICATE_EXTERNAL_IDENTITY_MAPPING,
+  STATUS_TRANSITION_CONFLICT
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -13,6 +13,7 @@ import com.aquilabank.domain.auth.exception.InvalidCredentialsException;
 import com.aquilabank.domain.auth.exception.PasswordRecoveryTokenNotFoundException;
 import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
+import com.aquilabank.domain.auth.model.InternalAuthConflictReasonCode;
 import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
@@ -148,7 +149,17 @@ public class ApiExceptionHandler {
     InsufficientBalanceException.class,
     LedgerSnapshotOpenDriftNotFoundException.class
   })
-  ResponseEntity<ApiErrorResponse> handleConflict(RuntimeException ex, HttpServletRequest request) {
+  ResponseEntity<?> handleConflict(RuntimeException ex, HttpServletRequest request) {
+    if (ex instanceof DuplicateLoginIdException) {
+      return conflictResponse(
+          InternalAuthConflictReasonCode.DUPLICATE_LOGIN_ID, ex.getMessage(), request);
+    }
+    if (ex instanceof DuplicateExternalIdentityMappingException) {
+      return conflictResponse(
+          InternalAuthConflictReasonCode.DUPLICATE_EXTERNAL_IDENTITY_MAPPING,
+          ex.getMessage(),
+          request);
+    }
     return response(HttpStatus.CONFLICT, ex.getMessage(), request);
   }
 
@@ -167,6 +178,20 @@ public class ApiExceptionHandler {
                 Instant.now(),
                 status.value(),
                 status.getReasonPhrase(),
+                message,
+                request.getRequestURI()));
+  }
+
+  private ResponseEntity<ApiConflictErrorResponse> conflictResponse(
+      InternalAuthConflictReasonCode reasonCode, String message, HttpServletRequest request) {
+    logInternalAuthStatusFailure(HttpStatus.CONFLICT, request, message);
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(
+            new ApiConflictErrorResponse(
+                Instant.now(),
+                HttpStatus.CONFLICT.value(),
+                HttpStatus.CONFLICT.getReasonPhrase(),
+                reasonCode.name(),
                 message,
                 request.getRequestURI()));
   }
@@ -292,4 +317,13 @@ public class ApiExceptionHandler {
   /** 모든 API가 공유하는 기본 error body */
   public record ApiErrorResponse(
       Instant timestamp, int status, String error, String message, String path) {}
+
+  /** 내부 auth conflict는 기존 message를 유지하되 분기 기준 reasonCode를 별도 제공합니다. */
+  public record ApiConflictErrorResponse(
+      Instant timestamp,
+      int status,
+      String error,
+      String reasonCode,
+      String message,
+      String path) {}
 }

--- a/back/src/test/java/com/aquilabank/global/web/auth/AuthBootstrapControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/AuthBootstrapControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.aquilabank.domain.auth.exception.DuplicateLoginIdException;
 import com.aquilabank.domain.auth.model.MembershipRole;
 import com.aquilabank.domain.auth.model.MembershipStatus;
 import com.aquilabank.domain.auth.model.UserAccountMembership;
@@ -124,5 +125,31 @@ class AuthBootstrapControllerTest {
                     """))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+
+  @Test
+  void rejectsDuplicateLoginIdAsConflictWithReasonCode() throws Exception {
+    when(userBootstrapUseCase.bootstrap(argThat(command -> "alice".equals(command.loginId()))))
+        .thenThrow(new DuplicateLoginIdException("loginId is already used"));
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/auth/users/bootstrap")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        "auth-bootstrap-test", InternalServiceScope.AUTH_BOOTSTRAP))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "loginId": "alice",
+                      "password": "password123!",
+                      "displayName": "Alice"
+                    }
+                    """))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.reasonCode").value("DUPLICATE_LOGIN_ID"))
+        .andExpect(jsonPath("$.message").value("loginId is already used"));
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthAdminControllerTest.java
@@ -329,6 +329,7 @@ class InternalAuthAdminControllerTest {
                     }
                     """))
         .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.reasonCode").value("DUPLICATE_EXTERNAL_IDENTITY_MAPPING"))
         .andExpect(jsonPath("$.message").value("external identity mapping already exists"));
   }
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #220

## 🌿 Base Branch
- `main`

## 📝 Summary
- 내부 auth 409 응답에 분기용 `reasonCode`를 추가합니다.
- 기존 `message`/`status`/`path`는 유지하고, auth conflict 예외만 전용 DTO로 매핑했습니다.

## 🛠 Changes
- `InternalAuthConflictReasonCode` enum 추가
- `DuplicateLoginIdException`, `DuplicateExternalIdentityMappingException`을 표준 409 `reasonCode`로 매핑
- internal auth/bootstrap controller 테스트에 reasonCode 검증 추가
- README에 409 reason code 목록과 fallback/rollback 기준 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh internal-auth-409-reason-code ./back/gradlew -p back test --tests '*InternalAuthAdminControllerTest' --tests '*AuthBootstrapControllerTest'`
- `tools/test/with-resource-lock.sh internal-auth-409-reason-code ./back/gradlew -p back check`
- `git rev-list --count main..HEAD` -> `2`

## 📸 Screenshot / API Example
```json
{
  "status": 409,
  "error": "Conflict",
  "reasonCode": "DUPLICATE_EXTERNAL_IDENTITY_MAPPING",
  "message": "external identity mapping already exists"
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: 409 응답을 파싱하는 스크립트가 새 `reasonCode`를 우선 사용하도록 전환해야 합니다. 기존 `message`는 유지됩니다.
- 롤백 방법: PR revert. 구버전 응답에서는 `message` fallback으로 계속 분기합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
