### PR TITLE
[Feat] internal auth status audit 검색/목록 API 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -965,6 +965,19 @@ tools/ops/internal-auth-find-status-change-audit.sh \
 - wrapper script 내부에서 exact lookup endpoint, `Authorization: Bearer`, `requestId` query를 고정합니다.
 - failure 원본은 structured log이므로 incident 시작점은 항상 로그 검색입니다.
 
+success audit 목록/검색 예시:
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $AUTH_ADMIN_SERVICE_TOKEN" \
+  "http://localhost:8080/internal/api/v1/auth/status-change-audits?fromCreatedAt=2026-04-01T00:00:00Z&toCreatedAt=2026-04-22T00:00:00Z&targetUserId=21&targetAccountId=101&changeType=MEMBERSHIP_STATUS&reasonCode=OPS_MANUAL&size=50"
+```
+
+- 목록 API는 `created_at DESC, id DESC` keyset pagination만 사용합니다. 다음 페이지는 응답 `nextCursor`를 `cursor` query로 그대로 전달합니다.
+- 지원 필터는 `fromCreatedAt`, `toCreatedAt`, `targetUserId`, `targetAccountId`, `changeType`, `reasonCode`, `size`, `cursor`입니다.
+- 기본 `size=50`, 최대 `size=200`이며 그 이상은 서버에서 `200`으로 제한합니다.
+- 검색 index는 `idx_auth_status_change_audit_*_created_id` 계열로 유지합니다. rollback 시 API PR revert와 함께 `V42__add_auth_status_change_audit_search_indexes.sql`로 추가된 index 제거 여부를 확인합니다.
+
 ## Outbox Ops Runbook
 
 Kafka producer 를 붙인 이후 outbox backlog 는 actuator health 와 내부 ops 경로를 같이 봐야 복구 판단이 빨라집니다.

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditCursor.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditCursor.java
@@ -1,0 +1,42 @@
+package com.aquilabank.domain.auth.model;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+public record AuthStatusChangeAuditCursor(Instant createdAt, long auditId) {
+
+  private static final String SEPARATOR = "|";
+
+  public AuthStatusChangeAuditCursor {
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+    if (auditId <= 0) {
+      throw new IllegalArgumentException("auditId must be positive");
+    }
+  }
+
+  public String encode() {
+    String value = createdAt + SEPARATOR + auditId;
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static AuthStatusChangeAuditCursor decode(String cursor) {
+    if (cursor == null || cursor.isBlank()) {
+      return null;
+    }
+    try {
+      String value = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+      String[] parts = value.split("\\|", -1);
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("cursor is invalid");
+      }
+      return new AuthStatusChangeAuditCursor(Instant.parse(parts[0]), Long.parseLong(parts[1]));
+    } catch (RuntimeException ex) {
+      throw new IllegalArgumentException("cursor is invalid", ex);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditItem.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditItem.java
@@ -1,0 +1,62 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+/** 목록 cursor 생성을 위해 exact lookup summary와 달리 audit id를 포함합니다. */
+public record AuthStatusChangeAuditItem(
+    long auditId,
+    String requestId,
+    String actorSubject,
+    AuthStatusChangeType changeType,
+    long targetUserId,
+    Long targetAccountId,
+    String beforeStatus,
+    String afterStatus,
+    AuthStatusChangeReason normalizedReason,
+    AuthStatusChangeOutcome outcome,
+    Instant createdAt) {
+
+  public AuthStatusChangeAuditItem {
+    if (auditId <= 0) {
+      throw new IllegalArgumentException("auditId must be positive");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (changeType == null) {
+      throw new IllegalArgumentException("changeType is required");
+    }
+    if (targetUserId <= 0) {
+      throw new IllegalArgumentException("targetUserId must be positive");
+    }
+    if (targetAccountId != null && targetAccountId <= 0) {
+      throw new IllegalArgumentException("targetAccountId must be positive");
+    }
+    if (beforeStatus == null || beforeStatus.isBlank()) {
+      throw new IllegalArgumentException("beforeStatus is required");
+    }
+    if (afterStatus == null || afterStatus.isBlank()) {
+      throw new IllegalArgumentException("afterStatus is required");
+    }
+    if (normalizedReason == null) {
+      throw new IllegalArgumentException("normalizedReason is required");
+    }
+    if (outcome == null) {
+      throw new IllegalArgumentException("outcome is required");
+    }
+    if (createdAt == null) {
+      throw new IllegalArgumentException("createdAt is required");
+    }
+  }
+
+  public AuthStatusChangeReasonCode reasonCode() {
+    return normalizedReason.reasonCode();
+  }
+
+  public String reasonDetail() {
+    return normalizedReason.reasonDetail();
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditSearchQuery.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditSearchQuery.java
@@ -1,0 +1,35 @@
+package com.aquilabank.domain.auth.model;
+
+import java.time.Instant;
+
+public record AuthStatusChangeAuditSearchQuery(
+    Instant fromCreatedAt,
+    Instant toCreatedAt,
+    Long targetUserId,
+    Long targetAccountId,
+    AuthStatusChangeType changeType,
+    AuthStatusChangeReasonCode reasonCode,
+    AuthStatusChangeAuditCursor cursor,
+    int size) {
+
+  public static final int DEFAULT_SIZE = 50;
+  public static final int MAX_SIZE = 200;
+
+  public AuthStatusChangeAuditSearchQuery {
+    if (fromCreatedAt != null && toCreatedAt != null && fromCreatedAt.isAfter(toCreatedAt)) {
+      throw new IllegalArgumentException("fromCreatedAt must be before or equal to toCreatedAt");
+    }
+    if (targetUserId != null && targetUserId <= 0) {
+      throw new IllegalArgumentException("targetUserId must be positive");
+    }
+    if (targetAccountId != null && targetAccountId <= 0) {
+      throw new IllegalArgumentException("targetAccountId must be positive");
+    }
+    if (size <= 0) {
+      size = DEFAULT_SIZE;
+    }
+    if (size > MAX_SIZE) {
+      size = MAX_SIZE;
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditSearchResult.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/AuthStatusChangeAuditSearchResult.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.auth.model;
+
+import java.util.List;
+
+public record AuthStatusChangeAuditSearchResult(
+    List<AuthStatusChangeAuditItem> items, String nextCursor) {
+
+  public AuthStatusChangeAuditSearchResult {
+    items = List.copyOf(items == null ? List.of() : items);
+    if (nextCursor != null && nextCursor.isBlank()) {
+      nextCursor = null;
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/port/AuthStatusChangeAuditQueryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/AuthStatusChangeAuditQueryPort.java
@@ -1,5 +1,7 @@
 package com.aquilabank.domain.auth.port;
 
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchQuery;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchResult;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 import java.util.Optional;
 
@@ -7,4 +9,8 @@ import java.util.Optional;
 public interface AuthStatusChangeAuditQueryPort {
 
   Optional<AuthStatusChangeAuditSummary> findByRequestId(String requestId);
+
+  default AuthStatusChangeAuditSearchResult search(AuthStatusChangeAuditSearchQuery query) {
+    throw new UnsupportedOperationException("auth status change audit search is not implemented");
+  }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryService.java
@@ -1,6 +1,8 @@
 package com.aquilabank.domain.auth.usecase;
 
 import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchQuery;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchResult;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
 
@@ -22,5 +24,13 @@ public final class AuthStatusChangeAuditQueryService implements AuthStatusChange
     return authStatusChangeAuditQueryPort
         .findByRequestId(requestId)
         .orElseThrow(() -> new AuthStatusChangeAuditNotFoundException("audit record is not found"));
+  }
+
+  @Override
+  public AuthStatusChangeAuditSearchResult search(AuthStatusChangeAuditSearchQuery query) {
+    if (query == null) {
+      throw new IllegalArgumentException("query is required");
+    }
+    return authStatusChangeAuditQueryPort.search(query);
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryUseCase.java
@@ -1,8 +1,12 @@
 package com.aquilabank.domain.auth.usecase;
 
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchQuery;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchResult;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 
 public interface AuthStatusChangeAuditQueryUseCase {
 
   AuthStatusChangeAuditSummary getByRequestId(String requestId);
+
+  AuthStatusChangeAuditSearchResult search(AuthStatusChangeAuditSearchQuery query);
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcAuthRepository.java
@@ -3,6 +3,10 @@ package com.aquilabank.global.persistence.auth;
 import com.aquilabank.domain.account.model.AccountStatus;
 import com.aquilabank.domain.auth.model.AccountAccessMembership;
 import com.aquilabank.domain.auth.model.AuthSessionSummary;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditCursor;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditItem;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchQuery;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchResult;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
@@ -43,6 +47,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -524,6 +529,87 @@ public class JdbcAuthRepository
         .findFirst();
   }
 
+  @Override
+  public AuthStatusChangeAuditSearchResult search(AuthStatusChangeAuditSearchQuery query) {
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("limit", query.size() + 1);
+    StringBuilder sql =
+        new StringBuilder(
+            """
+            SELECT id,
+                   request_id,
+                   actor_subject,
+                   change_type,
+                   target_user_id,
+                   target_account_id,
+                   before_status,
+                   after_status,
+                   reason_code,
+                   reason,
+                   outcome,
+                   created_at
+            FROM auth_status_change_audit
+            WHERE 1 = 1
+            """);
+    addFilter(
+        sql, parameters, "created_at >= :fromCreatedAt", "fromCreatedAt", query.fromCreatedAt());
+    addFilter(sql, parameters, "created_at <= :toCreatedAt", "toCreatedAt", query.toCreatedAt());
+    addFilter(
+        sql, parameters, "target_user_id = :targetUserId", "targetUserId", query.targetUserId());
+    addFilter(
+        sql,
+        parameters,
+        "target_account_id = :targetAccountId",
+        "targetAccountId",
+        query.targetAccountId());
+    addFilter(
+        sql,
+        parameters,
+        "change_type = :changeType",
+        "changeType",
+        query.changeType() == null ? null : query.changeType().name());
+    addFilter(
+        sql,
+        parameters,
+        "reason_code = :reasonCode",
+        "reasonCode",
+        query.reasonCode() == null ? null : query.reasonCode().name());
+    if (query.cursor() != null) {
+      sql.append(" AND (created_at, id) < (:cursorCreatedAt, :cursorId)\n");
+      parameters.addValue("cursorCreatedAt", Timestamp.from(query.cursor().createdAt()));
+      parameters.addValue("cursorId", query.cursor().auditId());
+    }
+    // keyset pagination 전용 정렬입니다. idx_auth_status_change_audit_*_created_id 계열과 맞춰 유지합니다.
+    sql.append(" ORDER BY created_at DESC, id DESC LIMIT :limit");
+
+    List<AuthStatusChangeAuditItem> rows =
+        jdbcTemplate.query(
+            sql.toString(), parameters, (rs, rowNum) -> mapStatusChangeAuditItem(rs));
+    List<AuthStatusChangeAuditItem> items = new ArrayList<>(rows);
+    String nextCursor = null;
+    if (items.size() > query.size()) {
+      items.removeLast();
+      AuthStatusChangeAuditItem lastItem = items.getLast();
+      nextCursor =
+          new AuthStatusChangeAuditCursor(lastItem.createdAt(), lastItem.auditId()).encode();
+    }
+    return new AuthStatusChangeAuditSearchResult(items, nextCursor);
+  }
+
+  private void addFilter(
+      StringBuilder sql,
+      MapSqlParameterSource parameters,
+      String condition,
+      String parameterName,
+      Object value) {
+    if (value == null) {
+      return;
+    }
+    sql.append(" AND ").append(condition).append('\n');
+    parameters.addValue(
+        parameterName, value instanceof Instant instant ? Timestamp.from(instant) : value);
+  }
+
   private LoginUser mapLoginUser(ResultSet rs) throws SQLException {
     return new LoginUser(
         rs.getLong("id"),
@@ -650,6 +736,24 @@ public class JdbcAuthRepository
       throws SQLException {
     Long targetAccountId = rs.getObject("target_account_id", Long.class);
     return new AuthStatusChangeAuditSummary(
+        rs.getString("request_id"),
+        rs.getString("actor_subject"),
+        AuthStatusChangeType.valueOf(rs.getString("change_type")),
+        rs.getLong("target_user_id"),
+        targetAccountId,
+        rs.getString("before_status"),
+        rs.getString("after_status"),
+        new AuthStatusChangeReason(
+            AuthStatusChangeReasonCode.valueOf(rs.getString("reason_code")),
+            rs.getString("reason")),
+        AuthStatusChangeOutcome.valueOf(rs.getString("outcome")),
+        toInstant(rs.getTimestamp("created_at")));
+  }
+
+  private AuthStatusChangeAuditItem mapStatusChangeAuditItem(ResultSet rs) throws SQLException {
+    Long targetAccountId = rs.getObject("target_account_id", Long.class);
+    return new AuthStatusChangeAuditItem(
+        rs.getLong("id"),
         rs.getString("request_id"),
         rs.getString("actor_subject"),
         AuthStatusChangeType.valueOf(rs.getString("change_type")),

--- a/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditController.java
@@ -1,13 +1,21 @@
 package com.aquilabank.global.web.auth;
 
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditCursor;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditItem;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchQuery;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchResult;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
+import com.aquilabank.domain.auth.model.AuthStatusChangeType;
 import com.aquilabank.domain.auth.usecase.AuthStatusChangeAuditQueryUseCase;
 import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotBlank;
 import java.time.Instant;
+import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,6 +49,35 @@ public class InternalAuthStatusChangeAuditController {
         authStatusChangeAuditQueryUseCase.getByRequestId(requestId));
   }
 
+  @GetMapping
+  public AuthStatusChangeAuditListResponse search(
+      HttpServletRequest httpServletRequest,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          Instant fromCreatedAt,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          Instant toCreatedAt,
+      @RequestParam(required = false) Long targetUserId,
+      @RequestParam(required = false) Long targetAccountId,
+      @RequestParam(required = false) AuthStatusChangeType changeType,
+      @RequestParam(required = false) AuthStatusChangeReasonCode reasonCode,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(defaultValue = "50") int size) {
+    internalServiceRequestAuthorizer.requireScope(
+        httpServletRequest, InternalServiceScope.AUTH_ADMIN);
+    AuthStatusChangeAuditSearchResult result =
+        authStatusChangeAuditQueryUseCase.search(
+            new AuthStatusChangeAuditSearchQuery(
+                fromCreatedAt,
+                toCreatedAt,
+                targetUserId,
+                targetAccountId,
+                changeType,
+                reasonCode,
+                AuthStatusChangeAuditCursor.decode(cursor),
+                size));
+    return AuthStatusChangeAuditListResponse.from(result);
+  }
+
   /** 내부 auth status change audit exact lookup 응답 */
   public record AuthStatusChangeAuditResponse(
       String requestId,
@@ -71,5 +108,31 @@ public class InternalAuthStatusChangeAuditController {
           summary.outcome().name(),
           summary.createdAt());
     }
+  }
+
+  public record AuthStatusChangeAuditListResponse(
+      List<AuthStatusChangeAuditResponse> items, String nextCursor) {
+
+    static AuthStatusChangeAuditListResponse from(AuthStatusChangeAuditSearchResult result) {
+      return new AuthStatusChangeAuditListResponse(
+          result.items().stream().map(InternalAuthStatusChangeAuditController::from).toList(),
+          result.nextCursor());
+    }
+  }
+
+  private static AuthStatusChangeAuditResponse from(AuthStatusChangeAuditItem item) {
+    return new AuthStatusChangeAuditResponse(
+        item.requestId(),
+        item.actorSubject(),
+        item.targetUserId(),
+        item.targetAccountId(),
+        item.changeType().name(),
+        item.beforeStatus(),
+        item.afterStatus(),
+        item.reasonCode().name(),
+        item.reasonDetail(),
+        item.reasonDetail(),
+        item.outcome().name(),
+        item.createdAt());
   }
 }

--- a/back/src/main/resources/db/migration/V42__add_auth_status_change_audit_search_indexes.sql
+++ b/back/src/main/resources/db/migration/V42__add_auth_status_change_audit_search_indexes.sql
@@ -1,0 +1,16 @@
+-- auth audit 목록은 created_at DESC, id DESC keyset pagination으로 고정해 offset 비용을 피합니다.
+CREATE INDEX idx_auth_status_change_audit_created_id
+    ON auth_status_change_audit (created_at DESC, id DESC);
+
+CREATE INDEX idx_auth_status_change_audit_user_created_id
+    ON auth_status_change_audit (target_user_id, created_at DESC, id DESC);
+
+CREATE INDEX idx_auth_status_change_audit_account_created_id
+    ON auth_status_change_audit (target_account_id, created_at DESC, id DESC)
+    WHERE target_account_id IS NOT NULL;
+
+CREATE INDEX idx_auth_status_change_audit_type_created_id
+    ON auth_status_change_audit (change_type, created_at DESC, id DESC);
+
+CREATE INDEX idx_auth_status_change_audit_reason_created_id
+    ON auth_status_change_audit (reason_code, created_at DESC, id DESC);

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/AuthStatusChangeAuditQueryServiceTest.java
@@ -1,0 +1,62 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditItem;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchQuery;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchResult;
+import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
+import com.aquilabank.domain.auth.model.AuthStatusChangeType;
+import com.aquilabank.domain.auth.port.AuthStatusChangeAuditQueryPort;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AuthStatusChangeAuditQueryServiceTest {
+
+  @Test
+  void searchesAuditWithBoundedSizeAndKeysetCursor() {
+    AuthStatusChangeAuditQueryPort port = mock(AuthStatusChangeAuditQueryPort.class);
+    AuthStatusChangeAuditSearchQuery query =
+        new AuthStatusChangeAuditSearchQuery(
+            Instant.parse("2026-04-01T00:00:00Z"),
+            Instant.parse("2026-04-22T00:00:00Z"),
+            21L,
+            null,
+            AuthStatusChangeType.USER_STATUS,
+            AuthStatusChangeReasonCode.FRAUD_REVIEW,
+            null,
+            500);
+    AuthStatusChangeAuditSearchResult result =
+        new AuthStatusChangeAuditSearchResult(List.of(item()), "next-cursor");
+    when(port.search(query)).thenReturn(result);
+    AuthStatusChangeAuditQueryService service = new AuthStatusChangeAuditQueryService(port);
+
+    AuthStatusChangeAuditSearchResult actual = service.search(query);
+
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.nextCursor()).isEqualTo("next-cursor");
+    assertThat(query.size()).isEqualTo(AuthStatusChangeAuditSearchQuery.MAX_SIZE);
+    verify(port).search(query);
+  }
+
+  private AuthStatusChangeAuditItem item() {
+    return new AuthStatusChangeAuditItem(
+        101L,
+        "request-001",
+        "ops-admin",
+        AuthStatusChangeType.USER_STATUS,
+        21L,
+        null,
+        "ACTIVE",
+        "DISABLED",
+        new AuthStatusChangeReason(AuthStatusChangeReasonCode.FRAUD_REVIEW, "fraud-review"),
+        AuthStatusChangeOutcome.SUCCESS,
+        Instant.parse("2026-04-21T00:00:00Z"));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthStatusChangeAuditSearchRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcAuthStatusChangeAuditSearchRepositoryIntegrationTest.java
@@ -1,0 +1,201 @@
+package com.aquilabank.global.persistence.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchQuery;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchResult;
+import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
+import com.aquilabank.domain.auth.model.AuthStatusChangeType;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcAuthStatusChangeAuditSearchRepositoryIntegrationTest
+    extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcAuthRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void searchesAuditWithFiltersAndKeysetCursor() {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("audit-search-user");
+          accountId[0] = insertAccount("audit-search-account");
+          insertAudit(
+              "request-old",
+              userId[0],
+              accountId[0],
+              AuthStatusChangeReasonCode.OPS_MANUAL,
+              Instant.parse("2026-04-19T01:00:00Z"));
+          insertAudit(
+              "request-new",
+              userId[0],
+              accountId[0],
+              AuthStatusChangeReasonCode.OPS_MANUAL,
+              Instant.parse("2026-04-20T01:00:00Z"));
+          insertAudit(
+              "request-noise",
+              userId[0],
+              accountId[0],
+              AuthStatusChangeReasonCode.FRAUD_REVIEW,
+              Instant.parse("2026-04-21T01:00:00Z"));
+        });
+
+    AuthStatusChangeAuditSearchResult firstPage =
+        repository.search(
+            new AuthStatusChangeAuditSearchQuery(
+                Instant.parse("2026-04-01T00:00:00Z"),
+                Instant.parse("2026-04-22T00:00:00Z"),
+                userId[0],
+                accountId[0],
+                AuthStatusChangeType.MEMBERSHIP_STATUS,
+                AuthStatusChangeReasonCode.OPS_MANUAL,
+                null,
+                1));
+
+    assertThat(firstPage.items()).extracting("requestId").containsExactly("request-new");
+    assertThat(firstPage.nextCursor()).isNotBlank();
+
+    AuthStatusChangeAuditSearchResult secondPage =
+        repository.search(
+            new AuthStatusChangeAuditSearchQuery(
+                Instant.parse("2026-04-01T00:00:00Z"),
+                Instant.parse("2026-04-22T00:00:00Z"),
+                userId[0],
+                accountId[0],
+                AuthStatusChangeType.MEMBERSHIP_STATUS,
+                AuthStatusChangeReasonCode.OPS_MANUAL,
+                com.aquilabank.domain.auth.model.AuthStatusChangeAuditCursor.decode(
+                    firstPage.nextCursor()),
+                1));
+
+    assertThat(secondPage.items()).extracting("requestId").containsExactly("request-old");
+    assertThat(secondPage.nextCursor()).isNull();
+  }
+
+  private long insertUser(String loginId) {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (
+                login_id,
+                password_hash,
+                display_name,
+                user_status,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :loginId,
+                '$2a$10$abcdefghijklmnopqrstuv',
+                :loginId,
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("loginId", loginId),
+            Long.class);
+    if (userId == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return userId;
+  }
+
+  private long insertAccount(String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                nextval('bank_account_number_seq')::text,
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource().addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertAudit(
+      String requestId,
+      long userId,
+      long accountId,
+      AuthStatusChangeReasonCode reasonCode,
+      Instant createdAt) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO auth_status_change_audit (
+            request_id,
+            actor_subject,
+            change_type,
+            target_user_id,
+            target_account_id,
+            before_status,
+            after_status,
+            reason_code,
+            reason,
+            outcome,
+            created_at
+        )
+        VALUES (
+            :requestId,
+            'ops-admin',
+            'MEMBERSHIP_STATUS',
+            :userId,
+            :accountId,
+            'ACTIVE',
+            'REVOKED',
+            :reasonCode,
+            :reason,
+            'SUCCESS',
+            :createdAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("requestId", requestId)
+            .addValue("userId", userId)
+            .addValue("accountId", accountId)
+            .addValue("reasonCode", reasonCode.name())
+            .addValue("reason", reasonCode.name().toLowerCase())
+            .addValue("createdAt", Timestamp.from(createdAt)));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/InternalAuthStatusChangeAuditControllerTest.java
@@ -7,6 +7,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.aquilabank.domain.auth.exception.AuthStatusChangeAuditNotFoundException;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditItem;
+import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSearchResult;
 import com.aquilabank.domain.auth.model.AuthStatusChangeAuditSummary;
 import com.aquilabank.domain.auth.model.AuthStatusChangeOutcome;
 import com.aquilabank.domain.auth.model.AuthStatusChangeReason;
@@ -17,6 +19,7 @@ import com.aquilabank.global.security.InternalServiceScope;
 import com.aquilabank.global.security.InternalServiceTokenTestSupport;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
@@ -37,6 +40,42 @@ class InternalAuthStatusChangeAuditControllerTest {
                     InternalServiceTokenTestSupport.authorizer()))
             .setControllerAdvice(new ApiExceptionHandler())
             .build();
+  }
+
+  @Test
+  void searchesAuditsWithFiltersAndKeysetCursor() throws Exception {
+    when(authStatusChangeAuditQueryUseCase.search(
+            org.mockito.ArgumentMatchers.argThat(
+                query ->
+                    query.fromCreatedAt().equals(Instant.parse("2026-04-01T00:00:00Z"))
+                        && query.toCreatedAt().equals(Instant.parse("2026-04-22T00:00:00Z"))
+                        && query.targetUserId().equals(21L)
+                        && query.targetAccountId().equals(101L)
+                        && query.changeType() == AuthStatusChangeType.MEMBERSHIP_STATUS
+                        && query.reasonCode() == AuthStatusChangeReasonCode.OPS_MANUAL
+                        && query.size() == 25)))
+        .thenReturn(new AuthStatusChangeAuditSearchResult(List.of(item()), "next-cursor"));
+
+    mockMvc
+        .perform(
+            get("/internal/api/v1/auth/status-change-audits")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        "ops-admin", InternalServiceScope.AUTH_ADMIN))
+                .param("fromCreatedAt", "2026-04-01T00:00:00Z")
+                .param("toCreatedAt", "2026-04-22T00:00:00Z")
+                .param("targetUserId", "21")
+                .param("targetAccountId", "101")
+                .param("changeType", "MEMBERSHIP_STATUS")
+                .param("reasonCode", "OPS_MANUAL")
+                .param("size", "25"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].requestId").value("request-001"))
+        .andExpect(jsonPath("$.items[0].targetUserId").value(21))
+        .andExpect(jsonPath("$.items[0].targetAccountId").value(101))
+        .andExpect(jsonPath("$.items[0].reasonCode").value("OPS_MANUAL"))
+        .andExpect(jsonPath("$.nextCursor").value("next-cursor"));
   }
 
   @Test
@@ -103,5 +142,20 @@ class InternalAuthStatusChangeAuditControllerTest {
                 .param("requestId", "membership-revoked-request"))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+
+  private AuthStatusChangeAuditItem item() {
+    return new AuthStatusChangeAuditItem(
+        101L,
+        "request-001",
+        "ops-admin",
+        AuthStatusChangeType.MEMBERSHIP_STATUS,
+        21L,
+        101L,
+        "ACTIVE",
+        "REVOKED",
+        new AuthStatusChangeReason(AuthStatusChangeReasonCode.OPS_MANUAL, "manual-revoke"),
+        AuthStatusChangeOutcome.SUCCESS,
+        Instant.parse("2026-04-21T00:00:00Z"));
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #221

## 🌿 Base Branch
- `main`

## 📝 Summary
- 내부 auth status change audit 목록/검색 API를 추가했습니다.
- 기간/대상/변경 타입/사유 필터와 `created_at DESC, id DESC` keyset pagination으로 대량 누적 경로를 bounded query로 유지합니다.

## 🛠 Changes
- `GET /internal/api/v1/auth/status-change-audits` controller/use case/query result/cursor 계약 추가
- JDBC keyset 검색, cursor 다음 페이지 계산, 검색용 index migration 추가
- 내부 운영 README에 검색 예시, 지원 필터, cursor, index/rollback 메모 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh internal-auth-audit-search ./back/gradlew -p back test --tests '*InternalAuthStatusChangeAuditControllerTest' --tests '*AuthStatusChangeAuditQueryServiceTest' --tests '*JdbcAuthStatusChangeAuditSearchRepositoryIntegrationTest'`
- `tools/test/with-resource-lock.sh internal-auth-audit-search ./back/gradlew -p back check`
- `git rev-list --count main..HEAD` → `3`

## 📸 Screenshot / API Example
```bash
curl -sS \
  -H "Authorization: Bearer $AUTH_ADMIN_SERVICE_TOKEN" \
  "http://localhost:8080/internal/api/v1/auth/status-change-audits?fromCreatedAt=2026-04-01T00:00:00Z&toCreatedAt=2026-04-22T00:00:00Z&targetUserId=21&targetAccountId=101&changeType=MEMBERSHIP_STATUS&reasonCode=OPS_MANUAL&size=50"
```

## ⚠️ Risk & Rollback
- 예상 리스크: 새 index 생성 시 기존 audit row 수에 따라 migration 시간이 늘 수 있습니다.
- 롤백 방법: PR revert 후 필요하면 `V42__add_auth_status_change_audit_search_indexes.sql`로 추가된 index 제거 여부를 확인합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
