### PR TITLE
[CI] main SHA staging deploy workflow 추가

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,184 @@
+name: Staging Deploy
+
+on:
+  workflow_run:
+    workflows:
+      - Main CI
+    types:
+      - completed
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: staging-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Main SHA To Staging
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: staging
+    env:
+      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+      DEPLOY_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Checkout deploy SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          fetch-depth: 0
+
+      - name: Validate main SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin main
+
+          checked_out_sha="$(git rev-parse HEAD)"
+          current_main_sha="$(git rev-parse origin/main)"
+
+          if [ "${checked_out_sha}" != "${DEPLOY_SHA}" ]; then
+            echo "::error::Checked out ${checked_out_sha}, expected ${DEPLOY_SHA}."
+            exit 1
+          fi
+
+          # staging은 main 최신 SHA만 자동 배포해 오래된 CI 완료가 역배포를 만들지 않게 한다.
+          if [ "${current_main_sha}" != "${DEPLOY_SHA}" ]; then
+            echo "::error::Deploy SHA ${DEPLOY_SHA} is not current origin/main ${current_main_sha}."
+            exit 1
+          fi
+
+      - name: Create staging deployment
+        id: deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(
+            jq -n \
+              --arg ref "${DEPLOY_SHA}" \
+              --arg description "Deploy main SHA ${DEPLOY_SHA} to staging" \
+              '{
+                ref: $ref,
+                environment: "staging",
+                description: $description,
+                auto_merge: false,
+                required_contexts: [],
+                production_environment: false,
+                transient_environment: false
+              }'
+          )"
+          deployment_id="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments" --input - --jq ".id" <<< "${payload}")"
+
+          if [ -z "${deployment_id}" ]; then
+            echo "::error::Failed to create staging deployment."
+            exit 1
+          fi
+
+          echo "deployment_id=${deployment_id}" >> "${GITHUB_OUTPUT}"
+
+      - name: Mark staging deployment in progress
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(
+            jq -n \
+              --arg log_url "${DEPLOY_LOG_URL}" \
+              '{
+                state: "in_progress",
+                environment: "staging",
+                log_url: $log_url,
+                auto_inactive: false
+              }'
+          )"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
+
+      - name: Dispatch staging deploy hook
+        env:
+          STAGING_DEPLOY_WEBHOOK_URL: ${{ secrets.STAGING_DEPLOY_WEBHOOK_URL }}
+          STAGING_DEPLOY_TOKEN: ${{ secrets.STAGING_DEPLOY_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${STAGING_DEPLOY_WEBHOOK_URL}" ]; then
+            echo "::error::Missing STAGING_DEPLOY_WEBHOOK_URL environment secret."
+            exit 1
+          fi
+
+          if [ -z "${STAGING_DEPLOY_TOKEN}" ]; then
+            echo "::error::Missing STAGING_DEPLOY_TOKEN environment secret."
+            exit 1
+          fi
+
+          payload="$(
+            jq -n \
+              --arg sha "${DEPLOY_SHA}" \
+              --arg repository "${GITHUB_REPOSITORY}" \
+              --arg run_url "${DEPLOY_LOG_URL}" \
+              '{
+                sha: $sha,
+                repository: $repository,
+                environment: "staging",
+                runUrl: $run_url
+              }'
+          )"
+
+          curl --fail-with-body --show-error --silent \
+            --request POST \
+            --header "Authorization: Bearer ${STAGING_DEPLOY_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "${payload}" \
+            "${STAGING_DEPLOY_WEBHOOK_URL}"
+
+      - name: Mark staging deployment success
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(
+            jq -n \
+              --arg log_url "${DEPLOY_LOG_URL}" \
+              '{
+                state: "success",
+                environment: "staging",
+                log_url: $log_url,
+                auto_inactive: false
+              }'
+          )"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
+
+      - name: Mark staging deployment failure
+        if: failure() && steps.deployment.outputs.deployment_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(
+            jq -n \
+              --arg log_url "${DEPLOY_LOG_URL}" \
+              '{
+                state: "failure",
+                environment: "staging",
+                log_url: $log_url,
+                auto_inactive: false
+              }'
+          )"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -21,8 +21,26 @@
 ## Main CI
 
 - `main`에 merge된 SHA는 `Main CI` workflow가 backend/frontend check를 다시 실행합니다.
-- 아직 자동 배포는 연결하지 않습니다.
-- 배포가 필요해지면 별도 workflow 또는 외부 CD 연동을 추가합니다.
+- `Main CI`가 push 이벤트에서 성공하면 `Staging Deploy` workflow가 같은 SHA를 staging에 배포합니다.
+- `Staging Deploy`는 `github.event.workflow_run.head_sha`를 deploy SHA로 고정하고, 현재 `origin/main`과 같은지 검증합니다.
+- 오래된 `Main CI` 완료가 뒤늦게 도착하면 workflow를 실패시켜 staging 역배포를 막습니다.
+
+## Staging Deploy
+
+- GitHub Environment: `staging`
+- concurrency group: `staging-deploy`
+- required environment secrets:
+  - `STAGING_DEPLOY_WEBHOOK_URL`
+  - `STAGING_DEPLOY_TOKEN`
+- deploy hook payload:
+  - `sha`: staging에 배포할 main SHA
+  - `repository`: `owner/repo`
+  - `environment`: `staging`
+  - `runUrl`: GitHub Actions run URL
+- deploy hook secret이 없으면 성공으로 위장하지 않고 fail-fast합니다.
+- workflow는 staging GitHub deployment status를 `in_progress`에서 `success` 또는 `failure`로 갱신합니다.
+- production 승격은 staging deployment status가 `success`인 같은 SHA만 대상으로 삼습니다.
+- rollback은 `main` 기준 revert PR을 merge해 새 staging SHA를 배포하거나, 운영자가 직전 staging 성공 SHA를 확인해 별도 재배포 절차로 진행합니다.
 
 ## Feature Flag
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #222

## 🌿 Base Branch
- `main`

## 📝 Summary
- `Main CI` 성공 후 같은 main merge SHA를 staging으로 배포하는 workflow를 추가했습니다.
- deploy SHA를 현재 `origin/main`과 대조해 오래된 CI 완료가 staging을 역배포하지 못하게 막습니다.

## 🛠 Changes
- `.github/workflows/staging-deploy.yml` 추가
- GitHub Environment `staging`, concurrency `staging-deploy`, GitHub deployment status 기록 추가
- staging deploy hook secret, payload, rollback 기준을 `docs/delivery-flow.md`에 문서화

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"`
- `git diff --check`
- `git rev-list --count main..HEAD` → `2`
- `actionlint`는 로컬에 설치되어 있지 않아 실행하지 못했습니다.

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `STAGING_DEPLOY_WEBHOOK_URL` 또는 `STAGING_DEPLOY_TOKEN` 미구성 시 workflow가 fail-fast합니다.
- 롤백 방법: PR revert 후 필요하면 GitHub Environment `staging` secret 설정을 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
