### PR TITLE
[CI] production promotion approval/tag workflow 추가

### DIFF
--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -1,0 +1,269 @@
+name: Production Promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Staging success main SHA to promote
+        required: true
+        type: string
+  push:
+    tags:
+      - prod-*
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: production-promotion
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Verify Staging Success SHA
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      target_sha: ${{ steps.resolve.outputs.target_sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve promotion target SHA
+        id: resolve
+        env:
+          DISPATCH_SHA: ${{ inputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin main:refs/remotes/origin/main
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [[ ! "${DISPATCH_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "::error::workflow_dispatch input sha must be a full 40-character commit SHA."
+              exit 1
+            fi
+            target_sha="$(git rev-parse "${DISPATCH_SHA}^{commit}")"
+          elif [[ "${GITHUB_REF}" == refs/tags/prod-* ]]; then
+            git fetch --force origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+            target_sha="$(git rev-list -n 1 "${GITHUB_REF_NAME}")"
+          else
+            echo "::error::Unsupported production promotion trigger ${GITHUB_EVENT_NAME} ${GITHUB_REF}."
+            exit 1
+          fi
+
+          if [[ ! "${target_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Resolved target ${target_sha} is not a commit SHA."
+            exit 1
+          fi
+
+          # production은 main 밖 SHA를 받지 않아 staging 검증 우회 배포를 막는다.
+          if ! git merge-base --is-ancestor "${target_sha}" origin/main; then
+            echo "::error::Target SHA ${target_sha} is not reachable from origin/main."
+            exit 1
+          fi
+
+          echo "target_sha=${target_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify staging deployment success
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          deployment_ids="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments" \
+              -f environment=staging \
+              -f sha="${TARGET_SHA}" \
+              --paginate \
+              --jq ".[].id"
+          )"
+
+          if [ -z "${deployment_ids}" ]; then
+            echo "::error::No staging deployment found for ${TARGET_SHA}."
+            exit 1
+          fi
+
+          found_success=false
+          while IFS= read -r deployment_id; do
+            if [ -z "${deployment_id}" ]; then
+              continue
+            fi
+
+            state="$(
+              gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+                --jq ".[0].state // \"\""
+            )"
+            if [ "${state}" = "success" ]; then
+              found_success=true
+              break
+            fi
+          done <<< "${deployment_ids}"
+
+          if [ "${found_success}" != "true" ]; then
+            echo "::error::No successful staging deployment status found for ${TARGET_SHA}."
+            exit 1
+          fi
+
+  promote:
+    name: Promote SHA To Production
+    needs:
+      - guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: production
+    env:
+      TARGET_SHA: ${{ needs.guard.outputs.target_sha }}
+      PROMOTION_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Checkout promotion SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_SHA }}
+          fetch-depth: 0
+
+      - name: Validate checkout SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [ "${checked_out_sha}" != "${TARGET_SHA}" ]; then
+            echo "::error::Checked out ${checked_out_sha}, expected ${TARGET_SHA}."
+            exit 1
+          fi
+
+      - name: Create production deployment
+        id: deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(
+            jq -n \
+              --arg ref "${TARGET_SHA}" \
+              --arg description "Promote staging success SHA ${TARGET_SHA} to production" \
+              '{
+                ref: $ref,
+                environment: "production",
+                description: $description,
+                auto_merge: false,
+                required_contexts: [],
+                production_environment: true,
+                transient_environment: false
+              }'
+          )"
+          deployment_id="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments" --input - --jq ".id" <<< "${payload}")"
+
+          if [ -z "${deployment_id}" ]; then
+            echo "::error::Failed to create production deployment."
+            exit 1
+          fi
+
+          echo "deployment_id=${deployment_id}" >> "${GITHUB_OUTPUT}"
+
+      - name: Mark production deployment in progress
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(
+            jq -n \
+              --arg log_url "${PROMOTION_LOG_URL}" \
+              '{
+                state: "in_progress",
+                environment: "production",
+                log_url: $log_url,
+                auto_inactive: false
+              }'
+          )"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
+
+      - name: Dispatch production deploy hook
+        env:
+          PRODUCTION_DEPLOY_WEBHOOK_URL: ${{ secrets.PRODUCTION_DEPLOY_WEBHOOK_URL }}
+          PRODUCTION_DEPLOY_TOKEN: ${{ secrets.PRODUCTION_DEPLOY_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PRODUCTION_DEPLOY_WEBHOOK_URL}" ]; then
+            echo "::error::Missing PRODUCTION_DEPLOY_WEBHOOK_URL environment secret."
+            exit 1
+          fi
+
+          if [ -z "${PRODUCTION_DEPLOY_TOKEN}" ]; then
+            echo "::error::Missing PRODUCTION_DEPLOY_TOKEN environment secret."
+            exit 1
+          fi
+
+          payload="$(
+            jq -n \
+              --arg sha "${TARGET_SHA}" \
+              --arg repository "${GITHUB_REPOSITORY}" \
+              --arg run_url "${PROMOTION_LOG_URL}" \
+              --arg trigger "${GITHUB_EVENT_NAME}" \
+              --arg ref "${GITHUB_REF_NAME}" \
+              '{
+                sha: $sha,
+                repository: $repository,
+                environment: "production",
+                runUrl: $run_url,
+                trigger: $trigger,
+                ref: $ref
+              }'
+          )"
+
+          curl --fail-with-body --show-error --silent \
+            --request POST \
+            --header "Authorization: Bearer ${PRODUCTION_DEPLOY_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "${payload}" \
+            "${PRODUCTION_DEPLOY_WEBHOOK_URL}"
+
+      - name: Mark production deployment success
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(
+            jq -n \
+              --arg log_url "${PROMOTION_LOG_URL}" \
+              '{
+                state: "success",
+                environment: "production",
+                log_url: $log_url,
+                auto_inactive: false
+              }'
+          )"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
+
+      - name: Mark production deployment failure
+        if: failure() && steps.deployment.outputs.deployment_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(
+            jq -n \
+              --arg log_url "${PROMOTION_LOG_URL}" \
+              '{
+                state: "failure",
+                environment: "production",
+                log_url: $log_url,
+                auto_inactive: false
+              }'
+          )"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"

--- a/docs/production-promotion.md
+++ b/docs/production-promotion.md
@@ -1,0 +1,54 @@
+# Production Promotion
+
+## Trigger
+
+- Manual: GitHub Actions `Production Promotion` workflow dispatch
+  - input `sha`: staging deployment status가 `success`인 40자 main commit SHA
+- Tag: `prod-*` tag push
+  - tag가 가리키는 commit을 promotion target SHA로 사용
+
+## Guard
+
+- target SHA는 `origin/main`에서 도달 가능해야 합니다.
+- target SHA와 같은 staging GitHub deployment가 있어야 합니다.
+- 해당 staging deployment의 최신 status가 `success`여야 합니다.
+- guard가 실패하면 `production` Environment approval 전 단계에서 workflow가 중단됩니다.
+
+## Approval
+
+- 실제 production hook 호출은 GitHub Environment `production` job에서만 실행됩니다.
+- repository settings에서 `production` Environment에 required reviewer를 설정해야 UI 승인 gate가 적용됩니다.
+- concurrency group은 `production-promotion`이며, 동시에 두 production 승격이 실행되지 않게 합니다.
+
+## Environment Secrets
+
+- `PRODUCTION_DEPLOY_WEBHOOK_URL`
+- `PRODUCTION_DEPLOY_TOKEN`
+
+Secret 값은 저장소에 기록하지 않습니다. workflow는 secret이 없으면 성공으로 위장하지 않고 fail-fast합니다.
+
+## Deploy Hook Payload
+
+```json
+{
+  "sha": "<target main sha>",
+  "repository": "owner/repo",
+  "environment": "production",
+  "runUrl": "https://github.com/owner/repo/actions/runs/<run-id>",
+  "trigger": "workflow_dispatch | push",
+  "ref": "<input ref or prod-* tag>"
+}
+```
+
+## Deployment Status
+
+- workflow는 production GitHub deployment를 생성합니다.
+- hook 호출 전 status를 `in_progress`로 기록합니다.
+- hook 성공 시 `success`, 실패 시 `failure`로 갱신합니다.
+- production 승격 이력은 GitHub deployments와 Actions run URL을 함께 확인합니다.
+
+## Rollback
+
+- 기본 rollback은 `main` 기준 revert PR을 merge한 뒤 새 staging 성공 SHA를 production으로 승격합니다.
+- 긴급 재승격이 필요하면 직전 production 성공 SHA가 staging success guard를 통과하는지 먼저 확인합니다.
+- main 밖 commit, staging 성공 기록이 없는 commit, 짧은 SHA 입력은 production promotion 대상이 아닙니다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #223

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging 성공 SHA만 production으로 승격하는 GitHub Actions workflow를 추가했습니다.
- `workflow_dispatch`의 40자 SHA 입력과 `prod-*` tag 경로를 모두 지원하고, production hook은 Environment approval 뒤에만 호출합니다.

## 🛠 Changes
- `.github/workflows/production-promotion.yml` 추가
- guard job에서 main ancestry와 staging deployment success status 검증
- production deployment status 기록과 deploy hook fail-fast 처리 추가
- `docs/production-promotion.md`에 입력, secret, approval, rollback 절차 문서화

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/production-promotion.yml'); puts 'ok'"`
- workflow `run` block 8개 `bash -n` 검증
- `ruby -e 'require "json"; ... JSON.parse(...)'` for `docs/production-promotion.md`
- `git diff --check`
- `git rev-list --count main..HEAD` → `2`
- `actionlint`는 로컬에 설치되어 있지 않아 실행하지 못했습니다.

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: GitHub Environment `production`에 required reviewer가 설정되지 않으면 UI 승인 gate가 적용되지 않습니다.
- 예상 리스크: staging deployment status가 없는 SHA는 production promotion에서 거부됩니다.
- 롤백 방법: PR revert 또는 직전 staging 성공 SHA를 확인한 뒤 production promotion workflow로 재승격합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
