### PR TITLE
[Fix] staging deploy stale main SHA skip 처리

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -37,9 +37,11 @@ jobs:
           fetch-depth: 0
 
       - name: Validate main SHA
+        id: validate
         shell: bash
         run: |
           set -euo pipefail
+          echo "should_deploy=false" >> "${GITHUB_OUTPUT}"
           git fetch --no-tags --depth=1 origin main
 
           checked_out_sha="$(git rev-parse HEAD)"
@@ -50,14 +52,17 @@ jobs:
             exit 1
           fi
 
-          # staging은 main 최신 SHA만 자동 배포해 오래된 CI 완료가 역배포를 만들지 않게 한다.
+          # staging은 main 최신 SHA만 자동 배포하되, 오래된 CI 완료는 정상 race로 보고 skip한다.
           if [ "${current_main_sha}" != "${DEPLOY_SHA}" ]; then
-            echo "::error::Deploy SHA ${DEPLOY_SHA} is not current origin/main ${current_main_sha}."
-            exit 1
+            echo "::notice::Skipping stale deploy SHA ${DEPLOY_SHA}; current origin/main is ${current_main_sha}."
+            exit 0
           fi
+
+          echo "should_deploy=true" >> "${GITHUB_OUTPUT}"
 
       - name: Create staging deployment
         id: deployment
+        if: steps.validate.outputs.should_deploy == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -87,6 +92,7 @@ jobs:
           echo "deployment_id=${deployment_id}" >> "${GITHUB_OUTPUT}"
 
       - name: Mark staging deployment in progress
+        if: steps.validate.outputs.should_deploy == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
@@ -106,6 +112,7 @@ jobs:
           gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
 
       - name: Dispatch staging deploy hook
+        if: steps.validate.outputs.should_deploy == 'true'
         env:
           STAGING_DEPLOY_WEBHOOK_URL: ${{ secrets.STAGING_DEPLOY_WEBHOOK_URL }}
           STAGING_DEPLOY_TOKEN: ${{ secrets.STAGING_DEPLOY_TOKEN }}
@@ -144,7 +151,7 @@ jobs:
             "${STAGING_DEPLOY_WEBHOOK_URL}"
 
       - name: Mark staging deployment success
-        if: success()
+        if: success() && steps.validate.outputs.should_deploy == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
@@ -164,7 +171,7 @@ jobs:
           gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
 
       - name: Mark staging deployment failure
-        if: failure() && steps.deployment.outputs.deployment_id != ''
+        if: failure() && steps.validate.outputs.should_deploy == 'true' && steps.deployment.outputs.deployment_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -23,7 +23,7 @@
 - `main`에 merge된 SHA는 `Main CI` workflow가 backend/frontend check를 다시 실행합니다.
 - `Main CI`가 push 이벤트에서 성공하면 `Staging Deploy` workflow가 같은 SHA를 staging에 배포합니다.
 - `Staging Deploy`는 `github.event.workflow_run.head_sha`를 deploy SHA로 고정하고, 현재 `origin/main`과 같은지 검증합니다.
-- 오래된 `Main CI` 완료가 뒤늦게 도착하면 workflow를 실패시켜 staging 역배포를 막습니다.
+- 오래된 `Main CI` 완료가 뒤늦게 도착하면 deploy step을 skip해 staging 역배포와 불필요한 failure를 같이 막습니다.
 
 ## Staging Deploy
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #230

## 🌿 Base Branch
- `main`

## 📝 Summary
- 오래된 `Main CI` 완료 이벤트가 `Staging Deploy`를 실패시키던 동작을 skip 처리로 바꿨습니다.
- deploy SHA가 현재 `origin/main`이 아니면 deployment 생성, hook 호출, status 갱신을 실행하지 않아 역배포와 불필요한 failure를 같이 막습니다.

## 🛠 Changes
- `Validate main SHA` 단계에 `should_deploy` output 추가
- stale SHA면 `::notice::`만 남기고 후속 deploy step skip
- delivery flow 문서의 stale run 처리 기준 갱신

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"`
- workflow `run` block 6개 `bash -n` 검증
- `git diff --check`
- `git rev-list --count main..HEAD` → `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: stale 판정이 잘못되면 staging deploy가 skip될 수 있습니다. 현재 `origin/main`과 deploy SHA가 같은 경우만 deploy하도록 제한합니다.
- 롤백 방법: PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
