### PR TITLE
[Fix] staging deploy hook secret 미구성 skip 처리

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -60,9 +60,39 @@ jobs:
 
           echo "should_deploy=true" >> "${GITHUB_OUTPUT}"
 
+      - name: Resolve staging deploy hook configuration
+        id: hook_config
+        if: steps.validate.outputs.should_deploy == 'true'
+        env:
+          STAGING_DEPLOY_WEBHOOK_URL: ${{ secrets.STAGING_DEPLOY_WEBHOOK_URL }}
+          STAGING_DEPLOY_TOKEN: ${{ secrets.STAGING_DEPLOY_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing_secret=false
+
+          if [ -z "${STAGING_DEPLOY_WEBHOOK_URL}" ]; then
+            echo "::notice::STAGING_DEPLOY_WEBHOOK_URL environment secret is not configured."
+            missing_secret=true
+          fi
+
+          if [ -z "${STAGING_DEPLOY_TOKEN}" ]; then
+            echo "::notice::STAGING_DEPLOY_TOKEN environment secret is not configured."
+            missing_secret=true
+          fi
+
+          # hook 미구성 환경에서는 실제 deploy가 없으므로 staging success status도 만들지 않는다.
+          if [ "${missing_secret}" = "true" ]; then
+            echo "::notice::Skipping staging deploy hook. Configure both staging Environment secrets to enable deployment."
+            echo "hook_configured=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "hook_configured=true" >> "${GITHUB_OUTPUT}"
+
       - name: Create staging deployment
         id: deployment
-        if: steps.validate.outputs.should_deploy == 'true'
+        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -92,7 +122,7 @@ jobs:
           echo "deployment_id=${deployment_id}" >> "${GITHUB_OUTPUT}"
 
       - name: Mark staging deployment in progress
-        if: steps.validate.outputs.should_deploy == 'true'
+        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
@@ -112,7 +142,7 @@ jobs:
           gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
 
       - name: Dispatch staging deploy hook
-        if: steps.validate.outputs.should_deploy == 'true'
+        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
         env:
           STAGING_DEPLOY_WEBHOOK_URL: ${{ secrets.STAGING_DEPLOY_WEBHOOK_URL }}
           STAGING_DEPLOY_TOKEN: ${{ secrets.STAGING_DEPLOY_TOKEN }}
@@ -151,7 +181,7 @@ jobs:
             "${STAGING_DEPLOY_WEBHOOK_URL}"
 
       - name: Mark staging deployment success
-        if: success() && steps.validate.outputs.should_deploy == 'true'
+        if: success() && steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
@@ -171,7 +201,7 @@ jobs:
           gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
 
       - name: Mark staging deployment failure
-        if: failure() && steps.validate.outputs.should_deploy == 'true' && steps.deployment.outputs.deployment_id != ''
+        if: failure() && steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true' && steps.deployment.outputs.deployment_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -29,7 +29,7 @@
 
 - GitHub Environment: `staging`
 - concurrency group: `staging-deploy`
-- required environment secrets:
+- actual deploy required environment secrets:
   - `STAGING_DEPLOY_WEBHOOK_URL`
   - `STAGING_DEPLOY_TOKEN`
 - deploy hook payload:
@@ -37,8 +37,8 @@
   - `repository`: `owner/repo`
   - `environment`: `staging`
   - `runUrl`: GitHub Actions run URL
-- deploy hook secret이 없으면 성공으로 위장하지 않고 fail-fast합니다.
-- workflow는 staging GitHub deployment status를 `in_progress`에서 `success` 또는 `failure`로 갱신합니다.
+- deploy hook secret이 없으면 workflow는 no-op skip으로 끝내고 staging GitHub deployment status를 만들지 않습니다.
+- workflow는 실제 hook 호출 시에만 staging GitHub deployment status를 `in_progress`에서 `success` 또는 `failure`로 갱신합니다.
 - production 승격은 staging deployment status가 `success`인 같은 SHA만 대상으로 삼습니다.
 - rollback은 `main` 기준 revert PR을 merge해 새 staging SHA를 배포하거나, 운영자가 직전 staging 성공 SHA를 확인해 별도 재배포 절차로 진행합니다.
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #232

## 🌿 Base Branch
- `main`

## 📝 Summary
- `STAGING_DEPLOY_WEBHOOK_URL` 또는 `STAGING_DEPLOY_TOKEN`이 없는 환경에서 `Staging Deploy`가 실패하던 동작을 no-op skip으로 바꿨습니다.
- hook 미구성 상태에서는 실제 deploy가 없으므로 staging GitHub deployment status도 만들지 않아 production promotion guard를 우회하지 않습니다.

## 🛠 Changes
- `Resolve staging deploy hook configuration` step 추가
- hook secret이 모두 있을 때만 deployment 생성, hook 호출, deployment status 갱신 수행
- delivery flow 문서에 hook 미구성 no-op과 production promotion 차단 기준 기록

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"`
- workflow `run` block 7개 `bash -n` 검증
- hook secret 미구성 로컬 재현: `hook_configured=false`, exit 0
- hook secret 구성 로컬 재현: `hook_configured=true`, exit 0
- `git diff --check`
- `git rev-list --count main..HEAD` → `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: secret 이름 오타도 no-op skip으로 보일 수 있습니다. Actions notice와 문서의 secret 이름을 기준으로 확인합니다.
- 롤백 방법: PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
