### PR TITLE
[Feat] transaction archive 조회 API 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -143,6 +143,32 @@ partition/archive 는 `GET /api/v1/transactions` read path를 실제로 줄여�
   - `transaction_read_model`의 historical row 때문에 autovacuum lag, index bloat, backup 시간이 운영 병목이 될 때
   - cold history와 hot path의 보존/SLA가 달라 separate archive tier가 필요해질 때
 
+### Transaction Archive Query
+
+`transaction_read_model_archive` 로 이동한 cold history 는 hot 조회와 분리해 `GET /api/v1/transactions/archive` 로 조회합니다.
+
+- hot path:
+  - `GET /api/v1/transactions`
+  - table: `transaction_read_model`
+  - 목적: 최근/활성 거래 timeline 조회
+- cold path:
+  - `GET /api/v1/transactions/archive`
+  - table: `transaction_read_model_archive`
+  - 목적: retention cleanup 이후 archive projection 조회
+- 두 endpoint 모두 같은 조회 계약을 씁니다.
+  - `accountId`, `from`, `to`, `limit`, `cursor`
+  - `status`, `direction`, `minAmountMinor`, `maxAmountMinor`, `transactionReference`
+  - 기간 상한 `31일`
+  - 정렬 `booked_at DESC, id DESC`
+- archive 조회는 hot table과 union하지 않습니다. 클라이언트는 조회 기간과 보존 정책에 맞춰 hot/cold endpoint를 선택합니다.
+- archive index:
+  - `idx_transaction_read_model_archive_account_cursor`
+  - `idx_transaction_read_model_archive_account_status_cursor`
+  - `idx_transaction_read_model_archive_account_reference_cursor`
+- rollback 기준:
+  - API rollback은 PR revert로 수행합니다.
+  - `V43__add_transaction_archive_reference_index.sql` 로 추가된 reference index 제거가 필요한지 DB 상태를 확인합니다.
+
 재현 명령:
 
 ```bash

--- a/back/src/main/java/com/aquilabank/domain/transaction/port/TransactionArchiveReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/port/TransactionArchiveReadPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.transaction.port;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+
+/** cold archive transaction read model 조회를 persistence adapter 로 위임합니다. */
+public interface TransactionArchiveReadPort {
+
+  TransactionSlice fetchArchived(TransactionQuery query);
+}

--- a/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionArchiveQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionArchiveQueryService.java
@@ -1,0 +1,19 @@
+package com.aquilabank.domain.transaction.usecase;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.port.TransactionArchiveReadPort;
+
+public final class TransactionArchiveQueryService implements TransactionArchiveQueryUseCase {
+
+  private final TransactionArchiveReadPort transactionArchiveReadPort;
+
+  public TransactionArchiveQueryService(TransactionArchiveReadPort transactionArchiveReadPort) {
+    this.transactionArchiveReadPort = transactionArchiveReadPort;
+  }
+
+  @Override
+  public TransactionSlice getArchivedTransactions(TransactionQuery query) {
+    return transactionArchiveReadPort.fetchArchived(query);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionArchiveQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/usecase/TransactionArchiveQueryUseCase.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.transaction.usecase;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+
+/** archive transaction timeline 조회 진입점 */
+public interface TransactionArchiveQueryUseCase {
+
+  TransactionSlice getArchivedTransactions(TransactionQuery query);
+}

--- a/back/src/main/java/com/aquilabank/global/config/TransactionArchiveQueryConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/TransactionArchiveQueryConfiguration.java
@@ -1,0 +1,18 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.transaction.port.TransactionArchiveReadPort;
+import com.aquilabank.domain.transaction.usecase.TransactionArchiveQueryService;
+import com.aquilabank.domain.transaction.usecase.TransactionArchiveQueryUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** transaction archive query use case와 archive read port를 연결 */
+@Configuration
+public class TransactionArchiveQueryConfiguration {
+
+  @Bean
+  TransactionArchiveQueryUseCase transactionArchiveQueryUseCase(
+      TransactionArchiveReadPort transactionArchiveReadPort) {
+    return new TransactionArchiveQueryService(transactionArchiveReadPort);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionArchiveReadRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionArchiveReadRepository.java
@@ -1,0 +1,67 @@
+package com.aquilabank.global.persistence.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionCursor;
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.model.TransactionSummary;
+import com.aquilabank.domain.transaction.port.TransactionArchiveReadPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** archive transaction timeline을 keyset pagination 기준으로 읽어오는 JDBC adapter */
+@Repository
+public class JdbcTransactionArchiveReadRepository implements TransactionArchiveReadPort {
+
+  private static final RowMapper<TransactionSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcTransactionArchiveReadRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public TransactionSlice fetchArchived(TransactionQuery query) {
+    TransactionArchiveReadQueryStatement statement =
+        TransactionArchiveReadQueryStatement.from(query);
+    List<TransactionSummary> rows =
+        jdbcTemplate.query(statement.sql(), statement.params(), ROW_MAPPER);
+    boolean hasNext = rows.size() > query.limit();
+    // hasNext 판단에만 쓴 sentinel row는 응답 전에 제거
+    List<TransactionSummary> items =
+        hasNext ? new ArrayList<>(rows.subList(0, query.limit())) : rows;
+    TransactionCursor nextCursor = hasNext ? toCursor(items.getLast()) : null;
+    return new TransactionSlice(items, nextCursor, hasNext, query.limit());
+  }
+
+  private static TransactionSummary mapRow(ResultSet rs) throws SQLException {
+    OffsetDateTime bookedAt = rs.getObject("booked_at", OffsetDateTime.class);
+    return new TransactionSummary(
+        rs.getLong("id"),
+        rs.getLong("account_id"),
+        rs.getString("transaction_reference"),
+        TransactionDirection.valueOf(rs.getString("direction")),
+        TransactionStatus.valueOf(rs.getString("transaction_status")),
+        rs.getLong("amount_minor"),
+        rs.getLong("balance_after_minor"),
+        rs.getString("currency_code"),
+        rs.getString("summary"),
+        rs.getString("counterparty_masked_name"),
+        bookedAt.toInstant());
+  }
+
+  private static TransactionCursor toCursor(TransactionSummary item) {
+    // 현재 slice의 마지막 visible row 다음부터 다음 page가 시작되게 cursor 생성
+    return new TransactionCursor(item.bookedAt(), item.id());
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionArchiveReadQueryStatement.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionArchiveReadQueryStatement.java
@@ -1,0 +1,97 @@
+package com.aquilabank.global.persistence.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import java.sql.Timestamp;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+/** archive 거래 조회 SQL을 hot query와 같은 keyset 계약으로 고정합니다. */
+final class TransactionArchiveReadQueryStatement {
+
+  private final String sql;
+  private final MapSqlParameterSource params;
+
+  private TransactionArchiveReadQueryStatement(String sql, MapSqlParameterSource params) {
+    this.sql = sql;
+    this.params = params;
+  }
+
+  static TransactionArchiveReadQueryStatement from(TransactionQuery query) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("accountId", query.accountId())
+            .addValue("from", Timestamp.from(query.from()))
+            .addValue("to", Timestamp.from(query.to()))
+            // 다음 page 존재 여부 판단용 sentinel row 한 건 추가 조회
+            .addValue("fetchLimit", query.limit() + 1);
+
+    StringBuilder sql =
+        new StringBuilder(
+            """
+            SELECT id,
+                   account_id,
+                   transaction_reference,
+                   direction,
+                   transaction_status,
+                   amount_minor,
+                   balance_after_minor,
+                   currency_code,
+                   summary,
+                   counterparty_masked_name,
+                   booked_at
+            FROM transaction_read_model_archive
+            WHERE account_id = :accountId
+              AND booked_at >= :from
+              AND booked_at < :to
+            """);
+
+    if (query.status() != null) {
+      sql.append("\n  AND transaction_status = :status");
+      params.addValue("status", query.status().name());
+    }
+
+    if (query.direction() != null) {
+      sql.append("\n  AND direction = :direction");
+      params.addValue("direction", query.direction().name());
+    }
+
+    if (query.minAmountMinor() != null) {
+      sql.append("\n  AND amount_minor >= :minAmountMinor");
+      params.addValue("minAmountMinor", query.minAmountMinor());
+    }
+
+    if (query.maxAmountMinor() != null) {
+      sql.append("\n  AND amount_minor <= :maxAmountMinor");
+      params.addValue("maxAmountMinor", query.maxAmountMinor());
+    }
+
+    if (query.transactionReference() != null) {
+      // archive exact lookup도 전용 index로 account 범위 안에서 좁힙니다.
+      sql.append("\n  AND transaction_reference = :transactionReference");
+      params.addValue("transactionReference", query.transactionReference());
+    }
+
+    if (query.cursor() != null) {
+      // keyset cursor와 ORDER BY tuple을 같게 두어 composite index range scan으로 이어지게 합니다.
+      sql.append("\n  AND (booked_at, id) < (:cursorBookedAt, :cursorId)");
+      params
+          .addValue("cursorBookedAt", Timestamp.from(query.cursor().bookedAt()))
+          .addValue("cursorId", query.cursor().id());
+    }
+
+    sql.append(
+        """
+
+            ORDER BY booked_at DESC, id DESC
+            LIMIT :fetchLimit
+        """);
+    return new TransactionArchiveReadQueryStatement(sql.toString(), params);
+  }
+
+  String sql() {
+    return sql;
+  }
+
+  MapSqlParameterSource params() {
+    return params;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryController.java
@@ -1,0 +1,74 @@
+package com.aquilabank.global.web.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionCursor;
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.usecase.TransactionArchiveQueryUseCase;
+import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import jakarta.validation.constraints.Positive;
+import java.time.OffsetDateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/** archive transaction timeline read use case를 노출하는 HTTP adapter */
+@Validated
+@RestController
+@RequestMapping("/api/v1/transactions/archive")
+public class TransactionArchiveQueryController {
+
+  private final TransactionArchiveQueryUseCase transactionArchiveQueryUseCase;
+  private final RequestAccountAuthorizationService requestAccountAuthorizationService;
+
+  public TransactionArchiveQueryController(
+      TransactionArchiveQueryUseCase transactionArchiveQueryUseCase,
+      RequestAccountAuthorizationService requestAccountAuthorizationService) {
+    this.transactionArchiveQueryUseCase = transactionArchiveQueryUseCase;
+    this.requestAccountAuthorizationService = requestAccountAuthorizationService;
+  }
+
+  @GetMapping
+  public TransactionQueryResponse getArchivedTransactions(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @RequestParam @Positive(message = "accountId must be positive") long accountId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
+      @RequestParam(defaultValue = "20") int limit,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) TransactionStatus status,
+      @RequestParam(required = false) TransactionDirection direction,
+      @RequestParam(required = false) Long minAmountMinor,
+      @RequestParam(required = false) Long maxAmountMinor,
+      @RequestParam(required = false) String transactionReference) {
+    try {
+      TransactionCursor decodedCursor =
+          cursor == null || cursor.isBlank() ? null : TransactionCursorCodec.decode(cursor);
+      long resolvedAccountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(principal, accountId);
+      TransactionQuery query =
+          new TransactionQuery(
+              resolvedAccountId,
+              from.toInstant(),
+              to.toInstant(),
+              limit,
+              decodedCursor,
+              status,
+              direction,
+              minAmountMinor,
+              maxAmountMinor,
+              transactionReference);
+      return TransactionQueryResponse.from(
+          transactionArchiveQueryUseCase.getArchivedTransactions(query));
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+    }
+  }
+}

--- a/back/src/main/resources/db/migration/V43__add_transaction_archive_reference_index.sql
+++ b/back/src/main/resources/db/migration/V43__add_transaction_archive_reference_index.sql
@@ -1,0 +1,5 @@
+CREATE INDEX idx_transaction_read_model_archive_account_reference_cursor
+    ON transaction_read_model_archive (account_id, transaction_reference, booked_at DESC, id DESC);
+
+COMMENT ON INDEX idx_transaction_read_model_archive_account_reference_cursor IS
+    'archive transactionReference exact lookup용. account_id + transaction_reference 뒤 booked_at DESC, id DESC 정렬 유지';

--- a/back/src/test/java/com/aquilabank/domain/transaction/usecase/TransactionArchiveQueryServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/transaction/usecase/TransactionArchiveQueryServiceTest.java
@@ -1,0 +1,41 @@
+package com.aquilabank.domain.transaction.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.port.TransactionArchiveReadPort;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TransactionArchiveQueryServiceTest {
+
+  @Test
+  void delegatesArchiveQueryToArchiveReadPort() {
+    TransactionArchiveReadPort readPort = mock(TransactionArchiveReadPort.class);
+    TransactionArchiveQueryService service = new TransactionArchiveQueryService(readPort);
+    TransactionQuery query =
+        new TransactionQuery(
+            101L,
+            Instant.parse("2025-01-01T00:00:00Z"),
+            Instant.parse("2025-01-31T00:00:00Z"),
+            20,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    TransactionSlice expected = new TransactionSlice(List.of(), null, false, 20);
+    when(readPort.fetchArchived(query)).thenReturn(expected);
+
+    TransactionSlice result = service.getArchivedTransactions(query);
+
+    assertThat(result).isSameAs(expected);
+    verify(readPort).fetchArchived(query);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionArchiveReadRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionArchiveReadRepositoryIntegrationTest.java
@@ -1,0 +1,318 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.transaction.model.TransactionCursor;
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.aquilabank.support.TransactionExplainPlan;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcTransactionArchiveReadRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  private static final Instant BASE = Instant.parse("2025-01-31T00:00:00Z");
+
+  @Autowired private JdbcTransactionArchiveReadRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  private long accountId;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+    commit(
+        transactionManager,
+        () -> {
+          accountId = insertAccount("archive query account");
+          for (int index = 0; index < 120; index++) {
+            insertArchivedTransaction(
+                accountId,
+                "archive-trx-" + index,
+                index % 2 == 0 ? "BOOKED" : "REVERSED",
+                BASE.minusSeconds(index * 60L));
+          }
+          insertHotTransaction(accountId, "hot-trx-not-in-archive-response", BASE.minusSeconds(30));
+        });
+  }
+
+  @Test
+  void firstPageReadsArchiveTableOnlyWithArchiveAccountCursorIndex() {
+    TransactionQuery query = query(null, null, null);
+
+    TransactionSlice slice = repository.fetchArchived(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(50);
+    assertThat(slice.items()).noneMatch(item -> item.transactionReference().startsWith("hot-"));
+    assertThat(slice.hasNext()).isTrue();
+    assertThat(plan.usesIndex("idx_transaction_read_model_archive_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void cursorPageKeepsArchiveAccountCursorIndex() {
+    TransactionSlice firstSlice = repository.fetchArchived(query(null, null, null));
+    TransactionQuery nextPageQuery = query(firstSlice.nextCursor(), null, null);
+
+    TransactionSlice nextSlice = repository.fetchArchived(nextPageQuery);
+    TransactionExplainPlan plan = explain(nextPageQuery);
+
+    assertThat(firstSlice.nextCursor()).isNotNull();
+    assertThat(nextSlice.items()).hasSize(50);
+    assertThat(nextSlice.items().getFirst().bookedAt())
+        .isBeforeOrEqualTo(firstSlice.items().getLast().bookedAt());
+    assertThat(plan.usesIndex("idx_transaction_read_model_archive_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void statusFilterUsesArchiveStatusCursorIndex() {
+    TransactionQuery query = query(null, TransactionStatus.BOOKED, null);
+
+    TransactionSlice slice = repository.fetchArchived(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(50);
+    assertThat(slice.items()).allMatch(item -> item.status() == TransactionStatus.BOOKED);
+    assertThat(plan.usesIndex("idx_transaction_read_model_archive_account_status_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void transactionReferenceUsesArchiveReferenceCursorIndex() {
+    TransactionQuery query = query(null, null, "archive-trx-80");
+
+    TransactionSlice slice = repository.fetchArchived(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(1);
+    assertThat(slice.items().getFirst().transactionReference()).isEqualTo("archive-trx-80");
+    assertThat(plan.usesIndex("idx_transaction_read_model_archive_account_reference_cursor"))
+        .isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  private TransactionQuery query(
+      TransactionCursor cursor, TransactionStatus status, String transactionReference) {
+    return new TransactionQuery(
+        accountId,
+        BASE.minusSeconds(30L * 24L * 60L * 60L),
+        BASE.plusSeconds(60L),
+        50,
+        cursor,
+        status,
+        null,
+        null,
+        null,
+        transactionReference);
+  }
+
+  private TransactionExplainPlan explain(TransactionQuery query) {
+    TransactionArchiveReadQueryStatement statement =
+        TransactionArchiveReadQueryStatement.from(query);
+    String explainJson =
+        jdbcTemplate.queryForObject(
+            "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)\n" + statement.sql(),
+            statement.params(),
+            (rs, rowNum) -> rs.getString(1));
+    if (explainJson == null) {
+      throw new IllegalStateException("EXPLAIN did not return JSON");
+    }
+    return TransactionExplainPlan.fromJson(objectMapper, explainJson);
+  }
+
+  private long insertAccount(String displayName) {
+    String accountNumber =
+        jdbcTemplate.queryForObject(
+            "SELECT '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0')",
+            new MapSqlParameterSource(),
+            String.class);
+    if (accountNumber == null) {
+      throw new IllegalStateException("account number is not generated");
+    }
+
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (:accountNumber, :displayName, 'ACTIVE', 'KRW', :createdAt, :createdAt)
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountNumber", accountNumber)
+                .addValue("displayName", displayName)
+                .addValue("createdAt", Timestamp.from(BASE)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("account insert did not return id");
+    }
+    return id;
+  }
+
+  private void insertArchivedTransaction(
+      long accountId, String reference, String status, Instant bookedAt) {
+    long ledgerEntryId = insertLedgerEntry(accountId, reference, bookedAt);
+    jdbcTemplate.update(
+        """
+        INSERT INTO transaction_read_model_archive (
+            id,
+            ledger_entry_id,
+            account_id,
+            transaction_reference,
+            direction,
+            transaction_status,
+            amount_minor,
+            balance_after_minor,
+            currency_code,
+            summary,
+            counterparty_masked_name,
+            booked_at,
+            created_at,
+            archived_at
+        )
+        VALUES (
+            :id,
+            :ledgerEntryId,
+            :accountId,
+            :reference,
+            'CREDIT',
+            :status,
+            1700,
+            1001700,
+            'KRW',
+            :reference,
+            'ATM',
+            :bookedAt,
+            :bookedAt,
+            :archivedAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("id", ledgerEntryId)
+            .addValue("ledgerEntryId", ledgerEntryId)
+            .addValue("accountId", accountId)
+            .addValue("reference", reference)
+            .addValue("status", status)
+            .addValue("bookedAt", Timestamp.from(bookedAt))
+            .addValue("archivedAt", Timestamp.from(BASE.plusSeconds(300))));
+  }
+
+  private void insertHotTransaction(long accountId, String reference, Instant bookedAt) {
+    long ledgerEntryId = insertLedgerEntry(accountId, reference, bookedAt);
+    jdbcTemplate.update(
+        """
+        INSERT INTO transaction_read_model (
+            ledger_entry_id,
+            account_id,
+            transaction_reference,
+            direction,
+            transaction_status,
+            amount_minor,
+            balance_after_minor,
+            currency_code,
+            summary,
+            counterparty_masked_name,
+            booked_at,
+            created_at
+        )
+        VALUES (
+            :ledgerEntryId,
+            :accountId,
+            :reference,
+            'CREDIT',
+            'BOOKED',
+            1700,
+            1001700,
+            'KRW',
+            :reference,
+            'ATM',
+            :bookedAt,
+            :bookedAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("ledgerEntryId", ledgerEntryId)
+            .addValue("accountId", accountId)
+            .addValue("reference", reference)
+            .addValue("bookedAt", Timestamp.from(bookedAt)));
+  }
+
+  private long insertLedgerEntry(long accountId, String reference, Instant bookedAt) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO ledger_entry (
+                account_id,
+                transaction_reference,
+                entry_reference,
+                direction,
+                entry_status,
+                amount_minor,
+                currency_code,
+                booked_at,
+                occurred_at,
+                description,
+                metadata,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountId,
+                :reference,
+                :reference || '-entry',
+                'CREDIT',
+                'BOOKED',
+                1700,
+                'KRW',
+                :bookedAt,
+                :bookedAt,
+                :reference,
+                '{}'::jsonb,
+                :bookedAt,
+                :bookedAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("reference", reference)
+                .addValue("bookedAt", Timestamp.from(bookedAt)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("ledger entry insert did not return id");
+    }
+    return id;
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/security/TransactionArchiveJwtSecurityIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/TransactionArchiveJwtSecurityIntegrationTest.java
@@ -1,0 +1,118 @@
+package com.aquilabank.global.security;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.auth.model.AccountAccessScope;
+import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.model.TransactionSummary;
+import com.aquilabank.domain.transaction.port.TransactionArchiveReadPort;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class TransactionArchiveJwtSecurityIntegrationTest {
+
+  private static final String TEST_SECRET = "test-local-jwt-secret-test-local-jwt-secret";
+
+  @Autowired private WebApplicationContext context;
+
+  @MockitoBean private AccountAccessUseCase accountAccessUseCase;
+
+  @MockitoBean private TransactionArchiveReadPort transactionArchiveReadPort;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUpMockMvc() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void acceptsBearerJwtAndResolvesArchiveAccountAccess() throws Exception {
+    when(transactionArchiveReadPort.fetchArchived(argThat(query -> query.accountId() == 555L)))
+        .thenReturn(
+            new TransactionSlice(
+                List.of(
+                    new TransactionSummary(
+                        1L,
+                        555L,
+                        "ARCHIVE-TX-1",
+                        TransactionDirection.CREDIT,
+                        TransactionStatus.BOOKED,
+                        5000L,
+                        15000L,
+                        "KRW",
+                        "archived salary",
+                        "COMPANY",
+                        Instant.parse("2025-01-16T09:00:00Z"))),
+                null,
+                false,
+                20));
+    when(accountAccessUseCase.verify(55L, 555L, AccountAccessScope.READ)).thenReturn(555L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/archive")
+                .header("Authorization", "Bearer " + issueToken("user-555", 55L))
+                .param("accountId", "555")
+                .param("from", "2025-01-01T00:00:00Z")
+                .param("to", "2025-01-31T00:00:00Z"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].transactionReference").value("ARCHIVE-TX-1"));
+  }
+
+  @Test
+  void rejectsArchiveRequestWithoutJwtOrBootstrapHeader() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/archive")
+                .param("accountId", "555")
+                .param("from", "2025-01-01T00:00:00Z")
+                .param("to", "2025-01-31T00:00:00Z"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  private String issueToken(String subject, long userId) throws JOSEException {
+    Instant now = Instant.now();
+    JWTClaimsSet claimsSet =
+        new JWTClaimsSet.Builder()
+            .subject(subject)
+            .issueTime(Date.from(now))
+            .expirationTime(Date.from(now.plusSeconds(300)))
+            .claim("user_id", userId)
+            .build();
+
+    SignedJWT signedJwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(), claimsSet);
+    signedJwt.sign(new MACSigner(TEST_SECRET.getBytes(StandardCharsets.UTF_8)));
+    return signedJwt.serialize();
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryControllerTest.java
@@ -1,0 +1,141 @@
+package com.aquilabank.global.web.transaction;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.transaction.model.TransactionCursor;
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.model.TransactionSummary;
+import com.aquilabank.domain.transaction.usecase.TransactionArchiveQueryUseCase;
+import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
+import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class TransactionArchiveQueryControllerTest {
+
+  private TransactionArchiveQueryUseCase transactionArchiveQueryUseCase;
+  private RequestAccountAuthorizationService requestAccountAuthorizationService;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    transactionArchiveQueryUseCase = mock(TransactionArchiveQueryUseCase.class);
+    requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new TransactionArchiveQueryController(
+                    transactionArchiveQueryUseCase, requestAccountAuthorizationService))
+            .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
+            .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
+            .build();
+  }
+
+  @Test
+  void returnsArchivedCursorPage() throws Exception {
+    TransactionCursor nextCursor =
+        new TransactionCursor(Instant.parse("2025-01-16T09:00:00Z"), 777L);
+    when(transactionArchiveQueryUseCase.getArchivedTransactions(
+            argThat(query -> query.accountId() == 101L)))
+        .thenReturn(
+            new TransactionSlice(
+                List.of(
+                    new TransactionSummary(
+                        777L,
+                        101L,
+                        "ARCHIVE-TX-777",
+                        TransactionDirection.DEBIT,
+                        TransactionStatus.BOOKED,
+                        1200L,
+                        8800L,
+                        "KRW",
+                        "archived card payment",
+                        "STORE",
+                        Instant.parse("2025-01-16T09:00:00Z"))),
+                nextCursor,
+                true,
+                20));
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/archive")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2025-01-01T00:00:00Z")
+                .param("to", "2025-01-31T00:00:00Z")
+                .param("limit", "20"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].transactionReference").value("ARCHIVE-TX-777"))
+        .andExpect(jsonPath("$.hasNext").value(true))
+        .andExpect(jsonPath("$.nextCursor").isString());
+  }
+
+  @Test
+  void passesArchiveFiltersIntoQuery() throws Exception {
+    when(transactionArchiveQueryUseCase.getArchivedTransactions(
+            argThat(this::matchesArchiveFilters)))
+        .thenReturn(new TransactionSlice(List.of(), null, false, 20));
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/archive")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2025-01-01T00:00:00Z")
+                .param("to", "2025-01-31T00:00:00Z")
+                .param("limit", "20")
+                .param("status", "BOOKED")
+                .param("direction", "CREDIT")
+                .param("minAmountMinor", "1000")
+                .param("maxAmountMinor", "2000")
+                .param("transactionReference", "ARCHIVE-TX-777"))
+        .andExpect(status().isOk());
+
+    verify(transactionArchiveQueryUseCase)
+        .getArchivedTransactions(argThat(this::matchesArchiveFilters));
+  }
+
+  @Test
+  void rejectsArchiveDateRangeLargerThanThirtyOneDays() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/archive")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2025-01-01T00:00:00Z")
+                .param("to", "2025-03-01T00:00:00Z"))
+        .andExpect(status().isBadRequest());
+  }
+
+  private boolean matchesArchiveFilters(TransactionQuery query) {
+    return query.accountId() == 101L
+        && query.status() == TransactionStatus.BOOKED
+        && query.direction() == TransactionDirection.CREDIT
+        && Long.valueOf(1000L).equals(query.minAmountMinor())
+        && Long.valueOf(2000L).equals(query.maxAmountMinor())
+        && "ARCHIVE-TX-777".equals(query.transactionReference());
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #234

## 🌿 Base Branch
- `main`

## 📝 Summary
- `transaction_read_model_archive` cold history 전용 조회 API를 추가했습니다.
- hot table과 union하지 않고 archive table만 `accountId + from/to + booked_at DESC, id DESC` keyset으로 조회합니다.

## 🛠 Changes
- `GET /api/v1/transactions/archive` controller/use case/port/JDBC adapter 추가
- archive reference exact lookup용 `idx_transaction_read_model_archive_account_reference_cursor` migration 추가
- controller/domain/JDBC/JWT security 테스트 추가
- README에 hot/cold endpoint 경계, archive index, rollback 기준 문서화

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh transaction-archive-query-api ./back/gradlew -p back test --tests '*TransactionArchiveQueryControllerTest' --tests '*TransactionArchiveQueryServiceTest' --tests '*JdbcTransactionArchiveReadRepositoryIntegrationTest' --tests '*TransactionArchiveJwtSecurityIntegrationTest'`
- `tools/test/with-resource-lock.sh transaction-archive-query-api ./back/gradlew -p back check`
- `git rev-list --count main..HEAD` → `2`

## 📸 Screenshot / API Example
```bash
curl -sS \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
  "https://api.example.com/api/v1/transactions/archive?accountId=101&from=2025-01-01T00:00:00Z&to=2025-01-31T00:00:00Z&limit=50"
```

## ⚠️ Risk & Rollback
- 예상 리스크: cold history 조회는 hot/cold union을 하지 않으므로 클라이언트가 보존 정책에 맞는 endpoint를 선택해야 합니다.
- 롤백 방법: PR revert 후 필요하면 `V43__add_transaction_archive_reference_index.sql`로 추가된 index 제거 여부를 확인합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
