### PR TITLE
[Perf] 1억 건 staging read model replay 검증 추가

### DIFF
--- a/.github/workflows/transaction-read-model-staging-replay.yml
+++ b/.github/workflows/transaction-read-model-staging-replay.yml
@@ -1,0 +1,121 @@
+name: Transaction Read Model Staging Replay
+
+on:
+  workflow_dispatch:
+    inputs:
+      hot_account_id:
+        description: Hot table account id with enough rows for cursor replay
+        required: true
+        type: string
+      hot_from:
+        description: Hot query from timestamp, ISO-8601
+        required: true
+        type: string
+      hot_to:
+        description: Hot query to timestamp, ISO-8601
+        required: true
+        type: string
+      cold_account_id:
+        description: Archive table account id with enough rows for cursor replay
+        required: true
+        type: string
+      cold_from:
+        description: Cold query from timestamp, ISO-8601
+        required: true
+        type: string
+      cold_to:
+        description: Cold query to timestamp, ISO-8601
+        required: true
+        type: string
+      iterations:
+        description: Replay iterations per hot/cold shape
+        required: true
+        default: "40"
+        type: string
+      page_limit:
+        description: API page limit, max 100
+        required: true
+        default: "50"
+        type: string
+      expected_total_rows:
+        description: Minimum estimated hot + archive rows in staging RDS
+        required: true
+        default: "100000000"
+        type: string
+      hot_p95_threshold_ms:
+        description: Hot first/cursor p95 threshold in milliseconds
+        required: true
+        default: "350"
+        type: string
+      cold_p95_threshold_ms:
+        description: Cold first/cursor p95 threshold in milliseconds
+        required: true
+        default: "750"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: transaction-read-model-staging-replay
+  cancel-in-progress: false
+
+jobs:
+  replay:
+    name: Replay Hot And Cold Transaction Queries
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v psql >/dev/null 2>&1; then
+            exit 0
+          fi
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Run staging replay
+        env:
+          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+          STAGING_REPLAY_TOKEN: ${{ secrets.STAGING_REPLAY_TOKEN }}
+          STAGING_RDS_DATABASE_URL: ${{ secrets.STAGING_RDS_DATABASE_URL }}
+          HOT_ACCOUNT_ID: ${{ inputs.hot_account_id }}
+          HOT_FROM: ${{ inputs.hot_from }}
+          HOT_TO: ${{ inputs.hot_to }}
+          COLD_ACCOUNT_ID: ${{ inputs.cold_account_id }}
+          COLD_FROM: ${{ inputs.cold_from }}
+          COLD_TO: ${{ inputs.cold_to }}
+          ITERATIONS: ${{ inputs.iterations }}
+          PAGE_LIMIT: ${{ inputs.page_limit }}
+          EXPECTED_TOTAL_ROWS: ${{ inputs.expected_total_rows }}
+          HOT_P95_THRESHOLD_MS: ${{ inputs.hot_p95_threshold_ms }}
+          COLD_P95_THRESHOLD_MS: ${{ inputs.cold_p95_threshold_ms }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools/ops/transaction-read-model-staging-replay.sh
+
+      - name: Append summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          summary_path="build/reports/transaction-staging-replay/summary.md"
+          if [ -f "${summary_path}" ]; then
+            cat "${summary_path}" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload replay report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: transaction-read-model-staging-replay
+          path: build/reports/transaction-staging-replay/
+          if-no-files-found: ignore

--- a/docs/transaction-read-model-staging-replay.md
+++ b/docs/transaction-read-model-staging-replay.md
@@ -1,0 +1,62 @@
+# Transaction Read Model Staging Replay
+
+## Purpose
+
+`Transaction Read Model Staging Replay` workflow는 로컬 fixture가 아니라 staging/RDS의 1억 건 분포에서 hot/cold 거래 조회 p95를 검증합니다.
+
+- hot: `GET /api/v1/transactions`
+- cold: `GET /api/v1/transactions/archive`
+- DB 분포 확인: `transaction_read_model` + `transaction_read_model_archive`의 `pg_class.reltuples` estimate
+- p95 산출: hot first, hot cursor, cold first, cold cursor
+
+## Prerequisites
+
+- staging GitHub Environment secrets:
+  - `STAGING_BASE_URL`
+  - `STAGING_REPLAY_TOKEN`
+  - `STAGING_RDS_DATABASE_URL`
+- staging RDS 통계가 최신이어야 합니다.
+  - 1억 건 분포 적재 또는 replay 전후 `ANALYZE` 수행
+  - full count 대신 `pg_class.reltuples` estimate를 쓰므로 오래된 통계는 검증 실패나 과소/과대 평가를 만들 수 있습니다.
+- cold path는 `GET /api/v1/transactions/archive` 배포 이후 실행합니다.
+
+## Workflow Inputs
+
+- `hot_account_id`: hot table에 cursor page가 나올 만큼 row가 있는 account id
+- `hot_from`, `hot_to`: hot 조회 기간, 최대 31일
+- `cold_account_id`: archive table에 cursor page가 나올 만큼 row가 있는 account id
+- `cold_from`, `cold_to`: cold 조회 기간, 최대 31일
+- `iterations`: shape별 반복 횟수, 기본 `40`
+- `page_limit`: API page size, 기본 `50`, 최대 `100`
+- `expected_total_rows`: hot + archive RDS estimate 최소값, 기본 `100000000`
+- `hot_p95_threshold_ms`: hot first/cursor p95 기준, 기본 `350`
+- `cold_p95_threshold_ms`: cold first/cursor p95 기준, 기본 `750`
+
+## Gate Behavior
+
+- RDS estimate가 `expected_total_rows`보다 작으면 실패합니다.
+- hot/cold account에 row가 없으면 실패합니다.
+- 각 first page가 `nextCursor`를 반환하지 않으면 cursor replay가 불가능하므로 실패합니다.
+- HTTP non-2xx, timeout, empty `items` 응답은 실패합니다.
+- hot first/cursor p95 중 하나라도 hot threshold를 넘으면 실패합니다.
+- cold first/cursor p95 중 하나라도 cold threshold를 넘으면 실패합니다.
+
+## Output
+
+workflow는 `transaction-read-model-staging-replay` artifact를 남깁니다.
+
+- `summary.json`: threshold, p95, RDS estimate, 실패 여부
+- `summary.md`: GitHub step summary용 요약
+- `*.ms`: shape별 latency sample
+- `*.json`: 각 API 응답 body sample
+
+## Local Syntax Check
+
+```bash
+bash -n tools/ops/transaction-read-model-staging-replay.sh
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/transaction-read-model-staging-replay.yml'); puts 'ok'"
+```
+
+## Rollback
+
+workflow/script/doc만 추가하므로 rollback은 PR revert로 수행합니다. staging/RDS 데이터나 production promotion 상태는 변경하지 않습니다.

--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPORT_DIR="${REPORT_DIR:-build/reports/transaction-staging-replay}"
+SUMMARY_JSON="${REPORT_DIR}/summary.json"
+SUMMARY_MD="${REPORT_DIR}/summary.md"
+
+STAGING_BASE_URL="${STAGING_BASE_URL:-}"
+STAGING_REPLAY_TOKEN="${STAGING_REPLAY_TOKEN:-}"
+STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-}"
+EXPECTED_TOTAL_ROWS="${EXPECTED_TOTAL_ROWS:-100000000}"
+ITERATIONS="${ITERATIONS:-40}"
+PAGE_LIMIT="${PAGE_LIMIT:-50}"
+REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-5}"
+HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID:-}"
+HOT_FROM="${HOT_FROM:-}"
+HOT_TO="${HOT_TO:-}"
+COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID:-}"
+COLD_FROM="${COLD_FROM:-}"
+COLD_TO="${COLD_TO:-}"
+HOT_P95_THRESHOLD_MS="${HOT_P95_THRESHOLD_MS:-350}"
+COLD_P95_THRESHOLD_MS="${COLD_P95_THRESHOLD_MS:-750}"
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+notice() {
+  echo "::notice::$*" >&2
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+require_env() {
+  local name="$1"
+  local value="${!name:-}"
+  [ -n "$value" ] || fail "Missing required environment variable: ${name}"
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="${!name:-}"
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "${name} must be a positive integer"
+}
+
+psql_scalar() {
+  local sql="$1"
+  psql "$STAGING_RDS_DATABASE_URL" -v ON_ERROR_STOP=1 --no-align --tuples-only --command "$sql"
+}
+
+validate_inputs() {
+  require_command curl
+  require_command jq
+  require_command psql
+  require_command awk
+  require_command sort
+
+  require_env STAGING_BASE_URL
+  require_env STAGING_REPLAY_TOKEN
+  require_env STAGING_RDS_DATABASE_URL
+  require_env HOT_ACCOUNT_ID
+  require_env HOT_FROM
+  require_env HOT_TO
+  require_env COLD_ACCOUNT_ID
+  require_env COLD_FROM
+  require_env COLD_TO
+
+  require_positive_integer EXPECTED_TOTAL_ROWS
+  require_positive_integer ITERATIONS
+  require_positive_integer PAGE_LIMIT
+  require_positive_integer REQUEST_TIMEOUT_SECONDS
+  require_positive_integer HOT_ACCOUNT_ID
+  require_positive_integer COLD_ACCOUNT_ID
+  require_positive_integer HOT_P95_THRESHOLD_MS
+  require_positive_integer COLD_P95_THRESHOLD_MS
+
+  if [ "$PAGE_LIMIT" -gt 100 ]; then
+    fail "PAGE_LIMIT must be 100 or less"
+  fi
+
+  STAGING_BASE_URL="${STAGING_BASE_URL%/}"
+}
+
+verify_staging_distribution() {
+  # 1억 건 검증에서 full count는 RDS에 부담이 커서 planner 통계 estimate로 gate를 둡니다.
+  local estimated_total
+  estimated_total="$(
+    psql_scalar \
+      "SELECT COALESCE(SUM(c.reltuples), 0)::bigint
+       FROM pg_class c
+       WHERE c.oid IN (
+         'transaction_read_model'::regclass,
+         'transaction_read_model_archive'::regclass
+       );"
+  )"
+
+  [[ "$estimated_total" =~ ^[0-9]+$ ]] || fail "RDS row estimate is not numeric: ${estimated_total}"
+  if [ "$estimated_total" -lt "$EXPECTED_TOTAL_ROWS" ]; then
+    fail "RDS read model estimate ${estimated_total} is below expected ${EXPECTED_TOTAL_ROWS}"
+  fi
+
+  local hot_exists
+  hot_exists="$(
+    psql_scalar \
+      "SELECT EXISTS (
+         SELECT 1
+         FROM transaction_read_model
+         WHERE account_id = ${HOT_ACCOUNT_ID}
+         LIMIT 1
+       );"
+  )"
+  [ "$hot_exists" = "t" ] || fail "HOT_ACCOUNT_ID ${HOT_ACCOUNT_ID} has no hot rows"
+
+  local cold_exists
+  cold_exists="$(
+    psql_scalar \
+      "SELECT EXISTS (
+         SELECT 1
+         FROM transaction_read_model_archive
+         WHERE account_id = ${COLD_ACCOUNT_ID}
+         LIMIT 1
+       );"
+  )"
+  [ "$cold_exists" = "t" ] || fail "COLD_ACCOUNT_ID ${COLD_ACCOUNT_ID} has no archive rows"
+
+  notice "RDS read model estimate ${estimated_total} rows"
+  echo "$estimated_total" >"${REPORT_DIR}/estimated-total-rows.txt"
+}
+
+record_latency() {
+  local shape="$1"
+  local latency_ms="$2"
+  printf '%s\n' "$latency_ms" >>"${REPORT_DIR}/${shape}.ms"
+}
+
+request_page() {
+  local shape="$1"
+  local path="$2"
+  local account_id="$3"
+  local from="$4"
+  local to="$5"
+  local cursor="${6:-}"
+  local iteration="$7"
+  local body_file="${REPORT_DIR}/${shape}-${iteration}.json"
+  local response http_status time_total latency_ms item_count next_cursor
+
+  local curl_args=(
+    --silent
+    --show-error
+    --output "$body_file"
+    --write-out "%{http_code} %{time_total}"
+    --max-time "$REQUEST_TIMEOUT_SECONDS"
+    --get "${STAGING_BASE_URL}${path}"
+    --header "Authorization: Bearer ${STAGING_REPLAY_TOKEN}"
+    --data-urlencode "accountId=${account_id}"
+    --data-urlencode "from=${from}"
+    --data-urlencode "to=${to}"
+    --data-urlencode "limit=${PAGE_LIMIT}"
+  )
+
+  if [ -n "$cursor" ]; then
+    curl_args+=(--data-urlencode "cursor=${cursor}")
+  fi
+
+  if ! response="$(curl "${curl_args[@]}")"; then
+    fail "${shape} iteration ${iteration} request failed"
+  fi
+
+  http_status="${response%% *}"
+  time_total="${response#* }"
+  if [[ ! "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+    fail "${shape} iteration ${iteration} returned HTTP ${http_status}"
+  fi
+
+  latency_ms="$(awk -v seconds="$time_total" 'BEGIN { printf "%.0f", seconds * 1000 }')"
+  item_count="$(jq '.items | length' "$body_file")"
+  if [ "$item_count" -le 0 ]; then
+    fail "${shape} iteration ${iteration} returned no items"
+  fi
+
+  record_latency "$shape" "$latency_ms"
+  next_cursor="$(jq -r '.nextCursor // ""' "$body_file")"
+  printf '%s\n' "$next_cursor"
+}
+
+run_replay() {
+  : >"${REPORT_DIR}/hot_first.ms"
+  : >"${REPORT_DIR}/hot_cursor.ms"
+  : >"${REPORT_DIR}/cold_first.ms"
+  : >"${REPORT_DIR}/cold_cursor.ms"
+
+  for iteration in $(seq 1 "$ITERATIONS"); do
+    local hot_cursor cold_cursor
+    hot_cursor="$(
+      request_page hot_first "/api/v1/transactions" \
+        "$HOT_ACCOUNT_ID" "$HOT_FROM" "$HOT_TO" "" "$iteration"
+    )"
+    [ -n "$hot_cursor" ] || fail "hot_first iteration ${iteration} did not return nextCursor"
+    request_page hot_cursor "/api/v1/transactions" \
+      "$HOT_ACCOUNT_ID" "$HOT_FROM" "$HOT_TO" "$hot_cursor" "$iteration" >/dev/null
+
+    cold_cursor="$(
+      request_page cold_first "/api/v1/transactions/archive" \
+        "$COLD_ACCOUNT_ID" "$COLD_FROM" "$COLD_TO" "" "$iteration"
+    )"
+    [ -n "$cold_cursor" ] || fail "cold_first iteration ${iteration} did not return nextCursor"
+    request_page cold_cursor "/api/v1/transactions/archive" \
+      "$COLD_ACCOUNT_ID" "$COLD_FROM" "$COLD_TO" "$cold_cursor" "$iteration" >/dev/null
+  done
+}
+
+p95_ms() {
+  local file="$1"
+  local count index
+  count="$(wc -l <"$file" | tr -d ' ')"
+  [ "$count" -gt 0 ] || fail "No latency samples in ${file}"
+  index=$(((count * 95 + 99) / 100))
+  sort -n "$file" | awk -v index="$index" 'NR == index { print; exit }'
+}
+
+write_summary() {
+  local estimated_total hot_first hot_cursor cold_first cold_cursor failed
+  estimated_total="$(cat "${REPORT_DIR}/estimated-total-rows.txt")"
+  hot_first="$(p95_ms "${REPORT_DIR}/hot_first.ms")"
+  hot_cursor="$(p95_ms "${REPORT_DIR}/hot_cursor.ms")"
+  cold_first="$(p95_ms "${REPORT_DIR}/cold_first.ms")"
+  cold_cursor="$(p95_ms "${REPORT_DIR}/cold_cursor.ms")"
+  failed=false
+
+  if [ "$hot_first" -gt "$HOT_P95_THRESHOLD_MS" ] || [ "$hot_cursor" -gt "$HOT_P95_THRESHOLD_MS" ]; then
+    failed=true
+  fi
+  if [ "$cold_first" -gt "$COLD_P95_THRESHOLD_MS" ] || [ "$cold_cursor" -gt "$COLD_P95_THRESHOLD_MS" ]; then
+    failed=true
+  fi
+
+  jq -n \
+    --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg baseUrl "$STAGING_BASE_URL" \
+    --argjson expectedTotalRows "$EXPECTED_TOTAL_ROWS" \
+    --argjson estimatedTotalRows "$estimated_total" \
+    --argjson iterations "$ITERATIONS" \
+    --argjson pageLimit "$PAGE_LIMIT" \
+    --argjson hotP95ThresholdMs "$HOT_P95_THRESHOLD_MS" \
+    --argjson coldP95ThresholdMs "$COLD_P95_THRESHOLD_MS" \
+    --argjson hotFirstP95Ms "$hot_first" \
+    --argjson hotCursorP95Ms "$hot_cursor" \
+    --argjson coldFirstP95Ms "$cold_first" \
+    --argjson coldCursorP95Ms "$cold_cursor" \
+    --argjson failed "$failed" \
+    '{
+      generatedAt: $generatedAt,
+      baseUrl: $baseUrl,
+      expectedTotalRows: $expectedTotalRows,
+      estimatedTotalRows: $estimatedTotalRows,
+      iterations: $iterations,
+      pageLimit: $pageLimit,
+      thresholds: {
+        hotP95Ms: $hotP95ThresholdMs,
+        coldP95Ms: $coldP95ThresholdMs
+      },
+      results: {
+        hotFirstP95Ms: $hotFirstP95Ms,
+        hotCursorP95Ms: $hotCursorP95Ms,
+        coldFirstP95Ms: $coldFirstP95Ms,
+        coldCursorP95Ms: $coldCursorP95Ms
+      },
+      failed: $failed
+    }' >"$SUMMARY_JSON"
+
+  {
+    echo "# Transaction Read Model Staging Replay"
+    echo
+    echo "- estimated total rows: ${estimated_total}"
+    echo "- iterations: ${ITERATIONS}"
+    echo "- page limit: ${PAGE_LIMIT}"
+    echo "- hot first p95: ${hot_first}ms / threshold ${HOT_P95_THRESHOLD_MS}ms"
+    echo "- hot cursor p95: ${hot_cursor}ms / threshold ${HOT_P95_THRESHOLD_MS}ms"
+    echo "- cold first p95: ${cold_first}ms / threshold ${COLD_P95_THRESHOLD_MS}ms"
+    echo "- cold cursor p95: ${cold_cursor}ms / threshold ${COLD_P95_THRESHOLD_MS}ms"
+  } >"$SUMMARY_MD"
+
+  if [ "$failed" = "true" ]; then
+    fail "transaction read model staging replay p95 threshold exceeded"
+  fi
+}
+
+main() {
+  mkdir -p "$REPORT_DIR"
+  validate_inputs
+  verify_staging_distribution
+  run_replay
+  write_summary
+}
+
+main "$@"


### PR DESCRIPTION
## 🔗 Related Issue
- close #235

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging/RDS 1억 건 분포에서 transaction hot/cold read model 조회 p95를 검증하는 수동 workflow를 추가했습니다.
- 로컬 fixture가 아니라 staging API와 RDS estimate를 사용해 hot first/cursor, cold first/cursor p95를 gate합니다.

## 🛠 Changes
- `tools/ops/transaction-read-model-staging-replay.sh` 추가
- `.github/workflows/transaction-read-model-staging-replay.yml` workflow_dispatch 추가
- `docs/transaction-read-model-staging-replay.md` 운영 절차/secret/input/artifact 문서화

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash -n tools/ops/transaction-read-model-staging-replay.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/transaction-read-model-staging-replay.yml'); puts 'ok'"`
- workflow `run` block 3개 `bash -n` 검증
- `git diff --check`
- `git rev-list --count main..HEAD` → `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: RDS 통계가 오래되면 `pg_class.reltuples` estimate가 실제 1억 건 분포와 어긋날 수 있습니다. 실행 전 staging RDS `ANALYZE` 상태를 확인해야 합니다.
- 예상 리스크: cold path는 #236 `[Feat] transaction archive 조회 API 추가`가 merge/deploy된 뒤 실행해야 합니다.
- 롤백 방법: PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
