### PR TITLE
[Perf] transaction archive query EXPLAIN baseline 추가

### DIFF
--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionArchiveReadRepositoryBaselineIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionArchiveReadRepositoryBaselineIntegrationTest.java
@@ -1,0 +1,161 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.aquilabank.support.TransactionArchiveReadModelBaselineFixture;
+import com.aquilabank.support.TransactionArchiveReadModelBaselineFixture.BaselineWindow;
+import com.aquilabank.support.TransactionExplainPlan;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcTransactionArchiveReadRepositoryBaselineIntegrationTest
+    extends PostgresContainerTestSupport {
+
+  private static final Object SEED_LOCK = new Object();
+  private static BaselineWindow sharedBaselineWindow;
+
+  private final TransactionArchiveReadModelBaselineFixture fixture =
+      new TransactionArchiveReadModelBaselineFixture();
+
+  @Autowired private JdbcTransactionArchiveReadRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  private BaselineWindow baselineWindow;
+
+  @BeforeEach
+  void setUpDatabase() {
+    if (sharedBaselineWindow != null) {
+      baselineWindow = sharedBaselineWindow;
+      return;
+    }
+
+    synchronized (SEED_LOCK) {
+      if (sharedBaselineWindow == null) {
+        resetBankingTables(jdbcTemplate);
+        // archive baseline fixture는 cold table plan 검증용이라 기본 transaction timeout보다 길게 둡니다.
+        commit(transactionManager, 45, () -> sharedBaselineWindow = fixture.seed(jdbcTemplate));
+      }
+      baselineWindow = sharedBaselineWindow;
+    }
+  }
+
+  @Test
+  void firstPageUsesArchiveAccountCursorIndexWithoutSeqScanOrSort() {
+    TransactionQuery query = query(null, null);
+
+    TransactionSlice slice = repository.fetchArchived(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(50);
+    assertThat(slice.hasNext()).isTrue();
+    assertThat(plan.rootNodeType()).isEqualTo("Limit");
+    assertThat(plan.actualRows()).isEqualTo(51.0d);
+    assertThat(plan.usesIndex("idx_transaction_read_model_archive_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void cursorPageKeepsArchiveAccountCursorIndex() {
+    TransactionSlice firstSlice = repository.fetchArchived(query(null, null));
+    TransactionQuery nextPageQuery = query(firstSlice.nextCursor(), null);
+
+    TransactionSlice nextSlice = repository.fetchArchived(nextPageQuery);
+    TransactionExplainPlan plan = explain(nextPageQuery);
+
+    assertThat(firstSlice.nextCursor()).isNotNull();
+    assertThat(nextSlice.items()).hasSize(50);
+    assertThat(nextSlice.items().getFirst().bookedAt())
+        .isBeforeOrEqualTo(firstSlice.items().getLast().bookedAt());
+    assertThat(plan.usesIndex("idx_transaction_read_model_archive_account_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void statusFilteredCursorPageUsesArchiveStatusCursorIndex() {
+    TransactionSlice firstSlice = repository.fetchArchived(query(null, TransactionStatus.BOOKED));
+    TransactionQuery nextPageQuery = query(firstSlice.nextCursor(), TransactionStatus.BOOKED);
+
+    TransactionSlice nextSlice = repository.fetchArchived(nextPageQuery);
+    TransactionExplainPlan plan = explain(nextPageQuery);
+
+    assertThat(firstSlice.nextCursor()).isNotNull();
+    assertThat(nextSlice.items()).hasSize(50);
+    assertThat(nextSlice.items()).allMatch(item -> item.status() == TransactionStatus.BOOKED);
+    assertThat(plan.usesIndex("idx_transaction_read_model_archive_account_status_cursor")).isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  @Test
+  void transactionReferenceExactLookupUsesArchiveReferenceCursorIndex() {
+    TransactionQuery query = query(null, null, "archive-hot-account-trx-40000");
+
+    TransactionSlice slice = repository.fetchArchived(query);
+    TransactionExplainPlan plan = explain(query);
+
+    assertThat(slice.items()).hasSize(1);
+    assertThat(slice.items().getFirst().transactionReference())
+        .isEqualTo("archive-hot-account-trx-40000");
+    assertThat(plan.usesIndex("idx_transaction_read_model_archive_account_reference_cursor"))
+        .isTrue();
+    assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
+  private TransactionQuery query(
+      com.aquilabank.domain.transaction.model.TransactionCursor cursor, TransactionStatus status) {
+    return query(cursor, status, null);
+  }
+
+  private TransactionQuery query(
+      com.aquilabank.domain.transaction.model.TransactionCursor cursor,
+      TransactionStatus status,
+      String transactionReference) {
+    return new TransactionQuery(
+        baselineWindow.hotAccountId(),
+        baselineWindow.from(),
+        baselineWindow.to(),
+        50,
+        cursor,
+        status,
+        null,
+        null,
+        null,
+        transactionReference);
+  }
+
+  private TransactionExplainPlan explain(TransactionQuery query) {
+    TransactionArchiveReadQueryStatement statement =
+        TransactionArchiveReadQueryStatement.from(query);
+    String explainJson =
+        jdbcTemplate.queryForObject(
+            "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)\n" + statement.sql(),
+            statement.params(),
+            (rs, rowNum) -> rs.getString(1));
+    if (explainJson == null) {
+      throw new IllegalStateException("EXPLAIN did not return JSON");
+    }
+    return TransactionExplainPlan.fromJson(objectMapper, explainJson);
+  }
+}

--- a/back/src/test/java/com/aquilabank/support/TransactionArchiveReadModelBaselineFixture.java
+++ b/back/src/test/java/com/aquilabank/support/TransactionArchiveReadModelBaselineFixture.java
@@ -1,0 +1,221 @@
+package com.aquilabank.support;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/** archive 거래 조회 baseline 테스트에서 cold table 데이터 분포를 반복 재현하는 fixture */
+public final class TransactionArchiveReadModelBaselineFixture {
+
+  private static final String ACTIVE = "ACTIVE";
+  private static final String CURRENCY_CODE = "KRW";
+  private static final Instant WINDOW_START = Instant.parse("2025-04-01T00:00:00Z");
+  private static final Instant WINDOW_END = Instant.parse("2025-05-01T00:00:00Z");
+  private static final Instant ARCHIVED_AT = Instant.parse("2026-04-01T00:00:00Z");
+  private static final long OPENING_BALANCE_MINOR = 1_000_000L;
+  private static final int HOT_ACCOUNT_ROW_COUNT = 80_000;
+  private static final int HOT_ACCOUNT_STEP_SECONDS = 30;
+  private static final int NOISE_ACCOUNT_COUNT = 6;
+  private static final int NOISE_ACCOUNT_ROW_COUNT = 4_000;
+  private static final int NOISE_ACCOUNT_STEP_SECONDS = 360;
+  private static final int INSERT_BATCH_SIZE = 5_000;
+
+  public BaselineWindow seed(NamedParameterJdbcTemplate jdbcTemplate) {
+    long hotAccountId = insertAccount(jdbcTemplate, "archive-baseline-hot-account", WINDOW_START);
+    insertArchiveRows(
+        jdbcTemplate,
+        hotAccountId,
+        HOT_ACCOUNT_ROW_COUNT,
+        HOT_ACCOUNT_STEP_SECONDS,
+        "archive-hot-account");
+
+    List<Long> noiseAccountIds = new ArrayList<>();
+    for (int index = 1; index <= NOISE_ACCOUNT_COUNT; index++) {
+      long accountId =
+          insertAccount(jdbcTemplate, "archive-baseline-noise-account-" + index, WINDOW_START);
+      insertArchiveRows(
+          jdbcTemplate,
+          accountId,
+          NOISE_ACCOUNT_ROW_COUNT,
+          NOISE_ACCOUNT_STEP_SECONDS,
+          "archive-noise-account-" + index);
+      noiseAccountIds.add(accountId);
+    }
+
+    analyzeTables(jdbcTemplate);
+    return new BaselineWindow(hotAccountId, noiseAccountIds, WINDOW_START, WINDOW_END);
+  }
+
+  private long insertAccount(
+      NamedParameterJdbcTemplate jdbcTemplate, String displayName, Instant createdAt) {
+    String accountNumber =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0')
+            """,
+            new MapSqlParameterSource(),
+            String.class);
+    if (accountNumber == null) {
+      throw new IllegalStateException("archive baseline account number is not generated");
+    }
+
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountNumber,
+                :displayName,
+                :accountStatus,
+                :currencyCode,
+                :createdAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountNumber", accountNumber)
+                .addValue("displayName", displayName)
+                .addValue("accountStatus", ACTIVE)
+                .addValue("currencyCode", CURRENCY_CODE)
+                .addValue("createdAt", Timestamp.from(createdAt)),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("archive baseline account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertArchiveRows(
+      NamedParameterJdbcTemplate jdbcTemplate,
+      long accountId,
+      int rowCount,
+      int stepSeconds,
+      String referencePrefix) {
+    for (int startSeq = 1; startSeq <= rowCount; startSeq += INSERT_BATCH_SIZE) {
+      int endSeq = Math.min(startSeq + INSERT_BATCH_SIZE - 1, rowCount);
+      jdbcTemplate.update(
+          """
+          WITH generated AS (
+              SELECT
+                  :accountId AS account_id,
+                  series AS seq,
+                  CAST(:windowStart AS timestamptz)
+                      + make_interval(secs => ((series - 1) * :stepSeconds)::integer) AS booked_at,
+                  CASE WHEN mod(series, 7) = 0 THEN 'DEBIT' ELSE 'CREDIT' END AS direction,
+                  CASE
+                      WHEN mod(series, 53) = 0 THEN 'REVERSED'
+                      WHEN mod(series, 5) = 0 THEN 'PENDING'
+                      ELSE 'BOOKED'
+                  END AS transaction_status,
+                  CASE WHEN mod(series, 7) = 0 THEN 1300 ELSE 1700 END AS amount_minor,
+                  :openingBalanceMinor
+                      + ((series - (series / 7)) * 1700)
+                      - ((series / 7) * 1300) AS balance_after_minor,
+                  :referencePrefix || '-trx-' || series AS transaction_reference,
+                  :referencePrefix || '-entry-' || series AS entry_reference,
+                  'archive-seed-' || :referencePrefix || '-' || series AS summary,
+                  CASE WHEN mod(series, 3) = 0 THEN 'MERCHANT' ELSE 'ATM' END
+                      AS counterparty_masked_name
+              FROM generate_series(:startSeq, :endSeq) AS series
+          ),
+          inserted_ledger AS (
+              INSERT INTO ledger_entry (
+                  account_id,
+                  transaction_reference,
+                  entry_reference,
+                  direction,
+                  entry_status,
+                  amount_minor,
+                  currency_code,
+                  booked_at,
+                  occurred_at,
+                  description,
+                  metadata,
+                  created_at,
+                  updated_at
+              )
+              SELECT
+                  account_id,
+                  transaction_reference,
+                  entry_reference,
+                  direction,
+                  transaction_status,
+                  amount_minor,
+                  :currencyCode,
+                  booked_at,
+                  booked_at,
+                  summary,
+                  '{}'::jsonb,
+                  booked_at,
+                  booked_at
+              FROM generated
+              RETURNING id, entry_reference
+          )
+          INSERT INTO transaction_read_model_archive (
+              id,
+              ledger_entry_id,
+              account_id,
+              transaction_reference,
+              direction,
+              transaction_status,
+              amount_minor,
+              balance_after_minor,
+              currency_code,
+              summary,
+              counterparty_masked_name,
+              booked_at,
+              created_at,
+              archived_at
+          )
+          SELECT
+              inserted_ledger.id,
+              inserted_ledger.id,
+              generated.account_id,
+              generated.transaction_reference,
+              generated.direction,
+              generated.transaction_status,
+              generated.amount_minor,
+              generated.balance_after_minor,
+              :currencyCode,
+              generated.summary,
+              generated.counterparty_masked_name,
+              generated.booked_at,
+              generated.booked_at,
+              :archivedAt
+          FROM generated
+          JOIN inserted_ledger
+            ON inserted_ledger.entry_reference = generated.entry_reference
+          """,
+          new MapSqlParameterSource()
+              .addValue("accountId", accountId)
+              .addValue("currencyCode", CURRENCY_CODE)
+              .addValue("referencePrefix", referencePrefix)
+              .addValue("openingBalanceMinor", OPENING_BALANCE_MINOR)
+              .addValue("startSeq", startSeq)
+              .addValue("endSeq", endSeq)
+              .addValue("stepSeconds", stepSeconds)
+              .addValue("windowStart", Timestamp.from(WINDOW_START))
+              .addValue("archivedAt", Timestamp.from(ARCHIVED_AT)));
+    }
+  }
+
+  private void analyzeTables(NamedParameterJdbcTemplate jdbcTemplate) {
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE bank_account");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE ledger_entry");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE transaction_read_model_archive");
+  }
+
+  public record BaselineWindow(
+      long hotAccountId, List<Long> noiseAccountIds, Instant from, Instant to) {}
+}

--- a/tools/test/run-transaction-archive-query-baseline.sh
+++ b/tools/test/run-transaction-archive-query-baseline.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[transaction-archive-baseline] fixture: archive hot account 80000 rows + noise 6x4000 rows"
+echo "[transaction-archive-baseline] target: first-page/cursor/status/reference keep archive account keyset indexes without Seq Scan or Sort"
+echo "[transaction-archive-baseline] timeout order: statement_timeout=3000ms query-timeout=3s request-timeout=5000ms"
+
+tools/test/with-resource-lock.sh back-gradle-transaction-archive-baseline ./back/gradlew -p back test \
+  --tests '*JdbcTransactionArchiveReadRepositoryBaselineIntegrationTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #238

## 🌿 Base Branch
- `main`

## 📝 Summary
- `transaction_read_model_archive` 조회 경로의 EXPLAIN baseline을 추가했습니다.
- archive cold table도 account-scoped keyset/index/timeout 기준을 로컬 검증 스크립트로 고정합니다.

## 🛠 Changes
- archive hot account 80,000건 + noise 6x4,000건 fixture를 추가했습니다.
- first page, cursor page, status cursor, reference exact lookup plan이 archive index를 쓰고 `Seq Scan`/`Sort`를 피하는지 검증합니다.
- `tools/test/run-transaction-archive-query-baseline.sh`를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-transaction-archive-query-baseline.sh`
- `./back/gradlew -p back spotlessApply`
- `./back/gradlew -p back check`
- pre-commit: `./back/gradlew -p back check`
- PR 전 확인: `git rev-list --count main..HEAD` = `1`, brief `commit_plan` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Testcontainers PostgreSQL planner가 환경별 통계 차이로 다른 plan을 선택할 수 있습니다.
- 롤백 방법: test/script 추가 커밋 revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A: test/script only
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A: 영향 없음
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A: 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A: 신규 로컬 검증 스크립트
