### PR TITLE
[Perf] transaction hot/cold retention cutoff 부하 검증 추가

### DIFF
--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadModelRetentionCutoffLoadIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadModelRetentionCutoffLoadIntegrationTest.java
@@ -1,0 +1,140 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.aquilabank.support.TransactionExplainPlan;
+import com.aquilabank.support.TransactionReadModelRetentionCutoffLoadFixture;
+import com.aquilabank.support.TransactionReadModelRetentionCutoffLoadFixture.CutoffLoadWindow;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcTransactionReadModelRetentionCutoffLoadIntegrationTest
+    extends PostgresContainerTestSupport {
+
+  private static final Object SEED_LOCK = new Object();
+  private static CutoffLoadWindow sharedWindow;
+
+  private final TransactionReadModelRetentionCutoffLoadFixture fixture =
+      new TransactionReadModelRetentionCutoffLoadFixture();
+
+  @Autowired private JdbcTransactionReadRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  private CutoffLoadWindow window;
+
+  @BeforeEach
+  void setUpDatabase() {
+    if (sharedWindow != null) {
+      window = sharedWindow;
+      return;
+    }
+
+    synchronized (SEED_LOCK) {
+      if (sharedWindow == null) {
+        resetBankingTables(jdbcTemplate);
+        // cutoff load fixture는 retention 기간별 hot/cold 분포 비교용이라 setup timeout을 늘립니다.
+        commit(transactionManager, 45, () -> sharedWindow = fixture.seed(jdbcTemplate));
+      }
+      window = sharedWindow;
+    }
+  }
+
+  @Test
+  void cutoffWindowsExposeHotTableAndCleanupCandidateCost() {
+    CutoffMetrics shortRetention = metrics(window.shortRetentionCutoff());
+    CutoffMetrics defaultRetention = metrics(window.defaultRetentionCutoff());
+    CutoffMetrics longRetention = metrics(window.longRetentionCutoff());
+
+    assertThat(shortRetention.hotCount()).isEqualTo(3_000L);
+    assertThat(shortRetention.candidateCount()).isEqualTo(69_000L);
+    assertThat(defaultRetention.hotCount()).isEqualTo(36_500L);
+    assertThat(defaultRetention.candidateCount()).isEqualTo(35_500L);
+    assertThat(longRetention.hotCount()).isEqualTo(72_000L);
+    assertThat(longRetention.candidateCount()).isZero();
+  }
+
+  @Test
+  void boundedReadWindowsKeepAccountKeysetIndexAcrossCutoffs() {
+    for (Instant cutoff :
+        List.of(
+            window.shortRetentionCutoff(),
+            window.defaultRetentionCutoff(),
+            window.longRetentionCutoff())) {
+      TransactionQuery query = query(cutoff);
+
+      TransactionSlice slice = repository.fetch(query);
+      TransactionExplainPlan plan = explain(query);
+
+      assertThat(slice.items()).hasSize(50);
+      assertThat(slice.hasNext()).isTrue();
+      assertThat(plan.usesIndex("idx_transaction_read_model_account_cursor")).isTrue();
+      assertThat(plan.hasNodeType("Seq Scan")).isFalse();
+      assertThat(plan.hasNodeType("Sort")).isFalse();
+    }
+  }
+
+  private CutoffMetrics metrics(Instant cutoff) {
+    CutoffMetrics metrics =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*) FILTER (WHERE booked_at >= :cutoff) AS hot_count,
+                   COUNT(*) FILTER (WHERE booked_at < :cutoff) AS candidate_count
+            FROM transaction_read_model
+            WHERE account_id = :accountId
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", window.hotAccountId())
+                .addValue("cutoff", Timestamp.from(cutoff)),
+            (rs, rowNum) ->
+                new CutoffMetrics(rs.getLong("hot_count"), rs.getLong("candidate_count")));
+    if (metrics == null) {
+      throw new IllegalStateException("cutoff metrics query returned no row");
+    }
+    return metrics;
+  }
+
+  private TransactionQuery query(Instant cutoff) {
+    Instant minimumFrom = window.to().minus(Duration.ofDays(31));
+    Instant from = cutoff.isAfter(minimumFrom) ? cutoff : minimumFrom;
+    return new TransactionQuery(
+        window.hotAccountId(), from, window.to(), 50, null, null, null, null, null, null);
+  }
+
+  private TransactionExplainPlan explain(TransactionQuery query) {
+    TransactionReadQueryStatement statement = TransactionReadQueryStatement.from(query);
+    String explainJson =
+        jdbcTemplate.queryForObject(
+            "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)\n" + statement.sql(),
+            statement.params(),
+            (rs, rowNum) -> rs.getString(1));
+    if (explainJson == null) {
+      throw new IllegalStateException("EXPLAIN did not return JSON");
+    }
+    return TransactionExplainPlan.fromJson(objectMapper, explainJson);
+  }
+
+  private record CutoffMetrics(long hotCount, long candidateCount) {}
+}

--- a/back/src/test/java/com/aquilabank/support/TransactionReadModelRetentionCutoffLoadFixture.java
+++ b/back/src/test/java/com/aquilabank/support/TransactionReadModelRetentionCutoffLoadFixture.java
@@ -1,0 +1,228 @@
+package com.aquilabank.support;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/** retention cutoff별 hot table 잔존량과 cleanup 후보량을 재현하는 fixture */
+public final class TransactionReadModelRetentionCutoffLoadFixture {
+
+  private static final String ACTIVE = "ACTIVE";
+  private static final String CURRENCY_CODE = "KRW";
+  private static final Instant WINDOW_START = Instant.parse("2024-05-02T00:00:00Z");
+  private static final Instant WINDOW_END = Instant.parse("2026-04-22T00:00:00Z");
+  private static final long OPENING_BALANCE_MINOR = 1_000_000L;
+  private static final int HOT_ACCOUNT_ROW_COUNT = 72_000;
+  private static final int HOT_ACCOUNT_STEP_SECONDS = 864;
+  private static final int NOISE_ACCOUNT_COUNT = 4;
+  private static final int NOISE_ACCOUNT_ROW_COUNT = 4_000;
+  private static final int NOISE_ACCOUNT_STEP_SECONDS = 3_600;
+  private static final int INSERT_BATCH_SIZE = 5_000;
+
+  public CutoffLoadWindow seed(NamedParameterJdbcTemplate jdbcTemplate) {
+    long hotAccountId =
+        insertAccount(jdbcTemplate, "retention-cutoff-load-hot-account", WINDOW_START);
+    insertTimelineRows(
+        jdbcTemplate,
+        hotAccountId,
+        HOT_ACCOUNT_ROW_COUNT,
+        HOT_ACCOUNT_STEP_SECONDS,
+        "retention-cutoff-hot");
+
+    List<Long> noiseAccountIds = new ArrayList<>();
+    for (int index = 1; index <= NOISE_ACCOUNT_COUNT; index++) {
+      long accountId =
+          insertAccount(jdbcTemplate, "retention-cutoff-load-noise-account-" + index, WINDOW_START);
+      insertTimelineRows(
+          jdbcTemplate,
+          accountId,
+          NOISE_ACCOUNT_ROW_COUNT,
+          NOISE_ACCOUNT_STEP_SECONDS,
+          "retention-cutoff-noise-" + index);
+      noiseAccountIds.add(accountId);
+    }
+
+    analyzeTables(jdbcTemplate);
+    return new CutoffLoadWindow(
+        hotAccountId,
+        noiseAccountIds,
+        WINDOW_END.minus(Duration.ofDays(30)),
+        WINDOW_END.minus(Duration.ofDays(365)),
+        WINDOW_END.minus(Duration.ofDays(730)),
+        WINDOW_END);
+  }
+
+  private long insertAccount(
+      NamedParameterJdbcTemplate jdbcTemplate, String displayName, Instant createdAt) {
+    String accountNumber =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0')
+            """,
+            new MapSqlParameterSource(),
+            String.class);
+    if (accountNumber == null) {
+      throw new IllegalStateException("retention cutoff account number is not generated");
+    }
+
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountNumber,
+                :displayName,
+                :accountStatus,
+                :currencyCode,
+                :createdAt,
+                :createdAt
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountNumber", accountNumber)
+                .addValue("displayName", displayName)
+                .addValue("accountStatus", ACTIVE)
+                .addValue("currencyCode", CURRENCY_CODE)
+                .addValue("createdAt", Timestamp.from(createdAt)),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("retention cutoff account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertTimelineRows(
+      NamedParameterJdbcTemplate jdbcTemplate,
+      long accountId,
+      int rowCount,
+      int stepSeconds,
+      String referencePrefix) {
+    for (int startSeq = 1; startSeq <= rowCount; startSeq += INSERT_BATCH_SIZE) {
+      int endSeq = Math.min(startSeq + INSERT_BATCH_SIZE - 1, rowCount);
+      jdbcTemplate.update(
+          """
+          WITH generated AS (
+              SELECT
+                  :accountId AS account_id,
+                  series AS seq,
+                  CAST(:windowStart AS timestamptz)
+                      + make_interval(secs => ((series - 1) * :stepSeconds)::integer) AS booked_at,
+                  CASE WHEN mod(series, 7) = 0 THEN 'DEBIT' ELSE 'CREDIT' END AS direction,
+                  CASE
+                      WHEN mod(series, 53) = 0 THEN 'REVERSED'
+                      WHEN mod(series, 5) = 0 THEN 'PENDING'
+                      ELSE 'BOOKED'
+                  END AS transaction_status,
+                  CASE WHEN mod(series, 7) = 0 THEN 1300 ELSE 1700 END AS amount_minor,
+                  :openingBalanceMinor
+                      + ((series - (series / 7)) * 1700)
+                      - ((series / 7) * 1300) AS balance_after_minor,
+                  :referencePrefix || '-trx-' || series AS transaction_reference,
+                  :referencePrefix || '-entry-' || series AS entry_reference,
+                  'retention-cutoff-seed-' || :referencePrefix || '-' || series AS summary,
+                  CASE WHEN mod(series, 3) = 0 THEN 'MERCHANT' ELSE 'ATM' END
+                      AS counterparty_masked_name
+              FROM generate_series(:startSeq, :endSeq) AS series
+          ),
+          inserted_ledger AS (
+              INSERT INTO ledger_entry (
+                  account_id,
+                  transaction_reference,
+                  entry_reference,
+                  direction,
+                  entry_status,
+                  amount_minor,
+                  currency_code,
+                  booked_at,
+                  occurred_at,
+                  description,
+                  metadata,
+                  created_at,
+                  updated_at
+              )
+              SELECT
+                  account_id,
+                  transaction_reference,
+                  entry_reference,
+                  direction,
+                  transaction_status,
+                  amount_minor,
+                  :currencyCode,
+                  booked_at,
+                  booked_at,
+                  summary,
+                  '{}'::jsonb,
+                  booked_at,
+                  booked_at
+              FROM generated
+              RETURNING id, entry_reference
+          )
+          INSERT INTO transaction_read_model (
+              ledger_entry_id,
+              account_id,
+              transaction_reference,
+              direction,
+              transaction_status,
+              amount_minor,
+              balance_after_minor,
+              currency_code,
+              summary,
+              counterparty_masked_name,
+              booked_at,
+              created_at
+          )
+          SELECT
+              inserted_ledger.id,
+              generated.account_id,
+              generated.transaction_reference,
+              generated.direction,
+              generated.transaction_status,
+              generated.amount_minor,
+              generated.balance_after_minor,
+              :currencyCode,
+              generated.summary,
+              generated.counterparty_masked_name,
+              generated.booked_at,
+              generated.booked_at
+          FROM generated
+          JOIN inserted_ledger
+            ON inserted_ledger.entry_reference = generated.entry_reference
+          """,
+          new MapSqlParameterSource()
+              .addValue("accountId", accountId)
+              .addValue("currencyCode", CURRENCY_CODE)
+              .addValue("referencePrefix", referencePrefix)
+              .addValue("openingBalanceMinor", OPENING_BALANCE_MINOR)
+              .addValue("startSeq", startSeq)
+              .addValue("endSeq", endSeq)
+              .addValue("stepSeconds", stepSeconds)
+              .addValue("windowStart", Timestamp.from(WINDOW_START)));
+    }
+  }
+
+  private void analyzeTables(NamedParameterJdbcTemplate jdbcTemplate) {
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE bank_account");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE ledger_entry");
+    jdbcTemplate.getJdbcTemplate().execute("ANALYZE transaction_read_model");
+  }
+
+  public record CutoffLoadWindow(
+      long hotAccountId,
+      List<Long> noiseAccountIds,
+      Instant shortRetentionCutoff,
+      Instant defaultRetentionCutoff,
+      Instant longRetentionCutoff,
+      Instant to) {}
+}

--- a/tools/test/run-transaction-retention-cutoff-load-test.sh
+++ b/tools/test/run-transaction-retention-cutoff-load-test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[transaction-retention-cutoff] fixture: hot account 72000 rows over 720 days + noise 4x4000 rows"
+echo "[transaction-retention-cutoff] target: short=30d hot=3000/candidate=69000, default=365d hot=36500/candidate=35500, long=730d hot=72000/candidate=0"
+echo "[transaction-retention-cutoff] index guard: cutoff windows keep idx_transaction_read_model_account_cursor without Seq Scan or Sort"
+echo "[transaction-retention-cutoff] runtime guard: small cleanup batch, statement_timeout=3000ms query-timeout=3s request-timeout=5000ms"
+
+tools/test/with-resource-lock.sh back-gradle-transaction-retention-cutoff ./back/gradlew -p back test \
+  --tests '*JdbcTransactionReadModelRetentionCutoffLoadIntegrationTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #239

## 🌿 Base Branch
- `main`

## 📝 Summary
- retention cutoff별 hot table 잔존량과 cleanup candidate 규모를 수치로 고정하는 load baseline을 추가했습니다.
- bounded transaction read window가 cutoff 변화와 관계없이 account keyset index를 유지하는지 검증합니다.

## 🛠 Changes
- hot account 72,000건/720일 + noise 4x4,000건 fixture를 추가했습니다.
- short/default/long retention cutoff별 hot/candidate count를 검증합니다.
- cutoff별 bounded read query가 `idx_transaction_read_model_account_cursor`를 쓰고 `Seq Scan`/`Sort`를 피하는지 검증합니다.
- `tools/test/run-transaction-retention-cutoff-load-test.sh`를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-transaction-retention-cutoff-load-test.sh`
- `./back/gradlew -p back spotlessApply`
- `./back/gradlew -p back check`
- pre-commit: `./back/gradlew -p back check`
- PR 전 확인: `git rev-list --count main..HEAD` = `1`, brief `commit_plan` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Testcontainers PostgreSQL planner가 환경별 통계 차이로 다른 plan을 선택할 수 있습니다.
- 롤백 방법: test/script 추가 커밋 revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A: test/script only
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A: 영향 없음
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A: 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A: 신규 로컬 검증 스크립트
