### PR TITLE
[Chore] transaction read model vacuum/analyze 운영 자동화 추가

### DIFF
--- a/tools/ops/transaction-read-model-vacuum-analyze.sh
+++ b/tools/ops/transaction-read-model-vacuum-analyze.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/ops/transaction-read-model-vacuum-analyze.sh [options]
+
+Options:
+  --target <hot|archive|both>          default both
+  --mode <vacuum-analyze|analyze>      default vacuum-analyze
+  --lock-timeout-ms <milliseconds>     default 1000
+  --statement-timeout-ms <milliseconds> default 30000
+  --print-sql                         print SQL and exit
+  --dry-run                           same as --print-sql
+  -h, --help                          show this help
+
+Environment:
+  DATABASE_URL   optional PostgreSQL URL. If set, it is passed directly to psql.
+  DB_HOST        fallback host, default localhost
+  DB_PORT        fallback port, default 5432
+  DB_NAME        fallback database, default aquila_bank
+  DB_USERNAME    fallback user, default postgres
+  DB_PASSWORD    fallback password, mapped to PGPASSWORD when PGPASSWORD is unset
+USAGE
+}
+
+target="both"
+mode="vacuum-analyze"
+lock_timeout_ms="${LOCK_TIMEOUT_MS:-1000}"
+statement_timeout_ms="${STATEMENT_TIMEOUT_MS:-30000}"
+print_sql=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 1
+      fi
+      target="$2"
+      shift 2
+      ;;
+    --mode)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 1
+      fi
+      mode="$2"
+      shift 2
+      ;;
+    --lock-timeout-ms)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 1
+      fi
+      lock_timeout_ms="$2"
+      shift 2
+      ;;
+    --statement-timeout-ms)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 1
+      fi
+      statement_timeout_ms="$2"
+      shift 2
+      ;;
+    --print-sql | --dry-run)
+      print_sql=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+case "${target}" in
+  hot)
+    tables=(transaction_read_model)
+    ;;
+  archive)
+    tables=(transaction_read_model_archive)
+    ;;
+  both)
+    tables=(transaction_read_model transaction_read_model_archive)
+    ;;
+  *)
+    echo "invalid target: ${target}" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+case "${mode}" in
+  vacuum-analyze | analyze)
+    ;;
+  *)
+    echo "invalid mode: ${mode}" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+if ! [[ "${lock_timeout_ms}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "lock timeout must be a positive integer millisecond value" >&2
+  exit 1
+fi
+
+if ! [[ "${statement_timeout_ms}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "statement timeout must be a positive integer millisecond value" >&2
+  exit 1
+fi
+
+commands=(
+  "SET lock_timeout = '${lock_timeout_ms}ms';"
+  "SET statement_timeout = '${statement_timeout_ms}ms';"
+)
+
+for table in "${tables[@]}"; do
+  if [[ "${mode}" == "vacuum-analyze" ]]; then
+    commands+=("VACUUM (ANALYZE, VERBOSE) public.${table};")
+  else
+    commands+=("ANALYZE VERBOSE public.${table};")
+  fi
+done
+
+if [[ "${print_sql}" == "true" ]]; then
+  printf '%s\n' "${commands[@]}"
+  exit 0
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "psql is required. Install PostgreSQL client tools or use --print-sql." >&2
+  exit 1
+fi
+
+echo "[transaction-vacuum-analyze] target=${target} mode=${mode}"
+echo "[transaction-vacuum-analyze] lock_timeout=${lock_timeout_ms}ms statement_timeout=${statement_timeout_ms}ms"
+echo "[transaction-vacuum-analyze] tables=${tables[*]}"
+
+psql_args=(--no-psqlrc --set ON_ERROR_STOP=1 --pset pager=off)
+psql_commands=()
+for command in "${commands[@]}"; do
+  psql_commands+=(--command "${command}")
+done
+
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  psql "${psql_args[@]}" "${psql_commands[@]}" "${DATABASE_URL}"
+else
+  export PGHOST="${PGHOST:-${DB_HOST:-localhost}}"
+  export PGPORT="${PGPORT:-${DB_PORT:-5432}}"
+  export PGDATABASE="${PGDATABASE:-${DB_NAME:-aquila_bank}}"
+  export PGUSER="${PGUSER:-${DB_USERNAME:-postgres}}"
+  if [[ -z "${PGPASSWORD:-}" && -n "${DB_PASSWORD:-}" ]]; then
+    export PGPASSWORD="${DB_PASSWORD}"
+  fi
+  psql "${psql_args[@]}" "${psql_commands[@]}"
+fi

--- a/tools/test/run-transaction-read-model-vacuum-automation.sh
+++ b/tools/test/run-transaction-read-model-vacuum-automation.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/ops/transaction-read-model-vacuum-analyze.sh"
+
+echo "[transaction-vacuum-automation] syntax: ${script}"
+bash -n "${script}"
+
+echo "[transaction-vacuum-automation] dry-run: both tables VACUUM (ANALYZE) with bounded timeout"
+sql="$("${script}" --target both --mode vacuum-analyze --lock-timeout-ms 1000 --statement-timeout-ms 30000 --print-sql)"
+grep -F "SET lock_timeout = '1000ms';" <<<"${sql}" >/dev/null
+grep -F "SET statement_timeout = '30000ms';" <<<"${sql}" >/dev/null
+grep -F "VACUUM (ANALYZE, VERBOSE) public.transaction_read_model;" <<<"${sql}" >/dev/null
+grep -F "VACUUM (ANALYZE, VERBOSE) public.transaction_read_model_archive;" <<<"${sql}" >/dev/null
+
+echo "[transaction-vacuum-automation] dry-run: archive ANALYZE only"
+archive_sql="$("${script}" --target archive --mode analyze --print-sql)"
+grep -F "ANALYZE VERBOSE public.transaction_read_model_archive;" <<<"${archive_sql}" >/dev/null
+if grep -F "transaction_read_model;" <<<"${archive_sql}" >/dev/null; then
+  echo "archive target must not include hot transaction_read_model" >&2
+  exit 1
+fi
+
+echo "[transaction-vacuum-automation] guard: invalid target/mode fail before psql"
+if "${script}" --target ledger_entry --print-sql >/dev/null 2>&1; then
+  echo "invalid target unexpectedly succeeded" >&2
+  exit 1
+fi
+if "${script}" --mode reindex --print-sql >/dev/null 2>&1; then
+  echo "invalid mode unexpectedly succeeded" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #242

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction read model hot/archive table의 `VACUUM (ANALYZE)`/`ANALYZE` 운영 실행 스크립트를 추가했습니다.
- target/mode whitelist와 bounded lock/statement timeout, `--print-sql`/`--dry-run` 확인 경로를 둬 운영 전 SQL을 검토할 수 있게 했습니다.

## 🛠 Changes
- `tools/ops/transaction-read-model-vacuum-analyze.sh` 추가
- `tools/test/run-transaction-read-model-vacuum-automation.sh` 추가
- invalid target/mode가 psql 실행 전 실패하는 guard 검증 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-transaction-read-model-vacuum-automation.sh`
- `./back/gradlew -p back check`
- PR 전 확인: `git rev-list --count main..HEAD` = `1`, brief `commit_plan` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 운영 시간대 `VACUUM` 실행은 table 크기와 lock 대기 상황에 따라 latency에 영향을 줄 수 있습니다. 기본 timeout을 낮게 두고 dry-run 확인 후 실행하도록 했습니다.
- 롤백 방법: script 추가 커밋 revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A: ops script only
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A: 영향 없음
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A: 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? 신규 운영 스크립트와 검증 스크립트 추가
