### PR TITLE
[Perf] t3.micro DB pool/thread saturation guard 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/global/config/T3MicroSaturationGuardConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/T3MicroSaturationGuardConfiguration.java
@@ -1,0 +1,156 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.global.ops.DbPoolSaturationProbe;
+import com.aquilabank.global.ops.DbPoolSaturationSnapshot;
+import com.aquilabank.global.ops.ServletThreadSaturationProbe;
+import com.aquilabank.global.ops.ServletThreadSaturationSnapshot;
+import com.aquilabank.global.ops.T3MicroQueryTimeoutSignal;
+import com.aquilabank.global.ops.T3MicroSaturationGuard;
+import com.aquilabank.global.ops.T3MicroSaturationGuardProperties;
+import com.aquilabank.global.web.T3MicroSaturationInterceptor;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.lang.management.ManagementFactory;
+import java.sql.SQLException;
+import java.time.Clock;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/** t3.micro 포화 guard는 global runtime 지표만 읽고 domain 경계 밖에서 fail-fast 처리합니다. */
+@Configuration
+@EnableConfigurationProperties(T3MicroSaturationGuardProperties.class)
+public class T3MicroSaturationGuardConfiguration {
+
+  @Bean
+  T3MicroQueryTimeoutSignal t3MicroQueryTimeoutSignal(MeterRegistry meterRegistry) {
+    return new T3MicroQueryTimeoutSignal(Clock.systemUTC(), meterRegistry);
+  }
+
+  @Bean
+  DbPoolSaturationProbe dbPoolSaturationProbe(ObjectProvider<DataSource> dataSourceProvider) {
+    return new HikariDbPoolSaturationProbe(dataSourceProvider);
+  }
+
+  @Bean
+  ServletThreadSaturationProbe servletThreadSaturationProbe() {
+    return new JmxServletThreadSaturationProbe();
+  }
+
+  @Bean
+  T3MicroSaturationGuard t3MicroSaturationGuard(
+      T3MicroSaturationGuardProperties properties,
+      DbPoolSaturationProbe dbPoolSaturationProbe,
+      ServletThreadSaturationProbe servletThreadSaturationProbe,
+      T3MicroQueryTimeoutSignal t3MicroQueryTimeoutSignal,
+      MeterRegistry meterRegistry) {
+    return new T3MicroSaturationGuard(
+        properties,
+        dbPoolSaturationProbe,
+        servletThreadSaturationProbe,
+        t3MicroQueryTimeoutSignal,
+        meterRegistry);
+  }
+
+  @Bean
+  T3MicroSaturationInterceptor t3MicroSaturationInterceptor(
+      T3MicroSaturationGuard t3MicroSaturationGuard) {
+    return new T3MicroSaturationInterceptor(t3MicroSaturationGuard);
+  }
+
+  @Bean
+  WebMvcConfigurer t3MicroSaturationGuardWebMvcConfigurer(
+      T3MicroSaturationInterceptor t3MicroSaturationInterceptor) {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(t3MicroSaturationInterceptor).addPathPatterns("/**");
+      }
+    };
+  }
+
+  private static final class HikariDbPoolSaturationProbe implements DbPoolSaturationProbe {
+
+    private final ObjectProvider<DataSource> dataSourceProvider;
+
+    private HikariDbPoolSaturationProbe(ObjectProvider<DataSource> dataSourceProvider) {
+      this.dataSourceProvider = dataSourceProvider;
+    }
+
+    @Override
+    public DbPoolSaturationSnapshot snapshot() {
+      DataSource dataSource = dataSourceProvider.getIfAvailable();
+      HikariDataSource hikariDataSource = unwrap(dataSource);
+      if (hikariDataSource == null || hikariDataSource.getHikariPoolMXBean() == null) {
+        return DbPoolSaturationSnapshot.empty();
+      }
+      HikariPoolMXBean mxBean = hikariDataSource.getHikariPoolMXBean();
+      return new DbPoolSaturationSnapshot(
+          mxBean.getActiveConnections(),
+          mxBean.getTotalConnections(),
+          mxBean.getThreadsAwaitingConnection());
+    }
+
+    private HikariDataSource unwrap(DataSource dataSource) {
+      if (dataSource instanceof HikariDataSource hikariDataSource) {
+        return hikariDataSource;
+      }
+      if (dataSource == null) {
+        return null;
+      }
+      try {
+        return dataSource.unwrap(HikariDataSource.class);
+      } catch (SQLException ex) {
+        return null;
+      }
+    }
+  }
+
+  private static final class JmxServletThreadSaturationProbe
+      implements ServletThreadSaturationProbe {
+
+    private final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    private volatile ObjectName threadPoolName;
+
+    @Override
+    public ServletThreadSaturationSnapshot snapshot() {
+      ObjectName name = threadPoolName;
+      if (name == null) {
+        name = findThreadPoolName();
+      }
+      if (name == null) {
+        return ServletThreadSaturationSnapshot.empty();
+      }
+      try {
+        Integer busyThreads = (Integer) mBeanServer.getAttribute(name, "currentThreadsBusy");
+        Integer maxThreads = (Integer) mBeanServer.getAttribute(name, "maxThreads");
+        return new ServletThreadSaturationSnapshot(busyThreads, maxThreads);
+      } catch (Exception ex) {
+        threadPoolName = null;
+        return ServletThreadSaturationSnapshot.empty();
+      }
+    }
+
+    private ObjectName findThreadPoolName() {
+      try {
+        for (ObjectName name :
+            mBeanServer.queryNames(new ObjectName("*:type=ThreadPool,*"), null)) {
+          if (mBeanServer.isRegistered(name)) {
+            threadPoolName = name;
+            return name;
+          }
+        }
+      } catch (Exception ex) {
+        return null;
+      }
+      return null;
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/DbPoolSaturationProbe.java
+++ b/back/src/main/java/com/aquilabank/global/ops/DbPoolSaturationProbe.java
@@ -1,0 +1,6 @@
+package com.aquilabank.global.ops;
+
+public interface DbPoolSaturationProbe {
+
+  DbPoolSaturationSnapshot snapshot();
+}

--- a/back/src/main/java/com/aquilabank/global/ops/DbPoolSaturationSnapshot.java
+++ b/back/src/main/java/com/aquilabank/global/ops/DbPoolSaturationSnapshot.java
@@ -1,0 +1,24 @@
+package com.aquilabank.global.ops;
+
+public record DbPoolSaturationSnapshot(
+    int activeConnections, int totalConnections, int threadsAwaitingConnection) {
+
+  public static DbPoolSaturationSnapshot empty() {
+    return new DbPoolSaturationSnapshot(0, 0, 0);
+  }
+
+  public boolean saturated(T3MicroSaturationGuardProperties.Pool properties) {
+    boolean activeSaturated =
+        totalConnections > 0
+            && activeConnections
+                >= thresholdCount(totalConnections, properties.activeThresholdPercent());
+    boolean awaitingSaturated =
+        properties.awaitingThreadsThreshold() > 0
+            && threadsAwaitingConnection >= properties.awaitingThreadsThreshold();
+    return activeSaturated || awaitingSaturated;
+  }
+
+  private int thresholdCount(int total, int percent) {
+    return Math.max(1, (int) Math.ceil(total * (percent / 100.0)));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/ServletThreadSaturationProbe.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ServletThreadSaturationProbe.java
@@ -1,0 +1,6 @@
+package com.aquilabank.global.ops;
+
+public interface ServletThreadSaturationProbe {
+
+  ServletThreadSaturationSnapshot snapshot();
+}

--- a/back/src/main/java/com/aquilabank/global/ops/ServletThreadSaturationSnapshot.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ServletThreadSaturationSnapshot.java
@@ -1,0 +1,15 @@
+package com.aquilabank.global.ops;
+
+public record ServletThreadSaturationSnapshot(int busyThreads, int maxThreads) {
+
+  public static ServletThreadSaturationSnapshot empty() {
+    return new ServletThreadSaturationSnapshot(0, 0);
+  }
+
+  public boolean saturated(T3MicroSaturationGuardProperties.ServletThreads properties) {
+    return maxThreads > 0
+        && busyThreads
+            >= Math.max(
+                1, (int) Math.ceil(maxThreads * (properties.busyThresholdPercent() / 100.0)));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroQueryTimeoutSignal.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroQueryTimeoutSignal.java
@@ -1,0 +1,37 @@
+package com.aquilabank.global.ops;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class T3MicroQueryTimeoutSignal {
+
+  private final Clock clock;
+  private final Counter timeoutCounter;
+  private final Deque<Instant> events = new ArrayDeque<>();
+
+  public T3MicroQueryTimeoutSignal(Clock clock, MeterRegistry meterRegistry) {
+    this.clock = clock;
+    this.timeoutCounter =
+        Counter.builder("aquila.t3micro.saturation.guard.query.timeouts")
+            .description("recent query timeout events recorded for t3.micro saturation guard")
+            .register(meterRegistry);
+  }
+
+  public synchronized void record() {
+    events.addLast(clock.instant());
+    timeoutCounter.increment();
+  }
+
+  public synchronized int recentCount(Duration window) {
+    Instant cutoff = clock.instant().minus(window);
+    while (!events.isEmpty() && events.peekFirst().isBefore(cutoff)) {
+      events.removeFirst();
+    }
+    return events.size();
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationDecision.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationDecision.java
@@ -1,0 +1,14 @@
+package com.aquilabank.global.ops;
+
+public record T3MicroSaturationDecision(
+    boolean allowed, int retryAfterSeconds, T3MicroSaturationSnapshot snapshot) {
+
+  public static T3MicroSaturationDecision allowed(T3MicroSaturationSnapshot snapshot) {
+    return new T3MicroSaturationDecision(true, 0, snapshot);
+  }
+
+  public static T3MicroSaturationDecision rejected(
+      int retryAfterSeconds, T3MicroSaturationSnapshot snapshot) {
+    return new T3MicroSaturationDecision(false, retryAfterSeconds, snapshot);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuard.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuard.java
@@ -1,0 +1,86 @@
+package com.aquilabank.global.ops;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class T3MicroSaturationGuard {
+
+  private final T3MicroSaturationGuardProperties properties;
+  private final DbPoolSaturationProbe poolProbe;
+  private final ServletThreadSaturationProbe servletThreadProbe;
+  private final T3MicroQueryTimeoutSignal timeoutSignal;
+  private final Counter acceptedCounter;
+  private final Counter rejectedCounter;
+  private final AtomicInteger saturatedGauge = new AtomicInteger();
+
+  public T3MicroSaturationGuard(
+      T3MicroSaturationGuardProperties properties,
+      DbPoolSaturationProbe poolProbe,
+      ServletThreadSaturationProbe servletThreadProbe,
+      T3MicroQueryTimeoutSignal timeoutSignal,
+      MeterRegistry meterRegistry) {
+    this.properties = properties;
+    this.poolProbe = poolProbe;
+    this.servletThreadProbe = servletThreadProbe;
+    this.timeoutSignal = timeoutSignal;
+    if (properties.enabled()) {
+      this.acceptedCounter = requestCounter(meterRegistry, "accepted");
+      this.rejectedCounter = requestCounter(meterRegistry, "rejected");
+      Gauge.builder("aquila.t3micro.saturation.guard.saturated", saturatedGauge, AtomicInteger::get)
+          .description("1 when t3.micro saturation guard currently rejects protected requests")
+          .register(meterRegistry);
+    } else {
+      this.acceptedCounter = null;
+      this.rejectedCounter = null;
+    }
+  }
+
+  public T3MicroSaturationDecision check(String path) {
+    if (!properties.enabled()) {
+      return T3MicroSaturationDecision.allowed(T3MicroSaturationSnapshot.empty());
+    }
+    T3MicroSaturationSnapshot snapshot = snapshot();
+    if (!protectedPath(path)) {
+      return T3MicroSaturationDecision.allowed(snapshot);
+    }
+    if (snapshot.saturated()) {
+      saturatedGauge.set(1);
+      rejectedCounter.increment();
+      return T3MicroSaturationDecision.rejected(properties.retryAfterSeconds(), snapshot);
+    }
+    saturatedGauge.set(0);
+    acceptedCounter.increment();
+    return T3MicroSaturationDecision.allowed(snapshot);
+  }
+
+  private T3MicroSaturationSnapshot snapshot() {
+    DbPoolSaturationSnapshot pool = poolProbe.snapshot();
+    ServletThreadSaturationSnapshot servletThreads = servletThreadProbe.snapshot();
+    Duration timeoutWindow = Duration.ofSeconds(properties.queryTimeout().windowSeconds());
+    int timeoutCount = timeoutSignal.recentCount(timeoutWindow);
+    boolean poolSaturated = pool.saturated(properties.pool());
+    boolean servletThreadsSaturated = servletThreads.saturated(properties.servletThreads());
+    boolean queryTimeoutSaturated = timeoutCount >= properties.queryTimeout().threshold();
+    return new T3MicroSaturationSnapshot(
+        pool,
+        servletThreads,
+        timeoutCount,
+        poolSaturated,
+        servletThreadsSaturated,
+        queryTimeoutSaturated);
+  }
+
+  private boolean protectedPath(String path) {
+    return properties.protectedPathPrefixes().stream().anyMatch(path::startsWith);
+  }
+
+  private Counter requestCounter(MeterRegistry meterRegistry, String outcome) {
+    return Counter.builder("aquila.t3micro.saturation.guard.requests")
+        .tag("outcome", outcome)
+        .description("protected request decisions by t3.micro saturation guard")
+        .register(meterRegistry);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuardProperties.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuardProperties.java
@@ -1,0 +1,58 @@
+package com.aquilabank.global.ops;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "ops.t3-micro-saturation-guard")
+public record T3MicroSaturationGuardProperties(
+    Boolean enabled,
+    int retryAfterSeconds,
+    List<String> protectedPathPrefixes,
+    Pool pool,
+    ServletThreads servletThreads,
+    QueryTimeout queryTimeout) {
+
+  public T3MicroSaturationGuardProperties {
+    enabled = enabled == null ? Boolean.TRUE : enabled;
+    retryAfterSeconds = retryAfterSeconds > 0 ? retryAfterSeconds : 2;
+    protectedPathPrefixes =
+        protectedPathPrefixes == null || protectedPathPrefixes.isEmpty()
+            ? List.of(
+                "/api/v1/accounts",
+                "/api/v1/transactions",
+                "/api/v1/transfers",
+                "/api/v1/notifications",
+                "/internal/api/v1/accounts",
+                "/internal/api/v1/ledger",
+                "/internal/api/v1/outbox")
+            : List.copyOf(protectedPathPrefixes);
+    pool = pool == null ? new Pool(90, 1) : pool;
+    servletThreads = servletThreads == null ? new ServletThreads(90) : servletThreads;
+    queryTimeout = queryTimeout == null ? new QueryTimeout(10, 1) : queryTimeout;
+  }
+
+  public record Pool(int activeThresholdPercent, int awaitingThreadsThreshold) {
+
+    public Pool {
+      activeThresholdPercent =
+          activeThresholdPercent > 0 && activeThresholdPercent <= 100 ? activeThresholdPercent : 90;
+      awaitingThreadsThreshold = awaitingThreadsThreshold > 0 ? awaitingThreadsThreshold : 1;
+    }
+  }
+
+  public record ServletThreads(int busyThresholdPercent) {
+
+    public ServletThreads {
+      busyThresholdPercent =
+          busyThresholdPercent > 0 && busyThresholdPercent <= 100 ? busyThresholdPercent : 90;
+    }
+  }
+
+  public record QueryTimeout(int windowSeconds, int threshold) {
+
+    public QueryTimeout {
+      windowSeconds = windowSeconds > 0 ? windowSeconds : 10;
+      threshold = threshold > 0 ? threshold : 1;
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationRejectedException.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationRejectedException.java
@@ -1,0 +1,16 @@
+package com.aquilabank.global.ops;
+
+/** DB pool/thread/query timeout이 함께 포화될 때 protected API를 즉시 거절합니다. */
+public final class T3MicroSaturationRejectedException extends RuntimeException {
+
+  private final int retryAfterSeconds;
+
+  public T3MicroSaturationRejectedException(int retryAfterSeconds) {
+    super("server is saturated; retry later");
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+
+  public int retryAfterSeconds() {
+    return retryAfterSeconds;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationSnapshot.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationSnapshot.java
@@ -1,0 +1,24 @@
+package com.aquilabank.global.ops;
+
+public record T3MicroSaturationSnapshot(
+    DbPoolSaturationSnapshot pool,
+    ServletThreadSaturationSnapshot servletThreads,
+    int recentQueryTimeoutCount,
+    boolean poolSaturated,
+    boolean servletThreadsSaturated,
+    boolean queryTimeoutSaturated) {
+
+  public static T3MicroSaturationSnapshot empty() {
+    return new T3MicroSaturationSnapshot(
+        DbPoolSaturationSnapshot.empty(),
+        ServletThreadSaturationSnapshot.empty(),
+        0,
+        false,
+        false,
+        false);
+  }
+
+  public boolean saturated() {
+    return poolSaturated && servletThreadsSaturated && queryTimeoutSaturated;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -26,6 +26,8 @@ import com.aquilabank.domain.ledger.exception.TransferReversalNotFoundException;
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
 import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
 import com.aquilabank.global.notification.NotificationSseOverloadException;
+import com.aquilabank.global.ops.T3MicroQueryTimeoutSignal;
+import com.aquilabank.global.ops.T3MicroSaturationRejectedException;
 import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
 import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceTokenClaims;
@@ -38,6 +40,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.QueryTimeoutException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -55,6 +59,12 @@ public class ApiExceptionHandler {
       Pattern.compile("^/internal/api/v1/auth/users/(\\d+)/status$");
   private static final Pattern MEMBERSHIP_STATUS_PATH_PATTERN =
       Pattern.compile("^/internal/api/v1/auth/users/(\\d+)/memberships/(\\d+)/status$");
+  private T3MicroQueryTimeoutSignal t3MicroQueryTimeoutSignal;
+
+  @Autowired(required = false)
+  void setT3MicroQueryTimeoutSignal(T3MicroQueryTimeoutSignal t3MicroQueryTimeoutSignal) {
+    this.t3MicroQueryTimeoutSignal = t3MicroQueryTimeoutSignal;
+  }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   ResponseEntity<ApiErrorResponse> handleValidation(
@@ -120,6 +130,29 @@ public class ApiExceptionHandler {
   ResponseEntity<ApiErrorResponse> handleServiceUnavailable(
       NotificationSseOverloadException ex, HttpServletRequest request) {
     return response(HttpStatus.SERVICE_UNAVAILABLE, ex.getMessage(), request);
+  }
+
+  @ExceptionHandler(T3MicroSaturationRejectedException.class)
+  ResponseEntity<ApiErrorResponse> handleT3MicroSaturationRejected(
+      T3MicroSaturationRejectedException ex, HttpServletRequest request) {
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        .header("Retry-After", Integer.toString(ex.retryAfterSeconds()))
+        .body(
+            new ApiErrorResponse(
+                Instant.now(),
+                HttpStatus.SERVICE_UNAVAILABLE.value(),
+                HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI()));
+  }
+
+  @ExceptionHandler(QueryTimeoutException.class)
+  ResponseEntity<ApiErrorResponse> handleQueryTimeout(
+      QueryTimeoutException ex, HttpServletRequest request) {
+    if (t3MicroQueryTimeoutSignal != null) {
+      t3MicroQueryTimeoutSignal.record();
+    }
+    return response(HttpStatus.SERVICE_UNAVAILABLE, "query timed out", request);
   }
 
   @ExceptionHandler({

--- a/back/src/main/java/com/aquilabank/global/web/T3MicroSaturationInterceptor.java
+++ b/back/src/main/java/com/aquilabank/global/web/T3MicroSaturationInterceptor.java
@@ -1,0 +1,28 @@
+package com.aquilabank.global.web;
+
+import com.aquilabank.global.ops.T3MicroSaturationDecision;
+import com.aquilabank.global.ops.T3MicroSaturationGuard;
+import com.aquilabank.global.ops.T3MicroSaturationRejectedException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/** DB 의존 API가 runtime 포화 상태를 더 키우지 않도록 controller 진입 전에 차단합니다. */
+public class T3MicroSaturationInterceptor implements HandlerInterceptor {
+
+  private final T3MicroSaturationGuard guard;
+
+  public T3MicroSaturationInterceptor(T3MicroSaturationGuard guard) {
+    this.guard = guard;
+  }
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    T3MicroSaturationDecision decision = guard.check(request.getRequestURI());
+    if (decision.allowed()) {
+      return true;
+    }
+    throw new T3MicroSaturationRejectedException(decision.retryAfterSeconds());
+  }
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -72,6 +72,27 @@ management:
         # p95 SLO alert가 쓰는 경계만 고정해 query_shape/outcome별 bucket 수를 제한합니다.
         aquila.transaction.query.latency: 50ms,80ms,120ms,150ms,180ms,350ms,750ms,1s,3s
 
+ops:
+  t3-micro-saturation-guard:
+    enabled: ${OPS_T3MICRO_SATURATION_GUARD_ENABLED:true}
+    retry-after-seconds: ${OPS_T3MICRO_SATURATION_GUARD_RETRY_AFTER_SECONDS:2}
+    protected-path-prefixes:
+      - /api/v1/accounts
+      - /api/v1/transactions
+      - /api/v1/transfers
+      - /api/v1/notifications
+      - /internal/api/v1/accounts
+      - /internal/api/v1/ledger
+      - /internal/api/v1/outbox
+    pool:
+      active-threshold-percent: ${OPS_T3MICRO_SATURATION_GUARD_POOL_ACTIVE_THRESHOLD_PERCENT:90}
+      awaiting-threads-threshold: ${OPS_T3MICRO_SATURATION_GUARD_POOL_AWAITING_THREADS_THRESHOLD:1}
+    servlet-threads:
+      busy-threshold-percent: ${OPS_T3MICRO_SATURATION_GUARD_THREADS_BUSY_THRESHOLD_PERCENT:90}
+    query-timeout:
+      window-seconds: ${OPS_T3MICRO_SATURATION_GUARD_QUERY_TIMEOUT_WINDOW_SECONDS:10}
+      threshold: ${OPS_T3MICRO_SATURATION_GUARD_QUERY_TIMEOUT_THRESHOLD:1}
+
 logging:
   pattern:
     level: '%5p [requestId:%X{requestId:-}]'

--- a/back/src/test/java/com/aquilabank/global/ops/T3MicroSaturationGuardTest.java
+++ b/back/src/test/java/com/aquilabank/global/ops/T3MicroSaturationGuardTest.java
@@ -1,0 +1,169 @@
+package com.aquilabank.global.ops;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class T3MicroSaturationGuardTest {
+
+  @Test
+  void rejectsProtectedRequestOnlyWhenPoolThreadAndTimeoutSignalsAreAllSaturated() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    MutableClock clock = new MutableClock(Instant.parse("2026-04-22T00:00:00Z"));
+    T3MicroQueryTimeoutSignal timeoutSignal = new T3MicroQueryTimeoutSignal(clock, meterRegistry);
+    MutableDbPoolProbe poolProbe = new MutableDbPoolProbe(new DbPoolSaturationSnapshot(4, 4, 1));
+    MutableServletThreadProbe threadProbe =
+        new MutableServletThreadProbe(new ServletThreadSaturationSnapshot(16, 16));
+    T3MicroSaturationGuard guard =
+        new T3MicroSaturationGuard(
+            properties(), poolProbe, threadProbe, timeoutSignal, meterRegistry);
+
+    assertThat(guard.check("/api/v1/transactions").allowed()).isTrue();
+
+    timeoutSignal.record();
+
+    T3MicroSaturationDecision decision = guard.check("/api/v1/transactions");
+
+    assertThat(decision.allowed()).isFalse();
+    assertThat(decision.retryAfterSeconds()).isEqualTo(2);
+    assertThat(decision.snapshot().pool().activeConnections()).isEqualTo(4);
+    assertThat(decision.snapshot().servletThreads().busyThreads()).isEqualTo(16);
+    assertThat(decision.snapshot().recentQueryTimeoutCount()).isEqualTo(1);
+    assertThat(guard.check("/actuator/health").allowed()).isTrue();
+    assertThat(
+            meterRegistry
+                .find("aquila.t3micro.saturation.guard.requests")
+                .tag("outcome", "accepted")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry
+                .find("aquila.t3micro.saturation.guard.requests")
+                .tag("outcome", "rejected")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(meterRegistry.find("aquila.t3micro.saturation.guard.saturated").gauge().value())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void allowsRequestWhenQueryTimeoutSignalExpires() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    MutableClock clock = new MutableClock(Instant.parse("2026-04-22T00:00:00Z"));
+    T3MicroQueryTimeoutSignal timeoutSignal = new T3MicroQueryTimeoutSignal(clock, meterRegistry);
+    timeoutSignal.record();
+    clock.plus(Duration.ofSeconds(11));
+    T3MicroSaturationGuard guard =
+        new T3MicroSaturationGuard(
+            properties(),
+            new MutableDbPoolProbe(new DbPoolSaturationSnapshot(4, 4, 1)),
+            new MutableServletThreadProbe(new ServletThreadSaturationSnapshot(16, 16)),
+            timeoutSignal,
+            meterRegistry);
+
+    T3MicroSaturationDecision decision = guard.check("/api/v1/transactions");
+
+    assertThat(decision.allowed()).isTrue();
+    assertThat(decision.snapshot().recentQueryTimeoutCount()).isZero();
+    assertThat(
+            meterRegistry.find("aquila.t3micro.saturation.guard.query.timeouts").counter().count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void disabledGuardAlwaysAllowsWithoutRequestMetrics() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    T3MicroSaturationGuard guard =
+        new T3MicroSaturationGuard(
+            new T3MicroSaturationGuardProperties(
+                false,
+                2,
+                List.of("/api/v1/transactions"),
+                new T3MicroSaturationGuardProperties.Pool(80, 1),
+                new T3MicroSaturationGuardProperties.ServletThreads(80),
+                new T3MicroSaturationGuardProperties.QueryTimeout(10, 1)),
+            new MutableDbPoolProbe(new DbPoolSaturationSnapshot(4, 4, 1)),
+            new MutableServletThreadProbe(new ServletThreadSaturationSnapshot(16, 16)),
+            new T3MicroQueryTimeoutSignal(Clock.systemUTC(), meterRegistry),
+            meterRegistry);
+
+    assertThat(guard.check("/api/v1/transactions").allowed()).isTrue();
+
+    assertThat(meterRegistry.find("aquila.t3micro.saturation.guard.requests").counter()).isNull();
+  }
+
+  private T3MicroSaturationGuardProperties properties() {
+    return new T3MicroSaturationGuardProperties(
+        true,
+        2,
+        List.of("/api/v1/transactions"),
+        new T3MicroSaturationGuardProperties.Pool(80, 1),
+        new T3MicroSaturationGuardProperties.ServletThreads(80),
+        new T3MicroSaturationGuardProperties.QueryTimeout(10, 1));
+  }
+
+  private static final class MutableDbPoolProbe implements DbPoolSaturationProbe {
+
+    private DbPoolSaturationSnapshot snapshot;
+
+    private MutableDbPoolProbe(DbPoolSaturationSnapshot snapshot) {
+      this.snapshot = snapshot;
+    }
+
+    @Override
+    public DbPoolSaturationSnapshot snapshot() {
+      return snapshot;
+    }
+  }
+
+  private static final class MutableServletThreadProbe implements ServletThreadSaturationProbe {
+
+    private ServletThreadSaturationSnapshot snapshot;
+
+    private MutableServletThreadProbe(ServletThreadSaturationSnapshot snapshot) {
+      this.snapshot = snapshot;
+    }
+
+    @Override
+    public ServletThreadSaturationSnapshot snapshot() {
+      return snapshot;
+    }
+  }
+
+  private static final class MutableClock extends Clock {
+
+    private Instant instant;
+
+    private MutableClock(Instant instant) {
+      this.instant = instant;
+    }
+
+    private void plus(Duration duration) {
+      instant = instant.plus(duration);
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/ApiExceptionHandlerT3MicroSaturationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ApiExceptionHandlerT3MicroSaturationTest.java
@@ -1,0 +1,48 @@
+package com.aquilabank.global.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.global.ops.T3MicroQueryTimeoutSignal;
+import com.aquilabank.global.ops.T3MicroSaturationRejectedException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class ApiExceptionHandlerT3MicroSaturationTest {
+
+  @Test
+  void handlesSaturationRejectionAsServiceUnavailableWithRetryAfter() {
+    ApiExceptionHandler handler = new ApiExceptionHandler();
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/transactions");
+
+    ResponseEntity<ApiExceptionHandler.ApiErrorResponse> response =
+        handler.handleT3MicroSaturationRejected(new T3MicroSaturationRejectedException(2), request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(response.getHeaders().getFirst("Retry-After")).isEqualTo("2");
+    assertThat(response.getBody().message()).isEqualTo("server is saturated; retry later");
+    assertThat(response.getBody().path()).isEqualTo("/api/v1/transactions");
+  }
+
+  @Test
+  void recordsQueryTimeoutSignalAndReturnsServiceUnavailable() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiExceptionHandler handler = new ApiExceptionHandler();
+    handler.setT3MicroQueryTimeoutSignal(
+        new T3MicroQueryTimeoutSignal(Clock.systemUTC(), meterRegistry));
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/transactions");
+
+    ResponseEntity<ApiExceptionHandler.ApiErrorResponse> response =
+        handler.handleQueryTimeout(new QueryTimeoutException("slow query"), request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(response.getBody().message()).isEqualTo("query timed out");
+    assertThat(
+            meterRegistry.find("aquila.t3micro.saturation.guard.query.timeouts").counter().count())
+        .isEqualTo(1.0);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/T3MicroSaturationInterceptorTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/T3MicroSaturationInterceptorTest.java
@@ -1,0 +1,84 @@
+package com.aquilabank.global.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.aquilabank.global.ops.DbPoolSaturationProbe;
+import com.aquilabank.global.ops.DbPoolSaturationSnapshot;
+import com.aquilabank.global.ops.ServletThreadSaturationProbe;
+import com.aquilabank.global.ops.ServletThreadSaturationSnapshot;
+import com.aquilabank.global.ops.T3MicroQueryTimeoutSignal;
+import com.aquilabank.global.ops.T3MicroSaturationGuard;
+import com.aquilabank.global.ops.T3MicroSaturationGuardProperties;
+import com.aquilabank.global.ops.T3MicroSaturationRejectedException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class T3MicroSaturationInterceptorTest {
+
+  @Test
+  void throwsFailFastExceptionWhenProtectedPathIsSaturated() {
+    T3MicroQueryTimeoutSignal timeoutSignal =
+        new T3MicroQueryTimeoutSignal(Clock.systemUTC(), new SimpleMeterRegistry());
+    timeoutSignal.record();
+    T3MicroSaturationInterceptor interceptor =
+        new T3MicroSaturationInterceptor(
+            guard(
+                new DbPoolSaturationSnapshot(4, 4, 1),
+                new ServletThreadSaturationSnapshot(16, 16),
+                timeoutSignal));
+
+    assertThatThrownBy(
+            () ->
+                interceptor.preHandle(
+                    new MockHttpServletRequest("GET", "/api/v1/transactions"),
+                    new MockHttpServletResponse(),
+                    null))
+        .isInstanceOf(T3MicroSaturationRejectedException.class)
+        .hasMessage("server is saturated; retry later")
+        .extracting("retryAfterSeconds")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void allowsUnprotectedPathEvenWhenSaturated() throws Exception {
+    T3MicroQueryTimeoutSignal timeoutSignal =
+        new T3MicroQueryTimeoutSignal(Clock.systemUTC(), new SimpleMeterRegistry());
+    timeoutSignal.record();
+    T3MicroSaturationInterceptor interceptor =
+        new T3MicroSaturationInterceptor(
+            guard(
+                new DbPoolSaturationSnapshot(4, 4, 1),
+                new ServletThreadSaturationSnapshot(16, 16),
+                timeoutSignal));
+
+    assertThat(
+            interceptor.preHandle(
+                new MockHttpServletRequest("GET", "/actuator/health"),
+                new MockHttpServletResponse(),
+                null))
+        .isTrue();
+  }
+
+  private T3MicroSaturationGuard guard(
+      DbPoolSaturationSnapshot pool,
+      ServletThreadSaturationSnapshot servletThreads,
+      T3MicroQueryTimeoutSignal timeoutSignal) {
+    return new T3MicroSaturationGuard(
+        new T3MicroSaturationGuardProperties(
+            true,
+            2,
+            List.of("/api/v1/transactions"),
+            new T3MicroSaturationGuardProperties.Pool(80, 1),
+            new T3MicroSaturationGuardProperties.ServletThreads(80),
+            new T3MicroSaturationGuardProperties.QueryTimeout(10, 1)),
+        (DbPoolSaturationProbe) () -> pool,
+        (ServletThreadSaturationProbe) () -> servletThreads,
+        timeoutSignal,
+        new SimpleMeterRegistry());
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #246

## 🌿 Base Branch
- `main`

## 📝 Summary
- Hikari pool, servlet thread, 최근 query timeout 신호가 동시에 포화될 때 DB 의존 API를 503으로 fail-fast 처리합니다.
- t3.micro 기본 임계값과 Micrometer metric을 추가해 포화/허용/거절/timeout 상태를 확인할 수 있게 했습니다.

## 🛠 Changes
- `ops.t3-micro-saturation-guard` 설정과 기본 protected path/임계값 추가
- Hikari MXBean, Tomcat JMX thread pool, query timeout signal 기반 saturation guard 추가
- MVC interceptor와 `QueryTimeoutException`/포화 예외 handler 추가
- guard 단위 테스트, interceptor 테스트, exception handler 테스트 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back test --tests '*T3MicroSaturationGuardTest'`
- `./back/gradlew -p back test --tests '*ApiExceptionHandlerT3MicroSaturationTest' --tests '*T3MicroSaturationInterceptorTest' --tests '*T3MicroSaturationGuardTest'`
- `tools/test/with-resource-lock.sh back-check ./back/gradlew -p back check`
- PR 생성 전 `commit_plan` 2개와 실제 브랜치 commit 2개 일치 확인

## 📸 Screenshot / API Example
- 포화 시 응답: HTTP 503, `Retry-After: 2`, body message `server is saturated; retry later`
- UI 변경 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 임계값이 낮으면 순간 부하에도 DB 의존 API가 503으로 빠르게 거절될 수 있습니다. Tomcat JMX thread pool을 찾지 못하는 환경에서는 thread 포화 신호가 false로 남아 guard가 보수적으로 동작합니다.
- 롤백 방법: `OPS_T3MICRO_SATURATION_GUARD_ENABLED=false`로 비활성화하거나 해당 커밋을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?