### PR TITLE
[Perf] API overload admission control 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/global/config/ApiAdmissionControlConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/ApiAdmissionControlConfiguration.java
@@ -1,0 +1,40 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.global.ops.ApiAdmissionControl;
+import com.aquilabank.global.ops.ApiAdmissionControlProperties;
+import com.aquilabank.global.web.ApiAdmissionControlInterceptor;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/** endpoint group별 admission control을 MVC 진입부에 연결합니다. */
+@Configuration
+@EnableConfigurationProperties(ApiAdmissionControlProperties.class)
+public class ApiAdmissionControlConfiguration {
+
+  @Bean
+  ApiAdmissionControl apiAdmissionControl(
+      ApiAdmissionControlProperties properties, MeterRegistry meterRegistry) {
+    return new ApiAdmissionControl(properties, meterRegistry);
+  }
+
+  @Bean
+  ApiAdmissionControlInterceptor apiAdmissionControlInterceptor(
+      ApiAdmissionControl apiAdmissionControl) {
+    return new ApiAdmissionControlInterceptor(apiAdmissionControl);
+  }
+
+  @Bean
+  WebMvcConfigurer apiAdmissionControlWebMvcConfigurer(
+      ApiAdmissionControlInterceptor apiAdmissionControlInterceptor) {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(apiAdmissionControlInterceptor).addPathPatterns("/**");
+      }
+    };
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControl.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControl.java
@@ -1,0 +1,91 @@
+package com.aquilabank.global.ops;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ApiAdmissionControl {
+
+  private final ApiAdmissionControlProperties properties;
+  private final MeterRegistry meterRegistry;
+  private final List<EndpointState> endpoints;
+
+  public ApiAdmissionControl(
+      ApiAdmissionControlProperties properties, MeterRegistry meterRegistry) {
+    this.properties = properties;
+    this.meterRegistry = meterRegistry;
+    this.endpoints =
+        properties.endpoints().stream()
+            .map(endpoint -> new EndpointState(endpoint, meterRegistry))
+            .toList();
+  }
+
+  public ApiAdmissionPermit tryAcquire(String rawPath) {
+    if (!properties.enabled()) {
+      return ApiAdmissionPermit.ignored();
+    }
+    EndpointState endpoint = findEndpoint(pathOnly(rawPath));
+    if (endpoint == null) {
+      return ApiAdmissionPermit.ignored();
+    }
+    if (!endpoint.semaphore().tryAcquire()) {
+      increment(endpoint.group(), "rejected");
+      return ApiAdmissionPermit.rejected(endpoint.group(), properties.retryAfterSeconds());
+    }
+    endpoint.inFlight().incrementAndGet();
+    increment(endpoint.group(), "accepted");
+    return ApiAdmissionPermit.acquired(endpoint.group(), endpoint::release);
+  }
+
+  private EndpointState findEndpoint(String path) {
+    for (EndpointState endpoint : endpoints) {
+      if (endpoint.matches(path)) {
+        return endpoint;
+      }
+    }
+    return null;
+  }
+
+  private void increment(String group, String outcome) {
+    Counter.builder("aquila.api.admission.requests")
+        .tag("group", group)
+        .tag("outcome", outcome)
+        .description("endpoint admission control request decisions")
+        .register(meterRegistry)
+        .increment();
+  }
+
+  private String pathOnly(String rawPath) {
+    int queryIndex = rawPath.indexOf('?');
+    return queryIndex < 0 ? rawPath : rawPath.substring(0, queryIndex);
+  }
+
+  private record EndpointState(
+      String group, List<String> pathPrefixes, Semaphore semaphore, AtomicInteger inFlight) {
+
+    private EndpointState(
+        ApiAdmissionControlProperties.EndpointLimit endpoint, MeterRegistry meterRegistry) {
+      this(
+          endpoint.group(),
+          endpoint.pathPrefixes(),
+          new Semaphore(endpoint.maxConcurrency()),
+          new AtomicInteger());
+      Gauge.builder("aquila.api.admission.inflight", inFlight, AtomicInteger::get)
+          .tag("group", group)
+          .description("endpoint admission control in-flight requests")
+          .register(meterRegistry);
+    }
+
+    private boolean matches(String path) {
+      return pathPrefixes.stream().anyMatch(path::startsWith);
+    }
+
+    private void release() {
+      inFlight.decrementAndGet();
+      semaphore.release();
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
@@ -19,11 +19,11 @@ public record ApiAdmissionControlProperties(
         new EndpointLimit("transaction-read", 3, List.of("/api/v1/transactions")),
         new EndpointLimit("account-read", 4, List.of("/api/v1/accounts")),
         new EndpointLimit("transfer-write", 2, List.of("/api/v1/transfers")),
+        new EndpointLimit("notification-stream", 4, List.of("/api/v1/notifications/stream")),
         new EndpointLimit(
             "notification-read",
             4,
             List.of("/api/v1/notifications", "/api/v1/notification-preferences")),
-        new EndpointLimit("notification-stream", 4, List.of("/api/v1/notifications/stream")),
         new EndpointLimit(
             "internal-ops",
             2,

--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
@@ -1,0 +1,53 @@
+package com.aquilabank.global.ops;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "ops.api-admission-control")
+public record ApiAdmissionControlProperties(
+    Boolean enabled, int retryAfterSeconds, List<EndpointLimit> endpoints) {
+
+  public ApiAdmissionControlProperties {
+    enabled = enabled == null ? Boolean.TRUE : enabled;
+    retryAfterSeconds = retryAfterSeconds > 0 ? retryAfterSeconds : 1;
+    endpoints =
+        endpoints == null || endpoints.isEmpty() ? defaultEndpoints() : List.copyOf(endpoints);
+  }
+
+  private static List<EndpointLimit> defaultEndpoints() {
+    return List.of(
+        new EndpointLimit("transaction-read", 3, List.of("/api/v1/transactions")),
+        new EndpointLimit("account-read", 4, List.of("/api/v1/accounts")),
+        new EndpointLimit("transfer-write", 2, List.of("/api/v1/transfers")),
+        new EndpointLimit(
+            "notification-read",
+            4,
+            List.of("/api/v1/notifications", "/api/v1/notification-preferences")),
+        new EndpointLimit("notification-stream", 4, List.of("/api/v1/notifications/stream")),
+        new EndpointLimit(
+            "internal-ops",
+            2,
+            List.of(
+                "/internal/api/v1/accounts",
+                "/internal/api/v1/ledger",
+                "/internal/api/v1/outbox")));
+  }
+
+  public record EndpointLimit(String group, int maxConcurrency, List<String> pathPrefixes) {
+
+    public EndpointLimit {
+      if (group == null || group.isBlank()) {
+        throw new IllegalArgumentException("ops.api-admission-control endpoint group is required");
+      }
+      if (maxConcurrency <= 0) {
+        throw new IllegalArgumentException(
+            "ops.api-admission-control max-concurrency must be positive");
+      }
+      if (pathPrefixes == null || pathPrefixes.isEmpty()) {
+        throw new IllegalArgumentException(
+            "ops.api-admission-control path-prefixes must not be empty");
+      }
+      pathPrefixes = List.copyOf(pathPrefixes);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionPermit.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionPermit.java
@@ -1,0 +1,52 @@
+package com.aquilabank.global.ops;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class ApiAdmissionPermit {
+
+  private static final ApiAdmissionPermit IGNORED = new ApiAdmissionPermit(true, "", 0, () -> {});
+
+  private final boolean allowed;
+  private final String group;
+  private final int retryAfterSeconds;
+  private final Runnable releaseCallback;
+  private final AtomicBoolean released = new AtomicBoolean();
+
+  private ApiAdmissionPermit(
+      boolean allowed, String group, int retryAfterSeconds, Runnable releaseCallback) {
+    this.allowed = allowed;
+    this.group = group;
+    this.retryAfterSeconds = retryAfterSeconds;
+    this.releaseCallback = releaseCallback;
+  }
+
+  public static ApiAdmissionPermit acquired(String group, Runnable releaseCallback) {
+    return new ApiAdmissionPermit(true, group, 0, releaseCallback);
+  }
+
+  public static ApiAdmissionPermit rejected(String group, int retryAfterSeconds) {
+    return new ApiAdmissionPermit(false, group, retryAfterSeconds, () -> {});
+  }
+
+  public static ApiAdmissionPermit ignored() {
+    return IGNORED;
+  }
+
+  public boolean allowed() {
+    return allowed;
+  }
+
+  public String group() {
+    return group;
+  }
+
+  public int retryAfterSeconds() {
+    return retryAfterSeconds;
+  }
+
+  public void release() {
+    if (allowed && released.compareAndSet(false, true)) {
+      releaseCallback.run();
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/ops/ApiOverloadRejectedException.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiOverloadRejectedException.java
@@ -1,0 +1,22 @@
+package com.aquilabank.global.ops;
+
+/** endpoint group 동시성 상한을 넘으면 queueing 없이 즉시 거절합니다. */
+public final class ApiOverloadRejectedException extends RuntimeException {
+
+  private final String group;
+  private final int retryAfterSeconds;
+
+  public ApiOverloadRejectedException(String group, int retryAfterSeconds) {
+    super("api overloaded; retry later");
+    this.group = group;
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+
+  public String group() {
+    return group;
+  }
+
+  public int retryAfterSeconds() {
+    return retryAfterSeconds;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiAdmissionControlInterceptor.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiAdmissionControlInterceptor.java
@@ -1,0 +1,55 @@
+package com.aquilabank.global.web;
+
+import com.aquilabank.global.ops.ApiAdmissionControl;
+import com.aquilabank.global.ops.ApiAdmissionPermit;
+import com.aquilabank.global.ops.ApiOverloadRejectedException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/** permit은 요청 완료/예외 완료 모두 afterCompletion에서 반환합니다. */
+public class ApiAdmissionControlInterceptor implements HandlerInterceptor, AsyncHandlerInterceptor {
+
+  private static final String PERMIT_ATTRIBUTE =
+      ApiAdmissionControlInterceptor.class.getName() + ".PERMIT";
+
+  private final ApiAdmissionControl admissionControl;
+
+  public ApiAdmissionControlInterceptor(ApiAdmissionControl admissionControl) {
+    this.admissionControl = admissionControl;
+  }
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    ApiAdmissionPermit permit = admissionControl.tryAcquire(request.getRequestURI());
+    if (!permit.allowed()) {
+      throw new ApiOverloadRejectedException(permit.group(), permit.retryAfterSeconds());
+    }
+    if (!permit.group().isBlank()) {
+      request.setAttribute(PERMIT_ATTRIBUTE, permit);
+    }
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    release(request);
+  }
+
+  @Override
+  public void afterConcurrentHandlingStarted(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    release(request);
+  }
+
+  private void release(HttpServletRequest request) {
+    Object value = request.getAttribute(PERMIT_ATTRIBUTE);
+    if (value instanceof ApiAdmissionPermit permit) {
+      permit.release();
+      request.removeAttribute(PERMIT_ATTRIBUTE);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -26,6 +26,7 @@ import com.aquilabank.domain.ledger.exception.TransferReversalNotFoundException;
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
 import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
 import com.aquilabank.global.notification.NotificationSseOverloadException;
+import com.aquilabank.global.ops.ApiOverloadRejectedException;
 import com.aquilabank.global.ops.T3MicroQueryTimeoutSignal;
 import com.aquilabank.global.ops.T3MicroSaturationRejectedException;
 import com.aquilabank.global.security.BootstrapApiAccessDeniedException;
@@ -107,6 +108,21 @@ public class ApiExceptionHandler {
     logInternalAuthStatusFailure(HttpStatus.TOO_MANY_REQUESTS, request, ex.getMessage());
     return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
         .header("Retry-After", Long.toString(ex.retryAfterSeconds()))
+        .body(
+            new ApiErrorResponse(
+                Instant.now(),
+                HttpStatus.TOO_MANY_REQUESTS.value(),
+                HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI()));
+  }
+
+  @ExceptionHandler(ApiOverloadRejectedException.class)
+  ResponseEntity<ApiErrorResponse> handleApiOverloadRejected(
+      ApiOverloadRejectedException ex, HttpServletRequest request) {
+    logInternalAuthStatusFailure(HttpStatus.TOO_MANY_REQUESTS, request, ex.getMessage());
+    return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+        .header("Retry-After", Integer.toString(ex.retryAfterSeconds()))
         .body(
             new ApiErrorResponse(
                 Instant.now(),

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -89,15 +89,15 @@ ops:
         max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSFER_WRITE_MAX:2}
         path-prefixes:
           - /api/v1/transfers
+      - group: notification-stream
+        max-concurrency: ${OPS_API_ADMISSION_CONTROL_NOTIFICATION_STREAM_MAX:4}
+        path-prefixes:
+          - /api/v1/notifications/stream
       - group: notification-read
         max-concurrency: ${OPS_API_ADMISSION_CONTROL_NOTIFICATION_READ_MAX:4}
         path-prefixes:
           - /api/v1/notifications
           - /api/v1/notification-preferences
-      - group: notification-stream
-        max-concurrency: ${OPS_API_ADMISSION_CONTROL_NOTIFICATION_STREAM_MAX:4}
-        path-prefixes:
-          - /api/v1/notifications/stream
       - group: internal-ops
         max-concurrency: ${OPS_API_ADMISSION_CONTROL_INTERNAL_OPS_MAX:2}
         path-prefixes:

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -73,6 +73,37 @@ management:
         aquila.transaction.query.latency: 50ms,80ms,120ms,150ms,180ms,350ms,750ms,1s,3s
 
 ops:
+  api-admission-control:
+    enabled: ${OPS_API_ADMISSION_CONTROL_ENABLED:true}
+    retry-after-seconds: ${OPS_API_ADMISSION_CONTROL_RETRY_AFTER_SECONDS:1}
+    endpoints:
+      - group: transaction-read
+        max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX:3}
+        path-prefixes:
+          - /api/v1/transactions
+      - group: account-read
+        max-concurrency: ${OPS_API_ADMISSION_CONTROL_ACCOUNT_READ_MAX:4}
+        path-prefixes:
+          - /api/v1/accounts
+      - group: transfer-write
+        max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSFER_WRITE_MAX:2}
+        path-prefixes:
+          - /api/v1/transfers
+      - group: notification-read
+        max-concurrency: ${OPS_API_ADMISSION_CONTROL_NOTIFICATION_READ_MAX:4}
+        path-prefixes:
+          - /api/v1/notifications
+          - /api/v1/notification-preferences
+      - group: notification-stream
+        max-concurrency: ${OPS_API_ADMISSION_CONTROL_NOTIFICATION_STREAM_MAX:4}
+        path-prefixes:
+          - /api/v1/notifications/stream
+      - group: internal-ops
+        max-concurrency: ${OPS_API_ADMISSION_CONTROL_INTERNAL_OPS_MAX:2}
+        path-prefixes:
+          - /internal/api/v1/accounts
+          - /internal/api/v1/ledger
+          - /internal/api/v1/outbox
   t3-micro-saturation-guard:
     enabled: ${OPS_T3MICRO_SATURATION_GUARD_ENABLED:true}
     retry-after-seconds: ${OPS_T3MICRO_SATURATION_GUARD_RETRY_AFTER_SECONDS:2}

--- a/back/src/test/java/com/aquilabank/global/ops/ApiAdmissionControlTest.java
+++ b/back/src/test/java/com/aquilabank/global/ops/ApiAdmissionControlTest.java
@@ -1,0 +1,102 @@
+package com.aquilabank.global.ops;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ApiAdmissionControlTest {
+
+  @Test
+  void rejectsOverLimitRequestWithoutQueueingAndReleasesPermit() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiAdmissionControl admissionControl = new ApiAdmissionControl(properties(true), meterRegistry);
+
+    ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit second = admissionControl.tryAcquire("/api/v1/transactions?size=20");
+
+    assertThat(first.allowed()).isTrue();
+    assertThat(first.group()).isEqualTo("transaction-read");
+    assertThat(second.allowed()).isFalse();
+    assertThat(second.group()).isEqualTo("transaction-read");
+    assertThat(second.retryAfterSeconds()).isEqualTo(1);
+    assertThat(
+            meterRegistry
+                .find("aquila.api.admission.requests")
+                .tag("group", "transaction-read")
+                .tag("outcome", "accepted")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry
+                .find("aquila.api.admission.requests")
+                .tag("group", "transaction-read")
+                .tag("outcome", "rejected")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry
+                .find("aquila.api.admission.inflight")
+                .tag("group", "transaction-read")
+                .gauge()
+                .value())
+        .isEqualTo(1.0);
+
+    first.release();
+    assertThat(
+            meterRegistry
+                .find("aquila.api.admission.inflight")
+                .tag("group", "transaction-read")
+                .gauge()
+                .value())
+        .isZero();
+
+    ApiAdmissionPermit third = admissionControl.tryAcquire("/api/v1/transactions");
+
+    assertThat(third.allowed()).isTrue();
+    assertThat(
+            meterRegistry
+                .find("aquila.api.admission.inflight")
+                .tag("group", "transaction-read")
+                .gauge()
+                .value())
+        .isEqualTo(1.0);
+    third.release();
+    assertThat(
+            meterRegistry
+                .find("aquila.api.admission.inflight")
+                .tag("group", "transaction-read")
+                .gauge()
+                .value())
+        .isZero();
+  }
+
+  @Test
+  void allowsUnmatchedAndDisabledRequestsWithoutMetrics() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiAdmissionControl enabledControl = new ApiAdmissionControl(properties(true), meterRegistry);
+    ApiAdmissionControl disabledControl = new ApiAdmissionControl(properties(false), meterRegistry);
+
+    assertThat(enabledControl.tryAcquire("/actuator/health").allowed()).isTrue();
+    assertThat(disabledControl.tryAcquire("/api/v1/transactions").allowed()).isTrue();
+
+    assertThat(
+            meterRegistry
+                .find("aquila.api.admission.requests")
+                .tag("group", "transaction-read")
+                .counter())
+        .isNull();
+  }
+
+  private ApiAdmissionControlProperties properties(boolean enabled) {
+    return new ApiAdmissionControlProperties(
+        enabled,
+        1,
+        List.of(
+            new ApiAdmissionControlProperties.EndpointLimit(
+                "transaction-read", 1, List.of("/api/v1/transactions"))));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/ApiAdmissionControlInterceptorTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ApiAdmissionControlInterceptorTest.java
@@ -1,0 +1,65 @@
+package com.aquilabank.global.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.aquilabank.global.ops.ApiAdmissionControl;
+import com.aquilabank.global.ops.ApiAdmissionControlProperties;
+import com.aquilabank.global.ops.ApiOverloadRejectedException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class ApiAdmissionControlInterceptorTest {
+
+  @Test
+  void rejectsOverLimitRequestAndReleasesPermitAfterCompletion() throws Exception {
+    ApiAdmissionControlInterceptor interceptor =
+        new ApiAdmissionControlInterceptor(admissionControl());
+    MockHttpServletRequest firstRequest = new MockHttpServletRequest("GET", "/api/v1/transactions");
+    MockHttpServletRequest secondRequest =
+        new MockHttpServletRequest("GET", "/api/v1/transactions");
+
+    assertThat(interceptor.preHandle(firstRequest, new MockHttpServletResponse(), null)).isTrue();
+    assertThatThrownBy(
+            () -> interceptor.preHandle(secondRequest, new MockHttpServletResponse(), null))
+        .isInstanceOf(ApiOverloadRejectedException.class)
+        .hasMessage("api overloaded; retry later")
+        .extracting("group")
+        .isEqualTo("transaction-read");
+
+    interceptor.afterCompletion(firstRequest, new MockHttpServletResponse(), null, null);
+
+    assertThat(interceptor.preHandle(secondRequest, new MockHttpServletResponse(), null)).isTrue();
+    interceptor.afterCompletion(secondRequest, new MockHttpServletResponse(), null, null);
+  }
+
+  @Test
+  void releasesPermitWhenRequestStartsAsyncHandling() throws Exception {
+    ApiAdmissionControlInterceptor interceptor =
+        new ApiAdmissionControlInterceptor(admissionControl());
+    MockHttpServletRequest firstRequest = new MockHttpServletRequest("GET", "/api/v1/transactions");
+    MockHttpServletRequest secondRequest =
+        new MockHttpServletRequest("GET", "/api/v1/transactions");
+
+    assertThat(interceptor.preHandle(firstRequest, new MockHttpServletResponse(), null)).isTrue();
+
+    interceptor.afterConcurrentHandlingStarted(firstRequest, new MockHttpServletResponse(), null);
+
+    assertThat(interceptor.preHandle(secondRequest, new MockHttpServletResponse(), null)).isTrue();
+    interceptor.afterCompletion(secondRequest, new MockHttpServletResponse(), null, null);
+  }
+
+  private ApiAdmissionControl admissionControl() {
+    return new ApiAdmissionControl(
+        new ApiAdmissionControlProperties(
+            true,
+            1,
+            List.of(
+                new ApiAdmissionControlProperties.EndpointLimit(
+                    "transaction-read", 1, List.of("/api/v1/transactions")))),
+        new SimpleMeterRegistry());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/ApiExceptionHandlerApiOverloadTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ApiExceptionHandlerApiOverloadTest.java
@@ -1,0 +1,27 @@
+package com.aquilabank.global.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.global.ops.ApiOverloadRejectedException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class ApiExceptionHandlerApiOverloadTest {
+
+  @Test
+  void handlesApiOverloadAsTooManyRequestsWithRetryAfter() {
+    ApiExceptionHandler handler = new ApiExceptionHandler();
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/transactions");
+
+    ResponseEntity<ApiExceptionHandler.ApiErrorResponse> response =
+        handler.handleApiOverloadRejected(
+            new ApiOverloadRejectedException("transaction-read", 1), request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+    assertThat(response.getHeaders().getFirst("Retry-After")).isEqualTo("1");
+    assertThat(response.getBody().message()).isEqualTo("api overloaded; retry later");
+    assertThat(response.getBody().path()).isEqualTo("/api/v1/transactions");
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #247

## 🌿 Base Branch
- `main`

## 📝 Summary
- endpoint group별 semaphore 기반 admission control을 추가해 t3.micro에서 초과 요청을 queueing 없이 429로 fail-fast 처리합니다.
- group별 in-flight gauge와 accepted/rejected counter를 낮은 cardinality로 노출합니다.

## 🛠 Changes
- `ops.api-admission-control` 설정과 transaction/account/transfer/notification/internal group 기본 상한 추가
- semaphore 기반 `ApiAdmissionControl`과 permit 반환 로직 추가
- MVC interceptor와 429 `Retry-After` overload 응답 추가
- SSE 같은 async request는 stream 생명주기가 아니라 개설 진입만 제한하도록 async 시작 시 permit 반환
- 단위/interceptor/exception handler 테스트 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back test --tests '*ApiAdmissionControlTest'`
- `./back/gradlew -p back test --tests '*ApiAdmissionControlInterceptorTest' --tests '*ApiExceptionHandlerApiOverloadTest' --tests '*ApiAdmissionControlTest'`
- `tools/test/with-resource-lock.sh notification-sse ./back/gradlew -p back test --tests '*NotificationSseIntegrationTest'`
- `tools/test/with-resource-lock.sh back-check ./back/gradlew -p back check`
- PR 생성 전 `commit_plan` 2개와 실제 브랜치 commit 2개 일치 확인

## 📸 Screenshot / API Example
- 상한 초과 시 응답: HTTP 429, `Retry-After: 1`, body message `api overloaded; retry later`
- UI 변경 없음

## ⚠️ Risk & Rollback
- 예상 리스크: group별 상한이 낮으면 정상 burst도 429로 빠르게 거절될 수 있습니다. SSE는 별도 session guard가 있으므로 generic admission control은 async 시작 시 permit을 반환합니다.
- 롤백 방법: `OPS_API_ADMISSION_CONTROL_ENABLED=false`로 비활성화하거나 해당 커밋을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?