### PR TITLE
[Perf] Postgres slow query/lock saturation alert 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -260,12 +260,20 @@ set +a
   - `aquila_notification_sse_sessions{principal_type="account|user|total"}`
   - `aquila_auth_current_session_gate_reject_count_total{reason_code="MISSING_SESSION_ID|INACTIVE_OR_MISMATCHED_SESSION"}`
   - `aquila_auth_refresh_token_reuse_detected_count_total{reason_code="ROTATED_TOKEN_REUSE"}`
+  - `aquila_t3micro_saturation_guard_query_timeouts_total`
   - `aquila_transaction_query_latency_seconds`
+- DB saturation metric:
+  - backend actuator scrape: `hikaricp_connections_pending`, `hikaricp_connections_active`, `hikaricp_connections_max`
+  - Postgres exporter scrape: `pg_stat_activity_lock_waiting_count`, `pg_stat_statements_seconds_total`, `pg_stat_statements_calls_total`
 - 활성화 조건:
   - outbox metric은 기본 wiring만 있으면 항상 export 됩니다.
   - notification consumer lag/DLQ metric은 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true` 와 DLQ topic 설정이 있어야 export 됩니다.
   - current session gate reject counter는 민감 mutation에서 legacy JWT `session_id` 누락 또는 inactive/mismatch session 차단이 발생하면 증가합니다.
   - refresh token reuse metric은 `ROTATED` refresh token 재사용 감지와 family revoke가 발생하면 증가합니다.
+  - t3.micro query timeout counter는 backend query timeout exception이 발생하면 증가합니다.
+  - Hikari pool metric은 Spring Boot/Micrometer 기본 binder와 `aquila-bank-pool` pool tag 기준으로 export 됩니다.
+  - Postgres exporter `pg_stat_statements_*`는 `pg_stat_statements` extension과 collector 활성화가 필요합니다.
+  - `pg_stat_activity_lock_waiting_count`는 `wait_event_type = 'Lock'` custom query metric으로 둡니다.
   - transaction latency timer는 `GET /api/v1/transactions` query path가 한 번이라도 호출되면 `query_shape` tag 기준으로 누적됩니다.
   - transaction latency histogram bucket은 p95 SLO alert용으로 `50ms, 80ms, 120ms, 150ms, 180ms, 350ms, 750ms, 1s, 3s` 경계를 export 합니다.
 - transaction `query_shape` 기준:
@@ -290,8 +298,14 @@ set +a
   - refresh token reuse metric label은 `reason_code`만 사용하고, `requestId`, `userId`, `reusedSessionId`, `familyRootId`는 structured audit log에서만 확인합니다.
   - `AquilaRefreshTokenReuseDetected` alert는 공격성 재사용 후보입니다. 같은 시간대 `requestId`로 `auth refresh token reuse detected` log를 조회하고 `reusedSessionId`, `familyRootId`, `revokedCount`를 먼저 확인합니다.
   - p95 alert는 `query_shape`별 5분 rate가 충분할 때만 평가해 low traffic 노이즈를 줄입니다.
+  - `AquilaDbPoolPendingWaitDetected`는 Hikari pending connection이 남은 상태라 lock wait, slow query, DB CPU, transaction p95를 같은 시간대에서 같이 확인합니다.
+  - `AquilaDbPoolActivePressureHigh`는 active/max pool ratio 90% 이상을 queueing 전조로 봅니다. t3.micro 기본 `DB_POOL_MAX_SIZE=4`에서는 순간 spike보다 10분 지속 여부가 중요합니다.
+  - `AquilaDbQueryTimeoutDetected`는 `statement_timeout` 또는 `lock_timeout` 전파 신호로 보고 blocking query와 pool pending을 먼저 좁힙니다.
+  - `AquilaPostgresLockWaitDetected`는 Postgres exporter custom metric이 있을 때만 동작합니다. alert label에는 query text/pid/user/requestId를 올리지 않고 DB drill-down에서 확인합니다.
+  - `AquilaPostgresSlowQueryDetected`는 `pg_stat_statements` database-level 평균이 750ms를 넘는지 보는 coarse guard입니다. query별 확인은 `queryid` 기준으로 별도 조회합니다.
   - refresh token reuse alert rollback은 `AquilaRefreshTokenReuseDetected` rule 제거 또는 notification routing 비활성화로 수행하고, refresh API 응답 계약은 그대로 유지합니다.
   - histogram bucket/alert rollback은 `management.metrics.distribution.*.aquila.transaction.query.latency`와 `AquilaTransactionQueryLatencyP95SloHigh` rule 제거로 수행합니다.
+  - DB saturation alert rollback은 `ops/prometheus/rules/aquila-bank-alerts.yml`의 `aquila-bank-postgres` group 제거 또는 threshold/`for` 시간 조정으로 수행합니다.
   - baseline 자산은 `ops/prometheus/` 아래에 두고 dashboard import, alert rule apply, tuning 가이드는 `ops/prometheus/README.md`를 기준으로 봅니다.
 - baseline 파일:
   - dashboard: `ops/prometheus/grafana/aquila-bank-overview.json`

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -17,6 +17,7 @@
   - outbox dispatch lag / failed count / stale sending
   - notification consumer lag / DLQ count
   - SSE total session, account/user/total trend, reject/drop trend
+  - DB pool pending/active pressure, query timeout, Postgres lock/slow query signal
   - transaction query rate by `query_shape`
   - transaction p95 latency by `query_shape`
 - datasource 기준:
@@ -25,6 +26,7 @@
 - query 기준:
   - transaction stat latency는 `sum(rate(..._sum)) / sum(rate(..._count))` 평균값을 유지합니다.
   - transaction shape별 latency는 `aquila_transaction_query_latency_seconds_bucket`의 `histogram_quantile(0.95, ...)`를 사용합니다.
+  - DB saturation panel은 Hikari pool metric과 Postgres exporter metric을 한 panel에 모아 p95 악화 전 전조를 먼저 봅니다.
   - notification lag panel은 topic label이 있을 때 topic별로 분리해 보여줍니다.
   - SSE reject/drop metric은 앱 재시작 전까지 누적되는 gauge 성격이므로 절대값 trend로만 봅니다.
 
@@ -38,6 +40,8 @@
    - `aquila_notification_consumer_lag_count`
    - `aquila_notification_sse_sessions`
    - `aquila_transaction_query_latency_seconds_count`
+   - `hikaricp_connections_pending`
+   - `aquila_t3micro_saturation_guard_query_timeouts_total`
 
 ## Alert Rule Baseline
 
@@ -55,9 +59,27 @@
 - auth baseline:
   - current session active gate reject rate `> 0` for `5m`
   - refresh token reuse detected rate `> 0` for `1m`
+- Postgres/DB saturation baseline:
+  - Hikari pending connection `> 0` for `5m`
+  - Hikari active/max pool ratio `> 90%` for `10m`
+  - t3.micro query timeout rate `> 0` for `5m`
+  - `pg_stat_activity` lock wait custom metric `> 0` for `5m`
+  - `pg_stat_statements` average query seconds `> 750ms` for `10m`
 - transaction baseline:
   - success query p95 SLO: reference_exact `80ms`, first_page `120ms`, cursor/status/direction `150ms`, amount/mixed `180ms`
   - success query 평균 latency `> 750ms`
+
+## Postgres Exporter Metrics
+
+Hikari metric과 `aquila_t3micro_saturation_guard_query_timeouts_total`는 backend actuator scrape에서 바로 나옵니다. `pg_*` 계열 metric은 Postgres exporter scrape가 별도로 있어야 합니다.
+
+- default collector 기준:
+  - `pg_locks_count`는 lock mode별 보유 lock 수를 보여주며, blocking 원인 후보를 좁히는 보조 지표입니다.
+  - `pg_stat_statements_*`는 `--collector.stat_statements=true`와 PostgreSQL `pg_stat_statements` extension이 필요합니다.
+- custom lock wait metric:
+  - alert rule은 `pg_stat_activity_lock_waiting_count`를 기대합니다.
+  - exporter custom query는 `wait_event_type = 'Lock'`인 backend 수를 `datname`별 gauge로 노출합니다.
+  - alert label에는 query text, pid, user, requestId를 올리지 않고 incident drill-down에서만 확인합니다.
 
 ## Alert Rule Apply
 
@@ -93,6 +115,10 @@ bash tools/ops/validate-prometheus-assets.sh
 ## Threshold Tuning
 
 - outbox/notification threshold는 현재 README와 actuator health 기본값을 기준으로 둔 값입니다.
+- Hikari pool alert는 `DB_POOL_MAX_SIZE=4`, `DB_CONNECTION_TIMEOUT_MS=3000`, `DB_LOCK_TIMEOUT_MS=1000`의 t3.micro 기본값을 기준으로 둡니다.
+- `AquilaDbPoolPendingWaitDetected`는 root cause가 아니라 queueing 전조입니다. 같은 시간대 lock wait, slow query, DB CPU, transaction p95를 같이 확인합니다.
+- `AquilaPostgresSlowQueryDetected`는 `pg_stat_statements`의 database-level 평균을 사용합니다. query별 drill-down은 별도 dashboard 또는 psql에서 `queryid` 기준으로 수행합니다.
+- `AquilaPostgresLockWaitDetected`는 custom exporter metric이 없으면 평가 series가 없으므로, 환경별 exporter 설정 적용 후 Prometheus rule을 활성화합니다.
 - `AquilaNotificationSseSessionPressureHigh`의 `56`은 기본 `NOTIFICATION_SSE_MAX_TOTAL_SESSIONS=64`의 `87.5%` baseline입니다.
 - transaction p95 SLO는 baseline fixture 기준 회귀 감지선입니다. 실제 production에서는 `query_shape`, account volume, DB latency 분포를 보고 threshold와 `for` 시간을 같이 조정합니다.
 - transaction 평균 latency `750ms` alert는 p95 SLO보다 느슨한 coarse guard로 남겨 둡니다.
@@ -100,3 +126,4 @@ bash tools/ops/validate-prometheus-assets.sh
 - multi-instance SSE 합계는 Grafana/Prometheus 쿼리에서 인스턴스 합산으로 해석하고, 단일 instance alert는 node별 pressure 확인 용도로만 씁니다.
 - `AquilaCurrentSessionActiveGateRejectDetected`는 `reason_code`만 집계합니다. `requestId`, `userId`, `sessionId`, `path`는 cardinality 때문에 alert label로 올리지 않고 app structured log에서 drill-down합니다.
 - `AquilaRefreshTokenReuseDetected`는 공격성 재사용 후보라 critical baseline입니다. `requestId`, `userId`, `reusedSessionId`, `familyRootId`는 cardinality 때문에 alert label로 올리지 않고 app structured log에서 drill-down합니다.
+- DB saturation alert rollback은 `aquila-bank-postgres` group 제거 또는 해당 rule의 threshold/`for` 시간 조정으로 수행합니다. 앱 API 계약과 DB schema는 그대로 유지합니다.

--- a/ops/prometheus/grafana/aquila-bank-overview.json
+++ b/ops/prometheus/grafana/aquila-bank-overview.json
@@ -558,6 +558,63 @@
       ],
       "title": "Transaction P95 Latency by Shape",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max(hikaricp_connections_pending{pool=\"aquila-bank-pool\"})",
+          "legendFormat": "pool_pending",
+          "refId": "A"
+        },
+        {
+          "expr": "max(hikaricp_connections_active{pool=\"aquila-bank-pool\"}) / clamp_min(max(hikaricp_connections_max{pool=\"aquila-bank-pool\"}), 1)",
+          "legendFormat": "pool_active_ratio",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(aquila_t3micro_saturation_guard_query_timeouts_total[5m]))",
+          "legendFormat": "query_timeout_rate",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(pg_stat_activity_lock_waiting_count)",
+          "legendFormat": "lock_waiting_count",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(pg_stat_statements_seconds_total[5m])) / clamp_min(sum(rate(pg_stat_statements_calls_total[5m])), 0.001)",
+          "legendFormat": "pg_stat_statements_avg_seconds",
+          "refId": "E"
+        }
+      ],
+      "title": "DB Pool and Postgres Slow/Lock Signals",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/ops/prometheus/rules/aquila-bank-alerts.yml
+++ b/ops/prometheus/rules/aquila-bank-alerts.yml
@@ -127,6 +127,91 @@ groups:
           description: "refresh token reuse 감지가 발생했습니다. requestId 기준 structured audit log와 revokedCount를 즉시 확인합니다."
           runbook_path: "back/README.md#prometheus-metrics"
 
+  - name: aquila-bank-postgres
+    interval: 30s
+    rules:
+      - alert: AquilaDbPoolPendingWaitDetected
+        expr: max(hikaricp_connections_pending{pool="aquila-bank-pool"}) > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: postgres
+          signal: pool_wait
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank DB pool wait detected"
+          description: "Hikari pending connection이 5분 이상 남아 있습니다. lock wait, slow query, DB CPU를 transaction p95와 함께 확인합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
+      - alert: AquilaDbPoolActivePressureHigh
+        expr: |
+          (
+            max(hikaricp_connections_active{pool="aquila-bank-pool"})
+            /
+            clamp_min(max(hikaricp_connections_max{pool="aquila-bank-pool"}), 1)
+          ) > 0.9
+        for: 10m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: postgres
+          signal: pool_active_pressure
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank DB pool active pressure is high"
+          description: "Hikari active connection이 max pool의 90%를 10분 이상 초과했습니다. t3.micro 기본 pool=4 기준 queueing 전조로 봅니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
+      - alert: AquilaDbQueryTimeoutDetected
+        expr: sum(rate(aquila_t3micro_saturation_guard_query_timeouts_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: postgres
+          signal: query_timeout
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank DB query timeouts detected"
+          description: "query timeout이 5분 window에서 증가했습니다. statement_timeout, lock_timeout, pool wait를 같은 시간대에서 확인합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
+      - alert: AquilaPostgresLockWaitDetected
+        expr: sum by (datname) (pg_stat_activity_lock_waiting_count) > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: postgres
+          signal: lock_wait
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank PostgreSQL lock wait detected"
+          description: "pg_stat_activity wait_event_type=Lock 기반 custom metric이 5분 이상 0건 초과입니다. blocking PID와 긴 transaction을 먼저 확인합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
+      - alert: AquilaPostgresSlowQueryDetected
+        expr: |
+          (
+            sum by (datname) (rate(pg_stat_statements_seconds_total[5m]))
+            /
+            clamp_min(sum by (datname) (rate(pg_stat_statements_calls_total[5m])), 0.001)
+          ) > 0.75
+          and on (datname)
+          sum by (datname) (rate(pg_stat_statements_calls_total[5m])) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: postgres
+          signal: slow_query
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank PostgreSQL slow query signal detected"
+          description: "pg_stat_statements 평균 실행 시간이 10분 이상 750ms를 초과했습니다. query text는 alert label로 올리지 않고 exporter/dashboard에서 queryid 기준으로 drill-down합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
   - name: aquila-bank-transaction
     interval: 30s
     rules:

--- a/tools/ops/validate-prometheus-assets.sh
+++ b/tools/ops/validate-prometheus-assets.sh
@@ -41,6 +41,25 @@ expr = p95_rule["expr"].to_s
 abort("transaction p95 SLO alert must use histogram_quantile(0.95)") unless expr.match?(/histogram_quantile\s*\(\s*0\.95/)
 abort("transaction p95 SLO alert must read histogram buckets") unless expr.include?("aquila_transaction_query_latency_seconds_bucket")
 abort("transaction p95 SLO alert must keep query_shape labels") unless expr.include?("query_shape")
+
+def require_alert(data, alert_name, required_fragments)
+  rule = data["groups"].flat_map { |group| group["rules"] }.find { |item| item["alert"] == alert_name }
+  abort("#{alert_name} alert missing") unless rule
+  expr = rule["expr"].to_s
+  required_fragments.each do |fragment|
+    abort("#{alert_name} alert must include #{fragment}") unless expr.include?(fragment)
+  end
+end
+
+{
+  "AquilaDbPoolPendingWaitDetected" => ["hikaricp_connections_pending"],
+  "AquilaDbPoolActivePressureHigh" => ["hikaricp_connections_active", "hikaricp_connections_max"],
+  "AquilaDbQueryTimeoutDetected" => ["aquila_t3micro_saturation_guard_query_timeouts_total"],
+  "AquilaPostgresLockWaitDetected" => ["pg_stat_activity_lock_waiting_count"],
+  "AquilaPostgresSlowQueryDetected" => ["pg_stat_statements_seconds_total", "pg_stat_statements_calls_total"]
+}.each do |alert_name, required_fragments|
+  require_alert(data, alert_name, required_fragments)
+end
 ' "${RULES_FILE}"
 
 echo "Prometheus dashboard and alert rule baseline look valid."


### PR DESCRIPTION
## 🔗 Related Issue
- close #250

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction p95 latency 외에 DB pool wait, query timeout, Postgres lock wait, slow query 전조를 Prometheus alert baseline에 추가합니다.
- t3.micro 작은 pool 환경에서 p95 악화 전 DB saturation 원인을 분리할 수 있도록 dashboard와 runbook 기준을 보강합니다.

## 🛠 Changes
- `aquila-bank-postgres` Prometheus alert group 추가
- Hikari pending/active pressure, query timeout, Postgres lock wait, slow query alert 추가
- Grafana overview dashboard에 DB pool/Postgres slow-lock signal panel 추가
- Prometheus asset validation script에 새 alert 계약 검증 추가
- `back/README.md`, `ops/prometheus/README.md` 운영 적용/rollback 기준 보강

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/ops/validate-prometheus-assets.sh`
- `jq empty ops/prometheus/grafana/aquila-bank-overview.json`
- `ruby -e "require 'yaml'; YAML.safe_load(File.read('ops/prometheus/rules/aquila-bank-alerts.yml'), permitted_classes: [], aliases: false)"`
- `tools/test/with-resource-lock.sh back-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Postgres exporter custom metric 또는 `pg_stat_statements` collector가 환경에 없으면 해당 rule은 series 없이 평가됩니다. Hikari pending alert는 순간 spike 노이즈를 줄이기 위해 `for` 시간을 둔 baseline입니다.
- 롤백 방법: `ops/prometheus/rules/aquila-bank-alerts.yml`의 `aquila-bank-postgres` group 제거 또는 threshold/`for` 시간 조정. 앱 API 계약과 DB schema 변경은 없습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?