### PR TITLE
[Perf] 1억 건 replay release gate 및 planner stats guard 추가

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -196,6 +196,31 @@ jobs:
           set -euo pipefail
           tools/ops/staging-postdeploy-smoke.sh
 
+      - name: Run transaction replay regression gate
+        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
+        env:
+          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+          STAGING_REPLAY_TOKEN: ${{ secrets.STAGING_REPLAY_TOKEN }}
+          STAGING_RDS_DATABASE_URL: ${{ secrets.STAGING_RDS_DATABASE_URL }}
+          HOT_ACCOUNT_ID: ${{ secrets.STAGING_REPLAY_HOT_ACCOUNT_ID }}
+          HOT_FROM: ${{ secrets.STAGING_REPLAY_HOT_FROM }}
+          HOT_TO: ${{ secrets.STAGING_REPLAY_HOT_TO }}
+          COLD_ACCOUNT_ID: ${{ secrets.STAGING_REPLAY_COLD_ACCOUNT_ID }}
+          COLD_FROM: ${{ secrets.STAGING_REPLAY_COLD_FROM }}
+          COLD_TO: ${{ secrets.STAGING_REPLAY_COLD_TO }}
+          ITERATIONS: ${{ secrets.STAGING_REPLAY_ITERATIONS }}
+          PAGE_LIMIT: ${{ secrets.STAGING_REPLAY_PAGE_LIMIT }}
+          REQUEST_TIMEOUT_SECONDS: ${{ secrets.STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS }}
+          EXPECTED_TOTAL_ROWS: ${{ secrets.STAGING_REPLAY_EXPECTED_TOTAL_ROWS }}
+          HOT_P95_THRESHOLD_MS: ${{ secrets.STAGING_REPLAY_HOT_P95_THRESHOLD_MS }}
+          COLD_P95_THRESHOLD_MS: ${{ secrets.STAGING_REPLAY_COLD_P95_THRESHOLD_MS }}
+          PLANNER_STATS_MAX_AGE_HOURS: ${{ secrets.STAGING_REPLAY_STATS_MAX_AGE_HOURS }}
+          PLANNER_STATS_MAX_MODIFIED_RATIO: ${{ secrets.STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools/ops/transaction-read-model-staging-replay.sh
+
       - name: Dispatch staging rollback guard
         if: failure() && steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true' && steps.deployment.outputs.deployment_id != ''
         env:

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -42,6 +42,24 @@
   - `STAGING_SMOKE_WRITE_BODY` (default: `{}`)
   - `STAGING_SMOKE_AUTH_HEADER_NAME`
   - `STAGING_SMOKE_AUTH_HEADER_VALUE`
+- transaction replay gate required environment secrets:
+  - `STAGING_REPLAY_TOKEN`
+  - `STAGING_RDS_DATABASE_URL`
+  - `STAGING_REPLAY_HOT_ACCOUNT_ID`
+  - `STAGING_REPLAY_HOT_FROM`
+  - `STAGING_REPLAY_HOT_TO`
+  - `STAGING_REPLAY_COLD_ACCOUNT_ID`
+  - `STAGING_REPLAY_COLD_FROM`
+  - `STAGING_REPLAY_COLD_TO`
+- transaction replay gate optional environment secrets:
+  - `STAGING_REPLAY_ITERATIONS` (default: `40`)
+  - `STAGING_REPLAY_PAGE_LIMIT` (default: `50`)
+  - `STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS` (default: `5`)
+  - `STAGING_REPLAY_EXPECTED_TOTAL_ROWS` (default: `100000000`)
+  - `STAGING_REPLAY_HOT_P95_THRESHOLD_MS` (default: `350`)
+  - `STAGING_REPLAY_COLD_P95_THRESHOLD_MS` (default: `750`)
+  - `STAGING_REPLAY_STATS_MAX_AGE_HOURS` (default: `24`)
+  - `STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO` (default: `0.05`)
 - rollback hook optional environment secrets:
   - `STAGING_ROLLBACK_WEBHOOK_URL`
   - `STAGING_ROLLBACK_TOKEN`
@@ -52,6 +70,8 @@
   - `runUrl`: GitHub Actions run URL
 - deploy hook secret이 없으면 workflow는 no-op skip으로 끝내고 staging GitHub deployment status를 만들지 않습니다.
 - workflow는 실제 hook 호출 후 post-deploy smoke를 통과한 경우에만 staging GitHub deployment status를 `success`로 갱신합니다.
+- transaction replay gate는 post-deploy smoke 뒤에 실행되며, `pg_class.reltuples` 검증 전에 planner stats freshness guard로 stale stats를 차단합니다.
+- replay gate가 실패하면 staging deployment status는 `success`로 올라가지 않으므로 production promotion guard가 같은 SHA를 자동으로 거부합니다.
 - post-deploy smoke는 health/read/write endpoint를 호출하며, read/write path는 환경별 smoke 전용 endpoint를 secret으로 주입합니다.
 - smoke 또는 deploy hook 실패 시 deployment status는 `failure`가 되고, rollback hook이 설정된 경우 `sha`, `repository`, `runUrl`, `deploymentId`와 함께 호출합니다.
 - production 승격은 staging deployment status가 `success`인 같은 SHA만 대상으로 삼습니다.

--- a/docs/transaction-read-model-staging-replay.md
+++ b/docs/transaction-read-model-staging-replay.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-`Transaction Read Model Staging Replay` workflow는 로컬 fixture가 아니라 staging/RDS의 1억 건 분포에서 hot/cold 거래 조회 p95를 검증합니다.
+`Transaction Read Model Staging Replay`는 수동 workflow와 staging deploy release gate가 같은 script를 공유하며, 로컬 fixture가 아니라 staging/RDS의 1억 건 분포에서 hot/cold 거래 조회 p95를 검증합니다.
 
 - hot: `GET /api/v1/transactions`
 - cold: `GET /api/v1/transactions/archive`
@@ -15,10 +15,39 @@
   - `STAGING_BASE_URL`
   - `STAGING_REPLAY_TOKEN`
   - `STAGING_RDS_DATABASE_URL`
+- staging deploy release gate용 추가 secrets:
+  - `STAGING_REPLAY_HOT_ACCOUNT_ID`
+  - `STAGING_REPLAY_HOT_FROM`
+  - `STAGING_REPLAY_HOT_TO`
+  - `STAGING_REPLAY_COLD_ACCOUNT_ID`
+  - `STAGING_REPLAY_COLD_FROM`
+  - `STAGING_REPLAY_COLD_TO`
 - staging RDS 통계가 최신이어야 합니다.
   - 1억 건 분포 적재 또는 replay 전후 `ANALYZE` 수행
   - full count 대신 `pg_class.reltuples` estimate를 쓰므로 오래된 통계는 검증 실패나 과소/과대 평가를 만들 수 있습니다.
 - cold path는 `GET /api/v1/transactions/archive` 배포 이후 실행합니다.
+
+## Staging Deploy Release Gate
+
+- `Staging Deploy` workflow는 post-deploy smoke 뒤에 같은 replay script를 실행합니다.
+- release gate는 아래 `staging` Environment secret을 읽어 수동 입력 없이 same SHA를 검증합니다.
+  - required:
+    - `STAGING_REPLAY_HOT_ACCOUNT_ID`
+    - `STAGING_REPLAY_HOT_FROM`
+    - `STAGING_REPLAY_HOT_TO`
+    - `STAGING_REPLAY_COLD_ACCOUNT_ID`
+    - `STAGING_REPLAY_COLD_FROM`
+    - `STAGING_REPLAY_COLD_TO`
+  - optional:
+    - `STAGING_REPLAY_ITERATIONS`
+    - `STAGING_REPLAY_PAGE_LIMIT`
+    - `STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS`
+    - `STAGING_REPLAY_EXPECTED_TOTAL_ROWS`
+    - `STAGING_REPLAY_HOT_P95_THRESHOLD_MS`
+    - `STAGING_REPLAY_COLD_P95_THRESHOLD_MS`
+    - `STAGING_REPLAY_STATS_MAX_AGE_HOURS`
+    - `STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO`
+- replay gate가 실패하면 staging deployment status가 `success`로 기록되지 않아 production promotion이 같은 SHA를 통과시키지 않습니다.
 
 ## Workflow Inputs
 
@@ -34,6 +63,8 @@
 
 ## Gate Behavior
 
+- planner stats freshness guard가 `transaction_read_model`, `transaction_read_model_archive`의 analyze 시각과 `n_mod_since_analyze / reltuples` 비율을 먼저 확인합니다.
+- freshness guard가 stale stats를 감지하면 table별 `ANALYZE VERBOSE public.<table>;` guidance와 함께 즉시 실패합니다.
 - RDS estimate가 `expected_total_rows`보다 작으면 실패합니다.
 - hot/cold account에 row가 없으면 실패합니다.
 - 각 first page가 `nextCursor`를 반환하지 않으면 cursor replay가 불가능하므로 실패합니다.

--- a/tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
+++ b/tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/ops/transaction-read-model-planner-stats-freshness-guard.sh [--print-sql]
+
+Environment:
+  DATABASE_URL   optional PostgreSQL URL. If set, it is passed directly to psql.
+  DB_HOST        fallback host, default localhost
+  DB_PORT        fallback port, default 5432
+  DB_NAME        fallback database, default aquila_bank
+  DB_USERNAME    fallback user, default postgres
+  DB_PASSWORD    fallback password, mapped to PGPASSWORD when PGPASSWORD is unset
+
+Threshold overrides:
+  STATS_MAX_AGE_HOURS        default 24
+  STATS_MAX_MODIFIED_RATIO   default 0.05
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+stats_max_age_hours="${STATS_MAX_AGE_HOURS:-24}"
+stats_max_modified_ratio="${STATS_MAX_MODIFIED_RATIO:-0.05}"
+
+validate_positive_integer() {
+  local name="$1"
+  local value="$2"
+  [[ "${value}" =~ ^[1-9][0-9]*$ ]] || {
+    echo "${name} must be a positive integer" >&2
+    exit 1
+  }
+}
+
+validate_ratio() {
+  local name="$1"
+  local value="$2"
+  [[ "${value}" =~ ^([0-9]+([.][0-9]+)?|[.][0-9]+)$ ]] || {
+    echo "${name} must be a decimal ratio between 0 and 1" >&2
+    exit 1
+  }
+  awk -v value="${value}" 'BEGIN { exit !(value > 0 && value < 1) }' || {
+    echo "${name} must be greater than 0 and less than 1" >&2
+    exit 1
+  }
+}
+
+validate_positive_integer "STATS_MAX_AGE_HOURS" "${stats_max_age_hours}"
+validate_ratio "STATS_MAX_MODIFIED_RATIO" "${stats_max_modified_ratio}"
+
+read -r -d '' sql <<'SQL' || true
+WITH target_table(table_name) AS (
+    VALUES
+        ('transaction_read_model'),
+        ('transaction_read_model_archive')
+),
+relation_data AS (
+    SELECT
+        t.table_name,
+        c.oid AS relid,
+        GREATEST(c.reltuples, 0)::bigint AS row_estimate,
+        s.n_live_tup,
+        s.n_mod_since_analyze,
+        s.last_analyze,
+        s.last_autoanalyze,
+        s.analyze_count,
+        s.autoanalyze_count
+    FROM target_table t
+    LEFT JOIN (
+        SELECT c.oid,
+               c.relname
+        FROM pg_class c
+        JOIN pg_namespace n
+          ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+    ) c
+      ON c.relname = t.table_name
+    LEFT JOIN pg_stat_user_tables s
+      ON s.relid = c.oid
+),
+calculated AS (
+    SELECT
+        table_name,
+        relid,
+        COALESCE(row_estimate, 0) AS row_estimate,
+        COALESCE(n_live_tup, 0) AS live_tuple_count,
+        COALESCE(n_mod_since_analyze, 0) AS modified_tuple_count,
+        CASE
+            WHEN COALESCE(row_estimate, 0) <= 0 THEN
+                CASE
+                    WHEN COALESCE(n_mod_since_analyze, 0) > 0 THEN 1::numeric
+                    ELSE 0::numeric
+                END
+            ELSE ROUND(
+                COALESCE(n_mod_since_analyze, 0)::numeric / COALESCE(row_estimate, 0),
+                4
+            )
+        END AS modified_ratio,
+        CASE
+            WHEN last_analyze IS NULL AND last_autoanalyze IS NULL THEN NULL
+            ELSE GREATEST(
+                COALESCE(last_analyze, '-infinity'::timestamp with time zone),
+                COALESCE(last_autoanalyze, '-infinity'::timestamp with time zone)
+            )
+        END AS last_analyze_at,
+        COALESCE(analyze_count, 0) AS analyze_count,
+        COALESCE(autoanalyze_count, 0) AS autoanalyze_count,
+        format('ANALYZE VERBOSE public.%I;', table_name) AS analyze_command
+    FROM relation_data
+)
+SELECT
+    table_name,
+    CASE
+        WHEN relid IS NULL THEN 'missing_table'
+        WHEN last_analyze_at IS NULL THEN 'missing_analyze'
+        WHEN ROUND(EXTRACT(EPOCH FROM (now() - last_analyze_at)) / 3600, 1) >= :'stats_max_age_hours'::numeric
+            THEN 'stale_analyze_age'
+        WHEN modified_ratio >= :'stats_max_modified_ratio'::numeric
+            THEN 'stale_modified_ratio'
+        ELSE 'ok'
+    END AS status,
+    row_estimate,
+    live_tuple_count,
+    modified_tuple_count,
+    modified_ratio,
+    last_analyze_at,
+    CASE
+        WHEN last_analyze_at IS NULL THEN NULL
+        ELSE ROUND(EXTRACT(EPOCH FROM (now() - last_analyze_at)) / 3600, 1)
+    END AS analyze_age_hours,
+    analyze_count,
+    autoanalyze_count,
+    analyze_command
+FROM calculated
+ORDER BY table_name;
+SQL
+
+if [[ "${1:-}" == "--print-sql" ]]; then
+  printf '%s\n' "${sql}"
+  exit 0
+fi
+
+if [[ $# -ne 0 ]]; then
+  usage
+  exit 1
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "psql is required. Install PostgreSQL client tools or use --print-sql." >&2
+  exit 1
+fi
+
+echo "[transaction-planner-stats-guard] target tables: transaction_read_model, transaction_read_model_archive"
+echo "[transaction-planner-stats-guard] max analyze age hours: ${stats_max_age_hours}"
+echo "[transaction-planner-stats-guard] max modified ratio: ${stats_max_modified_ratio}"
+
+result_file="$(mktemp)"
+trap 'rm -f "${result_file}"' EXIT
+
+psql_args=(--no-psqlrc --set ON_ERROR_STOP=1 --pset pager=off --csv)
+psql_vars=(
+  --set "stats_max_age_hours=${stats_max_age_hours}"
+  --set "stats_max_modified_ratio=${stats_max_modified_ratio}"
+)
+
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  psql "${psql_args[@]}" "${psql_vars[@]}" "${DATABASE_URL}" --command "${sql}" >"${result_file}"
+else
+  export PGHOST="${PGHOST:-${DB_HOST:-localhost}}"
+  export PGPORT="${PGPORT:-${DB_PORT:-5432}}"
+  export PGDATABASE="${PGDATABASE:-${DB_NAME:-aquila_bank}}"
+  export PGUSER="${PGUSER:-${DB_USERNAME:-postgres}}"
+  if [[ -z "${PGPASSWORD:-}" && -n "${DB_PASSWORD:-}" ]]; then
+    export PGPASSWORD="${DB_PASSWORD}"
+  fi
+  psql "${psql_args[@]}" "${psql_vars[@]}" --command "${sql}" >"${result_file}"
+fi
+
+cat "${result_file}"
+
+failure_count="$(
+  awk -F, 'NR > 1 && $2 != "ok" { count += 1 } END { print count + 0 }' "${result_file}"
+)"
+
+if [[ "${failure_count}" != "0" ]]; then
+  echo "::error::Planner stats freshness guard detected stale stats. Run ANALYZE on reported tables before replay." >&2
+  awk -F, '
+    NR > 1 && $2 != "ok" {
+      printf "::error::%s status=%s analyzeAgeHours=%s modifiedRatio=%s guidance=%s\n", $1, $2, $8, $6, $11 > "/dev/stderr"
+    }
+  ' "${result_file}"
+  exit 1
+fi
+
+echo "::notice::Planner stats freshness guard passed." >&2

--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -20,6 +20,9 @@ COLD_FROM="${COLD_FROM:-}"
 COLD_TO="${COLD_TO:-}"
 HOT_P95_THRESHOLD_MS="${HOT_P95_THRESHOLD_MS:-350}"
 COLD_P95_THRESHOLD_MS="${COLD_P95_THRESHOLD_MS:-750}"
+PLANNER_STATS_GUARD_SCRIPT="${PLANNER_STATS_GUARD_SCRIPT:-tools/ops/transaction-read-model-planner-stats-freshness-guard.sh}"
+PLANNER_STATS_MAX_AGE_HOURS="${PLANNER_STATS_MAX_AGE_HOURS:-24}"
+PLANNER_STATS_MAX_MODIFIED_RATIO="${PLANNER_STATS_MAX_MODIFIED_RATIO:-0.05}"
 
 fail() {
   echo "::error::$*" >&2
@@ -44,6 +47,15 @@ require_positive_integer() {
   local name="$1"
   local value="${!name:-}"
   [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "${name} must be a positive integer"
+}
+
+require_ratio_between_zero_and_one() {
+  local name="$1"
+  local value="${!name:-}"
+
+  [[ "$value" =~ ^([0-9]+([.][0-9]+)?|[.][0-9]+)$ ]] || fail "${name} must be a decimal ratio between 0 and 1"
+  awk -v value="$value" 'BEGIN { exit !(value > 0 && value < 1) }' \
+    || fail "${name} must be greater than 0 and less than 1"
 }
 
 psql_scalar() {
@@ -76,12 +88,26 @@ validate_inputs() {
   require_positive_integer COLD_ACCOUNT_ID
   require_positive_integer HOT_P95_THRESHOLD_MS
   require_positive_integer COLD_P95_THRESHOLD_MS
+  require_positive_integer PLANNER_STATS_MAX_AGE_HOURS
+  require_ratio_between_zero_and_one PLANNER_STATS_MAX_MODIFIED_RATIO
 
   if [ "$PAGE_LIMIT" -gt 100 ]; then
     fail "PAGE_LIMIT must be 100 or less"
   fi
 
+  [ -x "$PLANNER_STATS_GUARD_SCRIPT" ] || fail "Planner stats guard script is not executable: ${PLANNER_STATS_GUARD_SCRIPT}"
+
   STAGING_BASE_URL="${STAGING_BASE_URL%/}"
+}
+
+run_planner_stats_guard() {
+  # `reltuples` estimate는 stale stats에 취약해서 replay 전에 ANALYZE 필요 여부를 먼저 차단합니다.
+  if ! DATABASE_URL="$STAGING_RDS_DATABASE_URL" \
+    STATS_MAX_AGE_HOURS="$PLANNER_STATS_MAX_AGE_HOURS" \
+    STATS_MAX_MODIFIED_RATIO="$PLANNER_STATS_MAX_MODIFIED_RATIO" \
+    "$PLANNER_STATS_GUARD_SCRIPT"; then
+    fail "Planner stats freshness guard failed. Run ANALYZE on reported tables before replay."
+  fi
 }
 
 verify_staging_distribution() {
@@ -291,6 +317,7 @@ write_summary() {
 main() {
   mkdir -p "$REPORT_DIR"
   validate_inputs
+  run_planner_stats_guard
   verify_staging_distribution
   run_replay
   write_summary

--- a/tools/test/run-staging-deploy-transaction-replay-gate.sh
+++ b/tools/test/run-staging-deploy-transaction-replay-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/staging-deploy.yml"
+
+echo "[staging-replay-gate] yaml: ${workflow}"
+ruby -e "require 'yaml'; YAML.load_file('${workflow}'); puts 'ok'"
+
+echo "[staging-replay-gate] step order and env wiring"
+ruby <<'RUBY'
+require 'yaml'
+
+workflow = YAML.load_file('.github/workflows/staging-deploy.yml')
+steps = workflow.fetch('jobs').fetch('deploy').fetch('steps')
+step_names = steps.map { |step| step['name'] }
+
+replay_name = 'Run transaction replay regression gate'
+smoke_name = 'Run staging post-deploy smoke'
+success_name = 'Mark staging deployment success'
+
+replay_index = step_names.index(replay_name) or abort("missing step: #{replay_name}")
+smoke_index = step_names.index(smoke_name) or abort("missing step: #{smoke_name}")
+success_index = step_names.index(success_name) or abort("missing step: #{success_name}")
+
+abort('replay gate must run after staging smoke') unless smoke_index < replay_index
+abort('replay gate must run before success status') unless replay_index < success_index
+
+replay_step = steps.fetch(replay_index)
+env = replay_step.fetch('env')
+run = replay_step.fetch('run')
+
+required_keys = %w[
+  STAGING_BASE_URL
+  STAGING_REPLAY_TOKEN
+  STAGING_RDS_DATABASE_URL
+  HOT_ACCOUNT_ID
+  HOT_FROM
+  HOT_TO
+  COLD_ACCOUNT_ID
+  COLD_FROM
+  COLD_TO
+]
+required_keys.each do |key|
+  abort("missing env: #{key}") unless env.key?(key)
+end
+
+abort('replay step must call transaction replay script') unless run.include?('tools/ops/transaction-read-model-staging-replay.sh')
+abort('hot account must come from staging replay secret') unless env.fetch('HOT_ACCOUNT_ID').include?('STAGING_REPLAY_HOT_ACCOUNT_ID')
+abort('cold account must come from staging replay secret') unless env.fetch('COLD_ACCOUNT_ID').include?('STAGING_REPLAY_COLD_ACCOUNT_ID')
+RUBY

--- a/tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh
+++ b/tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/ops/transaction-read-model-planner-stats-freshness-guard.sh"
+
+echo "[transaction-planner-stats-guard] syntax: ${script}"
+bash -n "${script}"
+
+echo "[transaction-planner-stats-guard] dry-run: SQL exposes freshness signals and ANALYZE guidance"
+sql="$("${script}" --print-sql)"
+grep -F "n_mod_since_analyze" <<<"${sql}" >/dev/null
+grep -F "last_autoanalyze" <<<"${sql}" >/dev/null
+grep -F "stale_analyze_age" <<<"${sql}" >/dev/null
+grep -F "stale_modified_ratio" <<<"${sql}" >/dev/null
+grep -F "format('ANALYZE VERBOSE public.%I;', table_name)" <<<"${sql}" >/dev/null
+
+echo "[transaction-planner-stats-guard] guard: invalid threshold fails before querying"
+if STATS_MAX_AGE_HOURS=0 "${script}" --print-sql >/dev/null 2>&1; then
+  echo "invalid STATS_MAX_AGE_HOURS unexpectedly succeeded" >&2
+  exit 1
+fi
+if STATS_MAX_MODIFIED_RATIO=ratio "${script}" --print-sql >/dev/null 2>&1; then
+  echo "invalid STATS_MAX_MODIFIED_RATIO unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-read-model-staging-replay-guard.sh
+++ b/tools/test/run-transaction-read-model-staging-replay-guard.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/ops/transaction-read-model-staging-replay.sh"
+
+echo "[transaction-staging-replay-guard] syntax: ${script}"
+bash -n "${script}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+bin_dir="${temp_dir}/bin"
+mkdir -p "${bin_dir}"
+
+for command_name in curl jq psql awk sort; do
+  cat >"${bin_dir}/${command_name}" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "${bin_dir}/${command_name}"
+done
+
+guard_script="${temp_dir}/planner-guard.sh"
+cat >"${guard_script}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "guard-called" >"${GUARD_MARKER_PATH}"
+exit 19
+EOF
+chmod +x "${guard_script}"
+
+psql_marker="${temp_dir}/psql-called"
+cat >"${bin_dir}/psql" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "psql-called" >"${PSQL_MARKER_PATH}"
+exit 0
+EOF
+chmod +x "${bin_dir}/psql"
+
+set +e
+output="$(
+  PATH="${bin_dir}:${PATH}" \
+  GUARD_MARKER_PATH="${temp_dir}/guard-called" \
+  PSQL_MARKER_PATH="${psql_marker}" \
+  PLANNER_STATS_GUARD_SCRIPT="${guard_script}" \
+  STAGING_BASE_URL="https://staging.example.com" \
+  STAGING_REPLAY_TOKEN="token" \
+  STAGING_RDS_DATABASE_URL="postgres://user:pass@localhost:5432/db" \
+  HOT_ACCOUNT_ID="101" \
+  HOT_FROM="2026-04-01T00:00:00Z" \
+  HOT_TO="2026-04-15T00:00:00Z" \
+  COLD_ACCOUNT_ID="202" \
+  COLD_FROM="2026-03-01T00:00:00Z" \
+  COLD_TO="2026-03-31T00:00:00Z" \
+  "${script}" 2>&1
+)"
+status=$?
+set -e
+
+if [ "${status}" -eq 0 ]; then
+  echo "replay guard test unexpectedly succeeded" >&2
+  exit 1
+fi
+
+grep -F "Planner stats freshness guard failed" <<<"${output}" >/dev/null
+[ -f "${temp_dir}/guard-called" ] || {
+  echo "planner stats guard was not called" >&2
+  exit 1
+}
+
+if [ -f "${psql_marker}" ]; then
+  echo "psql must not run before planner stats guard passes" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #274

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging deploy success 전에 1억 건 transaction replay를 자동 실행해 성능 회귀를 release gate로 승격했습니다.
- replay가 의존하는 `pg_class.reltuples` 추정치 앞단에 planner stats freshness guard를 추가해 stale stats 상태를 `ANALYZE` guidance와 함께 차단합니다.

## 🛠 Changes
- `tools/ops/transaction-read-model-planner-stats-freshness-guard.sh` 추가
- `tools/ops/transaction-read-model-staging-replay.sh`에 planner stats freshness guard 선행 실행 추가
- `Staging Deploy` workflow에 transaction replay regression gate step 추가
- `tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh`, `tools/test/run-transaction-read-model-staging-replay-guard.sh`, `tools/test/run-staging-deploy-transaction-replay-gate.sh` 추가
- `docs/delivery-flow.md`, `docs/transaction-read-model-staging-replay.md` 갱신

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash -n tools/ops/transaction-read-model-planner-stats-freshness-guard.sh`
- `bash -n tools/ops/transaction-read-model-staging-replay.sh`
- `bash tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh`
- `bash tools/test/run-transaction-read-model-staging-replay-guard.sh`
- `bash tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"`
- `git diff --check`
- `git rev-list --count main..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - staging replay용 account/time-range secret이 비어 있으면 staging deploy가 fail-fast합니다.
  - `STAGING_REPLAY_STATS_MAX_AGE_HOURS`, `STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO`를 과도하게 낮추면 정상 staging도 차단될 수 있습니다.
- 롤백 방법:
  - 이 PR revert로 replay gate와 freshness guard를 함께 제거합니다.
  - 필요하면 staging Environment의 replay 관련 secret을 비워 자동 gate를 일시 해제한 뒤 원인 분석합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (`없음`)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (`없음`)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
