### PR TITLE
[Feat] account status 정책을 account list/notification 경로로 확장

### DIFF
--- a/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountListRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountListRepository.java
@@ -49,6 +49,7 @@ public class JdbcAccountListRepository implements AccountListReadPort {
             WHERE membership.user_id = :userId
               AND membership.membership_status = 'ACTIVE'
               AND bank_user.user_status = 'ACTIVE'
+              AND account.account_status IN ('ACTIVE', 'LOCKED')
             ORDER BY membership.account_id ASC
             """,
             new MapSqlParameterSource().addValue("userId", userId),
@@ -88,6 +89,7 @@ public class JdbcAccountListRepository implements AccountListReadPort {
               AND membership.membership_status = 'ACTIVE'
               AND membership.account_id > :afterAccountId
               AND bank_user.user_status = 'ACTIVE'
+              AND account.account_status IN ('ACTIVE', 'LOCKED')
             ORDER BY membership.account_id ASC
             LIMIT :limit
             """,

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationInboxRepository.java
@@ -109,12 +109,15 @@ public class JdbcNotificationInboxRepository
           ON m.account_id = n.account_id
         JOIN bank_user u
           ON u.id = m.user_id
+        JOIN bank_account a
+          ON a.id = n.account_id
         LEFT JOIN notification_user_read_state r
           ON r.user_id = :userId
          AND r.notification_id = n.id
         WHERE m.user_id = :userId
           AND m.membership_status = 'ACTIVE'
           AND u.user_status = 'ACTIVE'
+          AND a.account_status IN ('ACTIVE', 'LOCKED')
           AND n.archived_at IS NULL
           AND r.archived_at IS NULL
           AND r.deleted_at IS NULL
@@ -159,7 +162,33 @@ public class JdbcNotificationInboxRepository
   @Override
   @Transactional(readOnly = true)
   public long countUnreadByUserId(long userId) {
-    return unreadProjectionCount(USER_SCOPE, userId);
+    // user unread projection은 account_status 축이 없어 CLOSED 전환 직후에는 exact count로 보정합니다.
+    Long unreadCount =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM notification_inbox n
+            JOIN user_account_membership m
+              ON m.account_id = n.account_id
+            JOIN bank_user u
+              ON u.id = m.user_id
+            JOIN bank_account a
+              ON a.id = n.account_id
+            LEFT JOIN notification_user_read_state r
+              ON r.user_id = :userId
+             AND r.notification_id = n.id
+            WHERE m.user_id = :userId
+              AND m.membership_status = 'ACTIVE'
+              AND u.user_status = 'ACTIVE'
+              AND a.account_status IN ('ACTIVE', 'LOCKED')
+              AND n.archived_at IS NULL
+              AND r.read_at IS NULL
+              AND r.archived_at IS NULL
+              AND r.deleted_at IS NULL
+            """,
+            new MapSqlParameterSource().addValue("userId", userId),
+            Long.class);
+    return unreadCount == null ? 0L : unreadCount;
   }
 
   @Override
@@ -708,9 +737,12 @@ public class JdbcNotificationInboxRepository
               ON m.account_id = n.account_id
             JOIN bank_user u
               ON u.id = m.user_id
+            JOIN bank_account a
+              ON a.id = n.account_id
             WHERE m.user_id = :userId
               AND m.membership_status = 'ACTIVE'
               AND u.user_status = 'ACTIVE'
+              AND a.account_status IN ('ACTIVE', 'LOCKED')
               AND n.archived_at IS NULL
               AND n.id IN (:notificationIds)
         ),
@@ -755,9 +787,12 @@ public class JdbcNotificationInboxRepository
                   ON m.account_id = n.account_id
                 JOIN bank_user u
                   ON u.id = m.user_id
+                JOIN bank_account a
+                  ON a.id = n.account_id
                 WHERE m.user_id = :userId
                   AND m.membership_status = 'ACTIVE'
                   AND u.user_status = 'ACTIVE'
+                  AND a.account_status IN ('ACTIVE', 'LOCKED')
                   AND n.archived_at IS NULL
                   AND n.id IN (:notificationIds)
             ),
@@ -809,9 +844,12 @@ public class JdbcNotificationInboxRepository
                   ON m.account_id = n.account_id
                 JOIN bank_user u
                   ON u.id = m.user_id
+                JOIN bank_account a
+                  ON a.id = n.account_id
                 WHERE m.user_id = :userId
                   AND m.membership_status = 'ACTIVE'
                   AND u.user_status = 'ACTIVE'
+                  AND a.account_status IN ('ACTIVE', 'LOCKED')
                   AND n.archived_at IS NULL
                   AND n.id IN (:notificationIds)
             ),
@@ -1102,12 +1140,15 @@ public class JdbcNotificationInboxRepository
               ON m.account_id = n.account_id
             JOIN bank_user u
               ON u.id = m.user_id
+            JOIN bank_account a
+              ON a.id = n.account_id
             LEFT JOIN notification_user_read_state r
               ON r.user_id = :userId
              AND r.notification_id = n.id
             WHERE m.user_id = :userId
               AND m.membership_status = 'ACTIVE'
               AND u.user_status = 'ACTIVE'
+              AND a.account_status IN ('ACTIVE', 'LOCKED')
               AND n.archived_at IS NULL
               AND r.archived_at IS NULL
               AND r.deleted_at IS NULL

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationSseTargetResolver.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationSseTargetResolver.java
@@ -26,9 +26,12 @@ public class JdbcNotificationSseTargetResolver implements NotificationSseTargetR
         FROM user_account_membership m
         JOIN bank_user u
           ON u.id = m.user_id
+        JOIN bank_account a
+          ON a.id = m.account_id
         WHERE m.account_id = :accountId
           AND m.membership_status = 'ACTIVE'
           AND u.user_status = 'ACTIVE'
+          AND a.account_status IN ('ACTIVE', 'LOCKED')
         ORDER BY m.user_id
         """,
         new MapSqlParameterSource().addValue("accountId", accountId),

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/NotificationUserInboxQueryStatement.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/NotificationUserInboxQueryStatement.java
@@ -33,9 +33,12 @@ record NotificationUserInboxQueryStatement(String sql, MapSqlParameterSource par
             FROM user_account_membership m
             JOIN bank_user u
               ON u.id = m.user_id
+            JOIN bank_account a
+              ON a.id = m.account_id
             WHERE m.user_id = :userId
               AND m.membership_status = 'ACTIVE'
               AND u.user_status = 'ACTIVE'
+              AND a.account_status IN ('ACTIVE', 'LOCKED')
         )
         SELECT item.id,
                item.account_id,

--- a/back/src/main/java/com/aquilabank/global/web/account/AccountListController.java
+++ b/back/src/main/java/com/aquilabank/global/web/account/AccountListController.java
@@ -8,6 +8,7 @@ import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import java.time.Instant;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -28,12 +29,15 @@ public class AccountListController {
 
   private final AccountListQueryUseCase accountListQueryUseCase;
   private final AccountSummaryQueryUseCase accountSummaryQueryUseCase;
+  private final RequestAccountAuthorizationService requestAccountAuthorizationService;
 
   public AccountListController(
       AccountListQueryUseCase accountListQueryUseCase,
-      AccountSummaryQueryUseCase accountSummaryQueryUseCase) {
+      AccountSummaryQueryUseCase accountSummaryQueryUseCase,
+      RequestAccountAuthorizationService requestAccountAuthorizationService) {
     this.accountListQueryUseCase = accountListQueryUseCase;
     this.accountSummaryQueryUseCase = accountSummaryQueryUseCase;
+    this.requestAccountAuthorizationService = requestAccountAuthorizationService;
   }
 
   @GetMapping
@@ -60,9 +64,11 @@ public class AccountListController {
       return accountListQueryUseCase.getByUserId(userPrincipal.userId());
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
-      // bootstrap account principal도 같은 요약 모델을 재사용해 dev/test 응답 계약을 단순화합니다.
-      return new AccountSummaryList(
-          List.of(accountSummaryQueryUseCase.getByAccountId(accountPrincipal.accountId())));
+      // bootstrap account principal도 exact read gate를 재사용해 CLOSED 노출을 막습니다.
+      long accountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(
+              principal, accountPrincipal.accountId());
+      return new AccountSummaryList(List.of(accountSummaryQueryUseCase.getByAccountId(accountId)));
     }
     throw new IllegalArgumentException("unsupported principal type");
   }

--- a/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/notification/NotificationController.java
@@ -18,6 +18,7 @@ import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
@@ -59,6 +60,7 @@ public class NotificationController {
   private final NotificationPreferenceReadUseCase notificationPreferenceReadUseCase;
   private final NotificationPreferenceUpdateUseCase notificationPreferenceUpdateUseCase;
   private final NotificationSseBroker notificationSseBroker;
+  private final RequestAccountAuthorizationService requestAccountAuthorizationService;
   private final Clock notificationSearchClock;
 
   public NotificationController(
@@ -69,6 +71,7 @@ public class NotificationController {
       NotificationPreferenceReadUseCase notificationPreferenceReadUseCase,
       NotificationPreferenceUpdateUseCase notificationPreferenceUpdateUseCase,
       NotificationSseBroker notificationSseBroker,
+      RequestAccountAuthorizationService requestAccountAuthorizationService,
       @Qualifier("notificationSearchClock") Clock notificationSearchClock) {
     this.notificationQueryUseCase = notificationQueryUseCase;
     this.notificationReadUseCase = notificationReadUseCase;
@@ -77,6 +80,7 @@ public class NotificationController {
     this.notificationPreferenceReadUseCase = notificationPreferenceReadUseCase;
     this.notificationPreferenceUpdateUseCase = notificationPreferenceUpdateUseCase;
     this.notificationSseBroker = notificationSseBroker;
+    this.requestAccountAuthorizationService = requestAccountAuthorizationService;
     this.notificationSearchClock = notificationSearchClock;
   }
 
@@ -224,8 +228,10 @@ public class NotificationController {
       return notificationQueryUseCase.getNotificationsForUser(userPrincipal.userId(), query);
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
-      return notificationQueryUseCase.getNotificationsForAccount(
-          accountPrincipal.accountId(), query);
+      long accountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(
+              principal, accountPrincipal.accountId());
+      return notificationQueryUseCase.getNotificationsForAccount(accountId, query);
     }
     throw new IllegalArgumentException("unsupported principal type");
   }
@@ -235,7 +241,10 @@ public class NotificationController {
       return notificationQueryUseCase.getUnreadCountForUser(userPrincipal.userId());
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
-      return notificationQueryUseCase.getUnreadCountForAccount(accountPrincipal.accountId());
+      long accountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(
+              principal, accountPrincipal.accountId());
+      return notificationQueryUseCase.getUnreadCountForAccount(accountId);
     }
     throw new IllegalArgumentException("unsupported principal type");
   }
@@ -247,7 +256,10 @@ public class NotificationController {
       return notificationSearchUseCase.searchForUser(userPrincipal.userId(), query);
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
-      return notificationSearchUseCase.searchForAccount(accountPrincipal.accountId(), query);
+      long accountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(
+              principal, accountPrincipal.accountId());
+      return notificationSearchUseCase.searchForAccount(accountId, query);
     }
     throw new IllegalArgumentException("unsupported principal type");
   }
@@ -258,7 +270,10 @@ public class NotificationController {
       return;
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
-      notificationReadUseCase.markAsReadForAccount(accountPrincipal.accountId(), notificationId);
+      long accountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(
+              principal, accountPrincipal.accountId());
+      notificationReadUseCase.markAsReadForAccount(accountId, notificationId);
       return;
     }
     throw new IllegalArgumentException("unsupported principal type");
@@ -271,7 +286,10 @@ public class NotificationController {
       return;
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
-      notificationBulkActionUseCase.markAsReadForAccount(accountPrincipal.accountId(), command);
+      long accountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(
+              principal, accountPrincipal.accountId());
+      notificationBulkActionUseCase.markAsReadForAccount(accountId, command);
       return;
     }
     throw new IllegalArgumentException("unsupported principal type");
@@ -284,7 +302,10 @@ public class NotificationController {
       return;
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
-      notificationBulkActionUseCase.archiveForAccount(accountPrincipal.accountId(), command);
+      long accountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(
+              principal, accountPrincipal.accountId());
+      notificationBulkActionUseCase.archiveForAccount(accountId, command);
       return;
     }
     throw new IllegalArgumentException("unsupported principal type");
@@ -297,7 +318,10 @@ public class NotificationController {
       return;
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
-      notificationBulkActionUseCase.deleteForAccount(accountPrincipal.accountId(), command);
+      long accountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(
+              principal, accountPrincipal.accountId());
+      notificationBulkActionUseCase.deleteForAccount(accountId, command);
       return;
     }
     throw new IllegalArgumentException("unsupported principal type");
@@ -316,8 +340,11 @@ public class NotificationController {
           userPrincipal.userId(), userPrincipal.subject(), lastEventId);
     }
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
+      long accountId =
+          requestAccountAuthorizationService.resolveReadableAccountId(
+              principal, accountPrincipal.accountId());
       return notificationSseBroker.subscribeAccount(
-          accountPrincipal.accountId(), accountPrincipal.subject(), lastEventId);
+          accountId, accountPrincipal.subject(), lastEventId);
     }
     throw new IllegalArgumentException("unsupported principal type");
   }

--- a/back/src/test/java/com/aquilabank/global/persistence/account/JdbcAccountListRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/account/JdbcAccountListRepositoryIntegrationTest.java
@@ -59,6 +59,33 @@ class JdbcAccountListRepositoryIntegrationTest extends PostgresContainerTestSupp
   }
 
   @Test
+  void excludesClosedAccountsButKeepsLockedAccounts() {
+    long[] userId = new long[1];
+    long[] accountIds = new long[3];
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("account-list-status-user", "ACTIVE");
+          for (int index = 0; index < accountIds.length; index++) {
+            accountIds[index] = insertAccount("status-account-" + index);
+            insertSnapshot(accountIds[index]);
+            insertMembership(userId[0], accountIds[index], "ACTIVE");
+          }
+          updateAccountStatus(accountIds[1], "LOCKED");
+          updateAccountStatus(accountIds[2], "CLOSED");
+        });
+
+    AccountSummaryList result = repository.findByUserId(userId[0]);
+
+    assertThat(result.items())
+        .extracting(item -> item.accountId())
+        .containsExactly(accountIds[0], accountIds[1]);
+    assertThat(result.items())
+        .extracting(item -> item.accountStatus())
+        .containsExactly("ACTIVE", "LOCKED");
+  }
+
+  @Test
   void accountListKeysetPlanUsesUserStatusAccountCursorIndex() {
     long[] userId = new long[1];
     commit(transactionManager, () -> userId[0] = insertUser("account-list-plan-user", "ACTIVE"));
@@ -195,6 +222,19 @@ class JdbcAccountListRepositoryIntegrationTest extends PostgresContainerTestSupp
             .addValue("userId", userId)
             .addValue("accountId", accountId)
             .addValue("status", status));
+  }
+
+  private void updateAccountStatus(long accountId, String accountStatus) {
+    jdbcTemplate.update(
+        """
+        UPDATE bank_account
+        SET account_status = :accountStatus,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = :accountId
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("accountStatus", accountStatus));
   }
 
   private void bulkInsertAccountsAndMemberships(long userId, int count) {

--- a/back/src/test/java/com/aquilabank/global/web/account/AccountListControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/account/AccountListControllerTest.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.web.account;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -10,9 +11,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.aquilabank.domain.account.model.AccountSummary;
 import com.aquilabank.domain.account.usecase.AccountListQueryUseCase;
 import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,15 +26,20 @@ class AccountListControllerTest {
 
   private AccountListQueryUseCase accountListQueryUseCase;
   private AccountSummaryQueryUseCase accountSummaryQueryUseCase;
+  private RequestAccountAuthorizationService requestAccountAuthorizationService;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
     accountListQueryUseCase = mock(AccountListQueryUseCase.class);
     accountSummaryQueryUseCase = mock(AccountSummaryQueryUseCase.class);
+    requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
-                new AccountListController(accountListQueryUseCase, accountSummaryQueryUseCase))
+                new AccountListController(
+                    accountListQueryUseCase,
+                    accountSummaryQueryUseCase,
+                    requestAccountAuthorizationService))
             .setControllerAdvice(new ApiExceptionHandler())
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
@@ -40,6 +48,9 @@ class AccountListControllerTest {
 
   @Test
   void returnsSingleAccountForBootstrapPrincipal() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
     when(accountSummaryQueryUseCase.getByAccountId(101L))
         .thenReturn(
             new AccountSummary(
@@ -65,6 +76,24 @@ class AccountListControllerTest {
         .andExpect(jsonPath("$.items[0].availableBalanceMinor").value(8_000L));
 
     verifyNoInteractions(accountListQueryUseCase);
+    verify(requestAccountAuthorizationService)
+        .resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L));
+  }
+
+  @Test
+  void rejectsBootstrapPrincipalWhenReadableAccountAccessIsDenied() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenThrow(new AccountAccessDeniedException("account access is denied"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts")
+                .header("X-Account-Id", "101")
+                .header("X-Subject", "bootstrap-account"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -452,6 +452,47 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   }
 
   @Test
+  void accountListKeepsLockedAccountsButHidesClosedAccounts() throws Exception {
+    upsertMembership(userId, targetAccountId, "VIEWER", "ACTIVE");
+    String token = login("alice", "password123!");
+
+    updateAccountStatus(allowedSourceAccountId, "LOCKED", "account-list-locked-request");
+    updateAccountStatus(targetAccountId, "CLOSED", "account-list-closed-request");
+
+    mockMvc
+        .perform(get("/api/v1/accounts").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId))
+        .andExpect(jsonPath("$.items[0].accountStatus").value("LOCKED"));
+  }
+
+  @Test
+  void bootstrapAccountListAllowsLockedAccountButRejectsClosedAccount() throws Exception {
+    updateAccountStatus(allowedSourceAccountId, "LOCKED", "bootstrap-account-list-locked-request");
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts")
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].accountId").value(allowedSourceAccountId))
+        .andExpect(jsonPath("$.items[0].accountStatus").value("LOCKED"));
+
+    updateAccountStatus(allowedSourceAccountId, "CLOSED", "bootstrap-account-list-closed-request");
+
+    mockMvc
+        .perform(
+            get("/api/v1/accounts")
+                .header("X-Account-Id", String.valueOf(allowedSourceAccountId))
+                .header("X-Subject", "bootstrap-account"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
+  @Test
   void transactionDetailReturnsAllowedAccountDataAnd404ForMissingReference() throws Exception {
     String token = login("alice", "password123!");
 

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
@@ -535,6 +535,289 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
   }
 
   @Test
+  void jwtNotificationApisHideClosedAccountsButKeepLockedAccounts() throws Exception {
+    long[] userId = new long[1];
+    long[] accountIds = new long[2];
+    long[] notificationIds = new long[3];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    Instant from = base.minusSeconds(60);
+    Instant to = base.plusSeconds(300);
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("status-filter-user");
+          accountIds[0] = insertAccount("locked notification account");
+          accountIds[1] = insertAccount("closed notification account");
+          insertMembership(userId[0], accountIds[0], "OWNER", "ACTIVE");
+          insertMembership(userId[0], accountIds[1], "VIEWER", "ACTIVE");
+          notificationIds[0] =
+              insertNotification(
+                  accountIds[0],
+                  "evt-status-filter-1",
+                  "TransferBooked",
+                  "첫 LOCKED 알림",
+                  "A",
+                  null,
+                  base);
+          notificationIds[1] =
+              insertNotification(
+                  accountIds[1],
+                  "evt-status-filter-2",
+                  "TransferBooked",
+                  "CLOSED 알림",
+                  "B",
+                  null,
+                  base.plusSeconds(10));
+          notificationIds[2] =
+              insertNotification(
+                  accountIds[0],
+                  "evt-status-filter-3",
+                  "TransferBooked",
+                  "둘째 LOCKED 알림",
+                  "C",
+                  null,
+                  base.plusSeconds(20));
+        });
+
+    updateAccountStatus(accountIds[0], "LOCKED");
+    updateAccountStatus(accountIds[1], "CLOSED");
+    String token = issueToken("status-filter-user-subject", userId[0]);
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].accountId").value(accountIds[0]))
+        .andExpect(jsonPath("$.items[1].accountId").value(accountIds[0]));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("Authorization", "Bearer " + token)
+                .param("from", from.toString())
+                .param("to", to.toString()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2))
+        .andExpect(jsonPath("$.items[0].accountId").value(accountIds[0]))
+        .andExpect(jsonPath("$.items[1].accountId").value(accountIds[0]));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(2));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/" + notificationIds[1] + "/read")
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("notification is not found"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/" + notificationIds[0] + "/read")
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/archive")
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d,%d]}
+                    """
+                        .formatted(notificationIds[1], notificationIds[2])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/delete")
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d,%d]}
+                    """
+                        .formatted(notificationIds[1], notificationIds[0])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(0));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/unread-count").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(0));
+  }
+
+  @Test
+  void accountPrincipalNotificationApisAllowLockedAccountButRejectClosedAccount() throws Exception {
+    long[] accountId = new long[1];
+    long[] notificationIds = new long[2];
+    Instant base = Instant.parse("2026-04-17T00:00:00Z");
+    Instant from = base.minusSeconds(60);
+    Instant to = base.plusSeconds(300);
+    commit(
+        transactionManager,
+        () -> {
+          accountId[0] = insertAccount("account-principal status account");
+          notificationIds[0] =
+              insertNotification(
+                  accountId[0], "evt-account-status-1", "TransferBooked", "첫 알림", "A", null, base);
+          notificationIds[1] =
+              insertNotification(
+                  accountId[0],
+                  "evt-account-status-2",
+                  "TransferBooked",
+                  "둘째 알림",
+                  "B",
+                  null,
+                  base.plusSeconds(10));
+        });
+
+    updateAccountStatus(accountId[0], "LOCKED");
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("X-Account-Id", accountId[0]))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", accountId[0])
+                .param("from", from.toString())
+                .param("to", to.toString()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items.length()").value(2));
+
+    mockMvc
+        .perform(get("/api/v1/notifications/unread-count").header("X-Account-Id", accountId[0]))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.unreadCount").value(2));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/" + notificationIds[0] + "/read")
+                .header("X-Account-Id", Long.toString(accountId[0])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/read")
+                .header("X-Account-Id", Long.toString(accountId[0]))
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[1])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/archive")
+                .header("X-Account-Id", Long.toString(accountId[0]))
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[0])))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/delete")
+                .header("X-Account-Id", Long.toString(accountId[0]))
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[1])))
+        .andExpect(status().isNoContent());
+
+    updateAccountStatus(accountId[0], "CLOSED");
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("X-Account-Id", accountId[0]))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/notifications/search")
+                .header("X-Account-Id", accountId[0])
+                .param("from", from.toString())
+                .param("to", to.toString()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(get("/api/v1/notifications/unread-count").header("X-Account-Id", accountId[0]))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/" + notificationIds[0] + "/read")
+                .header("X-Account-Id", Long.toString(accountId[0])))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/read")
+                .header("X-Account-Id", Long.toString(accountId[0]))
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[1])))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/archive")
+                .header("X-Account-Id", Long.toString(accountId[0]))
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[0])))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/notifications/delete")
+                .header("X-Account-Id", Long.toString(accountId[0]))
+                .contentType("application/json")
+                .content(
+                    """
+                    {"notificationIds":[%d]}
+                    """
+                        .formatted(notificationIds[1])))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    mockMvc
+        .perform(get("/api/v1/notifications/stream").header("X-Account-Id", accountId[0]))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+  }
+
+  @Test
   void searchesNotificationsForJwtUserWithExplicitFilters() throws Exception {
     long[] userId = new long[1];
     long[] accountIds = new long[2];
@@ -875,6 +1158,27 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
             .addValue("accountId", accountId)
             .addValue("role", role)
             .addValue("status", status));
+  }
+
+  private void updateAccountStatus(long accountId, String accountStatus) {
+    commit(
+        transactionManager,
+        () -> {
+          int updated =
+              jdbcTemplate.update(
+                  """
+                  UPDATE bank_account
+                  SET account_status = :accountStatus,
+                      updated_at = CURRENT_TIMESTAMP
+                  WHERE id = :accountId
+                  """,
+                  new MapSqlParameterSource()
+                      .addValue("accountId", accountId)
+                      .addValue("accountStatus", accountStatus));
+          if (updated != 1) {
+            throw new IllegalStateException("bank_account update did not affect exactly one row");
+          }
+        });
   }
 
   private long insertNotification(

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
 import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
 import com.aquilabank.domain.notification.model.NotificationCursor;
@@ -40,6 +41,7 @@ import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -61,6 +63,7 @@ class NotificationControllerTest {
   private NotificationPreferenceReadUseCase notificationPreferenceReadUseCase;
   private NotificationPreferenceUpdateUseCase notificationPreferenceUpdateUseCase;
   private NotificationSseBroker notificationSseBroker;
+  private RequestAccountAuthorizationService requestAccountAuthorizationService;
   private MockMvc mockMvc;
 
   @BeforeEach
@@ -72,6 +75,9 @@ class NotificationControllerTest {
     notificationPreferenceReadUseCase = mock(NotificationPreferenceReadUseCase.class);
     notificationPreferenceUpdateUseCase = mock(NotificationPreferenceUpdateUseCase.class);
     notificationSseBroker = mock(NotificationSseBroker.class);
+    requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
+    when(requestAccountAuthorizationService.resolveReadableAccountId(any(), anyLong()))
+        .thenAnswer(invocation -> invocation.getArgument(1, Long.class));
     Clock notificationSearchClock =
         Clock.fixed(Instant.parse("2026-04-21T12:00:00Z"), ZoneOffset.UTC);
     mockMvc =
@@ -84,6 +90,7 @@ class NotificationControllerTest {
                     notificationPreferenceReadUseCase,
                     notificationPreferenceUpdateUseCase,
                     notificationSseBroker,
+                    requestAccountAuthorizationService,
                     notificationSearchClock))
             .setControllerAdvice(new ApiExceptionHandler())
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
@@ -209,6 +216,17 @@ class NotificationControllerTest {
         .andExpect(jsonPath("$.items[0].read").value(false))
         .andExpect(jsonPath("$.hasNext").value(true))
         .andExpect(jsonPath("$.nextCursor").isString());
+  }
+
+  @Test
+  void rejectsAccountPrincipalWhenReadableAccountAccessIsDenied() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(any(), eq(101L)))
+        .thenThrow(new AccountAccessDeniedException("account access is denied"));
+
+    mockMvc
+        .perform(get("/api/v1/notifications").header("X-Account-Id", "101"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationSseIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationSseIntegrationTest.java
@@ -272,6 +272,74 @@ class NotificationSseIntegrationTest extends PostgresContainerTestSupport {
   }
 
   @Test
+  @Timeout(15)
+  void jwtUserStreamKeepsLockedAccountNotificationsButHidesClosedAccounts() throws Exception {
+    long[] userId = new long[1];
+    long[] lockedAccountId = new long[1];
+    long[] closedAccountId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("status-stream-user");
+          lockedAccountId[0] = insertAccount("locked stream account");
+          closedAccountId[0] = insertAccount("closed stream account");
+          insertMembership(userId[0], lockedAccountId[0], "OWNER", "ACTIVE");
+          insertMembership(userId[0], closedAccountId[0], "VIEWER", "ACTIVE");
+        });
+
+    updateAccountStatus(lockedAccountId[0], "LOCKED");
+    updateAccountStatus(closedAccountId[0], "CLOSED");
+    String token = issueToken("status-stream-user-subject", userId[0]);
+    long lastEventId;
+
+    try (NotificationSseStream stream = openJwtStream(token)) {
+      assertThat(stream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      transferBookedNotificationConsumer.consume(
+          "transfer-booked:TRX-SSE-STATUS-LOCKED",
+          transferBookedPayload(lockedAccountId[0], closedAccountId[0], 1800L, "status-live"));
+
+      SseEvent liveEvent = stream.awaitEvent("notification", Duration.ofSeconds(3));
+      JsonNode payload = objectMapper.readTree(liveEvent.data());
+      lastEventId = Long.parseLong(liveEvent.id());
+      assertThat(payload.get("accountId").asLong()).isEqualTo(lockedAccountId[0]);
+      assertThat(payload.get("message").asText()).contains("status-live");
+      stream.assertNoEvent("notification", Duration.ofMillis(800));
+    }
+
+    long replayLockedId =
+        commitAndReturn(
+            () ->
+                insertNotification(
+                    lockedAccountId[0],
+                    "jwt-status-replay:TRX-SSE-403",
+                    "TransferBooked",
+                    "이체 완료",
+                    "2100 KRW 입금 · jwt-status-replay"));
+    commitAndReturn(
+        () ->
+            insertNotification(
+                closedAccountId[0],
+                "jwt-status-hidden:TRX-SSE-404",
+                "TransferBooked",
+                "이체 완료",
+                "2200 KRW 입금 · jwt-status-hidden"));
+
+    try (NotificationSseStream replayStream = openJwtStream(token, lastEventId)) {
+      assertThat(replayStream.awaitEvent("connected", Duration.ofSeconds(3)).name())
+          .isEqualTo("connected");
+
+      SseEvent replayEvent = replayStream.awaitEvent("notification", Duration.ofSeconds(3));
+      JsonNode payload = objectMapper.readTree(replayEvent.data());
+      assertThat(Long.parseLong(replayEvent.id())).isEqualTo(replayLockedId);
+      assertThat(payload.get("accountId").asLong()).isEqualTo(lockedAccountId[0]);
+      assertThat(payload.get("message").asText()).contains("jwt-status-replay");
+      replayStream.assertNoEvent("notification", Duration.ofMillis(800));
+    }
+  }
+
+  @Test
   @Timeout(20)
   void reconnectStormReplaysMissedNotificationsWithoutDuplicates() throws Exception {
     long[] accountIds = new long[2];
@@ -706,6 +774,27 @@ class NotificationSseIntegrationTest extends PostgresContainerTestSupport {
             .addValue("accountId", accountId)
             .addValue("role", role)
             .addValue("status", status));
+  }
+
+  private void updateAccountStatus(long accountId, String accountStatus) {
+    commit(
+        transactionManager,
+        () -> {
+          int updated =
+              jdbcTemplate.update(
+                  """
+                  UPDATE bank_account
+                  SET account_status = :accountStatus,
+                      updated_at = CURRENT_TIMESTAMP
+                  WHERE id = :accountId
+                  """,
+                  new MapSqlParameterSource()
+                      .addValue("accountId", accountId)
+                      .addValue("accountStatus", accountStatus));
+          if (updated != 1) {
+            throw new IllegalStateException("bank_account update did not affect exactly one row");
+          }
+        });
   }
 
   private long commitAndReturn(java.util.concurrent.Callable<Long> action) {


### PR DESCRIPTION
## 🔗 Related Issue
- close #276

## 🌿 Base Branch
- main

## 📝 Summary
- account list와 notification account-bound API에 LOCKED/CLOSED read policy를 기존 summary/transaction 정책과 맞췄습니다.
- JWT user는 CLOSED 계좌를 숨기고 LOCKED 계좌는 유지합니다.
- bootstrap account principal의 account list/notification 경로는 CLOSED를 403으로 차단합니다.

## 🛠 Changes
- NotificationController가 account principal 경로에서 RequestAccountAuthorizationService의 READ gate를 재사용하도록 정리했습니다.
- JWT user notification list/search/replay/unread/read/archive/delete SQL과 SSE fan-out 대상 조회에 account_status 필터를 추가했습니다.
- notification/account list 상태별 회귀 테스트를 API/SSE 경로 중심으로 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- tools/test/with-resource-lock.sh back-gradle-account-status-notification ./back/gradlew -p back test --tests '*NotificationControllerTest' --tests '*NotificationApiIntegrationTest' --tests '*NotificationSseIntegrationTest'
- tools/test/with-resource-lock.sh back-gradle-account-status-account-list ./back/gradlew -p back test --tests '*JdbcAccountListRepositoryIntegrationTest' --tests '*AccountListControllerTest' --tests '*LoginAndAccountAccessApiIntegrationTest'
- tools/test/with-resource-lock.sh back-gradle-transfer-target-status ./back/gradlew -p back test --tests '*TransferCommandApiIntegrationTest'
- git diff --check
- pre-commit hook ./back/gradlew -p back check

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: JWT user unread count가 projection 대신 exact count query로 보정돼 inbox row 수가 큰 계정에서 endpoint 비용이 늘 수 있습니다.
- 롤백 방법: 이 PR의 두 커밋을 순서대로 revert해 account list/notification status gate와 query filter를 원복합니다.

## ☑️ Checklist
- [x] base branch가 main인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
