### PR TITLE
[Feat] password recovery 실제 EMAIL/SMS provider adapter 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -639,7 +639,13 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
   - 응답에는 trace용 `X-Request-Id`와 별도로 internal handoff용 `X-Password-Recovery-Request-Id`가 내려간다.
   - active user가 있으면 같은 user의 기존 `PENDING` recovery token을 `SUPERSEDED`로 바꾸고 새 token을 발급한다.
   - token 발급 성공 뒤 delivery port를 best-effort로 호출하며 기본 adapter는 no-op이다.
-  - `AUTH_PASSWORD_RECOVERY_DELIVERY_ENABLED=true`이면 logging adapter가 requestId/userId/expiresAt metadata만 기록하고 token 원문은 기록하지 않는다.
+  - `AUTH_PASSWORD_RECOVERY_DELIVERY_ENABLED=true`이고 provider URL이 없으면 logging adapter가 requestId/userId/expiresAt metadata만 기록하고 token 원문은 기록하지 않는다.
+  - `AUTH_PASSWORD_RECOVERY_DELIVERY_ENABLED=true`이고
+    `AUTH_PASSWORD_RECOVERY_DELIVERY_EMAIL_URL` 또는 `AUTH_PASSWORD_RECOVERY_DELIVERY_SMS_URL`가 있으면 webhook adapter가 JSON payload를 실제 provider endpoint로 `POST` 한다.
+  - 현재 user/contact schema에는 별도 verified email/phone 컬럼이 없으므로, 실제 전달은 `loginId`가 email 또는 E.164 phone 형식일 때만 실행한다.
+  - `loginId`가 email/phone 형식이 아니거나 해당 channel URL이 비어 있으면 잘못된 대상 전송 대신 delivery를 skip 하고 token 발급 결과는 유지한다.
+  - webhook 요청 공통 header는 `AUTH_PASSWORD_RECOVERY_DELIVERY_AUTH_HEADER_NAME`, `AUTH_PASSWORD_RECOVERY_DELIVERY_AUTH_HEADER_VALUE`로 주입하고, timeout은 `AUTH_PASSWORD_RECOVERY_DELIVERY_CONNECT_TIMEOUT_MS`, `AUTH_PASSWORD_RECOVERY_DELIVERY_READ_TIMEOUT_MS`로 조정한다.
+  - webhook payload는 `channel`, `requestId`, `userId`, `loginId`, `destination`, `recoveryToken`, `expiresAt`, `issuedAt` 필드를 포함한다.
   - `POST /api/v1/auth/password-recovery/confirm`
   - 인증 없이 `recoveryToken`, `newPassword`를 받고 성공 시 `204 No Content`
   - wrong/expired/used token, `user_status != ACTIVE`는 모두 `401 password recovery failed`

--- a/back/src/main/java/com/aquilabank/global/auth/PasswordRecoveryDestinationResolver.java
+++ b/back/src/main/java/com/aquilabank/global/auth/PasswordRecoveryDestinationResolver.java
@@ -1,0 +1,33 @@
+package com.aquilabank.global.auth;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/** 별도 contact 모델이 없으므로 현재는 loginId 형식으로만 EMAIL/SMS 전달 대상을 판별합니다. */
+public final class PasswordRecoveryDestinationResolver {
+
+  private static final Pattern EMAIL_PATTERN =
+      Pattern.compile("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,63}$", Pattern.CASE_INSENSITIVE);
+  private static final Pattern E164_PHONE_PATTERN = Pattern.compile("^\\+[1-9][0-9]{7,14}$");
+
+  public Optional<ResolvedDestination> resolve(String loginId) {
+    if (loginId == null) {
+      return Optional.empty();
+    }
+    String value = loginId.trim();
+    if (EMAIL_PATTERN.matcher(value).matches()) {
+      return Optional.of(new ResolvedDestination(PasswordRecoveryChannel.EMAIL, value));
+    }
+    if (E164_PHONE_PATTERN.matcher(value).matches()) {
+      return Optional.of(new ResolvedDestination(PasswordRecoveryChannel.SMS, value));
+    }
+    return Optional.empty();
+  }
+
+  public record ResolvedDestination(PasswordRecoveryChannel channel, String value) {}
+
+  public enum PasswordRecoveryChannel {
+    EMAIL,
+    SMS
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/auth/WebhookPasswordRecoveryDeliveryAdapter.java
+++ b/back/src/main/java/com/aquilabank/global/auth/WebhookPasswordRecoveryDeliveryAdapter.java
@@ -1,0 +1,96 @@
+package com.aquilabank.global.auth;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
+import com.aquilabank.domain.auth.port.PasswordRecoveryDeliveryPort;
+import com.aquilabank.global.auth.PasswordRecoveryDestinationResolver.PasswordRecoveryChannel;
+import com.aquilabank.global.auth.PasswordRecoveryDestinationResolver.ResolvedDestination;
+import com.aquilabank.global.config.PasswordRecoveryDeliveryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/** contact schema 없이 잘못된 외부 전달을 막기 위해 email/E.164 phone 형식만 webhook으로 넘깁니다. */
+public final class WebhookPasswordRecoveryDeliveryAdapter implements PasswordRecoveryDeliveryPort {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(WebhookPasswordRecoveryDeliveryAdapter.class);
+
+  private final RestClient restClient;
+  private final PasswordRecoveryDestinationResolver destinationResolver;
+  private final PasswordRecoveryDeliveryProperties properties;
+
+  public WebhookPasswordRecoveryDeliveryAdapter(
+      RestClient restClient,
+      PasswordRecoveryDestinationResolver destinationResolver,
+      PasswordRecoveryDeliveryProperties properties) {
+    this.restClient = restClient;
+    this.destinationResolver = destinationResolver;
+    this.properties = properties;
+  }
+
+  @Override
+  public void deliver(PasswordRecoveryDeliveryCommand command) {
+    ResolvedDestination destination = destinationResolver.resolve(command.loginId()).orElse(null);
+    if (destination == null) {
+      log.warn(
+          "password recovery delivery skipped due to unsupported loginId format requestId={} userId={}",
+          command.requestId(),
+          command.userId());
+      return;
+    }
+
+    String url = targetUrl(destination.channel());
+    if (!StringUtils.hasText(url)) {
+      log.warn(
+          "password recovery delivery skipped because provider URL is missing requestId={} userId={} channel={}",
+          command.requestId(),
+          command.userId(),
+          destination.channel());
+      return;
+    }
+
+    RestClient.RequestBodySpec requestSpec =
+        restClient.post().uri(url).contentType(MediaType.APPLICATION_JSON);
+    if (StringUtils.hasText(properties.authHeaderValue())) {
+      requestSpec.header(properties.authHeaderName(), properties.authHeaderValue());
+    }
+    requestSpec
+        .body(
+            new PasswordRecoveryWebhookRequest(
+                destination.channel().name(),
+                command.requestId(),
+                command.userId(),
+                command.loginId(),
+                destination.value(),
+                command.recoveryToken(),
+                command.expiresAt().toString(),
+                command.issuedAt().toString()))
+        .retrieve()
+        .toBodilessEntity();
+
+    log.info(
+        "password recovery delivery dispatched requestId={} userId={} channel={} expiresAt={}",
+        command.requestId(),
+        command.userId(),
+        destination.channel(),
+        command.expiresAt());
+  }
+
+  private String targetUrl(PasswordRecoveryChannel channel) {
+    return channel == PasswordRecoveryChannel.EMAIL
+        ? properties.email().url()
+        : properties.sms().url();
+  }
+
+  private record PasswordRecoveryWebhookRequest(
+      String channel,
+      String requestId,
+      long userId,
+      String loginId,
+      String destination,
+      String recoveryToken,
+      String expiresAt,
+      String issuedAt) {}
+}

--- a/back/src/main/java/com/aquilabank/global/config/PasswordRecoveryDeliveryConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/PasswordRecoveryDeliveryConfiguration.java
@@ -3,11 +3,16 @@ package com.aquilabank.global.config;
 import com.aquilabank.domain.auth.port.PasswordRecoveryDeliveryPort;
 import com.aquilabank.global.auth.LoggingPasswordRecoveryDeliveryAdapter;
 import com.aquilabank.global.auth.NoOpPasswordRecoveryDeliveryAdapter;
+import com.aquilabank.global.auth.PasswordRecoveryDestinationResolver;
+import com.aquilabank.global.auth.WebhookPasswordRecoveryDeliveryAdapter;
+import java.time.Duration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
 
 /** password recovery delivery adapter를 runtime 설정으로 선택합니다. */
 @Configuration
@@ -16,7 +21,14 @@ public class PasswordRecoveryDeliveryConfiguration {
 
   @Bean
   @ConditionalOnProperty(name = "auth.password-recovery.delivery.enabled", havingValue = "true")
-  PasswordRecoveryDeliveryPort loggingPasswordRecoveryDeliveryPort() {
+  PasswordRecoveryDeliveryPort passwordRecoveryDeliveryPort(
+      PasswordRecoveryDeliveryProperties properties) {
+    if (properties.hasWebhookTarget()) {
+      return new WebhookPasswordRecoveryDeliveryAdapter(
+          passwordRecoveryRestClient(properties),
+          new PasswordRecoveryDestinationResolver(),
+          properties);
+    }
     return new LoggingPasswordRecoveryDeliveryAdapter();
   }
 
@@ -24,5 +36,12 @@ public class PasswordRecoveryDeliveryConfiguration {
   @ConditionalOnMissingBean(PasswordRecoveryDeliveryPort.class)
   PasswordRecoveryDeliveryPort noOpPasswordRecoveryDeliveryPort() {
     return new NoOpPasswordRecoveryDeliveryAdapter();
+  }
+
+  private RestClient passwordRecoveryRestClient(PasswordRecoveryDeliveryProperties properties) {
+    SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+    requestFactory.setConnectTimeout(Duration.ofMillis(properties.connectTimeoutMs()));
+    requestFactory.setReadTimeout(Duration.ofMillis(properties.readTimeoutMs()));
+    return RestClient.builder().requestFactory(requestFactory).build();
   }
 }

--- a/back/src/main/java/com/aquilabank/global/config/PasswordRecoveryDeliveryProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/PasswordRecoveryDeliveryProperties.java
@@ -1,7 +1,38 @@
 package com.aquilabank.global.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
 
 /** password recovery token 전달 adapter 활성화 설정입니다. */
 @ConfigurationProperties(prefix = "auth.password-recovery.delivery")
-public record PasswordRecoveryDeliveryProperties(boolean enabled) {}
+public record PasswordRecoveryDeliveryProperties(
+    boolean enabled,
+    String authHeaderName,
+    String authHeaderValue,
+    int connectTimeoutMs,
+    int readTimeoutMs,
+    ChannelProperties email,
+    ChannelProperties sms) {
+
+  public PasswordRecoveryDeliveryProperties {
+    authHeaderName =
+        StringUtils.hasText(authHeaderName) ? authHeaderName : HttpHeaders.AUTHORIZATION;
+    authHeaderValue = StringUtils.hasText(authHeaderValue) ? authHeaderValue : "";
+    connectTimeoutMs = connectTimeoutMs > 0 ? connectTimeoutMs : 3000;
+    readTimeoutMs = readTimeoutMs > 0 ? readTimeoutMs : 5000;
+    email = email == null ? new ChannelProperties(null) : email;
+    sms = sms == null ? new ChannelProperties(null) : sms;
+  }
+
+  public boolean hasWebhookTarget() {
+    return email.configured() || sms.configured();
+  }
+
+  public record ChannelProperties(String url) {
+
+    public boolean configured() {
+      return StringUtils.hasText(url);
+    }
+  }
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -184,6 +184,14 @@ auth:
   password-recovery:
     delivery:
       enabled: ${AUTH_PASSWORD_RECOVERY_DELIVERY_ENABLED:false}
+      auth-header-name: ${AUTH_PASSWORD_RECOVERY_DELIVERY_AUTH_HEADER_NAME:Authorization}
+      auth-header-value: ${AUTH_PASSWORD_RECOVERY_DELIVERY_AUTH_HEADER_VALUE:}
+      connect-timeout-ms: ${AUTH_PASSWORD_RECOVERY_DELIVERY_CONNECT_TIMEOUT_MS:3000}
+      read-timeout-ms: ${AUTH_PASSWORD_RECOVERY_DELIVERY_READ_TIMEOUT_MS:5000}
+      email:
+        url: ${AUTH_PASSWORD_RECOVERY_DELIVERY_EMAIL_URL:}
+      sms:
+        url: ${AUTH_PASSWORD_RECOVERY_DELIVERY_SMS_URL:}
   refresh-token-session:
     cleanup:
       enabled: ${AUTH_REFRESH_TOKEN_SESSION_CLEANUP_ENABLED:true}

--- a/back/src/test/java/com/aquilabank/global/auth/WebhookPasswordRecoveryDeliveryAdapterTest.java
+++ b/back/src/test/java/com/aquilabank/global/auth/WebhookPasswordRecoveryDeliveryAdapterTest.java
@@ -1,0 +1,121 @@
+package com.aquilabank.global.auth;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withAccepted;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
+import com.aquilabank.global.config.PasswordRecoveryDeliveryProperties;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class WebhookPasswordRecoveryDeliveryAdapterTest {
+
+  @Test
+  void sendsEmailWebhookWhenLoginIdIsEmail() {
+    RestClient.Builder builder = RestClient.builder();
+    MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+    server
+        .expect(requestTo("https://email-provider.example/recovery"))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(header("Authorization", "Bearer delivery-secret"))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.channel").value("EMAIL"))
+        .andExpect(jsonPath("$.requestId").value("request-1"))
+        .andExpect(jsonPath("$.destination").value("alice@example.com"))
+        .andExpect(jsonPath("$.recoveryToken").value("plain-recovery-token"))
+        .andRespond(withAccepted());
+
+    WebhookPasswordRecoveryDeliveryAdapter adapter =
+        new WebhookPasswordRecoveryDeliveryAdapter(
+            builder.build(), new PasswordRecoveryDestinationResolver(), properties());
+
+    adapter.deliver(emailCommand());
+
+    server.verify();
+  }
+
+  @Test
+  void sendsSmsWebhookWhenLoginIdIsE164Phone() {
+    RestClient.Builder builder = RestClient.builder();
+    MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+    server
+        .expect(requestTo("https://sms-provider.example/recovery"))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(jsonPath("$.channel").value("SMS"))
+        .andExpect(jsonPath("$.destination").value("+821012345678"))
+        .andRespond(withAccepted());
+
+    WebhookPasswordRecoveryDeliveryAdapter adapter =
+        new WebhookPasswordRecoveryDeliveryAdapter(
+            builder.build(), new PasswordRecoveryDestinationResolver(), properties());
+
+    adapter.deliver(phoneCommand());
+
+    server.verify();
+  }
+
+  @Test
+  void skipsUnsupportedLoginIdWithoutCallingWebhook() {
+    RestClient.Builder builder = RestClient.builder();
+    MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+    WebhookPasswordRecoveryDeliveryAdapter adapter =
+        new WebhookPasswordRecoveryDeliveryAdapter(
+            builder.build(), new PasswordRecoveryDestinationResolver(), properties());
+
+    assertThatCode(
+            () ->
+                adapter.deliver(
+                    new PasswordRecoveryDeliveryCommand(
+                        "request-3",
+                        9L,
+                        "alice",
+                        "plain-recovery-token",
+                        Instant.parse("2026-04-22T00:15:00Z"),
+                        Instant.parse("2026-04-22T00:00:00Z"))))
+        .doesNotThrowAnyException();
+
+    server.verify();
+  }
+
+  private PasswordRecoveryDeliveryProperties properties() {
+    return new PasswordRecoveryDeliveryProperties(
+        true,
+        "Authorization",
+        "Bearer delivery-secret",
+        3000,
+        5000,
+        new PasswordRecoveryDeliveryProperties.ChannelProperties(
+            "https://email-provider.example/recovery"),
+        new PasswordRecoveryDeliveryProperties.ChannelProperties(
+            "https://sms-provider.example/recovery"));
+  }
+
+  private PasswordRecoveryDeliveryCommand emailCommand() {
+    return new PasswordRecoveryDeliveryCommand(
+        "request-1",
+        7L,
+        "alice@example.com",
+        "plain-recovery-token",
+        Instant.parse("2026-04-22T00:15:00Z"),
+        Instant.parse("2026-04-22T00:00:00Z"));
+  }
+
+  private PasswordRecoveryDeliveryCommand phoneCommand() {
+    return new PasswordRecoveryDeliveryCommand(
+        "request-2",
+        8L,
+        "+821012345678",
+        "plain-recovery-token",
+        Instant.parse("2026-04-22T00:15:00Z"),
+        Instant.parse("2026-04-22T00:00:00Z"));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/PasswordRecoveryDeliveryConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/PasswordRecoveryDeliveryConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.aquilabank.domain.auth.port.PasswordRecoveryDeliveryPort;
 import com.aquilabank.global.auth.LoggingPasswordRecoveryDeliveryAdapter;
 import com.aquilabank.global.auth.NoOpPasswordRecoveryDeliveryAdapter;
+import com.aquilabank.global.auth.WebhookPasswordRecoveryDeliveryAdapter;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -33,6 +34,21 @@ class PasswordRecoveryDeliveryConfigurationTest {
               assertThat(context).hasSingleBean(PasswordRecoveryDeliveryPort.class);
               assertThat(context).hasSingleBean(LoggingPasswordRecoveryDeliveryAdapter.class);
               assertThat(context).doesNotHaveBean(NoOpPasswordRecoveryDeliveryAdapter.class);
+            });
+  }
+
+  @Test
+  void createsWebhookDeliveryAdapterWhenProviderUrlIsConfigured() {
+    contextRunner
+        .withPropertyValues(
+            "auth.password-recovery.delivery.enabled=true",
+            "auth.password-recovery.delivery.email.url=https://email-provider.example/recovery")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(PasswordRecoveryDeliveryPort.class);
+              assertThat(context).hasSingleBean(WebhookPasswordRecoveryDeliveryAdapter.class);
+              assertThat(context).doesNotHaveBean(NoOpPasswordRecoveryDeliveryAdapter.class);
+              assertThat(context).doesNotHaveBean(LoggingPasswordRecoveryDeliveryAdapter.class);
             });
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #280

## 🌿 Base Branch
- `main`

## 📝 Summary
- password recovery delivery를 실제 webhook provider adapter로 확장했습니다.
- `loginId`가 email 또는 E.164 phone 형식일 때만 실제 전달하고, 그 외 식별자는 fail-safe skip 합니다.
- no-op/logging fallback과 generic `204` 계약은 유지했습니다.

## 🛠 Changes
- webhook 기반 password recovery delivery adapter와 destination resolver를 추가했습니다.
- email/sms provider URL, auth header, timeout runtime 설정을 추가했습니다.
- adapter/configuration 테스트를 추가하고 README 운영 설명을 갱신했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-password-recovery-provider ./back/gradlew -p back test --tests '*PasswordRecoveryDeliveryConfigurationTest' --tests '*WebhookPasswordRecoveryDeliveryAdapterTest' --tests '*LoggingPasswordRecoveryDeliveryAdapterTest' --tests '*PasswordRecoveryRequestServiceTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - `loginId`가 email/phone 형식이 아닌 계정은 실제 전달이 skip 됩니다.
  - provider URL/secret 오구성 시 delivery 실패는 남지만 token 발급 결과는 유지됩니다.
- 롤백 방법:
  - `AUTH_PASSWORD_RECOVERY_DELIVERY_ENABLED=false`로 즉시 no-op 경로로 되돌립니다.
  - 필요 시 이 PR revert로 webhook adapter를 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
