### PR TITLE
[Chore] Alertmanager 실제 receiver secret smoke 추가

### DIFF
--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -137,6 +137,20 @@ jobs:
             exit 1
           fi
 
+      - name: Run Alertmanager receiver secret smoke
+        env:
+          ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT: production
+          ALERTMANAGER_RECEIVER_SLACK_ENABLED: ${{ secrets.ALERTMANAGER_RECEIVER_SLACK_ENABLED }}
+          ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL: ${{ secrets.ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL }}
+          ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED: ${{ secrets.ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED }}
+          ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY: ${{ secrets.ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY }}
+          ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED: ${{ secrets.ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED }}
+          ALERTMANAGER_RECEIVER_WEBHOOK_URL: ${{ secrets.ALERTMANAGER_RECEIVER_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools/ops/validate-alertmanager-receiver-secrets.sh
+
       - name: Create production deployment
         id: deployment
         env:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -90,6 +90,21 @@ jobs:
 
           echo "hook_configured=true" >> "${GITHUB_OUTPUT}"
 
+      - name: Run Alertmanager receiver secret smoke
+        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
+        env:
+          ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT: staging
+          ALERTMANAGER_RECEIVER_SLACK_ENABLED: ${{ secrets.ALERTMANAGER_RECEIVER_SLACK_ENABLED }}
+          ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL: ${{ secrets.ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL }}
+          ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED: ${{ secrets.ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED }}
+          ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY: ${{ secrets.ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY }}
+          ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED: ${{ secrets.ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED }}
+          ALERTMANAGER_RECEIVER_WEBHOOK_URL: ${{ secrets.ALERTMANAGER_RECEIVER_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools/ops/validate-alertmanager-receiver-secrets.sh
+
       - name: Create staging deployment
         id: deployment
         if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -125,12 +125,34 @@ cp ops/prometheus/rules/aquila-bank-alerts.yml /etc/prometheus/rules/
 
 Alertmanager baseline receiver는 route 구조만 고정하며 실제 Slack/PagerDuty/Webhook URL은 저장소에 두지 않습니다. 운영 환경에서는 `aquila-bank-critical`, `aquila-bank-warning` receiver에 환경별 notification config를 추가합니다.
 
+배포 전 secret smoke는 아래 env/secret 이름을 기준으로 실제 receiver 구성을 확인합니다.
+
+- 공통:
+  - `ALERTMANAGER_RECEIVER_SLACK_ENABLED`
+  - `ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED`
+  - `ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED`
+- Slack:
+  - `ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL`
+- PagerDuty:
+  - `ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY`
+- Webhook:
+  - `ALERTMANAGER_RECEIVER_WEBHOOK_URL`
+
+규칙은 단순합니다.
+
+- staging/production 배포 전에는 최소 한 개 이상의 실제 receiver를 `enabled=true`로 둡니다.
+- `enabled=true`인 receiver는 해당 secret이 비어 있으면 fail-fast 합니다.
+- receiver를 쓰지 않으면 `enabled=false`로 두고 secret은 비워 둡니다.
+- secret 값은 저장소에 기록하지 않고 GitHub Environment secret 또는 동등한 runtime secret으로만 주입합니다.
+
 ## Validation
 
 로컬 baseline 자산 문법 확인은 아래 스크립트로 먼저 닫습니다.
 
 ```bash
 bash tools/ops/validate-prometheus-assets.sh
+tools/test/run-alertmanager-receiver-secret-smoke.sh
+tools/test/run-alertmanager-receiver-secret-workflow-gate.sh
 ```
 
 - dashboard JSON은 `uid`, panel 개수, JSON syntax를 같이 확인합니다.
@@ -138,6 +160,7 @@ bash tools/ops/validate-prometheus-assets.sh
 - Prometheus provisioning은 rule file, Alertmanager target, backend/Postgres scrape job을 확인합니다.
 - Grafana provisioning은 datasource uid/type과 dashboard provider path를 확인합니다.
 - Alertmanager routing은 severity grouping과 critical/warning receiver route를 확인합니다.
+- receiver secret smoke는 실제 sink enable/secret 누락을 fail-fast로 확인합니다.
 - 실제 Prometheus 적용 전에는 여기에 더해 `promtool check rules`를 추가로 수행합니다.
 
 ## Threshold Tuning

--- a/tools/ops/validate-alertmanager-receiver-secrets.sh
+++ b/tools/ops/validate-alertmanager-receiver-secrets.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+environment_name="${ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT:-unknown}"
+
+fail() {
+  echo "[alertmanager-secret-smoke] ${1}" >&2
+  exit 1
+}
+
+normalize_flag() {
+  case "${1:-}" in
+    true | TRUE | 1 | yes | YES | on | ON) echo "true" ;;
+    false | FALSE | 0 | no | NO | off | OFF | "") echo "false" ;;
+    *) echo "invalid" ;;
+  esac
+}
+
+require_flag() {
+  local name="$1"
+  local value
+  value="$(normalize_flag "${!name:-}")"
+  if [[ "${value}" == "invalid" ]]; then
+    fail "${name} must be one of true/false/1/0/yes/no/on/off"
+  fi
+  echo "${value}"
+}
+
+require_secret_when_enabled() {
+  local enabled="$1"
+  local receiver_name="$2"
+  local secret_name="$3"
+  local secret_value="$4"
+
+  if [[ "${enabled}" == "true" && -z "${secret_value}" ]]; then
+    fail "${receiver_name} receiver is enabled but ${secret_name} is missing"
+  fi
+}
+
+slack_enabled="$(require_flag ALERTMANAGER_RECEIVER_SLACK_ENABLED)"
+pagerduty_enabled="$(require_flag ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED)"
+webhook_enabled="$(require_flag ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED)"
+
+enabled_count=0
+[[ "${slack_enabled}" == "true" ]] && enabled_count=$((enabled_count + 1))
+[[ "${pagerduty_enabled}" == "true" ]] && enabled_count=$((enabled_count + 1))
+[[ "${webhook_enabled}" == "true" ]] && enabled_count=$((enabled_count + 1))
+
+if [[ "${enabled_count}" -eq 0 ]]; then
+  fail "at least one real Alertmanager receiver must be enabled for ${environment_name}"
+fi
+
+require_secret_when_enabled \
+  "${slack_enabled}" \
+  "Slack" \
+  "ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL" \
+  "${ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL:-}"
+require_secret_when_enabled \
+  "${pagerduty_enabled}" \
+  "PagerDuty" \
+  "ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY" \
+  "${ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY:-}"
+require_secret_when_enabled \
+  "${webhook_enabled}" \
+  "Webhook" \
+  "ALERTMANAGER_RECEIVER_WEBHOOK_URL" \
+  "${ALERTMANAGER_RECEIVER_WEBHOOK_URL:-}"
+
+echo "[alertmanager-secret-smoke] environment=${environment_name} slack=${slack_enabled} pagerduty=${pagerduty_enabled} webhook=${webhook_enabled}"
+echo "[alertmanager-secret-smoke] passed"

--- a/tools/test/run-alertmanager-receiver-secret-smoke.sh
+++ b/tools/test/run-alertmanager-receiver-secret-smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/ops/validate-alertmanager-receiver-secrets.sh"
+
+expect_failure() {
+  local expected="$1"
+  shift
+
+  local output
+  if output="$("$@" 2>&1)"; then
+    echo "[alertmanager-secret-smoke-test] expected failure but command passed: $*" >&2
+    exit 1
+  fi
+
+  if [[ "${output}" != *"${expected}"* ]]; then
+    echo "[alertmanager-secret-smoke-test] missing expected message: ${expected}" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+}
+
+echo "[alertmanager-secret-smoke-test] bash syntax"
+bash -n "${script}"
+
+echo "[alertmanager-secret-smoke-test] fails when no receiver is enabled"
+expect_failure \
+  "at least one real Alertmanager receiver must be enabled" \
+  env ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT=staging \
+    ALERTMANAGER_RECEIVER_SLACK_ENABLED=false \
+    ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED=false \
+    ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED=false \
+    bash "${script}"
+
+echo "[alertmanager-secret-smoke-test] fails when enabled receiver secret is missing"
+expect_failure \
+  "Slack receiver is enabled but ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL is missing" \
+  env ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT=staging \
+    ALERTMANAGER_RECEIVER_SLACK_ENABLED=true \
+    ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED=false \
+    ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED=false \
+    bash "${script}"
+
+echo "[alertmanager-secret-smoke-test] passes with one configured receiver"
+env \
+  ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT=staging \
+  ALERTMANAGER_RECEIVER_SLACK_ENABLED=true \
+  ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL=https://hooks.slack.example/services/test \
+  ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED=false \
+  ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED=false \
+  bash "${script}"
+
+echo "[alertmanager-secret-smoke-test] passes with multiple configured receivers"
+env \
+  ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT=production \
+  ALERTMANAGER_RECEIVER_SLACK_ENABLED=true \
+  ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL=https://hooks.slack.example/services/test \
+  ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED=true \
+  ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY=prod-routing-key \
+  ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED=true \
+  ALERTMANAGER_RECEIVER_WEBHOOK_URL=https://alerts.example/internal \
+  bash "${script}"
+
+echo "[alertmanager-secret-smoke-test] passed"

--- a/tools/test/run-alertmanager-receiver-secret-workflow-gate.sh
+++ b/tools/test/run-alertmanager-receiver-secret-workflow-gate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[alertmanager-secret-workflow] yaml: staging-deploy"
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"
+
+echo "[alertmanager-secret-workflow] yaml: production-promotion"
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/production-promotion.yml'); puts 'ok'"
+
+echo "[alertmanager-secret-workflow] step order and env wiring"
+ruby <<'RUBY'
+require 'yaml'
+
+def validate_step(workflow_path, job_name, prerequisites, success_step = nil)
+  workflow = YAML.load_file(workflow_path)
+  steps = workflow.fetch('jobs').fetch(job_name).fetch('steps')
+  step_names = steps.map { |step| step['name'] }
+  target_name = 'Run Alertmanager receiver secret smoke'
+  target_index = step_names.index(target_name) or abort("missing step: #{target_name} in #{workflow_path}")
+
+  prerequisites.each do |name|
+    prerequisite_index = step_names.index(name) or abort("missing step: #{name} in #{workflow_path}")
+    abort("#{target_name} must run after #{name} in #{workflow_path}") unless prerequisite_index < target_index
+  end
+
+  if success_step
+    success_index = step_names.index(success_step) or abort("missing step: #{success_step} in #{workflow_path}")
+    abort("#{target_name} must run before #{success_step} in #{workflow_path}") unless target_index < success_index
+  end
+
+  step = steps.fetch(target_index)
+  env = step.fetch('env')
+  run = step.fetch('run')
+
+  required_keys = %w[
+    ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT
+    ALERTMANAGER_RECEIVER_SLACK_ENABLED
+    ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL
+    ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED
+    ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY
+    ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED
+    ALERTMANAGER_RECEIVER_WEBHOOK_URL
+  ]
+  required_keys.each do |key|
+    abort("missing env #{key} in #{workflow_path}") unless env.key?(key)
+  end
+
+  abort("smoke step must call validate-alertmanager-receiver-secrets.sh in #{workflow_path}") unless run.include?('tools/ops/validate-alertmanager-receiver-secrets.sh')
+  abort("slack enabled must come from secret in #{workflow_path}") unless env.fetch('ALERTMANAGER_RECEIVER_SLACK_ENABLED').include?('secrets.ALERTMANAGER_RECEIVER_SLACK_ENABLED')
+  abort("pagerduty key must come from secret in #{workflow_path}") unless env.fetch('ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY').include?('secrets.ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY')
+  abort("webhook url must come from secret in #{workflow_path}") unless env.fetch('ALERTMANAGER_RECEIVER_WEBHOOK_URL').include?('secrets.ALERTMANAGER_RECEIVER_WEBHOOK_URL')
+end
+
+validate_step(
+  '.github/workflows/staging-deploy.yml',
+  'deploy',
+  ['Resolve staging deploy hook configuration'],
+  'Create staging deployment'
+)
+
+validate_step(
+  '.github/workflows/production-promotion.yml',
+  'promote',
+  ['Validate checkout SHA'],
+  'Create production deployment'
+)
+RUBY
+
+echo "[alertmanager-secret-workflow] passed"


### PR DESCRIPTION
## 🔗 Related Issue
- close #282

## 🌿 Base Branch
- `main`

## 📝 Summary
- Alertmanager 실제 receiver secret smoke를 추가했습니다.
- staging/production 배포 전에 Slack/PagerDuty/Webhook secret 구성을 fail-fast로 검증합니다.
- 로컬 gate와 운영 문서를 함께 정리했습니다.

## 🛠 Changes
- `tools/ops/validate-alertmanager-receiver-secrets.sh`와 shell smoke를 추가했습니다.
- staging deploy, production promotion workflow에 Alertmanager secret smoke gate를 추가했습니다.
- `ops/prometheus/README.md`에 required env/secret 규칙을 문서화했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-alertmanager-receiver-secret-smoke.sh`
- `tools/test/run-alertmanager-receiver-secret-workflow-gate.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - staging/production 환경 secret가 아직 없으면 배포 workflow가 fail-fast 합니다.
  - enable flag와 실제 receiver overlay 구성이 어긋나면 오탐이 날 수 있습니다.
- 롤백 방법:
  - workflow의 Alertmanager smoke step을 revert 합니다.
  - 환경에서 해당 receiver를 쓰지 않으면 `*_ENABLED=false`로 명시합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
