### PR TITLE
[Perf] SSE multi-node drain/reconnect 운영 smoke 추가

### DIFF
--- a/.github/workflows/sse-multinode-drain-smoke.yml
+++ b/.github/workflows/sse-multinode-drain-smoke.yml
@@ -1,0 +1,51 @@
+name: SSE Multi-Node Drain Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      drain_grace_seconds:
+        description: Seconds to wait after upstream removal and reload
+        required: true
+        default: "5"
+        type: string
+      reconnect_delay_ms:
+        description: Expected client reconnect delay in milliseconds
+        required: true
+        default: "3000"
+        type: string
+  schedule:
+    - cron: "30 18 * * 3"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sse-multinode-drain-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Run SSE Multi-Node Drain Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant Gradle wrapper execute permission
+        run: chmod +x back/gradlew
+
+      - name: Run SSE multi-node drain smoke
+        env:
+          SSE_MULTINODE_DRAIN_GRACE_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.drain_grace_seconds || vars.SSE_MULTINODE_DRAIN_GRACE_SECONDS }}
+          SSE_RECONNECT_DELAY_MS: ${{ github.event_name == 'workflow_dispatch' && inputs.reconnect_delay_ms || vars.SSE_RECONNECT_DELAY_MS }}
+        run: tools/test/run-sse-multinode-drain-smoke.sh

--- a/back/README.md
+++ b/back/README.md
@@ -466,6 +466,16 @@ bash tools/test/check-nginx-sse-proxy.sh
 
 - backend가 이미 `X-Accel-Buffering: no` 헤더를 응답하므로 Nginx도 buffering off 상태를 같이 유지합니다.
 - `NOTIFICATION_SSE_CONNECTION_TIMEOUT_MS` 또는 upstream 포트를 바꾸면 Nginx timeout/upstream도 같이 맞춥니다.
+- multi-node drain/reconnect runbook smoke는 아래 엔트리포인트를 사용합니다.
+
+```bash
+tools/test/run-sse-multinode-drain-smoke.sh
+```
+
+- 위 script는 `check-nginx-sse-proxy.sh`, reconnect storm replay, `NotificationSseBrokerTest`를 한 runbook smoke로 묶습니다.
+- 기본 drain grace는 `5s`, reconnect delay baseline은 `3000ms` 입니다.
+- scheduled workflow `SSE Multi-Node Drain Smoke`는 매주 목요일 03:30 KST(`30 18 * * 3` UTC)와 manual `workflow_dispatch`를 지원합니다.
+- repository variable로 `SSE_MULTINODE_DRAIN_GRACE_SECONDS`, `SSE_RECONNECT_DELAY_MS`를 override 할 수 있습니다.
 
 ## Transfer Reversal
 

--- a/ops/nginx/README.md
+++ b/ops/nginx/README.md
@@ -66,11 +66,14 @@
 - multi-node로 확장할 때는 `aquila_bank_backend_api`와 `aquila_bank_backend_sse` 두 upstream에 같은 backend node 집합을 반영합니다.
 - 인스턴스 drain 시에는 대상 node를 upstream에서 제거한 뒤 reload 하고, client reconnect/pull 재동기화가 끝날 시간을 둡니다.
 - backend는 이미 `X-Accel-Buffering: no` 헤더를 내려주므로 Nginx도 같은 방향으로 buffering을 끈 상태를 유지합니다.
+- 운영 smoke는 `tools/test/run-sse-multinode-drain-smoke.sh`로 같은 순서를 반복 검증합니다.
 
 ## 검증
 
 ```bash
 bash tools/test/check-nginx-sse-proxy.sh
+tools/test/run-sse-multinode-drain-smoke.sh --print-plan
+tools/test/run-sse-multinode-drain-smoke.sh
 ```
 
 `nginx` binary와 실제 TLS 인증서 파일이 모두 있는 환경이면 위 smoke check가 추가로 `nginx -t`까지 수행합니다. placeholder 인증서 경로만 있는 상태에서는 directive smoke check까지만 수행합니다.

--- a/tools/test/check-sse-multinode-drain-smoke-script.sh
+++ b/tools/test/check-sse-multinode-drain-smoke-script.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-sse-multinode-drain-smoke.sh"
+
+echo "[sse-multinode-drain-script] syntax: ${script}"
+bash -n "${script}"
+
+echo "[sse-multinode-drain-script] plan includes drain sequence and replay checks"
+plan="$(
+  SSE_MULTINODE_DRAIN_GRACE_SECONDS=7 \
+  SSE_RECONNECT_DELAY_MS=4500 \
+  "${script}" --print-plan
+)"
+grep -F "upstream remove -> nginx reload -> wait 7s -> client reconnect" <<<"${plan}" >/dev/null
+grep -F "Last-Event-ID replay" <<<"${plan}" >/dev/null
+grep -F "reconnect delay 4500ms" <<<"${plan}" >/dev/null
+grep -F "check-nginx-sse-proxy.sh" <<<"${plan}" >/dev/null
+grep -F "*NotificationSseIntegrationTest.reconnectStormReplaysMissedNotificationsWithoutDuplicates" <<<"${plan}" >/dev/null
+grep -F "*NotificationSseBrokerTest" <<<"${plan}" >/dev/null
+
+echo "[sse-multinode-drain-script] invalid numeric input fails before Gradle"
+if SSE_MULTINODE_DRAIN_GRACE_SECONDS=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "SSE_MULTINODE_DRAIN_GRACE_SECONDS=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if SSE_RECONNECT_DELAY_MS=abc "${script}" --print-plan >/dev/null 2>&1; then
+  echo "SSE_RECONNECT_DELAY_MS=abc unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-sse-multinode-drain-smoke.sh
+++ b/tools/test/run-sse-multinode-drain-smoke.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-sse-multinode-drain-smoke.sh [--print-plan]
+
+Environment:
+  SSE_MULTINODE_DRAIN_GRACE_SECONDS  default 5
+  SSE_RECONNECT_DELAY_MS             default 3000
+
+Examples:
+  tools/test/run-sse-multinode-drain-smoke.sh
+  SSE_MULTINODE_DRAIN_GRACE_SECONDS=8 tools/test/run-sse-multinode-drain-smoke.sh
+  tools/test/run-sse-multinode-drain-smoke.sh --print-plan
+USAGE
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer" >&2
+    exit 1
+  fi
+}
+
+print_plan=false
+if [[ "${1:-}" == "--print-plan" ]]; then
+  print_plan=true
+  shift
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 0 ]]; then
+  usage
+  exit 1
+fi
+
+drain_grace_seconds="${SSE_MULTINODE_DRAIN_GRACE_SECONDS:-5}"
+reconnect_delay_ms="${SSE_RECONNECT_DELAY_MS:-3000}"
+
+require_positive_integer "SSE_MULTINODE_DRAIN_GRACE_SECONDS" "${drain_grace_seconds}"
+require_positive_integer "SSE_RECONNECT_DELAY_MS" "${reconnect_delay_ms}"
+
+echo "[sse-multinode-drain] plan: upstream remove -> nginx reload -> wait ${drain_grace_seconds}s -> client reconnect"
+echo "[sse-multinode-drain] reconnect: Last-Event-ID replay with reconnect delay ${reconnect_delay_ms}ms"
+echo "[sse-multinode-drain] checks: nginx directive drift + reconnect storm replay + broker fanout fault"
+echo "[sse-multinode-drain] selectors:"
+echo "  bash tools/test/check-nginx-sse-proxy.sh"
+echo "  --tests *NotificationSseIntegrationTest.reconnectStormReplaysMissedNotificationsWithoutDuplicates"
+echo "  --tests *NotificationSseBrokerTest"
+
+if [[ "${print_plan}" == "true" ]]; then
+  exit 0
+fi
+
+echo "[sse-multinode-drain] nginx: directive smoke"
+bash tools/test/check-nginx-sse-proxy.sh
+
+echo "[sse-multinode-drain] backend: reconnect replay + broker fanout fault"
+tools/test/with-resource-lock.sh back-gradle-sse-multinode-drain \
+  ./back/gradlew -p back test \
+  --tests '*NotificationSseIntegrationTest.reconnectStormReplaysMissedNotificationsWithoutDuplicates' \
+  --tests '*NotificationSseBrokerTest'
+
+echo "[sse-multinode-drain] passed"

--- a/tools/test/run-sse-multinode-drain-workflow-gate.sh
+++ b/tools/test/run-sse-multinode-drain-workflow-gate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/sse-multinode-drain-smoke.yml"
+
+echo "[sse-multinode-workflow] yaml: ${workflow}"
+ruby -e "require 'yaml'; YAML.load_file('${workflow}'); puts 'ok'"
+
+echo "[sse-multinode-workflow] trigger and wiring"
+ruby <<'RUBY'
+require 'yaml'
+
+workflow = YAML.load_file('.github/workflows/sse-multinode-drain-smoke.yml')
+on = workflow['on'] || workflow[true] || abort('workflow on section missing')
+abort('workflow_dispatch trigger missing') unless on.key?('workflow_dispatch')
+abort('schedule trigger missing') unless on.key?('schedule')
+abort('schedule must contain at least one cron entry') unless on.fetch('schedule').is_a?(Array) && !on.fetch('schedule').empty?
+
+inputs = on.fetch('workflow_dispatch').fetch('inputs')
+%w[drain_grace_seconds reconnect_delay_ms].each do |key|
+  abort("workflow_dispatch input missing: #{key}") unless inputs.key?(key)
+end
+
+abort('workflow concurrency group mismatch') unless workflow.fetch('concurrency').fetch('group') == 'sse-multinode-drain-smoke'
+
+steps = workflow.fetch('jobs').fetch('smoke').fetch('steps')
+step_names = steps.map { |step| step['name'] }
+run_name = 'Run SSE multi-node drain smoke'
+run_index = step_names.index(run_name) or abort("missing step: #{run_name}")
+
+step = steps.fetch(run_index)
+env = step.fetch('env')
+run = step.fetch('run')
+
+abort('run step must call sse multi-node drain smoke script') unless run.include?('tools/test/run-sse-multinode-drain-smoke.sh')
+abort('drain grace must come from input or repository variable') unless env.fetch('SSE_MULTINODE_DRAIN_GRACE_SECONDS').include?('inputs.drain_grace_seconds') && env.fetch('SSE_MULTINODE_DRAIN_GRACE_SECONDS').include?('vars.SSE_MULTINODE_DRAIN_GRACE_SECONDS')
+abort('reconnect delay must come from input or repository variable') unless env.fetch('SSE_RECONNECT_DELAY_MS').include?('inputs.reconnect_delay_ms') && env.fetch('SSE_RECONNECT_DELAY_MS').include?('vars.SSE_RECONNECT_DELAY_MS')
+RUBY
+
+echo "[sse-multinode-workflow] passed"


### PR DESCRIPTION
## 🔗 Related Issue
- close #281

## 🌿 Base Branch
- `main`

## 📝 Summary
- SSE multi-node drain/reconnect 운영 smoke entrypoint를 추가했습니다.
- Nginx multi-node drain runbook을 scheduled/manual workflow로 검증할 수 있게 했습니다.
- SSE reconnect replay와 broker fanout fault smoke를 한 경로로 묶었습니다.

## 🛠 Changes
- `tools/test/run-sse-multinode-drain-smoke.sh`와 shell check를 추가했습니다.
- `SSE Multi-Node Drain Smoke` workflow를 추가했습니다.
- `back/README.md`, `ops/nginx/README.md`에 drain smoke 실행 규칙을 문서화했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-sse-multinode-drain-smoke-script.sh`
- `tools/test/run-sse-multinode-drain-workflow-gate.sh`
- `tools/test/run-sse-multinode-drain-smoke.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - workflow schedule이 과하면 CI 비용이 커질 수 있습니다.
  - drain grace/reconnect delay variable이 실제 운영값과 어긋나면 오탐이 날 수 있습니다.
- 롤백 방법:
  - workflow를 비활성화하거나 revert 합니다.
  - repository variable 값을 기본 drain budget으로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
