### PR TITLE
[Perf] notification channel provider 실제 delivery smoke 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -488,6 +488,16 @@ tools/test/with-resource-lock.sh back-notification-provider \
   ./back/gradlew -p back test --tests '*NotificationChannelProvider*' --tests '*WebhookNotificationChannelProviderTest'
 ```
 
+- bounded smoke:
+
+```bash
+tools/test/with-resource-lock.sh back-notification-provider-smoke \
+  tools/test/run-notification-provider-delivery-smoke.sh
+```
+
+- smoke fixture는 local webhook server에서 `EMAIL=202 Accepted`, `SMS=delayed response`를 주입합니다.
+- smoke 기대값은 `EMAIL -> SENT`, `SMS -> FAILED + nextAttemptAt=base+5s` 입니다.
+- smoke가 실패하면 channel URL, timeout env, worker retry base delay drift를 먼저 확인합니다.
 - skip가 늘면 `bank_user.login_id` 형식 drift 또는 channel URL 오구성을 먼저 확인합니다.
 - retry가 늘면 provider timeout과 응답 코드, `last_error`, `available_at` backoff 증가를 같이 봅니다.
 

--- a/back/src/test/java/com/aquilabank/global/notification/NotificationChannelProviderDeliverySmokeTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/NotificationChannelProviderDeliverySmokeTest.java
@@ -1,0 +1,212 @@
+package com.aquilabank.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
+import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
+import com.aquilabank.domain.notification.model.NotificationPreferenceCategory;
+import com.aquilabank.domain.notification.model.NotificationPreferenceChannel;
+import com.aquilabank.domain.notification.port.NotificationChannelOutboxDispatchPort;
+import com.aquilabank.domain.notification.port.NotificationChannelRecipientLookupPort;
+import com.aquilabank.domain.notification.usecase.NotificationChannelProviderWorkerService;
+import com.aquilabank.global.config.NotificationChannelProviderDeliveryProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+class NotificationChannelProviderDeliverySmokeTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-23T10:00:00Z");
+
+  private HttpServer server;
+
+  @AfterEach
+  void tearDown() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void dispatchesImmediateEmailAndMarksSlowSmsForRetryBackoff() throws Exception {
+    AtomicInteger emailRequests = new AtomicInteger();
+    AtomicInteger smsRequests = new AtomicInteger();
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.setExecutor(Executors.newCachedThreadPool());
+    server.createContext(
+        "/email",
+        exchange -> {
+          emailRequests.incrementAndGet();
+          writeAccepted(exchange);
+        });
+    server.createContext(
+        "/sms",
+        exchange -> {
+          smsRequests.incrementAndGet();
+          try {
+            Thread.sleep(200L);
+          } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+          }
+          try {
+            writeAccepted(exchange);
+          } catch (IOException ignored) {
+            // read timeout 이후 client가 먼저 연결을 닫을 수 있어 서버 응답 write 실패는 무시합니다.
+          }
+        });
+    server.start();
+
+    int port = server.getAddress().getPort();
+    NotificationChannelProviderDeliveryProperties properties =
+        new NotificationChannelProviderDeliveryProperties(
+            true,
+            "Authorization",
+            "Bearer smoke-secret",
+            500,
+            50,
+            new NotificationChannelProviderDeliveryProperties.ChannelProperties(
+                "http://127.0.0.1:" + port + "/email"),
+            new NotificationChannelProviderDeliveryProperties.ChannelProperties(
+                "http://127.0.0.1:" + port + "/sms"));
+    NotificationChannelRecipientLookupPort recipientLookupPort =
+        userId ->
+            switch ((int) userId) {
+              case 101 -> Optional.of("alice@example.com");
+              case 202 -> Optional.of("+821012345678");
+              default -> Optional.empty();
+            };
+    WebhookNotificationChannelProvider provider =
+        new WebhookNotificationChannelProvider(
+            restClient(properties),
+            recipientLookupPort,
+            new NotificationChannelDeliveryDestinationResolver(),
+            properties,
+            new ObjectMapper().findAndRegisterModules());
+    RecordingDispatchPort dispatchPort =
+        new RecordingDispatchPort(List.of(emailItem(), smsItem()), NOW);
+    NotificationChannelProviderWorkerService service =
+        new NotificationChannelProviderWorkerService(
+            dispatchPort,
+            provider,
+            Clock.fixed(NOW, ZoneOffset.UTC),
+            2,
+            Duration.ofSeconds(5),
+            Duration.ofSeconds(60),
+            10);
+
+    int claimed = service.dispatchDueDeliveries();
+
+    assertThat(claimed).isEqualTo(2);
+    assertThat(emailRequests.get()).isEqualTo(1);
+    assertThat(smsRequests.get()).isEqualTo(1);
+    assertThat(dispatchPort.sentIds()).containsExactly(1L);
+    assertThat(dispatchPort.failedItems()).containsOnlyKeys(2L);
+    assertThat(dispatchPort.failedItems().get(2L).nextAttemptAt()).isEqualTo(NOW.plusSeconds(5));
+    assertThat(dispatchPort.failedItems().get(2L).errorMessage()).isNotBlank();
+  }
+
+  private RestClient restClient(NotificationChannelProviderDeliveryProperties properties) {
+    SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+    requestFactory.setConnectTimeout(Duration.ofMillis(properties.connectTimeoutMs()));
+    requestFactory.setReadTimeout(Duration.ofMillis(properties.readTimeoutMs()));
+    return RestClient.builder().requestFactory(requestFactory).build();
+  }
+
+  private void writeAccepted(HttpExchange exchange) throws IOException {
+    exchange.sendResponseHeaders(202, -1);
+    exchange.close();
+  }
+
+  private NotificationChannelOutboxItem emailItem() {
+    return item(1L, 101L, NotificationPreferenceChannel.EMAIL, "evt-provider-email");
+  }
+
+  private NotificationChannelOutboxItem smsItem() {
+    return item(2L, 202L, NotificationPreferenceChannel.SMS, "evt-provider-sms");
+  }
+
+  private NotificationChannelOutboxItem item(
+      long id, long userId, NotificationPreferenceChannel channel, String eventKey) {
+    return new NotificationChannelOutboxItem(
+        id,
+        10L + id,
+        userId,
+        30L + id,
+        NotificationPreferenceCategory.TRANSACTIONAL,
+        channel,
+        "TransferBooked",
+        eventKey,
+        "{\"title\":\"Transfer complete\",\"message\":\"10,000 won sent\"}",
+        NotificationChannelDeliveryStatus.SENDING,
+        NOW.minusSeconds(1),
+        null,
+        0,
+        null,
+        NOW.minusSeconds(10),
+        NOW);
+  }
+
+  private record FailedItem(Instant nextAttemptAt, String errorMessage) {}
+
+  private static final class RecordingDispatchPort
+      implements NotificationChannelOutboxDispatchPort {
+
+    private final List<NotificationChannelOutboxItem> items;
+    private final Instant expectedNow;
+    private final java.util.List<Long> sentIds = new java.util.ArrayList<>();
+    private final Map<Long, FailedItem> failedItems = new ConcurrentHashMap<>();
+
+    private RecordingDispatchPort(List<NotificationChannelOutboxItem> items, Instant expectedNow) {
+      this.items = items;
+      this.expectedNow = expectedNow;
+    }
+
+    @Override
+    public List<NotificationChannelOutboxItem> claimPending(int limit, Instant now) {
+      assertThat(limit).isEqualTo(2);
+      assertThat(now).isEqualTo(expectedNow);
+      return items;
+    }
+
+    @Override
+    public void markSent(long id, Instant sentAt) {
+      assertThat(sentAt).isEqualTo(expectedNow);
+      sentIds.add(id);
+    }
+
+    @Override
+    public void markFailed(long id, Instant nextAttemptAt, Instant failedAt, String errorMessage) {
+      assertThat(failedAt).isEqualTo(expectedNow);
+      failedItems.put(id, new FailedItem(nextAttemptAt, errorMessage));
+    }
+
+    @Override
+    public void markQuarantined(long id, Instant quarantinedAt, String errorMessage) {
+      throw new AssertionError("quarantine is not expected in smoke");
+    }
+
+    private java.util.List<Long> sentIds() {
+      return sentIds;
+    }
+
+    private Map<Long, FailedItem> failedItems() {
+      return failedItems;
+    }
+  }
+}

--- a/tools/test/run-notification-provider-delivery-smoke.sh
+++ b/tools/test/run-notification-provider-delivery-smoke.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[notification-provider-delivery] fixture: email accepted + sms delayed response on local webhook server"
+echo "[notification-provider-delivery] runtime budget: worker batch=2 connect-timeout=500ms read-timeout=50ms"
+echo "[notification-provider-delivery] expectation: email sent, sms timeout -> FAILED with nextAttemptAt=base+5s"
+
+./back/gradlew -p back test \
+  --tests '*NotificationChannelProviderDeliverySmokeTest'


### PR DESCRIPTION
## 🔗 Related Issue
- close #289
- 선행 의존 PR: #290
- stacked branch 기준 review target: `feat/notification-real-channel-provider..perf/notification-provider-delivery-smoke` 상단 2개 commit

## 🌿 Base Branch
- `main`

## 📝 Summary
- real notification webhook provider 경계에 bounded delivery smoke를 추가했습니다.
- local webhook server로 `EMAIL=success`, `SMS=timeout`을 주입해 worker retry/backoff drift를 빠르게 확인할 수 있습니다.
- README에 smoke 실행법과 실패 해석 기준도 정리했습니다.

## 🛠 Changes
- `NotificationChannelProviderDeliverySmokeTest`를 추가해 실제 worker + webhook provider + local HTTP server 경계를 검증합니다.
- `tools/test/run-notification-provider-delivery-smoke.sh` smoke entrypoint를 추가했습니다.
- `back/README.md`에 smoke fixture, 기대값, drift 해석 기준을 반영했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-notification-provider-smoke tools/test/run-notification-provider-delivery-smoke.sh`
- `tools/test/with-resource-lock.sh back-check ./back/gradlew -p back check`
- `git rev-list --count feat/notification-real-channel-provider..HEAD` 결과 `2`로 perf brief incremental `commit_plan` 2개와 일치 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - local mock smoke는 실제 provider RTT 전체를 대표하지는 않습니다.
  - read timeout 값을 과도하게 줄이면 오탐이 늘 수 있습니다.
- 롤백 방법:
  - `tools/test/run-notification-provider-delivery-smoke.sh`와 smoke test를 revert 합니다.
  - README smoke 섹션만 제거해도 runtime production code에는 영향이 없습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?