### PR TITLE
[Chore] auth throttling metric과 Prometheus alert 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -296,6 +296,7 @@ set +a
   - `aquila_notification_consumer_lag_count`
   - `aquila_notification_consumer_dlq_count`
   - `aquila_notification_sse_sessions{principal_type="account|user|total"}`
+  - `aquila_auth_throttling_reject_count_total{entry_point="login|password_recovery",scope="ip|global",store="memory|redis"}`
   - `aquila_auth_current_session_gate_reject_count_total{reason_code="MISSING_SESSION_ID|INACTIVE_OR_MISMATCHED_SESSION"}`
   - `aquila_auth_refresh_token_reuse_detected_count_total{reason_code="ROTATED_TOKEN_REUSE"}`
   - `aquila_t3micro_saturation_guard_query_timeouts_total`
@@ -307,6 +308,7 @@ set +a
   - outbox metric은 기본 wiring만 있으면 항상 export 됩니다.
   - notification consumer lag/DLQ metric은 `NOTIFICATION_INBOX_CONSUMER_OPS_ENABLED=true` 와 DLQ topic 설정이 있어야 export 됩니다.
   - current session gate reject counter는 민감 mutation에서 legacy JWT `session_id` 누락 또는 inactive/mismatch session 차단이 발생하면 증가합니다.
+  - auth throttling reject metric은 login/password recovery edge 직전 reject가 발생하면 `entry_point`, `scope`, `store` tag 기준으로 증가합니다.
   - refresh token reuse metric은 `ROTATED` refresh token 재사용 감지와 family revoke가 발생하면 증가합니다.
   - t3.micro query timeout counter는 backend query timeout exception이 발생하면 증가합니다.
   - Hikari pool metric은 Spring Boot/Micrometer 기본 binder와 `aquila-bank-pool` pool tag 기준으로 export 됩니다.
@@ -330,11 +332,14 @@ set +a
 - 운영 메모:
   - outbox/notification gauge는 scrape 한 번에 같은 summary를 여러 번 다시 조회하지 않게 `5초` cache 안에서 재사용합니다.
   - SSE session metric은 현재 app instance 메모리의 active session 수만 보여주므로 multi-instance 전체 합계는 Prometheus 쿼리에서 합산합니다.
+  - auth throttling reject metric label은 `entry_point`, `scope`, `store`만 사용하고, IP, `requestId`, `userId`, `path`는 structured log에서만 확인합니다.
+  - `AquilaAuthThrottlingRejectBurstDetected` alert는 brute-force/abuse 징후 investigation 시작점입니다. 같은 시간대 `auth login throttled`, `auth password recovery throttled` log와 Nginx auth edge `429` 추이를 같이 봅니다.
   - current session gate reject metric label은 `reason_code`만 사용하고, `requestId`, `userId`, `sessionId`, `path`는 structured audit log에서만 확인합니다.
   - `AquilaCurrentSessionActiveGateRejectDetected` alert는 장애 확정이 아니라 security investigation 시작점입니다. 같은 시간대 `requestId`로 `auth current session gate rejected` log를 조회하고, `reasonCode`, `userId`, `sessionId`, `method`, `path`를 확인합니다.
   - current session gate alert rollback은 `AquilaCurrentSessionActiveGateRejectDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행하고, API 응답 계약은 그대로 유지합니다.
   - refresh token reuse metric label은 `reason_code`만 사용하고, `requestId`, `userId`, `reusedSessionId`, `familyRootId`는 structured audit log에서만 확인합니다.
   - `AquilaRefreshTokenReuseDetected` alert는 공격성 재사용 후보입니다. 같은 시간대 `requestId`로 `auth refresh token reuse detected` log를 조회하고 `reusedSessionId`, `familyRootId`, `revokedCount`를 먼저 확인합니다.
+  - auth throttling alert rollback은 `AquilaAuthThrottlingRejectBurstDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행하고, auth API 응답 계약은 그대로 유지합니다.
   - p95 alert는 `query_shape`별 5분 rate가 충분할 때만 평가해 low traffic 노이즈를 줄입니다.
   - `AquilaDbPoolPendingWaitDetected`는 Hikari pending connection이 남은 상태라 lock wait, slow query, DB CPU, transaction p95를 같은 시간대에서 같이 확인합니다.
   - `AquilaDbPoolActivePressureHigh`는 active/max pool ratio 90% 이상을 queueing 전조로 봅니다. t3.micro 기본 `DB_POOL_MAX_SIZE=4`에서는 순간 spike보다 10분 지속 여부가 중요합니다.

--- a/back/src/main/java/com/aquilabank/global/config/LoginThrottlingConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/LoginThrottlingConfiguration.java
@@ -2,10 +2,12 @@ package com.aquilabank.global.config;
 
 import com.aquilabank.global.security.LoginThrottleGuard;
 import com.aquilabank.global.security.LoginThrottleStore;
+import com.aquilabank.global.security.LoginThrottlingMetricsRecorder;
 import com.aquilabank.global.security.LoginThrottlingProperties;
 import com.aquilabank.global.security.LoginThrottlingProperties.StoreType;
 import com.aquilabank.global.security.MemoryLoginThrottleStore;
 import com.aquilabank.global.security.RedisLoginThrottleStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
@@ -33,7 +35,15 @@ public class LoginThrottlingConfiguration {
   }
 
   @Bean
-  LoginThrottleGuard loginThrottleGuard(LoginThrottleStore loginThrottleStore) {
-    return new LoginThrottleGuard(loginThrottleStore);
+  LoginThrottlingMetricsRecorder loginThrottlingMetricsRecorder(
+      MeterRegistry meterRegistry, LoginThrottlingProperties properties) {
+    return new LoginThrottlingMetricsRecorder(meterRegistry, properties.store());
+  }
+
+  @Bean
+  LoginThrottleGuard loginThrottleGuard(
+      LoginThrottleStore loginThrottleStore,
+      LoginThrottlingMetricsRecorder loginThrottlingMetricsRecorder) {
+    return new LoginThrottleGuard(loginThrottleStore, loginThrottlingMetricsRecorder);
   }
 }

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottleGuard.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottleGuard.java
@@ -16,9 +16,12 @@ public class LoginThrottleGuard {
   private static final Logger log = LoggerFactory.getLogger(LoginThrottleGuard.class);
 
   private final LoginThrottleStore loginThrottleStore;
+  private final LoginThrottlingMetricsRecorder metricsRecorder;
 
-  public LoginThrottleGuard(LoginThrottleStore loginThrottleStore) {
+  public LoginThrottleGuard(
+      LoginThrottleStore loginThrottleStore, LoginThrottlingMetricsRecorder metricsRecorder) {
     this.loginThrottleStore = loginThrottleStore;
+    this.metricsRecorder = metricsRecorder;
   }
 
   public void check(String ipAddress) {
@@ -33,6 +36,7 @@ public class LoginThrottleGuard {
     String normalizedIpAddress = normalizeIpAddress(ipAddress);
     LoginThrottleStore.ThrottleDecision decision = loginThrottleStore.check(normalizedIpAddress);
     if (decision.throttled()) {
+      metricsRecorder.recordReject(entryPoint.metricTagValue(), decision.scope());
       logThrottle(
           entryPoint,
           decision.scope(),
@@ -106,6 +110,10 @@ public class LoginThrottleGuard {
     LoginThrottleEntryPoint(String logMessage, String message) {
       this.logMessage = logMessage;
       this.message = message;
+    }
+
+    String metricTagValue() {
+      return this == LOGIN ? "login" : "password_recovery";
     }
 
     String logMessage() {

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottlingMetricsRecorder.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottlingMetricsRecorder.java
@@ -1,0 +1,41 @@
+package com.aquilabank.global.security;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.EnumMap;
+import java.util.Map;
+
+/** auth throttling reject는 low-cardinality tag만 남겨 Prometheus 비용을 제한합니다. */
+public final class LoginThrottlingMetricsRecorder {
+
+  private static final String METRIC_NAME = "aquila.auth.throttling.reject.count";
+
+  private final Map<LoginThrottleScope, Map<String, Counter>> rejectCounters;
+
+  public LoginThrottlingMetricsRecorder(
+      MeterRegistry meterRegistry, LoginThrottlingProperties.StoreType storeType) {
+    String store = storeType.name().toLowerCase();
+    this.rejectCounters = new EnumMap<>(LoginThrottleScope.class);
+    for (LoginThrottleScope scope : LoginThrottleScope.values()) {
+      Map<String, Counter> entryPointCounters = new java.util.HashMap<>();
+      entryPointCounters.put("login", counter(meterRegistry, store, "login", scope));
+      entryPointCounters.put(
+          "password_recovery", counter(meterRegistry, store, "password_recovery", scope));
+      rejectCounters.put(scope, Map.copyOf(entryPointCounters));
+    }
+  }
+
+  public void recordReject(String entryPoint, LoginThrottleScope scope) {
+    rejectCounters.get(scope).get(entryPoint).increment();
+  }
+
+  private Counter counter(
+      MeterRegistry meterRegistry, String store, String entryPoint, LoginThrottleScope scope) {
+    return Counter.builder(METRIC_NAME)
+        .tag("entry_point", entryPoint)
+        .tag("scope", scope.name().toLowerCase())
+        .tag("store", store)
+        .description("auth throttling rejected request count")
+        .register(meterRegistry);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
@@ -8,6 +8,8 @@ import com.aquilabank.global.security.LoginThrottleStore;
 import com.aquilabank.global.security.LoginThrottlingProperties;
 import com.aquilabank.global.security.MemoryLoginThrottleStore;
 import com.aquilabank.global.security.RedisLoginThrottleStore;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -95,6 +97,11 @@ class LoginThrottlingConfigurationTest {
     @Bean
     Clock authClock() {
       return Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC);
+    }
+
+    @Bean
+    MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
     }
   }
 }

--- a/back/src/test/java/com/aquilabank/global/security/LoginThrottlingMetricsRecorderTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/LoginThrottlingMetricsRecorderTest.java
@@ -1,0 +1,40 @@
+package com.aquilabank.global.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+class LoginThrottlingMetricsRecorderTest {
+
+  private static final String METRIC_NAME = "aquila.auth.throttling.reject.count";
+
+  @Test
+  void incrementsRejectCounterByEntryPointScopeAndStoreOnly() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    LoginThrottlingMetricsRecorder recorder =
+        new LoginThrottlingMetricsRecorder(registry, LoginThrottlingProperties.StoreType.MEMORY);
+
+    recorder.recordReject("login", LoginThrottleScope.IP);
+    recorder.recordReject("login", LoginThrottleScope.IP);
+    recorder.recordReject("password_recovery", LoginThrottleScope.GLOBAL);
+
+    assertEquals(
+        2.0,
+        registry
+            .counter(METRIC_NAME, "entry_point", "login", "scope", "ip", "store", "memory")
+            .count());
+    assertEquals(
+        1.0,
+        registry
+            .counter(
+                METRIC_NAME,
+                "entry_point",
+                "password_recovery",
+                "scope",
+                "global",
+                "store",
+                "memory")
+            .count());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginThrottlingIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginThrottlingIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.aquilabank.global.web.auth;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -16,6 +18,7 @@ import com.aquilabank.global.security.LoginThrottleGuard;
 import com.aquilabank.support.PostgresContainerTestSupport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -149,6 +152,32 @@ class LoginThrottlingIntegrationTest extends PostgresContainerTestSupport {
     Thread.sleep(1200L);
 
     passwordRecoveryExpectNoContent("alice", "recovery-ip-throttle-004", sharedIp);
+  }
+
+  @Test
+  void exportsAuthThrottleRejectMetricsToPrometheus() throws Exception {
+    RequestClientMetadata loginIp = clientMetadata("203.0.113.230");
+    RequestClientMetadata recoveryIp = clientMetadata("203.0.113.231");
+
+    loginExpectUnauthorized("alice", "wrong-password", "login-metric-001", loginIp);
+    loginExpectUnauthorized("alice", "wrong-password", "login-metric-002", loginIp);
+    loginExpectTooManyRequests("alice", "password123!", "login-metric-003", loginIp);
+
+    passwordRecoveryExpectNoContent("alice", "recovery-metric-001", recoveryIp);
+    passwordRecoveryExpectNoContent("alice", "recovery-metric-002", recoveryIp);
+    passwordRecoveryExpectTooManyRequests("alice", "recovery-metric-003", recoveryIp);
+
+    String body =
+        mockMvc.perform(get("/actuator/prometheus")).andReturn().getResponse().getContentAsString();
+
+    assertThat(body)
+        .containsPattern(
+            Pattern.compile(
+                "aquila_auth_throttling_reject_count_total\\{[^\\n]*entry_point=\"login\"[^\\n]*scope=\"ip\"[^\\n]*store=\"memory\"[^\\n]*\\}\\s+1\\.0"));
+    assertThat(body)
+        .containsPattern(
+            Pattern.compile(
+                "aquila_auth_throttling_reject_count_total\\{[^\\n]*entry_point=\"password_recovery\"[^\\n]*scope=\"ip\"[^\\n]*store=\"memory\"[^\\n]*\\}\\s+1\\.0"));
   }
 
   private String login(

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -24,6 +24,7 @@
   - outbox dispatch lag / failed count / stale sending
   - notification consumer lag / DLQ count
   - SSE total session, account/user/total trend, reject/drop trend
+  - auth throttling reject rate by `entry_point`, `scope`, `store`
   - DB pool pending/active pressure, query timeout, Postgres lock/slow query signal
   - transaction query rate by `query_shape`
   - transaction p95 latency by `query_shape`
@@ -46,6 +47,7 @@
    - `aquila_outbox_dispatch_lag_seconds`
    - `aquila_notification_consumer_lag_count`
    - `aquila_notification_sse_sessions`
+   - `aquila_auth_throttling_reject_count_total`
    - `aquila_transaction_query_latency_seconds_count`
    - `hikaricp_connections_pending`
    - `aquila_t3micro_saturation_guard_query_timeouts_total`
@@ -66,6 +68,7 @@
 - auth baseline:
   - current session active gate reject rate `> 0` for `5m`
   - refresh token reuse detected rate `> 0` for `1m`
+  - auth throttling reject increase `>= 5` for `10m`
 - Postgres/DB saturation baseline:
   - Hikari pending connection `> 0` for `5m`
   - Hikari active/max pool ratio `> 90%` for `10m`
@@ -177,5 +180,6 @@ tools/test/run-alertmanager-receiver-secret-workflow-gate.sh
 - multi-instance SSE 합계는 Grafana/Prometheus 쿼리에서 인스턴스 합산으로 해석하고, 단일 instance alert는 node별 pressure 확인 용도로만 씁니다.
 - `AquilaCurrentSessionActiveGateRejectDetected`는 `reason_code`만 집계합니다. `requestId`, `userId`, `sessionId`, `path`는 cardinality 때문에 alert label로 올리지 않고 app structured log에서 drill-down합니다.
 - `AquilaRefreshTokenReuseDetected`는 공격성 재사용 후보라 critical baseline입니다. `requestId`, `userId`, `reusedSessionId`, `familyRootId`는 cardinality 때문에 alert label로 올리지 않고 app structured log에서 drill-down합니다.
+- `AquilaAuthThrottlingRejectBurstDetected`는 `entry_point`, `scope`, `store` 축만 사용합니다. IP, user, requestId, path는 cardinality 때문에 metric/alert label에 올리지 않고 app structured log에서 drill-down합니다.
 - DB saturation alert rollback은 `aquila-bank-postgres` group 제거 또는 해당 rule의 threshold/`for` 시간 조정으로 수행합니다. 앱 API 계약과 DB schema는 그대로 유지합니다.
 - provisioning rollback은 mount에서 해당 baseline 파일을 제거하거나 직전 runtime config로 되돌린 뒤 Prometheus/Grafana/Alertmanager를 reload합니다.

--- a/ops/prometheus/grafana/aquila-bank-overview.json
+++ b/ops/prometheus/grafana/aquila-bank-overview.json
@@ -615,6 +615,43 @@
       ],
       "title": "DB Pool and Postgres Slow/Lock Signals",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (entry_point, scope, store) (rate(aquila_auth_throttling_reject_count_total[5m]))",
+          "legendFormat": "{{entry_point}} {{scope}} {{store}} reject_rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Auth Throttling Reject Trend",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/ops/prometheus/rules/aquila-bank-alerts.yml
+++ b/ops/prometheus/rules/aquila-bank-alerts.yml
@@ -127,6 +127,19 @@ groups:
           description: "refresh token reuse 감지가 발생했습니다. requestId 기준 structured audit log와 revokedCount를 즉시 확인합니다."
           runbook_path: "back/README.md#prometheus-metrics"
 
+      - alert: AquilaAuthThrottlingRejectBurstDetected
+        expr: sum by (entry_point, scope, store) (increase(aquila_auth_throttling_reject_count_total[10m])) >= 5
+        for: 5m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: auth
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank auth throttling rejects are increasing"
+          description: "login/password recovery throttling reject가 10분 window에서 5건 이상 누적됐습니다. entry_point, scope, store 축과 auth structured log를 같이 확인합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
   - name: aquila-bank-postgres
     interval: 30s
     rules:

--- a/tools/ops/validate-prometheus-assets.sh
+++ b/tools/ops/validate-prometheus-assets.sh
@@ -33,6 +33,9 @@ done
 jq -e '.uid == "aquila-bank-overview" and (.panels | type == "array" and length >= 8)' \
   "${DASHBOARD_FILE}" >/dev/null
 
+jq -e '[.panels[] | .targets // [] | .[]? | .expr] | any(.[]; contains("aquila_auth_throttling_reject_count_total"))' \
+  "${DASHBOARD_FILE}" >/dev/null
+
 ruby -e '
 require "yaml"
 
@@ -67,6 +70,7 @@ def require_alert(data, alert_name, required_fragments)
 end
 
 {
+  "AquilaAuthThrottlingRejectBurstDetected" => ["aquila_auth_throttling_reject_count_total"],
   "AquilaDbPoolPendingWaitDetected" => ["hikaricp_connections_pending"],
   "AquilaDbPoolActivePressureHigh" => ["hikaricp_connections_active", "hikaricp_connections_max"],
   "AquilaDbQueryTimeoutDetected" => ["aquila_t3micro_saturation_guard_query_timeouts_total"],


### PR DESCRIPTION
## 🔗 Related Issue
close #302

## 🌿 Base Branch
main

## 📝 Summary
login/password-recovery throttling reject를 Prometheus에서 바로 볼 수 있도록 metric export를 추가했습니다.
Grafana overview와 Prometheus alert baseline도 함께 반영해 운영자가 reject burst를 즉시 감지할 수 있게 했습니다.

## 🛠 Changes
- login/password-recovery throttling reject 시 entry_point/scope/store tag 기반 counter를 기록하도록 backend wiring 추가
- auth throttling metric export integration test와 recorder 단위 테스트 추가
- Prometheus alert, Grafana overview panel, README/validator를 auth throttling baseline에 맞게 갱신

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-auth-throttling-metrics ./back/gradlew -p back test --tests com.aquilabank.global.config.LoginThrottlingConfigurationTest --tests com.aquilabank.global.security.LoginThrottlingMetricsRecorderTest --tests com.aquilabank.global.web.auth.LoginThrottlingIntegrationTest`
- `bash tools/ops/validate-prometheus-assets.sh`
- `./back/gradlew -p back check`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: auth throttling reject burst alert threshold가 shared IP 환경에서 민감할 수 있습니다.
- 롤백 방법: auth throttling recorder wiring과 Prometheus alert/panel 변경을 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?