### PR TITLE
[Chore] admission control·t3 saturation dashboard/alert 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -299,6 +299,10 @@ set +a
   - `aquila_auth_throttling_reject_count_total{entry_point="login|password_recovery",scope="ip|global",store="memory|redis"}`
   - `aquila_auth_current_session_gate_reject_count_total{reason_code="MISSING_SESSION_ID|INACTIVE_OR_MISMATCHED_SESSION"}`
   - `aquila_auth_refresh_token_reuse_detected_count_total{reason_code="ROTATED_TOKEN_REUSE"}`
+  - `aquila_api_admission_requests_total{group="transaction-read|account-read|transfer-write|notification-stream|notification-read|internal-ops",outcome="accepted|rejected"}`
+  - `aquila_api_admission_inflight{group="transaction-read|account-read|transfer-write|notification-stream|notification-read|internal-ops"}`
+  - `aquila_t3micro_saturation_guard_requests_total{outcome="accepted|rejected"}`
+  - `aquila_t3micro_saturation_guard_saturated`
   - `aquila_t3micro_saturation_guard_query_timeouts_total`
   - `aquila_transaction_query_latency_seconds`
 - DB saturation metric:
@@ -310,6 +314,8 @@ set +a
   - current session gate reject counter는 민감 mutation에서 legacy JWT `session_id` 누락 또는 inactive/mismatch session 차단이 발생하면 증가합니다.
   - auth throttling reject metric은 login/password recovery edge 직전 reject가 발생하면 `entry_point`, `scope`, `store` tag 기준으로 증가합니다.
   - refresh token reuse metric은 `ROTATED` refresh token 재사용 감지와 family revoke가 발생하면 증가합니다.
+  - admission control metric은 MVC edge에서 path group별 accepted/rejected와 in-flight를 바로 기록합니다.
+  - t3 saturation guard request/saturated metric은 protected path fail-fast 여부를 기록하고, query timeout counter는 DB timeout 신호를 따로 누적합니다.
   - t3.micro query timeout counter는 backend query timeout exception이 발생하면 증가합니다.
   - Hikari pool metric은 Spring Boot/Micrometer 기본 binder와 `aquila-bank-pool` pool tag 기준으로 export 됩니다.
   - Postgres exporter `pg_stat_statements_*`는 `pg_stat_statements` extension과 collector 활성화가 필요합니다.
@@ -339,6 +345,9 @@ set +a
   - current session gate alert rollback은 `AquilaCurrentSessionActiveGateRejectDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행하고, API 응답 계약은 그대로 유지합니다.
   - refresh token reuse metric label은 `reason_code`만 사용하고, `requestId`, `userId`, `reusedSessionId`, `familyRootId`는 structured audit log에서만 확인합니다.
   - `AquilaRefreshTokenReuseDetected` alert는 공격성 재사용 후보입니다. 같은 시간대 `requestId`로 `auth refresh token reuse detected` log를 조회하고 `reusedSessionId`, `familyRootId`, `revokedCount`를 먼저 확인합니다.
+  - admission control metric label은 `group`, `outcome`만 사용하고 IP/path/requestId는 edge log나 app log에서 drill-down 합니다.
+  - `AquilaApiAdmissionRejectBurstDetected`는 endpoint group reject burst를 의미합니다. 같은 시간대 `aquila_api_admission_inflight`, auth/Nginx throttling, t3 saturation signal을 같이 봅니다.
+  - `AquilaT3MicroSaturationRejectDetected`는 protected path fail-fast가 실제로 발생한 상태입니다. pool pending/active, servlet busy, query timeout, slow query를 같은 시간대에서 바로 확인합니다.
   - auth throttling alert rollback은 `AquilaAuthThrottlingRejectBurstDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행하고, auth API 응답 계약은 그대로 유지합니다.
   - p95 alert는 `query_shape`별 5분 rate가 충분할 때만 평가해 low traffic 노이즈를 줄입니다.
   - `AquilaDbPoolPendingWaitDetected`는 Hikari pending connection이 남은 상태라 lock wait, slow query, DB CPU, transaction p95를 같은 시간대에서 같이 확인합니다.
@@ -347,6 +356,7 @@ set +a
   - `AquilaPostgresLockWaitDetected`는 Postgres exporter custom metric이 있을 때만 동작합니다. alert label에는 query text/pid/user/requestId를 올리지 않고 DB drill-down에서 확인합니다.
   - `AquilaPostgresSlowQueryDetected`는 `pg_stat_statements` database-level 평균이 750ms를 넘는지 보는 coarse guard입니다. query별 확인은 `queryid` 기준으로 별도 조회합니다.
   - refresh token reuse alert rollback은 `AquilaRefreshTokenReuseDetected` rule 제거 또는 notification routing 비활성화로 수행하고, refresh API 응답 계약은 그대로 유지합니다.
+  - admission/t3 guard alert rollback은 `AquilaApiAdmissionRejectBurstDetected`, `AquilaT3MicroSaturationRejectDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행합니다.
   - histogram bucket/alert rollback은 `management.metrics.distribution.*.aquila.transaction.query.latency`와 `AquilaTransactionQueryLatencyP95SloHigh` rule 제거로 수행합니다.
   - DB saturation alert rollback은 `ops/prometheus/rules/aquila-bank-alerts.yml`의 `aquila-bank-postgres` group 제거 또는 threshold/`for` 시간 조정으로 수행합니다.
   - baseline 자산은 `ops/prometheus/` 아래에 두고 dashboard import, alert rule apply, tuning 가이드는 `ops/prometheus/README.md`를 기준으로 봅니다.

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -25,6 +25,8 @@
   - notification consumer lag / DLQ count
   - SSE total session, account/user/total trend, reject/drop trend
   - auth throttling reject rate by `entry_point`, `scope`, `store`
+  - admission control decision rate / inflight by `group`
+  - t3 saturation guard request, saturated, query timeout trend
   - DB pool pending/active pressure, query timeout, Postgres lock/slow query signal
   - transaction query rate by `query_shape`
   - transaction p95 latency by `query_shape`
@@ -34,6 +36,8 @@
 - query 기준:
   - transaction stat latency는 `sum(rate(..._sum)) / sum(rate(..._count))` 평균값을 유지합니다.
   - transaction shape별 latency는 `aquila_transaction_query_latency_seconds_bucket`의 `histogram_quantile(0.95, ...)`를 사용합니다.
+  - admission control panel은 `aquila_api_admission_requests_total`, `aquila_api_admission_inflight`를 `group` 기준으로 나눠 봅니다.
+  - t3 saturation guard panel은 reject rate, saturated gauge, query timeout rate를 같은 시간축에 두고 fail-fast와 DB 전조를 같이 봅니다.
   - DB saturation panel은 Hikari pool metric과 Postgres exporter metric을 한 panel에 모아 p95 악화 전 전조를 먼저 봅니다.
   - notification lag panel은 topic label이 있을 때 topic별로 분리해 보여줍니다.
   - SSE reject/drop metric은 앱 재시작 전까지 누적되는 gauge 성격이므로 절대값 trend로만 봅니다.
@@ -47,7 +51,10 @@
    - `aquila_outbox_dispatch_lag_seconds`
    - `aquila_notification_consumer_lag_count`
    - `aquila_notification_sse_sessions`
-   - `aquila_auth_throttling_reject_count_total`
+  - `aquila_auth_throttling_reject_count_total`
+  - `aquila_api_admission_requests_total`
+  - `aquila_api_admission_inflight`
+  - `aquila_t3micro_saturation_guard_requests_total`
    - `aquila_transaction_query_latency_seconds_count`
    - `hikaricp_connections_pending`
    - `aquila_t3micro_saturation_guard_query_timeouts_total`
@@ -69,6 +76,9 @@
   - current session active gate reject rate `> 0` for `5m`
   - refresh token reuse detected rate `> 0` for `1m`
   - auth throttling reject increase `>= 5` for `10m`
+- runtime guard baseline:
+  - endpoint `group`별 admission reject increase `>= 5` for `10m`
+  - t3 saturation guard reject + saturated signal 동시 발생 for `5m`
 - Postgres/DB saturation baseline:
   - Hikari pending connection `> 0` for `5m`
   - Hikari active/max pool ratio `> 90%` for `10m`

--- a/ops/prometheus/grafana/aquila-bank-overview.json
+++ b/ops/prometheus/grafana/aquila-bank-overview.json
@@ -652,6 +652,127 @@
       ],
       "title": "Auth Throttling Reject Trend",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (group, outcome) (rate(aquila_api_admission_requests_total[5m]))",
+          "legendFormat": "{{group}} {{outcome}}_rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Admission Control Decisions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max by (group) (aquila_api_admission_inflight)",
+          "legendFormat": "{{group}} inflight",
+          "refId": "A"
+        }
+      ],
+      "title": "Admission Control Inflight",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(aquila_t3micro_saturation_guard_requests_total[5m]))",
+          "legendFormat": "guard_{{outcome}}_rate",
+          "refId": "A"
+        },
+        {
+          "expr": "max(aquila_t3micro_saturation_guard_saturated)",
+          "legendFormat": "guard_saturated",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(aquila_t3micro_saturation_guard_query_timeouts_total[5m]))",
+          "legendFormat": "query_timeout_rate",
+          "refId": "C"
+        }
+      ],
+      "title": "T3 Saturation Guard Signals",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/ops/prometheus/rules/aquila-bank-alerts.yml
+++ b/ops/prometheus/rules/aquila-bank-alerts.yml
@@ -140,6 +140,45 @@ groups:
           description: "login/password recovery throttling reject가 10분 window에서 5건 이상 누적됐습니다. entry_point, scope, store 축과 auth structured log를 같이 확인합니다."
           runbook_path: "back/README.md#prometheus-metrics"
 
+  - name: aquila-bank-runtime-guard
+    interval: 30s
+    rules:
+      - alert: AquilaApiAdmissionRejectBurstDetected
+        expr: |
+          sum by (group) (
+            increase(aquila_api_admission_requests_total{outcome="rejected"}[10m])
+          ) >= 5
+        for: 5m
+        labels:
+          severity: warning
+          service: aquila-bank
+          domain: runtime
+          signal: admission_reject
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank API admission rejects increased"
+          description: "endpoint group별 admission reject가 10분 동안 5건 이상입니다. 같은 group의 inflight, edge throttling, t3 saturation 신호를 같이 확인합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
+      - alert: AquilaT3MicroSaturationRejectDetected
+        expr: |
+          max_over_time(aquila_t3micro_saturation_guard_saturated[5m]) >= 1
+          and
+          sum(
+            increase(aquila_t3micro_saturation_guard_requests_total{outcome="rejected"}[5m])
+          ) >= 1
+        for: 5m
+        labels:
+          severity: critical
+          service: aquila-bank
+          domain: runtime
+          signal: t3_saturation_guard
+          baseline: "true"
+        annotations:
+          summary: "Aquila Bank t3.micro saturation guard rejects requests"
+          description: "t3 saturation guard가 보호 경로를 실제로 차단했습니다. Hikari active/pending, servlet busy, query timeout, slow query를 같은 시간대에서 바로 확인합니다."
+          runbook_path: "back/README.md#prometheus-metrics"
+
   - name: aquila-bank-postgres
     interval: 30s
     rules:

--- a/tools/ops/validate-prometheus-assets.sh
+++ b/tools/ops/validate-prometheus-assets.sh
@@ -30,8 +30,14 @@ for provisioning_file in \
   fi
 done
 
-jq -e '.uid == "aquila-bank-overview" and (.panels | type == "array" and length >= 8)' \
-  "${DASHBOARD_FILE}" >/dev/null
+jq -e '
+  .uid == "aquila-bank-overview"
+  and (.panels | type == "array" and length >= 8)
+  and any(.panels[]?.targets[]?.expr?; contains("aquila_api_admission_requests_total"))
+  and any(.panels[]?.targets[]?.expr?; contains("aquila_api_admission_inflight"))
+  and any(.panels[]?.targets[]?.expr?; contains("aquila_t3micro_saturation_guard_requests_total"))
+  and any(.panels[]?.targets[]?.expr?; contains("aquila_t3micro_saturation_guard_saturated"))
+' "${DASHBOARD_FILE}" >/dev/null
 
 jq -e '[.panels[] | .targets // [] | .[]? | .expr] | any(.[]; contains("aquila_auth_throttling_reject_count_total"))' \
   "${DASHBOARD_FILE}" >/dev/null
@@ -71,6 +77,11 @@ end
 
 {
   "AquilaAuthThrottlingRejectBurstDetected" => ["aquila_auth_throttling_reject_count_total"],
+  "AquilaApiAdmissionRejectBurstDetected" => ["aquila_api_admission_requests_total"],
+  "AquilaT3MicroSaturationRejectDetected" => [
+    "aquila_t3micro_saturation_guard_requests_total",
+    "aquila_t3micro_saturation_guard_saturated"
+  ],
   "AquilaDbPoolPendingWaitDetected" => ["hikaricp_connections_pending"],
   "AquilaDbPoolActivePressureHigh" => ["hikaricp_connections_active", "hikaricp_connections_max"],
   "AquilaDbQueryTimeoutDetected" => ["aquila_t3micro_saturation_guard_query_timeouts_total"],


### PR DESCRIPTION
## 🔗 Related Issue
close #303

## 🌿 Base Branch
main

## 📝 Summary
이미 export 중인 admission control, t3 saturation guard metric을 Grafana overview와 Prometheus alert baseline에 반영했습니다.
runtime guard reject와 inflight를 transaction/DB 전조와 분리해서 바로 볼 수 있게 정리했습니다.

## 🛠 Changes
- admission control reject burst, t3 saturation guard reject를 위한 Prometheus alert baseline 추가
- Grafana overview에 admission control decision/inflight, t3 saturation guard signal panel 추가
- Prometheus/ops README와 validator를 새 baseline에 맞춰 갱신

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/ops/validate-prometheus-assets.sh`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: admission reject threshold가 burst traffic에서 다소 민감할 수 있습니다.
- 롤백 방법: runtime guard alert 2종과 dashboard panel, validator 조건을 함께 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?