### PR TITLE
[Chore] command_idempotency ops metric과 Prometheus export 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -303,6 +303,14 @@ set +a
   - `aquila_api_admission_inflight{group="transaction-read|account-read|transfer-write|notification-stream|notification-read|internal-ops"}`
   - `aquila_t3micro_saturation_guard_requests_total{outcome="accepted|rejected"}`
   - `aquila_t3micro_saturation_guard_saturated`
+  - `aquila_command_idempotency_started_count`
+  - `aquila_command_idempotency_stale_started_count`
+  - `aquila_command_idempotency_completed_count`
+  - `aquila_command_idempotency_failed_count`
+  - `aquila_command_idempotency_cleanup_candidate_count`
+  - `aquila_command_idempotency_conflict_count_total{reason_code="DIFFERENT_REQUEST|IN_PROGRESS|STATE_MISSING|ALREADY_REVERSED|AMOUNT_EXCEEDED|OTHER"}`
+  - `aquila_command_idempotency_recovery_recovered_count_total`
+  - `aquila_command_idempotency_cleanup_deleted_count_total`
   - `aquila_t3micro_saturation_guard_query_timeouts_total`
   - `aquila_transaction_query_latency_seconds`
 - DB saturation metric:
@@ -316,6 +324,9 @@ set +a
   - refresh token reuse metric은 `ROTATED` refresh token 재사용 감지와 family revoke가 발생하면 증가합니다.
   - admission control metric은 MVC edge에서 path group별 accepted/rejected와 in-flight를 바로 기록합니다.
   - t3 saturation guard request/saturated metric은 protected path fail-fast 여부를 기록하고, query timeout counter는 DB timeout 신호를 따로 누적합니다.
+  - command idempotency summary gauge는 ops summary를 5초 cache로 재사용해 stale/failed/cleanup candidate 숫자를 export 합니다.
+  - command idempotency conflict counter는 transfer/reversal conflict를 `reason_code` 축으로만 누적합니다.
+  - command idempotency recovery/cleanup counter는 stale recovery row 수, retention cleanup delete row 수를 누적합니다.
   - t3.micro query timeout counter는 backend query timeout exception이 발생하면 증가합니다.
   - Hikari pool metric은 Spring Boot/Micrometer 기본 binder와 `aquila-bank-pool` pool tag 기준으로 export 됩니다.
   - Postgres exporter `pg_stat_statements_*`는 `pg_stat_statements` extension과 collector 활성화가 필요합니다.
@@ -349,6 +360,8 @@ set +a
   - `AquilaApiAdmissionRejectBurstDetected`는 endpoint group reject burst를 의미합니다. 같은 시간대 `aquila_api_admission_inflight`, auth/Nginx throttling, t3 saturation signal을 같이 봅니다.
   - `AquilaT3MicroSaturationRejectDetected`는 protected path fail-fast가 실제로 발생한 상태입니다. pool pending/active, servlet busy, query timeout, slow query를 같은 시간대에서 바로 확인합니다.
   - auth throttling alert rollback은 `AquilaAuthThrottlingRejectBurstDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행하고, auth API 응답 계약은 그대로 유지합니다.
+  - command idempotency conflict metric label은 `reason_code`만 사용하고 idempotency key, transaction reference, account id는 API/app log 또는 ops API에서 drill-down 합니다.
+  - command idempotency summary gauge는 `ledger.command-idempotency.ops.enabled=true`일 때 live count를 export 하고, 비활성 상태에서는 zero baseline만 남깁니다.
   - p95 alert는 `query_shape`별 5분 rate가 충분할 때만 평가해 low traffic 노이즈를 줄입니다.
   - `AquilaDbPoolPendingWaitDetected`는 Hikari pending connection이 남은 상태라 lock wait, slow query, DB CPU, transaction p95를 같은 시간대에서 같이 확인합니다.
   - `AquilaDbPoolActivePressureHigh`는 active/max pool ratio 90% 이상을 queueing 전조로 봅니다. t3.micro 기본 `DB_POOL_MAX_SIZE=4`에서는 순간 spike보다 10분 지속 여부가 중요합니다.
@@ -357,6 +370,7 @@ set +a
   - `AquilaPostgresSlowQueryDetected`는 `pg_stat_statements` database-level 평균이 750ms를 넘는지 보는 coarse guard입니다. query별 확인은 `queryid` 기준으로 별도 조회합니다.
   - refresh token reuse alert rollback은 `AquilaRefreshTokenReuseDetected` rule 제거 또는 notification routing 비활성화로 수행하고, refresh API 응답 계약은 그대로 유지합니다.
   - admission/t3 guard alert rollback은 `AquilaApiAdmissionRejectBurstDetected`, `AquilaT3MicroSaturationRejectDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행합니다.
+  - command idempotency metric rollback은 `CommandIdempotencyPrometheusMetrics` wiring 제거와 recovery/cleanup/conflict recorder 호출 제거로 수행합니다.
   - histogram bucket/alert rollback은 `management.metrics.distribution.*.aquila.transaction.query.latency`와 `AquilaTransactionQueryLatencyP95SloHigh` rule 제거로 수행합니다.
   - DB saturation alert rollback은 `ops/prometheus/rules/aquila-bank-alerts.yml`의 `aquila-bank-postgres` group 제거 또는 threshold/`for` 시간 조정으로 수행합니다.
   - baseline 자산은 `ops/prometheus/` 아래에 두고 dashboard import, alert rule apply, tuning 가이드는 `ops/prometheus/README.md`를 기준으로 봅니다.

--- a/back/src/main/java/com/aquilabank/global/ledger/CommandIdempotencyCleanupPoller.java
+++ b/back/src/main/java/com/aquilabank/global/ledger/CommandIdempotencyCleanupPoller.java
@@ -15,9 +15,13 @@ public class CommandIdempotencyCleanupPoller {
   private static final Logger log = LoggerFactory.getLogger(CommandIdempotencyCleanupPoller.class);
 
   private final CommandIdempotencyCleanupUseCase cleanupUseCase;
+  private final CommandIdempotencyPrometheusMetrics commandIdempotencyPrometheusMetrics;
 
-  public CommandIdempotencyCleanupPoller(CommandIdempotencyCleanupUseCase cleanupUseCase) {
+  public CommandIdempotencyCleanupPoller(
+      CommandIdempotencyCleanupUseCase cleanupUseCase,
+      CommandIdempotencyPrometheusMetrics commandIdempotencyPrometheusMetrics) {
     this.cleanupUseCase = cleanupUseCase;
+    this.commandIdempotencyPrometheusMetrics = commandIdempotencyPrometheusMetrics;
   }
 
   @Scheduled(
@@ -25,6 +29,7 @@ public class CommandIdempotencyCleanupPoller {
       initialDelayString = "${ledger.command-idempotency.cleanup.initial-delay-ms:60000}")
   void cleanupExpiredRecords() {
     int deleted = cleanupUseCase.cleanupExpiredRecords();
+    commandIdempotencyPrometheusMetrics.recordCleanupDeleted(deleted);
     if (deleted > 0) {
       log.info("deleted {} command idempotency row(s)", deleted);
     }

--- a/back/src/main/java/com/aquilabank/global/ledger/CommandIdempotencyPrometheusMetrics.java
+++ b/back/src/main/java/com/aquilabank/global/ledger/CommandIdempotencyPrometheusMetrics.java
@@ -1,0 +1,162 @@
+package com.aquilabank.global.ledger;
+
+import com.aquilabank.domain.ledger.model.CommandIdempotencyOpsSummary;
+import com.aquilabank.domain.ledger.usecase.CommandIdempotencyOpsQueryUseCase;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.EnumMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/** summary gauge는 scrape마다 summary query를 반복하지 않게 짧은 cache 안에서만 재사용합니다. */
+@Component
+public final class CommandIdempotencyPrometheusMetrics {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(CommandIdempotencyPrometheusMetrics.class);
+  private static final Duration SNAPSHOT_TTL = Duration.ofSeconds(5);
+  private static final CommandIdempotencyOpsSummary EMPTY_SUMMARY =
+      new CommandIdempotencyOpsSummary(Instant.EPOCH, 0, 0, 0, 0, 0);
+
+  private final ObjectProvider<CommandIdempotencyOpsQueryUseCase> queryUseCaseProvider;
+  private final Map<ConflictReason, Counter> conflictCounters;
+  private final Counter recoveredCounter;
+  private final Counter cleanupDeletedCounter;
+
+  private volatile CachedSummary cachedSummary = new CachedSummary(EMPTY_SUMMARY, Instant.EPOCH);
+
+  public CommandIdempotencyPrometheusMetrics(
+      ObjectProvider<CommandIdempotencyOpsQueryUseCase> queryUseCaseProvider,
+      MeterRegistry meterRegistry) {
+    this.queryUseCaseProvider = queryUseCaseProvider;
+    this.conflictCounters = new EnumMap<>(ConflictReason.class);
+    for (ConflictReason reason : ConflictReason.values()) {
+      conflictCounters.put(
+          reason,
+          Counter.builder("aquila.command.idempotency.conflict.count")
+              .tag("reason_code", reason.name())
+              .description("command idempotency conflict count")
+              .register(meterRegistry));
+    }
+    this.recoveredCounter =
+        Counter.builder("aquila.command.idempotency.recovery.recovered.count")
+            .description("recovered stale command idempotency row count")
+            .register(meterRegistry);
+    this.cleanupDeletedCounter =
+        Counter.builder("aquila.command.idempotency.cleanup.deleted.count")
+            .description("deleted expired command idempotency row count")
+            .register(meterRegistry);
+
+    Gauge.builder(
+            "aquila.command.idempotency.started.count",
+            this,
+            metrics -> metrics.currentSummary().startedCount())
+        .description("current STARTED command idempotency row count")
+        .register(meterRegistry);
+    Gauge.builder(
+            "aquila.command.idempotency.stale.started.count",
+            this,
+            metrics -> metrics.currentSummary().staleStartedCount())
+        .description("current stale STARTED command idempotency row count")
+        .register(meterRegistry);
+    Gauge.builder(
+            "aquila.command.idempotency.completed.count",
+            this,
+            metrics -> metrics.currentSummary().completedCount())
+        .description("current COMPLETED command idempotency row count")
+        .register(meterRegistry);
+    Gauge.builder(
+            "aquila.command.idempotency.failed.count",
+            this,
+            metrics -> metrics.currentSummary().failedCount())
+        .description("current FAILED command idempotency row count")
+        .register(meterRegistry);
+    Gauge.builder(
+            "aquila.command.idempotency.cleanup.candidate.count",
+            this,
+            metrics -> metrics.currentSummary().cleanupCandidateCount())
+        .description("current cleanup candidate command idempotency row count")
+        .register(meterRegistry);
+  }
+
+  public void recordConflict(String message) {
+    conflictCounters.get(classifyConflict(message)).increment();
+  }
+
+  public void recordRecovered(long recoveredCount) {
+    if (recoveredCount <= 0) {
+      return;
+    }
+    recoveredCounter.increment(recoveredCount);
+  }
+
+  public void recordCleanupDeleted(long deletedCount) {
+    if (deletedCount <= 0) {
+      return;
+    }
+    cleanupDeletedCounter.increment(deletedCount);
+  }
+
+  private CommandIdempotencyOpsSummary currentSummary() {
+    Instant now = Instant.now();
+    CachedSummary current = cachedSummary;
+    if (current.expiresAt().isAfter(now)) {
+      return current.summary();
+    }
+    synchronized (this) {
+      CachedSummary refreshed = cachedSummary;
+      if (refreshed.expiresAt().isAfter(now)) {
+        return refreshed.summary();
+      }
+      CommandIdempotencyOpsQueryUseCase queryUseCase = queryUseCaseProvider.getIfAvailable();
+      if (queryUseCase == null) {
+        return EMPTY_SUMMARY;
+      }
+      try {
+        CommandIdempotencyOpsSummary summary = queryUseCase.getSummary();
+        cachedSummary = new CachedSummary(summary, now.plus(SNAPSHOT_TTL));
+        return summary;
+      } catch (RuntimeException ex) {
+        log.debug("command idempotency prometheus summary refresh failed", ex);
+        return refreshed.summary();
+      }
+    }
+  }
+
+  // 응답 message는 외부 계약이라 tag는 운영 triage에 필요한 축만 남깁니다.
+  private ConflictReason classifyConflict(String message) {
+    if ("idempotencyKey is already used with another request".equals(message)) {
+      return ConflictReason.DIFFERENT_REQUEST;
+    }
+    if ("same command is already in progress".equals(message)) {
+      return ConflictReason.IN_PROGRESS;
+    }
+    if ("idempotencyKey state is missing".equals(message)) {
+      return ConflictReason.STATE_MISSING;
+    }
+    if ("transfer is already reversed".equals(message)) {
+      return ConflictReason.ALREADY_REVERSED;
+    }
+    if ("reversal amount exceeds remaining amount".equals(message)) {
+      return ConflictReason.AMOUNT_EXCEEDED;
+    }
+    return ConflictReason.OTHER;
+  }
+
+  private record CachedSummary(CommandIdempotencyOpsSummary summary, Instant expiresAt) {}
+
+  private enum ConflictReason {
+    DIFFERENT_REQUEST,
+    IN_PROGRESS,
+    STATE_MISSING,
+    ALREADY_REVERSED,
+    AMOUNT_EXCEEDED,
+    OTHER
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -25,6 +25,7 @@ import com.aquilabank.domain.ledger.exception.TransferLimitExceededException;
 import com.aquilabank.domain.ledger.exception.TransferReversalNotFoundException;
 import com.aquilabank.domain.notification.exception.NotificationNotFoundException;
 import com.aquilabank.domain.transaction.exception.TransactionDetailNotFoundException;
+import com.aquilabank.global.ledger.CommandIdempotencyPrometheusMetrics;
 import com.aquilabank.global.notification.NotificationSseOverloadException;
 import com.aquilabank.global.ops.ApiOverloadRejectedException;
 import com.aquilabank.global.ops.T3MicroQueryTimeoutSignal;
@@ -61,10 +62,17 @@ public class ApiExceptionHandler {
   private static final Pattern MEMBERSHIP_STATUS_PATH_PATTERN =
       Pattern.compile("^/internal/api/v1/auth/users/(\\d+)/memberships/(\\d+)/status$");
   private T3MicroQueryTimeoutSignal t3MicroQueryTimeoutSignal;
+  private CommandIdempotencyPrometheusMetrics commandIdempotencyPrometheusMetrics;
 
   @Autowired(required = false)
   void setT3MicroQueryTimeoutSignal(T3MicroQueryTimeoutSignal t3MicroQueryTimeoutSignal) {
     this.t3MicroQueryTimeoutSignal = t3MicroQueryTimeoutSignal;
+  }
+
+  @Autowired(required = false)
+  void setCommandIdempotencyPrometheusMetrics(
+      CommandIdempotencyPrometheusMetrics commandIdempotencyPrometheusMetrics) {
+    this.commandIdempotencyPrometheusMetrics = commandIdempotencyPrometheusMetrics;
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -208,6 +216,9 @@ public class ApiExceptionHandler {
           InternalAuthConflictReasonCode.DUPLICATE_EXTERNAL_IDENTITY_MAPPING,
           ex.getMessage(),
           request);
+    }
+    if (ex instanceof CommandConflictException && commandIdempotencyPrometheusMetrics != null) {
+      commandIdempotencyPrometheusMetrics.recordConflict(ex.getMessage());
     }
     return response(HttpStatus.CONFLICT, ex.getMessage(), request);
   }

--- a/back/src/main/java/com/aquilabank/global/web/ledger/CommandIdempotencyOpsController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/CommandIdempotencyOpsController.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.web.ledger;
 import com.aquilabank.domain.ledger.usecase.CommandIdempotencyOpsQueryUseCase;
 import com.aquilabank.domain.ledger.usecase.CommandIdempotencyOpsRecoveryUseCase;
 import com.aquilabank.global.config.CommandIdempotencyOpsProperties;
+import com.aquilabank.global.ledger.CommandIdempotencyPrometheusMetrics;
 import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceScope;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,16 +27,19 @@ public class CommandIdempotencyOpsController {
   private final CommandIdempotencyOpsRecoveryUseCase recoveryUseCase;
   private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
   private final CommandIdempotencyOpsProperties opsProperties;
+  private final CommandIdempotencyPrometheusMetrics commandIdempotencyPrometheusMetrics;
 
   public CommandIdempotencyOpsController(
       CommandIdempotencyOpsQueryUseCase queryUseCase,
       CommandIdempotencyOpsRecoveryUseCase recoveryUseCase,
       InternalServiceRequestAuthorizer internalServiceRequestAuthorizer,
-      CommandIdempotencyOpsProperties opsProperties) {
+      CommandIdempotencyOpsProperties opsProperties,
+      CommandIdempotencyPrometheusMetrics commandIdempotencyPrometheusMetrics) {
     this.queryUseCase = queryUseCase;
     this.recoveryUseCase = recoveryUseCase;
     this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
     this.opsProperties = opsProperties;
+    this.commandIdempotencyPrometheusMetrics = commandIdempotencyPrometheusMetrics;
   }
 
   @GetMapping("/summary")
@@ -58,6 +62,9 @@ public class CommandIdempotencyOpsController {
   @PostMapping("/recovery/stale-started")
   public CommandIdempotencyStaleRecoveryResponse recoverStaleStarted(HttpServletRequest request) {
     internalServiceRequestAuthorizer.requireScope(request, InternalServiceScope.LEDGER_OPS);
-    return CommandIdempotencyStaleRecoveryResponse.from(recoveryUseCase.recoverStaleStarted());
+    CommandIdempotencyStaleRecoveryResponse response =
+        CommandIdempotencyStaleRecoveryResponse.from(recoveryUseCase.recoverStaleStarted());
+    commandIdempotencyPrometheusMetrics.recordRecovered(response.recoveredCount());
+    return response;
   }
 }

--- a/back/src/test/java/com/aquilabank/global/config/CommandIdempotencyCleanupConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/CommandIdempotencyCleanupConfigurationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import com.aquilabank.domain.ledger.port.CommandIdempotencyCleanupPort;
 import com.aquilabank.domain.ledger.usecase.CommandIdempotencyCleanupUseCase;
 import com.aquilabank.global.ledger.CommandIdempotencyCleanupPoller;
+import com.aquilabank.global.ledger.CommandIdempotencyPrometheusMetrics;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -17,6 +18,9 @@ class CommandIdempotencyCleanupConfigurationTest {
               CommandIdempotencyCleanupConfiguration.class, CommandIdempotencyCleanupPoller.class)
           .withBean(
               CommandIdempotencyCleanupPort.class, () -> mock(CommandIdempotencyCleanupPort.class))
+          .withBean(
+              CommandIdempotencyPrometheusMetrics.class,
+              () -> mock(CommandIdempotencyPrometheusMetrics.class))
           .withPropertyValues(
               "ledger.command-idempotency.cleanup.fixed-delay-ms=300000",
               "ledger.command-idempotency.cleanup.initial-delay-ms=60000",

--- a/back/src/test/java/com/aquilabank/global/ledger/CommandIdempotencyPrometheusMetricsIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/ledger/CommandIdempotencyPrometheusMetricsIntegrationTest.java
@@ -1,0 +1,211 @@
+package com.aquilabank.global.ledger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenIssuer;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      "spring.flyway.enabled=true",
+      "management.health.db.enabled=true",
+      "ledger.command-idempotency.ops.enabled=true",
+      "ledger.command-idempotency.ops.stale-after-seconds=30",
+      "ledger.command-idempotency.ops.recovery-batch-size=1",
+      "ledger.command-idempotency.cleanup.enabled=true",
+      "ledger.command-idempotency.cleanup.retention-days=14"
+    })
+class CommandIdempotencyPrometheusMetricsIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @Autowired private InternalServiceTokenIssuer internalServiceTokenIssuer;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private CommandIdempotencyCleanupPoller commandIdempotencyCleanupPoller;
+
+  private MockMvc mockMvc;
+  private long sourceAccountId;
+  private long targetAccountId;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    resetBankingTables(jdbcTemplate);
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+
+    sourceAccountId = bootstrapAccount("metrics source", 10_000L);
+    targetAccountId = bootstrapAccount("metrics target", 0L);
+  }
+
+  @Test
+  void exportsCommandIdempotencySummaryConflictRecoveryAndCleanupMetrics() throws Exception {
+    Instant now = Instant.now();
+    commit(
+        transactionManager,
+        () -> {
+          insertIdempotency("metrics-stale-001", "fp-stale-001", "STARTED", now.minusSeconds(90));
+          insertIdempotency("metrics-stale-002", "fp-stale-002", "STARTED", now.minusSeconds(80));
+          insertIdempotency("metrics-fresh-001", "fp-fresh-001", "STARTED", now.plusSeconds(90));
+          insertIdempotency(
+              "metrics-completed-old-001",
+              "fp-completed-001",
+              "COMPLETED",
+              now.minusSeconds(20L * 24 * 60 * 60));
+          insertIdempotency(
+              "metrics-failed-old-001",
+              "fp-failed-001",
+              "FAILED",
+              now.minusSeconds(20L * 24 * 60 * 60));
+          insertIdempotency(
+              "metrics-conflict-001", "seed-conflict", "STARTED", now.plusSeconds(90));
+        });
+
+    MvcResult conflict =
+        mockMvc
+            .perform(
+                post("/api/v1/transfers")
+                    .header("X-Account-Id", String.valueOf(sourceAccountId))
+                    .header("X-Request-Id", "metrics-conflict-001-request")
+                    .header("Idempotency-Key", "metrics-conflict-001")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "sourceAccountId": %d,
+                          "targetAccountId": %d,
+                          "amountMinor": 500,
+                          "currencyCode": "KRW",
+                          "summary": "metrics conflict"
+                        }
+                        """
+                            .formatted(sourceAccountId, targetAccountId)))
+            .andReturn();
+    assertThat(conflict.getResponse().getStatus()).isEqualTo(409);
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/ledger/command-idempotency/recovery/stale-started")
+                .header("Authorization", ledgerOpsAuthorization()))
+        .andExpect(result -> assertThat(result.getResponse().getStatus()).isEqualTo(200));
+
+    commandIdempotencyCleanupPoller.cleanupExpiredRecords();
+
+    String body =
+        mockMvc.perform(get("/actuator/prometheus")).andReturn().getResponse().getContentAsString();
+
+    assertThat(body).containsPattern("aquila_command_idempotency_started_count\\s+3\\.0");
+    assertThat(body).containsPattern("aquila_command_idempotency_stale_started_count\\s+1\\.0");
+    assertThat(body).containsPattern("aquila_command_idempotency_failed_count\\s+1\\.0");
+    assertThat(body).containsPattern("aquila_command_idempotency_cleanup_candidate_count\\s+0\\.0");
+    assertThat(body)
+        .containsPattern(
+            "aquila_command_idempotency_conflict_count_total\\{[^\\n]*reason_code=\"DIFFERENT_REQUEST\"[^\\n]*\\}\\s+1\\.0");
+    assertThat(body)
+        .containsPattern("aquila_command_idempotency_recovery_recovered_count_total\\s+1\\.0");
+    assertThat(body)
+        .containsPattern("aquila_command_idempotency_cleanup_deleted_count_total\\s+2\\.0");
+  }
+
+  private long bootstrapAccount(String displayName, long initialBalanceMinor) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/internal/api/v1/accounts/bootstrap")
+                    .header("X-Request-Id", "bootstrap-" + displayName.replace(" ", "-"))
+                    .header(
+                        "Authorization",
+                        "Bearer "
+                            + internalServiceTokenIssuer.issue(
+                                "account-bootstrap",
+                                java.util.Set.of(InternalServiceScope.ACCOUNT_BOOTSTRAP)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "displayName": "%s",
+                          "currencyCode": "KRW",
+                          "initialBalanceMinor": %d
+                        }
+                        """
+                            .formatted(displayName, initialBalanceMinor)))
+            .andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(200);
+    JsonNode body = objectMapper.readTree(result.getResponse().getContentAsByteArray());
+    return body.get("accountId").asLong();
+  }
+
+  private void insertIdempotency(
+      String key, String fingerprint, String status, Instant lockedUntil) {
+    Instant updatedAt =
+        switch (status) {
+          case "COMPLETED", "FAILED" -> lockedUntil;
+          default -> lockedUntil.minusSeconds(10);
+        };
+    jdbcTemplate.update(
+        """
+        INSERT INTO command_idempotency (
+            idempotency_key,
+            request_fingerprint,
+            processing_status,
+            response_code,
+            response_payload,
+            locked_until,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :key,
+            :fingerprint,
+            :status,
+            :responseCode,
+            CAST(:responsePayload AS jsonb),
+            :lockedUntil,
+            :createdAt,
+            :updatedAt
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("key", key)
+            .addValue("fingerprint", fingerprint)
+            .addValue("status", status)
+            .addValue("responseCode", "COMPLETED".equals(status) ? 200 : null)
+            .addValue("responsePayload", "COMPLETED".equals(status) ? "{\"ok\":true}" : null)
+            .addValue("lockedUntil", Timestamp.from(lockedUntil))
+            .addValue("createdAt", Timestamp.from(updatedAt.minusSeconds(30)))
+            .addValue("updatedAt", Timestamp.from(updatedAt)));
+  }
+
+  private String ledgerOpsAuthorization() {
+    return "Bearer "
+        + internalServiceTokenIssuer.issue(
+            "ledger-ops", java.util.Set.of(InternalServiceScope.LEDGER_OPS));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/ledger/CommandIdempotencyPrometheusMetricsTest.java
+++ b/back/src/test/java/com/aquilabank/global/ledger/CommandIdempotencyPrometheusMetricsTest.java
@@ -1,0 +1,73 @@
+package com.aquilabank.global.ledger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.ledger.model.CommandIdempotencyOpsSummary;
+import com.aquilabank.domain.ledger.model.StaleCommandIdempotencyRecord;
+import com.aquilabank.domain.ledger.usecase.CommandIdempotencyOpsQueryUseCase;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.support.StaticApplicationContext;
+
+class CommandIdempotencyPrometheusMetricsTest {
+
+  @Test
+  void exportsSummaryGaugeAndCountersWithLowCardinalityReasonCode() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    StaticApplicationContext context = new StaticApplicationContext();
+    context
+        .getBeanFactory()
+        .registerSingleton(
+            "commandIdempotencyOpsQueryUseCase",
+            new CommandIdempotencyOpsQueryUseCase() {
+              @Override
+              public CommandIdempotencyOpsSummary getSummary() {
+                return new CommandIdempotencyOpsSummary(
+                    Instant.parse("2026-04-24T00:00:00Z"), 4, 2, 7, 3, 5);
+              }
+
+              @Override
+              public List<StaleCommandIdempotencyRecord> findStaleStarted(int limit) {
+                return List.of();
+              }
+            });
+    ObjectProvider<CommandIdempotencyOpsQueryUseCase> provider =
+        context.getBeanProvider(CommandIdempotencyOpsQueryUseCase.class);
+    CommandIdempotencyPrometheusMetrics metrics =
+        new CommandIdempotencyPrometheusMetrics(provider, registry);
+
+    metrics.recordConflict("same command is already in progress");
+    metrics.recordConflict("idempotencyKey is already used with another request");
+    metrics.recordRecovered(3);
+    metrics.recordCleanupDeleted(2);
+
+    assertThat(registry.find("aquila.command.idempotency.started.count").gauge().value())
+        .isEqualTo(4.0);
+    assertThat(registry.find("aquila.command.idempotency.stale.started.count").gauge().value())
+        .isEqualTo(2.0);
+    assertThat(registry.find("aquila.command.idempotency.cleanup.candidate.count").gauge().value())
+        .isEqualTo(5.0);
+    assertThat(
+            registry
+                .find("aquila.command.idempotency.conflict.count")
+                .tag("reason_code", "IN_PROGRESS")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            registry
+                .find("aquila.command.idempotency.conflict.count")
+                .tag("reason_code", "DIFFERENT_REQUEST")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            registry.find("aquila.command.idempotency.recovery.recovered.count").counter().count())
+        .isEqualTo(3.0);
+    assertThat(registry.find("aquila.command.idempotency.cleanup.deleted.count").counter().count())
+        .isEqualTo(2.0);
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
close #301

## 🌿 Base Branch
main

## 📝 Summary
command idempotency 운영 상태를 Prometheus에서 바로 볼 수 있도록 summary gauge와 conflict/recovery/cleanup counter를 추가했습니다.
stale lock, conflict, cleanup 상태를 ops API 조회 없이 수치로 확인할 수 있게 정리했습니다.

## 🛠 Changes
- command idempotency summary gauge와 conflict/recovery/cleanup counter를 export 하는 Prometheus metrics component 추가
- conflict 예외 처리, stale recovery endpoint, cleanup poller에 metrics recorder 연결
- unit/integration/config test와 README metric inventory/runbook 갱신

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-command-idempotency ./back/gradlew -p back test --tests com.aquilabank.global.ledger.CommandIdempotencyPrometheusMetricsTest --tests com.aquilabank.global.ledger.CommandIdempotencyPrometheusMetricsIntegrationTest`
- `tools/test/with-resource-lock.sh back-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: summary gauge는 5초 cache라 scrape 직후 수치가 아주 짧게 지연될 수 있습니다.
- 롤백 방법: `CommandIdempotencyPrometheusMetrics` wiring과 conflict/recovery/cleanup recorder 호출을 함께 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?