### PR TITLE
[Perf] multi-node auth throttling Redis baseline 강제 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -32,6 +32,7 @@ com.aquilabank
 
 - 기본 저장소는 `memory`입니다.
 - `redis`는 분산 login throttling 이 필요할 때만 opt-in 으로 사용합니다.
+- multi-node 운영에서는 `SECURITY_LOGIN_THROTTLING_REQUIRE_REDIS=true`로 memory fallback 부팅을 차단합니다.
 - Redis 경로는 login throttling counter 에만 쓰고, SSE fan-out 은 계속 PostgreSQL `LISTEN/NOTIFY` 를 사용합니다.
 - local Redis는 compose `redis` profile로만 뜨며 기본 `postgres kafka` 경로에는 포함하지 않습니다.
 - 같은 counter/guard는 password recovery request entrypoint에도 적용되어 token write 전 burst를 차단합니다.
@@ -693,6 +694,7 @@ tools/test/run-sse-multinode-drain-smoke.sh
   - `SECURITY_LOGIN_THROTTLING_GLOBAL_WINDOW_SECONDS=10`
   - `SECURITY_LOGIN_THROTTLING_MAX_TRACKED_IPS=1024`
   - `SECURITY_LOGIN_THROTTLING_STORE=memory`
+  - `SECURITY_LOGIN_THROTTLING_REQUIRE_REDIS=false`
   - `SECURITY_LOGIN_THROTTLING_REDIS_KEY_PREFIX=auth:login:throttle:`
 - 동작 기준:
   - 같은 `loginId`에서 연속 `5회` 실패하면 `15분` 임시 잠금
@@ -702,8 +704,12 @@ tools/test/run-sse-multinode-drain-smoke.sh
   - 성공 login 시 `failed_login_count`, `last_login_failed_at`, `login_locked_until`은 reset
   - `loginId` 잠금은 존재 여부/잠금 여부를 드러내지 않도록 계속 `401 login failed` 유지
   - request-level throttling은 `Retry-After` 헤더와 함께 `429 too many login attempts`를 반환
+  - memory 저장소의 IP/global throttling은 per-instance 기준이며 multi-node 전체 합산 limit는 보장하지 않음
+  - Redis 저장소는 multi-node counter 공유가 필요할 때 사용하고, `require-redis=true` 운영값에서는 memory fallback 없이 설정 오류를 부팅 단계에서 드러냄
 - Redis opt-in:
   - `SECURITY_LOGIN_THROTTLING_STORE=redis`일 때만 Redis-backed counter를 사용
+  - multi-node 운영 baseline은 `SECURITY_LOGIN_THROTTLING_STORE=redis`와 `SECURITY_LOGIN_THROTTLING_REQUIRE_REDIS=true`를 같이 둠
+  - `SECURITY_LOGIN_THROTTLING_REQUIRE_REDIS=true`인데 store가 `memory`이면 startup 단계에서 실패시켜 per-instance limit 오적용을 막음
   - Redis 연결값은 `REDIS_HOST`, `REDIS_PORT`로 지정
   - Redis runtime smoke는 compose Redis profile을 띄운 뒤 실제 counter 공유와 TTL 만료를 확인
   - 실행:
@@ -714,8 +720,6 @@ tools/test/run-sse-multinode-drain-smoke.sh
 - 상태 우선순위:
   - 수동 운영 상태 `user_status=LOCKED|DISABLED`가 임시 잠금보다 우선
   - 임시 brute-force 잠금은 `login_locked_until`로만 관리하고 `user_status`는 직접 바꾸지 않음
-  - memory 저장소의 IP/global throttling은 per-instance 기준이며 multi-node 전체 합산 limit는 보장하지 않음
-  - Redis 저장소는 multi-node counter 공유가 필요할 때만 사용하고, 장애 시 memory fallback 없이 부팅 단계에서 설정 오류를 드러냄
 
 ### login 실패 감사 로그
 

--- a/back/src/main/java/com/aquilabank/global/config/LoginThrottlingConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/LoginThrottlingConfiguration.java
@@ -23,6 +23,11 @@ public class LoginThrottlingConfiguration {
       LoginThrottlingProperties properties,
       Clock authClock,
       ObjectProvider<StringRedisTemplate> stringRedisTemplateProvider) {
+    if (properties.requireRedis() && properties.store() != StoreType.REDIS) {
+      throw new IllegalStateException(
+          "security.login-throttling.require-redis=true requires "
+              + "security.login-throttling.store=redis");
+    }
     if (properties.store() == StoreType.REDIS) {
       StringRedisTemplate stringRedisTemplate = stringRedisTemplateProvider.getIfAvailable();
       if (stringRedisTemplate == null) {

--- a/back/src/main/java/com/aquilabank/global/security/LoginThrottlingProperties.java
+++ b/back/src/main/java/com/aquilabank/global/security/LoginThrottlingProperties.java
@@ -9,6 +9,7 @@ public record LoginThrottlingProperties(
     ScopeProperties ip,
     ScopeProperties global,
     StoreType store,
+    boolean requireRedis,
     RedisProperties redis) {
 
   public LoginThrottlingProperties {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -376,6 +376,7 @@ security:
   login-throttling:
     max-tracked-ips: ${SECURITY_LOGIN_THROTTLING_MAX_TRACKED_IPS:1024}
     store: ${SECURITY_LOGIN_THROTTLING_STORE:memory}
+    require-redis: ${SECURITY_LOGIN_THROTTLING_REQUIRE_REDIS:false}
     ip:
       max-attempts: ${SECURITY_LOGIN_THROTTLING_IP_MAX_ATTEMPTS:20}
       window-seconds: ${SECURITY_LOGIN_THROTTLING_IP_WINDOW_SECONDS:60}

--- a/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/LoginThrottlingConfigurationTest.java
@@ -74,6 +74,39 @@ class LoginThrottlingConfigurationTest {
   }
 
   @Test
+  void failsFastWhenRedisIsRequiredButMemoryStoreIsSelected() {
+    contextRunner
+        .withPropertyValues("security.login-throttling.require-redis=true")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .isInstanceOf(org.springframework.beans.factory.BeanCreationException.class)
+                  .hasRootCauseInstanceOf(IllegalStateException.class)
+                  .hasRootCauseMessage(
+                      "security.login-throttling.require-redis=true requires "
+                          + "security.login-throttling.store=redis");
+            });
+  }
+
+  @Test
+  void createsRedisStoreWhenRedisIsRequiredAndTemplateIsPresent() {
+    contextRunner
+        .withPropertyValues(
+            "security.login-throttling.require-redis=true", "security.login-throttling.store=redis")
+        .withBean(
+            org.springframework.data.redis.core.StringRedisTemplate.class,
+            () -> mock(org.springframework.data.redis.core.StringRedisTemplate.class))
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).hasSingleBean(LoginThrottleStore.class);
+              assertThat(context.getBean(LoginThrottleStore.class))
+                  .isInstanceOf(RedisLoginThrottleStore.class);
+            });
+  }
+
+  @Test
   void rejectsBlankRedisKeyPrefix() {
     contextRunner
         .withPropertyValues(

--- a/back/src/test/java/com/aquilabank/global/security/RedisLoginThrottleRuntimeSmokeTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/RedisLoginThrottleRuntimeSmokeTest.java
@@ -18,6 +18,7 @@ class RedisLoginThrottleRuntimeSmokeTest {
           new LoginThrottlingProperties.ScopeProperties(2, 1),
           new LoginThrottlingProperties.ScopeProperties(4, 1),
           LoginThrottlingProperties.StoreType.REDIS,
+          false,
           new LoginThrottlingProperties.RedisProperties(redisKeyPrefix()));
 
   private final StringRedisTemplate stringRedisTemplate = createTemplate();

--- a/back/src/test/java/com/aquilabank/global/security/RedisLoginThrottleStoreIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/RedisLoginThrottleStoreIntegrationTest.java
@@ -37,6 +37,7 @@ class RedisLoginThrottleStoreIntegrationTest {
           new LoginThrottlingProperties.ScopeProperties(2, 2),
           new LoginThrottlingProperties.ScopeProperties(4, 2),
           LoginThrottlingProperties.StoreType.REDIS,
+          false,
           new LoginThrottlingProperties.RedisProperties("auth:login:throttle:"));
 
   private StringRedisTemplate stringRedisTemplate;
@@ -102,6 +103,7 @@ class RedisLoginThrottleStoreIntegrationTest {
             new LoginThrottlingProperties.ScopeProperties(2, 60),
             new LoginThrottlingProperties.ScopeProperties(10, 60),
             LoginThrottlingProperties.StoreType.REDIS,
+            false,
             new LoginThrottlingProperties.RedisProperties("auth:login:sliding:"));
     RedisLoginThrottleStore store =
         new RedisLoginThrottleStore(slidingWindowProperties, stringRedisTemplate, clock);
@@ -129,6 +131,7 @@ class RedisLoginThrottleStoreIntegrationTest {
             new LoginThrottlingProperties.ScopeProperties(2, 60),
             new LoginThrottlingProperties.ScopeProperties(10, 60),
             LoginThrottlingProperties.StoreType.REDIS,
+            false,
             new LoginThrottlingProperties.RedisProperties("auth:login:concurrent-ip:"));
 
     List<LoginThrottleStore.ThrottleDecision> decisions =
@@ -154,6 +157,7 @@ class RedisLoginThrottleStoreIntegrationTest {
             new LoginThrottlingProperties.ScopeProperties(10, 60),
             new LoginThrottlingProperties.ScopeProperties(4, 60),
             LoginThrottlingProperties.StoreType.REDIS,
+            false,
             new LoginThrottlingProperties.RedisProperties("auth:login:concurrent-global:"));
 
     List<LoginThrottleStore.ThrottleDecision> decisions =


### PR DESCRIPTION
## 🔗 Related Issue
- close #313

## 🌿 Base Branch
- `main`

## 📝 Summary
- multi-node auth throttling 운영에서 memory store로 조용히 fallback 되는 설정 위험을 startup guard로 차단합니다.
- `SECURITY_LOGIN_THROTTLING_REQUIRE_REDIS` 운영값과 Redis-backed counter 기준을 문서화합니다.

## 🛠 Changes
- `security.login-throttling.require-redis` 설정 추가
- `require-redis=true`와 `store!=redis` 조합은 Spring context startup 단계에서 실패 처리
- Redis store 직접 생성 테스트의 record 생성자 업데이트
- multi-node Redis throttling baseline과 smoke 검증 경로 문서화

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh multinode-auth-throttling-red ./back/gradlew -p back test --tests com.aquilabank.global.config.LoginThrottlingConfigurationTest`
- `tools/test/with-resource-lock.sh multinode-auth-throttling ./back/gradlew -p back test --tests com.aquilabank.global.config.LoginThrottlingConfigurationTest --tests com.aquilabank.global.security.LoginThrottlingMetricsRecorderTest`
- `tools/test/with-resource-lock.sh multinode-auth-throttling-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 운영에서 `SECURITY_LOGIN_THROTTLING_REQUIRE_REDIS=true`만 켜고 `SECURITY_LOGIN_THROTTLING_STORE=redis`를 누락하면 의도적으로 부팅 실패
- 롤백 방법: `SECURITY_LOGIN_THROTTLING_REQUIRE_REDIS=false`로 되돌리거나 commit revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
