### PR TITLE
[Chore] provider delivery metric과 skip reason audit/state 분리 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -328,6 +328,9 @@ set +a
   - `aquila_command_idempotency_conflict_count_total{reason_code="DIFFERENT_REQUEST|IN_PROGRESS|STATE_MISSING|ALREADY_REVERSED|AMOUNT_EXCEEDED|OTHER"}`
   - `aquila_command_idempotency_recovery_recovered_count_total`
   - `aquila_command_idempotency_cleanup_deleted_count_total`
+  - `aquila_provider_delivery_status_count{queue="notification_channel|password_recovery",status="sent|skipped|failed|quarantined"}`
+  - `aquila_provider_delivery_skip_reason_count{queue="notification_channel|password_recovery",reason="..."}`
+  - `aquila_provider_delivery_retry_backlog_count{queue="notification_channel|password_recovery"}`
   - `aquila_t3micro_saturation_guard_query_timeouts_total`
   - `aquila_transaction_query_latency_seconds`
   - `aquila_transaction_read_replica_lag_ms`
@@ -346,6 +349,7 @@ set +a
   - command idempotency summary gauge는 ops summary를 5초 cache로 재사용해 stale/failed/cleanup candidate 숫자를 export 합니다.
   - command idempotency conflict counter는 transfer/reversal conflict를 `reason_code` 축으로만 누적합니다.
   - command idempotency recovery/cleanup counter는 stale recovery row 수, retention cleanup delete row 수를 누적합니다.
+  - provider delivery gauge는 notification/password recovery delivery table의 sent/skipped/failed/quarantined/retry backlog row 수와 skip reason을 5초 cache로 export 합니다.
   - t3.micro query timeout counter는 backend query timeout exception이 발생하면 증가합니다.
   - Hikari pool metric은 Spring Boot/Micrometer 기본 binder와 `aquila-bank-pool` pool tag 기준으로 export 됩니다.
   - Postgres exporter `pg_stat_statements_*`는 `pg_stat_statements` extension과 collector 활성화가 필요합니다.
@@ -369,6 +373,7 @@ set +a
   - `amount_first`, `amount_cursor`, `mixed_first`, `mixed_cursor`: `180ms`
 - 운영 메모:
   - outbox/notification gauge는 scrape 한 번에 같은 summary를 여러 번 다시 조회하지 않게 `5초` cache 안에서 재사용합니다.
+  - provider delivery metric label은 `queue`, `status`, `reason`만 사용하고, `userId`, `requestId`, `eventKey`, destination은 table/log drill-down에서만 확인합니다.
   - SSE session metric은 현재 app instance 메모리의 active session 수만 보여주므로 multi-instance 전체 합계는 Prometheus 쿼리에서 합산합니다.
   - auth throttling reject metric label은 `entry_point`, `scope`, `store`만 사용하고, IP, `requestId`, `userId`, `path`는 structured log에서만 확인합니다.
   - `AquilaAuthThrottlingRejectBurstDetected` alert는 brute-force/abuse 징후 investigation 시작점입니다. 같은 시간대 `auth login throttled`, `auth password recovery throttled` log와 Nginx auth edge `429` 추이를 같이 봅니다.
@@ -392,6 +397,7 @@ set +a
   - refresh token reuse alert rollback은 `AquilaRefreshTokenReuseDetected` rule 제거 또는 notification routing 비활성화로 수행하고, refresh API 응답 계약은 그대로 유지합니다.
   - admission/t3 guard alert rollback은 `AquilaApiAdmissionRejectBurstDetected`, `AquilaT3MicroSaturationRejectDetected` rule 제거 또는 threshold/`for` 시간 조정으로 수행합니다.
   - command idempotency metric rollback은 `CommandIdempotencyPrometheusMetrics` wiring 제거와 recovery/cleanup/conflict recorder 호출 제거로 수행합니다.
+  - provider delivery metric rollback은 `ProviderDeliveryPrometheusMetrics` wiring 제거로 제한하며 delivery outbox 상태 전이는 유지합니다.
   - histogram bucket/alert rollback은 `management.metrics.distribution.*.aquila.transaction.query.latency`와 `AquilaTransactionQueryLatencyP95SloHigh` rule 제거로 수행합니다.
   - DB saturation alert rollback은 `ops/prometheus/rules/aquila-bank-alerts.yml`의 `aquila-bank-postgres` group 제거 또는 threshold/`for` 시간 조정으로 수행합니다.
   - baseline 자산은 `ops/prometheus/` 아래에 두고 dashboard import, alert rule apply, tuning 가이드는 `ops/prometheus/README.md`를 기준으로 봅니다.
@@ -569,7 +575,7 @@ tools/test/run-production-t3micro-capacity-smoke.sh
   - `SMS` channel: `contact_channel='SMS'`의 `provider_destination`
 - `bank_user_verified_contact`는 `user_id + contact_channel` unique 기준이며, migration 시 active user의 email/E.164 `login_id`만 초기 verified contact로 backfill 합니다.
 - 내부 운영 경로는 `GET|PUT|DELETE /internal/api/v1/auth/users/{userId}/verified-contacts[/{$contactChannel}]`이고 `internal:auth-admin` scope가 필요합니다.
-- verified contact lookup miss, inactive user, channel URL 누락은 잘못된 외부 발송 대신 fail-safe skip 처리하고 row는 `SENT`로 정리합니다.
+- verified contact lookup miss, inactive user, channel URL 누락은 잘못된 외부 발송 대신 fail-safe skip 처리하고 row는 `SKIPPED`와 `skip_reason`으로 정리합니다.
 - webhook timeout, 4xx/5xx, network error 같은 실제 provider 장애만 예외로 전파돼 기존 bounded retry/backoff/quarantine 흐름으로 들어갑니다.
 - webhook 요청 공통 header는 `NOTIFICATION_CHANNEL_PROVIDER_DELIVERY_AUTH_HEADER_NAME`, `NOTIFICATION_CHANNEL_PROVIDER_DELIVERY_AUTH_HEADER_VALUE`로 주입합니다.
 - timeout은 `NOTIFICATION_CHANNEL_PROVIDER_DELIVERY_CONNECT_TIMEOUT_MS`, `NOTIFICATION_CHANNEL_PROVIDER_DELIVERY_READ_TIMEOUT_MS`로 조정합니다.
@@ -599,7 +605,7 @@ tools/test/with-resource-lock.sh back-notification-provider-smoke \
 - smoke fixture는 local webhook server에서 `EMAIL=202 Accepted`, `SMS=delayed response`를 주입합니다.
 - smoke 기대값은 `EMAIL -> SENT`, `SMS -> FAILED + nextAttemptAt=base+5s` 입니다.
 - smoke가 실패하면 channel URL, timeout env, worker retry base delay drift를 먼저 확인합니다.
-- skip가 늘면 verified contact 누락, inactive user, channel URL 오구성을 먼저 확인합니다.
+- skip가 늘면 `aquila_provider_delivery_skip_reason_count`의 reason별 증가와 verified contact 누락, inactive user, channel URL 오구성을 먼저 확인합니다.
 - retry가 늘면 provider timeout과 응답 코드, `last_error`, `available_at` backoff 증가를 같이 봅니다.
 
 ### Nginx Reverse Proxy Baseline
@@ -822,12 +828,12 @@ login 실패/잠금은 structured log 한 줄로 남습니다.
   - `AUTH_PASSWORD_RECOVERY_DELIVERY_ENABLED=true`이고 provider URL이 없으면 logging adapter가 requestId/userId/expiresAt metadata만 기록하고 token 원문은 기록하지 않는다.
   - `AUTH_PASSWORD_RECOVERY_DELIVERY_ENABLED=true`이고
     `AUTH_PASSWORD_RECOVERY_DELIVERY_EMAIL_URL` 또는 `AUTH_PASSWORD_RECOVERY_DELIVERY_SMS_URL`가 있으면 webhook adapter가 JSON payload를 실제 provider endpoint로 `POST` 한다.
-  - 해당 channel URL이 비어 있으면 잘못된 대상 전송 대신 delivery를 skip 하고 token 발급 결과는 유지한다.
+  - 해당 channel URL이 비어 있으면 잘못된 대상 전송 대신 delivery를 `SKIPPED`와 `skip_reason=PROVIDER_URL_MISSING`으로 정리하고 token 발급 결과는 유지한다.
   - webhook 요청 공통 header는 `AUTH_PASSWORD_RECOVERY_DELIVERY_AUTH_HEADER_NAME`, `AUTH_PASSWORD_RECOVERY_DELIVERY_AUTH_HEADER_VALUE`로 주입하고, `AUTH_PASSWORD_RECOVERY_DELIVERY_IDEMPOTENCY_HEADER_NAME` header에는 항상 `requestId`를 넣는다.
   - timeout은 `AUTH_PASSWORD_RECOVERY_DELIVERY_CONNECT_TIMEOUT_MS`, `AUTH_PASSWORD_RECOVERY_DELIVERY_READ_TIMEOUT_MS`로 조정하고, worker retry는 `AUTH_PASSWORD_RECOVERY_DELIVERY_WORKER_*` 설정으로 제어한다.
   - webhook payload는 `channel`, `requestId`, `userId`, `destination`, `recoveryToken`, `expiresAt`, `issuedAt` 필드를 포함한다.
   - worker는 작은 batch로 due row를 claim 하고 bounded exponential backoff 뒤 재시도하며, `AUTH_PASSWORD_RECOVERY_DELIVERY_WORKER_MAX_RETRY_ATTEMPTS` 도달 시 `QUARANTINED`로 격리한다.
-  - 이미 `USED|EXPIRED|SUPERSEDED` 된 token 또는 내부 조회에서 사라진 token은 provider로 보내지 않고 queue에서 skip 완료 처리한다.
+  - 이미 `USED|EXPIRED|SUPERSEDED` 된 token 또는 내부 조회에서 사라진 token은 provider로 보내지 않고 `SKIPPED`와 token 계열 `skip_reason`으로 정리한다.
   - `POST /api/v1/auth/password-recovery/confirm`
   - 인증 없이 `recoveryToken`, `newPassword`를 받고 성공 시 `204 No Content`
   - wrong/expired/used token, `user_status != ACTIVE`는 모두 `401 password recovery failed`

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryDeliveryResult.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryDeliveryResult.java
@@ -1,0 +1,28 @@
+package com.aquilabank.domain.auth.model;
+
+/** password recovery provider 결과를 실제 발송 성공과 fail-safe skip으로 분리합니다. */
+public record PasswordRecoveryDeliveryResult(
+    boolean success, PasswordRecoveryDeliverySkipReason skipReason) {
+
+  public PasswordRecoveryDeliveryResult {
+    if (success && skipReason != null) {
+      throw new IllegalArgumentException("sent result must not have skipReason");
+    }
+    if (!success && skipReason == null) {
+      throw new IllegalArgumentException("skipped result requires skipReason");
+    }
+  }
+
+  public boolean sent() {
+    return success;
+  }
+
+  public static PasswordRecoveryDeliveryResult delivered() {
+    return new PasswordRecoveryDeliveryResult(true, null);
+  }
+
+  public static PasswordRecoveryDeliveryResult skipped(
+      PasswordRecoveryDeliverySkipReason skipReason) {
+    return new PasswordRecoveryDeliveryResult(false, skipReason);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryDeliverySkipReason.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryDeliverySkipReason.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.auth.model;
+
+/** provider 미호출 완료 사유를 password recovery delivery 성공과 분리합니다. */
+public enum PasswordRecoveryDeliverySkipReason {
+  TOKEN_MISSING,
+  TOKEN_NOT_PENDING,
+  TOKEN_EXPIRED,
+  PROVIDER_URL_MISSING
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryDeliveryStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/model/PasswordRecoveryDeliveryStatus.java
@@ -5,6 +5,7 @@ public enum PasswordRecoveryDeliveryStatus {
   PENDING,
   SENDING,
   SENT,
+  SKIPPED,
   FAILED,
   QUARANTINED
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryDeliveryOutboxDispatchPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryDeliveryOutboxDispatchPort.java
@@ -1,6 +1,7 @@
 package com.aquilabank.domain.auth.port;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryOutboxItem;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliverySkipReason;
 import java.time.Instant;
 import java.util.List;
 
@@ -10,6 +11,8 @@ public interface PasswordRecoveryDeliveryOutboxDispatchPort {
   List<PasswordRecoveryDeliveryOutboxItem> claimPending(int limit, Instant now);
 
   void markSent(long id, Instant sentAt);
+
+  void markSkipped(long id, Instant skippedAt, PasswordRecoveryDeliverySkipReason skipReason);
 
   void markFailed(long id, Instant nextAttemptAt, Instant failedAt, String errorMessage);
 

--- a/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryDeliveryPort.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/port/PasswordRecoveryDeliveryPort.java
@@ -1,9 +1,10 @@
 package com.aquilabank.domain.auth.port;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryResult;
 
 /** password recovery token 전달 책임을 domain 밖 adapter로 분리합니다. */
 public interface PasswordRecoveryDeliveryPort {
 
-  void deliver(PasswordRecoveryDeliveryCommand command);
+  PasswordRecoveryDeliveryResult deliver(PasswordRecoveryDeliveryCommand command);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryDeliveryWorkerService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryDeliveryWorkerService.java
@@ -2,6 +2,8 @@ package com.aquilabank.domain.auth.usecase;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryOutboxItem;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryResult;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliverySkipReason;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenQueryRecord;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenStatus;
 import com.aquilabank.domain.auth.port.PasswordRecoveryDeliveryOutboxDispatchPort;
@@ -74,27 +76,33 @@ public final class PasswordRecoveryDeliveryWorkerService
   private void dispatchSingle(PasswordRecoveryDeliveryOutboxItem item, Instant now) {
     PasswordRecoveryTokenQueryRecord tokenRecord =
         tokenQueryPort.findByRequestId(item.requestId()).orElse(null);
-    if (tokenRecord == null
-        || tokenRecord.tokenStatus() != PasswordRecoveryTokenStatus.PENDING
-        || !tokenRecord.expiresAt().isAfter(now)) {
-      // 이미 사용/만료/정리된 token은 더 이상 provider로 보낼 의미가 없어 skip 완료 처리합니다.
-      dispatchPort.markSent(item.id(), now);
+    PasswordRecoveryDeliverySkipReason tokenSkipReason = tokenSkipReason(tokenRecord, now);
+    if (tokenSkipReason != null) {
+      // 이미 사용/만료/정리된 token은 provider 미호출 완료 사유로 남깁니다.
+      dispatchPort.markSkipped(item.id(), now, tokenSkipReason);
       return;
     }
 
     String recoveryToken =
         secretPort.reveal(tokenRecord.tokenCiphertext(), tokenRecord.tokenNonce());
     try {
-      deliveryPort.deliver(
-          new PasswordRecoveryDeliveryCommand(
-              item.requestId(),
-              item.userId(),
-              item.deliveryChannel(),
-              item.providerDestination(),
-              recoveryToken,
-              tokenRecord.expiresAt(),
-              tokenRecord.createdAt()));
-      dispatchPort.markSent(item.id(), now);
+      PasswordRecoveryDeliveryResult result =
+          Objects.requireNonNull(
+              deliveryPort.deliver(
+                  new PasswordRecoveryDeliveryCommand(
+                      item.requestId(),
+                      item.userId(),
+                      item.deliveryChannel(),
+                      item.providerDestination(),
+                      recoveryToken,
+                      tokenRecord.expiresAt(),
+                      tokenRecord.createdAt())),
+              "password recovery delivery result");
+      if (result.sent()) {
+        dispatchPort.markSent(item.id(), now);
+        return;
+      }
+      dispatchPort.markSkipped(item.id(), now, result.skipReason());
     } catch (RuntimeException ex) {
       String errorMessage = shorten(ex.getMessage());
       if (item.retryCount() + 1 >= maxRetryAttempts) {
@@ -104,6 +112,20 @@ public final class PasswordRecoveryDeliveryWorkerService
       Instant nextAttemptAt = now.plus(computeBackoff(item.retryCount()));
       dispatchPort.markFailed(item.id(), nextAttemptAt, now, errorMessage);
     }
+  }
+
+  private PasswordRecoveryDeliverySkipReason tokenSkipReason(
+      PasswordRecoveryTokenQueryRecord tokenRecord, Instant now) {
+    if (tokenRecord == null) {
+      return PasswordRecoveryDeliverySkipReason.TOKEN_MISSING;
+    }
+    if (tokenRecord.tokenStatus() != PasswordRecoveryTokenStatus.PENDING) {
+      return PasswordRecoveryDeliverySkipReason.TOKEN_NOT_PENDING;
+    }
+    if (!tokenRecord.expiresAt().isAfter(now)) {
+      return PasswordRecoveryDeliverySkipReason.TOKEN_EXPIRED;
+    }
+    return null;
   }
 
   private Duration computeBackoff(int retryCount) {

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliveryResult.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliveryResult.java
@@ -1,0 +1,28 @@
+package com.aquilabank.domain.notification.model;
+
+/** provider 호출 결과를 실제 발송 성공과 fail-safe skip으로 분리합니다. */
+public record NotificationChannelDeliveryResult(
+    boolean success, NotificationChannelDeliverySkipReason skipReason) {
+
+  public NotificationChannelDeliveryResult {
+    if (success && skipReason != null) {
+      throw new IllegalArgumentException("sent result must not have skipReason");
+    }
+    if (!success && skipReason == null) {
+      throw new IllegalArgumentException("skipped result requires skipReason");
+    }
+  }
+
+  public boolean sent() {
+    return success;
+  }
+
+  public static NotificationChannelDeliveryResult delivered() {
+    return new NotificationChannelDeliveryResult(true, null);
+  }
+
+  public static NotificationChannelDeliveryResult skipped(
+      NotificationChannelDeliverySkipReason skipReason) {
+    return new NotificationChannelDeliveryResult(false, skipReason);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliverySkipReason.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliverySkipReason.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.notification.model;
+
+/** provider 미호출 완료 사유를 SENT 상태와 분리해 운영자가 바로 구분합니다. */
+public enum NotificationChannelDeliverySkipReason {
+  VERIFIED_CONTACT_MISSING,
+  PROVIDER_URL_MISSING
+}

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliveryStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliveryStatus.java
@@ -4,6 +4,7 @@ public enum NotificationChannelDeliveryStatus {
   PENDING,
   SENDING,
   SENT,
+  SKIPPED,
   FAILED,
   QUARANTINED
 }

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationChannelOutboxDispatchPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationChannelOutboxDispatchPort.java
@@ -1,5 +1,6 @@
 package com.aquilabank.domain.notification.port;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
 import java.time.Instant;
 import java.util.List;
@@ -10,6 +11,8 @@ public interface NotificationChannelOutboxDispatchPort {
   List<NotificationChannelOutboxItem> claimPending(int limit, Instant now);
 
   void markSent(long id, Instant sentAt);
+
+  void markSkipped(long id, Instant skippedAt, NotificationChannelDeliverySkipReason skipReason);
 
   void markFailed(long id, Instant nextAttemptAt, Instant failedAt, String errorMessage);
 

--- a/back/src/main/java/com/aquilabank/domain/notification/port/NotificationChannelProviderPort.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/port/NotificationChannelProviderPort.java
@@ -1,9 +1,10 @@
 package com.aquilabank.domain.notification.port;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryResult;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
 
 /** EMAIL/SMS provider adapter가 구현하는 외부 발송 port */
 public interface NotificationChannelProviderPort {
 
-  void send(NotificationChannelOutboxItem item);
+  NotificationChannelDeliveryResult send(NotificationChannelOutboxItem item);
 }

--- a/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationChannelProviderWorkerService.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/usecase/NotificationChannelProviderWorkerService.java
@@ -1,5 +1,6 @@
 package com.aquilabank.domain.notification.usecase;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryResult;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
 import com.aquilabank.domain.notification.port.NotificationChannelOutboxDispatchPort;
 import com.aquilabank.domain.notification.port.NotificationChannelProviderPort;
@@ -72,8 +73,13 @@ public final class NotificationChannelProviderWorkerService
 
   private void dispatchSingle(NotificationChannelOutboxItem item, Instant now) {
     try {
-      providerPort.send(item);
-      dispatchPort.markSent(item.id(), now);
+      NotificationChannelDeliveryResult result =
+          Objects.requireNonNull(providerPort.send(item), "provider delivery result");
+      if (result.sent()) {
+        dispatchPort.markSent(item.id(), now);
+        return;
+      }
+      dispatchPort.markSkipped(item.id(), now, result.skipReason());
     } catch (RuntimeException ex) {
       String errorMessage = shorten(ex.getMessage());
       if (item.retryCount() + 1 >= maxRetryAttempts) {

--- a/back/src/main/java/com/aquilabank/global/auth/LoggingPasswordRecoveryDeliveryAdapter.java
+++ b/back/src/main/java/com/aquilabank/global/auth/LoggingPasswordRecoveryDeliveryAdapter.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.auth;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryResult;
 import com.aquilabank.domain.auth.port.PasswordRecoveryDeliveryPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,11 +13,12 @@ public final class LoggingPasswordRecoveryDeliveryAdapter implements PasswordRec
       LoggerFactory.getLogger(LoggingPasswordRecoveryDeliveryAdapter.class);
 
   @Override
-  public void deliver(PasswordRecoveryDeliveryCommand command) {
+  public PasswordRecoveryDeliveryResult deliver(PasswordRecoveryDeliveryCommand command) {
     log.info(
         "password recovery delivery requested requestId={} userId={} expiresAt={}",
         command.requestId(),
         command.userId(),
         command.expiresAt());
+    return PasswordRecoveryDeliveryResult.delivered();
   }
 }

--- a/back/src/main/java/com/aquilabank/global/auth/NoOpPasswordRecoveryDeliveryAdapter.java
+++ b/back/src/main/java/com/aquilabank/global/auth/NoOpPasswordRecoveryDeliveryAdapter.java
@@ -1,13 +1,15 @@
 package com.aquilabank.global.auth;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryResult;
 import com.aquilabank.domain.auth.port.PasswordRecoveryDeliveryPort;
 
 /** 외부 전달 채널이 없을 때 token을 노출하지 않는 기본 adapter입니다. */
 public final class NoOpPasswordRecoveryDeliveryAdapter implements PasswordRecoveryDeliveryPort {
 
   @Override
-  public void deliver(PasswordRecoveryDeliveryCommand command) {
+  public PasswordRecoveryDeliveryResult deliver(PasswordRecoveryDeliveryCommand command) {
     // 기본 경로는 외부 provider 없이 token 저장/confirm 계약만 유지합니다.
+    return PasswordRecoveryDeliveryResult.delivered();
   }
 }

--- a/back/src/main/java/com/aquilabank/global/auth/WebhookPasswordRecoveryDeliveryAdapter.java
+++ b/back/src/main/java/com/aquilabank/global/auth/WebhookPasswordRecoveryDeliveryAdapter.java
@@ -1,6 +1,8 @@
 package com.aquilabank.global.auth;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryResult;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliverySkipReason;
 import com.aquilabank.domain.auth.model.VerifiedContactChannel;
 import com.aquilabank.domain.auth.port.PasswordRecoveryDeliveryPort;
 import com.aquilabank.global.config.PasswordRecoveryDeliveryProperties;
@@ -26,7 +28,7 @@ public final class WebhookPasswordRecoveryDeliveryAdapter implements PasswordRec
   }
 
   @Override
-  public void deliver(PasswordRecoveryDeliveryCommand command) {
+  public PasswordRecoveryDeliveryResult deliver(PasswordRecoveryDeliveryCommand command) {
     String url = targetUrl(command.deliveryChannel());
     if (!StringUtils.hasText(url)) {
       log.warn(
@@ -34,7 +36,8 @@ public final class WebhookPasswordRecoveryDeliveryAdapter implements PasswordRec
           command.requestId(),
           command.userId(),
           command.deliveryChannel());
-      return;
+      return PasswordRecoveryDeliveryResult.skipped(
+          PasswordRecoveryDeliverySkipReason.PROVIDER_URL_MISSING);
     }
 
     RestClient.RequestBodySpec requestSpec =
@@ -62,6 +65,7 @@ public final class WebhookPasswordRecoveryDeliveryAdapter implements PasswordRec
         command.userId(),
         command.deliveryChannel(),
         command.expiresAt());
+    return PasswordRecoveryDeliveryResult.delivered();
   }
 
   private String targetUrl(VerifiedContactChannel channel) {

--- a/back/src/main/java/com/aquilabank/global/notification/LoggingNotificationChannelProvider.java
+++ b/back/src/main/java/com/aquilabank/global/notification/LoggingNotificationChannelProvider.java
@@ -1,5 +1,6 @@
 package com.aquilabank.global.notification;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryResult;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
 import com.aquilabank.domain.notification.port.NotificationChannelProviderPort;
 import org.slf4j.Logger;
@@ -12,7 +13,7 @@ public class LoggingNotificationChannelProvider implements NotificationChannelPr
       LoggerFactory.getLogger(LoggingNotificationChannelProvider.class);
 
   @Override
-  public void send(NotificationChannelOutboxItem item) {
+  public NotificationChannelDeliveryResult send(NotificationChannelOutboxItem item) {
     // 외부 secret 없이 worker 상태 전이와 idempotency key 로그 형태를 먼저 검증합니다.
     log.info(
         "sending notification channel delivery. id={}, channel={}, key={}, eventType={}",
@@ -20,5 +21,6 @@ public class LoggingNotificationChannelProvider implements NotificationChannelPr
         item.channel(),
         item.eventKey(),
         item.eventType());
+    return NotificationChannelDeliveryResult.delivered();
   }
 }

--- a/back/src/main/java/com/aquilabank/global/notification/ProviderDeliveryPrometheusMetrics.java
+++ b/back/src/main/java/com/aquilabank/global/notification/ProviderDeliveryPrometheusMetrics.java
@@ -1,0 +1,213 @@
+package com.aquilabank.global.notification;
+
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliverySkipReason;
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/** provider delivery 상태 gauge는 scrape 한 번에 같은 DB snapshot을 재사용합니다. */
+@Component
+public final class ProviderDeliveryPrometheusMetrics implements MeterBinder {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(ProviderDeliveryPrometheusMetrics.class);
+  private static final Duration SNAPSHOT_TTL = Duration.ofSeconds(5);
+  private static final List<String> STATUSES = List.of("sent", "skipped", "failed", "quarantined");
+  private static final List<String> NOTIFICATION_REASONS =
+      java.util.Arrays.stream(NotificationChannelDeliverySkipReason.values())
+          .map(Enum::name)
+          .toList();
+  private static final List<String> PASSWORD_RECOVERY_REASONS =
+      java.util.Arrays.stream(PasswordRecoveryDeliverySkipReason.values()).map(Enum::name).toList();
+  private static final ProviderDeliverySummary EMPTY_SUMMARY =
+      new ProviderDeliverySummary(Map.of(), Map.of(), Map.of());
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private volatile CachedSummary cachedSummary = new CachedSummary(EMPTY_SUMMARY, Instant.EPOCH);
+
+  public ProviderDeliveryPrometheusMetrics(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    for (ProviderDeliveryQueue queue : ProviderDeliveryQueue.values()) {
+      for (String status : STATUSES) {
+        Gauge.builder(
+                "aquila.provider.delivery.status.count",
+                this,
+                metrics -> metrics.currentSummary().statusCount(queue.metricName(), status))
+            .tag("queue", queue.metricName())
+            .tag("status", status)
+            .description("provider delivery row count by queue and status")
+            .register(registry);
+      }
+      Gauge.builder(
+              "aquila.provider.delivery.retry.backlog.count",
+              this,
+              metrics -> metrics.currentSummary().retryBacklogCount(queue.metricName()))
+          .tag("queue", queue.metricName())
+          .description("provider delivery PENDING or FAILED retry backlog row count")
+          .register(registry);
+      for (String reason : queue.skipReasons()) {
+        Gauge.builder(
+                "aquila.provider.delivery.skip.reason.count",
+                this,
+                metrics -> metrics.currentSummary().skipReasonCount(queue.metricName(), reason))
+            .tag("queue", queue.metricName())
+            .tag("reason", reason)
+            .description("provider delivery skipped row count by queue and reason")
+            .register(registry);
+      }
+    }
+  }
+
+  private ProviderDeliverySummary currentSummary() {
+    Instant now = Instant.now();
+    CachedSummary current = cachedSummary;
+    if (current.expiresAt().isAfter(now)) {
+      return current.summary();
+    }
+    synchronized (this) {
+      CachedSummary refreshed = cachedSummary;
+      if (refreshed.expiresAt().isAfter(now)) {
+        return refreshed.summary();
+      }
+      try {
+        ProviderDeliverySummary summary = loadSummary();
+        cachedSummary = new CachedSummary(summary, now.plus(SNAPSHOT_TTL));
+        return summary;
+      } catch (RuntimeException ex) {
+        log.debug("provider delivery prometheus metric refresh failed", ex);
+        return refreshed.summary();
+      }
+    }
+  }
+
+  private ProviderDeliverySummary loadSummary() {
+    Map<MetricKey, Long> statusCounts = new HashMap<>();
+    Map<MetricKey, Long> skipReasonCounts = new HashMap<>();
+    Map<String, Long> retryBacklogCounts = new HashMap<>();
+    for (ProviderDeliveryQueue queue : ProviderDeliveryQueue.values()) {
+      loadStatusCounts(queue, statusCounts);
+      loadSkipReasonCounts(queue, skipReasonCounts);
+      retryBacklogCounts.put(queue.metricName(), loadRetryBacklogCount(queue));
+    }
+    return new ProviderDeliverySummary(statusCounts, skipReasonCounts, retryBacklogCounts);
+  }
+
+  private void loadStatusCounts(ProviderDeliveryQueue queue, Map<MetricKey, Long> target) {
+    List<Map<String, Object>> rows =
+        jdbcTemplate.queryForList(
+            """
+            SELECT LOWER(delivery_status) AS metric_name,
+                   COUNT(*) AS metric_count
+            FROM %s
+            WHERE delivery_status IN ('SENT', 'SKIPPED', 'FAILED', 'QUARANTINED')
+            GROUP BY delivery_status
+            """
+                .formatted(queue.tableName()),
+            new MapSqlParameterSource());
+    for (Map<String, Object> row : rows) {
+      target.put(
+          new MetricKey(queue.metricName(), (String) row.get("metric_name")),
+          ((Number) row.get("metric_count")).longValue());
+    }
+  }
+
+  private void loadSkipReasonCounts(ProviderDeliveryQueue queue, Map<MetricKey, Long> target) {
+    List<Map<String, Object>> rows =
+        jdbcTemplate.queryForList(
+            """
+            SELECT skip_reason AS metric_name,
+                   COUNT(*) AS metric_count
+            FROM %s
+            WHERE delivery_status = 'SKIPPED'
+              AND skip_reason IS NOT NULL
+            GROUP BY skip_reason
+            """
+                .formatted(queue.tableName()),
+            new MapSqlParameterSource());
+    for (Map<String, Object> row : rows) {
+      target.put(
+          new MetricKey(queue.metricName(), (String) row.get("metric_name")),
+          ((Number) row.get("metric_count")).longValue());
+    }
+  }
+
+  private long loadRetryBacklogCount(ProviderDeliveryQueue queue) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM %s
+            WHERE delivery_status IN ('PENDING', 'FAILED')
+            """
+                .formatted(queue.tableName()),
+            new MapSqlParameterSource(),
+            Long.class);
+    return count == null ? 0L : count;
+  }
+
+  private record CachedSummary(ProviderDeliverySummary summary, Instant expiresAt) {}
+
+  private record ProviderDeliverySummary(
+      Map<MetricKey, Long> statusCounts,
+      Map<MetricKey, Long> skipReasonCounts,
+      Map<String, Long> retryBacklogCounts) {
+
+    private long statusCount(String queue, String status) {
+      return statusCounts.getOrDefault(new MetricKey(queue, status), 0L);
+    }
+
+    private long skipReasonCount(String queue, String reason) {
+      return skipReasonCounts.getOrDefault(new MetricKey(queue, reason), 0L);
+    }
+
+    private long retryBacklogCount(String queue) {
+      return retryBacklogCounts.getOrDefault(queue, 0L);
+    }
+  }
+
+  private record MetricKey(String queue, String name) {}
+
+  private enum ProviderDeliveryQueue {
+    NOTIFICATION_CHANNEL(
+        "notification_channel", "notification_channel_outbox", NOTIFICATION_REASONS),
+    PASSWORD_RECOVERY(
+        "password_recovery", "auth_password_recovery_delivery_outbox", PASSWORD_RECOVERY_REASONS);
+
+    private final String metricName;
+    private final String tableName;
+    private final List<String> skipReasons;
+
+    ProviderDeliveryQueue(String metricName, String tableName, List<String> skipReasons) {
+      this.metricName = metricName;
+      this.tableName = tableName;
+      this.skipReasons = skipReasons;
+    }
+
+    private String metricName() {
+      return metricName;
+    }
+
+    private String tableName() {
+      return tableName;
+    }
+
+    private List<String> skipReasons() {
+      return skipReasons;
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/notification/WebhookNotificationChannelProvider.java
+++ b/back/src/main/java/com/aquilabank/global/notification/WebhookNotificationChannelProvider.java
@@ -1,5 +1,7 @@
 package com.aquilabank.global.notification;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryResult;
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
 import com.aquilabank.domain.notification.model.NotificationPreferenceChannel;
 import com.aquilabank.domain.notification.port.NotificationChannelProviderPort;
@@ -36,7 +38,7 @@ public final class WebhookNotificationChannelProvider implements NotificationCha
   }
 
   @Override
-  public void send(NotificationChannelOutboxItem item) {
+  public NotificationChannelDeliveryResult send(NotificationChannelOutboxItem item) {
     String destination =
         recipientLookupPort.findProviderDestination(item.userId(), item.channel()).orElse(null);
     if (!StringUtils.hasText(destination)) {
@@ -45,7 +47,8 @@ public final class WebhookNotificationChannelProvider implements NotificationCha
           item.id(),
           item.userId(),
           item.channel());
-      return;
+      return NotificationChannelDeliveryResult.skipped(
+          NotificationChannelDeliverySkipReason.VERIFIED_CONTACT_MISSING);
     }
 
     String url = targetUrl(item.channel());
@@ -55,7 +58,8 @@ public final class WebhookNotificationChannelProvider implements NotificationCha
           item.id(),
           item.userId(),
           item.channel());
-      return;
+      return NotificationChannelDeliveryResult.skipped(
+          NotificationChannelDeliverySkipReason.PROVIDER_URL_MISSING);
     }
 
     RestClient.RequestBodySpec requestSpec =
@@ -84,6 +88,7 @@ public final class WebhookNotificationChannelProvider implements NotificationCha
         item.userId(),
         item.channel(),
         item.eventKey());
+    return NotificationChannelDeliveryResult.delivered();
   }
 
   private String targetUrl(NotificationPreferenceChannel channel) {

--- a/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcPasswordRecoveryDeliveryOutboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/auth/JdbcPasswordRecoveryDeliveryOutboxRepository.java
@@ -2,6 +2,7 @@ package com.aquilabank.global.persistence.auth;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryOutboxEntry;
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryOutboxItem;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliverySkipReason;
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryStatus;
 import com.aquilabank.domain.auth.model.VerifiedContactChannel;
 import com.aquilabank.domain.auth.port.PasswordRecoveryDeliveryOutboxAppendPort;
@@ -125,11 +126,38 @@ public class JdbcPasswordRecoveryDeliveryOutboxRepository
         SET delivery_status = 'SENT',
             sent_at = :sentAt,
             last_error = NULL,
+            skip_reason = NULL,
             updated_at = :sentAt
         WHERE id = :id
           AND delivery_status = 'SENDING'
         """,
         new MapSqlParameterSource().addValue("id", id).addValue("sentAt", Timestamp.from(sentAt)));
+  }
+
+  @Override
+  public void markSkipped(
+      long id, Instant skippedAt, PasswordRecoveryDeliverySkipReason skipReason) {
+    if (skippedAt == null) {
+      throw new IllegalArgumentException("skippedAt must not be null");
+    }
+    if (skipReason == null) {
+      throw new IllegalArgumentException("skipReason must not be null");
+    }
+    jdbcTemplate.update(
+        """
+        UPDATE auth_password_recovery_delivery_outbox
+        SET delivery_status = 'SKIPPED',
+            sent_at = NULL,
+            last_error = NULL,
+            skip_reason = :skipReason,
+            updated_at = :skippedAt
+        WHERE id = :id
+          AND delivery_status = 'SENDING'
+        """,
+        new MapSqlParameterSource()
+            .addValue("id", id)
+            .addValue("skippedAt", Timestamp.from(skippedAt))
+            .addValue("skipReason", skipReason.name()));
   }
 
   @Override
@@ -141,6 +169,7 @@ public class JdbcPasswordRecoveryDeliveryOutboxRepository
             available_at = :nextAttemptAt,
             retry_count = retry_count + 1,
             last_error = :lastError,
+            skip_reason = NULL,
             updated_at = :failedAt
         WHERE id = :id
           AND delivery_status = 'SENDING'
@@ -160,6 +189,7 @@ public class JdbcPasswordRecoveryDeliveryOutboxRepository
         SET delivery_status = 'QUARANTINED',
             retry_count = retry_count + 1,
             last_error = :lastError,
+            skip_reason = NULL,
             updated_at = :quarantinedAt
         WHERE id = :id
           AND delivery_status = 'SENDING'

--- a/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationChannelOutboxRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/notification/JdbcNotificationChannelOutboxRepository.java
@@ -1,5 +1,6 @@
 package com.aquilabank.global.persistence.notification;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
 import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxEntry;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
@@ -124,11 +125,39 @@ public class JdbcNotificationChannelOutboxRepository
         SET delivery_status = 'SENT',
             sent_at = :sentAt,
             last_error = NULL,
+            skip_reason = NULL,
             updated_at = :sentAt
         WHERE id = :id
           AND delivery_status = 'SENDING'
         """,
         new MapSqlParameterSource().addValue("id", id).addValue("sentAt", Timestamp.from(sentAt)));
+  }
+
+  @Override
+  @Transactional
+  public void markSkipped(
+      long id, Instant skippedAt, NotificationChannelDeliverySkipReason skipReason) {
+    if (skippedAt == null) {
+      throw new IllegalArgumentException("skippedAt must not be null");
+    }
+    if (skipReason == null) {
+      throw new IllegalArgumentException("skipReason must not be null");
+    }
+    jdbcTemplate.update(
+        """
+        UPDATE notification_channel_outbox
+        SET delivery_status = 'SKIPPED',
+            sent_at = NULL,
+            last_error = NULL,
+            skip_reason = :skipReason,
+            updated_at = :skippedAt
+        WHERE id = :id
+          AND delivery_status = 'SENDING'
+        """,
+        new MapSqlParameterSource()
+            .addValue("id", id)
+            .addValue("skippedAt", Timestamp.from(skippedAt))
+            .addValue("skipReason", skipReason.name()));
   }
 
   @Override
@@ -147,6 +176,7 @@ public class JdbcNotificationChannelOutboxRepository
             available_at = :nextAttemptAt,
             retry_count = retry_count + 1,
             last_error = :lastError,
+            skip_reason = NULL,
             updated_at = :failedAt
         WHERE id = :id
           AND delivery_status = 'SENDING'
@@ -170,6 +200,7 @@ public class JdbcNotificationChannelOutboxRepository
         SET delivery_status = 'QUARANTINED',
             retry_count = retry_count + 1,
             last_error = :lastError,
+            skip_reason = NULL,
             updated_at = :quarantinedAt
         WHERE id = :id
           AND delivery_status = 'SENDING'
@@ -238,6 +269,7 @@ public class JdbcNotificationChannelOutboxRepository
             available_at = :requestedAt,
             sent_at = NULL,
             last_error = NULL,
+            skip_reason = NULL,
             updated_at = :requestedAt
         WHERE id = :id
           AND delivery_status = 'QUARANTINED'
@@ -275,6 +307,16 @@ public class JdbcNotificationChannelOutboxRepository
                         WHERE delivery_status = 'SENT'
                           AND sent_at < :cutoff
                         ORDER BY sent_at ASC, id ASC
+                        LIMIT :limit
+                    )
+                    UNION ALL
+                    (
+                        SELECT id,
+                               updated_at AS finished_at
+                        FROM notification_channel_outbox
+                        WHERE delivery_status = 'SKIPPED'
+                          AND updated_at < :cutoff
+                        ORDER BY updated_at ASC, id ASC
                         LIMIT :limit
                     )
                     UNION ALL

--- a/back/src/main/resources/db/migration/V49__add_provider_delivery_skip_state.sql
+++ b/back/src/main/resources/db/migration/V49__add_provider_delivery_skip_state.sql
@@ -1,0 +1,53 @@
+ALTER TABLE notification_channel_outbox
+    ADD COLUMN skip_reason VARCHAR(64);
+
+ALTER TABLE notification_channel_outbox
+    DROP CONSTRAINT chk_notification_channel_outbox_status;
+
+ALTER TABLE notification_channel_outbox
+    ADD CONSTRAINT chk_notification_channel_outbox_status
+        CHECK (delivery_status IN ('PENDING', 'SENDING', 'SENT', 'SKIPPED', 'FAILED', 'QUARANTINED')),
+    ADD CONSTRAINT chk_notification_channel_outbox_skip_reason
+        CHECK (skip_reason IS NULL OR BTRIM(skip_reason) <> ''),
+    ADD CONSTRAINT chk_notification_channel_outbox_skip_state
+        CHECK ((delivery_status = 'SKIPPED') = (skip_reason IS NOT NULL));
+
+CREATE INDEX idx_notification_channel_outbox_skipped_cleanup
+    ON notification_channel_outbox (updated_at, id)
+    WHERE delivery_status = 'SKIPPED';
+
+COMMENT ON COLUMN notification_channel_outbox.skip_reason IS
+    'provider 미호출 완료 사유입니다. SKIPPED 상태에서만 값이 있으며 SENT와 운영상 분리합니다.';
+
+COMMENT ON CONSTRAINT chk_notification_channel_outbox_skip_state ON notification_channel_outbox IS
+    'SKIPPED row만 skip_reason을 가져 실제 발송 성공과 fail-safe skip을 분리합니다.';
+
+COMMENT ON INDEX idx_notification_channel_outbox_skipped_cleanup IS
+    '오래된 SKIPPED channel delivery row를 updated_at 기준 작은 batch로 삭제할 때 사용하는 cleanup index입니다.';
+
+ALTER TABLE auth_password_recovery_delivery_outbox
+    ADD COLUMN skip_reason VARCHAR(64);
+
+ALTER TABLE auth_password_recovery_delivery_outbox
+    DROP CONSTRAINT chk_auth_password_recovery_delivery_outbox_status;
+
+ALTER TABLE auth_password_recovery_delivery_outbox
+    ADD CONSTRAINT chk_auth_password_recovery_delivery_outbox_status
+        CHECK (delivery_status IN ('PENDING', 'SENDING', 'SENT', 'SKIPPED', 'FAILED', 'QUARANTINED')),
+    ADD CONSTRAINT chk_auth_password_recovery_delivery_skip_reason
+        CHECK (skip_reason IS NULL OR BTRIM(skip_reason) <> ''),
+    ADD CONSTRAINT chk_auth_password_recovery_delivery_skip_state
+        CHECK ((delivery_status = 'SKIPPED') = (skip_reason IS NOT NULL));
+
+CREATE INDEX idx_auth_password_recovery_delivery_skipped_cleanup
+    ON auth_password_recovery_delivery_outbox (updated_at, id)
+    WHERE delivery_status = 'SKIPPED';
+
+COMMENT ON COLUMN auth_password_recovery_delivery_outbox.skip_reason IS
+    'password recovery provider 미호출 완료 사유입니다. SKIPPED 상태에서만 값이 있으며 SENT와 운영상 분리합니다.';
+
+COMMENT ON CONSTRAINT chk_auth_password_recovery_delivery_skip_state ON auth_password_recovery_delivery_outbox IS
+    'SKIPPED row만 skip_reason을 가져 실제 발송 성공과 fail-safe skip을 분리합니다.';
+
+COMMENT ON INDEX idx_auth_password_recovery_delivery_skipped_cleanup IS
+    '오래된 SKIPPED password recovery delivery row를 updated_at 기준 작은 batch로 삭제할 때 사용하는 cleanup index입니다.';

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryDeliveryWorkerServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/PasswordRecoveryDeliveryWorkerServiceTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.when;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryOutboxItem;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryResult;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliverySkipReason;
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryStatus;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenQueryRecord;
 import com.aquilabank.domain.auth.model.PasswordRecoveryTokenStatus;
@@ -65,6 +67,7 @@ class PasswordRecoveryDeliveryWorkerServiceTest {
     when(tokenQueryPort.findByRequestId("request-1"))
         .thenReturn(Optional.of(activeToken("request-1")));
     when(secretPort.reveal("cipher-1", "nonce-1")).thenReturn("plain-token-1");
+    when(deliveryPort.deliver(any())).thenReturn(PasswordRecoveryDeliveryResult.delivered());
 
     int claimed = service.dispatchDueDeliveries();
 
@@ -83,7 +86,7 @@ class PasswordRecoveryDeliveryWorkerServiceTest {
   }
 
   @Test
-  void skipsMissingTokenAndMarksSentWithoutProviderCall() {
+  void skipsMissingTokenWithReasonWithoutProviderCall() {
     PasswordRecoveryDeliveryOutboxItem item = item(2L, "request-2", 0);
     when(dispatchPort.claimPending(10, NOW)).thenReturn(List.of(item));
     when(tokenQueryPort.findByRequestId("request-2")).thenReturn(Optional.empty());
@@ -91,12 +94,13 @@ class PasswordRecoveryDeliveryWorkerServiceTest {
     service.dispatchDueDeliveries();
 
     verify(deliveryPort, never()).deliver(any());
-    verify(dispatchPort).markSent(2L, NOW);
+    verify(dispatchPort).markSkipped(2L, NOW, PasswordRecoveryDeliverySkipReason.TOKEN_MISSING);
+    verify(dispatchPort, never()).markSent(2L, NOW);
     verify(secretPort, never()).reveal(any(), any());
   }
 
   @Test
-  void skipsExpiredOrUsedTokenAndMarksSentWithoutProviderCall() {
+  void skipsUsedTokenWithNotPendingReasonWithoutProviderCall() {
     PasswordRecoveryDeliveryOutboxItem item = item(3L, "request-3", 0);
     when(dispatchPort.claimPending(10, NOW)).thenReturn(List.of(item));
     when(tokenQueryPort.findByRequestId("request-3"))
@@ -116,8 +120,54 @@ class PasswordRecoveryDeliveryWorkerServiceTest {
     service.dispatchDueDeliveries();
 
     verify(deliveryPort, never()).deliver(any());
-    verify(dispatchPort).markSent(3L, NOW);
+    verify(dispatchPort).markSkipped(3L, NOW, PasswordRecoveryDeliverySkipReason.TOKEN_NOT_PENDING);
+    verify(dispatchPort, never()).markSent(3L, NOW);
     verify(secretPort, never()).reveal(any(), any());
+  }
+
+  @Test
+  void skipsExpiredTokenWithExpiredReasonWithoutProviderCall() {
+    PasswordRecoveryDeliveryOutboxItem item = item(6L, "request-6", 0);
+    when(dispatchPort.claimPending(10, NOW)).thenReturn(List.of(item));
+    when(tokenQueryPort.findByRequestId("request-6"))
+        .thenReturn(
+            Optional.of(
+                new PasswordRecoveryTokenQueryRecord(
+                    "request-6",
+                    7L,
+                    "alice@example.com",
+                    "cipher-6",
+                    "nonce-6",
+                    PasswordRecoveryTokenStatus.PENDING,
+                    NOW.minusSeconds(1),
+                    null,
+                    NOW.minusSeconds(60))));
+
+    service.dispatchDueDeliveries();
+
+    verify(deliveryPort, never()).deliver(any());
+    verify(dispatchPort).markSkipped(6L, NOW, PasswordRecoveryDeliverySkipReason.TOKEN_EXPIRED);
+    verify(dispatchPort, never()).markSent(6L, NOW);
+    verify(secretPort, never()).reveal(any(), any());
+  }
+
+  @Test
+  void marksSkippedWhenProviderReturnsSkipResult() {
+    PasswordRecoveryDeliveryOutboxItem item = item(7L, "request-7", 0);
+    when(dispatchPort.claimPending(10, NOW)).thenReturn(List.of(item));
+    when(tokenQueryPort.findByRequestId("request-7"))
+        .thenReturn(Optional.of(activeToken("request-7")));
+    when(secretPort.reveal("cipher-1", "nonce-1")).thenReturn("plain-token-7");
+    when(deliveryPort.deliver(any()))
+        .thenReturn(
+            PasswordRecoveryDeliveryResult.skipped(
+                PasswordRecoveryDeliverySkipReason.PROVIDER_URL_MISSING));
+
+    service.dispatchDueDeliveries();
+
+    verify(dispatchPort)
+        .markSkipped(7L, NOW, PasswordRecoveryDeliverySkipReason.PROVIDER_URL_MISSING);
+    verify(dispatchPort, never()).markSent(7L, NOW);
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationChannelProviderWorkerServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/notification/usecase/NotificationChannelProviderWorkerServiceTest.java
@@ -1,6 +1,7 @@
 package com.aquilabank.domain.notification.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -8,6 +9,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryResult;
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
 import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
 import com.aquilabank.domain.notification.model.NotificationPreferenceCategory;
@@ -49,6 +52,7 @@ class NotificationChannelProviderWorkerServiceTest {
   void marksClaimedItemAsSentWhenProviderSucceeds() {
     NotificationChannelOutboxItem item = item(1L, 0);
     when(dispatchPort.claimPending(20, NOW)).thenReturn(List.of(item));
+    when(providerPort.send(item)).thenReturn(NotificationChannelDeliveryResult.delivered());
 
     int claimed = service.dispatchDueDeliveries();
 
@@ -57,6 +61,24 @@ class NotificationChannelProviderWorkerServiceTest {
     verify(dispatchPort).markSent(1L, NOW);
     verify(dispatchPort, never())
         .markFailed(eq(1L), eq(NOW.plusSeconds(5)), eq(NOW), eq("provider timeout"));
+  }
+
+  @Test
+  void marksClaimedItemAsSkippedWhenProviderSkipsDelivery() {
+    NotificationChannelOutboxItem item = item(6L, 0);
+    when(dispatchPort.claimPending(20, NOW)).thenReturn(List.of(item));
+    when(providerPort.send(item))
+        .thenReturn(
+            NotificationChannelDeliveryResult.skipped(
+                NotificationChannelDeliverySkipReason.PROVIDER_URL_MISSING));
+
+    int claimed = service.dispatchDueDeliveries();
+
+    assertThat(claimed).isEqualTo(1);
+    verify(dispatchPort)
+        .markSkipped(6L, NOW, NotificationChannelDeliverySkipReason.PROVIDER_URL_MISSING);
+    verify(dispatchPort, never()).markSent(6L, NOW);
+    verify(dispatchPort, never()).markFailed(eq(6L), any(), eq(NOW), any());
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/auth/LoggingPasswordRecoveryDeliveryAdapterTest.java
+++ b/back/src/test/java/com/aquilabank/global/auth/LoggingPasswordRecoveryDeliveryAdapterTest.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryResult;
 import com.aquilabank.domain.auth.model.VerifiedContactChannel;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
@@ -17,16 +18,18 @@ class LoggingPasswordRecoveryDeliveryAdapterTest {
   void logsDeliveryMetadataWithoutPlainRecoveryToken(CapturedOutput output) {
     LoggingPasswordRecoveryDeliveryAdapter adapter = new LoggingPasswordRecoveryDeliveryAdapter();
 
-    adapter.deliver(
-        new PasswordRecoveryDeliveryCommand(
-            "request-1",
-            7L,
-            VerifiedContactChannel.EMAIL,
-            "alice@example.com",
-            "plain-recovery-token",
-            Instant.parse("2026-04-22T00:15:00Z"),
-            Instant.parse("2026-04-22T00:00:00Z")));
+    PasswordRecoveryDeliveryResult result =
+        adapter.deliver(
+            new PasswordRecoveryDeliveryCommand(
+                "request-1",
+                7L,
+                VerifiedContactChannel.EMAIL,
+                "alice@example.com",
+                "plain-recovery-token",
+                Instant.parse("2026-04-22T00:15:00Z"),
+                Instant.parse("2026-04-22T00:00:00Z")));
 
+    assertThat(result.sent()).isTrue();
     assertThat(output).contains("request-1");
     assertThat(output).contains("userId=7");
     assertThat(output).doesNotContain("plain-recovery-token");

--- a/back/src/test/java/com/aquilabank/global/auth/WebhookPasswordRecoveryDeliveryAdapterTest.java
+++ b/back/src/test/java/com/aquilabank/global/auth/WebhookPasswordRecoveryDeliveryAdapterTest.java
@@ -1,6 +1,6 @@
 package com.aquilabank.global.auth;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
@@ -9,6 +9,8 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withAccepted;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryCommand;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryResult;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliverySkipReason;
 import com.aquilabank.domain.auth.model.VerifiedContactChannel;
 import com.aquilabank.global.config.PasswordRecoveryDeliveryProperties;
 import java.time.Instant;
@@ -39,8 +41,9 @@ class WebhookPasswordRecoveryDeliveryAdapterTest {
     WebhookPasswordRecoveryDeliveryAdapter adapter =
         new WebhookPasswordRecoveryDeliveryAdapter(builder.build(), properties());
 
-    adapter.deliver(emailCommand());
+    PasswordRecoveryDeliveryResult result = adapter.deliver(emailCommand());
 
+    assertThat(result.sent()).isTrue();
     server.verify();
   }
 
@@ -59,8 +62,9 @@ class WebhookPasswordRecoveryDeliveryAdapterTest {
     WebhookPasswordRecoveryDeliveryAdapter adapter =
         new WebhookPasswordRecoveryDeliveryAdapter(builder.build(), properties());
 
-    adapter.deliver(phoneCommand());
+    PasswordRecoveryDeliveryResult result = adapter.deliver(phoneCommand());
 
+    assertThat(result.sent()).isTrue();
     server.verify();
   }
 
@@ -82,19 +86,20 @@ class WebhookPasswordRecoveryDeliveryAdapterTest {
                 new PasswordRecoveryDeliveryProperties.ChannelProperties(
                     "https://sms-provider.example/recovery")));
 
-    assertThatCode(
-            () ->
-                adapter.deliver(
-                    new PasswordRecoveryDeliveryCommand(
-                        "request-3",
-                        9L,
-                        VerifiedContactChannel.EMAIL,
-                        "alice@example.com",
-                        "plain-recovery-token",
-                        Instant.parse("2026-04-22T00:15:00Z"),
-                        Instant.parse("2026-04-22T00:00:00Z"))))
-        .doesNotThrowAnyException();
+    PasswordRecoveryDeliveryResult result =
+        adapter.deliver(
+            new PasswordRecoveryDeliveryCommand(
+                "request-3",
+                9L,
+                VerifiedContactChannel.EMAIL,
+                "alice@example.com",
+                "plain-recovery-token",
+                Instant.parse("2026-04-22T00:15:00Z"),
+                Instant.parse("2026-04-22T00:00:00Z")));
 
+    assertThat(result.sent()).isFalse();
+    assertThat(result.skipReason())
+        .isEqualTo(PasswordRecoveryDeliverySkipReason.PROVIDER_URL_MISSING);
     server.verify();
   }
 

--- a/back/src/test/java/com/aquilabank/global/notification/NotificationChannelProviderDeliverySmokeTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/NotificationChannelProviderDeliverySmokeTest.java
@@ -2,6 +2,7 @@ package com.aquilabank.global.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
 import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
 import com.aquilabank.domain.notification.model.NotificationPreferenceCategory;
@@ -187,6 +188,12 @@ class NotificationChannelProviderDeliverySmokeTest {
     public void markSent(long id, Instant sentAt) {
       assertThat(sentAt).isEqualTo(expectedNow);
       sentIds.add(id);
+    }
+
+    @Override
+    public void markSkipped(
+        long id, Instant skippedAt, NotificationChannelDeliverySkipReason skipReason) {
+      throw new AssertionError("skip is not expected in smoke");
     }
 
     @Override

--- a/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/PrometheusMetricsIntegrationTest.java
@@ -93,6 +93,35 @@ class PrometheusMetricsIntegrationTest extends PostgresKafkaContainerTestSupport
               "invalid payload",
               base.minusSeconds(30),
               base.minusSeconds(5));
+          long providerUserId = insertProviderMetricUser("prometheus-provider@example.com", base);
+          long providerAccountId = insertProviderMetricAccount("prometheus provider account", base);
+          long notificationId =
+              insertProviderMetricNotification(
+                  providerAccountId, "evt-prometheus-provider-notification", base);
+          insertNotificationProviderDelivery(
+              notificationId,
+              providerUserId,
+              providerAccountId,
+              "evt-prometheus-provider-skipped",
+              "SKIPPED",
+              "VERIFIED_CONTACT_MISSING",
+              base);
+          insertNotificationProviderDelivery(
+              notificationId,
+              providerUserId,
+              providerAccountId,
+              "evt-prometheus-provider-failed",
+              "FAILED",
+              null,
+              base);
+          insertPasswordRecoveryProviderDelivery(
+              providerUserId,
+              "prometheus-provider-recovery-skipped",
+              "SKIPPED",
+              "PROVIDER_URL_MISSING",
+              base);
+          insertPasswordRecoveryProviderDelivery(
+              providerUserId, "prometheus-provider-recovery-pending", "PENDING", null, base);
         });
 
     SseEmitter emitter = notificationSseBroker.subscribeAccount(1L, "metrics");
@@ -140,6 +169,15 @@ class PrometheusMetricsIntegrationTest extends PostgresKafkaContainerTestSupport
       assertThat(body).containsPattern("aquila_outbox_failed_count\\s+1\\.0");
       assertThat(body).containsPattern("aquila_outbox_quarantined_count\\s+1\\.0");
       assertThat(body).containsPattern("aquila_outbox_failed_producer_timeout_count\\s+1\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_provider_delivery_status_count\\{(?=[^\\n]*queue=\"notification_channel\")(?=[^\\n]*status=\"skipped\")[^\\n]*\\}\\s+1\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_provider_delivery_skip_reason_count\\{(?=[^\\n]*queue=\"notification_channel\")(?=[^\\n]*reason=\"VERIFIED_CONTACT_MISSING\")[^\\n]*\\}\\s+1\\.0");
+      assertThat(body)
+          .containsPattern(
+              "aquila_provider_delivery_retry_backlog_count\\{[^\\n]*queue=\"password_recovery\"[^\\n]*\\}\\s+1\\.0");
       assertThat(body)
           .containsPattern(
               "aquila_notification_consumer_lag_count\\{[^\\n]*topic=\""
@@ -226,6 +264,163 @@ class PrometheusMetricsIntegrationTest extends PostgresKafkaContainerTestSupport
       throw new IllegalStateException("outbox_event insert did not return id");
     }
     return id;
+  }
+
+  private long insertProviderMetricUser(String loginId, Instant now) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_user (login_id, password_hash, display_name, user_status, created_at, updated_at)
+            VALUES (:loginId, 'encoded-password', :loginId, 'ACTIVE', :now, :now)
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("loginId", loginId)
+                .addValue("now", Timestamp.from(now)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("bank_user insert did not return id");
+    }
+    return id;
+  }
+
+  private long insertProviderMetricAccount(String displayName, Instant now) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                :now,
+                :now
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("displayName", displayName)
+                .addValue("now", Timestamp.from(now)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return id;
+  }
+
+  private long insertProviderMetricNotification(long accountId, String eventKey, Instant now) {
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO notification_inbox (account_id, event_key, event_type, title, message, created_at)
+            VALUES (:accountId, :eventKey, 'TransferBooked', 'provider metrics', 'provider metrics', :now)
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountId", accountId)
+                .addValue("eventKey", eventKey)
+                .addValue("now", Timestamp.from(now)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("notification_inbox insert did not return id");
+    }
+    return id;
+  }
+
+  private void insertNotificationProviderDelivery(
+      long notificationId,
+      long userId,
+      long accountId,
+      String eventKey,
+      String status,
+      String skipReason,
+      Instant now) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_channel_outbox (
+            notification_id,
+            user_id,
+            account_id,
+            category,
+            channel,
+            event_type,
+            event_key,
+            payload,
+            delivery_status,
+            available_at,
+            skip_reason,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :notificationId,
+            :userId,
+            :accountId,
+            'TRANSACTIONAL',
+            'EMAIL',
+            'TransferBooked',
+            :eventKey,
+            '{"kind":"prometheus"}'::jsonb,
+            :status,
+            :now,
+            :skipReason,
+            :now,
+            :now
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("notificationId", notificationId)
+            .addValue("userId", userId)
+            .addValue("accountId", accountId)
+            .addValue("eventKey", eventKey)
+            .addValue("status", status)
+            .addValue("skipReason", skipReason)
+            .addValue("now", Timestamp.from(now)));
+  }
+
+  private void insertPasswordRecoveryProviderDelivery(
+      long userId, String requestId, String status, String skipReason, Instant now) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO auth_password_recovery_delivery_outbox (
+            request_id,
+            user_id,
+            login_id,
+            delivery_channel,
+            provider_destination,
+            delivery_status,
+            available_at,
+            skip_reason,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :requestId,
+            :userId,
+            'prometheus-provider@example.com',
+            'EMAIL',
+            'prometheus-provider@example.com',
+            :status,
+            :now,
+            :skipReason,
+            :now,
+            :now
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("requestId", requestId)
+            .addValue("userId", userId)
+            .addValue("status", status)
+            .addValue("skipReason", skipReason)
+            .addValue("now", Timestamp.from(now)));
   }
 
   private ProducerRecord<String, String> dlqRecord(String eventKey) {

--- a/back/src/test/java/com/aquilabank/global/notification/ProviderDeliveryPrometheusMetricsTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/ProviderDeliveryPrometheusMetricsTest.java
@@ -1,0 +1,263 @@
+package com.aquilabank.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.support.PostgresContainerTestSupport;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class ProviderDeliveryPrometheusMetricsTest extends PostgresContainerTestSupport {
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @Autowired private MeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUpDatabase() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void exportsProviderDeliveryStatusSkipReasonAndRetryBacklogGauges() {
+    Instant now = Instant.parse("2026-04-24T01:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          long userId = insertUser("provider-metrics@example.com", now);
+          long accountId = insertAccount("provider metrics account", now);
+          long notificationId = insertNotification(accountId, "evt-provider-metrics", now);
+          insertNotificationDelivery(
+              notificationId, userId, accountId, "evt-provider-metrics-sent", "SENT", null, now);
+          insertNotificationDelivery(
+              notificationId,
+              userId,
+              accountId,
+              "evt-provider-metrics-skipped",
+              "SKIPPED",
+              "VERIFIED_CONTACT_MISSING",
+              now);
+          insertNotificationDelivery(
+              notificationId,
+              userId,
+              accountId,
+              "evt-provider-metrics-failed",
+              "FAILED",
+              null,
+              now);
+          insertNotificationDelivery(
+              notificationId,
+              userId,
+              accountId,
+              "evt-provider-metrics-pending",
+              "PENDING",
+              null,
+              now);
+          insertPasswordRecoveryDelivery(
+              userId, "provider-metrics-request-sent", "SENT", null, now);
+          insertPasswordRecoveryDelivery(
+              userId, "provider-metrics-request-skipped", "SKIPPED", "PROVIDER_URL_MISSING", now);
+          insertPasswordRecoveryDelivery(
+              userId, "provider-metrics-request-quarantined", "QUARANTINED", null, now);
+          insertPasswordRecoveryDelivery(
+              userId, "provider-metrics-request-failed", "FAILED", null, now);
+        });
+
+    assertThat(statusGauge("notification_channel", "sent")).isEqualTo(1.0);
+    assertThat(statusGauge("notification_channel", "skipped")).isEqualTo(1.0);
+    assertThat(statusGauge("notification_channel", "failed")).isEqualTo(1.0);
+    assertThat(skipReasonGauge("notification_channel", "VERIFIED_CONTACT_MISSING")).isEqualTo(1.0);
+    assertThat(retryBacklogGauge("notification_channel")).isEqualTo(2.0);
+    assertThat(statusGauge("password_recovery", "sent")).isEqualTo(1.0);
+    assertThat(statusGauge("password_recovery", "skipped")).isEqualTo(1.0);
+    assertThat(statusGauge("password_recovery", "quarantined")).isEqualTo(1.0);
+    assertThat(skipReasonGauge("password_recovery", "PROVIDER_URL_MISSING")).isEqualTo(1.0);
+    assertThat(retryBacklogGauge("password_recovery")).isEqualTo(1.0);
+  }
+
+  private double statusGauge(String queue, String status) {
+    return meterRegistry
+        .get("aquila.provider.delivery.status.count")
+        .tag("queue", queue)
+        .tag("status", status)
+        .gauge()
+        .value();
+  }
+
+  private double skipReasonGauge(String queue, String reason) {
+    return meterRegistry
+        .get("aquila.provider.delivery.skip.reason.count")
+        .tag("queue", queue)
+        .tag("reason", reason)
+        .gauge()
+        .value();
+  }
+
+  private double retryBacklogGauge(String queue) {
+    return meterRegistry
+        .get("aquila.provider.delivery.retry.backlog.count")
+        .tag("queue", queue)
+        .gauge()
+        .value();
+  }
+
+  private long insertUser(String loginId, Instant now) {
+    return jdbcTemplate.queryForObject(
+        """
+        INSERT INTO bank_user (login_id, password_hash, display_name, user_status, created_at, updated_at)
+        VALUES (:loginId, 'encoded-password', :loginId, 'ACTIVE', :now, :now)
+        RETURNING id
+        """,
+        new MapSqlParameterSource()
+            .addValue("loginId", loginId)
+            .addValue("now", Timestamp.from(now)),
+        Long.class);
+  }
+
+  private long insertAccount(String displayName, Instant now) {
+    return jdbcTemplate.queryForObject(
+        """
+        INSERT INTO bank_account (
+            account_number,
+            display_name,
+            account_status,
+            currency_code,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            '100' || LPAD(nextval('bank_account_number_seq')::text, 11, '0'),
+            :displayName,
+            'ACTIVE',
+            'KRW',
+            :now,
+            :now
+        )
+        RETURNING id
+        """,
+        new MapSqlParameterSource()
+            .addValue("displayName", displayName)
+            .addValue("now", Timestamp.from(now)),
+        Long.class);
+  }
+
+  private long insertNotification(long accountId, String eventKey, Instant now) {
+    return jdbcTemplate.queryForObject(
+        """
+        INSERT INTO notification_inbox (account_id, event_key, event_type, title, message, created_at)
+        VALUES (:accountId, :eventKey, 'TransferBooked', 'provider metrics', 'provider metrics', :now)
+        RETURNING id
+        """,
+        new MapSqlParameterSource()
+            .addValue("accountId", accountId)
+            .addValue("eventKey", eventKey)
+            .addValue("now", Timestamp.from(now)),
+        Long.class);
+  }
+
+  private void insertNotificationDelivery(
+      long notificationId,
+      long userId,
+      long accountId,
+      String eventKey,
+      String status,
+      String skipReason,
+      Instant now) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO notification_channel_outbox (
+            notification_id,
+            user_id,
+            account_id,
+            category,
+            channel,
+            event_type,
+            event_key,
+            payload,
+            delivery_status,
+            available_at,
+            sent_at,
+            skip_reason,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :notificationId,
+            :userId,
+            :accountId,
+            'TRANSACTIONAL',
+            'EMAIL',
+            'TransferBooked',
+            :eventKey,
+            '{"kind":"metrics"}'::jsonb,
+            :status,
+            :now,
+            :sentAt,
+            :skipReason,
+            :now,
+            :now
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("notificationId", notificationId)
+            .addValue("userId", userId)
+            .addValue("accountId", accountId)
+            .addValue("eventKey", eventKey)
+            .addValue("status", status)
+            .addValue("sentAt", "SENT".equals(status) ? Timestamp.from(now) : null)
+            .addValue("skipReason", skipReason)
+            .addValue("now", Timestamp.from(now)));
+  }
+
+  private void insertPasswordRecoveryDelivery(
+      long userId, String requestId, String status, String skipReason, Instant now) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO auth_password_recovery_delivery_outbox (
+            request_id,
+            user_id,
+            login_id,
+            delivery_channel,
+            provider_destination,
+            delivery_status,
+            available_at,
+            sent_at,
+            skip_reason,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :requestId,
+            :userId,
+            'provider-metrics@example.com',
+            'EMAIL',
+            'provider-metrics@example.com',
+            :status,
+            :now,
+            :sentAt,
+            :skipReason,
+            :now,
+            :now
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("requestId", requestId)
+            .addValue("userId", userId)
+            .addValue("status", status)
+            .addValue("sentAt", "SENT".equals(status) ? Timestamp.from(now) : null)
+            .addValue("skipReason", skipReason)
+            .addValue("now", Timestamp.from(now)));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/notification/WebhookNotificationChannelProviderTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/WebhookNotificationChannelProviderTest.java
@@ -1,6 +1,6 @@
 package com.aquilabank.global.notification;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
@@ -10,6 +10,8 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withAccepted;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryResult;
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
 import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
 import com.aquilabank.domain.notification.model.NotificationPreferenceCategory;
@@ -51,8 +53,9 @@ class WebhookNotificationChannelProviderTest {
             properties(),
             new ObjectMapper().findAndRegisterModules());
 
-    provider.send(emailItem());
+    NotificationChannelDeliveryResult result = provider.send(emailItem());
 
+    assertThat(result.sent()).isTrue();
     server.verify();
   }
 
@@ -76,8 +79,9 @@ class WebhookNotificationChannelProviderTest {
             properties(),
             new ObjectMapper().findAndRegisterModules());
 
-    provider.send(smsItem());
+    NotificationChannelDeliveryResult result = provider.send(smsItem());
 
+    assertThat(result.sent()).isTrue();
     server.verify();
   }
 
@@ -94,8 +98,11 @@ class WebhookNotificationChannelProviderTest {
             properties(),
             new ObjectMapper().findAndRegisterModules());
 
-    assertThatCode(() -> provider.send(emailItem())).doesNotThrowAnyException();
+    NotificationChannelDeliveryResult result = provider.send(emailItem());
 
+    assertThat(result.sent()).isFalse();
+    assertThat(result.skipReason())
+        .isEqualTo(NotificationChannelDeliverySkipReason.VERIFIED_CONTACT_MISSING);
     server.verify();
   }
 
@@ -120,8 +127,11 @@ class WebhookNotificationChannelProviderTest {
                     "https://sms-provider.example/notifications")),
             new ObjectMapper().findAndRegisterModules());
 
-    assertThatCode(() -> provider.send(emailItem())).doesNotThrowAnyException();
+    NotificationChannelDeliveryResult result = provider.send(emailItem());
 
+    assertThat(result.sent()).isFalse();
+    assertThat(result.skipReason())
+        .isEqualTo(NotificationChannelDeliverySkipReason.PROVIDER_URL_MISSING);
     server.verify();
   }
 

--- a/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcPasswordRecoveryDeliveryOutboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/auth/JdbcPasswordRecoveryDeliveryOutboxRepositoryIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryOutboxEntry;
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryOutboxItem;
+import com.aquilabank.domain.auth.model.PasswordRecoveryDeliverySkipReason;
 import com.aquilabank.domain.auth.model.PasswordRecoveryDeliveryStatus;
 import com.aquilabank.domain.auth.model.VerifiedContactChannel;
 import com.aquilabank.support.PostgresContainerTestSupport;
@@ -131,6 +132,33 @@ class JdbcPasswordRecoveryDeliveryOutboxRepositoryIntegrationTest
   }
 
   @Test
+  void marksRowsSkippedWithReasonAfterClaim() {
+    long userId = insertUser("skip@example.com");
+    Instant base = Instant.parse("2026-04-23T14:42:00Z");
+    repository.append(
+        new PasswordRecoveryDeliveryOutboxEntry(
+            "request-skip",
+            userId,
+            "skip@example.com",
+            VerifiedContactChannel.EMAIL,
+            "skip.recovery@example.com",
+            base.minusSeconds(5),
+            base));
+    PasswordRecoveryDeliveryOutboxItem claimed = repository.claimPending(1, base).getFirst();
+
+    repository.markSkipped(
+        claimed.id(), base.plusSeconds(1), PasswordRecoveryDeliverySkipReason.TOKEN_MISSING);
+
+    DeliveryRow row = findRow(claimed.id());
+    assertThat(row.deliveryStatus()).isEqualTo(PasswordRecoveryDeliveryStatus.SKIPPED);
+    assertThat(row.skipReason()).isEqualTo(PasswordRecoveryDeliverySkipReason.TOKEN_MISSING.name());
+    assertThat(row.sentAt()).isNull();
+    assertThat(row.lastError()).isNull();
+    assertThat(row.updatedAt()).isEqualTo(base.plusSeconds(1));
+    assertThat(repository.claimPending(10, base.plusSeconds(3600))).isEmpty();
+  }
+
+  @Test
   void rejectsDuplicateRequestIdByUniqueConstraint() {
     long userId = insertUser("duplicate@example.com");
     Instant base = Instant.parse("2026-04-23T14:45:00Z");
@@ -213,6 +241,7 @@ class JdbcPasswordRecoveryDeliveryOutboxRepositoryIntegrationTest
                sent_at,
                retry_count,
                last_error,
+               skip_reason,
                updated_at
         FROM auth_password_recovery_delivery_outbox
         WHERE id = :id
@@ -226,6 +255,7 @@ class JdbcPasswordRecoveryDeliveryOutboxRepositoryIntegrationTest
                 rs.getTimestamp("sent_at") == null ? null : rs.getTimestamp("sent_at").toInstant(),
                 rs.getInt("retry_count"),
                 rs.getString("last_error"),
+                rs.getString("skip_reason"),
                 rs.getTimestamp("updated_at").toInstant()));
   }
 
@@ -236,5 +266,6 @@ class JdbcPasswordRecoveryDeliveryOutboxRepositoryIntegrationTest
       Instant sentAt,
       int retryCount,
       String lastError,
+      String skipReason,
       Instant updatedAt) {}
 }

--- a/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationChannelOutboxRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/notification/JdbcNotificationChannelOutboxRepositoryIntegrationTest.java
@@ -2,6 +2,7 @@ package com.aquilabank.global.persistence.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
 import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxEntry;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
@@ -209,6 +210,55 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
   }
 
   @Test
+  void marksClaimedRowsAsSkippedWithReasonAndRemovesThemFromDueQueue() {
+    long[] userId = new long[1];
+    long[] accountId = new long[1];
+    long[] notificationId = new long[1];
+    Instant base = Instant.parse("2026-04-22T03:10:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          userId[0] = insertUser("channel-skip-user");
+          accountId[0] = insertAccount("channel skip account");
+          notificationId[0] =
+              insertNotification(
+                  accountId[0],
+                  "evt-channel-skip-email",
+                  "TransferBooked",
+                  "이체 완료",
+                  "1000 KRW 입금",
+                  base);
+        });
+    repository.appendAllIfAbsent(
+        List.of(
+            new NotificationChannelOutboxEntry(
+                notificationId[0],
+                userId[0],
+                accountId[0],
+                NotificationPreferenceCategory.TRANSACTIONAL,
+                NotificationPreferenceChannel.EMAIL,
+                "TransferBooked",
+                "evt-channel-skip-email",
+                "{\"kind\":\"transfer\",\"amount\":\"1000\"}",
+                base.minusSeconds(10),
+                base)));
+    NotificationChannelOutboxItem claimed = repository.claimPending(1, base).getFirst();
+    Instant skippedAt = base.plusSeconds(1);
+
+    repository.markSkipped(
+        claimed.id(), skippedAt, NotificationChannelDeliverySkipReason.VERIFIED_CONTACT_MISSING);
+
+    DeliveryRow row = findDeliveryRow(claimed.id());
+    assertThat(row.deliveryStatus()).isEqualTo(NotificationChannelDeliveryStatus.SKIPPED);
+    assertThat(row.skipReason())
+        .isEqualTo(NotificationChannelDeliverySkipReason.VERIFIED_CONTACT_MISSING.name());
+    assertThat(row.sentAt()).isNull();
+    assertThat(row.lastError()).isNull();
+    assertThat(row.updatedAt()).isEqualTo(skippedAt);
+    assertThat(repository.findPending(10, base.plusSeconds(3600))).isEmpty();
+  }
+
+  @Test
   void findsQuarantinedRowsInNewestFirstOrder() {
     long[] userId = new long[1];
     long[] accountId = new long[1];
@@ -353,7 +403,7 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
   }
 
   @Test
-  void deletesOnlyOldSentAndQuarantinedRowsWithinBatch() {
+  void deletesOnlyOldSentSkippedAndQuarantinedRowsWithinBatch() {
     long[] userId = new long[1];
     long[] accountId = new long[1];
     Instant base = Instant.parse("2026-04-22T04:00:00Z");
@@ -368,6 +418,7 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
         transactionManager,
         () -> {
           items.add(cleanupItem(userId[0], accountId[0], "evt-cleanup-old-sent", base));
+          items.add(cleanupItem(userId[0], accountId[0], "evt-cleanup-old-skipped", base));
           items.add(cleanupItem(userId[0], accountId[0], "evt-cleanup-old-quarantine", base));
           items.add(cleanupItem(userId[0], accountId[0], "evt-cleanup-recent-sent", base));
           items.add(cleanupItem(userId[0], accountId[0], "evt-cleanup-pending", base));
@@ -382,6 +433,14 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
           updateDeliveryState(
               "evt-cleanup-old-sent", NotificationChannelDeliveryStatus.SENT, oldTime, oldTime);
           updateDeliveryState(
+              "evt-cleanup-old-skipped",
+              NotificationChannelDeliveryStatus.SKIPPED,
+              null,
+              oldTime,
+              0,
+              null,
+              NotificationChannelDeliverySkipReason.PROVIDER_URL_MISSING.name());
+          updateDeliveryState(
               "evt-cleanup-old-quarantine",
               NotificationChannelDeliveryStatus.QUARANTINED,
               null,
@@ -395,9 +454,9 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
               "evt-cleanup-failed", NotificationChannelDeliveryStatus.FAILED, null, oldTime);
         });
 
-    int deleted = repository.deleteFinishedBefore(base.minusSeconds(30L * 24 * 60 * 60), 2);
+    int deleted = repository.deleteFinishedBefore(base.minusSeconds(30L * 24 * 60 * 60), 3);
 
-    assertThat(deleted).isEqualTo(2);
+    assertThat(deleted).isEqualTo(3);
     assertThat(findDeliveryEventKeys())
         .containsExactlyInAnyOrder(
             "evt-cleanup-recent-sent", "evt-cleanup-pending", "evt-cleanup-failed");
@@ -615,6 +674,17 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
       Instant updatedAt,
       int retryCount,
       String lastError) {
+    updateDeliveryState(eventKey, status, sentAt, updatedAt, retryCount, lastError, null);
+  }
+
+  private void updateDeliveryState(
+      String eventKey,
+      NotificationChannelDeliveryStatus status,
+      Instant sentAt,
+      Instant updatedAt,
+      int retryCount,
+      String lastError,
+      String skipReason) {
     jdbcTemplate.update(
         """
         UPDATE notification_channel_outbox
@@ -622,6 +692,7 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
             sent_at = :sentAt,
             retry_count = :retryCount,
             last_error = :lastError,
+            skip_reason = :skipReason,
             updated_at = :updatedAt
         WHERE event_key = :eventKey
         """,
@@ -631,6 +702,7 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
             .addValue("sentAt", sentAt == null ? null : Timestamp.from(sentAt))
             .addValue("retryCount", retryCount)
             .addValue("lastError", lastError)
+            .addValue("skipReason", skipReason)
             .addValue("updatedAt", Timestamp.from(updatedAt)));
   }
 
@@ -669,6 +741,7 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
                sent_at,
                retry_count,
                last_error,
+               skip_reason,
                updated_at
         FROM notification_channel_outbox
         WHERE id = :id
@@ -681,6 +754,7 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
                 nullableInstant(rs.getObject("sent_at", OffsetDateTime.class)),
                 rs.getInt("retry_count"),
                 rs.getString("last_error"),
+                rs.getString("skip_reason"),
                 rs.getObject("updated_at", OffsetDateTime.class).toInstant()));
   }
 
@@ -694,5 +768,6 @@ class JdbcNotificationChannelOutboxRepositoryIntegrationTest extends PostgresCon
       Instant sentAt,
       int retryCount,
       String lastError,
+      String skipReason,
       Instant updatedAt) {}
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #314

## 🌿 Base Branch
- `main`

## 📝 Summary
- notification/password recovery provider delivery에서 fail-safe skip을 `SENT`와 분리해 `SKIPPED + skip_reason`으로 저장합니다.
- provider delivery status, skip reason, retry backlog를 Prometheus gauge로 export합니다.

## 🛠 Changes
- `notification_channel_outbox`, `auth_password_recovery_delivery_outbox`에 `SKIPPED` 상태와 `skip_reason` audit column 추가
- provider port 결과를 `delivered/skipped(reason)` 계약으로 변경하고 worker 상태 전이를 분리
- `aquila_provider_delivery_status_count`, `aquila_provider_delivery_skip_reason_count`, `aquila_provider_delivery_retry_backlog_count` export
- provider delivery 운영 문서와 prometheus actuator integration 갱신

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh provider-delivery-persistence-red ./back/gradlew -p back test --tests com.aquilabank.global.persistence.notification.JdbcNotificationChannelOutboxRepositoryIntegrationTest --tests com.aquilabank.global.persistence.auth.JdbcPasswordRecoveryDeliveryOutboxRepositoryIntegrationTest`
- `tools/test/with-resource-lock.sh provider-delivery-worker-red ./back/gradlew -p back test --tests com.aquilabank.domain.notification.usecase.NotificationChannelProviderWorkerServiceTest --tests com.aquilabank.domain.auth.usecase.PasswordRecoveryDeliveryWorkerServiceTest --tests com.aquilabank.global.notification.WebhookNotificationChannelProviderTest --tests com.aquilabank.global.auth.WebhookPasswordRecoveryDeliveryAdapterTest --tests com.aquilabank.global.auth.LoggingPasswordRecoveryDeliveryAdapterTest`
- `tools/test/with-resource-lock.sh provider-delivery-metrics-red ./back/gradlew -p back test --tests com.aquilabank.global.notification.ProviderDeliveryPrometheusMetricsTest`
- `tools/test/with-resource-lock.sh provider-delivery-observability ./back/gradlew -p back test --tests com.aquilabank.domain.notification.usecase.NotificationChannelProviderWorkerServiceTest --tests com.aquilabank.domain.auth.usecase.PasswordRecoveryDeliveryWorkerServiceTest --tests com.aquilabank.global.persistence.notification.JdbcNotificationChannelOutboxRepositoryIntegrationTest --tests com.aquilabank.global.persistence.auth.JdbcPasswordRecoveryDeliveryOutboxRepositoryIntegrationTest --tests com.aquilabank.global.notification.ProviderDeliveryPrometheusMetricsTest --tests com.aquilabank.global.notification.PrometheusMetricsIntegrationTest`
- pre-commit backend gate: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 운영 쿼리가 `delivery_status='SENT'`만 완료로 보던 경우 `SKIPPED`를 별도 완료 상태로 반영해야 함
- 롤백 방법: PR revert. metric만 되돌릴 때는 `ProviderDeliveryPrometheusMetrics` wiring 제거로 제한 가능

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
