### PR TITLE
[Perf] transaction read replica staging failover/lag smoke 추가

### DIFF
--- a/.github/workflows/transaction-read-replica-staging-smoke.yml
+++ b/.github/workflows/transaction-read-replica-staging-smoke.yml
@@ -1,0 +1,89 @@
+name: Transaction Read Replica Staging Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      archive_account_id:
+        description: Archive account id with enough rows for replica smoke
+        required: true
+        type: string
+      archive_from:
+        description: Archive query from timestamp, ISO-8601
+        required: true
+        type: string
+      archive_to:
+        description: Archive query to timestamp, ISO-8601
+        required: true
+        type: string
+      page_limit:
+        description: API page limit, max 100
+        required: true
+        default: "20"
+        type: string
+      replica_lag_threshold_ms:
+        description: Maximum accepted replica replay lag in milliseconds
+        required: true
+        default: "3000"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: transaction-read-replica-staging-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Verify Transaction Read Replica Lag And Route
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v psql >/dev/null 2>&1; then
+            exit 0
+          fi
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Run transaction read replica staging smoke
+        env:
+          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+          STAGING_REPLAY_TOKEN: ${{ secrets.STAGING_REPLAY_TOKEN }}
+          STAGING_RDS_DATABASE_URL: ${{ secrets.STAGING_RDS_DATABASE_URL }}
+          STAGING_RDS_REPLICA_DATABASE_URL: ${{ secrets.STAGING_RDS_REPLICA_DATABASE_URL }}
+          TRANSACTION_ARCHIVE_ACCOUNT_ID: ${{ inputs.archive_account_id }}
+          TRANSACTION_ARCHIVE_FROM: ${{ inputs.archive_from }}
+          TRANSACTION_ARCHIVE_TO: ${{ inputs.archive_to }}
+          PAGE_LIMIT: ${{ inputs.page_limit }}
+          REPLICA_LAG_THRESHOLD_MS: ${{ inputs.replica_lag_threshold_ms }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools/ops/transaction-read-replica-staging-smoke.sh
+
+      - name: Append summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          summary_path="build/reports/transaction-read-replica-staging-smoke/summary.md"
+          if [ -f "${summary_path}" ]; then
+            cat "${summary_path}" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: transaction-read-replica-staging-smoke
+          path: build/reports/transaction-read-replica-staging-smoke/
+          if-no-files-found: ignore

--- a/tools/ops/transaction-read-replica-staging-smoke.sh
+++ b/tools/ops/transaction-read-replica-staging-smoke.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPORT_DIR="${REPORT_DIR:-build/reports/transaction-read-replica-staging-smoke}"
+SUMMARY_MD="${REPORT_DIR}/summary.md"
+
+STAGING_BASE_URL="${STAGING_BASE_URL:-}"
+STAGING_REPLAY_TOKEN="${STAGING_REPLAY_TOKEN:-}"
+STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-}"
+STAGING_RDS_REPLICA_DATABASE_URL="${STAGING_RDS_REPLICA_DATABASE_URL:-}"
+TRANSACTION_ARCHIVE_ACCOUNT_ID="${TRANSACTION_ARCHIVE_ACCOUNT_ID:-}"
+TRANSACTION_ARCHIVE_FROM="${TRANSACTION_ARCHIVE_FROM:-}"
+TRANSACTION_ARCHIVE_TO="${TRANSACTION_ARCHIVE_TO:-}"
+PAGE_LIMIT="${PAGE_LIMIT:-20}"
+REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-5}"
+REPLICA_LAG_THRESHOLD_MS="${REPLICA_LAG_THRESHOLD_MS:-3000}"
+ROUTE_METRIC_WAIT_SECONDS="${ROUTE_METRIC_WAIT_SECONDS:-10}"
+PROMETHEUS_PATH="${PROMETHEUS_PATH:-/actuator/prometheus}"
+STAGING_PROMETHEUS_BEARER_TOKEN="${STAGING_PROMETHEUS_BEARER_TOKEN:-}"
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+notice() {
+  echo "::notice::$*" >&2
+}
+
+print_plan() {
+  cat <<'PLAN'
+[transaction-read-replica-staging-smoke] required env:
+- STAGING_BASE_URL
+- STAGING_REPLAY_TOKEN
+- STAGING_RDS_DATABASE_URL
+- STAGING_RDS_REPLICA_DATABASE_URL
+- TRANSACTION_ARCHIVE_ACCOUNT_ID
+- TRANSACTION_ARCHIVE_FROM
+- TRANSACTION_ARCHIVE_TO
+[transaction-read-replica-staging-smoke] checks:
+- primary and replica database URLs must differ
+- replica database must report pg_is_in_recovery() = true
+- replica lag must be <= REPLICA_LAG_THRESHOLD_MS
+- archive read must increase aquila_transaction_read_replica_route_decisions_total{query_shape="archive",route="replica",reason="replica_healthy"}
+PLAN
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+require_env() {
+  local name="$1"
+  local value="${!name:-}"
+  [ -n "$value" ] || fail "Missing required environment variable: ${name}"
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="${!name:-}"
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "${name} must be a positive integer"
+}
+
+validate_inputs() {
+  require_command curl
+  require_command psql
+  require_command awk
+  require_command grep
+
+  require_env STAGING_BASE_URL
+  require_env STAGING_REPLAY_TOKEN
+  require_env STAGING_RDS_DATABASE_URL
+  require_env STAGING_RDS_REPLICA_DATABASE_URL
+  require_env TRANSACTION_ARCHIVE_ACCOUNT_ID
+  require_env TRANSACTION_ARCHIVE_FROM
+  require_env TRANSACTION_ARCHIVE_TO
+
+  require_positive_integer TRANSACTION_ARCHIVE_ACCOUNT_ID
+  require_positive_integer PAGE_LIMIT
+  require_positive_integer REQUEST_TIMEOUT_SECONDS
+  require_positive_integer REPLICA_LAG_THRESHOLD_MS
+  require_positive_integer ROUTE_METRIC_WAIT_SECONDS
+
+  if [ "$PAGE_LIMIT" -gt 100 ]; then
+    fail "PAGE_LIMIT must be 100 or less"
+  fi
+  if [ "$STAGING_RDS_DATABASE_URL" = "$STAGING_RDS_REPLICA_DATABASE_URL" ]; then
+    fail "STAGING_RDS_REPLICA_DATABASE_URL must differ from STAGING_RDS_DATABASE_URL"
+  fi
+
+  STAGING_BASE_URL="${STAGING_BASE_URL%/}"
+}
+
+psql_scalar() {
+  local database_url="$1"
+  local sql="$2"
+  psql "$database_url" -v ON_ERROR_STOP=1 --no-align --tuples-only --command "$sql"
+}
+
+measure_replica_lag() {
+  local result in_recovery lag_ms
+  # staging smoke는 실제 replica 연결을 검증해야 하므로 primary 호환 local shortcut은 허용하지 않습니다.
+  result="$(
+    psql_scalar "$STAGING_RDS_REPLICA_DATABASE_URL" \
+      "SELECT pg_is_in_recovery()::text || '|' ||
+              COALESCE(
+                FLOOR(EXTRACT(EPOCH FROM (clock_timestamp() - pg_last_xact_replay_timestamp())) * 1000)::bigint,
+                -1
+              )::text;"
+  )"
+  in_recovery="${result%%|*}"
+  lag_ms="${result#*|}"
+
+  [ "$in_recovery" = "true" ] || [ "$in_recovery" = "t" ] \
+    || fail "Configured replica database is not in recovery"
+  [[ "$lag_ms" =~ ^-?[0-9]+$ ]] || fail "Replica lag is not numeric: ${lag_ms}"
+  [ "$lag_ms" -ge 0 ] || fail "Replica lag is unknown"
+  if [ "$lag_ms" -gt "$REPLICA_LAG_THRESHOLD_MS" ]; then
+    fail "Replica lag ${lag_ms}ms exceeds threshold ${REPLICA_LAG_THRESHOLD_MS}ms"
+  fi
+
+  notice "Replica lag ${lag_ms}ms within threshold ${REPLICA_LAG_THRESHOLD_MS}ms"
+  printf '%s\n' "$lag_ms"
+}
+
+curl_prometheus() {
+  local args=(
+    --silent
+    --show-error
+    --max-time "$REQUEST_TIMEOUT_SECONDS"
+    "${STAGING_BASE_URL}${PROMETHEUS_PATH}"
+  )
+  if [ -n "$STAGING_PROMETHEUS_BEARER_TOKEN" ]; then
+    args+=(--header "Authorization: Bearer ${STAGING_PROMETHEUS_BEARER_TOKEN}")
+  fi
+  curl "${args[@]}"
+}
+
+archive_replica_decision_count() {
+  curl_prometheus |
+    awk '
+      /^aquila_transaction_read_replica_route_decisions_total\{/ &&
+      /query_shape="archive"/ &&
+      /route="replica"/ &&
+      /reason="replica_healthy"/ {
+        value = $NF
+      }
+      END {
+        if (value == "") {
+          print 0
+        } else {
+          print value
+        }
+      }'
+}
+
+request_archive_page() {
+  local response http_status
+  response="$(
+    curl \
+      --silent \
+      --show-error \
+      --output "${REPORT_DIR}/archive-response.json" \
+      --write-out "%{http_code} %{time_total}" \
+      --max-time "$REQUEST_TIMEOUT_SECONDS" \
+      --get "${STAGING_BASE_URL}/api/v1/transactions/archive" \
+      --header "Authorization: Bearer ${STAGING_REPLAY_TOKEN}" \
+      --data-urlencode "accountId=${TRANSACTION_ARCHIVE_ACCOUNT_ID}" \
+      --data-urlencode "from=${TRANSACTION_ARCHIVE_FROM}" \
+      --data-urlencode "to=${TRANSACTION_ARCHIVE_TO}" \
+      --data-urlencode "limit=${PAGE_LIMIT}"
+  )" || fail "archive read request failed"
+
+  http_status="${response%% *}"
+  if [[ ! "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+    fail "archive read returned HTTP ${http_status}"
+  fi
+}
+
+wait_for_replica_route_delta() {
+  local before="$1"
+  local after="$before"
+  local deadline=$((SECONDS + ROUTE_METRIC_WAIT_SECONDS))
+
+  while [ "$SECONDS" -le "$deadline" ]; do
+    after="$(archive_replica_decision_count)"
+    awk -v before="$before" -v after="$after" 'BEGIN { exit !(after > before) }' && {
+      notice "Archive replica route counter increased from ${before} to ${after}"
+      printf '%s\n' "$after"
+      return 0
+    }
+    sleep 1
+  done
+
+  fail "Archive replica route decision counter did not increase from ${before}"
+}
+
+write_summary() {
+  local lag_ms="$1"
+  local before="$2"
+  local after="$3"
+  {
+    echo "# Transaction Read Replica Staging Smoke"
+    echo
+    echo "- replica lag: ${lag_ms}ms / threshold ${REPLICA_LAG_THRESHOLD_MS}ms"
+    echo "- archive replica route counter: ${before} -> ${after}"
+    echo "- account id: ${TRANSACTION_ARCHIVE_ACCOUNT_ID}"
+    echo "- page limit: ${PAGE_LIMIT}"
+  } >"$SUMMARY_MD"
+}
+
+main() {
+  if [ "${1:-}" = "--print-plan" ]; then
+    print_plan
+    return 0
+  fi
+
+  mkdir -p "$REPORT_DIR"
+  validate_inputs
+
+  local lag_ms before after
+  lag_ms="$(measure_replica_lag)"
+  before="$(archive_replica_decision_count)"
+  request_archive_page
+  after="$(wait_for_replica_route_delta "$before")"
+  write_summary "$lag_ms" "$before" "$after"
+}
+
+main "$@"

--- a/tools/test/run-transaction-read-replica-lag-failover-smoke.sh
+++ b/tools/test/run-transaction-read-replica-lag-failover-smoke.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/ops/transaction-read-replica-staging-smoke.sh"
+workflow=".github/workflows/transaction-read-replica-staging-smoke.yml"
+
+echo "[transaction-read-replica-smoke] syntax: ${script}"
+bash -n "${script}"
+
+echo "[transaction-read-replica-smoke] workflow wiring"
+ruby -e "require 'yaml'; YAML.load_file('${workflow}'); puts 'ok'" >/dev/null
+
+echo "[transaction-read-replica-smoke] plan includes replica lag and route decision"
+plan="$("${script}" --print-plan)"
+grep -F "STAGING_RDS_DATABASE_URL" <<<"${plan}" >/dev/null
+grep -F "STAGING_RDS_REPLICA_DATABASE_URL" <<<"${plan}" >/dev/null
+grep -F "aquila_transaction_read_replica_route_decisions_total" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-replica-smoke] guard: missing env fails before psql"
+if "${script}" >/dev/null 2>&1; then
+  echo "missing env unexpectedly succeeded" >&2
+  exit 1
+fi
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+bin_dir="${temp_dir}/bin"
+mkdir -p "${bin_dir}"
+
+cat >"${bin_dir}/psql" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"replica-lag-high"* ]]; then
+  echo "true|6000"
+else
+  echo "true|25"
+fi
+EOF
+chmod +x "${bin_dir}/psql"
+
+cat >"${bin_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+is_prometheus=false
+is_archive=false
+output_file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    *"/actuator/prometheus"*) is_prometheus=true ;;
+    *"/api/v1/transactions/archive"*) is_archive=true ;;
+    --output)
+      shift
+      output_file="$1"
+      ;;
+  esac
+  shift || true
+done
+
+if [ "$is_prometheus" = true ]; then
+  current=0
+  if [ -f "${CURL_METRIC_COUNTER_PATH}" ]; then
+    current="$(cat "${CURL_METRIC_COUNTER_PATH}")"
+  fi
+  next=$((current + 1))
+  echo "${next}" >"${CURL_METRIC_COUNTER_PATH}"
+  cat <<METRIC
+aquila_transaction_read_replica_route_decisions_total{query_shape="archive",route="replica",reason="replica_healthy"} ${next}
+METRIC
+  exit 0
+fi
+
+if [ "$is_archive" = true ]; then
+  [ -n "$output_file" ] && echo '{"items":[{"id":1}]}' >"$output_file"
+  echo "200 0.001"
+  exit 0
+fi
+
+echo "unexpected curl call" >&2
+exit 1
+EOF
+chmod +x "${bin_dir}/curl"
+
+cat >"${bin_dir}/awk" <<'EOF'
+#!/usr/bin/env bash
+exec /usr/bin/awk "$@"
+EOF
+chmod +x "${bin_dir}/awk"
+
+cat >"${bin_dir}/grep" <<'EOF'
+#!/usr/bin/env bash
+exec /usr/bin/grep "$@"
+EOF
+chmod +x "${bin_dir}/grep"
+
+echo "[transaction-read-replica-smoke] stub: healthy replica increments route metric"
+PATH="${bin_dir}:${PATH}" \
+  CURL_METRIC_COUNTER_PATH="${temp_dir}/metric-counter" \
+  REPORT_DIR="${temp_dir}/report" \
+  STAGING_BASE_URL="https://staging.example.com" \
+  STAGING_REPLAY_TOKEN="token" \
+  STAGING_RDS_DATABASE_URL="postgres://primary" \
+  STAGING_RDS_REPLICA_DATABASE_URL="postgres://replica" \
+  TRANSACTION_ARCHIVE_ACCOUNT_ID="101" \
+  TRANSACTION_ARCHIVE_FROM="2026-03-01T00:00:00Z" \
+  TRANSACTION_ARCHIVE_TO="2026-03-31T00:00:00Z" \
+  ROUTE_METRIC_WAIT_SECONDS="1" \
+  "${script}"
+
+grep -F "archive replica route counter" "${temp_dir}/report/summary.md" >/dev/null
+
+echo "[transaction-read-replica-smoke] stub: lag breach fails before archive request"
+set +e
+output="$(
+  PATH="${bin_dir}:${PATH}" \
+    CURL_METRIC_COUNTER_PATH="${temp_dir}/lag-metric-counter" \
+    REPORT_DIR="${temp_dir}/lag-report" \
+    STAGING_BASE_URL="https://staging.example.com" \
+    STAGING_REPLAY_TOKEN="token" \
+    STAGING_RDS_DATABASE_URL="postgres://primary" \
+    STAGING_RDS_REPLICA_DATABASE_URL="postgres://replica-lag-high" \
+    TRANSACTION_ARCHIVE_ACCOUNT_ID="101" \
+    TRANSACTION_ARCHIVE_FROM="2026-03-01T00:00:00Z" \
+    TRANSACTION_ARCHIVE_TO="2026-03-31T00:00:00Z" \
+    REPLICA_LAG_THRESHOLD_MS="3000" \
+    "${script}" 2>&1
+)"
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+  echo "lag breach unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -F "Replica lag 6000ms exceeds threshold 3000ms" <<<"${output}" >/dev/null
+if [ -f "${temp_dir}/lag-report/archive-response.json" ]; then
+  echo "archive request must not run when replica lag exceeds threshold" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #319

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging에서 transaction read replica의 recovery/lag 상태와 archive read replica route decision을 smoke로 검증합니다.
- destructive failover 대신 lag/unavailable 신호를 배포 전 fail-fast로 잡고, Prometheus route counter delta로 실제 replica route 사용을 확인합니다.

## 🛠 Changes
- `tools/ops/transaction-read-replica-staging-smoke.sh` 추가
- `transaction-read-replica-staging-smoke` workflow_dispatch 추가
- script/workflow/stub 기반 gate test 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-transaction-read-replica-lag-failover-smoke.sh`
- `tools/test/with-resource-lock.sh back-gradle-transaction-replica ./back/gradlew -p back test --tests '*TransactionReadReplica*' --tests '*TransactionReadRoutingPolicyTest'`
- `git rev-list --count main..HEAD` -> `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Prometheus scrape가 여러 backend instance 뒤에 있으면 단일 archive request의 counter delta가 즉시 보이지 않을 수 있습니다.
- 롤백 방법: PR revert로 workflow/script/test를 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?