### PR TITLE
[Perf] provider delivery metric summary rollup 추가

### DIFF
--- a/back/src/main/java/com/aquilabank/global/notification/ProviderDeliveryPrometheusMetrics.java
+++ b/back/src/main/java/com/aquilabank/global/notification/ProviderDeliveryPrometheusMetrics.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +17,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
-/** provider delivery 상태 gauge는 scrape 한 번에 같은 DB snapshot을 재사용합니다. */
+/** provider delivery 상태 gauge는 summary table snapshot만 읽어 scrape 비용을 고정합니다. */
 @Component
 public final class ProviderDeliveryPrometheusMetrics implements MeterBinder {
 
@@ -31,7 +32,7 @@ public final class ProviderDeliveryPrometheusMetrics implements MeterBinder {
   private static final List<String> PASSWORD_RECOVERY_REASONS =
       java.util.Arrays.stream(PasswordRecoveryDeliverySkipReason.values()).map(Enum::name).toList();
   private static final ProviderDeliverySummary EMPTY_SUMMARY =
-      new ProviderDeliverySummary(Map.of(), Map.of(), Map.of());
+      new ProviderDeliverySummary(Map.of(), Map.of());
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
   private volatile CachedSummary cachedSummary = new CachedSummary(EMPTY_SUMMARY, Instant.EPOCH);
@@ -98,74 +99,36 @@ public final class ProviderDeliveryPrometheusMetrics implements MeterBinder {
   private ProviderDeliverySummary loadSummary() {
     Map<MetricKey, Long> statusCounts = new HashMap<>();
     Map<MetricKey, Long> skipReasonCounts = new HashMap<>();
-    Map<String, Long> retryBacklogCounts = new HashMap<>();
-    for (ProviderDeliveryQueue queue : ProviderDeliveryQueue.values()) {
-      loadStatusCounts(queue, statusCounts);
-      loadSkipReasonCounts(queue, skipReasonCounts);
-      retryBacklogCounts.put(queue.metricName(), loadRetryBacklogCount(queue));
-    }
-    return new ProviderDeliverySummary(statusCounts, skipReasonCounts, retryBacklogCounts);
-  }
-
-  private void loadStatusCounts(ProviderDeliveryQueue queue, Map<MetricKey, Long> target) {
     List<Map<String, Object>> rows =
         jdbcTemplate.queryForList(
             """
-            SELECT LOWER(delivery_status) AS metric_name,
-                   COUNT(*) AS metric_count
-            FROM %s
-            WHERE delivery_status IN ('SENT', 'SKIPPED', 'FAILED', 'QUARANTINED')
-            GROUP BY delivery_status
-            """
-                .formatted(queue.tableName()),
+            SELECT queue_name,
+                   metric_type,
+                   metric_name,
+                   metric_count
+            FROM provider_delivery_metric_summary
+            WHERE queue_name IN ('notification_channel', 'password_recovery')
+              AND metric_type IN ('STATUS', 'SKIP_REASON')
+            """,
             new MapSqlParameterSource());
     for (Map<String, Object> row : rows) {
-      target.put(
-          new MetricKey(queue.metricName(), (String) row.get("metric_name")),
-          ((Number) row.get("metric_count")).longValue());
+      String queue = (String) row.get("queue_name");
+      String metricType = (String) row.get("metric_type");
+      String metricName = (String) row.get("metric_name");
+      long count = ((Number) row.get("metric_count")).longValue();
+      if ("STATUS".equals(metricType)) {
+        statusCounts.put(new MetricKey(queue, metricName.toLowerCase(Locale.ROOT)), count);
+      } else if ("SKIP_REASON".equals(metricType)) {
+        skipReasonCounts.put(new MetricKey(queue, metricName), count);
+      }
     }
-  }
-
-  private void loadSkipReasonCounts(ProviderDeliveryQueue queue, Map<MetricKey, Long> target) {
-    List<Map<String, Object>> rows =
-        jdbcTemplate.queryForList(
-            """
-            SELECT skip_reason AS metric_name,
-                   COUNT(*) AS metric_count
-            FROM %s
-            WHERE delivery_status = 'SKIPPED'
-              AND skip_reason IS NOT NULL
-            GROUP BY skip_reason
-            """
-                .formatted(queue.tableName()),
-            new MapSqlParameterSource());
-    for (Map<String, Object> row : rows) {
-      target.put(
-          new MetricKey(queue.metricName(), (String) row.get("metric_name")),
-          ((Number) row.get("metric_count")).longValue());
-    }
-  }
-
-  private long loadRetryBacklogCount(ProviderDeliveryQueue queue) {
-    Long count =
-        jdbcTemplate.queryForObject(
-            """
-            SELECT COUNT(*)
-            FROM %s
-            WHERE delivery_status IN ('PENDING', 'FAILED')
-            """
-                .formatted(queue.tableName()),
-            new MapSqlParameterSource(),
-            Long.class);
-    return count == null ? 0L : count;
+    return new ProviderDeliverySummary(statusCounts, skipReasonCounts);
   }
 
   private record CachedSummary(ProviderDeliverySummary summary, Instant expiresAt) {}
 
   private record ProviderDeliverySummary(
-      Map<MetricKey, Long> statusCounts,
-      Map<MetricKey, Long> skipReasonCounts,
-      Map<String, Long> retryBacklogCounts) {
+      Map<MetricKey, Long> statusCounts, Map<MetricKey, Long> skipReasonCounts) {
 
     private long statusCount(String queue, String status) {
       return statusCounts.getOrDefault(new MetricKey(queue, status), 0L);
@@ -176,34 +139,26 @@ public final class ProviderDeliveryPrometheusMetrics implements MeterBinder {
     }
 
     private long retryBacklogCount(String queue) {
-      return retryBacklogCounts.getOrDefault(queue, 0L);
+      return statusCount(queue, "pending") + statusCount(queue, "failed");
     }
   }
 
   private record MetricKey(String queue, String name) {}
 
   private enum ProviderDeliveryQueue {
-    NOTIFICATION_CHANNEL(
-        "notification_channel", "notification_channel_outbox", NOTIFICATION_REASONS),
-    PASSWORD_RECOVERY(
-        "password_recovery", "auth_password_recovery_delivery_outbox", PASSWORD_RECOVERY_REASONS);
+    NOTIFICATION_CHANNEL("notification_channel", NOTIFICATION_REASONS),
+    PASSWORD_RECOVERY("password_recovery", PASSWORD_RECOVERY_REASONS);
 
     private final String metricName;
-    private final String tableName;
     private final List<String> skipReasons;
 
-    ProviderDeliveryQueue(String metricName, String tableName, List<String> skipReasons) {
+    ProviderDeliveryQueue(String metricName, List<String> skipReasons) {
       this.metricName = metricName;
-      this.tableName = tableName;
       this.skipReasons = skipReasons;
     }
 
     private String metricName() {
       return metricName;
-    }
-
-    private String tableName() {
-      return tableName;
     }
 
     private List<String> skipReasons() {

--- a/back/src/main/resources/db/migration/V51__add_provider_delivery_metric_summary.sql
+++ b/back/src/main/resources/db/migration/V51__add_provider_delivery_metric_summary.sql
@@ -1,0 +1,247 @@
+CREATE TABLE provider_delivery_metric_summary (
+    queue_name VARCHAR(64) NOT NULL,
+    metric_type VARCHAR(32) NOT NULL,
+    metric_name VARCHAR(64) NOT NULL,
+    metric_count BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_provider_delivery_metric_summary
+        PRIMARY KEY (queue_name, metric_type, metric_name),
+    CONSTRAINT chk_provider_delivery_metric_summary_queue
+        CHECK (queue_name IN ('notification_channel', 'password_recovery')),
+    CONSTRAINT chk_provider_delivery_metric_summary_type
+        CHECK (metric_type IN ('STATUS', 'SKIP_REASON')),
+    CONSTRAINT chk_provider_delivery_metric_summary_count
+        CHECK (metric_count >= 0),
+    CONSTRAINT chk_provider_delivery_metric_summary_name
+        CHECK (BTRIM(metric_name) <> '')
+);
+
+COMMENT ON TABLE provider_delivery_metric_summary IS
+    'Prometheus provider delivery scrape가 원본 outbox table count를 반복하지 않도록 bounded summary row를 저장합니다.';
+
+COMMENT ON COLUMN provider_delivery_metric_summary.queue_name IS
+    'metric tag queue 값과 같은 provider delivery queue 이름입니다.';
+
+COMMENT ON COLUMN provider_delivery_metric_summary.metric_type IS
+    'STATUS 또는 SKIP_REASON summary 구분입니다.';
+
+CREATE OR REPLACE FUNCTION provider_delivery_metric_summary_adjust(
+    p_queue_name VARCHAR,
+    p_metric_type VARCHAR,
+    p_metric_name VARCHAR,
+    p_delta BIGINT
+) RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF p_metric_name IS NULL OR p_delta = 0 THEN
+        RETURN;
+    END IF;
+
+    IF p_delta > 0 THEN
+        INSERT INTO provider_delivery_metric_summary (
+            queue_name,
+            metric_type,
+            metric_name,
+            metric_count,
+            updated_at
+        )
+        VALUES (
+            p_queue_name,
+            p_metric_type,
+            p_metric_name,
+            p_delta,
+            CURRENT_TIMESTAMP
+        )
+        ON CONFLICT (queue_name, metric_type, metric_name)
+        DO UPDATE SET
+            metric_count = provider_delivery_metric_summary.metric_count + EXCLUDED.metric_count,
+            updated_at = CURRENT_TIMESTAMP;
+        RETURN;
+    END IF;
+
+    UPDATE provider_delivery_metric_summary
+    SET metric_count = GREATEST(metric_count + p_delta, 0),
+        updated_at = CURRENT_TIMESTAMP
+    WHERE queue_name = p_queue_name
+      AND metric_type = p_metric_type
+      AND metric_name = p_metric_name;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION provider_delivery_metric_summary_track()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    item RECORD;
+    current_queue_name VARCHAR(64) := TG_ARGV[0];
+BEGIN
+    -- statement-level transition table로 bulk DML도 summary row별 한 번만 갱신합니다.
+    IF TG_OP IN ('UPDATE', 'DELETE') THEN
+        FOR item IN
+            SELECT delivery_status AS metric_name,
+                   COUNT(*)::BIGINT AS metric_count
+            FROM old_rows
+            GROUP BY delivery_status
+        LOOP
+            PERFORM provider_delivery_metric_summary_adjust(
+                current_queue_name,
+                'STATUS',
+                item.metric_name,
+                -item.metric_count
+            );
+        END LOOP;
+
+        FOR item IN
+            SELECT skip_reason AS metric_name,
+                   COUNT(*)::BIGINT AS metric_count
+            FROM old_rows
+            WHERE delivery_status = 'SKIPPED'
+              AND skip_reason IS NOT NULL
+            GROUP BY skip_reason
+        LOOP
+            PERFORM provider_delivery_metric_summary_adjust(
+                current_queue_name,
+                'SKIP_REASON',
+                item.metric_name,
+                -item.metric_count
+            );
+        END LOOP;
+    END IF;
+
+    IF TG_OP IN ('INSERT', 'UPDATE') THEN
+        FOR item IN
+            SELECT delivery_status AS metric_name,
+                   COUNT(*)::BIGINT AS metric_count
+            FROM new_rows
+            GROUP BY delivery_status
+        LOOP
+            PERFORM provider_delivery_metric_summary_adjust(
+                current_queue_name,
+                'STATUS',
+                item.metric_name,
+                item.metric_count
+            );
+        END LOOP;
+
+        FOR item IN
+            SELECT skip_reason AS metric_name,
+                   COUNT(*)::BIGINT AS metric_count
+            FROM new_rows
+            WHERE delivery_status = 'SKIPPED'
+              AND skip_reason IS NOT NULL
+            GROUP BY skip_reason
+        LOOP
+            PERFORM provider_delivery_metric_summary_adjust(
+                current_queue_name,
+                'SKIP_REASON',
+                item.metric_name,
+                item.metric_count
+            );
+        END LOOP;
+    END IF;
+
+    RETURN NULL;
+END;
+$$;
+
+INSERT INTO provider_delivery_metric_summary (
+    queue_name,
+    metric_type,
+    metric_name,
+    metric_count,
+    updated_at
+)
+SELECT 'notification_channel',
+       'STATUS',
+       delivery_status,
+       COUNT(*)::BIGINT,
+       CURRENT_TIMESTAMP
+FROM notification_channel_outbox
+GROUP BY delivery_status;
+
+INSERT INTO provider_delivery_metric_summary (
+    queue_name,
+    metric_type,
+    metric_name,
+    metric_count,
+    updated_at
+)
+SELECT 'notification_channel',
+       'SKIP_REASON',
+       skip_reason,
+       COUNT(*)::BIGINT,
+       CURRENT_TIMESTAMP
+FROM notification_channel_outbox
+WHERE delivery_status = 'SKIPPED'
+  AND skip_reason IS NOT NULL
+GROUP BY skip_reason;
+
+INSERT INTO provider_delivery_metric_summary (
+    queue_name,
+    metric_type,
+    metric_name,
+    metric_count,
+    updated_at
+)
+SELECT 'password_recovery',
+       'STATUS',
+       delivery_status,
+       COUNT(*)::BIGINT,
+       CURRENT_TIMESTAMP
+FROM auth_password_recovery_delivery_outbox
+GROUP BY delivery_status;
+
+INSERT INTO provider_delivery_metric_summary (
+    queue_name,
+    metric_type,
+    metric_name,
+    metric_count,
+    updated_at
+)
+SELECT 'password_recovery',
+       'SKIP_REASON',
+       skip_reason,
+       COUNT(*)::BIGINT,
+       CURRENT_TIMESTAMP
+FROM auth_password_recovery_delivery_outbox
+WHERE delivery_status = 'SKIPPED'
+  AND skip_reason IS NOT NULL
+GROUP BY skip_reason;
+
+CREATE TRIGGER trg_notification_channel_outbox_metric_summary_insert
+AFTER INSERT ON notification_channel_outbox
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION provider_delivery_metric_summary_track('notification_channel');
+
+CREATE TRIGGER trg_notification_channel_outbox_metric_summary_update
+AFTER UPDATE ON notification_channel_outbox
+REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION provider_delivery_metric_summary_track('notification_channel');
+
+CREATE TRIGGER trg_notification_channel_outbox_metric_summary_delete
+AFTER DELETE ON notification_channel_outbox
+REFERENCING OLD TABLE AS old_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION provider_delivery_metric_summary_track('notification_channel');
+
+CREATE TRIGGER trg_auth_password_recovery_delivery_metric_summary_insert
+AFTER INSERT ON auth_password_recovery_delivery_outbox
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION provider_delivery_metric_summary_track('password_recovery');
+
+CREATE TRIGGER trg_auth_password_recovery_delivery_metric_summary_update
+AFTER UPDATE ON auth_password_recovery_delivery_outbox
+REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION provider_delivery_metric_summary_track('password_recovery');
+
+CREATE TRIGGER trg_auth_password_recovery_delivery_metric_summary_delete
+AFTER DELETE ON auth_password_recovery_delivery_outbox
+REFERENCING OLD TABLE AS old_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION provider_delivery_metric_summary_track('password_recovery');

--- a/back/src/test/java/com/aquilabank/global/notification/ProviderDeliveryMetricQueryBaselineIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/ProviderDeliveryMetricQueryBaselineIntegrationTest.java
@@ -99,6 +99,15 @@ class ProviderDeliveryMetricQueryBaselineIntegrationTest extends PostgresContain
     assertMetricPlans("auth_password_recovery_delivery_outbox", expectations);
   }
 
+  @Test
+  void summaryMetricQueryDoesNotScanSourceDeliveryTables() {
+    NotificationExplainPlan plan = explain(summaryCountSql());
+
+    assertThat(plan.seqScanRelations())
+        .doesNotContain("notification_channel_outbox", "auth_password_recovery_delivery_outbox");
+    assertThat(plan.hasNodeType("Sort")).isFalse();
+  }
+
   private void assertMetricPlans(String tableName, List<QueryPlanExpectation> expectations) {
     for (QueryPlanExpectation expectation : expectations) {
       NotificationExplainPlan plan = explain(expectation.sql());
@@ -153,6 +162,18 @@ class ProviderDeliveryMetricQueryBaselineIntegrationTest extends PostgresContain
         WHERE delivery_status IN ('PENDING', 'FAILED')
         """
         .formatted(tableName);
+  }
+
+  private String summaryCountSql() {
+    return """
+        SELECT queue_name,
+               metric_type,
+               metric_name,
+               metric_count
+        FROM provider_delivery_metric_summary
+        WHERE queue_name IN ('notification_channel', 'password_recovery')
+          AND metric_type IN ('STATUS', 'SKIP_REASON')
+        """;
   }
 
   private long insertUser(String loginId) {

--- a/back/src/test/java/com/aquilabank/global/notification/ProviderDeliveryPrometheusMetricsTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/ProviderDeliveryPrometheusMetricsTest.java
@@ -3,7 +3,7 @@ package com.aquilabank.global.notification;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.aquilabank.support.PostgresContainerTestSupport;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.sql.Timestamp;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +23,7 @@ class ProviderDeliveryPrometheusMetricsTest extends PostgresContainerTestSupport
 
   @Autowired private PlatformTransactionManager transactionManager;
 
-  @Autowired private MeterRegistry meterRegistry;
+  private ProviderDeliveryPrometheusMetrics boundMetrics;
 
   @BeforeEach
   void setUpDatabase() {
@@ -75,20 +75,118 @@ class ProviderDeliveryPrometheusMetricsTest extends PostgresContainerTestSupport
               userId, "provider-metrics-request-failed", "FAILED", null, now);
         });
 
-    assertThat(statusGauge("notification_channel", "sent")).isEqualTo(1.0);
-    assertThat(statusGauge("notification_channel", "skipped")).isEqualTo(1.0);
-    assertThat(statusGauge("notification_channel", "failed")).isEqualTo(1.0);
-    assertThat(skipReasonGauge("notification_channel", "VERIFIED_CONTACT_MISSING")).isEqualTo(1.0);
-    assertThat(retryBacklogGauge("notification_channel")).isEqualTo(2.0);
-    assertThat(statusGauge("password_recovery", "sent")).isEqualTo(1.0);
-    assertThat(statusGauge("password_recovery", "skipped")).isEqualTo(1.0);
-    assertThat(statusGauge("password_recovery", "quarantined")).isEqualTo(1.0);
-    assertThat(skipReasonGauge("password_recovery", "PROVIDER_URL_MISSING")).isEqualTo(1.0);
-    assertThat(retryBacklogGauge("password_recovery")).isEqualTo(1.0);
+    SimpleMeterRegistry registry = bindFreshRegistry();
+
+    assertThat(statusGauge(registry, "notification_channel", "sent")).isEqualTo(1.0);
+    assertThat(statusGauge(registry, "notification_channel", "skipped")).isEqualTo(1.0);
+    assertThat(statusGauge(registry, "notification_channel", "failed")).isEqualTo(1.0);
+    assertThat(skipReasonGauge(registry, "notification_channel", "VERIFIED_CONTACT_MISSING"))
+        .isEqualTo(1.0);
+    assertThat(retryBacklogGauge(registry, "notification_channel")).isEqualTo(2.0);
+    assertThat(statusGauge(registry, "password_recovery", "sent")).isEqualTo(1.0);
+    assertThat(statusGauge(registry, "password_recovery", "skipped")).isEqualTo(1.0);
+    assertThat(statusGauge(registry, "password_recovery", "quarantined")).isEqualTo(1.0);
+    assertThat(skipReasonGauge(registry, "password_recovery", "PROVIDER_URL_MISSING"))
+        .isEqualTo(1.0);
+    assertThat(retryBacklogGauge(registry, "password_recovery")).isEqualTo(1.0);
   }
 
-  private double statusGauge(String queue, String status) {
-    return meterRegistry
+  @Test
+  void exportsProviderDeliveryGaugesFromSummaryWithoutScanningSourceRows() {
+    Instant now = Instant.parse("2026-04-24T02:00:00Z");
+    commit(
+        transactionManager,
+        () -> {
+          insertMetricSummary("notification_channel", "STATUS", "SENT", 7, now);
+          insertMetricSummary("notification_channel", "STATUS", "PENDING", 3, now);
+          insertMetricSummary("notification_channel", "STATUS", "FAILED", 2, now);
+          insertMetricSummary(
+              "notification_channel", "SKIP_REASON", "VERIFIED_CONTACT_MISSING", 5, now);
+          insertMetricSummary("password_recovery", "STATUS", "QUARANTINED", 4, now);
+          insertMetricSummary("password_recovery", "STATUS", "FAILED", 6, now);
+          insertMetricSummary("password_recovery", "SKIP_REASON", "PROVIDER_URL_MISSING", 2, now);
+        });
+
+    assertThat(summaryCount("notification_channel", "STATUS", "SENT")).isEqualTo(7);
+
+    SimpleMeterRegistry registry = bindFreshRegistry();
+
+    assertThat(statusGauge(registry, "notification_channel", "sent")).isEqualTo(7.0);
+    assertThat(skipReasonGauge(registry, "notification_channel", "VERIFIED_CONTACT_MISSING"))
+        .isEqualTo(5.0);
+    assertThat(retryBacklogGauge(registry, "notification_channel")).isEqualTo(5.0);
+    assertThat(statusGauge(registry, "password_recovery", "quarantined")).isEqualTo(4.0);
+    assertThat(skipReasonGauge(registry, "password_recovery", "PROVIDER_URL_MISSING"))
+        .isEqualTo(2.0);
+    assertThat(retryBacklogGauge(registry, "password_recovery")).isEqualTo(6.0);
+  }
+
+  @Test
+  void maintainsProviderDeliverySummaryForDirectSqlChanges() {
+    Instant now = Instant.parse("2026-04-24T03:00:00Z");
+    long skippedId =
+        commitAndReturn(
+            transactionManager,
+            () -> {
+              long userId = insertUser("provider-summary@example.com", now);
+              long accountId = insertAccount("provider summary account", now);
+              long notificationId = insertNotification(accountId, "evt-provider-summary", now);
+              insertNotificationDelivery(
+                  notificationId, userId, accountId, "evt-summary-sent", "SENT", null, now);
+              return insertNotificationDelivery(
+                  notificationId,
+                  userId,
+                  accountId,
+                  "evt-summary-skipped",
+                  "SKIPPED",
+                  "VERIFIED_CONTACT_MISSING",
+                  now);
+            });
+
+    assertThat(summaryCount("notification_channel", "STATUS", "SENT")).isEqualTo(1);
+    assertThat(summaryCount("notification_channel", "STATUS", "SKIPPED")).isEqualTo(1);
+    assertThat(summaryCount("notification_channel", "SKIP_REASON", "VERIFIED_CONTACT_MISSING"))
+        .isEqualTo(1);
+
+    commit(
+        transactionManager,
+        () ->
+            jdbcTemplate.update(
+                """
+                UPDATE notification_channel_outbox
+                SET delivery_status = 'FAILED',
+                    skip_reason = NULL,
+                    updated_at = :now
+                WHERE id = :id
+                """,
+                new MapSqlParameterSource()
+                    .addValue("id", skippedId)
+                    .addValue("now", Timestamp.from(now))));
+
+    assertThat(summaryCount("notification_channel", "STATUS", "SKIPPED")).isZero();
+    assertThat(summaryCount("notification_channel", "STATUS", "FAILED")).isEqualTo(1);
+    assertThat(summaryCount("notification_channel", "SKIP_REASON", "VERIFIED_CONTACT_MISSING"))
+        .isZero();
+
+    commit(
+        transactionManager,
+        () ->
+            jdbcTemplate.update(
+                "DELETE FROM notification_channel_outbox WHERE id = :id",
+                new MapSqlParameterSource().addValue("id", skippedId)));
+
+    assertThat(summaryCount("notification_channel", "STATUS", "FAILED")).isZero();
+  }
+
+  private SimpleMeterRegistry bindFreshRegistry() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    boundMetrics = new ProviderDeliveryPrometheusMetrics(jdbcTemplate);
+    boundMetrics.bindTo(registry);
+    return registry;
+  }
+
+  private double statusGauge(SimpleMeterRegistry registry, String queue, String status) {
+    return registry
         .get("aquila.provider.delivery.status.count")
         .tag("queue", queue)
         .tag("status", status)
@@ -96,8 +194,8 @@ class ProviderDeliveryPrometheusMetricsTest extends PostgresContainerTestSupport
         .value();
   }
 
-  private double skipReasonGauge(String queue, String reason) {
-    return meterRegistry
+  private double skipReasonGauge(SimpleMeterRegistry registry, String queue, String reason) {
+    return registry
         .get("aquila.provider.delivery.skip.reason.count")
         .tag("queue", queue)
         .tag("reason", reason)
@@ -105,12 +203,58 @@ class ProviderDeliveryPrometheusMetricsTest extends PostgresContainerTestSupport
         .value();
   }
 
-  private double retryBacklogGauge(String queue) {
-    return meterRegistry
+  private double retryBacklogGauge(SimpleMeterRegistry registry, String queue) {
+    return registry
         .get("aquila.provider.delivery.retry.backlog.count")
         .tag("queue", queue)
         .gauge()
         .value();
+  }
+
+  private void insertMetricSummary(
+      String queue, String metricType, String metricName, long count, Instant now) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO provider_delivery_metric_summary (
+            queue_name,
+            metric_type,
+            metric_name,
+            metric_count,
+            updated_at
+        )
+        VALUES (:queue, :metricType, :metricName, :count, :now)
+        """,
+        new MapSqlParameterSource()
+            .addValue("queue", queue)
+            .addValue("metricType", metricType)
+            .addValue("metricName", metricName)
+            .addValue("count", count)
+            .addValue("now", Timestamp.from(now)));
+  }
+
+  private long summaryCount(String queue, String metricType, String metricName) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT metric_count
+            FROM provider_delivery_metric_summary
+            WHERE queue_name = :queue
+              AND metric_type = :metricType
+              AND metric_name = :metricName
+            """,
+            new MapSqlParameterSource()
+                .addValue("queue", queue)
+                .addValue("metricType", metricType)
+                .addValue("metricName", metricName),
+            Long.class);
+    return count == null ? 0 : count;
+  }
+
+  private long commitAndReturn(
+      PlatformTransactionManager transactionManager, java.util.function.LongSupplier callback) {
+    long[] result = new long[1];
+    commit(transactionManager, () -> result[0] = callback.getAsLong());
+    return result[0];
   }
 
   private long insertUser(String loginId, Instant now) {
@@ -167,7 +311,7 @@ class ProviderDeliveryPrometheusMetricsTest extends PostgresContainerTestSupport
         Long.class);
   }
 
-  private void insertNotificationDelivery(
+  private long insertNotificationDelivery(
       long notificationId,
       long userId,
       long accountId,
@@ -175,8 +319,9 @@ class ProviderDeliveryPrometheusMetricsTest extends PostgresContainerTestSupport
       String status,
       String skipReason,
       Instant now) {
-    jdbcTemplate.update(
-        """
+    Long id =
+        jdbcTemplate.queryForObject(
+            """
         INSERT INTO notification_channel_outbox (
             notification_id,
             user_id,
@@ -209,16 +354,22 @@ class ProviderDeliveryPrometheusMetricsTest extends PostgresContainerTestSupport
             :now,
             :now
         )
+        RETURNING id
         """,
-        new MapSqlParameterSource()
-            .addValue("notificationId", notificationId)
-            .addValue("userId", userId)
-            .addValue("accountId", accountId)
-            .addValue("eventKey", eventKey)
-            .addValue("status", status)
-            .addValue("sentAt", "SENT".equals(status) ? Timestamp.from(now) : null)
-            .addValue("skipReason", skipReason)
-            .addValue("now", Timestamp.from(now)));
+            new MapSqlParameterSource()
+                .addValue("notificationId", notificationId)
+                .addValue("userId", userId)
+                .addValue("accountId", accountId)
+                .addValue("eventKey", eventKey)
+                .addValue("status", status)
+                .addValue("sentAt", "SENT".equals(status) ? Timestamp.from(now) : null)
+                .addValue("skipReason", skipReason)
+                .addValue("now", Timestamp.from(now)),
+            Long.class);
+    if (id == null) {
+      throw new IllegalStateException("notification channel delivery insert did not return id");
+    }
+    return id;
   }
 
   private void insertPasswordRecoveryDelivery(

--- a/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
+++ b/back/src/test/java/com/aquilabank/support/PostgresContainerTestSupport.java
@@ -45,6 +45,7 @@ public abstract class PostgresContainerTestSupport {
                         """
                         TRUNCATE TABLE
                             auth_status_change_audit,
+                            provider_delivery_metric_summary,
                             auth_password_recovery_delivery_outbox,
                             bank_user_verified_contact,
                             notification_dlq_redrive_audit,


### PR DESCRIPTION
## 🔗 Related Issue
- close #326

## 🌿 Base Branch
- `main`

## 📝 Summary
- provider delivery Prometheus scrape가 원본 delivery outbox count query를 반복하지 않도록 `provider_delivery_metric_summary` rollup table로 전환했습니다.
- statement-level trigger transition table로 INSERT/UPDATE/DELETE 변경분을 queue/status/skip reason 단위 summary row에 증분 반영합니다.

## 🛠 Changes
- `V51__add_provider_delivery_metric_summary.sql` migration으로 summary table, backfill, statement-level trigger를 추가했습니다.
- `ProviderDeliveryPrometheusMetrics`가 summary table snapshot만 읽고 retry backlog는 `PENDING + FAILED` summary count로 계산하게 변경했습니다.
- direct SQL 변경/summary-only scrape/EXPLAIN baseline 테스트를 추가하고 test reset 대상에 summary table을 포함했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-provider-delivery-rollup ./back/gradlew -p back test --tests '*ProviderDeliveryPrometheusMetricsTest' --tests '*ProviderDeliveryMetricQueryBaselineIntegrationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- commit hook: `./back/gradlew -p back check` 성공
- `git rev-list --count main..HEAD` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 상태 전환 hot path에서 summary row 갱신이 추가되어 provider worker batch를 과도하게 키우면 row lock 경합이 생길 수 있습니다.
- 롤백 방법: PR revert로 `V51` migration 및 metric 조회 전환을 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A