### PR TITLE
[Perf] read replica pool pressure를 t3.micro saturation guard에 포함

### DIFF
--- a/back/src/main/java/com/aquilabank/global/config/T3MicroSaturationGuardConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/T3MicroSaturationGuardConfiguration.java
@@ -26,6 +26,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,6 +49,12 @@ public class T3MicroSaturationGuardConfiguration {
   }
 
   @Bean
+  DbPoolSaturationProbe transactionReadReplicaDbPoolSaturationProbe(
+      @Qualifier("transactionReadReplicaDataSource") ObjectProvider<DataSource> dataSourceProvider) {
+    return new HikariDbPoolSaturationProbe(dataSourceProvider);
+  }
+
+  @Bean
   ServletThreadSaturationProbe servletThreadSaturationProbe() {
     return new JmxServletThreadSaturationProbe();
   }
@@ -63,7 +70,8 @@ public class T3MicroSaturationGuardConfiguration {
   @Bean
   T3MicroSaturationGuard t3MicroSaturationGuard(
       T3MicroSaturationGuardProperties properties,
-      DbPoolSaturationProbe dbPoolSaturationProbe,
+      @Qualifier("dbPoolSaturationProbe") DbPoolSaturationProbe dbPoolSaturationProbe,
+      @Qualifier("transactionReadReplicaDbPoolSaturationProbe") DbPoolSaturationProbe transactionReadReplicaDbPoolSaturationProbe,
       ServletThreadSaturationProbe servletThreadSaturationProbe,
       JvmPressureProbe jvmPressureProbe,
       T3MicroQueryTimeoutSignal t3MicroQueryTimeoutSignal,
@@ -71,6 +79,7 @@ public class T3MicroSaturationGuardConfiguration {
     return new T3MicroSaturationGuard(
         properties,
         dbPoolSaturationProbe,
+        transactionReadReplicaDbPoolSaturationProbe,
         servletThreadSaturationProbe,
         jvmPressureProbe,
         t3MicroQueryTimeoutSignal,

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuard.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuard.java
@@ -12,6 +12,7 @@ public class T3MicroSaturationGuard {
 
   private final T3MicroSaturationGuardProperties properties;
   private final DbPoolSaturationProbe poolProbe;
+  private final DbPoolSaturationProbe readReplicaPoolProbe;
   private final ServletThreadSaturationProbe servletThreadProbe;
   private final JvmPressureProbe jvmPressureProbe;
   private final T3MicroQueryTimeoutSignal timeoutSignal;
@@ -29,8 +30,27 @@ public class T3MicroSaturationGuard {
       JvmPressureProbe jvmPressureProbe,
       T3MicroQueryTimeoutSignal timeoutSignal,
       MeterRegistry meterRegistry) {
+    this(
+        properties,
+        poolProbe,
+        DbPoolSaturationSnapshot::empty,
+        servletThreadProbe,
+        jvmPressureProbe,
+        timeoutSignal,
+        meterRegistry);
+  }
+
+  public T3MicroSaturationGuard(
+      T3MicroSaturationGuardProperties properties,
+      DbPoolSaturationProbe poolProbe,
+      DbPoolSaturationProbe readReplicaPoolProbe,
+      ServletThreadSaturationProbe servletThreadProbe,
+      JvmPressureProbe jvmPressureProbe,
+      T3MicroQueryTimeoutSignal timeoutSignal,
+      MeterRegistry meterRegistry) {
     this.properties = properties;
     this.poolProbe = poolProbe;
+    this.readReplicaPoolProbe = readReplicaPoolProbe;
     this.servletThreadProbe = servletThreadProbe;
     this.jvmPressureProbe = jvmPressureProbe;
     this.timeoutSignal = timeoutSignal;
@@ -55,7 +75,7 @@ public class T3MicroSaturationGuard {
     if (!protectedPath(path)) {
       return T3MicroSaturationDecision.allowed(snapshot);
     }
-    if (snapshot.saturated()) {
+    if (snapshot.saturated() || readReplicaPoolSaturated(path, snapshot)) {
       saturatedGauge.set(1);
       rejectedCounter.increment();
       return T3MicroSaturationDecision.rejected(properties.retryAfterSeconds(), snapshot);
@@ -84,21 +104,26 @@ public class T3MicroSaturationGuard {
 
   private T3MicroSaturationSnapshot snapshot() {
     DbPoolSaturationSnapshot pool = poolProbe.snapshot();
+    DbPoolSaturationSnapshot readReplicaPool = readReplicaPoolProbe.snapshot();
     ServletThreadSaturationSnapshot servletThreads = servletThreadProbe.snapshot();
     Duration timeoutWindow = Duration.ofSeconds(properties.queryTimeout().windowSeconds());
     Duration gcWindow = Duration.ofSeconds(properties.jvmPressure().gcWindowSeconds());
     JvmPressureSnapshot jvmPressure = jvmPressureProbe.snapshot(gcWindow);
     int timeoutCount = timeoutSignal.recentCount(timeoutWindow);
     boolean poolSaturated = pool.saturated(properties.pool());
+    boolean readReplicaPoolSaturated =
+        properties.readReplicaPool().enabled() && readReplicaPool.saturated(properties.pool());
     boolean servletThreadsSaturated = servletThreads.saturated(properties.servletThreads());
     boolean queryTimeoutSaturated = timeoutCount >= properties.queryTimeout().threshold();
     boolean jvmPressureSaturated = jvmPressure.saturated(properties.jvmPressure());
     return new T3MicroSaturationSnapshot(
         pool,
+        readReplicaPool,
         servletThreads,
         jvmPressure,
         timeoutCount,
         poolSaturated,
+        readReplicaPoolSaturated,
         servletThreadsSaturated,
         queryTimeoutSaturated,
         jvmPressureSaturated);
@@ -106,6 +131,14 @@ public class T3MicroSaturationGuard {
 
   private boolean protectedPath(String path) {
     return properties.protectedPathPrefixes().stream().anyMatch(path::startsWith);
+  }
+
+  private boolean readReplicaPoolSaturated(String path, T3MicroSaturationSnapshot snapshot) {
+    if (!snapshot.readReplicaPoolSaturated()) {
+      return false;
+    }
+    // replica pool은 transaction read 경로에만 묶어 다른 보호 API의 과잉 차단을 피합니다.
+    return properties.readReplicaPool().protectedPathPrefixes().stream().anyMatch(path::startsWith);
   }
 
   private Counter requestCounter(MeterRegistry meterRegistry, String outcome) {

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuardProperties.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuardProperties.java
@@ -12,7 +12,8 @@ public record T3MicroSaturationGuardProperties(
     ServletThreads servletThreads,
     QueryTimeout queryTimeout,
     JvmPressure jvmPressure,
-    BackgroundWorkers backgroundWorkers) {
+    BackgroundWorkers backgroundWorkers,
+    ReadReplicaPool readReplicaPool) {
 
   public T3MicroSaturationGuardProperties {
     enabled = enabled == null ? Boolean.TRUE : enabled;
@@ -33,6 +34,10 @@ public record T3MicroSaturationGuardProperties(
     queryTimeout = queryTimeout == null ? new QueryTimeout(10, 1) : queryTimeout;
     jvmPressure = jvmPressure == null ? new JvmPressure(true, 90, 10, 3, 250) : jvmPressure;
     backgroundWorkers = backgroundWorkers == null ? new BackgroundWorkers(true) : backgroundWorkers;
+    readReplicaPool =
+        readReplicaPool == null
+            ? new ReadReplicaPool(true, List.of("/api/v1/transactions"))
+            : readReplicaPool;
   }
 
   public record Pool(int activeThresholdPercent, int awaitingThreadsThreshold) {
@@ -83,6 +88,17 @@ public record T3MicroSaturationGuardProperties(
 
     public BackgroundWorkers {
       enabled = enabled == null ? Boolean.TRUE : enabled;
+    }
+  }
+
+  public record ReadReplicaPool(Boolean enabled, List<String> protectedPathPrefixes) {
+
+    public ReadReplicaPool {
+      enabled = enabled == null ? Boolean.TRUE : enabled;
+      protectedPathPrefixes =
+          protectedPathPrefixes == null || protectedPathPrefixes.isEmpty()
+              ? List.of("/api/v1/transactions")
+              : List.copyOf(protectedPathPrefixes);
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationSnapshot.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationSnapshot.java
@@ -2,10 +2,12 @@ package com.aquilabank.global.ops;
 
 public record T3MicroSaturationSnapshot(
     DbPoolSaturationSnapshot pool,
+    DbPoolSaturationSnapshot readReplicaPool,
     ServletThreadSaturationSnapshot servletThreads,
     JvmPressureSnapshot jvmPressure,
     int recentQueryTimeoutCount,
     boolean poolSaturated,
+    boolean readReplicaPoolSaturated,
     boolean servletThreadsSaturated,
     boolean queryTimeoutSaturated,
     boolean jvmPressureSaturated) {
@@ -13,9 +15,11 @@ public record T3MicroSaturationSnapshot(
   public static T3MicroSaturationSnapshot empty() {
     return new T3MicroSaturationSnapshot(
         DbPoolSaturationSnapshot.empty(),
+        DbPoolSaturationSnapshot.empty(),
         ServletThreadSaturationSnapshot.empty(),
         JvmPressureSnapshot.empty(),
         0,
+        false,
         false,
         false,
         false,

--- a/back/src/test/java/com/aquilabank/global/config/T3MicroSaturationGuardConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/T3MicroSaturationGuardConfigurationTest.java
@@ -1,0 +1,34 @@
+package com.aquilabank.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.aquilabank.global.ops.DbPoolSaturationProbe;
+import com.aquilabank.global.ops.DbPoolSaturationSnapshot;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class T3MicroSaturationGuardConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(T3MicroSaturationGuardConfiguration.class)
+          .withBean("dataSource", DataSource.class, () -> mock(DataSource.class))
+          .withBean(MeterRegistry.class, SimpleMeterRegistry::new);
+
+  @Test
+  void createsEmptyReadReplicaPoolProbeWhenReplicaDataSourceIsMissing() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasBean("transactionReadReplicaDbPoolSaturationProbe");
+          DbPoolSaturationProbe probe =
+              context.getBean(
+                  "transactionReadReplicaDbPoolSaturationProbe", DbPoolSaturationProbe.class);
+
+          assertThat(probe.snapshot()).isEqualTo(DbPoolSaturationSnapshot.empty());
+        });
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/ops/T3MicroSaturationGuardTest.java
+++ b/back/src/test/java/com/aquilabank/global/ops/T3MicroSaturationGuardTest.java
@@ -151,6 +151,46 @@ class T3MicroSaturationGuardTest {
   }
 
   @Test
+  void rejectsTransactionReadRequestWhenReadReplicaPoolIsSaturated() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    T3MicroSaturationGuard guard =
+        new T3MicroSaturationGuard(
+            properties(),
+            new MutableDbPoolProbe(new DbPoolSaturationSnapshot(1, 4, 0)),
+            new MutableDbPoolProbe(new DbPoolSaturationSnapshot(2, 2, 1)),
+            new MutableServletThreadProbe(new ServletThreadSaturationSnapshot(2, 16)),
+            new MutableJvmPressureProbe(JvmPressureSnapshot.empty()),
+            new T3MicroQueryTimeoutSignal(Clock.systemUTC(), meterRegistry),
+            meterRegistry);
+
+    T3MicroSaturationDecision decision = guard.check("/api/v1/transactions");
+
+    assertThat(decision.allowed()).isFalse();
+    assertThat(decision.snapshot().poolSaturated()).isFalse();
+    assertThat(decision.snapshot().readReplicaPool().activeConnections()).isEqualTo(2);
+    assertThat(decision.snapshot().readReplicaPoolSaturated()).isTrue();
+  }
+
+  @Test
+  void allowsOtherProtectedPathWhenOnlyReadReplicaPoolIsSaturated() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    T3MicroSaturationGuard guard =
+        new T3MicroSaturationGuard(
+            propertiesWithReadReplicaPool(List.of("/api/v1/transactions")),
+            new MutableDbPoolProbe(new DbPoolSaturationSnapshot(1, 4, 0)),
+            new MutableDbPoolProbe(new DbPoolSaturationSnapshot(2, 2, 1)),
+            new MutableServletThreadProbe(new ServletThreadSaturationSnapshot(2, 16)),
+            new MutableJvmPressureProbe(JvmPressureSnapshot.empty()),
+            new T3MicroQueryTimeoutSignal(Clock.systemUTC(), meterRegistry),
+            meterRegistry);
+
+    T3MicroSaturationDecision decision = guard.check("/api/v1/notifications");
+
+    assertThat(decision.allowed()).isTrue();
+    assertThat(decision.snapshot().readReplicaPoolSaturated()).isTrue();
+  }
+
+  @Test
   void rejectsProtectedRequestWhenRecentGcPressureIsSaturated() {
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     T3MicroSaturationGuard guard =
@@ -183,7 +223,9 @@ class T3MicroSaturationGuardTest {
                 new T3MicroSaturationGuardProperties.ServletThreads(80),
                 new T3MicroSaturationGuardProperties.QueryTimeout(10, 1),
                 new T3MicroSaturationGuardProperties.JvmPressure(true, 90, 10, 3, 250),
-                new T3MicroSaturationGuardProperties.BackgroundWorkers(true)),
+                new T3MicroSaturationGuardProperties.BackgroundWorkers(true),
+                new T3MicroSaturationGuardProperties.ReadReplicaPool(
+                    true, List.of("/api/v1/transactions"))),
             new MutableDbPoolProbe(new DbPoolSaturationSnapshot(4, 4, 1)),
             new MutableServletThreadProbe(new ServletThreadSaturationSnapshot(16, 16)),
             new MutableJvmPressureProbe(JvmPressureSnapshot.empty()),
@@ -218,15 +260,25 @@ class T3MicroSaturationGuardTest {
   }
 
   private T3MicroSaturationGuardProperties propertiesWithJvmPressure(boolean enabled) {
+    return propertiesWithJvmPressureAndReadReplicaPool(enabled, List.of("/api/v1/transactions"));
+  }
+
+  private T3MicroSaturationGuardProperties propertiesWithReadReplicaPool(List<String> prefixes) {
+    return propertiesWithJvmPressureAndReadReplicaPool(true, prefixes);
+  }
+
+  private T3MicroSaturationGuardProperties propertiesWithJvmPressureAndReadReplicaPool(
+      boolean enabled, List<String> prefixes) {
     return new T3MicroSaturationGuardProperties(
         true,
         2,
-        List.of("/api/v1/transactions"),
+        List.of("/api/v1/transactions", "/api/v1/notifications"),
         new T3MicroSaturationGuardProperties.Pool(80, 1),
         new T3MicroSaturationGuardProperties.ServletThreads(80),
         new T3MicroSaturationGuardProperties.QueryTimeout(10, 1),
         new T3MicroSaturationGuardProperties.JvmPressure(enabled, 90, 10, 3, 250),
-        new T3MicroSaturationGuardProperties.BackgroundWorkers(true));
+        new T3MicroSaturationGuardProperties.BackgroundWorkers(true),
+        new T3MicroSaturationGuardProperties.ReadReplicaPool(true, prefixes));
   }
 
   private T3MicroSaturationGuardProperties propertiesWithBackgroundWorkers(boolean enabled) {
@@ -238,7 +290,9 @@ class T3MicroSaturationGuardTest {
         new T3MicroSaturationGuardProperties.ServletThreads(80),
         new T3MicroSaturationGuardProperties.QueryTimeout(10, 1),
         new T3MicroSaturationGuardProperties.JvmPressure(true, 90, 10, 3, 250),
-        new T3MicroSaturationGuardProperties.BackgroundWorkers(enabled));
+        new T3MicroSaturationGuardProperties.BackgroundWorkers(enabled),
+        new T3MicroSaturationGuardProperties.ReadReplicaPool(
+            true, List.of("/api/v1/transactions")));
   }
 
   private static final class MutableDbPoolProbe implements DbPoolSaturationProbe {

--- a/back/src/test/java/com/aquilabank/global/web/T3MicroSaturationInterceptorTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/T3MicroSaturationInterceptorTest.java
@@ -79,7 +79,9 @@ class T3MicroSaturationInterceptorTest {
             new T3MicroSaturationGuardProperties.ServletThreads(80),
             new T3MicroSaturationGuardProperties.QueryTimeout(10, 1),
             new T3MicroSaturationGuardProperties.JvmPressure(true, 90, 10, 3, 250),
-            new T3MicroSaturationGuardProperties.BackgroundWorkers(true)),
+            new T3MicroSaturationGuardProperties.BackgroundWorkers(true),
+            new T3MicroSaturationGuardProperties.ReadReplicaPool(
+                true, List.of("/api/v1/transactions"))),
         (DbPoolSaturationProbe) () -> pool,
         (ServletThreadSaturationProbe) () -> servletThreads,
         (JvmPressureProbe) gcWindow -> JvmPressureSnapshot.empty(),


### PR DESCRIPTION
## 🔗 Related Issue
- close #328

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction read replica Hikari pool snapshot을 t3.micro saturation guard에 포함했습니다.
- replica pool 포화는 transaction read API prefix에서만 fail-fast 신호로 사용해 account/notification 등 다른 보호 API 과잉 차단을 피합니다.

## 🛠 Changes
- `transactionReadReplicaDbPoolSaturationProbe`를 추가해 `transactionReadReplicaDataSource`가 없으면 empty snapshot을 반환합니다.
- `T3MicroSaturationSnapshot`에 read replica pool snapshot/saturation flag를 추가했습니다.
- read replica pool saturation은 `/api/v1/transactions` prefix에만 reject 조건으로 적용했습니다.
- guard unit/config/web regression test를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-read-replica-pool-guard-red ./back/gradlew -p back test --tests '*T3MicroSaturationGuardTest' --tests '*T3MicroSaturationGuardConfigurationTest'` 실패 확인
- `tools/test/with-resource-lock.sh back-read-replica-pool-guard ./back/gradlew -p back test --tests '*T3MicroSaturationGuardTest' --tests '*T3MicroSaturationInterceptorTest' --tests '*T3MicroSaturationGuardConfigurationTest' --tests '*TransactionReadReplicaRoutingConfigurationTest'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit `./back/gradlew -p back check`
- `git diff --check`
- `git rev-list --count main..HEAD` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: replica pool threshold가 낮으면 transaction read burst에서 503이 빨리 발생할 수 있습니다. 기본 prefix를 transaction read로 제한해 다른 보호 API 영향은 줄였습니다.
- 롤백 방법: PR revert 또는 `OPS_T3MICRO_SATURATION_GUARD_ENABLED=false`로 guard 비활성화

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?