### PR TITLE
[Perf] Docker t3.micro 근사 capacity smoke 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 ├── back
 ├── ops
 ├── .github
-└── compose.yml
+├── compose.yml
+└── compose.t3micro.yml
 ```
 
 - `front`: 고객/운영 웹 애플리케이션
@@ -31,6 +32,7 @@
 - `ops`: reverse proxy 같은 운영 baseline 파일
 - `.github`: 이슈/PR 템플릿과 협업 메타 설정
 - `compose.yml`: 로컬 개발용 Docker Compose 인프라 실행 기준
+- `compose.t3micro.yml`: 로컬 인프라를 작은 CPU/메모리 budget으로 띄우는 t3.micro 근사 override
 
 ## Runtime Baseline
 
@@ -41,9 +43,11 @@
 ## Environment Split
 
 - 로컬 개발: `Docker Compose + PostgreSQL 18 + Kafka`
+- 로컬 t3.micro 근사 검증: `compose.t3micro.yml`과 `tools/test/run-docker-t3micro-capacity-smoke.sh`로 CPU/메모리 cgroup 제한을 적용합니다.
 - 배포 환경: `EC2 + RDS PostgreSQL 18`
 - EC2 reverse proxy baseline template은 [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)에 두고, runtime 값은 `ops/nginx/runtime.env.example` 기반으로 렌더링합니다.
 - `compose.yml`은 로컬 개발 전용이며, 배포용 인프라 정의는 포함하지 않습니다.
+- Docker 근사 검증은 AWS `t3.micro`의 CPU credit, EBS 지연, 실제 네트워크를 재현하지 못하므로 최종 120% headroom 판정은 EC2 `t3.micro` staging smoke 결과로 닫습니다.
 
 ## Delivery Flow
 

--- a/back/README.md
+++ b/back/README.md
@@ -492,6 +492,7 @@ tools/test/run-docker-t3micro-capacity-smoke.sh
 
 - 기본 Docker budget은 `--cpus=2`, `--memory=1024m`, `--memory-swap=1024m`, `--pids-limit=384` 입니다.
 - script는 새 부하 발생기를 만들지 않고 기존 `tools/test/run-production-t3micro-capacity-smoke.sh`를 container 안에서 재사용합니다.
+- 기본값은 실행 전 host에서 `testClasses`를 준비해 Gradle compile 비용을 Docker 1GiB 판정에서 분리합니다. 이 동작을 끄려면 `DOCKER_T3MICRO_PREPARE_TEST_CLASSES=false`를 사용합니다.
 - 기본 image는 `eclipse-temurin:21-jdk`이고, 로컬에 다른 Java 21 image가 있으면 `DOCKER_T3MICRO_IMAGE=<image>`로 바꿀 수 있습니다.
 - Docker smoke는 host 자원이 큰 개발 머신에서 놓칠 수 있는 JVM/thread/pool 압력 회귀를 빨리 잡는 용도입니다.
 - 최종 120% headroom 판정은 실제 EC2 `t3.micro` staging에서 transaction replay, read replica smoke, production capacity smoke를 실행한 결과로 닫습니다.

--- a/back/README.md
+++ b/back/README.md
@@ -261,6 +261,16 @@ docker compose up -d postgres kafka
 - topic partition을 늘릴 때는 `KAFKA_TOPIC_PROVISIONING_PARTITIONS`와 `NOTIFICATION_INBOX_CONSUMER_CONCURRENCY`를 같이 조정합니다.
 - 이 경로는 로컬 개발 전용입니다.
 
+t3.micro에 가까운 작은 로컬 인프라 budget으로 띄울 때는 override 파일을 함께 지정합니다.
+
+```bash
+docker compose -f compose.yml -f compose.t3micro.yml up -d postgres kafka
+```
+
+- [compose.t3micro.yml](/Users/aquila/Custom/GitProjects/aquila-bank/compose.t3micro.yml)은 Postgres/Kafka/Redis에 CPU, memory, swap, pids 상한을 겁니다.
+- 이 override는 로컬 병목 신호를 빨리 보기 위한 근사값이며, AWS `t3.micro`의 CPU credit, EBS 지연, 실제 네트워크를 재현하지 않습니다.
+- Redis까지 같은 budget으로 올릴 때는 `docker compose -f compose.yml -f compose.t3micro.yml --profile redis up -d redis`를 사용합니다.
+
 Redis login throttling runtime smoke가 필요할 때만 profile을 켭니다.
 
 ```bash
@@ -472,6 +482,19 @@ tools/test/run-production-t3micro-capacity-smoke.sh
   - `PRODUCTION_T3MICRO_SSE_MAX_TOTAL_SESSIONS`
   - `PRODUCTION_T3MICRO_NOTIFICATION_STREAM_MAX`
 - smoke rollback은 workflow 비활성화 또는 variable 값을 기본 budget으로 되돌리는 방식으로 처리합니다.
+
+로컬에서 Docker cgroup 제한까지 걸어 빠르게 회귀를 확인할 때는 아래 entrypoint를 사용합니다.
+
+```bash
+tools/test/run-docker-t3micro-capacity-smoke.sh --print-plan
+tools/test/run-docker-t3micro-capacity-smoke.sh
+```
+
+- 기본 Docker budget은 `--cpus=2`, `--memory=1024m`, `--memory-swap=1024m`, `--pids-limit=384` 입니다.
+- script는 새 부하 발생기를 만들지 않고 기존 `tools/test/run-production-t3micro-capacity-smoke.sh`를 container 안에서 재사용합니다.
+- 기본 image는 `eclipse-temurin:21-jdk`이고, 로컬에 다른 Java 21 image가 있으면 `DOCKER_T3MICRO_IMAGE=<image>`로 바꿀 수 있습니다.
+- Docker smoke는 host 자원이 큰 개발 머신에서 놓칠 수 있는 JVM/thread/pool 압력 회귀를 빨리 잡는 용도입니다.
+- 최종 120% headroom 판정은 실제 EC2 `t3.micro` staging에서 transaction replay, read replica smoke, production capacity smoke를 실행한 결과로 닫습니다.
 
 ## Notification Read State
 

--- a/compose.t3micro.yml
+++ b/compose.t3micro.yml
@@ -1,0 +1,32 @@
+services:
+  postgres:
+    cpus: "${T3MICRO_POSTGRES_CPUS:-0.60}"
+    mem_limit: "${T3MICRO_POSTGRES_MEMORY:-384m}"
+    memswap_limit: "${T3MICRO_POSTGRES_MEMORY_SWAP:-384m}"
+    pids_limit: ${T3MICRO_POSTGRES_PIDS_LIMIT:-128}
+
+  kafka:
+    cpus: "${T3MICRO_KAFKA_CPUS:-0.90}"
+    mem_limit: "${T3MICRO_KAFKA_MEMORY:-448m}"
+    memswap_limit: "${T3MICRO_KAFKA_MEMORY_SWAP:-448m}"
+    pids_limit: ${T3MICRO_KAFKA_PIDS_LIMIT:-256}
+    environment:
+      KAFKA_HEAP_OPTS: "${T3MICRO_KAFKA_HEAP_OPTS:--Xms128m -Xmx256m}"
+
+  redis:
+    cpus: "${T3MICRO_REDIS_CPUS:-0.10}"
+    mem_limit: "${T3MICRO_REDIS_MEMORY:-64m}"
+    memswap_limit: "${T3MICRO_REDIS_MEMORY_SWAP:-64m}"
+    pids_limit: ${T3MICRO_REDIS_PIDS_LIMIT:-64}
+    command:
+      [
+        "redis-server",
+        "--appendonly",
+        "no",
+        "--save",
+        "",
+        "--maxmemory",
+        "${T3MICRO_REDIS_MAXMEMORY:-48mb}",
+        "--maxmemory-policy",
+        "noeviction",
+      ]

--- a/tools/test/check-docker-t3micro-capacity-smoke-script.sh
+++ b/tools/test/check-docker-t3micro-capacity-smoke-script.sh
@@ -19,6 +19,7 @@ plan="$(
 grep -F "source=tools/test/run-production-t3micro-capacity-smoke.sh" <<<"${plan}" >/dev/null
 grep -F "image=local-java21" <<<"${plan}" >/dev/null
 grep -F "cpus=2 memory=1024m memory-swap=1024m pids-limit=384" <<<"${plan}" >/dev/null
+grep -F "prepare-test-classes=true" <<<"${plan}" >/dev/null
 grep -F "repeat=2" <<<"${plan}" >/dev/null
 grep -F "DB_POOL_MAX_SIZE=4" <<<"${plan}" >/dev/null
 grep -F "SERVER_THREADS_MAX=16" <<<"${plan}" >/dev/null
@@ -52,5 +53,9 @@ if DOCKER_T3MICRO_MEMORY=0m "${script}" --print-plan >/dev/null 2>&1; then
 fi
 if DOCKER_T3MICRO_PIDS_LIMIT=abc "${script}" --print-plan >/dev/null 2>&1; then
   echo "DOCKER_T3MICRO_PIDS_LIMIT=abc unexpectedly succeeded" >&2
+  exit 1
+fi
+if DOCKER_T3MICRO_PREPARE_TEST_CLASSES=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "DOCKER_T3MICRO_PREPARE_TEST_CLASSES=maybe unexpectedly succeeded" >&2
   exit 1
 fi

--- a/tools/test/check-docker-t3micro-capacity-smoke-script.sh
+++ b/tools/test/check-docker-t3micro-capacity-smoke-script.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-docker-t3micro-capacity-smoke.sh"
+
+echo "[docker-t3micro-capacity-script] syntax: ${script}"
+bash -n "${script}"
+
+echo "[docker-t3micro-capacity-script] plan includes Docker cgroup budget and production smoke source"
+plan="$(
+  DOCKER_T3MICRO_IMAGE=local-java21 \
+  DOCKER_T3MICRO_CPUS=2 \
+  DOCKER_T3MICRO_MEMORY=1024m \
+  DOCKER_T3MICRO_MEMORY_SWAP=1024m \
+  DOCKER_T3MICRO_PIDS_LIMIT=384 \
+  SOAK_REPEAT=2 \
+    "${script}" --print-plan
+)"
+grep -F "source=tools/test/run-production-t3micro-capacity-smoke.sh" <<<"${plan}" >/dev/null
+grep -F "image=local-java21" <<<"${plan}" >/dev/null
+grep -F "cpus=2 memory=1024m memory-swap=1024m pids-limit=384" <<<"${plan}" >/dev/null
+grep -F "repeat=2" <<<"${plan}" >/dev/null
+grep -F "DB_POOL_MAX_SIZE=4" <<<"${plan}" >/dev/null
+grep -F "SERVER_THREADS_MAX=16" <<<"${plan}" >/dev/null
+
+echo "[docker-t3micro-capacity-script] dry-run includes Docker resource flags"
+dry_run="$(
+  DOCKER_T3MICRO_IMAGE=local-java21 \
+  DOCKER_T3MICRO_CPUS=2 \
+  DOCKER_T3MICRO_MEMORY=1024m \
+  DOCKER_T3MICRO_MEMORY_SWAP=1024m \
+  DOCKER_T3MICRO_PIDS_LIMIT=384 \
+    "${script}" --dry-run
+)"
+grep -F -- "--cpus 2" <<<"${dry_run}" >/dev/null
+grep -F -- "--memory 1024m" <<<"${dry_run}" >/dev/null
+grep -F -- "--memory-swap 1024m" <<<"${dry_run}" >/dev/null
+grep -F -- "--pids-limit 384" <<<"${dry_run}" >/dev/null
+grep -F "local-java21 bash -lc tools/test/run-production-t3micro-capacity-smoke.sh" <<<"${dry_run}" >/dev/null
+
+echo "[docker-t3micro-capacity-script] compose override is valid"
+docker compose -f compose.yml -f compose.t3micro.yml config >/dev/null
+
+echo "[docker-t3micro-capacity-script] invalid Docker budget fails before run"
+if DOCKER_T3MICRO_CPUS=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "DOCKER_T3MICRO_CPUS=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if DOCKER_T3MICRO_MEMORY=0m "${script}" --print-plan >/dev/null 2>&1; then
+  echo "DOCKER_T3MICRO_MEMORY=0m unexpectedly succeeded" >&2
+  exit 1
+fi
+if DOCKER_T3MICRO_PIDS_LIMIT=abc "${script}" --print-plan >/dev/null 2>&1; then
+  echo "DOCKER_T3MICRO_PIDS_LIMIT=abc unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/check-t3micro-mixed-workload-soak-script.sh
+++ b/tools/test/check-t3micro-mixed-workload-soak-script.sh
@@ -16,6 +16,9 @@ grep -F "*TransferCommandApiIntegrationTest" <<<"${plan}" >/dev/null
 grep -F "*NotificationSseBrokerTest" <<<"${plan}" >/dev/null
 grep -F "*NotificationSseIntegrationTest" <<<"${plan}" >/dev/null
 
+echo "[t3micro-mixed-soak-script] smoke reruns test task"
+grep -F "cleanTest test" "${script}" >/dev/null
+
 echo "[t3micro-mixed-soak-script] guard: invalid repeat fails before Gradle"
 if SOAK_REPEAT=0 "${script}" --print-plan >/dev/null 2>&1; then
   echo "SOAK_REPEAT=0 unexpectedly succeeded" >&2

--- a/tools/test/run-docker-t3micro-capacity-smoke.sh
+++ b/tools/test/run-docker-t3micro-capacity-smoke.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-docker-t3micro-capacity-smoke.sh [--print-plan|--dry-run]
+
+Environment:
+  DOCKER_T3MICRO_IMAGE             Java 21 JDK image, default eclipse-temurin:21-jdk
+  DOCKER_T3MICRO_CPUS              Docker CPU quota, default 2
+  DOCKER_T3MICRO_MEMORY            Docker memory limit, default 1024m
+  DOCKER_T3MICRO_MEMORY_SWAP       Docker memory+swap limit, default 1024m
+  DOCKER_T3MICRO_PIDS_LIMIT        Docker pids limit, default 384
+  DOCKER_T3MICRO_GRADLE_USER_HOME  Host Gradle cache mount, default $HOME/.gradle
+  SOAK_REPEAT                      repeat count passed to production smoke, default 1
+
+Examples:
+  tools/test/run-docker-t3micro-capacity-smoke.sh --print-plan
+  tools/test/run-docker-t3micro-capacity-smoke.sh --dry-run
+  tools/test/run-docker-t3micro-capacity-smoke.sh
+USAGE
+}
+
+require_positive_number() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*([.][0-9]+)?$ ]]; then
+    echo "${name} must be a positive number" >&2
+    exit 1
+  fi
+}
+
+require_memory_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*[kKmMgG]?$ ]]; then
+    echo "${name} must be a positive Docker memory value" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer" >&2
+    exit 1
+  fi
+}
+
+mode="run"
+if [[ "${1:-}" == "--print-plan" ]]; then
+  mode="print-plan"
+  shift
+elif [[ "${1:-}" == "--dry-run" ]]; then
+  mode="dry-run"
+  shift
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 0 ]]; then
+  usage
+  exit 1
+fi
+
+image="${DOCKER_T3MICRO_IMAGE:-eclipse-temurin:21-jdk}"
+cpus="${DOCKER_T3MICRO_CPUS:-2}"
+memory="${DOCKER_T3MICRO_MEMORY:-1024m}"
+memory_swap="${DOCKER_T3MICRO_MEMORY_SWAP:-1024m}"
+pids_limit="${DOCKER_T3MICRO_PIDS_LIMIT:-384}"
+repeat="${SOAK_REPEAT:-1}"
+db_pool_max_size="${PRODUCTION_T3MICRO_DB_POOL_MAX_SIZE:-4}"
+server_threads_max="${PRODUCTION_T3MICRO_SERVER_THREADS_MAX:-16}"
+sse_max_total_sessions="${PRODUCTION_T3MICRO_SSE_MAX_TOTAL_SESSIONS:-64}"
+notification_stream_max="${PRODUCTION_T3MICRO_NOTIFICATION_STREAM_MAX:-4}"
+
+require_positive_number "DOCKER_T3MICRO_CPUS" "${cpus}"
+require_memory_value "DOCKER_T3MICRO_MEMORY" "${memory}"
+require_memory_value "DOCKER_T3MICRO_MEMORY_SWAP" "${memory_swap}"
+require_positive_integer "DOCKER_T3MICRO_PIDS_LIMIT" "${pids_limit}"
+require_positive_integer "SOAK_REPEAT" "${repeat}"
+require_positive_integer "PRODUCTION_T3MICRO_DB_POOL_MAX_SIZE" "${db_pool_max_size}"
+require_positive_integer "PRODUCTION_T3MICRO_SERVER_THREADS_MAX" "${server_threads_max}"
+require_positive_integer "PRODUCTION_T3MICRO_SSE_MAX_TOTAL_SESSIONS" "${sse_max_total_sessions}"
+require_positive_integer "PRODUCTION_T3MICRO_NOTIFICATION_STREAM_MAX" "${notification_stream_max}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+host_gradle_home="${DOCKER_T3MICRO_GRADLE_USER_HOME:-${HOME}/.gradle}"
+container_workdir="/workspace"
+container_name="aquila-bank-docker-t3micro-capacity-${USER:-local}-$$"
+container_command="tools/test/run-production-t3micro-capacity-smoke.sh"
+
+print_plan() {
+  echo "[docker-t3micro-capacity] source=tools/test/run-production-t3micro-capacity-smoke.sh"
+  echo "[docker-t3micro-capacity] image=${image}"
+  echo "[docker-t3micro-capacity] docker limit: cpus=${cpus} memory=${memory} memory-swap=${memory_swap} pids-limit=${pids_limit}"
+  echo "[docker-t3micro-capacity] gradle cache=${host_gradle_home}"
+  echo "[docker-t3micro-capacity] caveat: Docker cgroup은 CPU credit, EBS latency, 실제 AWS network를 재현하지 않습니다."
+  SOAK_REPEAT="${repeat}" \
+  PRODUCTION_T3MICRO_DB_POOL_MAX_SIZE="${db_pool_max_size}" \
+  PRODUCTION_T3MICRO_SERVER_THREADS_MAX="${server_threads_max}" \
+  PRODUCTION_T3MICRO_SSE_MAX_TOTAL_SESSIONS="${sse_max_total_sessions}" \
+  PRODUCTION_T3MICRO_NOTIFICATION_STREAM_MAX="${notification_stream_max}" \
+    tools/test/run-production-t3micro-capacity-smoke.sh --print-plan
+}
+
+docker_args=(
+  run
+  --rm
+  --name "${container_name}"
+  --cpus "${cpus}"
+  --memory "${memory}"
+  --memory-swap "${memory_swap}"
+  --pids-limit "${pids_limit}"
+  --workdir "${container_workdir}"
+  --user "$(id -u):$(id -g)"
+  -e "HOME=/tmp"
+  -e "GRADLE_USER_HOME=/tmp/.gradle"
+  -e "JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:--XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=40}"
+  -e "GRADLE_OPTS=${GRADLE_OPTS:--Dorg.gradle.jvmargs=-Xmx512m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false}"
+  -e "SOAK_REPEAT=${repeat}"
+  -e "PRODUCTION_T3MICRO_DB_POOL_MAX_SIZE=${db_pool_max_size}"
+  -e "PRODUCTION_T3MICRO_SERVER_THREADS_MAX=${server_threads_max}"
+  -e "PRODUCTION_T3MICRO_SSE_MAX_TOTAL_SESSIONS=${sse_max_total_sessions}"
+  -e "PRODUCTION_T3MICRO_NOTIFICATION_STREAM_MAX=${notification_stream_max}"
+  -v "${repo_root}:${container_workdir}"
+  -v "${host_gradle_home}:/tmp/.gradle"
+)
+
+print_command() {
+  printf '[docker-t3micro-capacity] docker command: docker'
+  printf ' %q' "${docker_args[@]}" "${image}" bash -lc "${container_command}"
+  printf '\n'
+}
+
+print_plan
+
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+print_command
+
+if [[ "${mode}" == "dry-run" ]]; then
+  exit 0
+fi
+
+command -v docker >/dev/null 2>&1 || {
+  echo "docker command is required" >&2
+  exit 1
+}
+
+mkdir -p "${host_gradle_home}"
+
+docker "${docker_args[@]}" "${image}" bash -lc "${container_command}"

--- a/tools/test/run-docker-t3micro-capacity-smoke.sh
+++ b/tools/test/run-docker-t3micro-capacity-smoke.sh
@@ -12,6 +12,7 @@ Environment:
   DOCKER_T3MICRO_MEMORY_SWAP       Docker memory+swap limit, default 1024m
   DOCKER_T3MICRO_PIDS_LIMIT        Docker pids limit, default 384
   DOCKER_T3MICRO_GRADLE_USER_HOME  Host Gradle cache mount, default $HOME/.gradle
+  DOCKER_T3MICRO_PREPARE_TEST_CLASSES  compile test classes on host before Docker run, default true
   SOAK_REPEAT                      repeat count passed to production smoke, default 1
 
 Examples:
@@ -48,6 +49,18 @@ require_positive_integer() {
   fi
 }
 
+require_boolean() {
+  local name="$1"
+  local value="$2"
+  case "${value}" in
+    true | false) ;;
+    *)
+      echo "${name} must be true or false" >&2
+      exit 1
+      ;;
+  esac
+}
+
 mode="run"
 if [[ "${1:-}" == "--print-plan" ]]; then
   mode="print-plan"
@@ -75,6 +88,7 @@ db_pool_max_size="${PRODUCTION_T3MICRO_DB_POOL_MAX_SIZE:-4}"
 server_threads_max="${PRODUCTION_T3MICRO_SERVER_THREADS_MAX:-16}"
 sse_max_total_sessions="${PRODUCTION_T3MICRO_SSE_MAX_TOTAL_SESSIONS:-64}"
 notification_stream_max="${PRODUCTION_T3MICRO_NOTIFICATION_STREAM_MAX:-4}"
+prepare_test_classes="${DOCKER_T3MICRO_PREPARE_TEST_CLASSES:-true}"
 
 require_positive_number "DOCKER_T3MICRO_CPUS" "${cpus}"
 require_memory_value "DOCKER_T3MICRO_MEMORY" "${memory}"
@@ -85,6 +99,7 @@ require_positive_integer "PRODUCTION_T3MICRO_DB_POOL_MAX_SIZE" "${db_pool_max_si
 require_positive_integer "PRODUCTION_T3MICRO_SERVER_THREADS_MAX" "${server_threads_max}"
 require_positive_integer "PRODUCTION_T3MICRO_SSE_MAX_TOTAL_SESSIONS" "${sse_max_total_sessions}"
 require_positive_integer "PRODUCTION_T3MICRO_NOTIFICATION_STREAM_MAX" "${notification_stream_max}"
+require_boolean "DOCKER_T3MICRO_PREPARE_TEST_CLASSES" "${prepare_test_classes}"
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 host_gradle_home="${DOCKER_T3MICRO_GRADLE_USER_HOME:-${HOME}/.gradle}"
@@ -96,6 +111,7 @@ print_plan() {
   echo "[docker-t3micro-capacity] source=tools/test/run-production-t3micro-capacity-smoke.sh"
   echo "[docker-t3micro-capacity] image=${image}"
   echo "[docker-t3micro-capacity] docker limit: cpus=${cpus} memory=${memory} memory-swap=${memory_swap} pids-limit=${pids_limit}"
+  echo "[docker-t3micro-capacity] prepare-test-classes=${prepare_test_classes}"
   echo "[docker-t3micro-capacity] gradle cache=${host_gradle_home}"
   echo "[docker-t3micro-capacity] caveat: Docker cgroup은 CPU credit, EBS latency, 실제 AWS network를 재현하지 않습니다."
   SOAK_REPEAT="${repeat}" \
@@ -153,5 +169,11 @@ command -v docker >/dev/null 2>&1 || {
 }
 
 mkdir -p "${host_gradle_home}"
+
+if [[ "${prepare_test_classes}" == "true" ]]; then
+  echo "[docker-t3micro-capacity] preparing testClasses on host before cgroup smoke"
+  # Gradle compile 비용은 앱 런타임 부하가 아니므로 Docker 1GiB 판정에서 분리합니다.
+  tools/test/with-resource-lock.sh back-gradle-docker-t3micro-testclasses ./back/gradlew -p back testClasses
+fi
 
 docker "${docker_args[@]}" "${image}" bash -lc "${container_command}"

--- a/tools/test/run-t3micro-mixed-workload-soak.sh
+++ b/tools/test/run-t3micro-mixed-workload-soak.sh
@@ -42,7 +42,8 @@ test_selectors=(
   "*NotificationSseIntegrationTest"
 )
 
-gradle_args=(./back/gradlew -p back test)
+# smoke는 이전 test result cache가 아니라 현재 budget에서의 실제 실행을 봅니다.
+gradle_args=(./back/gradlew -p back cleanTest test)
 for selector in "${test_selectors[@]}"; do
   gradle_args+=(--tests "${selector}")
 done


### PR DESCRIPTION
## 🔗 Related Issue
- close #336

## 🌿 Base Branch
- `main`

## 📝 Summary
- Docker cgroup 제한으로 기존 production t3.micro capacity smoke를 실행하는 로컬 검증 entrypoint를 추가합니다.
- 로컬 인프라용 `compose.t3micro.yml` override를 추가하고, Docker 근사 검증과 EC2 staging 최종 판정의 차이를 문서화합니다.

## 🛠 Changes
- `compose.t3micro.yml`로 Postgres/Kafka/Redis 로컬 인프라 CPU, memory, swap, pids budget을 고정했습니다.
- `tools/test/run-docker-t3micro-capacity-smoke.sh`를 추가해 2 vCPU / 1GiB / swap 1GiB / pids 384 제한 안에서 기존 production capacity smoke를 재사용합니다.
- Docker smoke가 Gradle compile 비용 때문에 false negative를 내지 않도록 host `testClasses` preflight를 추가했습니다.
- `run-t3micro-mixed-workload-soak.sh`가 `cleanTest test`를 실행해 smoke가 이전 test result cache에 묻히지 않도록 했습니다.
- README에 Docker 근사 검증은 빠른 로컬 회귀용이고, 최종 120% headroom 판정은 EC2 `t3.micro` staging smoke로 닫는다고 명시했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-docker-t3micro-capacity-smoke-script.sh` 통과
- `tools/test/check-t3micro-mixed-workload-soak-script.sh` 통과
- `docker compose -f compose.yml -f compose.t3micro.yml config >/tmp/aquila-compose-t3micro-config.yml` 통과
- `git diff --check` 통과
- `tools/test/run-docker-t3micro-capacity-smoke.sh` 통과: Docker `--cpus 2 --memory 1024m --memory-swap 1024m --pids-limit 384`, `BUILD SUCCESSFUL in 7s`
- `tools/test/run-production-t3micro-capacity-smoke.sh` 통과: `BUILD SUCCESSFUL in 1m 49s`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check` 통과: `BUILD SUCCESSFUL in 4m 51s`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Docker Desktop cgroup 동작은 AWS `t3.micro` CPU credit, EBS 지연, 실제 네트워크를 재현하지 못합니다. 이 PR의 Docker smoke는 빠른 로컬 회귀 검출용이고 최종 capacity 판정은 staging smoke가 담당합니다.
- 롤백 방법: 이 PR을 revert하면 Docker smoke entrypoint, compose override, `cleanTest test` smoke 변경이 함께 제거됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
