### PR TITLE
[Docs] Docker t3.micro 로컬 성능 테스트 결과 문서화

### DIFF
--- a/docs/performance-results/2026-04-25-docker-t3micro-local-smoke.md
+++ b/docs/performance-results/2026-04-25-docker-t3micro-local-smoke.md
@@ -1,0 +1,100 @@
+# 2026-04-25 Docker t3.micro Local Smoke Result
+
+## 목적
+
+- 로컬 Docker cgroup 제한에서 대용량 트래픽 대응 smoke와 거래 조회 regression gate를 실행했다.
+- 이번 결과는 `t3.micro` 근사 로컬 회귀 검증이다.
+- 실제 1억 건 실데이터 HTTP replay, k6, Prometheus, Grafana 기반 검증은 아직 이 저장소의 로컬 실행 환경으로 구성되어 있지 않아 실행하지 않았다.
+
+## 테스트 환경
+
+- 실행 시각: 2026-04-25 01:14:24 KST
+- 실행 위치: `/Users/aquila/Custom/GitProjects/aquila-bank`
+- Git 기준: `main`
+- Docker image: `eclipse-temurin:21-jdk`
+- Docker cgroup budget:
+  - CPU: `--cpus 2`
+  - memory: `--memory 1024m`
+  - memory swap: `--memory-swap 1024m`
+  - pids: `--pids-limit 384`
+- JVM/Gradle budget:
+  - `JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=40`
+  - `GRADLE_OPTS=-Dorg.gradle.jvmargs=-Xmx512m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false`
+
+## 실행 결과
+
+### 대용량 트래픽 mixed workload
+
+명령:
+
+```bash
+tools/test/run-docker-t3micro-capacity-smoke.sh
+```
+
+검증 범위:
+
+- transaction query concurrency
+- transfer write / outbox side effect
+- notification fanout
+- SSE stream / duplicate / backpressure guard
+
+결과:
+
+- 상태: 통과
+- Docker 제한: `2 vCPU / 1GiB / swap 1GiB / pids 384`
+- Gradle 결과: `BUILD SUCCESSFUL in 6s`
+- 실행 task: `cleanTest`, `test`
+
+### 거래 조회 regression gate
+
+명령:
+
+```bash
+tools/test/with-resource-lock.sh back-gradle-docker-t3micro-testclasses ./back/gradlew -p back testClasses
+docker run --rm \
+  --name aquila-bank-docker-t3micro-transaction-plan \
+  --cpus 2 \
+  --memory 1024m \
+  --memory-swap 1024m \
+  --pids-limit 384 \
+  --workdir /workspace \
+  --user 501:20 \
+  -e HOME=/tmp \
+  -e GRADLE_USER_HOME=/tmp/.gradle \
+  -e JAVA_TOOL_OPTIONS='-XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=40' \
+  -e GRADLE_OPTS='-Dorg.gradle.jvmargs=-Xmx512m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false' \
+  -v /Users/aquila/Custom/GitProjects/aquila-bank:/workspace \
+  -v /Users/aquila/.gradle:/tmp/.gradle \
+  eclipse-temurin:21-jdk \
+  bash -lc 'tools/test/run-transaction-query-plan-regression-gate.sh'
+```
+
+검증 범위:
+
+- baseline hot account query
+- long-history partition-fit fixture
+- account-scoped keyset plan
+- `Seq Scan` / `Sort` 회귀 방지
+- statement timeout / query timeout / request timeout
+- transaction concurrency SLO
+
+결과:
+
+- 상태: 통과
+- Docker 제한: `2 vCPU / 1GiB / swap 1GiB / pids 384`
+- Gradle 결과: `BUILD SUCCESSFUL in 5s`
+
+## 해석
+
+- 현재 저장소에 있는 Docker t3.micro 근사 smoke와 거래 조회 regression gate는 로컬 cgroup 제한 안에서 통과했다.
+- 이 결과는 “1억 건 실데이터를 로컬 PostgreSQL에 적재한 뒤 HTTP로 조회했다”는 의미가 아니다.
+- 현재 1억 건 실데이터 replay는 `tools/ops/transaction-read-model-staging-replay.sh` 기준으로 staging/RDS 환경의 `reltuples` estimate와 hot/cold account를 요구한다.
+- 로컬에서 k6, Prometheus, Grafana를 함께 띄워 HTTP p95와 dashboard artifact를 남기는 환경은 아직 없다.
+
+## 후속 작업
+
+- k6 + Prometheus + Grafana compose profile 추가
+- backend app container 또는 t3.micro 제한 host runner 고정
+- 1억 건 로컬 데이터 적재 또는 staging replay와 동일한 report contract 결정
+- `docs/performance-results/YYYY-MM-DD-*.md` 형식으로 모든 성능 실행 결과 자동 기록
+- k6 summary JSON, Prometheus snapshot query, Grafana dashboard 링크 또는 export artifact를 report에 연결


### PR DESCRIPTION
## 🔗 Related Issue
- close #338

## 🌿 Base Branch
- `main`

## 📝 Summary
- 2026-04-25 KST 로컬 Docker t3.micro 근사 환경에서 실행한 성능 smoke 결과를 문서로 남깁니다.
- 현재 저장소에 k6/Prometheus/Grafana 기반 실 HTTP 부하 환경과 로컬 1억 row 적재기는 없으므로, 이번 문서는 기존 Docker/JUnit gate 결과와 한계를 명시합니다.

## 🛠 Changes
- `docs/performance-results/2026-04-25-docker-t3micro-local-smoke.md` 추가
- Docker cgroup budget, 실행 명령, 통과 결과, 1억 실데이터/k6 미실행 한계, 후속 작업 기록

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-docker-t3micro-capacity-smoke.sh` 통과: Docker `2 vCPU / 1GiB / swap 1GiB / pids 384`, `BUILD SUCCESSFUL in 6s`
- Docker 제한 안에서 `tools/test/run-transaction-query-plan-regression-gate.sh` 통과: `BUILD SUCCESSFUL in 5s`
- `git diff --check` 통과

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 문서가 현재 가능한 Docker/JUnit smoke 결과와 실제 k6/1억 row HTTP replay를 혼동하게 만들 수 있어, 한계와 후속 작업을 명시했습니다.
- 롤백 방법: 이 PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
