### PR TITLE
[Perf] transaction read model 100m local seed/runner 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - 로컬 개발: `Docker Compose + PostgreSQL 18 + Kafka`
 - 로컬 t3.micro 근사 검증: `compose.t3micro.yml`과 `tools/test/run-docker-t3micro-capacity-smoke.sh`로 CPU/메모리 cgroup 제한을 적용합니다.
 - 로컬 HTTP 부하 테스트: `compose.loadtest.yml`로 backend, k6, Prometheus, Grafana, Alertmanager, Postgres exporter를 함께 띄웁니다.
+- 로컬 1억 건 synthetic 조회 테스트: `tools/test/run-transaction-read-model-100m-k6-local.sh`로 read model seed와 k6 실행을 연결합니다.
 - 배포 환경: `EC2 + RDS PostgreSQL 18`
 - EC2 reverse proxy baseline template은 [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)에 두고, runtime 값은 `ops/nginx/runtime.env.example` 기반으로 렌더링합니다.
 - `compose.yml`은 로컬 개발 전용이며, 배포용 인프라 정의는 포함하지 않습니다.

--- a/back/README.md
+++ b/back/README.md
@@ -518,6 +518,23 @@ tools/test/run-k6-transaction-100m-loadtest.sh
 - k6 summary 원본은 `build/reports/k6`, 리뷰용 Markdown은 `docs/performance-results`에 남깁니다.
 - 이 runner는 1억 row를 적재하지 않습니다. `K6_*_ACCOUNT_ID`와 기간은 이미 데이터가 준비된 local/staging dataset에 맞춰 넣어야 합니다.
 
+로컬 PostgreSQL에 read model 전용 1억 건 synthetic dataset을 직접 만들고 k6까지 이어서 실행하려면 아래 wrapper를 사용합니다.
+
+```bash
+SEED_TOTAL_ROWS=100000000 \
+SEED_TRUNCATE=true \
+tools/test/run-transaction-read-model-100m-k6-local.sh
+```
+
+- 기본 dataset은 `transaction_read_model` 5천만 row, `transaction_read_model_archive` 5천만 row입니다.
+- 기본 hot account는 `910000001`, cold account는 `910000002`입니다.
+- 기본 조회 기간은 hot `2026-04-01T00:00:00Z..2026-04-30T00:00:00Z`, cold `2026-01-01T00:00:00Z..2026-01-31T00:00:00Z`입니다.
+- seed는 read path 성능 검증 전용입니다. 원장 1억 건을 생성하지 않고, seed 중에만 read model FK trigger를 비활성화합니다.
+- 적재 시간을 줄이기 위해 secondary read index를 seed 전 drop하고 seed 후 재생성합니다.
+- local disk와 Docker volume을 크게 사용합니다. 실행 전 `df -h .`로 여유 공간을 확인합니다.
+- 실패 후 재시도할 때는 `SEED_TRUNCATE=true`를 유지해 중간 적재 데이터를 정리하고 다시 시작합니다.
+- k6 결과 Markdown은 `docs/performance-results`, 원본 JSON/Markdown은 `build/reports/k6`에 남습니다.
+
 ## Notification Read State
 
 - JWT user 경로의 읽음 상태는 `notification_user_read_state`에 user별로 저장됩니다.

--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -26,6 +26,21 @@ YYYY-MM-DD-<environment>-<workload>.md
 
 `tools/test/run-k6-transaction-100m-loadtest.sh`는 k6 summary Markdown을 생성한 뒤 기본적으로 이 디렉터리에 복사합니다.
 
+로컬 DB에 1억 건 synthetic read model을 먼저 적재하고 k6까지 이어서 실행하는 표준 경로는 아래 명령입니다.
+
+```bash
+SEED_TOTAL_ROWS=100000000 \
+SEED_TRUNCATE=true \
+tools/test/run-transaction-read-model-100m-k6-local.sh
+```
+
+실행 전 확인값:
+
+- local disk 여유 공간
+- Docker Desktop memory/disk limit
+- `compose.loadtest.yml`의 backend `2 vCPU / 1GiB` budget
+- hot/cold account와 기간 기본값이 테스트 의도와 맞는지 여부
+
 수동 보관이 필요하면 아래 명령을 사용합니다.
 
 ```bash

--- a/docs/performance-results/transaction-100m-small-smoke-summary.md
+++ b/docs/performance-results/transaction-100m-small-smoke-summary.md
@@ -1,0 +1,43 @@
+# transaction-100m-small-smoke-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-24T16:46:55Z
+- sourceMarkdown: build/reports/k6/transaction-100m-small-smoke-summary.md
+- sourceJson: build/reports/k6/transaction-100m-small-smoke-summary.json
+
+## Smoke Scope
+
+- seed total rows: 1,000
+- hot read model rows: 500
+- archive read model rows: 500
+- 실제 1억 row 적재/부하 실행 결과가 아니라 local runner 계약 검증용 작은 smoke 결과입니다.
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 1
+- duration: 5s
+- limit: 50
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- http failed rate threshold: 0.01
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- hot first p95 ms: 1.8344381
+- hot cursor p95 ms: 1.8610963999999997
+- cold first p95 ms: 1.8423172999999993
+- cold cursor p95 ms: 1.7916246999999996
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- Prometheus remote write 대상은 `K6_PROMETHEUS_RW_SERVER_URL`입니다.

--- a/tools/test/check-transaction-read-model-100m-local-runner.sh
+++ b/tools/test/check-transaction-read-model-100m-local-runner.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[transaction-100m-local-runner] shell syntax"
+bash -n tools/test/seed-transaction-read-model-100m.sh
+
+echo "[transaction-100m-local-runner] compose config"
+docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/dev/null
+
+echo "[transaction-100m-local-runner] seed plan"
+plan="$(
+  SEED_TOTAL_ROWS=1000 \
+  SEED_HOT_ROWS=600 \
+  SEED_BATCH_SIZE=200 \
+  SEED_TRUNCATE=true \
+    tools/test/seed-transaction-read-model-100m.sh --print-plan
+)"
+grep -F "total_rows=1000" <<<"${plan}" >/dev/null
+grep -F "hot_rows=600 archive_rows=400 batch_size=200" <<<"${plan}" >/dev/null
+grep -F "truncate=true" <<<"${plan}" >/dev/null
+grep -F "local read-path seed only" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-local-runner] seed script contract"
+grep -F "TRIGGER ALL" tools/test/seed-transaction-read-model-100m.sh >/dev/null
+grep -F "CREATE INDEX IF NOT EXISTS idx_transaction_read_model_account_cursor" tools/test/seed-transaction-read-model-100m.sh >/dev/null
+grep -F "generate_series" tools/test/seed-transaction-read-model-100m.sh >/dev/null
+grep -F "ANALYZE transaction_read_model" tools/test/seed-transaction-read-model-100m.sh >/dev/null
+
+echo "[transaction-100m-local-runner] invalid seed input fails"
+if SEED_TOTAL_ROWS=0 tools/test/seed-transaction-read-model-100m.sh --print-plan >/dev/null 2>&1; then
+  echo "SEED_TOTAL_ROWS=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if SEED_TOTAL_ROWS=100 SEED_HOT_ROWS=100 tools/test/seed-transaction-read-model-100m.sh --print-plan >/dev/null 2>&1; then
+  echo "SEED_HOT_ROWS=SEED_TOTAL_ROWS unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/check-transaction-read-model-100m-local-runner.sh
+++ b/tools/test/check-transaction-read-model-100m-local-runner.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 echo "[transaction-100m-local-runner] shell syntax"
 bash -n tools/test/seed-transaction-read-model-100m.sh
+bash -n tools/test/run-transaction-read-model-100m-k6-local.sh
 
 echo "[transaction-100m-local-runner] compose config"
 docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/dev/null
@@ -35,3 +36,18 @@ if SEED_TOTAL_ROWS=100 SEED_HOT_ROWS=100 tools/test/seed-transaction-read-model-
   echo "SEED_HOT_ROWS=SEED_TOTAL_ROWS unexpectedly succeeded" >&2
   exit 1
 fi
+
+echo "[transaction-100m-local-runner] wrapper plan"
+wrapper_plan="$(
+  SEED_TOTAL_ROWS=1000 \
+  K6_REPORT_NAME=transaction-100m-check \
+    tools/test/run-transaction-read-model-100m-k6-local.sh --print-plan
+)"
+grep -F "mode=print-plan" <<<"${wrapper_plan}" >/dev/null
+grep -F "seed_total_rows=1000" <<<"${wrapper_plan}" >/dev/null
+grep -F "k6 report=transaction-100m-check" <<<"${wrapper_plan}" >/dev/null
+grep -F "Prometheus http://localhost:9090, Grafana http://localhost:3001" <<<"${wrapper_plan}" >/dev/null
+
+echo "[transaction-100m-local-runner] wrapper contract"
+grep -F "run-k6-transaction-100m-loadtest.sh --no-up" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
+grep -F "seed-transaction-read-model-100m.sh" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null

--- a/tools/test/run-transaction-read-model-100m-k6-local.sh
+++ b/tools/test/run-transaction-read-model-100m-k6-local.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-model-100m-k6-local.sh [--print-plan|--seed-only|--k6-only]
+
+Environment:
+  SEED_TOTAL_ROWS      default 100000000
+  SEED_TRUNCATE        default true for this wrapper
+  K6_REPORT_NAME       default transaction-100m-local-<timestamp>
+  K6_VUS               default 8
+  K6_DURATION          default 1m
+
+Examples:
+  tools/test/run-transaction-read-model-100m-k6-local.sh --print-plan
+  SEED_TOTAL_ROWS=100000000 tools/test/run-transaction-read-model-100m-k6-local.sh
+USAGE
+}
+
+mode="run"
+if [[ "${1:-}" == "--print-plan" ]]; then
+  mode="print-plan"
+  shift
+elif [[ "${1:-}" == "--seed-only" ]]; then
+  mode="seed-only"
+  shift
+elif [[ "${1:-}" == "--k6-only" ]]; then
+  mode="k6-only"
+  shift
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$#" -ne 0 ]]; then
+  usage
+  exit 1
+fi
+
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+seed_total_rows="${SEED_TOTAL_ROWS:-100000000}"
+seed_hot_account_id="${SEED_HOT_ACCOUNT_ID:-910000001}"
+seed_cold_account_id="${SEED_COLD_ACCOUNT_ID:-910000002}"
+seed_hot_from="${SEED_HOT_FROM:-2026-04-01T00:00:00Z}"
+seed_hot_to="${SEED_HOT_TO:-2026-04-30T00:00:00Z}"
+seed_cold_from="${SEED_COLD_FROM:-2026-01-01T00:00:00Z}"
+seed_cold_to="${SEED_COLD_TO:-2026-01-31T00:00:00Z}"
+seed_truncate="${SEED_TRUNCATE:-true}"
+k6_report_name="${K6_REPORT_NAME:-transaction-100m-local-$(date +%Y-%m-%d-%H%M%S)}"
+
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
+
+print_plan() {
+  echo "[transaction-100m-local] mode=${mode}"
+  echo "[transaction-100m-local] seed_total_rows=${seed_total_rows} seed_truncate=${seed_truncate}"
+  echo "[transaction-100m-local] hot account=${seed_hot_account_id} window=${seed_hot_from}..${seed_hot_to}"
+  echo "[transaction-100m-local] cold account=${seed_cold_account_id} window=${seed_cold_from}..${seed_cold_to}"
+  echo "[transaction-100m-local] k6 report=${k6_report_name} vus=${K6_VUS:-8} duration=${K6_DURATION:-1m}"
+  echo "[transaction-100m-local] observability: Prometheus http://localhost:9090, Grafana http://localhost:3001"
+}
+
+wait_for_schema() {
+  local attempt exists
+  for attempt in $(seq 1 90); do
+    if exists="$("${psql_base[@]}" --no-align --tuples-only --command "SELECT to_regclass('public.transaction_read_model') IS NOT NULL;" 2>/dev/null)"; then
+      if [[ "${exists}" == "t" ]]; then
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  echo "transaction_read_model schema was not created in time" >&2
+  exit 1
+}
+
+start_runtime() {
+  echo "[transaction-100m-local] building backend bootJar"
+  tools/test/with-resource-lock.sh back-gradle-loadtest-bootjar ./back/gradlew -p back bootJar
+
+  echo "[transaction-100m-local] starting loadtest runtime"
+  docker compose "${compose_files[@]}" --profile loadtest up -d \
+    postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter
+
+  echo "[transaction-100m-local] waiting for Flyway schema"
+  wait_for_schema
+}
+
+run_seed() {
+  SEED_TOTAL_ROWS="${seed_total_rows}" \
+  SEED_HOT_ACCOUNT_ID="${seed_hot_account_id}" \
+  SEED_COLD_ACCOUNT_ID="${seed_cold_account_id}" \
+  SEED_HOT_FROM="${seed_hot_from}" \
+  SEED_HOT_TO="${seed_hot_to}" \
+  SEED_COLD_FROM="${seed_cold_from}" \
+  SEED_COLD_TO="${seed_cold_to}" \
+  SEED_TRUNCATE="${seed_truncate}" \
+    tools/test/seed-transaction-read-model-100m.sh
+}
+
+run_k6() {
+  K6_REPORT_NAME="${k6_report_name}" \
+  K6_HOT_ACCOUNT_ID="${seed_hot_account_id}" \
+  K6_HOT_FROM="${seed_hot_from}" \
+  K6_HOT_TO="${seed_hot_to}" \
+  K6_COLD_ACCOUNT_ID="${seed_cold_account_id}" \
+  K6_COLD_FROM="${seed_cold_from}" \
+  K6_COLD_TO="${seed_cold_to}" \
+    tools/test/run-k6-transaction-100m-loadtest.sh --no-up
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+if [[ "${mode}" != "k6-only" ]]; then
+  start_runtime
+  run_seed
+fi
+
+if [[ "${mode}" != "seed-only" ]]; then
+  if [[ "${mode}" == "k6-only" ]]; then
+    wait_for_schema
+  fi
+  run_k6
+fi

--- a/tools/test/seed-transaction-read-model-100m.sh
+++ b/tools/test/seed-transaction-read-model-100m.sh
@@ -161,7 +161,7 @@ insert_hot_batch() {
   local start="$1"
   local finish="$2"
   psql_sql "
-    INSERT INTO transaction_read_model OVERRIDING SYSTEM VALUE (
+    INSERT INTO transaction_read_model (
       id,
       ledger_entry_id,
       account_id,
@@ -176,6 +176,7 @@ insert_hot_batch() {
       booked_at,
       created_at
     )
+    OVERRIDING SYSTEM VALUE
     SELECT
       n,
       n,

--- a/tools/test/seed-transaction-read-model-100m.sh
+++ b/tools/test/seed-transaction-read-model-100m.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/seed-transaction-read-model-100m.sh [--print-plan]
+
+Environment:
+  SEED_TOTAL_ROWS                 total rows, default 100000000
+  SEED_HOT_ROWS                   hot table rows, default half of total
+  SEED_BATCH_SIZE                 insert batch size, default 1000000
+  SEED_HOT_ACCOUNT_ID             default 910000001
+  SEED_COLD_ACCOUNT_ID            default 910000002
+  SEED_HOT_FROM                   default 2026-04-01T00:00:00Z
+  SEED_HOT_TO                     default 2026-04-30T00:00:00Z
+  SEED_COLD_FROM                  default 2026-01-01T00:00:00Z
+  SEED_COLD_TO                    default 2026-01-31T00:00:00Z
+  SEED_TRUNCATE                   truncate read model tables first, default false
+  SEED_REBUILD_SECONDARY_INDEXES  drop/recreate read indexes around seed, default true
+  SEED_DISABLE_FK_TRIGGERS        disable read model FK triggers around seed, default true
+
+Examples:
+  tools/test/seed-transaction-read-model-100m.sh --print-plan
+  SEED_TOTAL_ROWS=100000000 SEED_TRUNCATE=true tools/test/seed-transaction-read-model-100m.sh
+USAGE
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer" >&2
+    exit 1
+  fi
+}
+
+require_boolean() {
+  local name="$1"
+  local value="$2"
+  case "${value}" in
+    true | false) ;;
+    *)
+      echo "${name} must be true or false" >&2
+      exit 1
+      ;;
+  esac
+}
+
+mode="run"
+if [[ "${1:-}" == "--print-plan" ]]; then
+  mode="print-plan"
+  shift
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$#" -ne 0 ]]; then
+  usage
+  exit 1
+fi
+
+total_rows="${SEED_TOTAL_ROWS:-100000000}"
+hot_rows="${SEED_HOT_ROWS:-$((total_rows / 2))}"
+cold_rows=$((total_rows - hot_rows))
+batch_size="${SEED_BATCH_SIZE:-1000000}"
+hot_account_id="${SEED_HOT_ACCOUNT_ID:-910000001}"
+cold_account_id="${SEED_COLD_ACCOUNT_ID:-910000002}"
+hot_from="${SEED_HOT_FROM:-2026-04-01T00:00:00Z}"
+hot_to="${SEED_HOT_TO:-2026-04-30T00:00:00Z}"
+cold_from="${SEED_COLD_FROM:-2026-01-01T00:00:00Z}"
+cold_to="${SEED_COLD_TO:-2026-01-31T00:00:00Z}"
+truncate_tables="${SEED_TRUNCATE:-false}"
+rebuild_indexes="${SEED_REBUILD_SECONDARY_INDEXES:-true}"
+disable_fk_triggers="${SEED_DISABLE_FK_TRIGGERS:-true}"
+
+require_positive_integer SEED_TOTAL_ROWS "${total_rows}"
+require_positive_integer SEED_HOT_ROWS "${hot_rows}"
+require_positive_integer SEED_BATCH_SIZE "${batch_size}"
+require_positive_integer SEED_HOT_ACCOUNT_ID "${hot_account_id}"
+require_positive_integer SEED_COLD_ACCOUNT_ID "${cold_account_id}"
+require_boolean SEED_TRUNCATE "${truncate_tables}"
+require_boolean SEED_REBUILD_SECONDARY_INDEXES "${rebuild_indexes}"
+require_boolean SEED_DISABLE_FK_TRIGGERS "${disable_fk_triggers}"
+
+if ((hot_rows >= total_rows)); then
+  echo "SEED_HOT_ROWS must be lower than SEED_TOTAL_ROWS" >&2
+  exit 1
+fi
+
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
+
+print_plan() {
+  echo "[transaction-100m-seed] total_rows=${total_rows}"
+  echo "[transaction-100m-seed] hot_rows=${hot_rows} archive_rows=${cold_rows} batch_size=${batch_size}"
+  echo "[transaction-100m-seed] hot account=${hot_account_id} window=${hot_from}..${hot_to}"
+  echo "[transaction-100m-seed] cold account=${cold_account_id} window=${cold_from}..${cold_to}"
+  echo "[transaction-100m-seed] truncate=${truncate_tables} rebuild-secondary-indexes=${rebuild_indexes} disable-fk-triggers=${disable_fk_triggers}"
+  echo "[transaction-100m-seed] caveat: local read-path seed only; ledger source-of-truth rows are not generated."
+}
+
+psql_exec() {
+  "${psql_base[@]}" "$@"
+}
+
+psql_sql() {
+  psql_exec --command "$1"
+}
+
+ensure_schema() {
+  local exists
+  exists="$(psql_exec --no-align --tuples-only --command "SELECT to_regclass('public.transaction_read_model') IS NOT NULL;")"
+  if [[ "${exists}" != "t" ]]; then
+    echo "transaction_read_model schema is missing. Start aquila-bank-backend once so Flyway applies migrations." >&2
+    exit 1
+  fi
+}
+
+drop_secondary_indexes() {
+  psql_sql "
+    DROP INDEX IF EXISTS idx_transaction_read_model_account_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_account_status_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_account_reference_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_cleanup_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_archive_account_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_archive_account_status_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_archive_account_reference_cursor;
+  "
+}
+
+create_secondary_indexes() {
+  psql_sql "
+    CREATE INDEX IF NOT EXISTS idx_transaction_read_model_account_cursor
+      ON transaction_read_model (account_id, booked_at DESC, id DESC);
+    CREATE INDEX IF NOT EXISTS idx_transaction_read_model_account_status_cursor
+      ON transaction_read_model (account_id, transaction_status, booked_at DESC, id DESC);
+    CREATE INDEX IF NOT EXISTS idx_transaction_read_model_account_reference_cursor
+      ON transaction_read_model (account_id, transaction_reference, booked_at DESC, id DESC);
+    CREATE INDEX IF NOT EXISTS idx_transaction_read_model_cleanup_cursor
+      ON transaction_read_model USING BRIN (booked_at)
+      WITH (pages_per_range = 32);
+    CREATE INDEX IF NOT EXISTS idx_transaction_read_model_archive_account_cursor
+      ON transaction_read_model_archive (account_id, booked_at DESC, id DESC);
+    CREATE INDEX IF NOT EXISTS idx_transaction_read_model_archive_account_status_cursor
+      ON transaction_read_model_archive (account_id, transaction_status, booked_at DESC, id DESC);
+    CREATE INDEX IF NOT EXISTS idx_transaction_read_model_archive_account_reference_cursor
+      ON transaction_read_model_archive (account_id, transaction_reference, booked_at DESC, id DESC);
+  "
+}
+
+set_trigger_state() {
+  local state="$1"
+  psql_sql "
+    ALTER TABLE transaction_read_model ${state} TRIGGER ALL;
+    ALTER TABLE transaction_read_model_archive ${state} TRIGGER ALL;
+  "
+}
+
+insert_hot_batch() {
+  local start="$1"
+  local finish="$2"
+  psql_sql "
+    INSERT INTO transaction_read_model OVERRIDING SYSTEM VALUE (
+      id,
+      ledger_entry_id,
+      account_id,
+      transaction_reference,
+      direction,
+      transaction_status,
+      amount_minor,
+      balance_after_minor,
+      currency_code,
+      summary,
+      counterparty_masked_name,
+      booked_at,
+      created_at
+    )
+    SELECT
+      n,
+      n,
+      ${hot_account_id},
+      'TRX-HOT-' || n,
+      CASE WHEN n % 2 = 0 THEN 'DEBIT' ELSE 'CREDIT' END,
+      'BOOKED',
+      (n % 100000) + 1,
+      1000000000 + n,
+      'KRW',
+      '100m hot seed',
+      'seed',
+      '${hot_to}'::timestamptz - (((n - 1) % 2500000) * interval '1 second'),
+      now()
+    FROM generate_series(${start}, ${finish}) AS series(n)
+    ON CONFLICT (id) DO NOTHING;
+  "
+}
+
+insert_archive_batch() {
+  local start="$1"
+  local finish="$2"
+  local id_offset="$hot_rows"
+  local ledger_offset="1000000000000"
+  psql_sql "
+    INSERT INTO transaction_read_model_archive (
+      id,
+      ledger_entry_id,
+      account_id,
+      transaction_reference,
+      direction,
+      transaction_status,
+      amount_minor,
+      balance_after_minor,
+      currency_code,
+      summary,
+      counterparty_masked_name,
+      booked_at,
+      created_at,
+      archived_at
+    )
+    SELECT
+      ${id_offset} + n,
+      ${ledger_offset} + n,
+      ${cold_account_id},
+      'TRX-COLD-' || n,
+      CASE WHEN n % 2 = 0 THEN 'DEBIT' ELSE 'CREDIT' END,
+      'BOOKED',
+      (n % 100000) + 1,
+      2000000000 + n,
+      'KRW',
+      '100m archive seed',
+      'seed',
+      '${cold_to}'::timestamptz - (((n - 1) % 2500000) * interval '1 second'),
+      now(),
+      now()
+    FROM generate_series(${start}, ${finish}) AS series(n)
+    ON CONFLICT (id) DO NOTHING;
+  "
+}
+
+insert_batches() {
+  local table_name="$1"
+  local rows="$2"
+  local start finish
+
+  start=1
+  while ((start <= rows)); do
+    finish=$((start + batch_size - 1))
+    if ((finish > rows)); then
+      finish="$rows"
+    fi
+    echo "[transaction-100m-seed] inserting ${table_name} rows ${start}..${finish}"
+    if [[ "${table_name}" == "hot" ]]; then
+      insert_hot_batch "$start" "$finish"
+    else
+      insert_archive_batch "$start" "$finish"
+    fi
+    start=$((finish + 1))
+  done
+}
+
+verify_seed() {
+  psql_sql "
+    SELECT setval(pg_get_serial_sequence('transaction_read_model', 'id'), COALESCE((SELECT MAX(id) FROM transaction_read_model), 1), true);
+    ANALYZE transaction_read_model;
+    ANALYZE transaction_read_model_archive;
+  "
+  psql_exec --command "
+    SELECT
+      'transaction_read_model_estimate' AS metric,
+      reltuples::bigint AS value
+    FROM pg_class
+    WHERE oid = 'transaction_read_model'::regclass
+    UNION ALL
+    SELECT
+      'transaction_read_model_archive_estimate' AS metric,
+      reltuples::bigint AS value
+    FROM pg_class
+    WHERE oid = 'transaction_read_model_archive'::regclass
+    UNION ALL
+    SELECT 'hot_account_id', ${hot_account_id}
+    UNION ALL
+    SELECT 'cold_account_id', ${cold_account_id};
+  "
+}
+
+main() {
+  print_plan
+  if [[ "${mode}" == "print-plan" ]]; then
+    exit 0
+  fi
+
+  docker compose "${compose_files[@]}" --profile loadtest up -d postgres
+  ensure_schema
+
+  if [[ "${truncate_tables}" == "true" ]]; then
+    echo "[transaction-100m-seed] truncating transaction read model tables"
+    psql_sql "TRUNCATE transaction_read_model, transaction_read_model_archive RESTART IDENTITY;"
+  fi
+
+  if [[ "${rebuild_indexes}" == "true" ]]; then
+    echo "[transaction-100m-seed] dropping secondary read indexes"
+    drop_secondary_indexes
+  fi
+
+  if [[ "${disable_fk_triggers}" == "true" ]]; then
+    echo "[transaction-100m-seed] disabling read model FK triggers"
+    set_trigger_state DISABLE
+  fi
+
+  trap 'if [[ "${disable_fk_triggers}" == "true" ]]; then set_trigger_state ENABLE || true; fi' EXIT
+
+  insert_batches hot "${hot_rows}"
+  insert_batches archive "${cold_rows}"
+
+  if [[ "${disable_fk_triggers}" == "true" ]]; then
+    echo "[transaction-100m-seed] enabling read model FK triggers"
+    set_trigger_state ENABLE
+  fi
+  trap - EXIT
+
+  if [[ "${rebuild_indexes}" == "true" ]]; then
+    echo "[transaction-100m-seed] recreating secondary read indexes"
+    create_secondary_indexes
+  fi
+
+  verify_seed
+}
+
+main "$@"


### PR DESCRIPTION
## 🔗 Related Issue
- close #342

## 🌿 Base Branch
- `main`

## 📝 Summary
- local Docker PostgreSQL에 transaction read model 1억 row를 준비하기 위한 seed script와 k6 wrapper를 추가합니다.
- 실제 1억 row 적재/부하 실행은 이 PR에서 수행하지 않고, 실행 시 `K6_HOT_ACCOUNT_ID`, `K6_COLD_ACCOUNT_ID`, 기간 env를 준비된 dataset에 맞춰 넣도록 문서화했습니다.

## 🛠 Changes
- `tools/test/seed-transaction-read-model-100m.sh` 추가: 기본 1억 row를 hot read model 5천만 + archive 5천만으로 적재할 수 있는 local 전용 seed runner.
- `tools/test/run-transaction-read-model-100m-k6-local.sh` 추가: seed 후 기존 k6 transaction loadtest를 같은 account/기간 env로 연결하는 wrapper.
- `tools/test/check-transaction-read-model-100m-local-runner.sh` 추가: shell syntax, compose config, dry-run 계약, invalid input 실패 검증.
- README/back README/docs performance index에 실행 절차와 주의사항 추가.
- 1,000 row synthetic small smoke 결과를 `docs/performance-results`에 보존.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash -n tools/test/seed-transaction-read-model-100m.sh`
- `bash -n tools/test/run-transaction-read-model-100m-k6-local.sh`
- `tools/test/check-transaction-read-model-100m-local-runner.sh`
- `docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/tmp/aquila-compose-loadtest-config.yml`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- `git diff --check`
- small smoke: `SEED_TOTAL_ROWS=1000 SEED_BATCH_SIZE=500 SEED_TRUNCATE=true K6_VUS=1 K6_DURATION=5s K6_REPORT_NAME=transaction-100m-small-smoke tools/test/run-transaction-read-model-100m-k6-local.sh`

### small smoke 결과
- seed total rows: 1,000
- hot read model rows: 500
- archive read model rows: 500
- `http_req_failed rate`: 0
- `checks rate`: 1
- hot first p95: 1.8344381 ms
- hot cursor p95: 1.8610964 ms
- cold first p95: 1.8423173 ms
- cold cursor p95: 1.7916247 ms

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 1억 row seed는 local disk/SSD/Docker Desktop 설정에 따라 수십 분 이상 걸릴 수 있고, 실행 중 DB truncate 옵션을 켜면 local read model 데이터가 초기화됩니다.
- 롤백 방법: 이 PR revert. local DB에 적재한 synthetic read model 데이터는 `SEED_TRUNCATE=true` 재실행 또는 Docker volume 초기화로 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
