### PR TITLE
[Perf] transaction 100m t3micro bottleneck 결과 기록

### DIFF
--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -26,6 +26,11 @@ YYYY-MM-DD-<environment>-<workload>.md
 
 `tools/test/run-k6-transaction-100m-loadtest.sh`는 k6 summary Markdown을 생성한 뒤 기본적으로 이 디렉터리에 복사합니다.
 
+실행 결과:
+
+- [transaction-100m-small-smoke-summary.md](transaction-100m-small-smoke-summary.md)
+- [transaction-100m-local-t3micro-20260425-bottleneck.md](transaction-100m-local-t3micro-20260425-bottleneck.md)
+
 로컬 DB에 1억 건 synthetic read model을 먼저 적재하고 k6까지 이어서 실행하는 표준 경로는 아래 명령입니다.
 
 ```bash

--- a/docs/performance-results/transaction-100m-local-t3micro-20260425-bottleneck.md
+++ b/docs/performance-results/transaction-100m-local-t3micro-20260425-bottleneck.md
@@ -1,0 +1,186 @@
+# transaction-100m-local-t3micro-20260425-bottleneck
+
+## Summary
+
+- 실행일: 2026-04-25 KST
+- 환경: local Docker compose `compose.yml` + `compose.t3micro.yml` + `compose.loadtest.yml`
+- 목표: transaction read model 1억 row 적재 후 k6 HTTP 부하 테스트로 병목 확인
+- 결과: k6 HTTP 부하 단계까지 도달하지 못함
+- 주 병목: PostgreSQL 384MiB 제한에서 5천만 row 단일 btree secondary index build가 OOM을 유발
+
+## Command
+
+```bash
+K6_REPORT_NAME=transaction-100m-local-t3micro-20260425-8vu-1m \
+K6_VUS=8 \
+K6_DURATION=1m \
+SEED_TOTAL_ROWS=100000000 \
+SEED_BATCH_SIZE=1000000 \
+SEED_TRUNCATE=true \
+tools/test/run-transaction-read-model-100m-k6-local.sh
+```
+
+## Dataset State
+
+- seed 설정: hot 50,000,000 rows + archive 50,000,000 rows
+- insert log 기준 hot/archive batch는 모두 완료됨
+- PK 범위 확인:
+
+```text
+transaction_read_model         min_id=1        max_id=50000000
+transaction_read_model_archive min_id=50000001 max_id=100000000
+```
+
+- crash 이후 secondary read index 상태:
+
+```text
+transaction_read_model         transaction_read_model_pkey
+transaction_read_model         uq_transaction_read_model_ledger_entry
+transaction_read_model_archive transaction_read_model_archive_pkey
+transaction_read_model_archive uq_transaction_read_model_archive_ledger_entry
+```
+
+- 누락된 조회 index:
+
+```text
+idx_transaction_read_model_account_cursor
+idx_transaction_read_model_account_status_cursor
+idx_transaction_read_model_account_reference_cursor
+idx_transaction_read_model_cleanup_cursor
+idx_transaction_read_model_archive_account_cursor
+idx_transaction_read_model_archive_account_status_cursor
+idx_transaction_read_model_archive_account_reference_cursor
+```
+
+## Failure Evidence
+
+### 1. secondary index 재생성 중 PostgreSQL OOM
+
+- 위치: `seed-transaction-read-model-100m.sh`의 `create_secondary_indexes`
+- 로그:
+
+```text
+2026-04-25 02:08:55.509 KST [1] LOG: background writer process (PID 74) was terminated by signal 9: Killed
+2026-04-25 02:08:55.510 KST [1] LOG: terminating any other active server processes
+```
+
+- Docker state:
+
+```text
+OOMKilled=true
+```
+
+### 2. exact count 확인 쿼리도 OOM 유발
+
+- 실행 쿼리:
+
+```sql
+SELECT 'transaction_read_model' AS table_name, count(*) AS rows, min(id) AS min_id, max(id) AS max_id
+FROM transaction_read_model
+UNION ALL
+SELECT 'transaction_read_model_archive', count(*), min(id), max(id)
+FROM transaction_read_model_archive;
+```
+
+- 로그:
+
+```text
+2026-04-25 02:09:49.424 KST [1] LOG: background worker "parallel worker" (PID 2538) was terminated by signal 9: Killed
+2026-04-25 02:09:49.424 KST [1] DETAIL: Failed process was running: SELECT ... count(*) ...
+```
+
+### 3. 최소 index 1개도 low-memory/no-parallel 조건에서 OOM
+
+- 실행 쿼리:
+
+```sql
+SET maintenance_work_mem='16MB';
+SET max_parallel_maintenance_workers=0;
+CREATE INDEX IF NOT EXISTS idx_transaction_read_model_account_cursor
+  ON transaction_read_model (account_id, booked_at DESC, id DESC);
+```
+
+- 로그:
+
+```text
+2026-04-25 02:10:38.442 KST [1] LOG: checkpointer process (PID 30) was terminated by signal 9: Killed
+2026-04-25 02:10:38.442 KST [1] LOG: terminating any other active server processes
+```
+
+## Query Plan Without Secondary Index
+
+secondary index가 없는 상태에서 hot account 조회는 `Parallel Seq Scan + Sort`로 떨어진다.
+
+```text
+Limit
+  -> Gather Merge
+       Workers Planned: 2
+       -> Sort
+            Sort Key: booked_at DESC, id DESC
+            -> Parallel Seq Scan on transaction_read_model
+                 Filter: booked_at range + account_id
+```
+
+이 상태에서 k6를 실행하면 1억 row 조회 성능 검증이 아니라 index 부재에 따른 seq scan/timeout/OOM 검증이 되므로 중단했다.
+
+## Resource Snapshots
+
+### Before seed
+
+```text
+aquila-bank-backend-loadtest  416.1MiB / 1GiB
+aquila-bank-postgres           94.7MiB / 384MiB
+disk available                170Gi
+```
+
+### During insert
+
+```text
+aquila-bank-postgres CPU      약 55~64%
+aquila-bank-postgres memory   약 208~244MiB / 384MiB
+```
+
+### After OOM recovery
+
+```text
+aquila-bank-postgres memory   약 43MiB / 384MiB
+disk available                151Gi
+```
+
+### Relation size after failed index build
+
+```text
+transaction_read_model         8879 MB
+transaction_read_model_archive 9656 MB
+```
+
+## Secondary Findings
+
+- PostgreSQL logs에 checkpoint 빈발 경고가 반복됨.
+
+```text
+checkpoints are occurring too frequently (10 seconds apart)
+HINT: Consider increasing the configuration parameter "max_wal_size".
+```
+
+- 현재 `max_wal_size`는 `1GB`.
+- `postgres-exporter:v0.15.0`가 PostgreSQL 18의 `pg_stat_bgwriter` 컬럼과 맞지 않아 5초마다 error를 기록함.
+
+```text
+ERROR: column "checkpoints_timed" does not exist
+STATEMENT: SELECT checkpoints_timed, checkpoints_req, ...
+```
+
+## Bottleneck Conclusion
+
+1. t3.micro PostgreSQL 384MiB 제한에서 5천만 row 단일 테이블 btree index build는 OOM으로 실패한다.
+2. secondary read index가 없으면 transaction read API는 5천만 row `Parallel Seq Scan + Sort` 계획으로 떨어져 k6 HTTP 부하 테스트를 진행할 수 없다.
+3. 1억 row seed 자체보다 `index build`, `full scan`, `checkpoint/WAL pressure`가 먼저 터지는 병목이다.
+4. 관찰 환경도 PostgreSQL 18과 exporter collector 호환성 문제가 있어 부하 중 DB 로그 노이즈가 크다.
+
+## Next Actions
+
+- 1순위: 1억 row read model을 단일 5천만 row btree index build에 의존하지 않도록 partition/monthly chunk 또는 pre-indexed insert 방식으로 seed 전략을 바꾼다.
+- 2순위: t3.micro PostgreSQL config에 `max_wal_size`, `max_parallel_workers_per_gather`, autovacuum, maintenance 관련 local loadtest profile을 명시한다.
+- 3순위: k6 runner가 required read index 존재 여부와 Docker `OOMKilled` 상태를 preflight/postflight로 검사하고, index가 없으면 k6를 실행하지 않게 한다.
+- 4순위: PostgreSQL 18 호환 exporter로 교체하거나 깨지는 collector를 비활성화한다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #344

## 🌿 Base Branch
- `main`

## 📝 Summary
- local Docker t3.micro 환경에서 transaction read model 1억 row seed/loadtest를 실제 실행한 결과를 문서화합니다.
- k6 HTTP 부하 단계는 실행되지 않았고, 1억 row seed 후 secondary index build에서 PostgreSQL OOM이 먼저 재현됐습니다.

## 🛠 Changes
- 1억 row 실행 실패 지점, Docker/PostgreSQL 로그, index 상태, query plan, resource snapshot을 `docs/performance-results`에 기록했습니다.
- performance result README에서 이번 bottleneck report를 바로 찾을 수 있게 링크를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `git diff --check`
- 실제 실행: `K6_REPORT_NAME=transaction-100m-local-t3micro-20260425-8vu-1m K6_VUS=8 K6_DURATION=1m SEED_TOTAL_ROWS=100000000 SEED_BATCH_SIZE=1000000 SEED_TRUNCATE=true tools/test/run-transaction-read-model-100m-k6-local.sh`
- 증거 수집: `docker logs`, `docker inspect`, `docker stats`, PostgreSQL `pg_indexes`, `EXPLAIN`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 문서-only 변경입니다. local Docker DB에는 synthetic 1억 row 일부 상태와 OOM 이후 복구된 컨테이너가 남아 있습니다.
- 롤백 방법: 이 PR revert. local synthetic 데이터는 별도 Docker volume 정리 또는 seed 재실행으로 처리합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
