### PR TITLE
[Chore] root build 산출물 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ logs/
 tmp/
 temp/
 .cache/
+/build/
 
 # Workspace local env
 .env


### PR DESCRIPTION
## 🔗 Related Issue
- close #346

## 🌿 Base Branch
- `main`

## 📝 Summary
- 루트 `build/` 아래 생성되는 k6 raw report 산출물이 Git status에 표시되지 않도록 `.gitignore`에 `/build/`를 추가합니다.
- 공유용 성능 결과는 `docs/performance-results/**`에 보관하고, raw 실행 산출물은 추적하지 않습니다.

## 🛠 Changes
- `.gitignore`에 루트 `/build/` 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `git diff --check`
- `git status --short --untracked-files=all`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 루트 `build/` 아래 파일을 의도적으로 추적해야 하는 경우 별도 예외 패턴이 필요합니다.
- 롤백 방법: 이 PR revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
