### PR TITLE
[Perf] t3micro 100m loadtest 측정 경로 복구

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 - 로컬 개발: `Docker Compose + PostgreSQL 18 + Kafka`
 - 로컬 t3.micro 근사 검증: `compose.t3micro.yml`과 `tools/test/run-docker-t3micro-capacity-smoke.sh`로 CPU/메모리 cgroup 제한을 적용합니다.
 - 로컬 HTTP 부하 테스트: `compose.loadtest.yml`로 backend, k6, Prometheus, Grafana, Alertmanager, Postgres exporter를 함께 띄웁니다.
-- 로컬 1억 건 synthetic 조회 테스트: `tools/test/run-transaction-read-model-100m-k6-local.sh`로 read model seed와 k6 실행을 연결합니다.
+- 로컬 1억 건 synthetic 조회 테스트: `tools/test/run-transaction-read-model-100m-k6-local.sh`로 read model seed와 k6 실행을 연결합니다. 기본 seed 전략은 t3.micro에서 사후 대형 btree build를 피하는 `SEED_INDEX_STRATEGY=required`입니다.
 - 배포 환경: `EC2 + RDS PostgreSQL 18`
 - EC2 reverse proxy baseline template은 [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)에 두고, runtime 값은 `ops/nginx/runtime.env.example` 기반으로 렌더링합니다.
 - `compose.yml`은 로컬 개발 전용이며, 배포용 인프라 정의는 포함하지 않습니다.

--- a/back/README.md
+++ b/back/README.md
@@ -530,7 +530,9 @@ tools/test/run-transaction-read-model-100m-k6-local.sh
 - 기본 hot account는 `910000001`, cold account는 `910000002`입니다.
 - 기본 조회 기간은 hot `2026-04-01T00:00:00Z..2026-04-30T00:00:00Z`, cold `2026-01-01T00:00:00Z..2026-01-31T00:00:00Z`입니다.
 - seed는 read path 성능 검증 전용입니다. 원장 1억 건을 생성하지 않고, seed 중에만 read model FK trigger를 비활성화합니다.
-- 적재 시간을 줄이기 위해 secondary read index를 seed 전 drop하고 seed 후 재생성합니다.
+- 기본 `SEED_INDEX_STRATEGY=required`는 k6에 필요한 account cursor index만 빈 테이블 상태에서 먼저 유지합니다. t3.micro에서는 5천만 row btree를 seed 후 한 번에 build하면 OOM이 발생할 수 있으므로 기본값으로 사용하지 않습니다.
+- 전체 filter index 재생성 검증이 필요하면 `SEED_INDEX_STRATEGY=rebuild-all`을 명시합니다. 이 모드는 t3.micro보다 큰 메모리 budget 또는 partition/chunk 전환 검증에서만 사용합니다.
+- k6 runner는 실행 전 PostgreSQL `OOMKilled` 상태와 필수 account cursor index 존재 여부를 preflight로 확인합니다.
 - local disk와 Docker volume을 크게 사용합니다. 실행 전 `df -h .`로 여유 공간을 확인합니다.
 - 실패 후 재시도할 때는 `SEED_TRUNCATE=true`를 유지해 중간 적재 데이터를 정리하고 다시 시작합니다.
 - k6 결과 Markdown은 `docs/performance-results`, 원본 JSON/Markdown은 `build/reports/k6`에 남습니다.

--- a/compose.loadtest.yml
+++ b/compose.loadtest.yml
@@ -1,4 +1,28 @@
 services:
+  postgres:
+    command:
+      [
+        "postgres",
+        "-c",
+        "max_wal_size=${LOADTEST_POSTGRES_MAX_WAL_SIZE:-4GB}",
+        "-c",
+        "checkpoint_timeout=${LOADTEST_POSTGRES_CHECKPOINT_TIMEOUT:-15min}",
+        "-c",
+        "checkpoint_completion_target=${LOADTEST_POSTGRES_CHECKPOINT_COMPLETION_TARGET:-0.9}",
+        "-c",
+        "maintenance_work_mem=${LOADTEST_POSTGRES_MAINTENANCE_WORK_MEM:-16MB}",
+        "-c",
+        "work_mem=${LOADTEST_POSTGRES_WORK_MEM:-2MB}",
+        "-c",
+        "max_parallel_workers_per_gather=${LOADTEST_POSTGRES_MAX_PARALLEL_WORKERS_PER_GATHER:-0}",
+        "-c",
+        "max_parallel_maintenance_workers=${LOADTEST_POSTGRES_MAX_PARALLEL_MAINTENANCE_WORKERS:-0}",
+        "-c",
+        "jit=${LOADTEST_POSTGRES_JIT:-off}",
+        "-c",
+        "autovacuum=${LOADTEST_POSTGRES_AUTOVACUUM:-off}",
+      ]
+
   aquila-bank-backend:
     image: eclipse-temurin:21-jre
     container_name: aquila-bank-backend-loadtest
@@ -112,6 +136,8 @@ services:
       - "${POSTGRES_EXPORTER_PORT:-9187}:9187"
     environment:
       DATA_SOURCE_NAME: "postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_NAME:-aquila_bank}?sslmode=disable"
+    command:
+      - "--no-collector.stat_bgwriter"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -30,6 +30,7 @@ YYYY-MM-DD-<environment>-<workload>.md
 
 - [transaction-100m-small-smoke-summary.md](transaction-100m-small-smoke-summary.md)
 - [transaction-100m-local-t3micro-20260425-bottleneck.md](transaction-100m-local-t3micro-20260425-bottleneck.md)
+- [transaction-100m-required-index-smoke-summary.md](transaction-100m-required-index-smoke-summary.md)
 
 로컬 DB에 1억 건 synthetic read model을 먼저 적재하고 k6까지 이어서 실행하는 표준 경로는 아래 명령입니다.
 

--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -39,11 +39,16 @@ SEED_TRUNCATE=true \
 tools/test/run-transaction-read-model-100m-k6-local.sh
 ```
 
+기본값은 `SEED_INDEX_STRATEGY=required`입니다. 이 전략은 hot/archive account cursor index를 빈 table 상태에서 먼저 유지해, t3.micro PostgreSQL에서 5천만 row btree를 사후 build하다 OOM 나는 경로를 피합니다.
+
+`SEED_INDEX_STRATEGY=rebuild-all`은 전체 secondary filter index를 drop 후 재생성합니다. 이 모드는 partition/chunk 구조 검증 또는 더 큰 memory budget에서만 사용하고, t3.micro 측정 경로에서는 기본값으로 사용하지 않습니다.
+
 실행 전 확인값:
 
 - local disk 여유 공간
 - Docker Desktop memory/disk limit
 - `compose.loadtest.yml`의 backend `2 vCPU / 1GiB` budget
+- PostgreSQL container가 이전 실행에서 `OOMKilled=true`로 남아 있지 않은지 여부
 - hot/cold account와 기간 기본값이 테스트 의도와 맞는지 여부
 
 수동 보관이 필요하면 아래 명령을 사용합니다.

--- a/docs/performance-results/transaction-100m-local-t3micro-20260425-bottleneck.md
+++ b/docs/performance-results/transaction-100m-local-t3micro-20260425-bottleneck.md
@@ -180,7 +180,9 @@ STATEMENT: SELECT checkpoints_timed, checkpoints_req, ...
 
 ## Next Actions
 
-- 1순위: 1억 row read model을 단일 5천만 row btree index build에 의존하지 않도록 partition/monthly chunk 또는 pre-indexed insert 방식으로 seed 전략을 바꾼다.
-- 2순위: t3.micro PostgreSQL config에 `max_wal_size`, `max_parallel_workers_per_gather`, autovacuum, maintenance 관련 local loadtest profile을 명시한다.
-- 3순위: k6 runner가 required read index 존재 여부와 Docker `OOMKilled` 상태를 preflight/postflight로 검사하고, index가 없으면 k6를 실행하지 않게 한다.
-- 4순위: PostgreSQL 18 호환 exporter로 교체하거나 깨지는 collector를 비활성화한다.
+- 완료: local seed 기본값을 `SEED_INDEX_STRATEGY=required`로 바꿔 k6에 필요한 account cursor index를 빈 table 상태에서 유지한다.
+- 완료: t3.micro loadtest PostgreSQL config에 `max_wal_size`, checkpoint, parallel worker, JIT, autovacuum 기준을 명시한다.
+- 완료: k6 runner가 required read index 존재 여부와 Docker `OOMKilled` 상태를 preflight로 검사하고, index가 없으면 k6를 실행하지 않게 한다.
+- 완료: PostgreSQL 18에서 깨지는 `postgres-exporter` `stat_bgwriter` collector를 local loadtest runtime에서 비활성화한다.
+- 후속: transaction read model을 월/기간 기준 partition 또는 chunk 구조로 전환해 운영에서도 1억 row index build 폭탄이 생기지 않게 한다.
+- 후속: partition lifecycle/runbook/retention automation을 추가한다.

--- a/docs/performance-results/transaction-100m-required-index-smoke-summary.md
+++ b/docs/performance-results/transaction-100m-required-index-smoke-summary.md
@@ -1,0 +1,44 @@
+# transaction-100m-required-index-smoke-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-24T17:33:43Z
+- sourceMarkdown: build/reports/k6/transaction-100m-required-index-smoke-summary.md
+- sourceJson: build/reports/k6/transaction-100m-required-index-smoke-summary.json
+
+## Smoke Scope
+
+- seed total rows: 1,000
+- hot read model rows: 500
+- archive read model rows: 500
+- seed index strategy: `required`
+- 실제 1억 row 결과가 아니라 t3.micro 측정 경로 복구용 small smoke 결과입니다.
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 1
+- duration: 5s
+- limit: 50
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- http failed rate threshold: 0.01
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- hot first p95 ms: 0.7912714999999999
+- hot cursor p95 ms: 0.7842087
+- cold first p95 ms: 0.8102628
+- cold cursor p95 ms: 0.8632499999999991
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- Prometheus remote write 대상은 `K6_PROMETHEUS_RW_SERVER_URL`입니다.

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -18,10 +18,17 @@ plan="$(
 grep -F "backend: aquila-bank-backend:8080 with t3.micro budget" <<<"${plan}" >/dev/null
 grep -F "observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-exporter:9187" <<<"${plan}" >/dev/null
 grep -F "k6 report name: transaction-100m-check" <<<"${plan}" >/dev/null
+grep -F "preflight=true" <<<"${plan}" >/dev/null
 
 echo "[k6-transaction-100m] k6 script contract"
 grep -F "experimental-prometheus-rw" compose.loadtest.yml >/dev/null
 grep -F "K6_PROMETHEUS_RW_SERVER_URL" compose.loadtest.yml >/dev/null
+grep -F -- "--no-collector.stat_bgwriter" compose.loadtest.yml >/dev/null
+grep -F "max_wal_size" compose.loadtest.yml >/dev/null
+grep -F "checkpoint_timeout" compose.loadtest.yml >/dev/null
+grep -F "assert_k6_preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "idx_transaction_read_model_account_cursor" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "OOMKilled" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "aquila_transaction_hot_first_ms" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "aquila_transaction_cold_cursor_ms" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "handleSummary" ops/k6/transaction-read-100m.js >/dev/null

--- a/tools/test/check-transaction-read-model-100m-local-runner.sh
+++ b/tools/test/check-transaction-read-model-100m-local-runner.sh
@@ -19,11 +19,14 @@ plan="$(
 grep -F "total_rows=1000" <<<"${plan}" >/dev/null
 grep -F "hot_rows=600 archive_rows=400 batch_size=200" <<<"${plan}" >/dev/null
 grep -F "truncate=true" <<<"${plan}" >/dev/null
+grep -F "index-strategy=required" <<<"${plan}" >/dev/null
 grep -F "local read-path seed only" <<<"${plan}" >/dev/null
 
 echo "[transaction-100m-local-runner] seed script contract"
 grep -F "TRIGGER ALL" tools/test/seed-transaction-read-model-100m.sh >/dev/null
-grep -F "CREATE INDEX IF NOT EXISTS idx_transaction_read_model_account_cursor" tools/test/seed-transaction-read-model-100m.sh >/dev/null
+grep -F "SEED_INDEX_STRATEGY" tools/test/seed-transaction-read-model-100m.sh >/dev/null
+grep -F "ensure_required_indexes" tools/test/seed-transaction-read-model-100m.sh >/dev/null
+grep -F "drop_optional_secondary_indexes" tools/test/seed-transaction-read-model-100m.sh >/dev/null
 grep -F "generate_series" tools/test/seed-transaction-read-model-100m.sh >/dev/null
 grep -F "ANALYZE transaction_read_model" tools/test/seed-transaction-read-model-100m.sh >/dev/null
 
@@ -49,5 +52,6 @@ grep -F "k6 report=transaction-100m-check" <<<"${wrapper_plan}" >/dev/null
 grep -F "Prometheus http://localhost:9090, Grafana http://localhost:3001" <<<"${wrapper_plan}" >/dev/null
 
 echo "[transaction-100m-local-runner] wrapper contract"
+grep -F "assert_k6_preflight" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
 grep -F "run-k6-transaction-100m-loadtest.sh --no-up" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
 grep -F "seed-transaction-read-model-100m.sh" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -20,6 +20,7 @@ Optional environment:
   K6_LIMIT             default 50
   K6_AUTH_TOKEN        bearer token, optional when bootstrap header auth is enabled
   K6_ARCHIVE_RESULTS   copy markdown summary to docs/performance-results, default true
+  K6_PREFLIGHT         check PostgreSQL OOM/index readiness before k6, default true
 
 Examples:
   K6_HOT_ACCOUNT_ID=101 K6_HOT_FROM=2026-04-01T00:00:00Z K6_HOT_TO=2026-04-30T00:00:00Z \
@@ -66,8 +67,9 @@ fi
 K6_VUS="${K6_VUS:-8}"
 K6_LIMIT="${K6_LIMIT:-50}"
 K6_ARCHIVE_RESULTS="${K6_ARCHIVE_RESULTS:-true}"
+K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
 K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-$(date +%Y-%m-%d-%H%M%S)}"
-export K6_VUS K6_LIMIT K6_ARCHIVE_RESULTS K6_REPORT_NAME
+export K6_VUS K6_LIMIT K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_REPORT_NAME
 
 require_positive_integer K6_VUS
 require_positive_integer K6_LIMIT
@@ -76,6 +78,7 @@ compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
 report_dir="build/reports/k6"
 summary_md="${report_dir}/${K6_REPORT_NAME}-summary.md"
 summary_json="${report_dir}/${K6_REPORT_NAME}-summary.json"
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
 
 print_plan() {
   echo "[k6-transaction-100m] compose files: ${compose_files[*]}"
@@ -83,6 +86,7 @@ print_plan() {
   echo "[k6-transaction-100m] observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-exporter:9187"
   echo "[k6-transaction-100m] k6 report name: ${K6_REPORT_NAME}"
   echo "[k6-transaction-100m] k6 vus=${K6_VUS} duration=${K6_DURATION:-1m} limit=${K6_LIMIT}"
+  echo "[k6-transaction-100m] preflight=${K6_PREFLIGHT}"
   echo "[k6-transaction-100m] required dataset: prepared 100m transaction read model hot/cold accounts"
   echo "[k6-transaction-100m] archive results: ${K6_ARCHIVE_RESULTS}"
 }
@@ -102,6 +106,38 @@ require_env K6_COLD_TO
 
 mkdir -p "${report_dir}"
 
+assert_k6_preflight() {
+  if [[ "${K6_PREFLIGHT}" != "true" ]]; then
+    echo "[k6-transaction-100m] preflight skipped"
+    return 0
+  fi
+
+  local oom_killed
+  oom_killed="$(docker inspect aquila-bank-postgres --format '{{.State.OOMKilled}}' 2>/dev/null || echo unknown)"
+  if [[ "${oom_killed}" == "true" ]]; then
+    echo "PostgreSQL container has OOMKilled=true. Recreate postgres before running k6." >&2
+    exit 1
+  fi
+
+  local missing_indexes
+  missing_indexes="$("${psql_base[@]}" --no-align --tuples-only --command "
+    WITH required(index_name) AS (
+      VALUES
+        ('idx_transaction_read_model_account_cursor'),
+        ('idx_transaction_read_model_archive_account_cursor')
+    )
+    SELECT index_name
+    FROM required
+    WHERE to_regclass('public.' || index_name) IS NULL
+    ORDER BY index_name;
+  ")"
+  if [[ -n "${missing_indexes}" ]]; then
+    echo "Required transaction read indexes are missing:" >&2
+    echo "${missing_indexes}" >&2
+    exit 1
+  fi
+}
+
 if [[ "${mode}" != "no-up" ]]; then
   echo "[k6-transaction-100m] building backend bootJar"
   tools/test/with-resource-lock.sh back-gradle-loadtest-bootjar ./back/gradlew -p back bootJar
@@ -110,6 +146,8 @@ if [[ "${mode}" != "no-up" ]]; then
   docker compose "${compose_files[@]}" --profile loadtest up -d \
     postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter
 fi
+
+assert_k6_preflight
 
 set +e
 docker compose "${compose_files[@]}" --profile loadtest run --rm \

--- a/tools/test/run-transaction-read-model-100m-k6-local.sh
+++ b/tools/test/run-transaction-read-model-100m-k6-local.sh
@@ -8,6 +8,7 @@ usage: tools/test/run-transaction-read-model-100m-k6-local.sh [--print-plan|--se
 Environment:
   SEED_TOTAL_ROWS      default 100000000
   SEED_TRUNCATE        default true for this wrapper
+  SEED_INDEX_STRATEGY  default required
   K6_REPORT_NAME       default transaction-100m-local-<timestamp>
   K6_VUS               default 8
   K6_DURATION          default 1m
@@ -47,13 +48,14 @@ seed_hot_to="${SEED_HOT_TO:-2026-04-30T00:00:00Z}"
 seed_cold_from="${SEED_COLD_FROM:-2026-01-01T00:00:00Z}"
 seed_cold_to="${SEED_COLD_TO:-2026-01-31T00:00:00Z}"
 seed_truncate="${SEED_TRUNCATE:-true}"
+seed_index_strategy="${SEED_INDEX_STRATEGY:-required}"
 k6_report_name="${K6_REPORT_NAME:-transaction-100m-local-$(date +%Y-%m-%d-%H%M%S)}"
 
 psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
 
 print_plan() {
   echo "[transaction-100m-local] mode=${mode}"
-  echo "[transaction-100m-local] seed_total_rows=${seed_total_rows} seed_truncate=${seed_truncate}"
+  echo "[transaction-100m-local] seed_total_rows=${seed_total_rows} seed_truncate=${seed_truncate} seed_index_strategy=${seed_index_strategy}"
   echo "[transaction-100m-local] hot account=${seed_hot_account_id} window=${seed_hot_from}..${seed_hot_to}"
   echo "[transaction-100m-local] cold account=${seed_cold_account_id} window=${seed_cold_from}..${seed_cold_to}"
   echo "[transaction-100m-local] k6 report=${k6_report_name} vus=${K6_VUS:-8} duration=${K6_DURATION:-1m}"
@@ -95,7 +97,21 @@ run_seed() {
   SEED_COLD_FROM="${seed_cold_from}" \
   SEED_COLD_TO="${seed_cold_to}" \
   SEED_TRUNCATE="${seed_truncate}" \
+  SEED_INDEX_STRATEGY="${seed_index_strategy}" \
     tools/test/seed-transaction-read-model-100m.sh
+}
+
+assert_k6_preflight() {
+  K6_HOT_ACCOUNT_ID="${seed_hot_account_id}" \
+  K6_HOT_FROM="${seed_hot_from}" \
+  K6_HOT_TO="${seed_hot_to}" \
+  K6_COLD_ACCOUNT_ID="${seed_cold_account_id}" \
+  K6_COLD_FROM="${seed_cold_from}" \
+  K6_COLD_TO="${seed_cold_to}" \
+  K6_REPORT_NAME="${k6_report_name}" \
+  K6_VUS="${K6_VUS:-8}" \
+  K6_DURATION="${K6_DURATION:-1m}" \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null
 }
 
 run_k6() {
@@ -123,5 +139,6 @@ if [[ "${mode}" != "seed-only" ]]; then
   if [[ "${mode}" == "k6-only" ]]; then
     wait_for_schema
   fi
+  assert_k6_preflight
   run_k6
 fi

--- a/tools/test/seed-transaction-read-model-100m.sh
+++ b/tools/test/seed-transaction-read-model-100m.sh
@@ -16,7 +16,8 @@ Environment:
   SEED_COLD_FROM                  default 2026-01-01T00:00:00Z
   SEED_COLD_TO                    default 2026-01-31T00:00:00Z
   SEED_TRUNCATE                   truncate read model tables first, default false
-  SEED_REBUILD_SECONDARY_INDEXES  drop/recreate read indexes around seed, default true
+  SEED_INDEX_STRATEGY             required|rebuild-all|none, default required
+  SEED_REBUILD_SECONDARY_INDEXES  legacy true->rebuild-all false->none when SEED_INDEX_STRATEGY is unset
   SEED_DISABLE_FK_TRIGGERS        disable read model FK triggers around seed, default true
 
 Examples:
@@ -41,6 +42,17 @@ require_boolean() {
     true | false) ;;
     *)
       echo "${name} must be true or false" >&2
+      exit 1
+      ;;
+  esac
+}
+
+require_index_strategy() {
+  local value="$1"
+  case "${value}" in
+    required | rebuild-all | none) ;;
+    *)
+      echo "SEED_INDEX_STRATEGY must be required, rebuild-all, or none" >&2
       exit 1
       ;;
   esac
@@ -71,7 +83,18 @@ hot_to="${SEED_HOT_TO:-2026-04-30T00:00:00Z}"
 cold_from="${SEED_COLD_FROM:-2026-01-01T00:00:00Z}"
 cold_to="${SEED_COLD_TO:-2026-01-31T00:00:00Z}"
 truncate_tables="${SEED_TRUNCATE:-false}"
-rebuild_indexes="${SEED_REBUILD_SECONDARY_INDEXES:-true}"
+if [[ -n "${SEED_INDEX_STRATEGY:-}" ]]; then
+  index_strategy="${SEED_INDEX_STRATEGY}"
+elif [[ -n "${SEED_REBUILD_SECONDARY_INDEXES:-}" ]]; then
+  require_boolean SEED_REBUILD_SECONDARY_INDEXES "${SEED_REBUILD_SECONDARY_INDEXES}"
+  if [[ "${SEED_REBUILD_SECONDARY_INDEXES}" == "true" ]]; then
+    index_strategy="rebuild-all"
+  else
+    index_strategy="none"
+  fi
+else
+  index_strategy="required"
+fi
 disable_fk_triggers="${SEED_DISABLE_FK_TRIGGERS:-true}"
 
 require_positive_integer SEED_TOTAL_ROWS "${total_rows}"
@@ -80,7 +103,7 @@ require_positive_integer SEED_BATCH_SIZE "${batch_size}"
 require_positive_integer SEED_HOT_ACCOUNT_ID "${hot_account_id}"
 require_positive_integer SEED_COLD_ACCOUNT_ID "${cold_account_id}"
 require_boolean SEED_TRUNCATE "${truncate_tables}"
-require_boolean SEED_REBUILD_SECONDARY_INDEXES "${rebuild_indexes}"
+require_index_strategy "${index_strategy}"
 require_boolean SEED_DISABLE_FK_TRIGGERS "${disable_fk_triggers}"
 
 if ((hot_rows >= total_rows)); then
@@ -96,7 +119,7 @@ print_plan() {
   echo "[transaction-100m-seed] hot_rows=${hot_rows} archive_rows=${cold_rows} batch_size=${batch_size}"
   echo "[transaction-100m-seed] hot account=${hot_account_id} window=${hot_from}..${hot_to}"
   echo "[transaction-100m-seed] cold account=${cold_account_id} window=${cold_from}..${cold_to}"
-  echo "[transaction-100m-seed] truncate=${truncate_tables} rebuild-secondary-indexes=${rebuild_indexes} disable-fk-triggers=${disable_fk_triggers}"
+  echo "[transaction-100m-seed] truncate=${truncate_tables} index-strategy=${index_strategy} disable-fk-triggers=${disable_fk_triggers}"
   echo "[transaction-100m-seed] caveat: local read-path seed only; ledger source-of-truth rows are not generated."
 }
 
@@ -126,6 +149,25 @@ drop_secondary_indexes() {
     DROP INDEX IF EXISTS idx_transaction_read_model_archive_account_cursor;
     DROP INDEX IF EXISTS idx_transaction_read_model_archive_account_status_cursor;
     DROP INDEX IF EXISTS idx_transaction_read_model_archive_account_reference_cursor;
+  "
+}
+
+drop_optional_secondary_indexes() {
+  psql_sql "
+    DROP INDEX IF EXISTS idx_transaction_read_model_account_status_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_account_reference_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_cleanup_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_archive_account_status_cursor;
+    DROP INDEX IF EXISTS idx_transaction_read_model_archive_account_reference_cursor;
+  "
+}
+
+ensure_required_indexes() {
+  psql_sql "
+    CREATE INDEX IF NOT EXISTS idx_transaction_read_model_account_cursor
+      ON transaction_read_model (account_id, booked_at DESC, id DESC);
+    CREATE INDEX IF NOT EXISTS idx_transaction_read_model_archive_account_cursor
+      ON transaction_read_model_archive (account_id, booked_at DESC, id DESC);
   "
 }
 
@@ -298,9 +340,14 @@ main() {
     psql_sql "TRUNCATE transaction_read_model, transaction_read_model_archive RESTART IDENTITY;"
   fi
 
-  if [[ "${rebuild_indexes}" == "true" ]]; then
+  if [[ "${index_strategy}" == "rebuild-all" ]]; then
     echo "[transaction-100m-seed] dropping secondary read indexes"
     drop_secondary_indexes
+  elif [[ "${index_strategy}" == "required" ]]; then
+    echo "[transaction-100m-seed] dropping optional secondary read indexes"
+    drop_optional_secondary_indexes
+    echo "[transaction-100m-seed] ensuring required account cursor indexes before insert"
+    ensure_required_indexes
   fi
 
   if [[ "${disable_fk_triggers}" == "true" ]]; then
@@ -319,9 +366,12 @@ main() {
   fi
   trap - EXIT
 
-  if [[ "${rebuild_indexes}" == "true" ]]; then
+  if [[ "${index_strategy}" == "rebuild-all" ]]; then
     echo "[transaction-100m-seed] recreating secondary read indexes"
     create_secondary_indexes
+  elif [[ "${index_strategy}" == "required" ]]; then
+    echo "[transaction-100m-seed] verifying required account cursor indexes"
+    ensure_required_indexes
   fi
 
   verify_seed


### PR DESCRIPTION
## 🔗 Related Issue
- close #348

## 🌿 Base Branch
- `main`

## 📝 Summary
- t3.micro local 100m loadtest가 seed 후 대형 btree index build OOM으로 막히던 경로를 복구합니다.
- 기본 seed 전략을 `required`로 바꿔 k6에 필요한 account cursor index를 빈 테이블 상태에서 유지하고, k6 전 OOM/index preflight를 추가합니다.

## 🛠 Changes
- `SEED_INDEX_STRATEGY=required|rebuild-all|none` 추가 및 기본값 `required` 적용
- k6 실행 전 PostgreSQL `OOMKilled` 상태와 필수 account cursor index 존재 여부 검사
- local loadtest PostgreSQL `max_wal_size`, checkpoint, parallel worker, JIT, autovacuum 설정 보정
- PostgreSQL 18에서 깨지는 `postgres-exporter` `stat_bgwriter` collector 비활성화
- required-index small smoke 결과 문서화

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-read-model-100m-local-runner.sh`
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/tmp/aquila-compose-loadtest-config.yml`
- `K6_HOT_ACCOUNT_ID=910000001 K6_HOT_FROM=2026-04-01T00:00:00Z K6_HOT_TO=2026-04-30T00:00:00Z K6_COLD_ACCOUNT_ID=910000002 K6_COLD_FROM=2026-01-01T00:00:00Z K6_COLD_TO=2026-01-31T00:00:00Z K6_REPORT_NAME=preflight-oom-check tools/test/run-k6-transaction-100m-loadtest.sh --no-up`
- `SEED_TOTAL_ROWS=1000 SEED_BATCH_SIZE=500 SEED_TRUNCATE=true K6_VUS=1 K6_DURATION=5s K6_REPORT_NAME=transaction-100m-required-index-smoke tools/test/run-transaction-read-model-100m-k6-local.sh`
- `docker logs --since 2m aquila-bank-postgres | rg -n "checkpoints_timed|pg_stat_bgwriter|OOM|Killed|ERROR" || true`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- `git diff --check`

### small smoke 결과
- seed total rows: 1,000
- seed index strategy: `required`
- `http_req_failed rate`: 0
- `checks rate`: 1
- hot first p95: 0.7912715 ms
- hot cursor p95: 0.7842087 ms
- cold first p95: 0.8102628 ms
- cold cursor p95: 0.86325 ms

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `required` 전략은 k6에 필요한 account cursor index만 유지하므로 status/reference filter index 재생성 검증은 `SEED_INDEX_STRATEGY=rebuild-all` 또는 후속 partition/chunk PR에서 별도로 수행해야 합니다.
- 롤백 방법: 이 PR revert. local Docker DB에 생성된 synthetic data는 `SEED_TRUNCATE=true` 재실행 또는 Docker volume 정리로 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
