### PR TITLE
[Ops] transaction read model chunk lifecycle 자동화

### DIFF
--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -59,3 +59,15 @@ tools/test/archive-k6-transaction-100m-result.sh \
   build/reports/k6/<name>-summary.md \
   build/reports/k6/<name>-summary.json
 ```
+
+## 월별 chunk lifecycle
+
+월별 partition 선생성, archive detach/drop guard, partition별 `ANALYZE`/`VACUUM` 절차는 [Transaction Read Model Chunk Lifecycle Runbook](../transaction-read-model-chunk-lifecycle.md)을 기준으로 실행합니다.
+
+1억 row SLO 검증 전에는 다음 순서를 지킵니다.
+
+```bash
+tools/ops/transaction-read-model-chunk-lifecycle.sh --action precreate --target both --print-sql
+tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target both --print-sql
+tools/test/run-transaction-read-model-100m-k6-local.sh --print-plan
+```

--- a/docs/transaction-read-model-chunk-lifecycle.md
+++ b/docs/transaction-read-model-chunk-lifecycle.md
@@ -1,0 +1,188 @@
+# Transaction Read Model Chunk Lifecycle Runbook
+
+## Purpose
+
+`transaction_read_model`과 `transaction_read_model_archive`는 `booked_at` 월별 partition parent입니다. 이 runbook은 운영에서 다음 달 chunk를 미리 만들고, 오래된 archive chunk를 detach/drop 후보로 분리하며, partition별 planner stats를 최신 상태로 유지하는 절차를 고정합니다.
+
+## Principles
+
+- hot table 삭제는 row-level retention을 먼저 사용합니다. hot partition detach는 이 PR 범위가 아닙니다.
+- archive partition detach/drop은 월 경계가 지난 cold data에만 적용합니다.
+- 모든 destructive 작업은 먼저 `--print-sql`로 review합니다.
+- `drop-detached` 실행은 `CONFIRM_DROP=drop-detached-transaction-read-model`이 없으면 실패합니다.
+- `lock_timeout` 기본값은 `1000ms`, `statement_timeout` 기본값은 `30000ms`로 두어 t3.micro에서 장기 lock을 만들지 않습니다.
+
+## Monthly Precreate
+
+다음 4개월 hot/archive partition을 미리 생성합니다. 신규 데이터는 이미 index가 붙은 작은 partition에 insert되어 사후 대형 btree build를 피합니다.
+
+```bash
+tools/ops/transaction-read-model-chunk-lifecycle.sh \
+  --action precreate \
+  --target both \
+  --reference-month "$(date -u +%Y-%m)" \
+  --months-ahead 4 \
+  --print-sql
+```
+
+실행:
+
+```bash
+DATABASE_URL="$STAGING_RDS_DATABASE_URL" \
+tools/ops/transaction-read-model-chunk-lifecycle.sh \
+  --action precreate \
+  --target both \
+  --reference-month "$(date -u +%Y-%m)" \
+  --months-ahead 4
+```
+
+권장 주기:
+
+- 매월 25일 이후 1회
+- 대량 bootstrap/import 전 1회
+- staging 배포 후 1억 row replay 전 1회
+
+## Retention Plan
+
+오래된 archive partition 후보를 먼저 조회합니다. `before-month`는 해당 월 1일보다 `month_end`가 작거나 같은 partition만 후보로 봅니다.
+
+```bash
+tools/ops/transaction-read-model-chunk-lifecycle.sh \
+  --action retention-plan \
+  --target archive \
+  --before-month 2025-10 \
+  --print-sql
+```
+
+출력의 `recommended_action` 기준:
+
+- `detach_archive_candidate`: archive partition detach 가능 후보
+- `run_row_retention_before_hot_detach`: hot partition은 row retention 선행 필요
+- `keep`: cutoff 밖이라 유지
+
+## Detach Archive Chunk
+
+detach는 archive parent만 지원합니다. detached table은 `transaction_read_model_detached` schema로 이동합니다.
+
+```bash
+DATABASE_URL="$STAGING_RDS_DATABASE_URL" \
+tools/ops/transaction-read-model-chunk-lifecycle.sh \
+  --action detach \
+  --target archive \
+  --before-month 2025-10
+```
+
+검증:
+
+```sql
+SELECT schemaname, tablename
+FROM pg_tables
+WHERE schemaname = 'transaction_read_model_detached'
+ORDER BY tablename;
+```
+
+## Drop Detached Archive Chunk
+
+drop은 detach 이후 별도 window에서 실행합니다. review 없이 실행되지 않도록 confirmation env가 필요합니다.
+
+```bash
+tools/ops/transaction-read-model-chunk-lifecycle.sh \
+  --action drop-detached \
+  --before-month 2025-10 \
+  --print-sql
+```
+
+실행:
+
+```bash
+CONFIRM_DROP=drop-detached-transaction-read-model \
+DATABASE_URL="$STAGING_RDS_DATABASE_URL" \
+tools/ops/transaction-read-model-chunk-lifecycle.sh \
+  --action drop-detached \
+  --before-month 2025-10
+```
+
+## Partition Maintenance
+
+planner stats는 parent만이 아니라 leaf partition 기준으로 갱신합니다.
+
+```bash
+DATABASE_URL="$STAGING_RDS_DATABASE_URL" \
+tools/ops/transaction-read-model-chunk-lifecycle.sh \
+  --action analyze \
+  --target both
+```
+
+dead tuple이 많은 archive partition은 보수적으로 `vacuum-analyze`를 실행합니다.
+
+```bash
+DATABASE_URL="$STAGING_RDS_DATABASE_URL" \
+tools/ops/transaction-read-model-chunk-lifecycle.sh \
+  --action vacuum-analyze \
+  --target archive
+```
+
+대상 parent table의 stale stats guard는 기존 script로 확인합니다.
+
+```bash
+DATABASE_URL="$STAGING_RDS_DATABASE_URL" \
+tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
+```
+
+## SLO Verification
+
+로컬 t3.micro loadtest:
+
+```bash
+SEED_TOTAL_ROWS=100000000 \
+SEED_TRUNCATE=true \
+tools/test/run-transaction-read-model-100m-k6-local.sh
+```
+
+이미 dataset이 준비되어 있으면 k6만 실행합니다.
+
+```bash
+K6_HOT_ACCOUNT_ID="$HOT_ACCOUNT_ID" \
+K6_COLD_ACCOUNT_ID="$COLD_ACCOUNT_ID" \
+K6_HOT_FROM="$HOT_FROM" \
+K6_HOT_TO="$HOT_TO" \
+K6_COLD_FROM="$COLD_FROM" \
+K6_COLD_TO="$COLD_TO" \
+tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only
+```
+
+관측 지점:
+
+- Prometheus: `http://localhost:9090`
+- Grafana: `http://localhost:3001`
+- k6 summary: `build/reports/k6/*-summary.md`
+- archived summary: `docs/performance-results/*`
+
+운영/staging replay:
+
+```bash
+STAGING_BASE_URL="$STAGING_BASE_URL" \
+STAGING_REPLAY_TOKEN="$STAGING_REPLAY_TOKEN" \
+STAGING_RDS_DATABASE_URL="$STAGING_RDS_DATABASE_URL" \
+HOT_ACCOUNT_ID="$HOT_ACCOUNT_ID" \
+HOT_FROM="$HOT_FROM" \
+HOT_TO="$HOT_TO" \
+COLD_ACCOUNT_ID="$COLD_ACCOUNT_ID" \
+COLD_FROM="$COLD_FROM" \
+COLD_TO="$COLD_TO" \
+tools/ops/transaction-read-model-staging-replay.sh
+```
+
+SLO 기준:
+
+- hot first/cursor p95: 기본 `350ms` 이하
+- cold first/cursor p95: 기본 `750ms` 이하
+- `aquila_transaction_query_latency_seconds_bucket` 기반 p95 alert가 query shape별로 과도하게 치솟지 않아야 합니다.
+- k6 `http_req_failed` rate는 `0.01` 이하를 유지합니다.
+
+## Rollback
+
+- precreate rollback: 생성된 future partition이 비어 있으면 수동 `DROP TABLE public.<partition_name>;`로 제거합니다.
+- detach rollback: `transaction_read_model_detached` schema의 table을 원래 parent에 다시 attach해야 하므로, 같은 월 range와 row overlap을 먼저 확인합니다.
+- drop rollback: table drop 이후에는 DB snapshot/PITR 복구가 필요합니다.
+- script/doc rollback: PR revert로 수행합니다.

--- a/docs/transaction-read-model-staging-replay.md
+++ b/docs/transaction-read-model-staging-replay.md
@@ -25,6 +25,9 @@
 - staging RDS 통계가 최신이어야 합니다.
   - 1억 건 분포 적재 또는 replay 전후 `ANALYZE` 수행
   - full count 대신 `pg_class.reltuples` estimate를 쓰므로 오래된 통계는 검증 실패나 과소/과대 평가를 만들 수 있습니다.
+- 월별 partition lifecycle은 replay 전에 확인합니다.
+  - 다음 기간 partition 선생성: `tools/ops/transaction-read-model-chunk-lifecycle.sh --action precreate --target both`
+  - partition별 stats 갱신: `tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target both`
 - cold path는 `GET /api/v1/transactions/archive` 배포 이후 실행합니다.
 
 ## Staging Deploy Release Gate

--- a/tools/ops/transaction-read-model-chunk-lifecycle.sh
+++ b/tools/ops/transaction-read-model-chunk-lifecycle.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/ops/transaction-read-model-chunk-lifecycle.sh [options]
+
+Options:
+  --action <precreate|retention-plan|detach|drop-detached|analyze|vacuum-analyze>
+  --target <hot|archive|both>              default both, detach supports archive only
+  --reference-month <YYYY-MM>              default current UTC month, precreate start month
+  --months-ahead <count>                   default 4, number of months to precreate
+  --before-month <YYYY-MM>                 required for retention-plan/detach/drop-detached
+  --lock-timeout-ms <milliseconds>         default 1000
+  --statement-timeout-ms <milliseconds>    default 30000
+  --print-sql                             print SQL and exit
+  --dry-run                               same as --print-sql
+  -h, --help                              show this help
+
+Environment:
+  CONFIRM_DROP   must be `drop-detached-transaction-read-model` for drop-detached execution
+  DATABASE_URL   optional PostgreSQL URL. If set, it is passed directly to psql.
+  DB_HOST        fallback host, default localhost
+  DB_PORT        fallback port, default 5432
+  DB_NAME        fallback database, default aquila_bank
+  DB_USERNAME    fallback user, default postgres
+  DB_PASSWORD    fallback password, mapped to PGPASSWORD when PGPASSWORD is unset
+USAGE
+}
+
+action=""
+target="both"
+reference_month="$(date -u +%Y-%m)"
+months_ahead="${MONTHS_AHEAD:-4}"
+before_month=""
+lock_timeout_ms="${LOCK_TIMEOUT_MS:-1000}"
+statement_timeout_ms="${STATEMENT_TIMEOUT_MS:-30000}"
+print_sql=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --action)
+      [[ $# -ge 2 ]] || {
+        usage
+        exit 1
+      }
+      action="$2"
+      shift 2
+      ;;
+    --target)
+      [[ $# -ge 2 ]] || {
+        usage
+        exit 1
+      }
+      target="$2"
+      shift 2
+      ;;
+    --reference-month)
+      [[ $# -ge 2 ]] || {
+        usage
+        exit 1
+      }
+      reference_month="$2"
+      shift 2
+      ;;
+    --months-ahead)
+      [[ $# -ge 2 ]] || {
+        usage
+        exit 1
+      }
+      months_ahead="$2"
+      shift 2
+      ;;
+    --before-month)
+      [[ $# -ge 2 ]] || {
+        usage
+        exit 1
+      }
+      before_month="$2"
+      shift 2
+      ;;
+    --lock-timeout-ms)
+      [[ $# -ge 2 ]] || {
+        usage
+        exit 1
+      }
+      lock_timeout_ms="$2"
+      shift 2
+      ;;
+    --statement-timeout-ms)
+      [[ $# -ge 2 ]] || {
+        usage
+        exit 1
+      }
+      statement_timeout_ms="$2"
+      shift 2
+      ;;
+    --print-sql | --dry-run)
+      print_sql=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+validate_positive_integer() {
+  local name="$1"
+  local value="$2"
+  [[ "${value}" =~ ^[1-9][0-9]*$ ]] || fail "${name} must be a positive integer"
+}
+
+validate_month() {
+  local name="$1"
+  local value="$2"
+  [[ "${value}" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]] || fail "${name} must use YYYY-MM"
+}
+
+case "${action}" in
+  precreate | retention-plan | detach | drop-detached | analyze | vacuum-analyze) ;;
+  "")
+    fail "--action is required"
+    ;;
+  *)
+    fail "invalid action: ${action}"
+    ;;
+esac
+
+case "${target}" in
+  hot | archive | both) ;;
+  *)
+    fail "invalid target: ${target}"
+    ;;
+esac
+
+validate_month "reference-month" "${reference_month}"
+validate_positive_integer "months-ahead" "${months_ahead}"
+validate_positive_integer "lock-timeout-ms" "${lock_timeout_ms}"
+validate_positive_integer "statement-timeout-ms" "${statement_timeout_ms}"
+
+case "${action}" in
+  retention-plan | detach | drop-detached)
+    [[ -n "${before_month}" ]] || fail "--before-month is required for ${action}"
+    validate_month "before-month" "${before_month}"
+    ;;
+esac
+
+if [[ "${action}" == "detach" && "${target}" != "archive" ]]; then
+  fail "detach only supports --target archive; hot chunks must be emptied by row retention first"
+fi
+
+if [[ "${action}" == "drop-detached" && "${target}" == "hot" ]]; then
+  fail "drop-detached only supports archive detached chunks"
+fi
+
+if [[ "${action}" == "drop-detached" && "${print_sql}" != "true" ]]; then
+  [[ "${CONFIRM_DROP:-}" == "drop-detached-transaction-read-model" ]] \
+    || fail "set CONFIRM_DROP=drop-detached-transaction-read-model to execute drop-detached"
+fi
+
+target_parent_values() {
+  case "${target}" in
+    hot)
+      printf "('transaction_read_model')"
+      ;;
+    archive)
+      printf "('transaction_read_model_archive')"
+      ;;
+    both)
+      printf "('transaction_read_model'),\n        ('transaction_read_model_archive')"
+      ;;
+  esac
+}
+
+sql_header() {
+  printf "SET lock_timeout = '%sms';\n" "${lock_timeout_ms}"
+  printf "SET statement_timeout = '%sms';\n" "${statement_timeout_ms}"
+}
+
+build_precreate_sql() {
+  local parents
+  parents="$(target_parent_values)"
+  cat <<SQL
+$(sql_header)
+DO \$\$
+DECLARE
+    reference_month DATE := DATE '${reference_month}-01';
+    month_count INTEGER := ${months_ahead};
+    month_offset INTEGER;
+    month_start DATE;
+    parent_name TEXT;
+    parent_regclass REGCLASS;
+    partition_name TEXT;
+BEGIN
+    FOR parent_name IN
+        SELECT value
+        FROM (VALUES
+        ${parents}
+        ) AS target(value)
+    LOOP
+        parent_regclass := to_regclass('public.' || parent_name);
+        IF parent_regclass IS NULL THEN
+            RAISE EXCEPTION 'missing transaction read model parent table: %', parent_name;
+        END IF;
+
+        FOR month_offset IN 0..(month_count - 1) LOOP
+            month_start := reference_month + make_interval(months => month_offset);
+            partition_name := parent_name || '_y' || to_char(month_start, 'YYYYMM');
+            -- 다음 달 partition은 적재 전에 생성해 t3.micro에서 사후 대형 index build를 피합니다.
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF %s FOR VALUES FROM (%L) TO (%L)',
+                partition_name,
+                parent_regclass,
+                month_start::timestamptz,
+                (month_start + INTERVAL '1 month')::timestamptz
+            );
+        END LOOP;
+    END LOOP;
+END \$\$;
+SQL
+}
+
+build_retention_plan_sql() {
+  local parents
+  parents="$(target_parent_values)"
+  cat <<SQL
+$(sql_header)
+WITH target_parent(parent_name) AS (
+    VALUES
+        ${parents}
+),
+partition_data AS (
+    SELECT
+        parent.relname AS parent_name,
+        child.relname AS partition_name,
+        ns.nspname AS partition_schema,
+        to_date(substring(child.relname FROM '_y([0-9]{6})$'), 'YYYYMM') AS month_start,
+        to_date(substring(child.relname FROM '_y([0-9]{6})$'), 'YYYYMM') + INTERVAL '1 month'
+            AS month_end,
+        GREATEST(child.reltuples, 0)::bigint AS row_estimate,
+        pg_size_pretty(pg_total_relation_size(child.oid)) AS total_size
+    FROM target_parent target
+    JOIN pg_class parent
+      ON parent.relname = target.parent_name
+    JOIN pg_namespace parent_ns
+      ON parent_ns.oid = parent.relnamespace
+     AND parent_ns.nspname = 'public'
+    JOIN pg_inherits inherits
+      ON inherits.inhparent = parent.oid
+    JOIN pg_class child
+      ON child.oid = inherits.inhrelid
+    JOIN pg_namespace ns
+      ON ns.oid = child.relnamespace
+    WHERE child.relname <> parent.relname || '_default'
+      AND child.relname ~ '_y[0-9]{6}$'
+)
+SELECT
+    parent_name,
+    partition_schema,
+    partition_name,
+    month_start,
+    month_end,
+    row_estimate,
+    total_size,
+    CASE
+        WHEN parent_name = 'transaction_read_model_archive'
+             AND month_end <= DATE '${before_month}-01' THEN 'detach_archive_candidate'
+        WHEN parent_name = 'transaction_read_model'
+             AND month_end <= DATE '${before_month}-01' THEN 'run_row_retention_before_hot_detach'
+        ELSE 'keep'
+    END AS recommended_action
+FROM partition_data
+WHERE month_end <= DATE '${before_month}-01'
+ORDER BY parent_name, month_start;
+SQL
+}
+
+build_detach_sql() {
+  cat <<SQL
+$(sql_header)
+CREATE SCHEMA IF NOT EXISTS transaction_read_model_detached;
+DO \$\$
+DECLARE
+    before_month DATE := DATE '${before_month}-01';
+    item RECORD;
+BEGIN
+    FOR item IN
+        SELECT
+            child.oid AS child_oid,
+            child.relname AS partition_name,
+            to_date(substring(child.relname FROM '_y([0-9]{6})$'), 'YYYYMM') + INTERVAL '1 month'
+                AS month_end
+        FROM pg_inherits inherits
+        JOIN pg_class parent
+          ON parent.oid = inherits.inhparent
+        JOIN pg_namespace parent_ns
+          ON parent_ns.oid = parent.relnamespace
+         AND parent_ns.nspname = 'public'
+        JOIN pg_class child
+          ON child.oid = inherits.inhrelid
+        JOIN pg_namespace child_ns
+          ON child_ns.oid = child.relnamespace
+         AND child_ns.nspname = 'public'
+        WHERE parent.relname = 'transaction_read_model_archive'
+          AND child.relname ~ '^transaction_read_model_archive_y[0-9]{6}$'
+          AND to_date(substring(child.relname FROM '_y([0-9]{6})$'), 'YYYYMM') + INTERVAL '1 month'
+              <= before_month
+        ORDER BY child.relname
+    LOOP
+        -- archive partition만 detach합니다. hot partition은 row retention으로 먼저 비워야 합니다.
+        EXECUTE format('ALTER TABLE public.transaction_read_model_archive DETACH PARTITION %s', item.child_oid::regclass);
+        EXECUTE format('ALTER TABLE %s SET SCHEMA transaction_read_model_detached', item.child_oid::regclass);
+    END LOOP;
+END \$\$;
+SQL
+}
+
+build_drop_detached_sql() {
+  cat <<SQL
+$(sql_header)
+DO \$\$
+DECLARE
+    before_month DATE := DATE '${before_month}-01';
+    item RECORD;
+BEGIN
+    FOR item IN
+        SELECT
+            child.relname AS partition_name,
+            to_date(substring(child.relname FROM '_y([0-9]{6})$'), 'YYYYMM') + INTERVAL '1 month'
+                AS month_end
+        FROM pg_class child
+        JOIN pg_namespace ns
+          ON ns.oid = child.relnamespace
+         AND ns.nspname = 'transaction_read_model_detached'
+        WHERE child.relkind = 'r'
+          AND child.relname ~ '^transaction_read_model_archive_y[0-9]{6}$'
+          AND to_date(substring(child.relname FROM '_y([0-9]{6})$'), 'YYYYMM') + INTERVAL '1 month'
+              <= before_month
+        ORDER BY child.relname
+    LOOP
+        EXECUTE format('DROP TABLE transaction_read_model_detached.%I', item.partition_name);
+    END LOOP;
+END \$\$;
+SQL
+}
+
+build_maintenance_sql() {
+  local parents command
+  parents="$(target_parent_values)"
+  if [[ "${action}" == "analyze" ]]; then
+    command="ANALYZE VERBOSE"
+  else
+    command="VACUUM (ANALYZE, VERBOSE)"
+  fi
+  cat <<SQL
+$(sql_header)
+WITH target_parent(parent_name) AS (
+    VALUES
+        ${parents}
+),
+partition_data AS (
+    SELECT child.oid::regclass AS partition_regclass
+    FROM target_parent target
+    JOIN pg_class parent
+      ON parent.relname = target.parent_name
+    JOIN pg_namespace parent_ns
+      ON parent_ns.oid = parent.relnamespace
+     AND parent_ns.nspname = 'public'
+    JOIN pg_inherits inherits
+      ON inherits.inhparent = parent.oid
+    JOIN pg_class child
+      ON child.oid = inherits.inhrelid
+    WHERE child.relname <> parent.relname || '_default'
+      AND child.relname ~ '_y[0-9]{6}$'
+)
+SELECT format('${command} %s;', partition_regclass)
+FROM partition_data
+ORDER BY partition_regclass::text
+\\gexec
+SQL
+}
+
+case "${action}" in
+  precreate)
+    sql="$(build_precreate_sql)"
+    ;;
+  retention-plan)
+    sql="$(build_retention_plan_sql)"
+    ;;
+  detach)
+    sql="$(build_detach_sql)"
+    ;;
+  drop-detached)
+    sql="$(build_drop_detached_sql)"
+    ;;
+  analyze | vacuum-analyze)
+    sql="$(build_maintenance_sql)"
+    ;;
+esac
+
+if [[ "${print_sql}" == "true" ]]; then
+  printf '%s\n' "${sql}"
+  exit 0
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  fail "psql is required. Install PostgreSQL client tools or use --print-sql."
+fi
+
+echo "[transaction-chunk-lifecycle] action=${action} target=${target}"
+echo "[transaction-chunk-lifecycle] lock_timeout=${lock_timeout_ms}ms statement_timeout=${statement_timeout_ms}ms"
+
+psql_args=(--no-psqlrc --set ON_ERROR_STOP=1 --pset pager=off)
+
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  printf '%s\n' "${sql}" | psql "${psql_args[@]}" "${DATABASE_URL}"
+else
+  export PGHOST="${PGHOST:-${DB_HOST:-localhost}}"
+  export PGPORT="${PGPORT:-${DB_PORT:-5432}}"
+  export PGDATABASE="${PGDATABASE:-${DB_NAME:-aquila_bank}}"
+  export PGUSER="${PGUSER:-${DB_USERNAME:-postgres}}"
+  if [[ -z "${PGPASSWORD:-}" && -n "${DB_PASSWORD:-}" ]]; then
+    export PGPASSWORD="${DB_PASSWORD}"
+  fi
+  printf '%s\n' "${sql}" | psql "${psql_args[@]}"
+fi

--- a/tools/test/run-transaction-read-model-chunk-lifecycle.sh
+++ b/tools/test/run-transaction-read-model-chunk-lifecycle.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/ops/transaction-read-model-chunk-lifecycle.sh"
+
+echo "[transaction-chunk-lifecycle] syntax: ${script}"
+bash -n "${script}"
+
+echo "[transaction-chunk-lifecycle] precreate: future monthly partitions for hot/archive"
+precreate_sql="$("${script}" --action precreate --target both --reference-month 2026-04 --months-ahead 2 --print-sql)"
+grep -F "SET lock_timeout = '1000ms';" <<<"${precreate_sql}" >/dev/null
+grep -F "SET statement_timeout = '30000ms';" <<<"${precreate_sql}" >/dev/null
+grep -F "reference_month DATE := DATE '2026-04-01';" <<<"${precreate_sql}" >/dev/null
+grep -F "month_count INTEGER := 2;" <<<"${precreate_sql}" >/dev/null
+grep -F "('transaction_read_model')" <<<"${precreate_sql}" >/dev/null
+grep -F "('transaction_read_model_archive')" <<<"${precreate_sql}" >/dev/null
+grep -F "CREATE TABLE IF NOT EXISTS %I PARTITION OF %s" <<<"${precreate_sql}" >/dev/null
+
+echo "[transaction-chunk-lifecycle] retention-plan: old monthly archive candidates only"
+plan_sql="$("${script}" --action retention-plan --target archive --before-month 2026-02 --print-sql)"
+grep -F "transaction_read_model_archive" <<<"${plan_sql}" >/dev/null
+grep -F "recommended_action" <<<"${plan_sql}" >/dev/null
+grep -F "detach_archive_candidate" <<<"${plan_sql}" >/dev/null
+if grep -F "transaction_read_model')" <<<"${plan_sql}" >/dev/null; then
+  echo "archive retention plan must not include hot parent" >&2
+  exit 1
+fi
+
+echo "[transaction-chunk-lifecycle] detach: archive partition only with explicit cutoff"
+detach_sql="$("${script}" --action detach --target archive --before-month 2026-02 --print-sql)"
+grep -F "CREATE SCHEMA IF NOT EXISTS transaction_read_model_detached;" <<<"${detach_sql}" >/dev/null
+grep -F "ALTER TABLE public.transaction_read_model_archive DETACH PARTITION" <<<"${detach_sql}" >/dev/null
+grep -F "ALTER TABLE %s SET SCHEMA transaction_read_model_detached" <<<"${detach_sql}" >/dev/null
+
+echo "[transaction-chunk-lifecycle] drop-detached: requires confirmation outside dry-run"
+drop_sql="$("${script}" --action drop-detached --before-month 2026-01 --print-sql)"
+grep -F "DROP TABLE transaction_read_model_detached" <<<"${drop_sql}" >/dev/null
+if "${script}" --action drop-detached --before-month 2026-01 >/dev/null 2>&1; then
+  echo "drop-detached must require CONFIRM_DROP when not dry-run" >&2
+  exit 1
+fi
+
+echo "[transaction-chunk-lifecycle] maintenance: partition-level analyze/vacuum"
+analyze_sql="$("${script}" --action analyze --target both --print-sql)"
+grep -F "ANALYZE VERBOSE" <<<"${analyze_sql}" >/dev/null
+grep -F "pg_inherits" <<<"${analyze_sql}" >/dev/null
+
+vacuum_sql="$("${script}" --action vacuum-analyze --target archive --print-sql)"
+grep -F "VACUUM (ANALYZE, VERBOSE)" <<<"${vacuum_sql}" >/dev/null
+grep -F "transaction_read_model_archive" <<<"${vacuum_sql}" >/dev/null
+if grep -F "transaction_read_model')" <<<"${vacuum_sql}" >/dev/null; then
+  echo "archive vacuum must not include hot parent" >&2
+  exit 1
+fi
+
+echo "[transaction-chunk-lifecycle] guards: invalid input fails before psql"
+if "${script}" --action detach --target hot --before-month 2026-02 --print-sql >/dev/null 2>&1; then
+  echo "detach target hot unexpectedly succeeded" >&2
+  exit 1
+fi
+if "${script}" --action precreate --reference-month 2026-4 --print-sql >/dev/null 2>&1; then
+  echo "invalid reference month unexpectedly succeeded" >&2
+  exit 1
+fi
+if "${script}" --action retention-plan --target archive --print-sql >/dev/null 2>&1; then
+  echo "missing before-month unexpectedly succeeded" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #351

## 🌿 Base Branch
- `main`

## 📝 Summary
- monthly partition 전환 이후 운영 lifecycle을 script/runbook으로 고정합니다.
- 다음 기간 chunk 선생성, 오래된 archive chunk detach/drop guard, partition별 `ANALYZE`/`VACUUM`, k6/Prometheus/Grafana SLO 확인 절차를 한 PR 범위로 묶었습니다.

## 🛠 Changes
- `tools/ops/transaction-read-model-chunk-lifecycle.sh` 추가
- `precreate`, `retention-plan`, `detach`, `drop-detached`, `analyze`, `vacuum-analyze` action 지원
- `drop-detached` 실행 시 `CONFIRM_DROP=drop-detached-transaction-read-model` guard 적용
- dry-run/print-sql contract test 추가
- chunk lifecycle runbook과 staging replay/performance 결과 문서 연결

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-transaction-read-model-chunk-lifecycle.sh`
- `tools/test/run-transaction-read-model-vacuum-automation.sh`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `detach`/`drop-detached`는 DB partition metadata와 cold data를 다루므로, 운영 실행 전 `--print-sql` review와 snapshot/PITR 가능 상태 확인이 필요합니다.
- 롤백 방법: script/doc 변경은 PR revert로 되돌립니다. 이미 detach한 partition은 `transaction_read_model_detached` schema에서 같은 월 range로 재attach해야 하며, drop 이후는 DB snapshot/PITR 복구가 필요합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
