### PR TITLE
[Perf] 로컬 t3.micro 1억 거래 seed 안정화

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 - 로컬 개발: `Docker Compose + PostgreSQL 18 + Kafka`
 - 로컬 t3.micro 근사 검증: `compose.t3micro.yml`과 `tools/test/run-docker-t3micro-capacity-smoke.sh`로 CPU/메모리 cgroup 제한을 적용합니다.
 - 로컬 HTTP 부하 테스트: `compose.loadtest.yml`로 backend, k6, Prometheus, Grafana, Alertmanager, Postgres exporter를 함께 띄웁니다.
-- 로컬 1억 건 synthetic 조회 테스트: `tools/test/run-transaction-read-model-100m-k6-local.sh`로 read model seed와 k6 실행을 연결합니다. 기본 seed 전략은 t3.micro에서 사후 대형 btree build를 피하는 `SEED_INDEX_STRATEGY=required`입니다.
+- 로컬 1억 건 synthetic 조회 테스트: `tools/test/run-transaction-read-model-100m-k6-local.sh`로 read model seed와 k6 실행을 연결합니다. 기본 seed 전략은 t3.micro에서 사후 대형 btree build를 피하는 `SEED_INDEX_STRATEGY=required`, 작은 batch 기본값 `SEED_BATCH_SIZE=250000`, truncate 신규 seed용 `SEED_CONFLICT_MODE=fail`입니다.
 - 배포 환경: `EC2 + RDS PostgreSQL 18`
 - EC2 reverse proxy baseline template은 [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)에 두고, runtime 값은 `ops/nginx/runtime.env.example` 기반으로 렌더링합니다.
 - `compose.yml`은 로컬 개발 전용이며, 배포용 인프라 정의는 포함하지 않습니다.

--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -36,11 +36,18 @@ YYYY-MM-DD-<environment>-<workload>.md
 
 ```bash
 SEED_TOTAL_ROWS=100000000 \
+SEED_BATCH_SIZE=250000 \
 SEED_TRUNCATE=true \
 tools/test/run-transaction-read-model-100m-k6-local.sh
 ```
 
 기본값은 `SEED_INDEX_STRATEGY=required`입니다. 이 전략은 hot/archive account cursor index를 빈 table 상태에서 먼저 유지해, t3.micro PostgreSQL에서 5천만 row btree를 사후 build하다 OOM 나는 경로를 피합니다.
+
+기본 batch는 `SEED_BATCH_SIZE=250000`입니다. PostgreSQL 384MiB cgroup에서 100만 row 단위 insert가 recovery loop를 만든 전례가 있어 local t3.micro 경로는 더 작은 batch를 기본으로 둡니다.
+
+기본 conflict mode는 `SEED_CONFLICT_MODE=fail`입니다. `SEED_TRUNCATE=true` 신규 seed는 중복 가능성이 없어 `ON CONFLICT` 비용을 제거합니다. 기존 dataset 위에 idempotent append를 의도할 때만 `SEED_TRUNCATE=false SEED_CONFLICT_MODE=ignore`를 명시합니다.
+
+wrapper는 backend bootJar를 만든 뒤 `aquila-bank-backend`를 force-recreate하고, DB의 `flyway_schema_history` 최신 version이 로컬 migration 파일 최신 version 이상인지 확인한 뒤 seed를 실행합니다.
 
 `SEED_INDEX_STRATEGY=rebuild-all`은 전체 secondary filter index를 drop 후 재생성합니다. 이 모드는 partition/chunk 구조 검증 또는 더 큰 memory budget에서만 사용하고, t3.micro 측정 경로에서는 기본값으로 사용하지 않습니다.
 
@@ -50,6 +57,7 @@ tools/test/run-transaction-read-model-100m-k6-local.sh
 - Docker Desktop memory/disk limit
 - `compose.loadtest.yml`의 backend `2 vCPU / 1GiB` budget
 - PostgreSQL container가 이전 실행에서 `OOMKilled=true`로 남아 있지 않은지 여부
+- `tools/test/run-transaction-read-model-100m-k6-local.sh --print-plan`의 batch/conflict/Flyway preflight 값
 - hot/cold account와 기간 기본값이 테스트 의도와 맞는지 여부
 
 수동 보관이 필요하면 아래 명령을 사용합니다.

--- a/docs/performance-results/transaction-100m-local-t3micro-20260425-monthly-chunk-bottleneck.md
+++ b/docs/performance-results/transaction-100m-local-t3micro-20260425-monthly-chunk-bottleneck.md
@@ -134,6 +134,12 @@ Recovery 중 cgroup memory는 `memory.max`에 거의 붙어 있었고 startup pr
 - PostgreSQL cgroup memory headroom을 보장하도록 loadtest profile에서 seed phase와 query phase의 memory/WAL 설정을 분리한다.
 - seed 성공 후에만 k6를 실행하고, 실패 시 k6 미실행을 정상적인 fail-fast 결과로 문서화한다.
 
+## Follow-up Mitigation
+
+- `SEED_BATCH_SIZE` 기본값을 `250000`으로 낮춰 PostgreSQL 384MiB cgroup에서 batch별 index/WAL memory pressure를 줄인다.
+- `SEED_CONFLICT_MODE=fail`을 기본값으로 두고, truncate 신규 seed에서는 `ON CONFLICT`를 생성하지 않는다. 기존 dataset 위 idempotent append가 필요할 때만 `SEED_CONFLICT_MODE=ignore`를 명시한다.
+- local k6 wrapper는 backend bootJar 생성 후 `aquila-bank-backend`를 force-recreate하고, DB의 Flyway latest version이 로컬 migration latest version 이상인지 확인한 뒤 seed를 시작한다.
+
 ## Cleanup
 
 반복 recovery loop로 로컬 자원을 계속 쓰지 않도록 증거 수집 후 PostgreSQL loadtest container를 중지했다.

--- a/docs/performance-results/transaction-read-model-monthly-chunk-summary.md
+++ b/docs/performance-results/transaction-read-model-monthly-chunk-summary.md
@@ -28,9 +28,10 @@
 
 ## Local 100m Seed 영향
 
-- `tools/test/seed-transaction-read-model-100m.sh`는 explicit id insert를 유지하되 `ON CONFLICT (id, booked_at)`으로 partitioned primary key와 맞춥니다.
+- `tools/test/seed-transaction-read-model-100m.sh`는 explicit id insert를 유지합니다. `SEED_CONFLICT_MODE=ignore` idempotent mode에서만 `ON CONFLICT (id, booked_at)`을 사용해 partitioned primary key와 맞춥니다.
 - FK trigger disable/enable은 parent만이 아니라 `pg_partition_tree()` 전체에 적용합니다.
 - `SEED_INDEX_STRATEGY=required` 경로는 account cursor index가 있는 상태에서 적재해 t3.micro의 사후 대형 index build OOM을 피합니다.
+- local t3.micro 기본 batch는 `250000`이며, truncate 신규 seed 기본 경로는 conflict check 비용을 제거합니다.
 
 ## 검증
 

--- a/docs/transaction-read-model-chunk-lifecycle.md
+++ b/docs/transaction-read-model-chunk-lifecycle.md
@@ -135,9 +135,12 @@ tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
 
 ```bash
 SEED_TOTAL_ROWS=100000000 \
+SEED_BATCH_SIZE=250000 \
 SEED_TRUNCATE=true \
 tools/test/run-transaction-read-model-100m-k6-local.sh
 ```
+
+local t3.micro wrapper는 backend를 force-recreate해 최신 Flyway runtime을 보장하고, `flyway_schema_history` 최신 version을 로컬 migration 최신 version과 비교한 뒤 seed를 시작합니다. 기본 conflict mode는 `fail`이라 truncate 신규 seed에서 `ON CONFLICT` 비용을 내지 않습니다.
 
 이미 dataset이 준비되어 있으면 k6만 실행합니다.
 

--- a/tools/test/check-transaction-read-model-100m-local-runner.sh
+++ b/tools/test/check-transaction-read-model-100m-local-runner.sh
@@ -12,21 +12,35 @@ echo "[transaction-100m-local-runner] seed plan"
 plan="$(
   SEED_TOTAL_ROWS=1000 \
   SEED_HOT_ROWS=600 \
-  SEED_BATCH_SIZE=200 \
   SEED_TRUNCATE=true \
     tools/test/seed-transaction-read-model-100m.sh --print-plan
 )"
 grep -F "total_rows=1000" <<<"${plan}" >/dev/null
-grep -F "hot_rows=600 archive_rows=400 batch_size=200" <<<"${plan}" >/dev/null
+grep -F "hot_rows=600 archive_rows=400 batch_size=250000" <<<"${plan}" >/dev/null
 grep -F "truncate=true" <<<"${plan}" >/dev/null
 grep -F "index-strategy=required" <<<"${plan}" >/dev/null
+grep -F "conflict-mode=fail" <<<"${plan}" >/dev/null
 grep -F "local read-path seed only" <<<"${plan}" >/dev/null
+
+idempotent_plan="$(
+  SEED_TOTAL_ROWS=1000 \
+  SEED_HOT_ROWS=600 \
+  SEED_BATCH_SIZE=200 \
+  SEED_TRUNCATE=false \
+  SEED_CONFLICT_MODE=ignore \
+    tools/test/seed-transaction-read-model-100m.sh --print-plan
+)"
+grep -F "hot_rows=600 archive_rows=400 batch_size=200" <<<"${idempotent_plan}" >/dev/null
+grep -F "truncate=false" <<<"${idempotent_plan}" >/dev/null
+grep -F "conflict-mode=ignore" <<<"${idempotent_plan}" >/dev/null
 
 echo "[transaction-100m-local-runner] seed script contract"
 grep -F "TRIGGER ALL" tools/test/seed-transaction-read-model-100m.sh >/dev/null
 grep -F "SEED_INDEX_STRATEGY" tools/test/seed-transaction-read-model-100m.sh >/dev/null
+grep -F "SEED_CONFLICT_MODE" tools/test/seed-transaction-read-model-100m.sh >/dev/null
 grep -F "ensure_required_indexes" tools/test/seed-transaction-read-model-100m.sh >/dev/null
 grep -F "drop_optional_secondary_indexes" tools/test/seed-transaction-read-model-100m.sh >/dev/null
+grep -F "conflict_clause" tools/test/seed-transaction-read-model-100m.sh >/dev/null
 grep -F "generate_series" tools/test/seed-transaction-read-model-100m.sh >/dev/null
 grep -F "ANALYZE transaction_read_model" tools/test/seed-transaction-read-model-100m.sh >/dev/null
 
@@ -39,6 +53,10 @@ if SEED_TOTAL_ROWS=100 SEED_HOT_ROWS=100 tools/test/seed-transaction-read-model-
   echo "SEED_HOT_ROWS=SEED_TOTAL_ROWS unexpectedly succeeded" >&2
   exit 1
 fi
+if SEED_CONFLICT_MODE=bad tools/test/seed-transaction-read-model-100m.sh --print-plan >/dev/null 2>&1; then
+  echo "SEED_CONFLICT_MODE=bad unexpectedly succeeded" >&2
+  exit 1
+fi
 
 echo "[transaction-100m-local-runner] wrapper plan"
 wrapper_plan="$(
@@ -48,10 +66,16 @@ wrapper_plan="$(
 )"
 grep -F "mode=print-plan" <<<"${wrapper_plan}" >/dev/null
 grep -F "seed_total_rows=1000" <<<"${wrapper_plan}" >/dev/null
+grep -F "seed_batch_size=250000" <<<"${wrapper_plan}" >/dev/null
+grep -F "seed_conflict_mode=fail" <<<"${wrapper_plan}" >/dev/null
+grep -F "flyway preflight=latest local migration" <<<"${wrapper_plan}" >/dev/null
 grep -F "k6 report=transaction-100m-check" <<<"${wrapper_plan}" >/dev/null
 grep -F "Prometheus http://localhost:9090, Grafana http://localhost:3001" <<<"${wrapper_plan}" >/dev/null
 
 echo "[transaction-100m-local-runner] wrapper contract"
+grep -F -- "--force-recreate aquila-bank-backend" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
+grep -F "assert_flyway_latest" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
+grep -F "flyway latest applied" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
 grep -F "assert_k6_preflight" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
 grep -F "run-k6-transaction-100m-loadtest.sh --no-up" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
 grep -F "seed-transaction-read-model-100m.sh" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null

--- a/tools/test/run-transaction-read-model-100m-k6-local.sh
+++ b/tools/test/run-transaction-read-model-100m-k6-local.sh
@@ -7,8 +7,10 @@ usage: tools/test/run-transaction-read-model-100m-k6-local.sh [--print-plan|--se
 
 Environment:
   SEED_TOTAL_ROWS      default 100000000
+  SEED_BATCH_SIZE      default 250000
   SEED_TRUNCATE        default true for this wrapper
   SEED_INDEX_STRATEGY  default required
+  SEED_CONFLICT_MODE   default fail
   K6_REPORT_NAME       default transaction-100m-local-<timestamp>
   K6_VUS               default 8
   K6_DURATION          default 1m
@@ -41,6 +43,7 @@ fi
 
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
 seed_total_rows="${SEED_TOTAL_ROWS:-100000000}"
+seed_batch_size="${SEED_BATCH_SIZE:-250000}"
 seed_hot_account_id="${SEED_HOT_ACCOUNT_ID:-910000001}"
 seed_cold_account_id="${SEED_COLD_ACCOUNT_ID:-910000002}"
 seed_hot_from="${SEED_HOT_FROM:-2026-04-01T00:00:00Z}"
@@ -49,15 +52,17 @@ seed_cold_from="${SEED_COLD_FROM:-2026-01-01T00:00:00Z}"
 seed_cold_to="${SEED_COLD_TO:-2026-01-31T00:00:00Z}"
 seed_truncate="${SEED_TRUNCATE:-true}"
 seed_index_strategy="${SEED_INDEX_STRATEGY:-required}"
+seed_conflict_mode="${SEED_CONFLICT_MODE:-fail}"
 k6_report_name="${K6_REPORT_NAME:-transaction-100m-local-$(date +%Y-%m-%d-%H%M%S)}"
 
 psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
 
 print_plan() {
   echo "[transaction-100m-local] mode=${mode}"
-  echo "[transaction-100m-local] seed_total_rows=${seed_total_rows} seed_truncate=${seed_truncate} seed_index_strategy=${seed_index_strategy}"
+  echo "[transaction-100m-local] seed_total_rows=${seed_total_rows} seed_batch_size=${seed_batch_size} seed_truncate=${seed_truncate} seed_index_strategy=${seed_index_strategy} seed_conflict_mode=${seed_conflict_mode}"
   echo "[transaction-100m-local] hot account=${seed_hot_account_id} window=${seed_hot_from}..${seed_hot_to}"
   echo "[transaction-100m-local] cold account=${seed_cold_account_id} window=${seed_cold_from}..${seed_cold_to}"
+  echo "[transaction-100m-local] flyway preflight=latest local migration"
   echo "[transaction-100m-local] k6 report=${k6_report_name} vus=${K6_VUS:-8} duration=${K6_DURATION:-1m}"
   echo "[transaction-100m-local] observability: Prometheus http://localhost:9090, Grafana http://localhost:3001"
 }
@@ -76,20 +81,62 @@ wait_for_schema() {
   exit 1
 }
 
+latest_local_flyway_version() {
+  local version
+  version="$(
+    find back/src/main/resources/db/migration -maxdepth 1 -type f -name 'V*__*.sql' \
+      | sed -E 's#^.*/V([0-9]+)__.*$#\1#' \
+      | sort -n \
+      | tail -1
+  )"
+  if [[ -z "${version}" ]]; then
+    echo "no local Flyway migrations found" >&2
+    exit 1
+  fi
+  echo "${version}"
+}
+
+assert_flyway_latest() {
+  local required_version applied_version
+  required_version="$(latest_local_flyway_version)"
+  applied_version="$(
+    "${psql_base[@]}" --no-align --tuples-only --command "
+      SELECT COALESCE(MAX(version::integer), 0)
+      FROM flyway_schema_history
+      WHERE success
+        AND version ~ '^[0-9]+$';
+    "
+  )"
+  if ! [[ "${applied_version}" =~ ^[0-9]+$ ]]; then
+    echo "Flyway latest version check returned invalid value: ${applied_version}" >&2
+    exit 1
+  fi
+  echo "[transaction-100m-local] flyway latest applied=${applied_version} required=${required_version}"
+  if ((applied_version < required_version)); then
+    echo "Flyway schema is stale. Recreate aquila-bank-backend and retry before seed." >&2
+    exit 1
+  fi
+}
+
 start_runtime() {
   echo "[transaction-100m-local] building backend bootJar"
   tools/test/with-resource-lock.sh back-gradle-loadtest-bootjar ./back/gradlew -p back bootJar
 
   echo "[transaction-100m-local] starting loadtest runtime"
   docker compose "${compose_files[@]}" --profile loadtest up -d \
-    postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter
+    postgres prometheus grafana alertmanager postgres-exporter
+
+  # stale backend container는 새 bootJar/Flyway를 놓칠 수 있어 backend만 강제 재생성합니다.
+  docker compose "${compose_files[@]}" --profile loadtest up -d --force-recreate aquila-bank-backend
 
   echo "[transaction-100m-local] waiting for Flyway schema"
   wait_for_schema
+  assert_flyway_latest
 }
 
 run_seed() {
   SEED_TOTAL_ROWS="${seed_total_rows}" \
+  SEED_BATCH_SIZE="${seed_batch_size}" \
   SEED_HOT_ACCOUNT_ID="${seed_hot_account_id}" \
   SEED_COLD_ACCOUNT_ID="${seed_cold_account_id}" \
   SEED_HOT_FROM="${seed_hot_from}" \
@@ -98,6 +145,7 @@ run_seed() {
   SEED_COLD_TO="${seed_cold_to}" \
   SEED_TRUNCATE="${seed_truncate}" \
   SEED_INDEX_STRATEGY="${seed_index_strategy}" \
+  SEED_CONFLICT_MODE="${seed_conflict_mode}" \
     tools/test/seed-transaction-read-model-100m.sh
 }
 
@@ -138,6 +186,7 @@ fi
 if [[ "${mode}" != "seed-only" ]]; then
   if [[ "${mode}" == "k6-only" ]]; then
     wait_for_schema
+    assert_flyway_latest
   fi
   assert_k6_preflight
   run_k6

--- a/tools/test/seed-transaction-read-model-100m.sh
+++ b/tools/test/seed-transaction-read-model-100m.sh
@@ -8,7 +8,7 @@ usage: tools/test/seed-transaction-read-model-100m.sh [--print-plan]
 Environment:
   SEED_TOTAL_ROWS                 total rows, default 100000000
   SEED_HOT_ROWS                   hot table rows, default half of total
-  SEED_BATCH_SIZE                 insert batch size, default 1000000
+  SEED_BATCH_SIZE                 insert batch size, default 250000
   SEED_HOT_ACCOUNT_ID             default 910000001
   SEED_COLD_ACCOUNT_ID            default 910000002
   SEED_HOT_FROM                   default 2026-04-01T00:00:00Z
@@ -18,11 +18,13 @@ Environment:
   SEED_TRUNCATE                   truncate read model tables first, default false
   SEED_INDEX_STRATEGY             required|rebuild-all|none, default required
   SEED_REBUILD_SECONDARY_INDEXES  legacy true->rebuild-all false->none when SEED_INDEX_STRATEGY is unset
+  SEED_CONFLICT_MODE              fail|ignore, default fail
   SEED_DISABLE_FK_TRIGGERS        disable read model FK triggers around seed, default true
 
 Examples:
   tools/test/seed-transaction-read-model-100m.sh --print-plan
   SEED_TOTAL_ROWS=100000000 SEED_TRUNCATE=true tools/test/seed-transaction-read-model-100m.sh
+  SEED_TRUNCATE=false SEED_CONFLICT_MODE=ignore tools/test/seed-transaction-read-model-100m.sh
 USAGE
 }
 
@@ -58,6 +60,17 @@ require_index_strategy() {
   esac
 }
 
+require_conflict_mode() {
+  local value="$1"
+  case "${value}" in
+    fail | ignore) ;;
+    *)
+      echo "SEED_CONFLICT_MODE must be fail or ignore" >&2
+      exit 1
+      ;;
+  esac
+}
+
 mode="run"
 if [[ "${1:-}" == "--print-plan" ]]; then
   mode="print-plan"
@@ -75,7 +88,7 @@ fi
 total_rows="${SEED_TOTAL_ROWS:-100000000}"
 hot_rows="${SEED_HOT_ROWS:-$((total_rows / 2))}"
 cold_rows=$((total_rows - hot_rows))
-batch_size="${SEED_BATCH_SIZE:-1000000}"
+batch_size="${SEED_BATCH_SIZE:-250000}"
 hot_account_id="${SEED_HOT_ACCOUNT_ID:-910000001}"
 cold_account_id="${SEED_COLD_ACCOUNT_ID:-910000002}"
 hot_from="${SEED_HOT_FROM:-2026-04-01T00:00:00Z}"
@@ -83,6 +96,7 @@ hot_to="${SEED_HOT_TO:-2026-04-30T00:00:00Z}"
 cold_from="${SEED_COLD_FROM:-2026-01-01T00:00:00Z}"
 cold_to="${SEED_COLD_TO:-2026-01-31T00:00:00Z}"
 truncate_tables="${SEED_TRUNCATE:-false}"
+conflict_mode="${SEED_CONFLICT_MODE:-fail}"
 if [[ -n "${SEED_INDEX_STRATEGY:-}" ]]; then
   index_strategy="${SEED_INDEX_STRATEGY}"
 elif [[ -n "${SEED_REBUILD_SECONDARY_INDEXES:-}" ]]; then
@@ -104,6 +118,7 @@ require_positive_integer SEED_HOT_ACCOUNT_ID "${hot_account_id}"
 require_positive_integer SEED_COLD_ACCOUNT_ID "${cold_account_id}"
 require_boolean SEED_TRUNCATE "${truncate_tables}"
 require_index_strategy "${index_strategy}"
+require_conflict_mode "${conflict_mode}"
 require_boolean SEED_DISABLE_FK_TRIGGERS "${disable_fk_triggers}"
 
 if ((hot_rows >= total_rows)); then
@@ -119,7 +134,7 @@ print_plan() {
   echo "[transaction-100m-seed] hot_rows=${hot_rows} archive_rows=${cold_rows} batch_size=${batch_size}"
   echo "[transaction-100m-seed] hot account=${hot_account_id} window=${hot_from}..${hot_to}"
   echo "[transaction-100m-seed] cold account=${cold_account_id} window=${cold_from}..${cold_to}"
-  echo "[transaction-100m-seed] truncate=${truncate_tables} index-strategy=${index_strategy} disable-fk-triggers=${disable_fk_triggers}"
+  echo "[transaction-100m-seed] truncate=${truncate_tables} index-strategy=${index_strategy} conflict-mode=${conflict_mode} disable-fk-triggers=${disable_fk_triggers}"
   echo "[transaction-100m-seed] caveat: local read-path seed only; ledger source-of-truth rows are not generated."
 }
 
@@ -220,9 +235,17 @@ set_trigger_state() {
   "
 }
 
+conflict_clause() {
+  if [[ "${conflict_mode}" == "ignore" ]]; then
+    echo "ON CONFLICT (id, booked_at) DO NOTHING"
+  fi
+}
+
 insert_hot_batch() {
   local start="$1"
   local finish="$2"
+  local conflict_sql
+  conflict_sql="$(conflict_clause)"
   psql_sql "
     INSERT INTO transaction_read_model (
       id,
@@ -254,7 +277,7 @@ insert_hot_batch() {
       '${hot_to}'::timestamptz - (((n - 1) % 2500000) * interval '1 second'),
       now()
     FROM generate_series(${start}, ${finish}) AS series(n)
-    ON CONFLICT (id, booked_at) DO NOTHING;
+    ${conflict_sql};
   "
 }
 
@@ -263,6 +286,8 @@ insert_archive_batch() {
   local finish="$2"
   local id_offset="$hot_rows"
   local ledger_offset="1000000000000"
+  local conflict_sql
+  conflict_sql="$(conflict_clause)"
   psql_sql "
     INSERT INTO transaction_read_model_archive (
       id,
@@ -296,7 +321,7 @@ insert_archive_batch() {
       now(),
       now()
     FROM generate_series(${start}, ${finish}) AS series(n)
-    ON CONFLICT (id, booked_at) DO NOTHING;
+    ${conflict_sql};
   "
 }
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #356

## 🌿 Base Branch
- `main`

## 📝 Summary
- PostgreSQL 384MiB cgroup에서 1억 row seed가 100만 row batch + `ON CONFLICT` + stale Flyway runtime으로 k6 전 단계에서 죽는 경로를 낮춥니다.
- local loadtest 기본값을 작은 batch, truncate 신규 seed의 conflict fail mode, backend force-recreate/Flyway latest preflight 중심으로 조정합니다.

## 🛠 Changes
- `SEED_BATCH_SIZE` 기본값을 `250000`으로 낮추고 wrapper에서도 seed에 전달합니다.
- `SEED_CONFLICT_MODE=fail|ignore`를 추가해 기본 truncate 신규 seed에서는 `ON CONFLICT`를 생성하지 않고, idempotent append는 `ignore` 명시 시에만 사용합니다.
- local 100m k6 wrapper가 backend bootJar 후 `aquila-bank-backend`를 force-recreate하고 DB Flyway latest version을 로컬 migration latest version과 비교한 뒤 seed를 시작합니다.
- static runner check와 운영 문서에 새 batch/conflict/Flyway preflight 계약을 반영했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-read-model-100m-local-runner.sh`
- `SEED_TOTAL_ROWS=1000 SEED_HOT_ROWS=600 SEED_BATCH_SIZE=200 SEED_TRUNCATE=true tools/test/seed-transaction-read-model-100m.sh --print-plan`
- `tools/test/run-transaction-read-model-100m-k6-local.sh --print-plan`
- `git diff --check`
- `SEED_TOTAL_ROWS=1000 SEED_HOT_ROWS=600 SEED_BATCH_SIZE=200 SEED_TRUNCATE=true K6_REPORT_NAME=transaction-100m-seed-stability-smoke K6_VUS=1 K6_DURATION=5s K6_LIMIT=10 K6_ARCHIVE_RESULTS=false tools/test/run-transaction-read-model-100m-k6-local.sh` 실행: `bootJar`는 성공했고, 기존 고정 이름 loadtest 컨테이너(`aquila-bank-alertmanager-loadtest`) 충돌로 compose runtime 시작 단계에서 중단됨

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: batch 기본값을 낮춰 1억 row 전체 seed 시간은 늘 수 있습니다. `SEED_CONFLICT_MODE=fail` 기본값에서는 기존 dataset 위 중복 append가 실패하므로 idempotent 재실행은 `SEED_CONFLICT_MODE=ignore`를 명시해야 합니다.
- 롤백 방법: 이 PR의 script/docs 변경 commit을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A - local loadtest tooling/docs only
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A - 영향 없음
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A - migration/API 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
