### PR TITLE
[Perf] transaction 100m fixture 생성과 k6 조회 단계 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 - 로컬 개발: `Docker Compose + PostgreSQL 18 + Kafka`
 - 로컬 t3.micro 근사 검증: `compose.t3micro.yml`과 `tools/test/run-docker-t3micro-capacity-smoke.sh`로 CPU/메모리 cgroup 제한을 적용합니다.
 - 로컬 HTTP 부하 테스트: `compose.loadtest.yml`로 backend, k6, Prometheus, Grafana, Alertmanager, Postgres exporter를 함께 띄웁니다.
-- 로컬 1억 건 synthetic 조회 테스트: `tools/test/run-transaction-read-model-100m-k6-local.sh`로 read model seed와 k6 실행을 연결합니다. 기본 seed 전략은 t3.micro에서 사후 대형 btree build를 피하는 `SEED_INDEX_STRATEGY=required`, 작은 batch 기본값 `SEED_BATCH_SIZE=250000`, truncate 신규 seed용 `SEED_CONFLICT_MODE=fail`입니다.
+- 로컬 1억 건 synthetic 조회 테스트: dataset 생성은 `tools/test/prepare-transaction-read-model-100m-fixture.sh`, t3.micro 조회 부하는 `tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only`로 분리합니다. 생성 phase는 별도 PostgreSQL budget을 사용하고, 조회 phase만 t3.micro budget으로 제한합니다.
 - 배포 환경: `EC2 + RDS PostgreSQL 18`
 - EC2 reverse proxy baseline template은 [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)에 두고, runtime 값은 `ops/nginx/runtime.env.example` 기반으로 렌더링합니다.
 - `compose.yml`은 로컬 개발 전용이며, 배포용 인프라 정의는 포함하지 않습니다.

--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -32,13 +32,24 @@ YYYY-MM-DD-<environment>-<workload>.md
 - [transaction-100m-local-t3micro-20260425-bottleneck.md](transaction-100m-local-t3micro-20260425-bottleneck.md)
 - [transaction-100m-required-index-smoke-summary.md](transaction-100m-required-index-smoke-summary.md)
 
-로컬 DB에 1억 건 synthetic read model을 먼저 적재하고 k6까지 이어서 실행하는 표준 경로는 아래 명령입니다.
+로컬 1억 건 synthetic read model 검증은 생성 phase와 조회 phase를 분리합니다. t3.micro PostgreSQL 384MiB에서 dataset 생성까지 함께 제한하면 seed OOM이 먼저 발생해 read bottleneck을 측정하지 못합니다.
+
+### Phase 1. fixture 생성
+
+1억 row dataset 생성은 fixture 전용 PostgreSQL budget에서 실행합니다. 이 phase는 기본적으로 Prometheus/Grafana/Postgres exporter/k6를 띄우지 않고 `postgres`와 `aquila-bank-backend`만 사용합니다.
 
 ```bash
 SEED_TOTAL_ROWS=100000000 \
 SEED_BATCH_SIZE=250000 \
 SEED_TRUNCATE=true \
-tools/test/run-transaction-read-model-100m-k6-local.sh
+FIXTURE_POSTGRES_MEMORY=2g \
+tools/test/prepare-transaction-read-model-100m-fixture.sh
+```
+
+실행 전 plan을 먼저 확인합니다.
+
+```bash
+tools/test/prepare-transaction-read-model-100m-fixture.sh --print-plan
 ```
 
 기본값은 `SEED_INDEX_STRATEGY=required`입니다. 이 전략은 hot/archive account cursor index를 빈 table 상태에서 먼저 유지해, t3.micro PostgreSQL에서 5천만 row btree를 사후 build하다 OOM 나는 경로를 피합니다.
@@ -47,17 +58,35 @@ tools/test/run-transaction-read-model-100m-k6-local.sh
 
 기본 conflict mode는 `SEED_CONFLICT_MODE=fail`입니다. `SEED_TRUNCATE=true` 신규 seed는 중복 가능성이 없어 `ON CONFLICT` 비용을 제거합니다. 기존 dataset 위에 idempotent append를 의도할 때만 `SEED_TRUNCATE=false SEED_CONFLICT_MODE=ignore`를 명시합니다.
 
-wrapper는 backend bootJar를 만든 뒤 `aquila-bank-backend`를 force-recreate하고, DB의 `flyway_schema_history` 최신 version이 로컬 migration 파일 최신 version 이상인지 확인한 뒤 seed를 실행합니다.
+fixture prepare runner는 backend bootJar를 만든 뒤 `aquila-bank-backend`를 force-recreate하고, DB의 `flyway_schema_history` 최신 version이 로컬 migration 파일 최신 version 이상인지 확인한 뒤 seed를 실행합니다.
 
 `SEED_INDEX_STRATEGY=rebuild-all`은 전체 secondary filter index를 drop 후 재생성합니다. 이 모드는 partition/chunk 구조 검증 또는 더 큰 memory budget에서만 사용하고, t3.micro 측정 경로에서는 기본값으로 사용하지 않습니다.
+
+### Phase 2. t3.micro k6 조회
+
+fixture 생성이 끝난 volume을 유지한 상태에서 조회 phase만 t3.micro budget으로 실행합니다.
+
+```bash
+K6_HOT_ACCOUNT_ID=910000001 \
+K6_COLD_ACCOUNT_ID=910000002 \
+K6_HOT_FROM=2026-04-01T00:00:00Z \
+K6_HOT_TO=2026-04-30T00:00:00Z \
+K6_COLD_FROM=2026-01-01T00:00:00Z \
+K6_COLD_TO=2026-01-31T00:00:00Z \
+tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only
+```
+
+기존 `tools/test/run-transaction-read-model-100m-k6-local.sh` 단일 실행은 seed와 k6를 이어서 수행하는 호환 경로입니다. 1억 row read bottleneck 검증에서는 생성과 조회를 분리한 두 phase 절차를 우선 사용합니다.
 
 실행 전 확인값:
 
 - local disk 여유 공간
 - Docker Desktop memory/disk limit
-- `compose.loadtest.yml`의 backend `2 vCPU / 1GiB` budget
+- fixture phase의 `FIXTURE_POSTGRES_MEMORY`, `FIXTURE_POSTGRES_CPUS`, `FIXTURE_POSTGRES_PIDS_LIMIT`
+- query phase의 `compose.loadtest.yml` backend `2 vCPU / 1GiB` budget과 PostgreSQL t3.micro budget
 - PostgreSQL container가 이전 실행에서 `OOMKilled=true`로 남아 있지 않은지 여부
-- `tools/test/run-transaction-read-model-100m-k6-local.sh --print-plan`의 batch/conflict/Flyway preflight 값
+- `tools/test/prepare-transaction-read-model-100m-fixture.sh --print-plan`의 fixture budget/batch/conflict/Flyway preflight 값
+- `tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only` 실행 전 hot/cold account와 기간 값
 - hot/cold account와 기간 기본값이 테스트 의도와 맞는지 여부
 
 수동 보관이 필요하면 아래 명령을 사용합니다.

--- a/tools/test/check-transaction-read-model-100m-local-runner.sh
+++ b/tools/test/check-transaction-read-model-100m-local-runner.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 echo "[transaction-100m-local-runner] shell syntax"
 bash -n tools/test/seed-transaction-read-model-100m.sh
 bash -n tools/test/run-transaction-read-model-100m-k6-local.sh
+bash -n tools/test/prepare-transaction-read-model-100m-fixture.sh
 
 echo "[transaction-100m-local-runner] compose config"
 docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/dev/null
@@ -79,3 +80,24 @@ grep -F "flyway latest applied" tools/test/run-transaction-read-model-100m-k6-lo
 grep -F "assert_k6_preflight" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
 grep -F "run-k6-transaction-100m-loadtest.sh --no-up" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
 grep -F "seed-transaction-read-model-100m.sh" tools/test/run-transaction-read-model-100m-k6-local.sh >/dev/null
+
+echo "[transaction-100m-local-runner] fixture prepare plan"
+fixture_plan="$(
+  SEED_TOTAL_ROWS=1000 \
+  K6_REPORT_NAME=transaction-100m-check \
+    tools/test/prepare-transaction-read-model-100m-fixture.sh --print-plan
+)"
+grep -F "mode=print-plan" <<<"${fixture_plan}" >/dev/null
+grep -F "fixture phase only" <<<"${fixture_plan}" >/dev/null
+grep -F "seed_total_rows=1000" <<<"${fixture_plan}" >/dev/null
+grep -F "seed_batch_size=250000" <<<"${fixture_plan}" >/dev/null
+grep -F "seed_conflict_mode=fail" <<<"${fixture_plan}" >/dev/null
+grep -F "observability=off" <<<"${fixture_plan}" >/dev/null
+grep -F "read phase: tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only" <<<"${fixture_plan}" >/dev/null
+
+echo "[transaction-100m-local-runner] fixture prepare contract"
+grep -F "fixture phase only" tools/test/prepare-transaction-read-model-100m-fixture.sh >/dev/null
+grep -F "run-transaction-read-model-100m-k6-local.sh --k6-only" tools/test/prepare-transaction-read-model-100m-fixture.sh >/dev/null
+grep -F "SEED_TOTAL_ROWS" tools/test/prepare-transaction-read-model-100m-fixture.sh >/dev/null
+grep -F "SEED_BATCH_SIZE" tools/test/prepare-transaction-read-model-100m-fixture.sh >/dev/null
+grep -F "assert_flyway_latest" tools/test/prepare-transaction-read-model-100m-fixture.sh >/dev/null

--- a/tools/test/prepare-transaction-read-model-100m-fixture.sh
+++ b/tools/test/prepare-transaction-read-model-100m-fixture.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/prepare-transaction-read-model-100m-fixture.sh [--print-plan]
+
+Fixture environment:
+  FIXTURE_POSTGRES_CPUS         default 2
+  FIXTURE_POSTGRES_MEMORY       default 2g
+  FIXTURE_POSTGRES_MEMORY_SWAP  default same as FIXTURE_POSTGRES_MEMORY
+  FIXTURE_POSTGRES_PIDS_LIMIT   default 256
+
+Seed environment:
+  SEED_TOTAL_ROWS      default 100000000
+  SEED_BATCH_SIZE      default 250000
+  SEED_TRUNCATE        default true for this wrapper
+  SEED_INDEX_STRATEGY  default required
+  SEED_CONFLICT_MODE   default fail
+
+Examples:
+  tools/test/prepare-transaction-read-model-100m-fixture.sh --print-plan
+  FIXTURE_POSTGRES_MEMORY=4g SEED_TOTAL_ROWS=100000000 tools/test/prepare-transaction-read-model-100m-fixture.sh
+
+After success, run the read phase with:
+  tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only
+USAGE
+}
+
+mode="run"
+if [[ "${1:-}" == "--print-plan" ]]; then
+  mode="print-plan"
+  shift
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$#" -ne 0 ]]; then
+  usage
+  exit 1
+fi
+
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+fixture_postgres_cpus="${FIXTURE_POSTGRES_CPUS:-2}"
+fixture_postgres_memory="${FIXTURE_POSTGRES_MEMORY:-2g}"
+fixture_postgres_memory_swap="${FIXTURE_POSTGRES_MEMORY_SWAP:-${fixture_postgres_memory}}"
+fixture_postgres_pids_limit="${FIXTURE_POSTGRES_PIDS_LIMIT:-256}"
+seed_total_rows="${SEED_TOTAL_ROWS:-100000000}"
+seed_batch_size="${SEED_BATCH_SIZE:-250000}"
+seed_hot_account_id="${SEED_HOT_ACCOUNT_ID:-910000001}"
+seed_cold_account_id="${SEED_COLD_ACCOUNT_ID:-910000002}"
+seed_hot_from="${SEED_HOT_FROM:-2026-04-01T00:00:00Z}"
+seed_hot_to="${SEED_HOT_TO:-2026-04-30T00:00:00Z}"
+seed_cold_from="${SEED_COLD_FROM:-2026-01-01T00:00:00Z}"
+seed_cold_to="${SEED_COLD_TO:-2026-01-31T00:00:00Z}"
+seed_truncate="${SEED_TRUNCATE:-true}"
+seed_index_strategy="${SEED_INDEX_STRATEGY:-required}"
+seed_conflict_mode="${SEED_CONFLICT_MODE:-fail}"
+
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
+
+print_plan() {
+  echo "[transaction-100m-fixture] mode=${mode}"
+  echo "[transaction-100m-fixture] fixture phase only"
+  echo "[transaction-100m-fixture] seed_total_rows=${seed_total_rows} seed_batch_size=${seed_batch_size} seed_truncate=${seed_truncate} seed_index_strategy=${seed_index_strategy} seed_conflict_mode=${seed_conflict_mode}"
+  echo "[transaction-100m-fixture] hot account=${seed_hot_account_id} window=${seed_hot_from}..${seed_hot_to}"
+  echo "[transaction-100m-fixture] cold account=${seed_cold_account_id} window=${seed_cold_from}..${seed_cold_to}"
+  echo "[transaction-100m-fixture] postgres budget cpus=${fixture_postgres_cpus} memory=${fixture_postgres_memory} memory_swap=${fixture_postgres_memory_swap} pids=${fixture_postgres_pids_limit}"
+  echo "[transaction-100m-fixture] observability=off services=postgres,aquila-bank-backend"
+  echo "[transaction-100m-fixture] flyway preflight=latest local migration"
+  echo "[transaction-100m-fixture] read phase: tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only"
+}
+
+compose_with_fixture_budget() {
+  T3MICRO_POSTGRES_CPUS="${fixture_postgres_cpus}" \
+  T3MICRO_POSTGRES_MEMORY="${fixture_postgres_memory}" \
+  T3MICRO_POSTGRES_MEMORY_SWAP="${fixture_postgres_memory_swap}" \
+  T3MICRO_POSTGRES_PIDS_LIMIT="${fixture_postgres_pids_limit}" \
+    docker compose "${compose_files[@]}" "$@"
+}
+
+latest_local_flyway_version() {
+  local version
+  version="$(
+    find back/src/main/resources/db/migration -maxdepth 1 -type f -name 'V*__*.sql' \
+      | sed -E 's#^.*/V([0-9]+)__.*$#\1#' \
+      | sort -n \
+      | tail -1
+  )"
+  if [[ -z "${version}" ]]; then
+    echo "no local Flyway migrations found" >&2
+    exit 1
+  fi
+  echo "${version}"
+}
+
+wait_for_schema() {
+  local attempt exists
+  for attempt in $(seq 1 90); do
+    if exists="$("${psql_base[@]}" --no-align --tuples-only --command "SELECT to_regclass('public.transaction_read_model') IS NOT NULL;" 2>/dev/null)"; then
+      if [[ "${exists}" == "t" ]]; then
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  echo "transaction_read_model schema was not created in time" >&2
+  exit 1
+}
+
+assert_flyway_latest() {
+  local required_version applied_version
+  required_version="$(latest_local_flyway_version)"
+  applied_version="$(
+    "${psql_base[@]}" --no-align --tuples-only --command "
+      SELECT COALESCE(MAX(version::integer), 0)
+      FROM flyway_schema_history
+      WHERE success
+        AND version ~ '^[0-9]+$';
+    "
+  )"
+  if ! [[ "${applied_version}" =~ ^[0-9]+$ ]]; then
+    echo "Flyway latest version check returned invalid value: ${applied_version}" >&2
+    exit 1
+  fi
+  echo "[transaction-100m-fixture] flyway latest applied=${applied_version} required=${required_version}"
+  if ((applied_version < required_version)); then
+    echo "Flyway schema is stale. Recreate aquila-bank-backend and retry before seed." >&2
+    exit 1
+  fi
+}
+
+stop_observability() {
+  # fixture 생성 중에는 exporter/Prometheus 부하를 제거해 seed resource만 측정합니다.
+  compose_with_fixture_budget --profile loadtest stop \
+    prometheus grafana alertmanager postgres-exporter >/dev/null 2>&1 || true
+}
+
+start_runtime() {
+  echo "[transaction-100m-fixture] building backend bootJar"
+  tools/test/with-resource-lock.sh back-gradle-fixture-bootjar ./back/gradlew -p back bootJar
+
+  echo "[transaction-100m-fixture] stopping observability services"
+  stop_observability
+
+  echo "[transaction-100m-fixture] starting fixture runtime"
+  compose_with_fixture_budget --profile loadtest up -d postgres
+  compose_with_fixture_budget --profile loadtest up -d --force-recreate aquila-bank-backend
+
+  echo "[transaction-100m-fixture] waiting for Flyway schema"
+  wait_for_schema
+  assert_flyway_latest
+}
+
+run_seed() {
+  T3MICRO_POSTGRES_CPUS="${fixture_postgres_cpus}" \
+  T3MICRO_POSTGRES_MEMORY="${fixture_postgres_memory}" \
+  T3MICRO_POSTGRES_MEMORY_SWAP="${fixture_postgres_memory_swap}" \
+  T3MICRO_POSTGRES_PIDS_LIMIT="${fixture_postgres_pids_limit}" \
+  SEED_TOTAL_ROWS="${seed_total_rows}" \
+  SEED_BATCH_SIZE="${seed_batch_size}" \
+  SEED_HOT_ACCOUNT_ID="${seed_hot_account_id}" \
+  SEED_COLD_ACCOUNT_ID="${seed_cold_account_id}" \
+  SEED_HOT_FROM="${seed_hot_from}" \
+  SEED_HOT_TO="${seed_hot_to}" \
+  SEED_COLD_FROM="${seed_cold_from}" \
+  SEED_COLD_TO="${seed_cold_to}" \
+  SEED_TRUNCATE="${seed_truncate}" \
+  SEED_INDEX_STRATEGY="${seed_index_strategy}" \
+  SEED_CONFLICT_MODE="${seed_conflict_mode}" \
+    tools/test/seed-transaction-read-model-100m.sh
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+start_runtime
+run_seed
+
+echo "[transaction-100m-fixture] fixture seed complete"
+echo "[transaction-100m-fixture] read phase: tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only"


### PR DESCRIPTION
## 🔗 Related Issue
- close #362

## 🌿 Base Branch
- `main`

## 📝 Summary
- 1억 row dataset 생성 phase와 t3.micro k6 조회 phase를 분리했습니다.
- 새 fixture prepare runner는 별도 PostgreSQL budget에서 seed만 수행하고, read bottleneck 검증은 기존 `--k6-only` 경로로 실행하도록 정리했습니다.

## 🛠 Changes
- `tools/test/prepare-transaction-read-model-100m-fixture.sh` 추가
- `tools/test/check-transaction-read-model-100m-local-runner.sh`에 fixture/read 분리 contract 추가
- `README.md`, `docs/performance-results/README.md`에 two-phase 실행 절차 문서화

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-read-model-100m-local-runner.sh`
- `tools/test/prepare-transaction-read-model-100m-fixture.sh --print-plan`
- `tools/test/run-transaction-read-model-100m-k6-local.sh --print-plan`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: shell runner와 문서 변경입니다. 실제 1억 row fixture 생성은 별도 실행 비용이 크므로 PR 검증에서는 print-plan/contract까지 확인했습니다.
- 롤백 방법: 이 PR의 세 commit revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A, runner/docs 변경
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? 영향 없음
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?