### PR TITLE
[Perf] transaction 100m two-phase local loadtest 병목 리포트

### DIFF
--- a/docs/performance-results/transaction-100m-local-t3micro-20260426-two-phase-loadtest-bottleneck.md
+++ b/docs/performance-results/transaction-100m-local-t3micro-20260426-two-phase-loadtest-bottleneck.md
@@ -1,0 +1,189 @@
+# Transaction 100m local t3.micro two-phase loadtest bottleneck
+
+## Scope
+
+- date: 2026-04-26 KST
+- issue: #364
+- branch: `perf/transaction-100m-two-phase-loadtest-report`
+- base main sha: `242ce2c`
+- goal: 1억 row 거래 조회와 대용량 HTTP 부하를 로컬 Docker t3.micro 예산에서 분리 측정
+
+## Environment
+
+- compose: `compose.yml`, `compose.t3micro.yml`, `compose.loadtest.yml`
+- PostgreSQL: 18.3
+- backend: Spring Boot app, Java 21, loadtest profile container
+- observability: k6, Prometheus remote write, Grafana, postgres-exporter
+- dataset: hot `transaction_read_model` 50,000,000 rows, archive `transaction_read_model_archive` 약 50,000,028 rows
+- hot account: `910000001`, window `2026-04-01T00:00:00Z..2026-04-30T00:00:00Z`
+- cold account: `910000002`, window `2026-01-01T00:00:00Z..2026-01-31T00:00:00Z`
+
+## Phase 1 Fixture Generation
+
+Command:
+
+```bash
+tools/test/prepare-transaction-read-model-100m-fixture.sh
+```
+
+Result:
+
+- fresh PostgreSQL volume에서 1억 row fixture 생성 완료
+- fixture budget: PostgreSQL `2GiB`, `2 CPU`, observability off
+- output estimate: hot 50,000,000, archive 50,000,028
+- peak observed sample: PostgreSQL CPU 약 90%, memory 약 256MiB/2GiB, Block I/O write 약 172GB
+- disk free after fixture sample: 약 141GiB
+
+Conclusion:
+
+- 1억 row 생성은 t3.micro 384MiB PostgreSQL에서 직접 수행할 작업이 아니다.
+- pre-indexed insert 전략은 2GiB fixture budget에서는 성공했다.
+- fixture 생성 병목은 memory보다 CPU + WAL/disk write이다.
+
+## Phase 2 Read Loadtest
+
+Before read test:
+
+- 같은 Docker volume 유지
+- PostgreSQL을 t3.micro budget으로 recreate: memory `384MiB`, CPU `0.6`, OOM false, healthy
+- backend loadtest budget: memory `1GiB`, CPU `2`
+- default transaction read admission: `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=3`
+
+### Run A: default guard, VU=8
+
+Command:
+
+```bash
+K6_REPORT_NAME=transaction-100m-two-phase-t3micro-20260426 \
+K6_VUS=8 K6_DURATION=1m \
+tools/test/run-k6-transaction-100m-loadtest.sh --no-up
+```
+
+Summary:
+
+- report: `docs/performance-results/transaction-100m-two-phase-t3micro-20260426-summary.md`
+- result: failed threshold
+- `http_req_failed`: `0.7257660989557434`
+- `checks`: `0.43042945383813314`
+- p95: hot first 2.16ms, hot cursor 2.79ms, cold first 3.03ms, cold cursor 3.09ms
+
+Conclusion:
+
+- 8 VU에서 첫 병목은 DB query plan이 아니라 backend admission guard이다.
+- p95가 낮은데 실패율만 높은 형태라, 대부분 요청은 과부하 보호 정책으로 429 처리됐다.
+
+### Run B: default guard, VU=3
+
+Command:
+
+```bash
+K6_REPORT_NAME=transaction-100m-two-phase-t3micro-vu3-20260426 \
+K6_VUS=3 K6_DURATION=1m \
+tools/test/run-k6-transaction-100m-loadtest.sh --no-up
+```
+
+Summary:
+
+- report: `docs/performance-results/transaction-100m-two-phase-t3micro-vu3-20260426-summary.md`
+- result: passed
+- complete iterations: 47,751/min
+- `http_req_failed`: `0`
+- `checks`: `1`
+- p95: hot first 1.05ms, hot cursor 1.04ms, cold first 1.02ms, cold cursor 1.08ms
+- observed sample: backend CPU 약 98%, PostgreSQL CPU 약 61%, PostgreSQL memory 약 62MiB/384MiB
+
+Conclusion:
+
+- default guard 안쪽에서는 1억 row 조회가 index 경로로 안정적으로 수행된다.
+- PostgreSQL memory는 여유가 있고, 다음 한계는 backend CPU와 PostgreSQL CPU 사용률이다.
+
+### Run C: attempted admission8 through wrapper
+
+Command:
+
+```bash
+K6_REPORT_NAME=transaction-100m-two-phase-t3micro-vu8-admission8-20260426 \
+K6_VUS=8 K6_DURATION=1m \
+tools/test/run-k6-transaction-100m-loadtest.sh --no-up
+```
+
+Summary:
+
+- report: `docs/performance-results/transaction-100m-two-phase-t3micro-vu8-admission8-20260426-summary.md`
+- result: invalid for capacity decision
+- reason: `docker compose run` dependency handling recreated backend with default `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=3`
+- observed backend env after run: `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=3`
+
+Conclusion:
+
+- 현재 k6 wrapper는 dependency recreate가 섞이면 admission setting 검증 없이 결과를 만들 수 있다.
+- report name의 `admission8`만 믿으면 안 되고, preflight에서 backend env를 검증해야 한다.
+
+### Run D: admission8, no-deps direct k6, VU=8
+
+Setup:
+
+```bash
+OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=8 \
+docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml \
+  --profile loadtest up -d --force-recreate aquila-bank-backend
+```
+
+Command:
+
+```bash
+docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml \
+  --profile loadtest run --rm --no-deps \
+  -e K6_REPORT_NAME=transaction-100m-two-phase-t3micro-vu8-admission8-nodeps-20260426 \
+  -e K6_HOT_ACCOUNT_ID=910000001 \
+  -e K6_HOT_FROM=2026-04-01T00:00:00Z \
+  -e K6_HOT_TO=2026-04-30T00:00:00Z \
+  -e K6_COLD_ACCOUNT_ID=910000002 \
+  -e K6_COLD_FROM=2026-01-01T00:00:00Z \
+  -e K6_COLD_TO=2026-01-31T00:00:00Z \
+  -e K6_VUS=8 \
+  -e K6_DURATION=1m \
+  -e K6_LIMIT=50 \
+  k6-transaction-read-100m
+```
+
+Summary:
+
+- report: `docs/performance-results/transaction-100m-two-phase-t3micro-vu8-admission8-nodeps-20260426-summary.md`
+- result: passed
+- complete iterations: 31,701/min
+- `http_req_failed`: `0`
+- `checks`: `1`
+- p95: hot first 5.09ms, hot cursor 5.27ms, cold first 5.05ms, cold cursor 5.39ms
+- observed sample: backend CPU 약 115%, PostgreSQL CPU 약 61%, PostgreSQL memory 약 56MiB/384MiB
+
+Conclusion:
+
+- guard를 8로 올려도 1억 row 조회 p95는 SLO보다 충분히 낮다.
+- 다만 VU=8 throughput은 VU=3 대비 선형 증가하지 않았다.
+- next bottleneck은 query memory가 아니라 backend CPU, JDBC/request 처리 비용, PostgreSQL CPU budget 조합이다.
+
+## Additional Harness Finding
+
+`tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only`는 같은 DB에서 수동 schema query가 `t`로 즉시 응답했는데도 `transaction_read_model schema was not created in time`으로 실패했다.
+
+Implication:
+
+- 1억 row 조회 자체와 별개로 loadtest wrapper 신뢰성 문제가 있다.
+- 다음 PR에서 k6-only preflight를 `docker compose exec` 결과 원문 로깅, backend env 검증, `--no-deps` 실행 옵션으로 보강해야 한다.
+
+## Bottleneck Order
+
+1. Fixture generation: 1억 row 생성은 t3.micro DB budget에서 수행하지 말고 별도 fixture budget 또는 외부 dump/restore로 분리한다.
+2. Default production-like t3.micro read traffic: `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=3`이 첫 병목이자 보호 장치이다.
+3. Guard-internal read path: VU=3은 실패율 0, p95 약 1ms로 정상이다.
+4. Raised guard read path: VU=8은 실패율 0, p95 약 5ms로 정상이나 throughput이 선형 확장되지 않는다.
+5. Next optimization target: backend CPU/request overhead, DB CPU allocation, Hikari pool/admission limit의 조합을 튜닝한다.
+
+## Follow-up Work
+
+- k6 wrapper에 `--no-deps` 경로와 backend env preflight 추가
+- admission limit과 Hikari pool size를 같은 실험 축으로 둔 matrix loadtest 추가
+- backend/DB CPU saturation 기준 Prometheus alert와 Grafana panel 추가
+- fixture 생성은 dump/restore 또는 prebuilt volume workflow로 분리
+- 1억 row 조회 SLO는 default guard 기준과 raised guard 기준을 별도 문서화

--- a/docs/performance-results/transaction-100m-two-phase-t3micro-20260426-summary.md
+++ b/docs/performance-results/transaction-100m-two-phase-t3micro-20260426-summary.md
@@ -1,0 +1,36 @@
+# transaction-100m-two-phase-t3micro-20260426-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-26T02:11:10Z
+- sourceMarkdown: build/reports/k6/transaction-100m-two-phase-t3micro-20260426-summary.md
+- sourceJson: build/reports/k6/transaction-100m-two-phase-t3micro-20260426-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 8
+- duration: 1m
+- limit: 50
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- http failed rate threshold: 0.01
+
+## Results
+
+- http_req_failed rate: 0.7257660989557434
+- checks rate: 0.43042945383813314
+- hot first p95 ms: 2.160333
+- hot cursor p95 ms: 2.792910099999999
+- cold first p95 ms: 3.032993899999998
+- cold cursor p95 ms: 3.086087499999996
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- Prometheus remote write 대상은 `K6_PROMETHEUS_RW_SERVER_URL`입니다.

--- a/docs/performance-results/transaction-100m-two-phase-t3micro-vu3-20260426-summary.md
+++ b/docs/performance-results/transaction-100m-two-phase-t3micro-vu3-20260426-summary.md
@@ -1,0 +1,36 @@
+# transaction-100m-two-phase-t3micro-vu3-20260426-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-26T02:16:23Z
+- sourceMarkdown: build/reports/k6/transaction-100m-two-phase-t3micro-vu3-20260426-summary.md
+- sourceJson: build/reports/k6/transaction-100m-two-phase-t3micro-vu3-20260426-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 3
+- duration: 1m
+- limit: 50
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- http failed rate threshold: 0.01
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- hot first p95 ms: 1.0476454999999991
+- hot cursor p95 ms: 1.0447494999999996
+- cold first p95 ms: 1.0223119999999986
+- cold cursor p95 ms: 1.0845204999999987
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- Prometheus remote write 대상은 `K6_PROMETHEUS_RW_SERVER_URL`입니다.

--- a/docs/performance-results/transaction-100m-two-phase-t3micro-vu8-admission8-20260426-summary.md
+++ b/docs/performance-results/transaction-100m-two-phase-t3micro-vu8-admission8-20260426-summary.md
@@ -1,0 +1,36 @@
+# transaction-100m-two-phase-t3micro-vu8-admission8-20260426-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-26T02:18:45Z
+- sourceMarkdown: build/reports/k6/transaction-100m-two-phase-t3micro-vu8-admission8-20260426-summary.md
+- sourceJson: build/reports/k6/transaction-100m-two-phase-t3micro-vu8-admission8-20260426-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 8
+- duration: 1m
+- limit: 50
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- http failed rate threshold: 0.01
+
+## Results
+
+- http_req_failed rate: 0.7979967129367054
+- checks rate: 0.3361110393580107
+- hot first p95 ms: 1.6306438999999993
+- hot cursor p95 ms: 2.440683999999999
+- cold first p95 ms: 2.554625
+- cold cursor p95 ms: 2.70258935
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- Prometheus remote write 대상은 `K6_PROMETHEUS_RW_SERVER_URL`입니다.

--- a/docs/performance-results/transaction-100m-two-phase-t3micro-vu8-admission8-nodeps-20260426-summary.md
+++ b/docs/performance-results/transaction-100m-two-phase-t3micro-vu8-admission8-nodeps-20260426-summary.md
@@ -1,0 +1,36 @@
+# transaction-100m-two-phase-t3micro-vu8-admission8-nodeps-20260426-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-26T02:20:29Z
+- sourceMarkdown: build/reports/k6/transaction-100m-two-phase-t3micro-vu8-admission8-nodeps-20260426-summary.md
+- sourceJson: build/reports/k6/transaction-100m-two-phase-t3micro-vu8-admission8-nodeps-20260426-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 8
+- duration: 1m
+- limit: 50
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- http failed rate threshold: 0.01
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- hot first p95 ms: 5.091583
+- hot cursor p95 ms: 5.269083
+- cold first p95 ms: 5.050709
+- cold cursor p95 ms: 5.393542
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- Prometheus remote write 대상은 `K6_PROMETHEUS_RW_SERVER_URL`입니다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #364

## 🌿 Base Branch
- `main`

## 📝 Summary
- 2026-04-26 실제 1억 row fixture 생성과 로컬 Docker t3.micro 조회 부하 테스트 결과를 문서화했습니다.
- default admission guard, guard 내부 VU=3, raised guard VU=8 no-deps 결과를 분리해 병목 순서를 정리했습니다.

## 🛠 Changes
- `docs/performance-results/transaction-100m-local-t3micro-20260426-two-phase-loadtest-bottleneck.md` 추가
- k6 archived summary 4개 추가: default VU=8, default VU=3, invalid admission8 wrapper run, valid admission8 no-deps VU=8
- k6 wrapper 신뢰성 이슈와 후속 작업을 문서화

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/prepare-transaction-read-model-100m-fixture.sh`
- `tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only` failed: `transaction_read_model schema was not created in time`
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-up` default guard VU=8: threshold failed, 429 bottleneck confirmed
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-up` default guard VU=3: passed, p95 약 1ms
- direct `docker compose ... run --rm --no-deps ... k6-transaction-read-100m` admission8 VU=8: passed, p95 약 5ms
- `git diff --cached --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 문서 PR이며 런타임 코드 영향 없음. invalid admission8 wrapper run summary는 리포트에서 capacity 판단 제외로 명시했습니다.
- 롤백 방법: 이 PR의 문서 commit revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A, 문서 PR
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
