### PR TITLE
[Perf] transaction read backend CPU hot path profiling gate 추가

### DIFF
--- a/tools/test/check-transaction-read-hotpath-profile.sh
+++ b/tools/test/check-transaction-read-hotpath-profile.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-read-hotpath-profile.sh"
+
+echo "[transaction-read-hotpath-profile] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-read-hotpath-profile] print plan"
+plan="$(
+  PROFILE_NAME=transaction-read-hotpath-check \
+  PROFILE_DURATION=20s \
+  K6_DURATION=15s \
+  K6_VUS=8 \
+    "${script}" --print-plan
+)"
+grep -F "profile=transaction-read-hotpath-check" <<<"${plan}" >/dev/null
+grep -F "profiler=jfr" <<<"${plan}" >/dev/null
+grep -F "k6 vus=8 duration=15s" <<<"${plan}" >/dev/null
+grep -F "jfr duration=20s" <<<"${plan}" >/dev/null
+grep -F "artifact=build/reports/profiling/transaction-read-hotpath-check/transaction-read-hotpath-check.jfr" <<<"${plan}" >/dev/null
+grep -F "summary=build/reports/profiling/transaction-read-hotpath-check/transaction-read-hotpath-check-summary.md" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-hotpath-profile] runner contract"
+grep -F "StartFlightRecording" "${script}" >/dev/null
+grep -F "LOADTEST_BACKEND_JAVA_TOOL_OPTIONS" "${script}" >/dev/null
+grep -F "docker cp" "${script}" >/dev/null
+grep -F "docker compose" "${script}" >/dev/null
+grep -F "k6-transaction-read-100m" "${script}" >/dev/null
+grep -F -- "--no-deps" "${script}" >/dev/null
+grep -F "jfr summary" "${script}" >/dev/null
+grep -F "artifact missing or empty" "${script}" >/dev/null
+
+echo "[transaction-read-hotpath-profile] invalid input fails"
+if PROFILE_DURATION=0s "${script}" --print-plan >/dev/null 2>&1; then
+  echo "PROFILE_DURATION=0s unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_VUS=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "K6_VUS=0 unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-read-hotpath-profile.sh
+++ b/tools/test/run-transaction-read-hotpath-profile.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-hotpath-profile.sh [--print-plan]
+
+Required runtime environment for actual runs:
+  K6_HOT_ACCOUNT_ID
+  K6_HOT_FROM
+  K6_HOT_TO
+  K6_COLD_ACCOUNT_ID
+  K6_COLD_FROM
+  K6_COLD_TO
+
+Optional environment:
+  PROFILE_NAME              default transaction-read-hotpath-<timestamp>
+  PROFILE_DURATION          default 75s
+  PROFILE_ADMISSION         default 8
+  PROFILE_DB_POOL_MAX_SIZE  default 4
+  PROFILE_BUILD_BACKEND     default true
+  K6_VUS                    default 8
+  K6_DURATION               default 1m
+  K6_LIMIT                  default 50
+  K6_REPORT_NAME            default <profile-name>-k6
+
+Examples:
+  tools/test/run-transaction-read-hotpath-profile.sh --print-plan
+  K6_HOT_ACCOUNT_ID=910000001 K6_COLD_ACCOUNT_ID=910000002 \
+    tools/test/run-transaction-read-hotpath-profile.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+profile_name="${PROFILE_NAME:-transaction-read-hotpath-$(date +%Y-%m-%d-%H%M%S)}"
+profile_duration="${PROFILE_DURATION-75s}"
+profile_admission="${PROFILE_ADMISSION:-8}"
+profile_db_pool_max_size="${PROFILE_DB_POOL_MAX_SIZE:-4}"
+profile_build_backend="${PROFILE_BUILD_BACKEND:-true}"
+k6_vus="${K6_VUS:-8}"
+k6_duration="${K6_DURATION:-1m}"
+k6_limit="${K6_LIMIT:-50}"
+k6_report_name="${K6_REPORT_NAME:-${profile_name}-k6}"
+report_dir="build/reports/profiling/${profile_name}"
+jfr_container_path="/tmp/${profile_name}.jfr"
+jfr_artifact="${report_dir}/${profile_name}.jfr"
+jfr_summary_txt="${report_dir}/${profile_name}-jfr-summary.txt"
+run_log="${report_dir}/${profile_name}.log"
+summary_md="${report_dir}/${profile_name}-summary.md"
+k6_summary_json="build/reports/k6/${k6_report_name}-summary.json"
+k6_summary_md="build/reports/k6/${k6_report_name}-summary.md"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_duration() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*(s|m)$ ]]; then
+    echo "${name} must use a positive second/minute duration, for example 75s or 2m: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_env() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "${value}" ]]; then
+    echo "${name} is required" >&2
+    exit 1
+  fi
+}
+
+require_duration "PROFILE_DURATION" "${profile_duration}"
+require_duration "K6_DURATION" "${k6_duration}"
+require_positive_integer "PROFILE_ADMISSION" "${profile_admission}"
+require_positive_integer "PROFILE_DB_POOL_MAX_SIZE" "${profile_db_pool_max_size}"
+require_positive_integer "K6_VUS" "${k6_vus}"
+require_positive_integer "K6_LIMIT" "${k6_limit}"
+
+print_plan() {
+  echo "[transaction-read-hotpath-profile] profile=${profile_name}"
+  echo "[transaction-read-hotpath-profile] profiler=jfr"
+  echo "[transaction-read-hotpath-profile] admission=${profile_admission} db_pool=${profile_db_pool_max_size}"
+  echo "[transaction-read-hotpath-profile] k6 vus=${k6_vus} duration=${k6_duration} limit=${k6_limit} report=${k6_report_name}"
+  echo "[transaction-read-hotpath-profile] jfr duration=${profile_duration}"
+  echo "[transaction-read-hotpath-profile] artifact=${jfr_artifact}"
+  echo "[transaction-read-hotpath-profile] jfr_summary=${jfr_summary_txt}"
+  echo "[transaction-read-hotpath-profile] summary=${summary_md}"
+  echo "[transaction-read-hotpath-profile] log=${run_log}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+require_env K6_HOT_ACCOUNT_ID
+require_env K6_HOT_FROM
+require_env K6_HOT_TO
+require_env K6_COLD_ACCOUNT_ID
+require_env K6_COLD_FROM
+require_env K6_COLD_TO
+
+mkdir -p "${report_dir}" build/reports/k6
+
+if [[ "${profile_build_backend}" == "true" ]]; then
+  echo "[transaction-read-hotpath-profile] building backend bootJar"
+  tools/test/with-resource-lock.sh back-gradle-loadtest-bootjar ./back/gradlew -p back bootJar
+fi
+
+echo "[transaction-read-hotpath-profile] starting shared loadtest services"
+docker compose "${compose_files[@]}" --profile loadtest up -d \
+  postgres alertmanager postgres-exporter
+
+jfr_options="-XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=40 -XX:StartFlightRecording=name=${profile_name},settings=profile,dumponexit=true,filename=${jfr_container_path},duration=${profile_duration}"
+
+echo "[transaction-read-hotpath-profile] starting backend with JFR"
+LOADTEST_BACKEND_JAVA_TOOL_OPTIONS="${jfr_options}" \
+OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX="${profile_admission}" \
+DB_POOL_MAX_SIZE="${profile_db_pool_max_size}" \
+  docker compose "${compose_files[@]}" --profile loadtest up -d --force-recreate aquila-bank-backend prometheus grafana
+
+echo "[transaction-read-hotpath-profile] running k6"
+set +e
+docker compose "${compose_files[@]}" --profile loadtest run --rm --no-deps \
+  -e K6_REPORT_NAME="${k6_report_name}" \
+  -e K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
+  -e K6_HOT_FROM="${K6_HOT_FROM}" \
+  -e K6_HOT_TO="${K6_HOT_TO}" \
+  -e K6_COLD_ACCOUNT_ID="${K6_COLD_ACCOUNT_ID}" \
+  -e K6_COLD_FROM="${K6_COLD_FROM}" \
+  -e K6_COLD_TO="${K6_COLD_TO}" \
+  -e K6_AUTH_TOKEN="${K6_AUTH_TOKEN:-}" \
+  -e K6_VUS="${k6_vus}" \
+  -e K6_DURATION="${k6_duration}" \
+  -e K6_LIMIT="${k6_limit}" \
+  k6-transaction-read-100m >"${run_log}" 2>&1
+k6_status=$?
+set -e
+
+echo "[transaction-read-hotpath-profile] stopping backend to dump JFR"
+docker compose "${compose_files[@]}" --profile loadtest stop aquila-bank-backend >/dev/null 2>&1 || true
+
+echo "[transaction-read-hotpath-profile] copying JFR artifact"
+docker cp "aquila-bank-backend-loadtest:${jfr_container_path}" "${jfr_artifact}" >/dev/null 2>&1 || true
+
+if [[ ! -s "${jfr_artifact}" ]]; then
+  echo "artifact missing or empty: ${jfr_artifact}" >&2
+  exit 1
+fi
+
+if command -v jfr >/dev/null 2>&1; then
+  jfr summary "${jfr_artifact}" >"${jfr_summary_txt}" 2>&1 || true
+else
+  echo "jfr CLI is not available on host; inspect ${jfr_artifact} with a JDK." >"${jfr_summary_txt}"
+fi
+
+cat >"${summary_md}" <<SUMMARY
+# Transaction Read Hotpath Profile
+
+## Environment
+
+- profile: ${profile_name}
+- profiler: JFR
+- admission: ${profile_admission}
+- db pool max size: ${profile_db_pool_max_size}
+- k6 vus: ${k6_vus}
+- k6 duration: ${k6_duration}
+- k6 limit: ${k6_limit}
+
+## Artifacts
+
+- jfr: ${jfr_artifact}
+- jfr summary: ${jfr_summary_txt}
+- k6 summary json: ${k6_summary_json}
+- k6 summary markdown: ${k6_summary_md}
+- run log: ${run_log}
+
+## Result
+
+- k6 status: ${k6_status}
+
+## Notes
+
+- JFR artifact는 저장소에 commit하지 않고 `build/reports/profiling` 아래에만 둡니다.
+- response mapping/serialization 최적화는 이 artifact를 분석한 뒤 별도 PR에서 진행합니다.
+SUMMARY
+
+echo "[transaction-read-hotpath-profile] summary=${summary_md}"
+exit "${k6_status}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #367

## 🌿 Base Branch
- `main`

## 📝 Summary
- VU=8 transaction read k6 실행에서 backend JFR artifact를 남기는 profiling gate를 추가했다.
- gate는 backend를 JFR `StartFlightRecording` 옵션으로 재기동하고, k6를 `--no-deps`로 실행한 뒤 JFR/k6/log/summary 경로를 `build/reports/profiling/<profile-name>/`에 정리한다.
- 실제 response mapping/serialization 최적화는 이 artifact 분석 후 별도 이슈에서 진행한다.

## 🛠 Changes
- `tools/test/run-transaction-read-hotpath-profile.sh` 추가
- `tools/test/check-transaction-read-hotpath-profile.sh` 추가
- `docs/performance-results/README.md`에 JFR profiling gate 실행 절차 문서화

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash -n tools/test/run-transaction-read-hotpath-profile.sh`
- `bash -n tools/test/check-transaction-read-hotpath-profile.sh`
- `tools/test/check-transaction-read-hotpath-profile.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` -> `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: JFR recording은 backend CPU/IO를 소폭 추가 사용하고, 실행 종료 시 backend를 stop해 artifact dump를 강제한다.
- 롤백 방법: 이 PR의 두 commit을 revert한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?