### PR TITLE
[Docs] 로컬 성능 절차 문서 Git 추적 제거

### DIFF
--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -97,34 +97,6 @@ tools/test/archive-k6-transaction-100m-result.sh \
   build/reports/k6/<name>-summary.json
 ```
 
-### Admission / DB pool / VU matrix
-
-1억 row fixture가 이미 준비된 상태에서 transaction read admission, Hikari pool, k6 VU 조합을 직렬로 측정합니다.
-
-```bash
-MATRIX_NAME=transaction-read-admission-pool-$(date +%Y%m%d-%H%M%S) \
-MATRIX_ADMISSION_VALUES=3,4,6,8 \
-MATRIX_DB_POOL_VALUES=4,6,8 \
-MATRIX_VU_VALUES=3,4,6,8 \
-K6_HOT_ACCOUNT_ID=910000001 \
-K6_COLD_ACCOUNT_ID=910000002 \
-K6_HOT_FROM=2026-04-01T00:00:00Z \
-K6_HOT_TO=2026-04-30T00:00:00Z \
-K6_COLD_FROM=2026-01-01T00:00:00Z \
-K6_COLD_TO=2026-01-31T00:00:00Z \
-tools/test/run-transaction-read-admission-pool-matrix.sh
-```
-
-실행 전 plan을 먼저 확인합니다.
-
-```bash
-tools/test/run-transaction-read-admission-pool-matrix.sh --print-plan
-```
-
-결과는 `build/reports/k6/<matrix-name>/matrix-summary.tsv`에 남깁니다. 각 row는 admission, `DB_POOL_MAX_SIZE`, VU, k6 p95, HTTP failure rate, admission 429 rate, backend/PostgreSQL CPU sample, Hikari active/pending/max snapshot, 조합별 log path를 포함합니다.
-
-matrix runner는 조합마다 backend를 `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX`와 `DB_POOL_MAX_SIZE`로 force-recreate하고, k6는 `--no-up --no-deps`로 실행합니다. 이 순서를 지키는 이유는 Docker Compose dependency 처리로 backend가 기본 env로 다시 뜨면 report name과 실제 admission 값이 달라질 수 있기 때문입니다.
-
 ## 월별 chunk lifecycle
 
 월별 partition 선생성, archive detach/drop guard, partition별 `ANALYZE`/`VACUUM` 절차는 [Transaction Read Model Chunk Lifecycle Runbook](../transaction-read-model-chunk-lifecycle.md)을 기준으로 실행합니다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #374

## 🌿 Base Branch
- `main`

## 📝 Summary
- PR #372에서 main에 들어간 로컬 matrix benchmark 실행 절차 README 섹션을 제거한다.
- PR #373은 별도 force update로 문서 diff를 제거했고, 이 PR은 이미 main에 들어간 문서 변경만 정리한다.

## 🛠 Changes
- `docs/performance-results/README.md`에서 `Admission / DB pool / VU matrix` 로컬 실행 절차 섹션 제거
- runner/checker 코드는 유지

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-read-admission-pool-matrix.sh`
- `git diff --check`
- `gh pr diff 373 --repo AquilaXk/aquila-bank --name-only` -> `docs/performance-results/README.md` 없음
- `git rev-list --count main..HEAD` -> `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: README에서 로컬 실행 절차가 제거되어 사용자는 로컬 brief 또는 스크립트 `--print-plan`을 통해 확인해야 한다.
- 롤백 방법: 이 PR의 단일 commit을 revert한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A