### PR TITLE
[Perf] transaction read admission budget 정책을 측정값 기반으로 보정

### DIFF
--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -78,6 +78,7 @@ ops:
     retry-after-seconds: ${OPS_API_ADMISSION_CONTROL_RETRY_AFTER_SECONDS:1}
     endpoints:
       - group: transaction-read
+        # t3.micro 기본 보호값. high-traffic 승격값은 production gate에서 별도 검증합니다.
         max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX:3}
         path-prefixes:
           - /api/v1/transactions

--- a/tools/ops/validate-production-high-traffic-config.sh
+++ b/tools/ops/validate-production-high-traffic-config.sh
@@ -19,7 +19,9 @@ print_plan() {
 - KAFKA_TOPIC_PROVISIONING_ENABLED=true
 - KAFKA_TOPIC_STARTUP_VALIDATION_ENABLED=true
 - OPS_API_ADMISSION_CONTROL_ENABLED=true
+- OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=8
 - OPS_T3MICRO_SATURATION_GUARD_ENABLED=true
+- DB_POOL_MAX_SIZE=6
 - Redis/read replica/Kafka/admission/t3.micro required env values must be present
 PLAN
 }
@@ -126,7 +128,7 @@ validate_kafka() {
 
 validate_admission_and_t3micro() {
   require_true OPS_API_ADMISSION_CONTROL_ENABLED
-  require_positive_integer OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX
+  require_equal OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX 8
   require_positive_integer OPS_API_ADMISSION_CONTROL_ACCOUNT_READ_MAX
   require_positive_integer OPS_API_ADMISSION_CONTROL_TRANSFER_WRITE_MAX
   require_positive_integer OPS_API_ADMISSION_CONTROL_NOTIFICATION_STREAM_MAX
@@ -138,7 +140,7 @@ validate_admission_and_t3micro() {
   require_positive_integer OPS_T3MICRO_SATURATION_GUARD_THREADS_BUSY_THRESHOLD_PERCENT
   require_positive_integer OPS_T3MICRO_SATURATION_GUARD_QUERY_TIMEOUT_THRESHOLD
 
-  require_positive_integer DB_POOL_MAX_SIZE
+  require_equal DB_POOL_MAX_SIZE 6
   require_lte_integer NOTIFICATION_INBOX_CONSUMER_CONCURRENCY DB_POOL_MAX_SIZE
   require_positive_integer SERVER_THREADS_MAX
   require_positive_integer NOTIFICATION_SSE_MAX_TOTAL_SESSIONS

--- a/tools/test/check-transaction-read-admission-pool-matrix.sh
+++ b/tools/test/check-transaction-read-admission-pool-matrix.sh
@@ -40,6 +40,8 @@ grep -F "run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${script}" >/de
 grep -F "wait_for_backend_readiness" "${script}" >/dev/null
 grep -F "wait_for_prometheus_readiness" "${script}" >/dev/null
 grep -F "/actuator/health" "${script}" >/dev/null
+grep -F "MATRIX_METRIC_SCRAPE_WAIT_SECONDS" "${script}" >/dev/null
+grep -F "returned HTTP 429" "${script}" >/dev/null
 grep -F "matrix-summary.tsv" "${script}" >/dev/null
 grep -F "continue_on_failure" "${script}" >/dev/null
 

--- a/tools/test/check-transaction-read-admission-pool-matrix.sh
+++ b/tools/test/check-transaction-read-admission-pool-matrix.sh
@@ -42,6 +42,8 @@ grep -F "wait_for_prometheus_readiness" "${script}" >/dev/null
 grep -F "/actuator/health" "${script}" >/dev/null
 grep -F "MATRIX_METRIC_SCRAPE_WAIT_SECONDS" "${script}" >/dev/null
 grep -F "returned HTTP 429" "${script}" >/dev/null
+grep -F "MATRIX_CPU_SAMPLE_INTERVAL_SECONDS" "${script}" >/dev/null
+grep -F "start_cpu_sampler" "${script}" >/dev/null
 grep -F "matrix-summary.tsv" "${script}" >/dev/null
 grep -F "continue_on_failure" "${script}" >/dev/null
 

--- a/tools/test/check-transaction-read-admission-pool-matrix.sh
+++ b/tools/test/check-transaction-read-admission-pool-matrix.sh
@@ -37,6 +37,9 @@ grep -F "docker stats --no-stream" "${script}" >/dev/null
 grep -F "hikaricp_connections_active" "${script}" >/dev/null
 grep -F "aquila_api_admission_requests_total" "${script}" >/dev/null
 grep -F "run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${script}" >/dev/null
+grep -F "wait_for_backend_readiness" "${script}" >/dev/null
+grep -F "wait_for_prometheus_readiness" "${script}" >/dev/null
+grep -F "/actuator/health" "${script}" >/dev/null
 grep -F "matrix-summary.tsv" "${script}" >/dev/null
 grep -F "continue_on_failure" "${script}" >/dev/null
 

--- a/tools/test/run-production-high-traffic-config-gate.sh
+++ b/tools/test/run-production-high-traffic-config-gate.sh
@@ -56,6 +56,8 @@ grep -F "TRANSACTION_READ_REPLICA_ENABLED=true" <<<"${plan}" >/dev/null
 grep -F "OUTBOX_KAFKA_ENABLED=true" <<<"${plan}" >/dev/null
 grep -F "NOTIFICATION_INBOX_CONSUMER_CONCURRENCY>=2" <<<"${plan}" >/dev/null
 grep -F "OPS_API_ADMISSION_CONTROL_ENABLED=true" <<<"${plan}" >/dev/null
+grep -F "OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=8" <<<"${plan}" >/dev/null
+grep -F "DB_POOL_MAX_SIZE=6" <<<"${plan}" >/dev/null
 
 echo "[production-high-traffic-config] guard: missing env fails"
 if "${script}" >/dev/null 2>&1; then
@@ -95,7 +97,7 @@ valid_gate_env=(
   KAFKA_TOPIC_PROVISIONING_REPLICATION_FACTOR=3
   KAFKA_TOPIC_PROVISIONING_MIN_IN_SYNC_REPLICAS=2
   OPS_API_ADMISSION_CONTROL_ENABLED=true
-  OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=3
+  OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=8
   OPS_API_ADMISSION_CONTROL_ACCOUNT_READ_MAX=4
   OPS_API_ADMISSION_CONTROL_TRANSFER_WRITE_MAX=2
   OPS_API_ADMISSION_CONTROL_NOTIFICATION_STREAM_MAX=4
@@ -105,13 +107,25 @@ valid_gate_env=(
   OPS_T3MICRO_SATURATION_GUARD_POOL_ACTIVE_THRESHOLD_PERCENT=90
   OPS_T3MICRO_SATURATION_GUARD_THREADS_BUSY_THRESHOLD_PERCENT=90
   OPS_T3MICRO_SATURATION_GUARD_QUERY_TIMEOUT_THRESHOLD=1
-  DB_POOL_MAX_SIZE=4
+  DB_POOL_MAX_SIZE=6
   SERVER_THREADS_MAX=16
   NOTIFICATION_SSE_MAX_TOTAL_SESSIONS=64
 )
 
 echo "[production-high-traffic-config] valid production baseline passes"
 env "${valid_gate_env[@]}" "${script}" >/dev/null
+
+echo "[production-high-traffic-config] guard: t3.micro transaction read default fails"
+if env "${valid_gate_env[@]}" OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=3 "${script}" >/dev/null 2>&1; then
+  echo "t3.micro transaction read admission default unexpectedly succeeded" >&2
+  exit 1
+fi
+
+echo "[production-high-traffic-config] guard: t3.micro DB pool default fails"
+if env "${valid_gate_env[@]}" DB_POOL_MAX_SIZE=4 "${script}" >/dev/null 2>&1; then
+  echo "t3.micro DB pool default unexpectedly succeeded" >&2
+  exit 1
+fi
 
 echo "[production-high-traffic-config] guard: Redis memory fallback fails"
 if env "${valid_gate_env[@]}" SECURITY_LOGIN_THROTTLING_STORE=memory "${script}" >/dev/null 2>&1; then
@@ -138,7 +152,7 @@ if env "${valid_gate_env[@]}" NOTIFICATION_INBOX_CONSUMER_CONCURRENCY=7 "${scrip
 fi
 
 echo "[production-high-traffic-config] guard: consumer concurrency above DB pool fails"
-if env "${valid_gate_env[@]}" NOTIFICATION_INBOX_CONSUMER_CONCURRENCY=5 "${script}" >/dev/null 2>&1; then
+if env "${valid_gate_env[@]}" KAFKA_TOPIC_PROVISIONING_PARTITIONS=8 NOTIFICATION_INBOX_CONSUMER_CONCURRENCY=7 "${script}" >/dev/null 2>&1; then
   echo "consumer concurrency above DB pool unexpectedly succeeded" >&2
   exit 1
 fi

--- a/tools/test/run-transaction-read-admission-pool-matrix.sh
+++ b/tools/test/run-transaction-read-admission-pool-matrix.sh
@@ -22,6 +22,7 @@ Optional environment:
   MATRIX_BUILD_BACKEND     default true
   MATRIX_READINESS_TIMEOUT_SECONDS default 90
   MATRIX_METRIC_SCRAPE_WAIT_SECONDS default 6
+  MATRIX_CPU_SAMPLE_INTERVAL_SECONDS default 2
   MATRIX_BACKEND_HEALTH_URL default http://localhost:${BACKEND_PORT:-8080}/actuator/health
   PROMETHEUS_URL           default http://localhost:9090
   K6_DURATION              default 1m
@@ -62,10 +63,12 @@ prometheus_url="${PROMETHEUS_URL:-http://localhost:9090}"
 prometheus_base_url="${prometheus_url%/}"
 readiness_timeout_seconds="${MATRIX_READINESS_TIMEOUT_SECONDS:-90}"
 metric_scrape_wait_seconds="${MATRIX_METRIC_SCRAPE_WAIT_SECONDS:-6}"
+cpu_sample_interval_seconds="${MATRIX_CPU_SAMPLE_INTERVAL_SECONDS:-2}"
 backend_health_url="${MATRIX_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
 report_dir="build/reports/k6/${matrix_name}"
 summary_tsv="${report_dir}/matrix-summary.tsv"
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+CPU_SAMPLER_PID=""
 
 require_csv_positive_integers() {
   local name="$1"
@@ -101,6 +104,10 @@ if ! [[ "${metric_scrape_wait_seconds}" =~ ^[0-9]+$ ]]; then
   echo "MATRIX_METRIC_SCRAPE_WAIT_SECONDS must be zero or a positive integer" >&2
   exit 1
 fi
+if ! [[ "${cpu_sample_interval_seconds}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MATRIX_CPU_SAMPLE_INTERVAL_SECONDS must be a positive integer" >&2
+  exit 1
+fi
 
 admission_count="$(csv_count "${admission_values}")"
 db_pool_count="$(csv_count "${db_pool_values}")"
@@ -120,6 +127,7 @@ print_plan() {
   echo "[transaction-read-matrix] backend_health_url=${backend_health_url}"
   echo "[transaction-read-matrix] readiness_timeout_seconds=${readiness_timeout_seconds}"
   echo "[transaction-read-matrix] metric_scrape_wait_seconds=${metric_scrape_wait_seconds}"
+  echo "[transaction-read-matrix] cpu_sample_interval_seconds=${cpu_sample_interval_seconds}"
   echo "[transaction-read-matrix] summary=${summary_tsv}"
 }
 
@@ -211,6 +219,56 @@ log_count() {
   grep -F -c "${pattern}" "${log_path}" 2>/dev/null || true
 }
 
+start_cpu_sampler() {
+  local stats_path="$1"
+  : >"${stats_path}"
+  (
+    while true; do
+      docker stats --no-stream --format '{{.Name}}	{{.CPUPerc}}' \
+          aquila-bank-backend-loadtest aquila-bank-postgres 2>/dev/null \
+        | awk -F '\t' -v ts="$(date +%s)" '{
+            gsub("%", "", $2)
+            print ts "\t" $1 "\t" $2
+          }' >>"${stats_path}" || true
+      sleep "${cpu_sample_interval_seconds}"
+    done
+  ) &
+  CPU_SAMPLER_PID="$!"
+}
+
+stop_cpu_sampler() {
+  if [[ -n "${CPU_SAMPLER_PID}" ]]; then
+    kill "${CPU_SAMPLER_PID}" >/dev/null 2>&1 || true
+    wait "${CPU_SAMPLER_PID}" >/dev/null 2>&1 || true
+    CPU_SAMPLER_PID=""
+  fi
+}
+
+container_cpu_max_percent() {
+  local stats_path="$1"
+  local container_name="$2"
+  if [[ ! -f "${stats_path}" ]]; then
+    echo "n/a"
+    return 0
+  fi
+  awk -F '\t' -v name="${container_name}" '
+    $2 == name {
+      value = $3 + 0
+      if (!found || value > max) {
+        max = value
+      }
+      found = 1
+    }
+    END {
+      if (found) {
+        printf "%.2f", max
+      } else {
+        print "n/a"
+      }
+    }
+  ' "${stats_path}"
+}
+
 container_cpu_percent() {
   local container_name="$1"
   local value
@@ -273,6 +331,7 @@ run_combination() {
   local report_name="${matrix_name}-admission${admission}-pool${db_pool}-vu${vus}"
   local log_path="${report_dir}/${report_name}.log"
   local summary_json="build/reports/k6/${report_name}-summary.json"
+  local stats_path="${report_dir}/${report_name}-docker-stats.tsv"
   local accepted_before rejected_before accepted_after rejected_after
   local accepted_delta rejected_delta total_admission admission_429_rate
   local log_429_count
@@ -292,13 +351,15 @@ run_combination() {
   accepted_before="$(prometheus_value 'aquila_api_admission_requests_total{group="transaction-read",outcome="accepted"}')"
   rejected_before="$(prometheus_value 'aquila_api_admission_requests_total{group="transaction-read",outcome="rejected"}')"
 
+  start_cpu_sampler "${stats_path}"
   set +e
   K6_REPORT_NAME="${report_name}" \
   K6_VUS="${vus}" \
-  K6_ARCHIVE_RESULTS=false \
+    K6_ARCHIVE_RESULTS=false \
     tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${log_path}" 2>&1
   status=$?
   set -e
+  stop_cpu_sampler
 
   if [[ "${metric_scrape_wait_seconds}" -gt 0 ]]; then
     sleep "${metric_scrape_wait_seconds}"
@@ -324,8 +385,14 @@ run_combination() {
   hot_cursor="$(metric_from_json "${summary_json}" "aquila_transaction_hot_cursor_ms" "p(95)")"
   cold_first="$(metric_from_json "${summary_json}" "aquila_transaction_cold_first_ms" "p(95)")"
   cold_cursor="$(metric_from_json "${summary_json}" "aquila_transaction_cold_cursor_ms" "p(95)")"
-  backend_cpu="$(container_cpu_percent aquila-bank-backend-loadtest)"
-  postgres_cpu="$(container_cpu_percent aquila-bank-postgres)"
+  backend_cpu="$(container_cpu_max_percent "${stats_path}" aquila-bank-backend-loadtest)"
+  postgres_cpu="$(container_cpu_max_percent "${stats_path}" aquila-bank-postgres)"
+  if [[ "${backend_cpu}" == "n/a" ]]; then
+    backend_cpu="$(container_cpu_percent aquila-bank-backend-loadtest)"
+  fi
+  if [[ "${postgres_cpu}" == "n/a" ]]; then
+    postgres_cpu="$(container_cpu_percent aquila-bank-postgres)"
+  fi
   hikari_active="$(prometheus_value 'max(hikaricp_connections_active{pool="aquila-bank-pool"})')"
   hikari_pending="$(prometheus_value 'max(hikaricp_connections_pending{pool="aquila-bank-pool"})')"
   hikari_max="$(prometheus_value 'max(hikaricp_connections_max{pool="aquila-bank-pool"})')"

--- a/tools/test/run-transaction-read-admission-pool-matrix.sh
+++ b/tools/test/run-transaction-read-admission-pool-matrix.sh
@@ -20,6 +20,8 @@ Optional environment:
   MATRIX_VU_VALUES         default 3,4,6,8
   MATRIX_CONTINUE_ON_FAILURE default true
   MATRIX_BUILD_BACKEND     default true
+  MATRIX_READINESS_TIMEOUT_SECONDS default 90
+  MATRIX_BACKEND_HEALTH_URL default http://localhost:${BACKEND_PORT:-8080}/actuator/health
   PROMETHEUS_URL           default http://localhost:9090
   K6_DURATION              default 1m
   K6_LIMIT                 default 50
@@ -56,6 +58,9 @@ vu_values="${MATRIX_VU_VALUES-3,4,6,8}"
 continue_on_failure="${MATRIX_CONTINUE_ON_FAILURE:-true}"
 build_backend="${MATRIX_BUILD_BACKEND:-true}"
 prometheus_url="${PROMETHEUS_URL:-http://localhost:9090}"
+prometheus_base_url="${prometheus_url%/}"
+readiness_timeout_seconds="${MATRIX_READINESS_TIMEOUT_SECONDS:-90}"
+backend_health_url="${MATRIX_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
 report_dir="build/reports/k6/${matrix_name}"
 summary_tsv="${report_dir}/matrix-summary.tsv"
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
@@ -86,6 +91,10 @@ csv_count() {
 require_csv_positive_integers "MATRIX_ADMISSION_VALUES" "${admission_values}"
 require_csv_positive_integers "MATRIX_DB_POOL_VALUES" "${db_pool_values}"
 require_csv_positive_integers "MATRIX_VU_VALUES" "${vu_values}"
+if ! [[ "${readiness_timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MATRIX_READINESS_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 1
+fi
 
 admission_count="$(csv_count "${admission_values}")"
 db_pool_count="$(csv_count "${db_pool_values}")"
@@ -102,6 +111,8 @@ print_plan() {
   echo "[transaction-read-matrix] continue_on_failure=${continue_on_failure}"
   echo "[transaction-read-matrix] build_backend=${build_backend}"
   echo "[transaction-read-matrix] prometheus_url=${prometheus_url}"
+  echo "[transaction-read-matrix] backend_health_url=${backend_health_url}"
+  echo "[transaction-read-matrix] readiness_timeout_seconds=${readiness_timeout_seconds}"
   echo "[transaction-read-matrix] summary=${summary_tsv}"
 }
 
@@ -139,7 +150,7 @@ prometheus_value() {
     echo "n/a"
     return 0
   fi
-  curl -fsS --get "${prometheus_url}/api/v1/query" \
+  curl -fsS --get "${prometheus_base_url}/api/v1/query" \
     --data-urlencode "query=${query}" 2>/dev/null \
     | jq -r '.data.result[0].value[1] // "0"' 2>/dev/null \
     || echo "n/a"
@@ -183,6 +194,42 @@ container_cpu_percent() {
   echo "${value:-n/a}"
 }
 
+wait_for_backend_readiness() {
+  local deadline=$((SECONDS + readiness_timeout_seconds))
+  local body=""
+
+  echo "[transaction-read-matrix] waiting backend readiness: ${backend_health_url}"
+  while ((SECONDS < deadline)); do
+    body="$(curl -sS --max-time 2 "${backend_health_url}" 2>/dev/null || true)"
+    # 전체 health는 outbox 등 선택 기능 때문에 DOWN일 수 있어 readinessState만 본다.
+    if grep -F '"readinessState":{"status":"UP"}' <<<"${body}" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "backend readiness timeout: ${backend_health_url}" >&2
+  if [[ -n "${body}" ]]; then
+    echo "${body}" >&2
+  fi
+  exit 1
+}
+
+wait_for_prometheus_readiness() {
+  local deadline=$((SECONDS + readiness_timeout_seconds))
+
+  echo "[transaction-read-matrix] waiting prometheus readiness: ${prometheus_base_url}/-/ready"
+  while ((SECONDS < deadline)); do
+    if curl -fsS --max-time 2 "${prometheus_base_url}/-/ready" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "prometheus readiness timeout: ${prometheus_base_url}/-/ready" >&2
+  exit 1
+}
+
 write_header() {
   printf "status\tadmission\tdb_pool\tvus\treport\thttp_failed_rate\thttp_reqs\tadmission_429_rate\tadmission_accepted\tadmission_rejected\thot_first_p95_ms\thot_cursor_p95_ms\tcold_first_p95_ms\tcold_cursor_p95_ms\tbackend_cpu_percent\tpostgres_cpu_percent\thikari_active\thikari_pending\thikari_max\tlog_path\tsummary_json\n" >"${summary_tsv}"
 }
@@ -208,6 +255,9 @@ run_combination() {
   OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX="${admission}" \
   DB_POOL_MAX_SIZE="${db_pool}" \
     docker compose "${compose_files[@]}" --profile loadtest up -d --force-recreate aquila-bank-backend prometheus grafana
+
+  wait_for_backend_readiness
+  wait_for_prometheus_readiness
 
   # 조합별 backend env가 docker compose run 의존성 처리로 바뀌지 않도록 k6는 --no-deps로 실행합니다.
   accepted_before="$(prometheus_value 'aquila_api_admission_requests_total{group="transaction-read",outcome="accepted"}')"

--- a/tools/test/run-transaction-read-admission-pool-matrix.sh
+++ b/tools/test/run-transaction-read-admission-pool-matrix.sh
@@ -21,6 +21,7 @@ Optional environment:
   MATRIX_CONTINUE_ON_FAILURE default true
   MATRIX_BUILD_BACKEND     default true
   MATRIX_READINESS_TIMEOUT_SECONDS default 90
+  MATRIX_METRIC_SCRAPE_WAIT_SECONDS default 6
   MATRIX_BACKEND_HEALTH_URL default http://localhost:${BACKEND_PORT:-8080}/actuator/health
   PROMETHEUS_URL           default http://localhost:9090
   K6_DURATION              default 1m
@@ -60,6 +61,7 @@ build_backend="${MATRIX_BUILD_BACKEND:-true}"
 prometheus_url="${PROMETHEUS_URL:-http://localhost:9090}"
 prometheus_base_url="${prometheus_url%/}"
 readiness_timeout_seconds="${MATRIX_READINESS_TIMEOUT_SECONDS:-90}"
+metric_scrape_wait_seconds="${MATRIX_METRIC_SCRAPE_WAIT_SECONDS:-6}"
 backend_health_url="${MATRIX_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
 report_dir="build/reports/k6/${matrix_name}"
 summary_tsv="${report_dir}/matrix-summary.tsv"
@@ -95,6 +97,10 @@ if ! [[ "${readiness_timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
   echo "MATRIX_READINESS_TIMEOUT_SECONDS must be a positive integer" >&2
   exit 1
 fi
+if ! [[ "${metric_scrape_wait_seconds}" =~ ^[0-9]+$ ]]; then
+  echo "MATRIX_METRIC_SCRAPE_WAIT_SECONDS must be zero or a positive integer" >&2
+  exit 1
+fi
 
 admission_count="$(csv_count "${admission_values}")"
 db_pool_count="$(csv_count "${db_pool_values}")"
@@ -113,6 +119,7 @@ print_plan() {
   echo "[transaction-read-matrix] prometheus_url=${prometheus_url}"
   echo "[transaction-read-matrix] backend_health_url=${backend_health_url}"
   echo "[transaction-read-matrix] readiness_timeout_seconds=${readiness_timeout_seconds}"
+  echo "[transaction-read-matrix] metric_scrape_wait_seconds=${metric_scrape_wait_seconds}"
   echo "[transaction-read-matrix] summary=${summary_tsv}"
 }
 
@@ -174,6 +181,17 @@ numeric_sum() {
   }'
 }
 
+numeric_subtract() {
+  local left="$1"
+  local right="$2"
+  awk -v left="${left}" -v right="${right}" 'BEGIN {
+    if (left == "n/a" || right == "n/a") { print "n/a"; exit }
+    result = left - right
+    if (result < 0) result = 0
+    print result
+  }'
+}
+
 ratio() {
   local numerator="$1"
   local denominator="$2"
@@ -181,6 +199,16 @@ ratio() {
     if (numerator == "n/a" || denominator == "n/a" || denominator <= 0) { print "n/a"; exit }
     printf "%.6f", numerator / denominator
   }'
+}
+
+log_count() {
+  local log_path="$1"
+  local pattern="$2"
+  if [[ ! -f "${log_path}" ]]; then
+    echo "0"
+    return 0
+  fi
+  grep -F -c "${pattern}" "${log_path}" 2>/dev/null || true
 }
 
 container_cpu_percent() {
@@ -247,6 +275,7 @@ run_combination() {
   local summary_json="build/reports/k6/${report_name}-summary.json"
   local accepted_before rejected_before accepted_after rejected_after
   local accepted_delta rejected_delta total_admission admission_429_rate
+  local log_429_count
   local status http_failed_rate http_reqs hot_first hot_cursor cold_first cold_cursor
   local backend_cpu postgres_cpu hikari_active hikari_pending hikari_max
 
@@ -271,6 +300,10 @@ run_combination() {
   status=$?
   set -e
 
+  if [[ "${metric_scrape_wait_seconds}" -gt 0 ]]; then
+    sleep "${metric_scrape_wait_seconds}"
+  fi
+
   accepted_after="$(prometheus_value 'aquila_api_admission_requests_total{group="transaction-read",outcome="accepted"}')"
   rejected_after="$(prometheus_value 'aquila_api_admission_requests_total{group="transaction-read",outcome="rejected"}')"
   accepted_delta="$(numeric_delta "${accepted_before}" "${accepted_after}")"
@@ -280,6 +313,13 @@ run_combination() {
 
   http_failed_rate="$(metric_from_json "${summary_json}" "http_req_failed" "rate")"
   http_reqs="$(metric_from_json "${summary_json}" "http_reqs" "count")"
+  log_429_count="$(log_count "${log_path}" "returned HTTP 429")"
+  # k6 status log는 scrape 지연 영향을 받지 않아 admission 429 rate의 1차 근거로 사용합니다.
+  if [[ "${http_reqs}" != "n/a" ]]; then
+    rejected_delta="${log_429_count}"
+    accepted_delta="$(numeric_subtract "${http_reqs}" "${log_429_count}")"
+    admission_429_rate="$(ratio "${log_429_count}" "${http_reqs}")"
+  fi
   hot_first="$(metric_from_json "${summary_json}" "aquila_transaction_hot_first_ms" "p(95)")"
   hot_cursor="$(metric_from_json "${summary_json}" "aquila_transaction_hot_cursor_ms" "p(95)")"
   cold_first="$(metric_from_json "${summary_json}" "aquila_transaction_cold_first_ms" "p(95)")"


### PR DESCRIPTION
## 🔗 Related Issue
- close #370

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction read admission/Hikari matrix를 실제 측정 가능한 형태로 보정했습니다.
- matrix 결과 기준으로 t3.micro 기본값은 admission 3 유지, production high-traffic 승격값은 admission 8 / DB pool 6으로 분리했습니다.

## 🛠 Changes
- matrix runner가 backend readiness, Prometheus readiness, 429 log count, 부하 중 Docker CPU max를 기록합니다.
- production high-traffic config gate가 `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=8`, `DB_POOL_MAX_SIZE=6`을 요구합니다.
- application 기본 transaction-read admission 3에 t3.micro 보호값 주석을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-read-admission-pool-matrix.sh`
- `tools/test/run-production-high-traffic-config-gate.sh`
- `tools/test/with-resource-lock.sh back-gradle-api-admission ./back/gradlew -p back test --tests '*ApiAdmission*'`
- pre-commit: `./back/gradlew -p back check`
- 실제 matrix: `build/reports/k6/transaction-read-admission-pool-20260426-ready-v3/matrix-summary.tsv`
- t3.micro 기준: admission=3, DB pool=4, VU=3, 429=0, hot cursor p95=1.83ms, cold cursor p95=1.84ms, backend CPU max=200.86%, Postgres CPU max=62.19%
- high-traffic 기준: admission=8, DB pool=6, VU=8, 429=0, hot cursor p95=5.07ms, cold cursor p95=5.14ms, backend CPU max=202.47%, Postgres CPU max=62.18%

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: production high-traffic promotion에서 기존 `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=3` 또는 `DB_POOL_MAX_SIZE=4` vars는 gate에서 실패합니다.
- 롤백 방법: 이 PR revert 후 production high-traffic gate 기준을 이전 positive integer 검증으로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
