### PR TITLE
[Perf] transaction read response mapping/serialization CPU 절감

### DIFF
--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryResponse.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.web.transaction;
 import com.aquilabank.domain.transaction.model.TransactionSlice;
 import com.aquilabank.domain.transaction.model.TransactionSummary;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 /** transaction timeline endpoint 응답 모델 */
@@ -11,10 +12,23 @@ public record TransactionQueryResponse(
 
   public static TransactionQueryResponse from(TransactionSlice slice) {
     return new TransactionQueryResponse(
-        slice.items().stream().map(TransactionItemResponse::from).toList(),
+        toItemResponses(slice.items()),
         slice.nextCursor() == null ? null : TransactionCursorCodec.encode(slice.nextCursor()),
         slice.hasNext(),
         slice.limit());
+  }
+
+  private static List<TransactionItemResponse> toItemResponses(List<TransactionSummary> items) {
+    int size = items.size();
+    if (size == 0) {
+      return List.of();
+    }
+    // JFR에서 DTO mapping allocation site로 확인된 경로라 Stream/Iterator를 피한다.
+    List<TransactionItemResponse> responses = new ArrayList<>(size);
+    for (int i = 0; i < size; i++) {
+      responses.add(TransactionItemResponse.from(items.get(i)));
+    }
+    return List.copyOf(responses);
   }
 
   /** 웹/모바일 클라이언트용 flat item shape */

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryResponseTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryResponseTest.java
@@ -1,0 +1,80 @@
+package com.aquilabank.global.web.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.aquilabank.domain.transaction.model.TransactionCursor;
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.model.TransactionSummary;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TransactionQueryResponseTest {
+
+  @Test
+  void preservesCursorPageContract() {
+    TransactionCursor nextCursor = new TransactionCursor(Instant.parse("2026-04-16T09:00:00Z"), 2L);
+    TransactionSlice slice =
+        new TransactionSlice(
+            List.of(
+                summary(1L, "TX-1", TransactionDirection.DEBIT),
+                summary(2L, "TX-2", TransactionDirection.CREDIT)),
+            nextCursor,
+            true,
+            20);
+
+    TransactionQueryResponse response = TransactionQueryResponse.from(slice);
+
+    assertEquals(2, response.items().size());
+    assertEquals("TX-1", response.items().get(0).transactionReference());
+    assertEquals("DEBIT", response.items().get(0).direction());
+    assertEquals("TX-2", response.items().get(1).transactionReference());
+    assertEquals("CREDIT", response.items().get(1).direction());
+    assertEquals(TransactionCursorCodec.encode(nextCursor), response.nextCursor());
+    assertEquals(true, response.hasNext());
+    assertEquals(20, response.limit());
+    assertThrows(
+        UnsupportedOperationException.class, () -> response.items().add(response.items().get(0)));
+  }
+
+  @Test
+  void avoidsStreamPipelineInHotPathMapping() throws Exception {
+    Path source =
+        Path.of(
+            "src/main/java/com/aquilabank/global/web/transaction/TransactionQueryResponse.java");
+
+    String code = Files.readString(source);
+
+    assertFalse(
+        code.contains("slice.items().stream()"),
+        "JFR에서 response item mapping이 allocation site로 확인된 경로는 Stream pipeline을 피한다.");
+    assertFalse(
+        code.contains("Collections.unmodifiableList"),
+        "JFR에서 ArrayList iterator allocation이 확인된 경로는 mutable list wrapper를 피한다.");
+    assertFalse(
+        code.contains("for (TransactionSummary item : items)"),
+        "JFR에서 response item mapping 경로는 iterator 대신 index loop를 사용한다.");
+  }
+
+  private static TransactionSummary summary(
+      long id, String transactionReference, TransactionDirection direction) {
+    return new TransactionSummary(
+        id,
+        101L,
+        transactionReference,
+        direction,
+        TransactionStatus.BOOKED,
+        1200L,
+        8800L,
+        "KRW",
+        "card payment",
+        "STORE",
+        Instant.parse("2026-04-16T09:00:00Z"));
+  }
+}

--- a/tools/test/check-transaction-read-hotpath-profile.sh
+++ b/tools/test/check-transaction-read-hotpath-profile.sh
@@ -18,17 +18,21 @@ grep -F "profile=transaction-read-hotpath-check" <<<"${plan}" >/dev/null
 grep -F "profiler=jfr" <<<"${plan}" >/dev/null
 grep -F "k6 vus=8 duration=15s" <<<"${plan}" >/dev/null
 grep -F "jfr duration=20s" <<<"${plan}" >/dev/null
+grep -F "backend_health_url=http://localhost:8080/actuator/health" <<<"${plan}" >/dev/null
 grep -F "artifact=build/reports/profiling/transaction-read-hotpath-check/transaction-read-hotpath-check.jfr" <<<"${plan}" >/dev/null
 grep -F "summary=build/reports/profiling/transaction-read-hotpath-check/transaction-read-hotpath-check-summary.md" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-hotpath-profile] runner contract"
 grep -F "StartFlightRecording" "${script}" >/dev/null
+grep -F "wait_for_backend_readiness" "${script}" >/dev/null
 grep -F "LOADTEST_BACKEND_JAVA_TOOL_OPTIONS" "${script}" >/dev/null
 grep -F "docker cp" "${script}" >/dev/null
 grep -F "docker compose" "${script}" >/dev/null
 grep -F "k6-transaction-read-100m" "${script}" >/dev/null
 grep -F -- "--no-deps" "${script}" >/dev/null
 grep -F "jfr summary" "${script}" >/dev/null
+grep -F "view --width 160 hot-methods" "${script}" >/dev/null
+grep -F "view --width 160 allocation-by-class" "${script}" >/dev/null
 grep -F "artifact missing or empty" "${script}" >/dev/null
 
 echo "[transaction-read-hotpath-profile] invalid input fails"

--- a/tools/test/check-transaction-read-hotpath-profile.sh
+++ b/tools/test/check-transaction-read-hotpath-profile.sh
@@ -18,6 +18,7 @@ grep -F "profile=transaction-read-hotpath-check" <<<"${plan}" >/dev/null
 grep -F "profiler=jfr" <<<"${plan}" >/dev/null
 grep -F "k6 vus=8 duration=15s" <<<"${plan}" >/dev/null
 grep -F "jfr duration=20s" <<<"${plan}" >/dev/null
+grep -F "jfr_dump_timeout_seconds=60" <<<"${plan}" >/dev/null
 grep -F "backend_health_url=http://localhost:8080/actuator/health" <<<"${plan}" >/dev/null
 grep -F "artifact=build/reports/profiling/transaction-read-hotpath-check/transaction-read-hotpath-check.jfr" <<<"${plan}" >/dev/null
 grep -F "summary=build/reports/profiling/transaction-read-hotpath-check/transaction-read-hotpath-check-summary.md" <<<"${plan}" >/dev/null
@@ -25,6 +26,7 @@ grep -F "summary=build/reports/profiling/transaction-read-hotpath-check/transact
 echo "[transaction-read-hotpath-profile] runner contract"
 grep -F "StartFlightRecording" "${script}" >/dev/null
 grep -F "wait_for_backend_readiness" "${script}" >/dev/null
+grep -F "wait_for_jfr_dump" "${script}" >/dev/null
 grep -F "LOADTEST_BACKEND_JAVA_TOOL_OPTIONS" "${script}" >/dev/null
 grep -F "docker cp" "${script}" >/dev/null
 grep -F "docker compose" "${script}" >/dev/null

--- a/tools/test/check-transaction-read-hotpath-profile.sh
+++ b/tools/test/check-transaction-read-hotpath-profile.sh
@@ -35,6 +35,7 @@ grep -F -- "--no-deps" "${script}" >/dev/null
 grep -F "jfr summary" "${script}" >/dev/null
 grep -F "view --width 160 hot-methods" "${script}" >/dev/null
 grep -F "view --width 160 allocation-by-class" "${script}" >/dev/null
+grep -F '\`build/reports/profiling\`' "${script}" >/dev/null
 grep -F "artifact missing or empty" "${script}" >/dev/null
 
 echo "[transaction-read-hotpath-profile] invalid input fails"

--- a/tools/test/run-transaction-read-hotpath-profile.sh
+++ b/tools/test/run-transaction-read-hotpath-profile.sh
@@ -291,7 +291,7 @@ cat >"${summary_md}" <<SUMMARY
 
 ## Notes
 
-- JFR artifact는 저장소에 commit하지 않고 `build/reports/profiling` 아래에만 둡니다.
+- JFR artifact는 저장소에 commit하지 않고 \`build/reports/profiling\` 아래에만 둡니다.
 - response mapping/serialization 최적화는 이 artifact를 분석한 뒤 별도 PR에서 진행합니다.
 SUMMARY
 

--- a/tools/test/run-transaction-read-hotpath-profile.sh
+++ b/tools/test/run-transaction-read-hotpath-profile.sh
@@ -19,6 +19,8 @@ Optional environment:
   PROFILE_ADMISSION         default 8
   PROFILE_DB_POOL_MAX_SIZE  default 4
   PROFILE_BUILD_BACKEND     default true
+  PROFILE_READINESS_TIMEOUT_SECONDS default 90
+  PROFILE_BACKEND_HEALTH_URL default http://localhost:${BACKEND_PORT:-8080}/actuator/health
   K6_VUS                    default 8
   K6_DURATION               default 1m
   K6_LIMIT                  default 50
@@ -54,6 +56,8 @@ profile_duration="${PROFILE_DURATION-75s}"
 profile_admission="${PROFILE_ADMISSION:-8}"
 profile_db_pool_max_size="${PROFILE_DB_POOL_MAX_SIZE:-4}"
 profile_build_backend="${PROFILE_BUILD_BACKEND:-true}"
+profile_readiness_timeout_seconds="${PROFILE_READINESS_TIMEOUT_SECONDS:-90}"
+backend_health_url="${PROFILE_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
 k6_vus="${K6_VUS:-8}"
 k6_duration="${K6_DURATION:-1m}"
 k6_limit="${K6_LIMIT:-50}"
@@ -62,6 +66,10 @@ report_dir="build/reports/profiling/${profile_name}"
 jfr_container_path="/tmp/${profile_name}.jfr"
 jfr_artifact="${report_dir}/${profile_name}.jfr"
 jfr_summary_txt="${report_dir}/${profile_name}-jfr-summary.txt"
+jfr_hot_methods_txt="${report_dir}/${profile_name}-jfr-hot-methods.txt"
+jfr_cpu_hot_methods_txt="${report_dir}/${profile_name}-jfr-cpu-time-hot-methods.txt"
+jfr_allocation_by_class_txt="${report_dir}/${profile_name}-jfr-allocation-by-class.txt"
+jfr_allocation_by_site_txt="${report_dir}/${profile_name}-jfr-allocation-by-site.txt"
 run_log="${report_dir}/${profile_name}.log"
 summary_md="${report_dir}/${profile_name}-summary.md"
 k6_summary_json="build/reports/k6/${k6_report_name}-summary.json"
@@ -99,8 +107,46 @@ require_duration "PROFILE_DURATION" "${profile_duration}"
 require_duration "K6_DURATION" "${k6_duration}"
 require_positive_integer "PROFILE_ADMISSION" "${profile_admission}"
 require_positive_integer "PROFILE_DB_POOL_MAX_SIZE" "${profile_db_pool_max_size}"
+require_positive_integer "PROFILE_READINESS_TIMEOUT_SECONDS" "${profile_readiness_timeout_seconds}"
 require_positive_integer "K6_VUS" "${k6_vus}"
 require_positive_integer "K6_LIMIT" "${k6_limit}"
+
+find_jfr_cli() {
+  if command -v jfr >/dev/null 2>&1; then
+    command -v jfr
+    return 0
+  fi
+  if command -v /usr/libexec/java_home >/dev/null 2>&1; then
+    local java_home
+    java_home="$(/usr/libexec/java_home 2>/dev/null || true)"
+    if [[ -x "${java_home}/bin/jfr" ]]; then
+      echo "${java_home}/bin/jfr"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+wait_for_backend_readiness() {
+  local deadline=$((SECONDS + profile_readiness_timeout_seconds))
+  local body=""
+
+  echo "[transaction-read-hotpath-profile] waiting backend readiness: ${backend_health_url}"
+  while ((SECONDS < deadline)); do
+    body="$(curl -sS --max-time 2 "${backend_health_url}" 2>/dev/null || true)"
+    # 전체 health는 optional outbox 상태 때문에 DOWN일 수 있어 readinessState만 확인합니다.
+    if grep -F '"readinessState":{"status":"UP"}' <<<"${body}" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "backend readiness timeout: ${backend_health_url}" >&2
+  if [[ -n "${body}" ]]; then
+    echo "${body}" >&2
+  fi
+  exit 1
+}
 
 print_plan() {
   echo "[transaction-read-hotpath-profile] profile=${profile_name}"
@@ -108,6 +154,8 @@ print_plan() {
   echo "[transaction-read-hotpath-profile] admission=${profile_admission} db_pool=${profile_db_pool_max_size}"
   echo "[transaction-read-hotpath-profile] k6 vus=${k6_vus} duration=${k6_duration} limit=${k6_limit} report=${k6_report_name}"
   echo "[transaction-read-hotpath-profile] jfr duration=${profile_duration}"
+  echo "[transaction-read-hotpath-profile] backend_health_url=${backend_health_url}"
+  echo "[transaction-read-hotpath-profile] readiness_timeout_seconds=${profile_readiness_timeout_seconds}"
   echo "[transaction-read-hotpath-profile] artifact=${jfr_artifact}"
   echo "[transaction-read-hotpath-profile] jfr_summary=${jfr_summary_txt}"
   echo "[transaction-read-hotpath-profile] summary=${summary_md}"
@@ -145,6 +193,8 @@ OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX="${profile_admission}" \
 DB_POOL_MAX_SIZE="${profile_db_pool_max_size}" \
   docker compose "${compose_files[@]}" --profile loadtest up -d --force-recreate aquila-bank-backend prometheus grafana
 
+wait_for_backend_readiness
+
 echo "[transaction-read-hotpath-profile] running k6"
 set +e
 docker compose "${compose_files[@]}" --profile loadtest run --rm --no-deps \
@@ -174,10 +224,18 @@ if [[ ! -s "${jfr_artifact}" ]]; then
   exit 1
 fi
 
-if command -v jfr >/dev/null 2>&1; then
-  jfr summary "${jfr_artifact}" >"${jfr_summary_txt}" 2>&1 || true
+if jfr_cli="$(find_jfr_cli)"; then
+  "${jfr_cli}" summary "${jfr_artifact}" >"${jfr_summary_txt}" 2>&1 || true
+  "${jfr_cli}" view --width 160 hot-methods "${jfr_artifact}" >"${jfr_hot_methods_txt}" 2>&1 || true
+  "${jfr_cli}" view --width 160 cpu-time-hot-methods "${jfr_artifact}" >"${jfr_cpu_hot_methods_txt}" 2>&1 || true
+  "${jfr_cli}" view --width 160 allocation-by-class "${jfr_artifact}" >"${jfr_allocation_by_class_txt}" 2>&1 || true
+  "${jfr_cli}" view --width 160 allocation-by-site "${jfr_artifact}" >"${jfr_allocation_by_site_txt}" 2>&1 || true
 else
   echo "jfr CLI is not available on host; inspect ${jfr_artifact} with a JDK." >"${jfr_summary_txt}"
+  echo "jfr CLI is not available on host." >"${jfr_hot_methods_txt}"
+  echo "jfr CLI is not available on host." >"${jfr_cpu_hot_methods_txt}"
+  echo "jfr CLI is not available on host." >"${jfr_allocation_by_class_txt}"
+  echo "jfr CLI is not available on host." >"${jfr_allocation_by_site_txt}"
 fi
 
 cat >"${summary_md}" <<SUMMARY
@@ -197,6 +255,10 @@ cat >"${summary_md}" <<SUMMARY
 
 - jfr: ${jfr_artifact}
 - jfr summary: ${jfr_summary_txt}
+- jfr hot methods: ${jfr_hot_methods_txt}
+- jfr cpu hot methods: ${jfr_cpu_hot_methods_txt}
+- jfr allocation by class: ${jfr_allocation_by_class_txt}
+- jfr allocation by site: ${jfr_allocation_by_site_txt}
 - k6 summary json: ${k6_summary_json}
 - k6 summary markdown: ${k6_summary_md}
 - run log: ${run_log}

--- a/tools/test/run-transaction-read-hotpath-profile.sh
+++ b/tools/test/run-transaction-read-hotpath-profile.sh
@@ -20,6 +20,7 @@ Optional environment:
   PROFILE_DB_POOL_MAX_SIZE  default 4
   PROFILE_BUILD_BACKEND     default true
   PROFILE_READINESS_TIMEOUT_SECONDS default 90
+  PROFILE_JFR_DUMP_TIMEOUT_SECONDS default 60
   PROFILE_BACKEND_HEALTH_URL default http://localhost:${BACKEND_PORT:-8080}/actuator/health
   K6_VUS                    default 8
   K6_DURATION               default 1m
@@ -57,6 +58,7 @@ profile_admission="${PROFILE_ADMISSION:-8}"
 profile_db_pool_max_size="${PROFILE_DB_POOL_MAX_SIZE:-4}"
 profile_build_backend="${PROFILE_BUILD_BACKEND:-true}"
 profile_readiness_timeout_seconds="${PROFILE_READINESS_TIMEOUT_SECONDS:-90}"
+profile_jfr_dump_timeout_seconds="${PROFILE_JFR_DUMP_TIMEOUT_SECONDS:-60}"
 backend_health_url="${PROFILE_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
 k6_vus="${K6_VUS:-8}"
 k6_duration="${K6_DURATION:-1m}"
@@ -108,6 +110,7 @@ require_duration "K6_DURATION" "${k6_duration}"
 require_positive_integer "PROFILE_ADMISSION" "${profile_admission}"
 require_positive_integer "PROFILE_DB_POOL_MAX_SIZE" "${profile_db_pool_max_size}"
 require_positive_integer "PROFILE_READINESS_TIMEOUT_SECONDS" "${profile_readiness_timeout_seconds}"
+require_positive_integer "PROFILE_JFR_DUMP_TIMEOUT_SECONDS" "${profile_jfr_dump_timeout_seconds}"
 require_positive_integer "K6_VUS" "${k6_vus}"
 require_positive_integer "K6_LIMIT" "${k6_limit}"
 
@@ -148,12 +151,29 @@ wait_for_backend_readiness() {
   exit 1
 }
 
+wait_for_jfr_dump() {
+  local deadline=$((SECONDS + profile_jfr_dump_timeout_seconds))
+
+  echo "[transaction-read-hotpath-profile] waiting JFR dump: ${jfr_container_path}"
+  while ((SECONDS < deadline)); do
+    if docker compose "${compose_files[@]}" --profile loadtest exec -T aquila-bank-backend \
+        sh -c "test -s '${jfr_container_path}'" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "JFR dump timeout: ${jfr_container_path}" >&2
+  return 1
+}
+
 print_plan() {
   echo "[transaction-read-hotpath-profile] profile=${profile_name}"
   echo "[transaction-read-hotpath-profile] profiler=jfr"
   echo "[transaction-read-hotpath-profile] admission=${profile_admission} db_pool=${profile_db_pool_max_size}"
   echo "[transaction-read-hotpath-profile] k6 vus=${k6_vus} duration=${k6_duration} limit=${k6_limit} report=${k6_report_name}"
   echo "[transaction-read-hotpath-profile] jfr duration=${profile_duration}"
+  echo "[transaction-read-hotpath-profile] jfr_dump_timeout_seconds=${profile_jfr_dump_timeout_seconds}"
   echo "[transaction-read-hotpath-profile] backend_health_url=${backend_health_url}"
   echo "[transaction-read-hotpath-profile] readiness_timeout_seconds=${profile_readiness_timeout_seconds}"
   echo "[transaction-read-hotpath-profile] artifact=${jfr_artifact}"
@@ -212,6 +232,8 @@ docker compose "${compose_files[@]}" --profile loadtest run --rm --no-deps \
   k6-transaction-read-100m >"${run_log}" 2>&1
 k6_status=$?
 set -e
+
+wait_for_jfr_dump || true
 
 echo "[transaction-read-hotpath-profile] stopping backend to dump JFR"
 docker compose "${compose_files[@]}" --profile loadtest stop aquila-bank-backend >/dev/null 2>&1 || true


### PR DESCRIPTION
## 🔗 Related Issue
- close #368

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction read hotpath JFR runner를 readiness/JFR dump 기준으로 보정하고, 실제 high-traffic 조건(admission=8, DB pool=6, VU=8) JFR 결과를 확보했습니다.
- JFR에서 확인된 response item mapping allocation site만 좁게 수정해 `Stream`/iterator 기반 DTO mapping을 pre-sized index loop로 교체했습니다.
- 로컬 전용 brief와 JFR/k6 artifact는 `.gitignore` 대상이며 PR에 포함하지 않았습니다.

## 🛠 Changes
- hotpath profile runner가 backend readiness와 JFR dump 완료를 기다리도록 보정했습니다.
- JFR summary 생성 중 shell heredoc command substitution 오류가 나지 않도록 보정했습니다.
- `TransactionQueryResponse.from(...)` item mapping을 `Stream.toList()`에서 pre-sized loop + `List.copyOf`로 변경했습니다.
- response 계약 보존 및 hotpath mapping 회귀 방지 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-read-hotpath-profile.sh`
- `tools/test/with-resource-lock.sh back-gradle-transaction-web ./back/gradlew -p back test --tests 'com.aquilabank.global.web.transaction.*'`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit hook: `./back/gradlew -p back check`
- 실제 JFR/k6 baseline: `transaction-read-hotpath-20260426-adm8-pool6-vu8`
  - `http_req_failed rate=0`, hot cursor p95 `5.3304166ms`, cold cursor p95 `5.2568746ms`
  - `TransactionItemResponse.from(TransactionSummary)` allocation pressure `1.60%`
- 실제 JFR/k6 after: `transaction-read-hotpath-20260426-adm8-pool6-vu8-response-copy`
  - `http_req_failed rate=0`, checks rate `1`
  - hot cursor p95 `5.85303355ms`, cold cursor p95 `5.73566875ms`
  - `TransactionItemResponse.from(TransactionSummary)` allocation pressure `1.30%`
  - `ArrayList.iterator()` allocation site 없음

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: response DTO mapping 구현만 변경하며 API 필드/커서/필터 계약 변경은 없습니다. latency p95는 실행 간 변동 범위가 있어 allocation 감소 근거 중심으로 판단합니다.
- 롤백 방법: 이 PR의 response mapping commit을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?