### PR TITLE
[Perf] transaction k6 overload mode Retry-After backoff 추가

### DIFF
--- a/ops/k6/transaction-read-100m.js
+++ b/ops/k6/transaction-read-100m.js
@@ -1,6 +1,18 @@
 import http from "k6/http";
-import {check, fail} from "k6";
-import {Trend} from "k6/metrics";
+import {check, fail, sleep} from "k6";
+import {Rate, Trend} from "k6/metrics";
+
+function booleanEnv(value) {
+  return ["1", "true", "yes", "on"].includes(String(value || "").toLowerCase());
+}
+
+function nonNegativeNumberEnv(value, fallback) {
+  const result = Number(value || fallback);
+  if (!Number.isFinite(result) || result < 0) {
+    return fallback;
+  }
+  return result;
+}
 
 const baseUrl = (__ENV.BASE_URL || "http://aquila-bank-backend:8080").replace(/\/$/, "");
 const hotAccountId = __ENV.K6_HOT_ACCOUNT_ID || "";
@@ -17,11 +29,29 @@ const hotP95ThresholdMs = Number(__ENV.K6_HOT_P95_THRESHOLD_MS || "350");
 const coldP95ThresholdMs = Number(__ENV.K6_COLD_P95_THRESHOLD_MS || "750");
 const failedRate = Number(__ENV.K6_HTTP_FAILED_RATE || "0.01");
 const reportName = __ENV.K6_REPORT_NAME || "transaction-100m";
+const overloadMode = booleanEnv(__ENV.K6_OVERLOAD_MODE);
+const maxRetryAfterSleepSeconds = nonNegativeNumberEnv(__ENV.K6_MAX_RETRY_AFTER_SLEEP_SECONDS, 1);
+const httpFailedRateThreshold = overloadMode ? "disabled in overload mode" : failedRate;
 
 const hotFirst = new Trend("aquila_transaction_hot_first_ms", true);
 const hotCursor = new Trend("aquila_transaction_hot_cursor_ms", true);
 const coldFirst = new Trend("aquila_transaction_cold_first_ms", true);
 const coldCursor = new Trend("aquila_transaction_cold_cursor_ms", true);
+const transaction429Rate = new Rate("aquila_transaction_429_rate");
+
+function thresholds() {
+  const result = {
+    checks: ["rate>0.99"],
+    aquila_transaction_hot_first_ms: [`p(95)<${hotP95ThresholdMs}`],
+    aquila_transaction_hot_cursor_ms: [`p(95)<${hotP95ThresholdMs}`],
+    aquila_transaction_cold_first_ms: [`p(95)<${coldP95ThresholdMs}`],
+    aquila_transaction_cold_cursor_ms: [`p(95)<${coldP95ThresholdMs}`],
+  };
+  if (!overloadMode) {
+    result.http_req_failed = [`rate<${failedRate}`];
+  }
+  return result;
+}
 
 export const options = {
   scenarios: {
@@ -31,14 +61,7 @@ export const options = {
       duration,
     },
   },
-  thresholds: {
-    http_req_failed: [`rate<${failedRate}`],
-    checks: ["rate>0.99"],
-    aquila_transaction_hot_first_ms: [`p(95)<${hotP95ThresholdMs}`],
-    aquila_transaction_hot_cursor_ms: [`p(95)<${hotP95ThresholdMs}`],
-    aquila_transaction_cold_first_ms: [`p(95)<${coldP95ThresholdMs}`],
-    aquila_transaction_cold_cursor_ms: [`p(95)<${coldP95ThresholdMs}`],
-  },
+  thresholds: thresholds(),
   tags: {
     service: "aquila-bank",
     workload: "transaction-read-100m",
@@ -89,6 +112,24 @@ function record(shape, durationMs) {
   }
 }
 
+function header(response, name) {
+  const target = name.toLowerCase();
+  for (const [key, value] of Object.entries(response.headers || {})) {
+    if (key.toLowerCase() === target) {
+      return value;
+    }
+  }
+  return "";
+}
+
+function sleepAfter429(response) {
+  const retryAfter = Number(header(response, "Retry-After"));
+  if (!Number.isFinite(retryAfter) || retryAfter <= 0 || maxRetryAfterSleepSeconds <= 0) {
+    return;
+  }
+  sleep(Math.min(retryAfter, maxRetryAfterSleepSeconds));
+}
+
 function requestPage(shape, path, accountId, from, to, cursor) {
   const query = queryString({
     accountId,
@@ -104,6 +145,17 @@ function requestPage(shape, path, accountId, from, to, cursor) {
       query_shape: shape,
     },
   });
+
+  const is429 = response.status === 429;
+  transaction429Rate.add(is429);
+  if (is429 && overloadMode) {
+    // 429는 admission guard의 정상 보호 신호라 overload mode에서만 예외 없이 집계합니다.
+    check(response, {
+      [`${shape} overload returned 429`]: (item) => item.status === 429,
+    });
+    sleepAfter429(response);
+    return null;
+  }
 
   record(shape, response.timings.duration);
 
@@ -140,10 +192,23 @@ export default function () {
     hotTo,
     "",
   );
+  if (!hotFirstBody) {
+    return;
+  }
   if (!hotFirstBody.nextCursor) {
     fail("hot_first did not return nextCursor");
   }
-  requestPage("hot_cursor", "/api/v1/transactions", hotAccountId, hotFrom, hotTo, hotFirstBody.nextCursor);
+  const hotCursorBody = requestPage(
+    "hot_cursor",
+    "/api/v1/transactions",
+    hotAccountId,
+    hotFrom,
+    hotTo,
+    hotFirstBody.nextCursor,
+  );
+  if (!hotCursorBody) {
+    return;
+  }
 
   const coldFirstBody = requestPage(
     "cold_first",
@@ -153,10 +218,13 @@ export default function () {
     coldTo,
     "",
   );
+  if (!coldFirstBody) {
+    return;
+  }
   if (!coldFirstBody.nextCursor) {
     fail("cold_first did not return nextCursor");
   }
-  requestPage(
+  const coldCursorBody = requestPage(
     "cold_cursor",
     "/api/v1/transactions/archive",
     coldAccountId,
@@ -164,6 +232,9 @@ export default function () {
     coldTo,
     coldFirstBody.nextCursor,
   );
+  if (!coldCursorBody) {
+    return;
+  }
 }
 
 function metric(data, name, valueName) {
@@ -183,16 +254,19 @@ function markdownSummary(data) {
 - vus: ${vus}
 - duration: ${duration}
 - limit: ${limit}
+- overload mode: ${overloadMode}
+- max retry-after sleep seconds: ${maxRetryAfterSleepSeconds}
 - hot account id: ${hotAccountId}
 - cold account id: ${coldAccountId}
 - hot p95 threshold ms: ${hotP95ThresholdMs}
 - cold p95 threshold ms: ${coldP95ThresholdMs}
-- http failed rate threshold: ${failedRate}
+- http failed rate threshold: ${httpFailedRateThreshold}
 
 ## Results
 
 - http_req_failed rate: ${metric(data, "http_req_failed", "rate")}
 - checks rate: ${metric(data, "checks", "rate")}
+- transaction 429 rate: ${metric(data, "aquila_transaction_429_rate", "rate")}
 - hot first p95 ms: ${metric(data, "aquila_transaction_hot_first_ms", "p(95)")}
 - hot cursor p95 ms: ${metric(data, "aquila_transaction_hot_cursor_ms", "p(95)")}
 - cold first p95 ms: ${metric(data, "aquila_transaction_cold_first_ms", "p(95)")}
@@ -201,6 +275,7 @@ function markdownSummary(data) {
 ## Notes
 
 - 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
 - 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
 - Prometheus remote write 대상은 \`K6_PROMETHEUS_RW_SERVER_URL\`입니다.
 `;

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -18,7 +18,17 @@ plan="$(
 grep -F "backend: aquila-bank-backend:8080 with t3.micro budget" <<<"${plan}" >/dev/null
 grep -F "observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-exporter:9187" <<<"${plan}" >/dev/null
 grep -F "k6 report name: transaction-100m-check" <<<"${plan}" >/dev/null
+grep -F "overload mode=false max retry-after sleep seconds=1" <<<"${plan}" >/dev/null
 grep -F "preflight=true" <<<"${plan}" >/dev/null
+
+overload_plan="$(
+  K6_REPORT_NAME=transaction-100m-overload-check \
+  K6_OVERLOAD_MODE=true \
+  K6_MAX_RETRY_AFTER_SLEEP_SECONDS=2 \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "k6 report name: transaction-100m-overload-check" <<<"${overload_plan}" >/dev/null
+grep -F "overload mode=true max retry-after sleep seconds=2" <<<"${overload_plan}" >/dev/null
 
 echo "[k6-transaction-100m] k6 script contract"
 grep -F "experimental-prometheus-rw" compose.loadtest.yml >/dev/null
@@ -31,6 +41,11 @@ grep -F "idx_transaction_read_model_account_cursor" tools/test/run-k6-transactio
 grep -F "OOMKilled" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "aquila_transaction_hot_first_ms" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "aquila_transaction_cold_cursor_ms" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "K6_OVERLOAD_MODE" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "K6_MAX_RETRY_AFTER_SLEEP_SECONDS" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "aquila_transaction_429_rate" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "Retry-After" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "K6_OVERLOAD_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "handleSummary" ops/k6/transaction-read-100m.js >/dev/null
 grep -F '/reports/${reportName}-summary.md' ops/k6/transaction-read-100m.js >/dev/null
 

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -21,6 +21,9 @@ Optional environment:
   K6_AUTH_TOKEN        bearer token, optional when bootstrap header auth is enabled
   K6_ARCHIVE_RESULTS   copy markdown summary to docs/performance-results, default true
   K6_PREFLIGHT         check PostgreSQL OOM/index readiness before k6, default true
+  K6_OVERLOAD_MODE     treat 429 as expected rejected samples, default false
+  K6_MAX_RETRY_AFTER_SLEEP_SECONDS
+                       cap Retry-After backoff in overload mode, default 1
 
 Examples:
   K6_HOT_ACCOUNT_ID=101 K6_HOT_FROM=2026-04-01T00:00:00Z K6_HOT_TO=2026-04-30T00:00:00Z \
@@ -43,6 +46,15 @@ require_positive_integer() {
   local value="${!name:-}"
   if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
     echo "${name} must be a positive integer" >&2
+    exit 1
+  fi
+}
+
+require_non_negative_integer() {
+  local name="$1"
+  local value="${!name:-}"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${name} must be a non-negative integer" >&2
     exit 1
   fi
 }
@@ -76,11 +88,14 @@ K6_VUS="${K6_VUS:-8}"
 K6_LIMIT="${K6_LIMIT:-50}"
 K6_ARCHIVE_RESULTS="${K6_ARCHIVE_RESULTS:-true}"
 K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
+K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE:-false}"
+K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${K6_MAX_RETRY_AFTER_SLEEP_SECONDS:-1}"
 K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-$(date +%Y-%m-%d-%H%M%S)}"
-export K6_VUS K6_LIMIT K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_REPORT_NAME
+export K6_VUS K6_LIMIT K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OVERLOAD_MODE K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_REPORT_NAME
 
 require_positive_integer K6_VUS
 require_positive_integer K6_LIMIT
+require_non_negative_integer K6_MAX_RETRY_AFTER_SLEEP_SECONDS
 
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
 report_dir="build/reports/k6"
@@ -94,6 +109,7 @@ print_plan() {
   echo "[k6-transaction-100m] observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-exporter:9187"
   echo "[k6-transaction-100m] k6 report name: ${K6_REPORT_NAME}"
   echo "[k6-transaction-100m] k6 vus=${K6_VUS} duration=${K6_DURATION:-1m} limit=${K6_LIMIT}"
+  echo "[k6-transaction-100m] overload mode=${K6_OVERLOAD_MODE} max retry-after sleep seconds=${K6_MAX_RETRY_AFTER_SLEEP_SECONDS}"
   echo "[k6-transaction-100m] preflight=${K6_PREFLIGHT}"
   if [[ "${run_dependencies}" == "true" ]]; then
     echo "[k6-transaction-100m] dependencies=compose-default"
@@ -179,6 +195,8 @@ docker compose "${compose_files[@]}" --profile loadtest run "${run_args[@]}" \
   -e K6_VUS="${K6_VUS}" \
   -e K6_DURATION="${K6_DURATION:-1m}" \
   -e K6_LIMIT="${K6_LIMIT}" \
+  -e K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE}" \
+  -e K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${K6_MAX_RETRY_AFTER_SLEEP_SECONDS}" \
   k6-transaction-read-100m
 status=$?
 set -e


### PR DESCRIPTION
## 🔗 Related Issue
- close #380

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction 100m k6 overload mode를 추가해 admission guard의 정상 `429`를 stacktrace 예외가 아닌 rejected sample로 집계합니다.
- `Retry-After` header 기반 bounded backoff를 적용해 VU=16 overload 실험의 k6 client/log overhead를 줄입니다.

## 🛠 Changes
- `K6_OVERLOAD_MODE=true`일 때 `429`를 `aquila_transaction_429_rate`로 기록하고 iteration을 조기 종료합니다.
- `K6_MAX_RETRY_AFTER_SLEEP_SECONDS`로 `Retry-After` sleep 상한을 제어합니다.
- 기본 mode는 기존 strict `2xx`/payload check와 `http_req_failed` threshold를 유지합니다.
- loadtest runner `--print-plan`과 checker에 overload mode 계약 검증을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인 - N/A: 이번 변경은 runner/k6 계약 수정이며 1억 row overload 실측은 별도 실행 환경이 필요합니다.
- [x] 로그 / 메트릭 확인 - checker가 `aquila_transaction_429_rate`, overload env, `Retry-After` backoff token을 검증합니다.

### 실행한 검증
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `bash -n tools/test/run-k6-transaction-100m-loadtest.sh`
- `git diff --check HEAD`
- `git log --oneline main..HEAD`로 commit_plan 1개와 실제 commit 1개 일치 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: overload mode에서 429가 많으면 accepted request p95 sample 수가 줄어들 수 있습니다. 기본 mode는 기존 strict threshold를 유지합니다.
- 롤백 방법: 이 PR commit revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?