### PR TITLE
[Perf] transaction 100m capacity gate 묶음 추가

### DIFF
--- a/tools/test/check-transaction-100m-capacity-gates.sh
+++ b/tools/test/check-transaction-100m-capacity-gates.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-capacity-gates.sh"
+
+echo "[transaction-100m-capacity] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-100m-capacity] print plan"
+plan="$(
+  CAPACITY_NAME=transaction-capacity-check \
+  CAPACITY_LONG_SOAK_DURATION=30m \
+    "${script}" --print-plan
+)"
+grep -F "capacity=transaction-capacity-check" <<<"${plan}" >/dev/null
+grep -F "single_host_profiles=single-host-default,single-host-high-traffic" <<<"${plan}" >/dev/null
+grep -F "cpu_split_profiles=cpu-backend040-postgres060,cpu-backend100-postgres060" <<<"${plan}" >/dev/null
+grep -F "long_soak_profile=long-soak-high-traffic duration=30m" <<<"${plan}" >/dev/null
+grep -F "summary=build/reports/k6/transaction-capacity-check/capacity-summary.tsv" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-capacity] runner contract"
+grep -F "T3MICRO_BACKEND_CPUS" "${script}" >/dev/null
+grep -F "T3MICRO_POSTGRES_CPUS" "${script}" >/dev/null
+grep -F "OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX" "${script}" >/dev/null
+grep -F "DB_POOL_MAX_SIZE" "${script}" >/dev/null
+grep -F "K6_OVERLOAD_MODE" "${script}" >/dev/null
+grep -F "K6_DURATION" "${script}" >/dev/null
+grep -F "docker stats --no-stream" "${script}" >/dev/null
+grep -F "run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${script}" >/dev/null
+grep -F "capacity-summary.tsv" "${script}" >/dev/null
+grep -F "single-host" "${script}" >/dev/null
+grep -F "long-soak" "${script}" >/dev/null
+grep -F "metric_from_json" "${script}" >/dev/null
+
+echo "[transaction-100m-capacity] invalid input fails"
+if CAPACITY_LONG_SOAK_DURATION=0m "${script}" --print-plan >/dev/null 2>&1; then
+  echo "CAPACITY_LONG_SOAK_DURATION=0m unexpectedly succeeded" >&2
+  exit 1
+fi
+if CAPACITY_SINGLE_HOST_PROFILES=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad CAPACITY_SINGLE_HOST_PROFILES unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-100m-capacity-gates.sh
+++ b/tools/test/run-transaction-100m-capacity-gates.sh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-capacity-gates.sh [--print-plan]
+
+Required runtime environment for actual runs:
+  K6_HOT_ACCOUNT_ID
+  K6_HOT_FROM
+  K6_HOT_TO
+  K6_COLD_ACCOUNT_ID
+  K6_COLD_FROM
+  K6_COLD_TO
+
+Optional environment:
+  CAPACITY_NAME              default transaction-100m-capacity-<timestamp>
+  CAPACITY_BUILD_BACKEND     default true
+  CAPACITY_RUN_SINGLE_HOST   default true
+  CAPACITY_RUN_CPU_SPLIT     default true
+  CAPACITY_RUN_LONG_SOAK     default true
+  CAPACITY_CONTINUE_ON_FAILURE default true
+  CAPACITY_LONG_SOAK_DURATION default 30m
+  CAPACITY_READINESS_TIMEOUT_SECONDS default 120
+  CAPACITY_METRIC_SCRAPE_WAIT_SECONDS default 6
+  CAPACITY_CPU_SAMPLE_INTERVAL_SECONDS default 5
+  PROMETHEUS_URL             default http://localhost:9090
+
+Profile format:
+  name:admission:vus:backend_cpus:backend_memory:postgres_cpus:postgres_memory:db_pool:overload_mode:duration
+
+Examples:
+  tools/test/run-transaction-100m-capacity-gates.sh --print-plan
+  CAPACITY_RUN_CPU_SPLIT=false CAPACITY_LONG_SOAK_DURATION=30m \
+    tools/test/run-transaction-100m-capacity-gates.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+capacity_name="${CAPACITY_NAME:-transaction-100m-capacity-$(date +%Y-%m-%d-%H%M%S)}"
+build_backend="${CAPACITY_BUILD_BACKEND:-true}"
+run_single_host="${CAPACITY_RUN_SINGLE_HOST:-true}"
+run_cpu_split="${CAPACITY_RUN_CPU_SPLIT:-true}"
+run_long_soak="${CAPACITY_RUN_LONG_SOAK:-true}"
+continue_on_failure="${CAPACITY_CONTINUE_ON_FAILURE:-true}"
+long_soak_duration="${CAPACITY_LONG_SOAK_DURATION:-30m}"
+readiness_timeout_seconds="${CAPACITY_READINESS_TIMEOUT_SECONDS:-120}"
+metric_scrape_wait_seconds="${CAPACITY_METRIC_SCRAPE_WAIT_SECONDS:-6}"
+cpu_sample_interval_seconds="${CAPACITY_CPU_SAMPLE_INTERVAL_SECONDS:-5}"
+prometheus_url="${PROMETHEUS_URL:-http://localhost:9090}"
+prometheus_base_url="${prometheus_url%/}"
+backend_health_url="${CAPACITY_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
+report_dir="build/reports/k6/${capacity_name}"
+summary_tsv="${report_dir}/capacity-summary.tsv"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+CPU_SAMPLER_PID=""
+
+single_host_profiles="${CAPACITY_SINGLE_HOST_PROFILES:-single-host-default:3:8:0.40:512m:0.60:384m:4:true:1m,single-host-high-traffic:8:8:0.80:640m:0.60:384m:6:false:1m}"
+cpu_split_profiles="${CAPACITY_CPU_SPLIT_PROFILES:-cpu-backend040-postgres060:8:8:0.40:512m:0.60:384m:4:false:1m,cpu-backend100-postgres060:8:8:1.00:640m:0.60:384m:6:false:1m}"
+long_soak_profile="${CAPACITY_LONG_SOAK_PROFILE:-long-soak-high-traffic:8:8:0.80:640m:0.60:384m:6:false:${long_soak_duration}}"
+
+require_bool() {
+  local name="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${name} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_non_negative_integer_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${name} must be zero or a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_duration_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*(s|m|h)$ ]]; then
+    echo "${name} must use a positive duration such as 60s, 30m, or 1h: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_memory_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*[mMgG]$ ]]; then
+    echo "${name} must use Docker memory notation such as 384m or 1g: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_cpu_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${name} must be a positive CPU number: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value > 0) }' \
+    || {
+      echo "${name} must be greater than zero: ${value}" >&2
+      exit 1
+    }
+}
+
+validate_profile() {
+  local group="$1"
+  local profile="$2"
+  IFS=':' read -r name admission vus backend_cpus backend_memory postgres_cpus postgres_memory db_pool overload_mode duration extra <<<"${profile}"
+  if [[ -n "${extra:-}" || -z "${duration:-}" ]]; then
+    echo "${group} profile must have 10 fields: ${profile}" >&2
+    exit 1
+  fi
+  if [[ ! "${name}" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "${group} profile name must be kebab-case: ${name}" >&2
+    exit 1
+  fi
+  require_positive_integer_value "${group}.admission" "${admission}"
+  require_positive_integer_value "${group}.vus" "${vus}"
+  require_cpu_value "${group}.backend_cpus" "${backend_cpus}"
+  require_memory_value "${group}.backend_memory" "${backend_memory}"
+  require_cpu_value "${group}.postgres_cpus" "${postgres_cpus}"
+  require_memory_value "${group}.postgres_memory" "${postgres_memory}"
+  require_positive_integer_value "${group}.db_pool" "${db_pool}"
+  require_bool "${group}.overload_mode" "${overload_mode}"
+  require_duration_value "${group}.duration" "${duration}"
+}
+
+validate_profiles() {
+  local group="$1"
+  local csv="$2"
+  if [[ -z "${csv}" ]]; then
+    echo "${group} profiles must not be empty" >&2
+    exit 1
+  fi
+  IFS=',' read -r -a profiles <<<"${csv}"
+  local profile
+  for profile in "${profiles[@]}"; do
+    validate_profile "${group}" "${profile}"
+  done
+}
+
+profile_names() {
+  local csv="$1"
+  IFS=',' read -r -a profiles <<<"${csv}"
+  local result=""
+  local profile name
+  for profile in "${profiles[@]}"; do
+    name="${profile%%:*}"
+    if [[ -n "${result}" ]]; then
+      result+=","
+    fi
+    result+="${name}"
+  done
+  echo "${result}"
+}
+
+require_env() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "${value}" ]]; then
+    echo "${name} is required" >&2
+    exit 1
+  fi
+}
+
+require_bool "CAPACITY_BUILD_BACKEND" "${build_backend}"
+require_bool "CAPACITY_RUN_SINGLE_HOST" "${run_single_host}"
+require_bool "CAPACITY_RUN_CPU_SPLIT" "${run_cpu_split}"
+require_bool "CAPACITY_RUN_LONG_SOAK" "${run_long_soak}"
+require_bool "CAPACITY_CONTINUE_ON_FAILURE" "${continue_on_failure}"
+require_duration_value "CAPACITY_LONG_SOAK_DURATION" "${long_soak_duration}"
+require_positive_integer_value "CAPACITY_READINESS_TIMEOUT_SECONDS" "${readiness_timeout_seconds}"
+require_non_negative_integer_value "CAPACITY_METRIC_SCRAPE_WAIT_SECONDS" "${metric_scrape_wait_seconds}"
+require_positive_integer_value "CAPACITY_CPU_SAMPLE_INTERVAL_SECONDS" "${cpu_sample_interval_seconds}"
+validate_profiles "CAPACITY_SINGLE_HOST_PROFILES" "${single_host_profiles}"
+validate_profiles "CAPACITY_CPU_SPLIT_PROFILES" "${cpu_split_profiles}"
+validate_profile "CAPACITY_LONG_SOAK_PROFILE" "${long_soak_profile}"
+
+print_plan() {
+  echo "[transaction-100m-capacity] capacity=${capacity_name}"
+  echo "[transaction-100m-capacity] build_backend=${build_backend}"
+  echo "[transaction-100m-capacity] run_single_host=${run_single_host}"
+  echo "[transaction-100m-capacity] run_cpu_split=${run_cpu_split}"
+  echo "[transaction-100m-capacity] run_long_soak=${run_long_soak}"
+  echo "[transaction-100m-capacity] continue_on_failure=${continue_on_failure}"
+  echo "[transaction-100m-capacity] single_host_profiles=$(profile_names "${single_host_profiles}")"
+  echo "[transaction-100m-capacity] cpu_split_profiles=$(profile_names "${cpu_split_profiles}")"
+  echo "[transaction-100m-capacity] long_soak_profile=${long_soak_profile%%:*} duration=${long_soak_duration}"
+  echo "[transaction-100m-capacity] prometheus_url=${prometheus_url}"
+  echo "[transaction-100m-capacity] backend_health_url=${backend_health_url}"
+  echo "[transaction-100m-capacity] readiness_timeout_seconds=${readiness_timeout_seconds}"
+  echo "[transaction-100m-capacity] metric_scrape_wait_seconds=${metric_scrape_wait_seconds}"
+  echo "[transaction-100m-capacity] cpu_sample_interval_seconds=${cpu_sample_interval_seconds}"
+  echo "[transaction-100m-capacity] summary=${summary_tsv}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+require_env K6_HOT_ACCOUNT_ID
+require_env K6_HOT_FROM
+require_env K6_HOT_TO
+require_env K6_COLD_ACCOUNT_ID
+require_env K6_COLD_FROM
+require_env K6_COLD_TO
+
+mkdir -p "${report_dir}" build/reports/k6
+
+if [[ "${build_backend}" == "true" ]]; then
+  echo "[transaction-100m-capacity] building backend bootJar"
+  tools/test/with-resource-lock.sh back-gradle-loadtest-bootjar ./back/gradlew -p back bootJar
+fi
+
+metric_from_json() {
+  local json_path="$1"
+  local metric="$2"
+  local value_name="$3"
+  if [[ ! -f "${json_path}" ]] || ! command -v jq >/dev/null 2>&1; then
+    echo "n/a"
+    return 0
+  fi
+  jq -r --arg metric "${metric}" --arg value_name "${value_name}" \
+    '.metrics[$metric].values[$value_name] // "n/a"' "${json_path}"
+}
+
+prometheus_value() {
+  local query="$1"
+  if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    echo "n/a"
+    return 0
+  fi
+  curl -fsS --get "${prometheus_base_url}/api/v1/query" \
+    --data-urlencode "query=${query}" 2>/dev/null \
+    | jq -r '.data.result[0].value[1] // "0"' 2>/dev/null \
+    || echo "n/a"
+}
+
+wait_for_backend_readiness() {
+  local deadline=$((SECONDS + readiness_timeout_seconds))
+  local body=""
+  echo "[transaction-100m-capacity] waiting backend readiness: ${backend_health_url}"
+  while ((SECONDS < deadline)); do
+    body="$(curl -sS --max-time 2 "${backend_health_url}" 2>/dev/null || true)"
+    # 전체 health는 optional runtime 때문에 DOWN일 수 있어 readinessState만 확인합니다.
+    if grep -F '"readinessState":{"status":"UP"}' <<<"${body}" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "backend readiness timeout: ${backend_health_url}" >&2
+  [[ -z "${body}" ]] || echo "${body}" >&2
+  exit 1
+}
+
+wait_for_prometheus_readiness() {
+  local deadline=$((SECONDS + readiness_timeout_seconds))
+  echo "[transaction-100m-capacity] waiting prometheus readiness: ${prometheus_base_url}/-/ready"
+  while ((SECONDS < deadline)); do
+    if curl -fsS --max-time 2 "${prometheus_base_url}/-/ready" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "prometheus readiness timeout: ${prometheus_base_url}/-/ready" >&2
+  exit 1
+}
+
+start_cpu_sampler() {
+  local stats_path="$1"
+  : >"${stats_path}"
+  (
+    while true; do
+      docker stats --no-stream --format '{{.Name}}	{{.CPUPerc}}' \
+          aquila-bank-backend-loadtest aquila-bank-postgres 2>/dev/null \
+        | awk -F '\t' -v ts="$(date +%s)" '{
+            gsub("%", "", $2)
+            print ts "\t" $1 "\t" $2
+          }' >>"${stats_path}" || true
+      sleep "${cpu_sample_interval_seconds}"
+    done
+  ) &
+  CPU_SAMPLER_PID="$!"
+}
+
+stop_cpu_sampler() {
+  if [[ -n "${CPU_SAMPLER_PID}" ]]; then
+    kill "${CPU_SAMPLER_PID}" >/dev/null 2>&1 || true
+    wait "${CPU_SAMPLER_PID}" >/dev/null 2>&1 || true
+    CPU_SAMPLER_PID=""
+  fi
+}
+
+container_cpu_max_percent() {
+  local stats_path="$1"
+  local container_name="$2"
+  if [[ ! -f "${stats_path}" ]]; then
+    echo "n/a"
+    return 0
+  fi
+  awk -F '\t' -v name="${container_name}" '
+    $2 == name {
+      value = $3 + 0
+      if (!found || value > max) {
+        max = value
+      }
+      found = 1
+    }
+    END {
+      if (found) {
+        printf "%.2f", max
+      } else {
+        print "n/a"
+      }
+    }
+  ' "${stats_path}"
+}
+
+write_header() {
+  printf "phase\tprofile\tstatus\tadmission\tvus\tbackend_cpus\tbackend_memory\tpostgres_cpus\tpostgres_memory\tdb_pool\toverload_mode\tduration\thttp_failed_rate\thttp_reqs\ttransaction_429_rate\thot_first_p95_ms\thot_cursor_p95_ms\tcold_first_p95_ms\tcold_cursor_p95_ms\tbackend_cpu_percent\tpostgres_cpu_percent\thikari_active\thikari_pending\thikari_max\tlog_path\tsummary_json\n" >"${summary_tsv}"
+}
+
+append_summary() {
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$@" >>"${summary_tsv}"
+}
+
+run_profile() {
+  local phase="$1"
+  local profile="$2"
+  IFS=':' read -r name admission vus backend_cpus backend_memory postgres_cpus postgres_memory db_pool overload_mode duration <<<"${profile}"
+  local report_name="${capacity_name}-${name}"
+  local log_path="${report_dir}/${report_name}.log"
+  local summary_json="build/reports/k6/${report_name}-summary.json"
+  local stats_path="${report_dir}/${report_name}-docker-stats.tsv"
+  local status
+
+  echo "[transaction-100m-capacity] running phase=${phase} profile=${name}"
+
+  T3MICRO_BACKEND_CPUS="${backend_cpus}" \
+  T3MICRO_BACKEND_MEMORY="${backend_memory}" \
+  T3MICRO_BACKEND_MEMORY_SWAP="${backend_memory}" \
+  T3MICRO_POSTGRES_CPUS="${postgres_cpus}" \
+  T3MICRO_POSTGRES_MEMORY="${postgres_memory}" \
+  T3MICRO_POSTGRES_MEMORY_SWAP="${postgres_memory}" \
+  OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX="${admission}" \
+  DB_POOL_MAX_SIZE="${db_pool}" \
+    docker compose "${compose_files[@]}" --profile loadtest up -d --force-recreate \
+      postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter
+
+  wait_for_backend_readiness
+  wait_for_prometheus_readiness
+
+  start_cpu_sampler "${stats_path}"
+  set +e
+  K6_REPORT_NAME="${report_name}" \
+  K6_VUS="${vus}" \
+  K6_DURATION="${duration}" \
+  K6_OVERLOAD_MODE="${overload_mode}" \
+  K6_ARCHIVE_RESULTS=false \
+    tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${log_path}" 2>&1
+  status=$?
+  set -e
+  stop_cpu_sampler
+
+  if [[ "${metric_scrape_wait_seconds}" -gt 0 ]]; then
+    sleep "${metric_scrape_wait_seconds}"
+  fi
+
+  append_summary \
+    "${phase}" "${name}" "${status}" "${admission}" "${vus}" \
+    "${backend_cpus}" "${backend_memory}" "${postgres_cpus}" "${postgres_memory}" \
+    "${db_pool}" "${overload_mode}" "${duration}" \
+    "$(metric_from_json "${summary_json}" "http_req_failed" "rate")" \
+    "$(metric_from_json "${summary_json}" "http_reqs" "count")" \
+    "$(metric_from_json "${summary_json}" "aquila_transaction_429_rate" "rate")" \
+    "$(metric_from_json "${summary_json}" "aquila_transaction_hot_first_ms" "p(95)")" \
+    "$(metric_from_json "${summary_json}" "aquila_transaction_hot_cursor_ms" "p(95)")" \
+    "$(metric_from_json "${summary_json}" "aquila_transaction_cold_first_ms" "p(95)")" \
+    "$(metric_from_json "${summary_json}" "aquila_transaction_cold_cursor_ms" "p(95)")" \
+    "$(container_cpu_max_percent "${stats_path}" aquila-bank-backend-loadtest)" \
+    "$(container_cpu_max_percent "${stats_path}" aquila-bank-postgres)" \
+    "$(prometheus_value 'max(hikaricp_connections_active{pool="aquila-bank-pool"})')" \
+    "$(prometheus_value 'max(hikaricp_connections_pending{pool="aquila-bank-pool"})')" \
+    "$(prometheus_value 'max(hikaricp_connections_max{pool="aquila-bank-pool"})')" \
+    "${log_path}" "${summary_json}"
+
+  if [[ "${status}" -ne 0 && "${continue_on_failure}" != "true" ]]; then
+    echo "[transaction-100m-capacity] profile failed and CAPACITY_CONTINUE_ON_FAILURE=false: ${name}" >&2
+    exit "${status}"
+  fi
+}
+
+run_profiles() {
+  local phase="$1"
+  local csv="$2"
+  IFS=',' read -r -a profiles <<<"${csv}"
+  local profile
+  for profile in "${profiles[@]}"; do
+    run_profile "${phase}" "${profile}"
+  done
+}
+
+write_header
+
+if [[ "${run_single_host}" == "true" ]]; then
+  run_profiles "single-host" "${single_host_profiles}"
+fi
+if [[ "${run_cpu_split}" == "true" ]]; then
+  run_profiles "cpu-split" "${cpu_split_profiles}"
+fi
+if [[ "${run_long_soak}" == "true" ]]; then
+  run_profile "long-soak" "${long_soak_profile}"
+fi
+
+echo "[transaction-100m-capacity] summary=${summary_tsv}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #382

## 🌿 Base Branch
- `main`

## 📝 Summary
- 1억 row transaction read capacity 판단을 위한 single-host, CPU split, long soak runner를 추가합니다.
- default admission guard는 `K6_OVERLOAD_MODE=true`로 429 보호 신호를 집계하고, high-traffic/long-soak는 strict threshold를 유지합니다.

## 🛠 Changes
- `tools/test/run-transaction-100m-capacity-gates.sh` 추가
  - single-host default/high-traffic profile
  - backend/PostgreSQL CPU split profile
  - 30~60분 long soak profile
  - profile별 `capacity-summary.tsv` 작성
- `tools/test/check-transaction-100m-capacity-gates.sh` 추가
  - shell syntax, print-plan, contract, invalid input 검증

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-capacity-gates.sh`
- `bash -n tools/test/run-transaction-100m-capacity-gates.sh`
- `git diff --check HEAD`
- `git log --oneline main..HEAD`로 commit_plan 1개와 실제 commit 1개 일치 확인

### 실제 1억 row loadtest / 30분 long soak
실행:
`CAPACITY_NAME=transaction-100m-capacity-20260426-actual CAPACITY_LONG_SOAK_DURATION=30m K6_HOT_ACCOUNT_ID=910000001 K6_HOT_FROM=2026-04-01T00:00:00Z K6_HOT_TO=2026-04-30T00:00:00Z K6_COLD_ACCOUNT_ID=910000002 K6_COLD_FROM=2026-01-01T00:00:00Z K6_COLD_TO=2026-01-31T00:00:00Z tools/test/run-transaction-100m-capacity-gates.sh`

결과 artifact:
- `build/reports/k6/transaction-100m-capacity-20260426-actual/capacity-summary.tsv`

핵심 수치:
- `single-host-default`: status `0`, admission `3`, VU `8`, 429 rate `0.1282926829`, p95 hot/cold `206~294ms`
- `single-host-high-traffic`: status `0`, admission `8`, VU `8`, 429 rate `0`, p95 `102~104ms`
- `cpu-backend040-postgres060`: status `99`, p95 `553~602ms`; 낮은 backend CPU budget 병목 재현
- `cpu-backend100-postgres060`: status `0`, p95 `80~82ms`
- `long-soak-high-traffic`: status `0`, duration `30m`, requests `2,870,904`, 429 rate `0`, p95 `26~45ms`, backend CPU max `85.73%`, Postgres CPU max `56.42%`

주의:
- 최초 fixture 확인에서 `count(*)` preflight를 직접 실행했다가 PostgreSQL backend process가 signal 9로 종료되어 recovery가 발생했습니다. 이후 확인은 `EXISTS ... LIMIT 1`로 바꿨고, 최종 PostgreSQL 상태는 `running healthy false`입니다.

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: profile별 `docker compose up --force-recreate`가 실행 중인 수동 loadtest session을 끊을 수 있습니다.
- 롤백 방법: 이 PR commit revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?