### PR TITLE
[Perf] transaction 100m workload/profile benchmark 묶음 추가

### DIFF
--- a/ops/k6/transaction-read-100m-weighted.js
+++ b/ops/k6/transaction-read-100m-weighted.js
@@ -1,0 +1,257 @@
+import http from "k6/http";
+import {check, fail} from "k6";
+import {Rate, Trend} from "k6/metrics";
+
+const baseUrl = (__ENV.BASE_URL || "http://aquila-bank-backend:8080").replace(/\/$/, "");
+const hotAccountId = __ENV.K6_HOT_ACCOUNT_ID || "";
+const hotFrom = __ENV.K6_HOT_FROM || "";
+const hotTo = __ENV.K6_HOT_TO || "";
+const coldAccountId = __ENV.K6_COLD_ACCOUNT_ID || "";
+const coldFrom = __ENV.K6_COLD_FROM || "";
+const coldTo = __ENV.K6_COLD_TO || "";
+const authToken = __ENV.K6_AUTH_TOKEN || "";
+const limit = Number(__ENV.K6_LIMIT || "50");
+const vus = Number(__ENV.K6_VUS || "8");
+const duration = __ENV.K6_DURATION || "1m";
+const reportName = __ENV.K6_REPORT_NAME || "transaction-100m-weighted";
+
+const weights = [
+  ["hot_first", Number(__ENV.K6_WEIGHT_HOT_FIRST || "45")],
+  ["hot_cursor", Number(__ENV.K6_WEIGHT_HOT_CURSOR || "25")],
+  ["cold_first", Number(__ENV.K6_WEIGHT_COLD_FIRST || "15")],
+  ["cold_cursor", Number(__ENV.K6_WEIGHT_COLD_CURSOR || "10")],
+  ["detail", Number(__ENV.K6_WEIGHT_DETAIL || "0")],
+];
+const totalWeight = weights.reduce((sum, [, value]) => sum + Math.max(0, value), 0);
+const detailWeight = Math.max(0, weights.find(([shape]) => shape === "detail")[1]);
+
+const hotFirst = new Trend("aquila_transaction_weighted_hot_first_ms", true);
+const hotCursor = new Trend("aquila_transaction_weighted_hot_cursor_ms", true);
+const coldFirst = new Trend("aquila_transaction_weighted_cold_first_ms", true);
+const coldCursor = new Trend("aquila_transaction_weighted_cold_cursor_ms", true);
+const detailTrend = new Trend("aquila_transaction_detail_ms", true);
+const transaction429Rate = new Rate("aquila_transaction_weighted_429_rate");
+
+let hotCursorValue = "";
+let coldCursorValue = "";
+let lastHotReference = "";
+
+function thresholds() {
+  const result = {
+    http_req_failed: ["rate<0.01"],
+    checks: ["rate>0.99"],
+    aquila_transaction_weighted_hot_first_ms: ["p(95)<350"],
+    aquila_transaction_weighted_hot_cursor_ms: ["p(95)<350"],
+    aquila_transaction_weighted_cold_first_ms: ["p(95)<750"],
+    aquila_transaction_weighted_cold_cursor_ms: ["p(95)<750"],
+  };
+  if (detailWeight > 0) {
+    result.aquila_transaction_detail_ms = ["p(95)<350"];
+  }
+  return result;
+}
+
+export const options = {
+  scenarios: {
+    transaction_read_100m_weighted: {
+      executor: "constant-vus",
+      vus,
+      duration,
+    },
+  },
+  thresholds: thresholds(),
+  tags: {
+    service: "aquila-bank",
+    workload: "transaction-read-100m-weighted",
+  },
+};
+
+function requireEnv(name, value) {
+  if (!value) {
+    fail(`${name} is required`);
+  }
+}
+
+function headers(accountId) {
+  const result = {
+    "X-Account-Id": String(accountId),
+    "X-Subject": "k6-transaction-100m-weighted",
+  };
+  if (authToken) {
+    result.Authorization = `Bearer ${authToken}`;
+  }
+  return result;
+}
+
+function queryString(params) {
+  return Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null && value !== "")
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+    .join("&");
+}
+
+function randomWeightedShape() {
+  if (totalWeight <= 0) {
+    fail("weighted workload total weight must be positive");
+  }
+  let cursor = Math.random() * totalWeight;
+  for (const [shape, weight] of weights) {
+    cursor -= Math.max(0, weight);
+    if (cursor < 0) {
+      return shape;
+    }
+  }
+  return "hot_first";
+}
+
+function parseJson(response, shape) {
+  try {
+    return response.json();
+  } catch (error) {
+    fail(`${shape} returned non-json response: ${error}`);
+  }
+}
+
+function record(shape, durationMs) {
+  if (shape === "hot_first") {
+    hotFirst.add(durationMs);
+  } else if (shape === "hot_cursor") {
+    hotCursor.add(durationMs);
+  } else if (shape === "cold_first") {
+    coldFirst.add(durationMs);
+  } else if (shape === "cold_cursor") {
+    coldCursor.add(durationMs);
+  } else if (shape === "detail") {
+    detailTrend.add(durationMs);
+  }
+}
+
+function requestPage(shape, path, accountId, from, to, cursor) {
+  const query = queryString({accountId, from, to, limit, cursor});
+  const response = http.get(`${baseUrl}${path}?${query}`, {
+    headers: headers(accountId),
+    tags: {name: shape, query_shape: shape},
+  });
+  transaction429Rate.add(response.status === 429);
+  record(shape, response.timings.duration);
+  const ok = check(response, {
+    [`${shape} status is 2xx`]: (item) => item.status >= 200 && item.status < 300,
+  });
+  if (!ok) {
+    fail(`${shape} returned HTTP ${response.status}`);
+  }
+
+  const body = parseJson(response, shape);
+  const hasItems = check(body, {
+    [`${shape} has items`]: (item) => Array.isArray(item.items) && item.items.length > 0,
+  });
+  if (!hasItems) {
+    fail(`${shape} returned no items`);
+  }
+  if (shape === "hot_first" && body.items[0].transactionReference) {
+    lastHotReference = body.items[0].transactionReference;
+  }
+  return body;
+}
+
+function requestDetail() {
+  if (!lastHotReference) {
+    const body = requestPage("hot_first", "/api/v1/transactions", hotAccountId, hotFrom, hotTo, "");
+    lastHotReference = body.items[0].transactionReference;
+  }
+  const query = queryString({accountId: hotAccountId});
+  const response = http.get(
+    `${baseUrl}/api/v1/transactions/${encodeURIComponent(lastHotReference)}?${query}`,
+    {headers: headers(hotAccountId), tags: {name: "detail", query_shape: "detail"}},
+  );
+  transaction429Rate.add(response.status === 429);
+  record("detail", response.timings.duration);
+  const ok = check(response, {
+    "detail status is 2xx": (item) => item.status >= 200 && item.status < 300,
+  });
+  if (!ok) {
+    fail(`detail returned HTTP ${response.status}`);
+  }
+}
+
+export default function () {
+  requireEnv("K6_HOT_ACCOUNT_ID", hotAccountId);
+  requireEnv("K6_HOT_FROM", hotFrom);
+  requireEnv("K6_HOT_TO", hotTo);
+  requireEnv("K6_COLD_ACCOUNT_ID", coldAccountId);
+  requireEnv("K6_COLD_FROM", coldFrom);
+  requireEnv("K6_COLD_TO", coldTo);
+
+  const shape = randomWeightedShape();
+  if (shape === "hot_first") {
+    const body = requestPage("hot_first", "/api/v1/transactions", hotAccountId, hotFrom, hotTo, "");
+    hotCursorValue = body.nextCursor || hotCursorValue;
+  } else if (shape === "hot_cursor") {
+    if (!hotCursorValue) {
+      hotCursorValue =
+        requestPage("hot_first", "/api/v1/transactions", hotAccountId, hotFrom, hotTo, "").nextCursor || "";
+    }
+    requestPage("hot_cursor", "/api/v1/transactions", hotAccountId, hotFrom, hotTo, hotCursorValue);
+  } else if (shape === "cold_first") {
+    const body = requestPage("cold_first", "/api/v1/transactions/archive", coldAccountId, coldFrom, coldTo, "");
+    coldCursorValue = body.nextCursor || coldCursorValue;
+  } else if (shape === "cold_cursor") {
+    if (!coldCursorValue) {
+      coldCursorValue =
+        requestPage("cold_first", "/api/v1/transactions/archive", coldAccountId, coldFrom, coldTo, "")
+          .nextCursor || "";
+    }
+    requestPage(
+      "cold_cursor",
+      "/api/v1/transactions/archive",
+      coldAccountId,
+      coldFrom,
+      coldTo,
+      coldCursorValue,
+    );
+  } else {
+    requestDetail();
+  }
+}
+
+function metric(data, name, valueName) {
+  const item = data.metrics[name];
+  if (!item || !item.values || item.values[valueName] === undefined) {
+    return "n/a";
+  }
+  return item.values[valueName];
+}
+
+function markdownSummary(data) {
+  return `# k6 Transaction 100m Weighted Load Test
+
+## Environment
+
+- baseUrl: ${baseUrl}
+- vus: ${vus}
+- duration: ${duration}
+- limit: ${limit}
+- weights hot_first/hot_cursor/cold_first/cold_cursor/detail: ${weights.map(([, value]) => value).join("/")}
+
+## Results
+
+- http_req_failed rate: ${metric(data, "http_req_failed", "rate")}
+- checks rate: ${metric(data, "checks", "rate")}
+- weighted 429 rate: ${metric(data, "aquila_transaction_weighted_429_rate", "rate")}
+- hot first p95 ms: ${metric(data, "aquila_transaction_weighted_hot_first_ms", "p(95)")}
+- hot cursor p95 ms: ${metric(data, "aquila_transaction_weighted_hot_cursor_ms", "p(95)")}
+- cold first p95 ms: ${metric(data, "aquila_transaction_weighted_cold_first_ms", "p(95)")}
+- cold cursor p95 ms: ${metric(data, "aquila_transaction_weighted_cold_cursor_ms", "p(95)")}
+- detail p95 ms: ${metric(data, "aquila_transaction_detail_ms", "p(95)")}
+`;
+}
+
+export function handleSummary(data) {
+  const jsonPath = `/reports/${reportName}-summary.json`;
+  const markdownPath = `/reports/${reportName}-summary.md`;
+  return {
+    [jsonPath]: JSON.stringify(data, null, 2),
+    [markdownPath]: markdownSummary(data),
+    stdout: markdownSummary(data),
+  };
+}

--- a/tools/test/check-transaction-100m-workload-profile-benchmarks.sh
+++ b/tools/test/check-transaction-100m-workload-profile-benchmarks.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+weighted_runner="tools/test/run-k6-transaction-100m-weighted-loadtest.sh"
+compression_runner="tools/test/run-transaction-read-compression-benchmark.sh"
+mapper_runner="tools/test/run-transaction-read-jdbc-mapper-allocation.sh"
+fixture_runner="tools/test/run-transaction-100m-fixture-restore.sh"
+weighted_script="ops/k6/transaction-read-100m-weighted.js"
+
+echo "[transaction-100m-workload-profile] shell syntax"
+bash -n "${weighted_runner}"
+bash -n "${compression_runner}"
+bash -n "${mapper_runner}"
+bash -n "${fixture_runner}"
+
+echo "[transaction-100m-workload-profile] weighted plan"
+weighted_plan="$(
+  K6_REPORT_NAME=transaction-weighted-check \
+  K6_WEIGHT_HOT_FIRST=45 \
+  K6_WEIGHT_HOT_CURSOR=25 \
+  K6_WEIGHT_COLD_FIRST=15 \
+  K6_WEIGHT_COLD_CURSOR=10 \
+  K6_WEIGHT_DETAIL=5 \
+    "${weighted_runner}" --print-plan --no-deps
+)"
+grep -F "weighted report name: transaction-weighted-check" <<<"${weighted_plan}" >/dev/null
+grep -F "weights hot_first=45 hot_cursor=25 cold_first=15 cold_cursor=10 detail=5" <<<"${weighted_plan}" >/dev/null
+grep -F "script=/scripts/transaction-read-100m-weighted.js" <<<"${weighted_plan}" >/dev/null
+
+echo "[transaction-100m-workload-profile] compression plan"
+compression_plan="$(
+  COMPRESSION_BENCHMARK_NAME=transaction-compression-check \
+  COMPRESSION_PROFILES=off:false:0,on-2kb:true:2048 \
+    "${compression_runner}" --print-plan
+)"
+grep -F "benchmark=transaction-compression-check" <<<"${compression_plan}" >/dev/null
+grep -F "profiles=off,on-2kb" <<<"${compression_plan}" >/dev/null
+grep -F "admission max=8" <<<"${compression_plan}" >/dev/null
+grep -F "backend_health_url=http://localhost:8080/actuator/health" <<<"${compression_plan}" >/dev/null
+grep -F "summary=build/reports/k6/transaction-compression-check/compression-summary.tsv" <<<"${compression_plan}" >/dev/null
+
+echo "[transaction-100m-workload-profile] mapper plan"
+mapper_plan="$(
+  MAPPER_PROFILE_NAME=transaction-mapper-check \
+    "${mapper_runner}" --print-plan
+)"
+grep -F "profile=transaction-mapper-check" <<<"${mapper_plan}" >/dev/null
+grep -F "target=JdbcTransactionReadRepository,JDBC RowMapper,OffsetDateTime,enum" <<<"${mapper_plan}" >/dev/null
+grep -F "run-transaction-read-hotpath-profile.sh" <<<"${mapper_plan}" >/dev/null
+
+echo "[transaction-100m-workload-profile] fixture plan"
+fixture_plan="$(
+  FIXTURE_NAME=transaction-fixture-check \
+    "${fixture_runner}" --print-plan
+)"
+grep -F "fixture=transaction-fixture-check" <<<"${fixture_plan}" >/dev/null
+grep -F "dump=build/fixtures/transaction-fixture-check.dump" <<<"${fixture_plan}" >/dev/null
+grep -F "modes=verify,dump,restore" <<<"${fixture_plan}" >/dev/null
+
+echo "[transaction-100m-workload-profile] script contract"
+grep -F "K6_WEIGHT_DETAIL" "${weighted_script}" >/dev/null
+grep -F "transaction_detail_ms" "${weighted_script}" >/dev/null
+grep -F "transactionReference" "${weighted_script}" >/dev/null
+grep -F "randomWeightedShape" "${weighted_script}" >/dev/null
+grep -F "SERVER_COMPRESSION_ENABLED" "${compression_runner}" >/dev/null
+grep -F "OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX" "${compression_runner}" >/dev/null
+grep -F "wait_for_backend_readiness" "${compression_runner}" >/dev/null
+grep -F "server.compression.min-response-size" "${compression_runner}" >/dev/null
+grep -F "allocation-by-site" "${mapper_runner}" >/dev/null
+grep -F "pg_dump" "${fixture_runner}" >/dev/null
+grep -F "pg_restore" "${fixture_runner}" >/dev/null
+
+echo "[transaction-100m-workload-profile] invalid input fails"
+if COMPRESSION_PROFILES=bad "${compression_runner}" --print-plan >/dev/null 2>&1; then
+  echo "bad COMPRESSION_PROFILES unexpectedly succeeded" >&2
+  exit 1
+fi
+if FIXTURE_MODE=restore FIXTURE_RESTORE_TRUNCATE=false "${fixture_runner}" >/dev/null 2>&1; then
+  echo "restore without explicit truncate unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-k6-transaction-100m-weighted-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-weighted-loadtest.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-k6-transaction-100m-weighted-loadtest.sh [--print-plan|--no-up] [--no-deps]
+
+Required runtime environment:
+  K6_HOT_ACCOUNT_ID K6_HOT_FROM K6_HOT_TO
+  K6_COLD_ACCOUNT_ID K6_COLD_FROM K6_COLD_TO
+
+Optional environment:
+  K6_REPORT_NAME default transaction-100m-weighted-<timestamp>
+  K6_VUS default 8
+  K6_DURATION default 1m
+  K6_LIMIT default 50
+  K6_WEIGHT_HOT_FIRST default 45
+  K6_WEIGHT_HOT_CURSOR default 25
+  K6_WEIGHT_COLD_FIRST default 15
+  K6_WEIGHT_COLD_CURSOR default 10
+  K6_WEIGHT_DETAIL default 0, synthetic 100m fixture usually has no detail rows
+USAGE
+}
+
+mode="run"
+run_dependencies="true"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan) mode="print-plan" ;;
+    --no-up) mode="no-up" ;;
+    --no-deps) run_dependencies="false" ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 1 ;;
+  esac
+  shift
+done
+
+K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-weighted-$(date +%Y-%m-%d-%H%M%S)}"
+K6_VUS="${K6_VUS:-8}"
+K6_DURATION="${K6_DURATION:-1m}"
+K6_LIMIT="${K6_LIMIT:-50}"
+K6_WEIGHT_HOT_FIRST="${K6_WEIGHT_HOT_FIRST:-45}"
+K6_WEIGHT_HOT_CURSOR="${K6_WEIGHT_HOT_CURSOR:-25}"
+K6_WEIGHT_COLD_FIRST="${K6_WEIGHT_COLD_FIRST:-15}"
+K6_WEIGHT_COLD_CURSOR="${K6_WEIGHT_COLD_CURSOR:-10}"
+K6_WEIGHT_DETAIL="${K6_WEIGHT_DETAIL:-0}"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+script_path="/scripts/transaction-read-100m-weighted.js"
+
+require_positive_integer() {
+  local name="$1"
+  local value="${!name:-}"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer" >&2
+    exit 1
+  fi
+}
+
+require_non_negative_integer() {
+  local name="$1"
+  local value="${!name:-}"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${name} must be zero or a positive integer" >&2
+    exit 1
+  fi
+}
+
+require_env() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "${value}" ]]; then
+    echo "${name} is required" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer K6_VUS
+require_positive_integer K6_LIMIT
+require_non_negative_integer K6_WEIGHT_HOT_FIRST
+require_non_negative_integer K6_WEIGHT_HOT_CURSOR
+require_non_negative_integer K6_WEIGHT_COLD_FIRST
+require_non_negative_integer K6_WEIGHT_COLD_CURSOR
+require_non_negative_integer K6_WEIGHT_DETAIL
+
+echo "[k6-transaction-100m-weighted] weighted report name: ${K6_REPORT_NAME}"
+echo "[k6-transaction-100m-weighted] vus=${K6_VUS} duration=${K6_DURATION} limit=${K6_LIMIT}"
+echo "[k6-transaction-100m-weighted] weights hot_first=${K6_WEIGHT_HOT_FIRST} hot_cursor=${K6_WEIGHT_HOT_CURSOR} cold_first=${K6_WEIGHT_COLD_FIRST} cold_cursor=${K6_WEIGHT_COLD_CURSOR} detail=${K6_WEIGHT_DETAIL}"
+echo "[k6-transaction-100m-weighted] script=${script_path}"
+if [[ "${run_dependencies}" == "true" ]]; then
+  echo "[k6-transaction-100m-weighted] dependencies=compose-default"
+else
+  echo "[k6-transaction-100m-weighted] dependencies=no-deps"
+fi
+
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+require_env K6_HOT_ACCOUNT_ID
+require_env K6_HOT_FROM
+require_env K6_HOT_TO
+require_env K6_COLD_ACCOUNT_ID
+require_env K6_COLD_FROM
+require_env K6_COLD_TO
+
+if [[ "${mode}" != "no-up" ]]; then
+  tools/test/with-resource-lock.sh back-gradle-loadtest-bootjar ./back/gradlew -p back bootJar
+  docker compose "${compose_files[@]}" --profile loadtest up -d \
+    postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter
+fi
+
+run_args=(--rm)
+if [[ "${run_dependencies}" != "true" ]]; then
+  run_args+=(--no-deps)
+fi
+docker compose "${compose_files[@]}" --profile loadtest run "${run_args[@]}" \
+  -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
+  -e K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
+  -e K6_HOT_FROM="${K6_HOT_FROM}" \
+  -e K6_HOT_TO="${K6_HOT_TO}" \
+  -e K6_COLD_ACCOUNT_ID="${K6_COLD_ACCOUNT_ID}" \
+  -e K6_COLD_FROM="${K6_COLD_FROM}" \
+  -e K6_COLD_TO="${K6_COLD_TO}" \
+  -e K6_AUTH_TOKEN="${K6_AUTH_TOKEN:-}" \
+  -e K6_VUS="${K6_VUS}" \
+  -e K6_DURATION="${K6_DURATION}" \
+  -e K6_LIMIT="${K6_LIMIT}" \
+  -e K6_WEIGHT_HOT_FIRST="${K6_WEIGHT_HOT_FIRST}" \
+  -e K6_WEIGHT_HOT_CURSOR="${K6_WEIGHT_HOT_CURSOR}" \
+  -e K6_WEIGHT_COLD_FIRST="${K6_WEIGHT_COLD_FIRST}" \
+  -e K6_WEIGHT_COLD_CURSOR="${K6_WEIGHT_COLD_CURSOR}" \
+  -e K6_WEIGHT_DETAIL="${K6_WEIGHT_DETAIL}" \
+  k6-transaction-read-100m \
+  run --out experimental-prometheus-rw "${script_path}"

--- a/tools/test/run-transaction-100m-fixture-restore.sh
+++ b/tools/test/run-transaction-100m-fixture-restore.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-fixture-restore.sh [--print-plan]
+
+Environment:
+  FIXTURE_MODE              verify|dump|restore, default verify
+  FIXTURE_NAME              default transaction-100m-fixture
+  FIXTURE_RESTORE_TRUNCATE  must be true for restore
+USAGE
+}
+
+if [[ "${1:-}" == "--print-plan" ]]; then
+  print_plan=true
+  shift
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+else
+  print_plan=false
+fi
+[[ "$#" -eq 0 ]] || { usage; exit 1; }
+
+fixture_mode="${FIXTURE_MODE:-verify}"
+fixture_name="${FIXTURE_NAME:-transaction-100m-fixture}"
+fixture_dir="${FIXTURE_DIR:-build/fixtures}"
+fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+container_dump_path="/tmp/${fixture_name}.dump"
+
+case "${fixture_mode}" in
+  verify|dump|restore) ;;
+  *) echo "FIXTURE_MODE must be verify, dump, or restore" >&2; exit 1 ;;
+esac
+
+echo "[transaction-fixture-restore] fixture=${fixture_name}"
+echo "[transaction-fixture-restore] mode=${fixture_mode}"
+echo "[transaction-fixture-restore] dump=${fixture_path}"
+echo "[transaction-fixture-restore] modes=verify,dump,restore"
+
+if [[ "${print_plan}" == "true" ]]; then
+  exit 0
+fi
+
+if [[ "${fixture_mode}" == "restore" && "${FIXTURE_RESTORE_TRUNCATE:-false}" != "true" ]]; then
+  echo "FIXTURE_RESTORE_TRUNCATE=true is required for restore" >&2
+  exit 1
+fi
+
+mkdir -p "${fixture_dir}"
+
+if [[ "${fixture_mode}" == "verify" ]]; then
+  docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 \
+    -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}" \
+    --no-align --tuples-only --command "
+      SELECT to_regclass('public.transaction_read_model') IS NOT NULL
+          AND to_regclass('public.transaction_read_model_archive') IS NOT NULL
+          AND to_regclass('public.idx_transaction_read_model_account_cursor') IS NOT NULL
+          AND to_regclass('public.idx_transaction_read_model_archive_account_cursor') IS NOT NULL;"
+elif [[ "${fixture_mode}" == "dump" ]]; then
+  docker compose "${compose_files[@]}" exec -T postgres pg_dump \
+    -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}" \
+    --format=custom \
+    --file="${container_dump_path}" \
+    --table=public.transaction_read_model \
+    --table=public.transaction_read_model_archive
+  docker cp "aquila-bank-postgres:${container_dump_path}" "${fixture_path}"
+else
+  test -s "${fixture_path}" || { echo "fixture dump not found: ${fixture_path}" >&2; exit 1; }
+  docker cp "${fixture_path}" "aquila-bank-postgres:${container_dump_path}"
+  docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 \
+    -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}" \
+    --command "TRUNCATE public.transaction_read_model, public.transaction_read_model_archive;"
+  docker compose "${compose_files[@]}" exec -T postgres pg_restore \
+    -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}" \
+    --jobs="${FIXTURE_RESTORE_JOBS:-2}" \
+    "${container_dump_path}"
+fi

--- a/tools/test/run-transaction-read-compression-benchmark.sh
+++ b/tools/test/run-transaction-read-compression-benchmark.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-compression-benchmark.sh [--print-plan]
+
+Profile format:
+  name:enabled:min_response_size_bytes
+
+Optional environment:
+  COMPRESSION_ADMISSION_MAX default K6_VUS or 8
+  COMPRESSION_BACKEND_HEALTH_URL default http://localhost:${BACKEND_PORT:-8080}/actuator/health
+  COMPRESSION_READINESS_TIMEOUT_SECONDS default 60
+USAGE
+}
+
+mode="run"
+if [[ "${1:-}" == "--print-plan" ]]; then
+  mode="print-plan"
+  shift
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+[[ "$#" -eq 0 ]] || { usage; exit 1; }
+
+benchmark_name="${COMPRESSION_BENCHMARK_NAME:-transaction-read-compression-$(date +%Y-%m-%d-%H%M%S)}"
+profiles="${COMPRESSION_PROFILES:-off:false:0,on-2kb:true:2048,on-8kb:true:8192}"
+admission_max="${COMPRESSION_ADMISSION_MAX:-${K6_VUS:-8}}"
+backend_health_url="${COMPRESSION_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
+readiness_timeout_seconds="${COMPRESSION_READINESS_TIMEOUT_SECONDS:-60}"
+report_dir="build/reports/k6/${benchmark_name}"
+summary_tsv="${report_dir}/compression-summary.tsv"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+
+restore_backend() {
+  docker compose "${compose_files[@]}" --profile loadtest up -d --force-recreate aquila-bank-backend >/dev/null 2>&1 || true
+}
+
+wait_for_backend_readiness() {
+  local deadline=$((SECONDS + readiness_timeout_seconds))
+  local body=""
+
+  echo "[transaction-compression] waiting backend readiness: ${backend_health_url}"
+  while ((SECONDS < deadline)); do
+    body="$(curl -sS --max-time 2 "${backend_health_url}" 2>/dev/null || true)"
+    # 전체 health는 optional outbox 상태 때문에 DOWN일 수 있어 readinessState만 확인합니다.
+    if grep -F '"readinessState":{"status":"UP"}' <<<"${body}" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "backend readiness timeout: ${backend_health_url}" >&2
+  if [[ -n "${body}" ]]; then
+    echo "${body}" >&2
+  fi
+  exit 1
+}
+
+validate_profile() {
+  local profile="$1"
+  IFS=':' read -r name enabled min_size extra <<<"${profile}"
+  if [[ -n "${extra:-}" || -z "${min_size:-}" ]]; then
+    echo "COMPRESSION_PROFILES profile must have 3 fields: ${profile}" >&2
+    exit 1
+  fi
+  [[ "${name}" =~ ^[a-z0-9][a-z0-9-]*$ ]] || { echo "bad profile name: ${name}" >&2; exit 1; }
+  [[ "${enabled}" == "true" || "${enabled}" == "false" ]] || { echo "enabled must be true/false" >&2; exit 1; }
+  [[ "${min_size}" =~ ^[0-9]+$ ]] || { echo "min size must be non-negative integer" >&2; exit 1; }
+}
+
+profile_names() {
+  IFS=',' read -r -a items <<<"$1"
+  local result="" item
+  for item in "${items[@]}"; do
+    [[ -z "${result}" ]] || result+=","
+    result+="${item%%:*}"
+  done
+  echo "${result}"
+}
+
+validate_profiles() {
+  IFS=',' read -r -a items <<<"$1"
+  local item
+  for item in "${items[@]}"; do
+    validate_profile "${item}"
+  done
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="${!name:-}"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer" >&2
+    exit 1
+  fi
+}
+
+validate_profiles "${profiles}"
+require_positive_integer admission_max
+require_positive_integer readiness_timeout_seconds
+
+echo "[transaction-compression] benchmark=${benchmark_name}"
+echo "[transaction-compression] profiles=$(profile_names "${profiles}")"
+echo "[transaction-compression] admission max=${admission_max}"
+echo "[transaction-compression] backend_health_url=${backend_health_url}"
+echo "[transaction-compression] summary=${summary_tsv}"
+
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+mkdir -p "${report_dir}"
+printf "profile\tstatus\tenabled\tmin_response_size_bytes\tsummary_json\tlog_path\n" >"${summary_tsv}"
+trap restore_backend EXIT
+
+IFS=',' read -r -a items <<<"${profiles}"
+for item in "${items[@]}"; do
+  IFS=':' read -r name enabled min_size <<<"${item}"
+  report_name="${benchmark_name}-${name}"
+  log_path="${report_dir}/${report_name}.log"
+  java_options="-XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=40 -Dserver.compression.enabled=${enabled} -Dserver.compression.min-response-size=${min_size}B"
+  SERVER_COMPRESSION_ENABLED="${enabled}" \
+  SERVER_COMPRESSION_MIN_RESPONSE_SIZE="${min_size}" \
+  OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX="${admission_max}" \
+  LOADTEST_BACKEND_JAVA_TOOL_OPTIONS="${java_options}" \
+    docker compose "${compose_files[@]}" --profile loadtest up -d --force-recreate aquila-bank-backend prometheus grafana
+  wait_for_backend_readiness
+  set +e
+  K6_REPORT_NAME="${report_name}" K6_ARCHIVE_RESULTS=false \
+    tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${log_path}" 2>&1
+  status=$?
+  set -e
+  printf "%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "${name}" "${status}" "${enabled}" "${min_size}" \
+    "build/reports/k6/${report_name}-summary.json" "${log_path}" >>"${summary_tsv}"
+done

--- a/tools/test/run-transaction-read-jdbc-mapper-allocation.sh
+++ b/tools/test/run-transaction-read-jdbc-mapper-allocation.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-jdbc-mapper-allocation.sh [--print-plan]
+
+Wraps run-transaction-read-hotpath-profile.sh with a row-mapper allocation preset.
+USAGE
+}
+
+mode="run"
+if [[ "${1:-}" == "--print-plan" ]]; then
+  mode="print-plan"
+  shift
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+[[ "$#" -eq 0 ]] || { usage; exit 1; }
+
+profile_name="${MAPPER_PROFILE_NAME:-transaction-read-jdbc-mapper-$(date +%Y-%m-%d-%H%M%S)}"
+profile_duration="${MAPPER_PROFILE_DURATION:-90s}"
+k6_duration="${K6_DURATION:-75s}"
+
+echo "[transaction-jdbc-mapper-allocation] profile=${profile_name}"
+echo "[transaction-jdbc-mapper-allocation] target=JdbcTransactionReadRepository,JDBC RowMapper,OffsetDateTime,enum"
+echo "[transaction-jdbc-mapper-allocation] runner=tools/test/run-transaction-read-hotpath-profile.sh"
+echo "[transaction-jdbc-mapper-allocation] jfr_views=hot-methods,cpu-time-hot-methods,allocation-by-class,allocation-by-site"
+
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+PROFILE_NAME="${profile_name}" \
+PROFILE_DURATION="${profile_duration}" \
+K6_DURATION="${k6_duration}" \
+  tools/test/run-transaction-read-hotpath-profile.sh


### PR DESCRIPTION
## 🔗 Related Issue
- close #383

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction 100m 조회 부하를 현실적인 weighted workload로 분리했습니다.
- compression threshold, JDBC row mapper allocation, prebuilt fixture restore를 재현 가능한 runner/checker로 묶었습니다.

## 🛠 Changes
- `ops/k6/transaction-read-100m-weighted.js` weighted hot/cold/cursor/detail 시나리오 추가
- `tools/test/run-k6-transaction-100m-weighted-loadtest.sh` weighted k6 runner 추가
- `tools/test/run-transaction-read-compression-benchmark.sh` compression off/on threshold benchmark 추가
- `tools/test/run-transaction-read-jdbc-mapper-allocation.sh` JDBC row mapper allocation JFR preset 추가
- `tools/test/run-transaction-100m-fixture-restore.sh` verify/dump/restore fixture workflow 추가
- `tools/test/check-transaction-100m-workload-profile-benchmarks.sh` runner contract checker 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-workload-profile-benchmarks.sh`
- `git diff --check`
- `FIXTURE_NAME=transaction-fixture-verify-20260426 tools/test/run-transaction-100m-fixture-restore.sh` → `t`
- `K6_REPORT_NAME=transaction-100m-weighted-20260426-actual ... K6_VUS=8 K6_DURATION=1m tools/test/run-k6-transaction-100m-weighted-loadtest.sh --no-up --no-deps` → status 0, 97,056 iterations, http_req_failed 0, checks 1, 429 0
- `COMPRESSION_BENCHMARK_NAME=transaction-compression-20260426-actual ... K6_VUS=8 K6_DURATION=30s tools/test/run-transaction-read-compression-benchmark.sh` → off/on-2kb/on-8kb 모두 status 0
- `MAPPER_PROFILE_NAME=transaction-jdbc-mapper-20260426-actual MAPPER_PROFILE_DURATION=45s PROFILE_BUILD_BACKEND=false ... K6_VUS=8 K6_DURATION=30s tools/test/run-transaction-read-jdbc-mapper-allocation.sh` → k6 status 0, JFR artifact 생성

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: benchmark runner 추가라 운영 runtime 변경은 없습니다. synthetic 100m fixture는 detail 원본 row가 없어 weighted runner의 detail 비중 기본값을 0으로 둡니다.
- 롤백 방법: 이 PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?