### PR TITLE
[Perf] transaction read adaptive admission control 적용

### DIFF
--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControl.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControl.java
@@ -4,7 +4,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ApiAdmissionControl {
@@ -31,11 +30,11 @@ public class ApiAdmissionControl {
     if (endpoint == null) {
       return ApiAdmissionPermit.ignored();
     }
-    if (!endpoint.semaphore().tryAcquire()) {
+    if (!endpoint.tryAcquire()) {
+      endpoint.recordRejection();
       increment(endpoint.group(), "rejected");
       return ApiAdmissionPermit.rejected(endpoint.group(), properties.retryAfterSeconds());
     }
-    endpoint.inFlight().incrementAndGet();
     increment(endpoint.group(), "accepted");
     return ApiAdmissionPermit.acquired(endpoint.group(), endpoint::release);
   }
@@ -64,18 +63,29 @@ public class ApiAdmissionControl {
   }
 
   private record EndpointState(
-      String group, List<String> pathPrefixes, Semaphore semaphore, AtomicInteger inFlight) {
+      String group,
+      List<String> pathPrefixes,
+      ApiAdmissionControlProperties.AdaptiveLimit adaptive,
+      AtomicInteger currentLimit,
+      AtomicInteger inFlight,
+      AtomicInteger healthyCompletions) {
 
     private EndpointState(
         ApiAdmissionControlProperties.EndpointLimit endpoint, MeterRegistry meterRegistry) {
       this(
           endpoint.group(),
           endpoint.pathPrefixes(),
-          new Semaphore(endpoint.maxConcurrency()),
+          endpoint.adaptive(),
+          new AtomicInteger(endpoint.maxConcurrency()),
+          new AtomicInteger(),
           new AtomicInteger());
       Gauge.builder("aquila.api.admission.inflight", inFlight, AtomicInteger::get)
           .tag("group", group)
           .description("endpoint admission control in-flight requests")
+          .register(meterRegistry);
+      Gauge.builder("aquila.api.admission.limit", currentLimit, AtomicInteger::get)
+          .tag("group", group)
+          .description("endpoint admission control current concurrency limit")
           .register(meterRegistry);
     }
 
@@ -83,9 +93,44 @@ public class ApiAdmissionControl {
       return pathPrefixes.stream().anyMatch(path::startsWith);
     }
 
+    private boolean tryAcquire() {
+      while (true) {
+        int current = inFlight.get();
+        if (current >= currentLimit.get()) {
+          return false;
+        }
+        if (inFlight.compareAndSet(current, current + 1)) {
+          return true;
+        }
+      }
+    }
+
+    private void recordRejection() {
+      if (!adaptive.enabled()) {
+        return;
+      }
+      healthyCompletions.set(0);
+      // 429는 이미 포화 신호이므로 다음 요청부터 즉시 낮은 한도로 되돌립니다.
+      currentLimit.updateAndGet(
+          value -> Math.max(adaptive.minConcurrency(), value - adaptive.decreaseOnRejections()));
+    }
+
     private void release() {
       inFlight.decrementAndGet();
-      semaphore.release();
+      recordHealthyCompletion();
+    }
+
+    private void recordHealthyCompletion() {
+      if (!adaptive.enabled() || currentLimit.get() >= adaptive.maxConcurrency()) {
+        return;
+      }
+      int completions = healthyCompletions.incrementAndGet();
+      if (completions < adaptive.increaseEverySuccesses()) {
+        return;
+      }
+      if (healthyCompletions.compareAndSet(completions, 0)) {
+        currentLimit.updateAndGet(value -> Math.min(adaptive.maxConcurrency(), value + 1));
+      }
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
@@ -16,24 +16,29 @@ public record ApiAdmissionControlProperties(
 
   private static List<EndpointLimit> defaultEndpoints() {
     return List.of(
-        new EndpointLimit("transaction-read", 3, List.of("/api/v1/transactions")),
-        new EndpointLimit("account-read", 4, List.of("/api/v1/accounts")),
-        new EndpointLimit("transfer-write", 2, List.of("/api/v1/transfers")),
-        new EndpointLimit("notification-stream", 4, List.of("/api/v1/notifications/stream")),
+        new EndpointLimit(
+            "transaction-read",
+            3,
+            List.of("/api/v1/transactions"),
+            new AdaptiveLimit(true, 3, 8, 200, 1)),
+        new EndpointLimit("account-read", 4, List.of("/api/v1/accounts"), null),
+        new EndpointLimit("transfer-write", 2, List.of("/api/v1/transfers"), null),
+        new EndpointLimit("notification-stream", 4, List.of("/api/v1/notifications/stream"), null),
         new EndpointLimit(
             "notification-read",
             4,
-            List.of("/api/v1/notifications", "/api/v1/notification-preferences")),
+            List.of("/api/v1/notifications", "/api/v1/notification-preferences"),
+            null),
         new EndpointLimit(
             "internal-ops",
             2,
             List.of(
-                "/internal/api/v1/accounts",
-                "/internal/api/v1/ledger",
-                "/internal/api/v1/outbox")));
+                "/internal/api/v1/accounts", "/internal/api/v1/ledger", "/internal/api/v1/outbox"),
+            null));
   }
 
-  public record EndpointLimit(String group, int maxConcurrency, List<String> pathPrefixes) {
+  public record EndpointLimit(
+      String group, int maxConcurrency, List<String> pathPrefixes, AdaptiveLimit adaptive) {
 
     public EndpointLimit {
       if (group == null || group.isBlank()) {
@@ -48,6 +53,44 @@ public record ApiAdmissionControlProperties(
             "ops.api-admission-control path-prefixes must not be empty");
       }
       pathPrefixes = List.copyOf(pathPrefixes);
+      adaptive = adaptive == null ? AdaptiveLimit.disabled(maxConcurrency) : adaptive;
+      if (adaptive.enabled()
+          && (maxConcurrency < adaptive.minConcurrency()
+              || maxConcurrency > adaptive.maxConcurrency())) {
+        throw new IllegalArgumentException(
+            "ops.api-admission-control max-concurrency must be within adaptive bounds");
+      }
+    }
+  }
+
+  public record AdaptiveLimit(
+      Boolean enabled,
+      int minConcurrency,
+      int maxConcurrency,
+      int increaseEverySuccesses,
+      int decreaseOnRejections) {
+
+    public AdaptiveLimit {
+      enabled = enabled == null ? Boolean.FALSE : enabled;
+      if (!enabled) {
+        minConcurrency = minConcurrency > 0 ? minConcurrency : 1;
+        maxConcurrency = maxConcurrency >= minConcurrency ? maxConcurrency : minConcurrency;
+        increaseEverySuccesses = increaseEverySuccesses > 0 ? increaseEverySuccesses : 100;
+        decreaseOnRejections = decreaseOnRejections > 0 ? decreaseOnRejections : 1;
+      } else if (minConcurrency <= 0) {
+        throw new IllegalArgumentException(
+            "ops.api-admission-control adaptive min-concurrency must be positive");
+      } else if (maxConcurrency < minConcurrency) {
+        throw new IllegalArgumentException(
+            "ops.api-admission-control adaptive max-concurrency must be greater than or equal to min-concurrency");
+      } else {
+        increaseEverySuccesses = increaseEverySuccesses > 0 ? increaseEverySuccesses : 100;
+        decreaseOnRejections = decreaseOnRejections > 0 ? decreaseOnRejections : 1;
+      }
+    }
+
+    static AdaptiveLimit disabled(int maxConcurrency) {
+      return new AdaptiveLimit(false, maxConcurrency, maxConcurrency, 100, 1);
     }
   }
 }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -80,6 +80,12 @@ ops:
       - group: transaction-read
         # t3.micro 기본 보호값. high-traffic 승격값은 production gate에서 별도 검증합니다.
         max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX:3}
+        adaptive:
+          enabled: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_ENABLED:true}
+          min-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_MIN:3}
+          max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_MAX:8}
+          increase-every-successes: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_INCREASE_EVERY_SUCCESSES:200}
+          decrease-on-rejections: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_DECREASE_ON_REJECTIONS:1}
         path-prefixes:
           - /api/v1/transactions
       - group: account-read

--- a/back/src/test/java/com/aquilabank/global/ops/ApiAdmissionControlTest.java
+++ b/back/src/test/java/com/aquilabank/global/ops/ApiAdmissionControlTest.java
@@ -91,12 +91,128 @@ class ApiAdmissionControlTest {
         .isNull();
   }
 
+  @Test
+  void raisesAdaptiveLimitWithinBoundAfterHealthyCompletions() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiAdmissionControl admissionControl =
+        new ApiAdmissionControl(adaptiveProperties(1, 1, 2, 2, 1), meterRegistry);
+
+    ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit rejected = admissionControl.tryAcquire("/api/v1/transactions");
+
+    assertThat(first.allowed()).isTrue();
+    assertThat(rejected.allowed()).isFalse();
+    assertCurrentLimit(meterRegistry, 1.0);
+
+    first.release();
+    ApiAdmissionPermit second = admissionControl.tryAcquire("/api/v1/transactions");
+    second.release();
+
+    assertCurrentLimit(meterRegistry, 2.0);
+
+    ApiAdmissionPermit allowedA = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit allowedB = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit rejectedAfterMax = admissionControl.tryAcquire("/api/v1/transactions");
+
+    assertThat(allowedA.allowed()).isTrue();
+    assertThat(allowedB.allowed()).isTrue();
+    assertThat(rejectedAfterMax.allowed()).isFalse();
+
+    allowedA.release();
+    allowedB.release();
+  }
+
+  @Test
+  void lowersAdaptiveLimitAfterRejectedAdmission() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiAdmissionControl admissionControl =
+        new ApiAdmissionControl(adaptiveProperties(2, 1, 3, 100, 1), meterRegistry);
+
+    ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit second = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit rejected = admissionControl.tryAcquire("/api/v1/transactions");
+
+    assertThat(first.allowed()).isTrue();
+    assertThat(second.allowed()).isTrue();
+    assertThat(rejected.allowed()).isFalse();
+    assertCurrentLimit(meterRegistry, 1.0);
+
+    first.release();
+    second.release();
+
+    ApiAdmissionPermit allowed = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit rejectedAfterDecrease = admissionControl.tryAcquire("/api/v1/transactions");
+
+    assertThat(allowed.allowed()).isTrue();
+    assertThat(rejectedAfterDecrease.allowed()).isFalse();
+
+    allowed.release();
+  }
+
+  @Test
+  void disabledAdaptiveBlockDoesNotRequireBounds() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiAdmissionControl admissionControl =
+        new ApiAdmissionControl(
+            new ApiAdmissionControlProperties(
+                true,
+                1,
+                List.of(
+                    new ApiAdmissionControlProperties.EndpointLimit(
+                        "transaction-read",
+                        1,
+                        List.of("/api/v1/transactions"),
+                        new ApiAdmissionControlProperties.AdaptiveLimit(false, 0, 0, 0, 0)))),
+            meterRegistry);
+
+    ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit second = admissionControl.tryAcquire("/api/v1/transactions");
+
+    assertThat(first.allowed()).isTrue();
+    assertThat(second.allowed()).isFalse();
+    assertCurrentLimit(meterRegistry, 1.0);
+
+    first.release();
+  }
+
   private ApiAdmissionControlProperties properties(boolean enabled) {
     return new ApiAdmissionControlProperties(
         enabled,
         1,
         List.of(
             new ApiAdmissionControlProperties.EndpointLimit(
-                "transaction-read", 1, List.of("/api/v1/transactions"))));
+                "transaction-read", 1, List.of("/api/v1/transactions"), null)));
+  }
+
+  private ApiAdmissionControlProperties adaptiveProperties(
+      int maxConcurrency,
+      int minConcurrency,
+      int adaptiveMaxConcurrency,
+      int increaseEverySuccesses,
+      int decreaseOnRejections) {
+    return new ApiAdmissionControlProperties(
+        true,
+        1,
+        List.of(
+            new ApiAdmissionControlProperties.EndpointLimit(
+                "transaction-read",
+                maxConcurrency,
+                List.of("/api/v1/transactions"),
+                new ApiAdmissionControlProperties.AdaptiveLimit(
+                    true,
+                    minConcurrency,
+                    adaptiveMaxConcurrency,
+                    increaseEverySuccesses,
+                    decreaseOnRejections))));
+  }
+
+  private void assertCurrentLimit(SimpleMeterRegistry meterRegistry, double expected) {
+    assertThat(
+            meterRegistry
+                .find("aquila.api.admission.limit")
+                .tag("group", "transaction-read")
+                .gauge()
+                .value())
+        .isEqualTo(expected);
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/ApiAdmissionControlInterceptorTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ApiAdmissionControlInterceptorTest.java
@@ -59,7 +59,7 @@ class ApiAdmissionControlInterceptorTest {
             1,
             List.of(
                 new ApiAdmissionControlProperties.EndpointLimit(
-                    "transaction-read", 1, List.of("/api/v1/transactions")))),
+                    "transaction-read", 1, List.of("/api/v1/transactions"), null))),
         new SimpleMeterRegistry());
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #396

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction-read admission을 bounded adaptive current limit으로 변경했습니다.
- 기본 baseline `3`은 유지하고, healthy completion 누적 시 최대 `8`까지 한 칸씩 상승하며, admission 429 발생 시 즉시 하향합니다.

## 🛠 Changes
- `ApiAdmissionControl`을 fixed semaphore에서 atomic in-flight/current limit 기반으로 변경
- endpoint별 `adaptive` 설정과 `aquila.api.admission.limit` gauge 추가
- transaction-read adaptive 기본값 및 단위/바인딩 테스트 보강

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- RED: `tools/test/with-resource-lock.sh back-gradle-admission-test ./back/gradlew -p back test --tests com.aquilabank.global.ops.ApiAdmissionControlTest` 실패 확인
- GREEN: `tools/test/with-resource-lock.sh back-gradle-admission-test ./back/gradlew -p back test --tests com.aquilabank.global.ops.ApiAdmissionControlTest`
- `tools/test/with-resource-lock.sh back-gradle-context-test ./back/gradlew -p back test --tests com.aquilabank.AquilaBankApplicationTests`
- `./back/gradlew -p back spotlessApply`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`
- pre-commit: `./back/gradlew -p back check`
- `git diff --cached --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: adaptive 상향은 정상 완료 누적 기반이라 실제 HTTP status나 CPU sample을 직접 읽지는 않습니다. Hikari/JVM/thread 포화는 기존 `T3MicroSaturationGuard`가 fail-fast로 유지합니다.
- 롤백 방법: 이 PR commit revert 또는 `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_ENABLED=false`

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?