### PR TITLE
[Perf] transaction read overload 429 ratio gate 추가

### DIFF
--- a/ops/k6/transaction-read-100m.js
+++ b/ops/k6/transaction-read-100m.js
@@ -30,8 +30,12 @@ const coldP95ThresholdMs = Number(__ENV.K6_COLD_P95_THRESHOLD_MS || "750");
 const failedRate = Number(__ENV.K6_HTTP_FAILED_RATE || "0.01");
 const reportName = __ENV.K6_REPORT_NAME || "transaction-100m";
 const overloadMode = booleanEnv(__ENV.K6_OVERLOAD_MODE);
+const overload429RateThreshold = nonNegativeNumberEnv(__ENV.K6_OVERLOAD_429_RATE_THRESHOLD, 0.05);
 const maxRetryAfterSleepSeconds = nonNegativeNumberEnv(__ENV.K6_MAX_RETRY_AFTER_SLEEP_SECONDS, 1);
 const httpFailedRateThreshold = overloadMode ? "disabled in overload mode" : failedRate;
+const overload429RateThresholdText = overloadMode
+  ? overload429RateThreshold
+  : "disabled outside overload mode";
 
 const hotFirst = new Trend("aquila_transaction_hot_first_ms", true);
 const hotCursor = new Trend("aquila_transaction_hot_cursor_ms", true);
@@ -49,6 +53,8 @@ function thresholds() {
   };
   if (!overloadMode) {
     result.http_req_failed = [`rate<${failedRate}`];
+  } else {
+    result.aquila_transaction_429_rate = [`rate<${overload429RateThreshold}`];
   }
   return result;
 }
@@ -261,6 +267,7 @@ function markdownSummary(data) {
 - hot p95 threshold ms: ${hotP95ThresholdMs}
 - cold p95 threshold ms: ${coldP95ThresholdMs}
 - http failed rate threshold: ${httpFailedRateThreshold}
+- overload 429 rate threshold: ${overload429RateThresholdText}
 
 ## Results
 

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -19,6 +19,7 @@ grep -F "backend: aquila-bank-backend:8080 with t3.micro budget" <<<"${plan}" >/
 grep -F "observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-exporter:9187" <<<"${plan}" >/dev/null
 grep -F "k6 report name: transaction-100m-check" <<<"${plan}" >/dev/null
 grep -F "overload mode=false max retry-after sleep seconds=1" <<<"${plan}" >/dev/null
+grep -F "overload 429 rate threshold=0.05" <<<"${plan}" >/dev/null
 grep -F "preflight=true" <<<"${plan}" >/dev/null
 
 overload_plan="$(
@@ -29,6 +30,7 @@ overload_plan="$(
 )"
 grep -F "k6 report name: transaction-100m-overload-check" <<<"${overload_plan}" >/dev/null
 grep -F "overload mode=true max retry-after sleep seconds=2" <<<"${overload_plan}" >/dev/null
+grep -F "overload 429 rate threshold=0.05" <<<"${overload_plan}" >/dev/null
 
 echo "[k6-transaction-100m] k6 script contract"
 grep -F "experimental-prometheus-rw" compose.loadtest.yml >/dev/null
@@ -42,12 +44,21 @@ grep -F "OOMKilled" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "aquila_transaction_hot_first_ms" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "aquila_transaction_cold_cursor_ms" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "K6_OVERLOAD_MODE" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "K6_OVERLOAD_429_RATE_THRESHOLD" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "K6_MAX_RETRY_AFTER_SLEEP_SECONDS" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "aquila_transaction_429_rate" ops/k6/transaction-read-100m.js >/dev/null
+grep -F 'rate<${overload429RateThreshold}' ops/k6/transaction-read-100m.js >/dev/null
 grep -F "Retry-After" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "K6_OVERLOAD_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_OVERLOAD_429_RATE_THRESHOLD" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "handleSummary" ops/k6/transaction-read-100m.js >/dev/null
 grep -F '/reports/${reportName}-summary.md' ops/k6/transaction-read-100m.js >/dev/null
+
+echo "[k6-transaction-100m] invalid input fails"
+if K6_OVERLOAD_429_RATE_THRESHOLD=1.5 tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_OVERLOAD_429_RATE_THRESHOLD=1.5 unexpectedly succeeded" >&2
+  exit 1
+fi
 
 echo "[k6-transaction-100m] archive script"
 temp_dir="$(mktemp -d)"

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -22,6 +22,8 @@ Optional environment:
   K6_ARCHIVE_RESULTS   copy markdown summary to docs/performance-results, default true
   K6_PREFLIGHT         check PostgreSQL OOM/index readiness before k6, default true
   K6_OVERLOAD_MODE     treat 429 as expected rejected samples, default false
+  K6_OVERLOAD_429_RATE_THRESHOLD
+                       max 429 rate in overload mode, default 0.05
   K6_MAX_RETRY_AFTER_SLEEP_SECONDS
                        cap Retry-After backoff in overload mode, default 1
 
@@ -59,6 +61,20 @@ require_non_negative_integer() {
   fi
 }
 
+require_rate() {
+  local name="$1"
+  local value="${!name:-}"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${name} must be a rate between 0 and 1" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0 && value <= 1) }' \
+    || {
+      echo "${name} must be a rate between 0 and 1" >&2
+      exit 1
+    }
+}
+
 mode="run"
 run_dependencies="true"
 while [[ "$#" -gt 0 ]]; do
@@ -89,13 +105,15 @@ K6_LIMIT="${K6_LIMIT:-50}"
 K6_ARCHIVE_RESULTS="${K6_ARCHIVE_RESULTS:-true}"
 K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
 K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE:-false}"
+K6_OVERLOAD_429_RATE_THRESHOLD="${K6_OVERLOAD_429_RATE_THRESHOLD:-0.05}"
 K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${K6_MAX_RETRY_AFTER_SLEEP_SECONDS:-1}"
 K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-$(date +%Y-%m-%d-%H%M%S)}"
-export K6_VUS K6_LIMIT K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OVERLOAD_MODE K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_REPORT_NAME
+export K6_VUS K6_LIMIT K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_REPORT_NAME
 
 require_positive_integer K6_VUS
 require_positive_integer K6_LIMIT
 require_non_negative_integer K6_MAX_RETRY_AFTER_SLEEP_SECONDS
+require_rate K6_OVERLOAD_429_RATE_THRESHOLD
 
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
 report_dir="build/reports/k6"
@@ -110,6 +128,7 @@ print_plan() {
   echo "[k6-transaction-100m] k6 report name: ${K6_REPORT_NAME}"
   echo "[k6-transaction-100m] k6 vus=${K6_VUS} duration=${K6_DURATION:-1m} limit=${K6_LIMIT}"
   echo "[k6-transaction-100m] overload mode=${K6_OVERLOAD_MODE} max retry-after sleep seconds=${K6_MAX_RETRY_AFTER_SLEEP_SECONDS}"
+  echo "[k6-transaction-100m] overload 429 rate threshold=${K6_OVERLOAD_429_RATE_THRESHOLD}"
   echo "[k6-transaction-100m] preflight=${K6_PREFLIGHT}"
   if [[ "${run_dependencies}" == "true" ]]; then
     echo "[k6-transaction-100m] dependencies=compose-default"


### PR DESCRIPTION
## 🔗 Related Issue
- close #398

## 🌿 Base Branch
- `main`

## 📝 Summary
- overload mode에서 `aquila_transaction_429_rate`가 지정 상한을 넘으면 k6 threshold 실패가 나도록 추가했습니다.
- `K6_OVERLOAD_429_RATE_THRESHOLD` 기본값은 `0.05`이며 runner print-plan과 summary에 노출됩니다.

## 🛠 Changes
- k6 overload mode threshold에 `aquila_transaction_429_rate` 연결
- runner env/default/validation/print-plan 추가
- checker에 threshold contract와 invalid rate fail-fast 검증 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- RED: `tools/test/check-k6-transaction-100m-loadtest.sh` 실패 확인
- GREEN: `tools/test/check-k6-transaction-100m-loadtest.sh`
- `bash -n tools/test/run-k6-transaction-100m-loadtest.sh`
- `git diff --cached --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 overload 실험 중 429 비율이 5%를 넘으면 k6가 실패합니다. 탐색 목적이면 `K6_OVERLOAD_429_RATE_THRESHOLD`를 명시적으로 높여 실행할 수 있습니다.
- 롤백 방법: 이 PR commit revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?