### PR TITLE
[Perf] transaction read remote k6 load generator 분리

### DIFF
--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -20,7 +20,25 @@ grep -F "observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-
 grep -F "k6 report name: transaction-100m-check" <<<"${plan}" >/dev/null
 grep -F "overload mode=false max retry-after sleep seconds=1" <<<"${plan}" >/dev/null
 grep -F "overload 429 rate threshold=0.05" <<<"${plan}" >/dev/null
+grep -F "generator mode=local" <<<"${plan}" >/dev/null
+grep -F "generator runner=docker compose service k6-transaction-read-100m" <<<"${plan}" >/dev/null
 grep -F "preflight=true" <<<"${plan}" >/dev/null
+
+remote_plan="$(
+  K6_REPORT_NAME=transaction-100m-remote-check \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=transaction-k6-remote \
+  K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+  K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.10:9090/api/v1/write \
+  K6_REMOTE_WORKDIR=/srv/aquila-bank \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "k6 report name: transaction-100m-remote-check" <<<"${remote_plan}" >/dev/null
+grep -F "generator mode=docker-context" <<<"${remote_plan}" >/dev/null
+grep -F "generator runner=docker --context transaction-k6-remote run grafana/k6:0.54.0" <<<"${remote_plan}" >/dev/null
+grep -F "remote base url=http://192.0.2.10:8080" <<<"${remote_plan}" >/dev/null
+grep -F "remote prometheus rw=http://192.0.2.10:9090/api/v1/write" <<<"${remote_plan}" >/dev/null
+grep -F "remote workdir=/srv/aquila-bank" <<<"${remote_plan}" >/dev/null
 
 overload_plan="$(
   K6_REPORT_NAME=transaction-100m-overload-check \
@@ -51,12 +69,25 @@ grep -F 'rate<${overload429RateThreshold}' ops/k6/transaction-read-100m.js >/dev
 grep -F "Retry-After" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "K6_OVERLOAD_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_OVERLOAD_429_RATE_THRESHOLD" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_GENERATOR_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_DOCKER_CONTEXT" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_REMOTE_BASE_URL" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_REMOTE_PROMETHEUS_RW_SERVER_URL" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_REMOTE_WORKDIR" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "handleSummary" ops/k6/transaction-read-100m.js >/dev/null
 grep -F '/reports/${reportName}-summary.md' ops/k6/transaction-read-100m.js >/dev/null
 
 echo "[k6-transaction-100m] invalid input fails"
 if K6_OVERLOAD_429_RATE_THRESHOLD=1.5 tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
   echo "K6_OVERLOAD_429_RATE_THRESHOLD=1.5 unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_GENERATOR_MODE=unknown tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_GENERATOR_MODE=unknown unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_GENERATOR_MODE=docker-context tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_GENERATOR_MODE=docker-context without remote inputs unexpectedly succeeded" >&2
   exit 1
 fi
 

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -26,6 +26,12 @@ Optional environment:
                        max 429 rate in overload mode, default 0.05
   K6_MAX_RETRY_AFTER_SLEEP_SECONDS
                        cap Retry-After backoff in overload mode, default 1
+  K6_GENERATOR_MODE   local|docker-context, default local
+  K6_DOCKER_CONTEXT   docker context for remote k6 generator, required when mode=docker-context
+  K6_REMOTE_BASE_URL  backend URL reachable from remote k6, required when mode=docker-context
+  K6_REMOTE_PROMETHEUS_RW_SERVER_URL
+                       Prometheus remote-write URL reachable from remote k6, required when mode=docker-context
+  K6_REMOTE_WORKDIR   repo path visible from docker context host, default current working directory
 
 Examples:
   K6_HOT_ACCOUNT_ID=101 K6_HOT_FROM=2026-04-01T00:00:00Z K6_HOT_TO=2026-04-30T00:00:00Z \
@@ -75,6 +81,17 @@ require_rate() {
     }
 }
 
+require_generator_mode() {
+  case "${K6_GENERATOR_MODE}" in
+    local|docker-context)
+      ;;
+    *)
+      echo "K6_GENERATOR_MODE must be local or docker-context" >&2
+      exit 1
+      ;;
+  esac
+}
+
 mode="run"
 run_dependencies="true"
 while [[ "$#" -gt 0 ]]; do
@@ -107,13 +124,25 @@ K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
 K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE:-false}"
 K6_OVERLOAD_429_RATE_THRESHOLD="${K6_OVERLOAD_429_RATE_THRESHOLD:-0.05}"
 K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${K6_MAX_RETRY_AFTER_SLEEP_SECONDS:-1}"
+K6_GENERATOR_MODE="${K6_GENERATOR_MODE:-local}"
+K6_DOCKER_CONTEXT="${K6_DOCKER_CONTEXT:-}"
+K6_REMOTE_BASE_URL="${K6_REMOTE_BASE_URL:-}"
+K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-}"
+K6_REMOTE_WORKDIR="${K6_REMOTE_WORKDIR:-$(pwd)}"
 K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-$(date +%Y-%m-%d-%H%M%S)}"
-export K6_VUS K6_LIMIT K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_REPORT_NAME
+export K6_VUS K6_LIMIT K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
 
 require_positive_integer K6_VUS
 require_positive_integer K6_LIMIT
 require_non_negative_integer K6_MAX_RETRY_AFTER_SLEEP_SECONDS
 require_rate K6_OVERLOAD_429_RATE_THRESHOLD
+require_generator_mode
+
+if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
+  require_env K6_DOCKER_CONTEXT
+  require_env K6_REMOTE_BASE_URL
+  require_env K6_REMOTE_PROMETHEUS_RW_SERVER_URL
+fi
 
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
 report_dir="build/reports/k6"
@@ -129,6 +158,15 @@ print_plan() {
   echo "[k6-transaction-100m] k6 vus=${K6_VUS} duration=${K6_DURATION:-1m} limit=${K6_LIMIT}"
   echo "[k6-transaction-100m] overload mode=${K6_OVERLOAD_MODE} max retry-after sleep seconds=${K6_MAX_RETRY_AFTER_SLEEP_SECONDS}"
   echo "[k6-transaction-100m] overload 429 rate threshold=${K6_OVERLOAD_429_RATE_THRESHOLD}"
+  echo "[k6-transaction-100m] generator mode=${K6_GENERATOR_MODE}"
+  if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
+    echo "[k6-transaction-100m] generator runner=docker --context ${K6_DOCKER_CONTEXT} run grafana/k6:0.54.0"
+    echo "[k6-transaction-100m] remote base url=${K6_REMOTE_BASE_URL}"
+    echo "[k6-transaction-100m] remote prometheus rw=${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}"
+    echo "[k6-transaction-100m] remote workdir=${K6_REMOTE_WORKDIR}"
+  else
+    echo "[k6-transaction-100m] generator runner=docker compose service k6-transaction-read-100m"
+  fi
   echo "[k6-transaction-100m] preflight=${K6_PREFLIGHT}"
   if [[ "${run_dependencies}" == "true" ]]; then
     echo "[k6-transaction-100m] dependencies=compose-default"
@@ -197,26 +235,74 @@ fi
 
 assert_k6_preflight
 
+run_k6_local() {
+  local run_args
+  run_args=(--rm)
+  if [[ "${run_dependencies}" != "true" ]]; then
+    run_args+=(--no-deps)
+  fi
+
+  docker compose "${compose_files[@]}" --profile loadtest run "${run_args[@]}" \
+    -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
+    -e K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
+    -e K6_HOT_FROM="${K6_HOT_FROM}" \
+    -e K6_HOT_TO="${K6_HOT_TO}" \
+    -e K6_COLD_ACCOUNT_ID="${K6_COLD_ACCOUNT_ID}" \
+    -e K6_COLD_FROM="${K6_COLD_FROM}" \
+    -e K6_COLD_TO="${K6_COLD_TO}" \
+    -e K6_AUTH_TOKEN="${K6_AUTH_TOKEN:-}" \
+    -e K6_VUS="${K6_VUS}" \
+    -e K6_DURATION="${K6_DURATION:-1m}" \
+    -e K6_LIMIT="${K6_LIMIT}" \
+    -e K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE}" \
+    -e K6_OVERLOAD_429_RATE_THRESHOLD="${K6_OVERLOAD_429_RATE_THRESHOLD}" \
+    -e K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${K6_MAX_RETRY_AFTER_SLEEP_SECONDS}" \
+    k6-transaction-read-100m
+}
+
+run_k6_docker_context() {
+  local remote_report_dir="${K6_REMOTE_WORKDIR}/build/reports/k6"
+
+  # backend/PostgreSQL CPU와 k6 CPU를 분리하기 위한 별도 Docker context 실행 경로.
+  echo "[k6-transaction-100m] running remote k6 generator on docker context ${K6_DOCKER_CONTEXT}"
+  echo "[k6-transaction-100m] remote reports: ${remote_report_dir}/${K6_REPORT_NAME}-summary.{md,json}"
+
+  docker --context "${K6_DOCKER_CONTEXT}" run --rm \
+    -e BASE_URL="${K6_REMOTE_BASE_URL}" \
+    -e K6_PROMETHEUS_RW_SERVER_URL="${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" \
+    -e K6_PROMETHEUS_RW_TREND_STATS="p(50),p(90),p(95),p(99),min,max,avg" \
+    -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
+    -e K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
+    -e K6_HOT_FROM="${K6_HOT_FROM}" \
+    -e K6_HOT_TO="${K6_HOT_TO}" \
+    -e K6_COLD_ACCOUNT_ID="${K6_COLD_ACCOUNT_ID}" \
+    -e K6_COLD_FROM="${K6_COLD_FROM}" \
+    -e K6_COLD_TO="${K6_COLD_TO}" \
+    -e K6_AUTH_TOKEN="${K6_AUTH_TOKEN:-}" \
+    -e K6_VUS="${K6_VUS}" \
+    -e K6_DURATION="${K6_DURATION:-1m}" \
+    -e K6_LIMIT="${K6_LIMIT}" \
+    -e K6_HOT_P95_THRESHOLD_MS="${K6_HOT_P95_THRESHOLD_MS:-350}" \
+    -e K6_COLD_P95_THRESHOLD_MS="${K6_COLD_P95_THRESHOLD_MS:-750}" \
+    -e K6_HTTP_FAILED_RATE="${K6_HTTP_FAILED_RATE:-0.01}" \
+    -e K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE}" \
+    -e K6_OVERLOAD_429_RATE_THRESHOLD="${K6_OVERLOAD_429_RATE_THRESHOLD}" \
+    -e K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${K6_MAX_RETRY_AFTER_SLEEP_SECONDS}" \
+    -v "${K6_REMOTE_WORKDIR}/ops/k6:/scripts:ro" \
+    -v "${remote_report_dir}:/reports" \
+    grafana/k6:0.54.0 \
+    run \
+    --out \
+    experimental-prometheus-rw \
+    /scripts/transaction-read-100m.js
+}
+
 set +e
-run_args=(--rm)
-if [[ "${run_dependencies}" != "true" ]]; then
-  run_args+=(--no-deps)
+if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
+  run_k6_docker_context
+else
+  run_k6_local
 fi
-docker compose "${compose_files[@]}" --profile loadtest run "${run_args[@]}" \
-  -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
-  -e K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
-  -e K6_HOT_FROM="${K6_HOT_FROM}" \
-  -e K6_HOT_TO="${K6_HOT_TO}" \
-  -e K6_COLD_ACCOUNT_ID="${K6_COLD_ACCOUNT_ID}" \
-  -e K6_COLD_FROM="${K6_COLD_FROM}" \
-  -e K6_COLD_TO="${K6_COLD_TO}" \
-  -e K6_AUTH_TOKEN="${K6_AUTH_TOKEN:-}" \
-  -e K6_VUS="${K6_VUS}" \
-  -e K6_DURATION="${K6_DURATION:-1m}" \
-  -e K6_LIMIT="${K6_LIMIT}" \
-  -e K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE}" \
-  -e K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${K6_MAX_RETRY_AFTER_SLEEP_SECONDS}" \
-  k6-transaction-read-100m
 status=$?
 set -e
 
@@ -224,6 +310,9 @@ if [[ "${K6_ARCHIVE_RESULTS}" == "true" && -f "${summary_md}" ]]; then
   tools/test/archive-k6-transaction-100m-result.sh "${summary_md}" "${summary_json}"
 elif [[ "${K6_ARCHIVE_RESULTS}" == "true" ]]; then
   echo "k6 summary markdown was not produced: ${summary_md}" >&2
+  if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
+    echo "remote generator writes summaries under ${K6_REMOTE_WORKDIR}/build/reports/k6 on docker context ${K6_DOCKER_CONTEXT}" >&2
+  fi
 fi
 
 exit "${status}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #400

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction 100m k6 runner에 `local|docker-context` generator mode를 추가했습니다.
- remote mode에서는 k6만 별도 Docker context에서 실행해 backend/PostgreSQL CPU와 부하 생성기 CPU를 분리합니다.

## 🛠 Changes
- `K6_GENERATOR_MODE=docker-context` 실행 경로 추가
- remote mode 필수값 `K6_DOCKER_CONTEXT`, `K6_REMOTE_BASE_URL`, `K6_REMOTE_PROMETHEUS_RW_SERVER_URL` fail-fast 검증 추가
- `--print-plan`과 checker에 local/remote generator 계약 검증 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `bash -n tools/test/run-k6-transaction-100m-loadtest.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: remote Docker context 호스트에 동일 repo path가 없으면 volume mount가 실패합니다. 이 경우 `K6_REMOTE_WORKDIR`를 context 호스트의 repo path로 지정해야 합니다.
- 롤백 방법: 이 PR revert 후 기존 local compose k6 runner만 사용합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?