### PR TITLE
[Perf] transaction 100m cold-start cache-warm SLO gate 추가

### DIFF
--- a/tools/test/check-transaction-100m-cold-start-cache-warm-gate.sh
+++ b/tools/test/check-transaction-100m-cold-start-cache-warm-gate.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh"
+
+echo "[transaction-100m-cold-warm] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-100m-cold-warm] print plan"
+plan="$(
+  COLD_WARM_NAME=transaction-cold-warm-check \
+  COLD_WARM_COLD_START_DURATION=45s \
+  COLD_WARM_WARMUP_DURATION=60s \
+  COLD_WARM_WARM_READ_DURATION=45s \
+    "${script}" --print-plan
+)"
+grep -F "name=transaction-cold-warm-check" <<<"${plan}" >/dev/null
+grep -F "force_recreate=true" <<<"${plan}" >/dev/null
+grep -F "cold_start_duration=45s" <<<"${plan}" >/dev/null
+grep -F "warmup_duration=60s" <<<"${plan}" >/dev/null
+grep -F "warm_read_duration=45s" <<<"${plan}" >/dev/null
+grep -F "vus=8" <<<"${plan}" >/dev/null
+grep -F "limit=50" <<<"${plan}" >/dev/null
+grep -F "hard_thresholds=true" <<<"${plan}" >/dev/null
+grep -F "cold_start_p95_threshold_ms=1000" <<<"${plan}" >/dev/null
+grep -F "warm_hot_p95_threshold_ms=350" <<<"${plan}" >/dev/null
+grep -F "warm_cold_p95_threshold_ms=750" <<<"${plan}" >/dev/null
+grep -F "transaction_429_rate_threshold=0" <<<"${plan}" >/dev/null
+grep -F "runner=tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" <<<"${plan}" >/dev/null
+grep -F "summary=build/reports/k6/transaction-cold-warm-check/cold-warm-summary.tsv" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-cold-warm] runner contract"
+grep -F "COLD_WARM_FORCE_RECREATE" "${script}" >/dev/null
+grep -F "COLD_WARM_COLD_START_DURATION" "${script}" >/dev/null
+grep -F "COLD_WARM_WARMUP_DURATION" "${script}" >/dev/null
+grep -F "COLD_WARM_WARM_READ_DURATION" "${script}" >/dev/null
+grep -F "COLD_WARM_COLD_START_P95_THRESHOLD_MS" "${script}" >/dev/null
+grep -F "COLD_WARM_WARM_HOT_P95_THRESHOLD_MS" "${script}" >/dev/null
+grep -F "COLD_WARM_WARM_COLD_P95_THRESHOLD_MS" "${script}" >/dev/null
+grep -F "COLD_WARM_429_RATE_THRESHOLD" "${script}" >/dev/null
+grep -F "docker compose" "${script}" >/dev/null
+grep -F -- "--force-recreate" "${script}" >/dev/null
+grep -F "wait_for_backend_readiness" "${script}" >/dev/null
+grep -F "wait_for_prometheus_readiness" "${script}" >/dev/null
+grep -F "run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${script}" >/dev/null
+grep -F "cold-start" "${script}" >/dev/null
+grep -F "warm-read" "${script}" >/dev/null
+grep -F "cold-warm-summary.tsv" "${script}" >/dev/null
+grep -F "check_phase_thresholds" "${script}" >/dev/null
+
+echo "[transaction-100m-cold-warm] invalid input fails"
+if COLD_WARM_COLD_START_DURATION=0m "${script}" --print-plan >/dev/null 2>&1; then
+  echo "COLD_WARM_COLD_START_DURATION=0m unexpectedly succeeded" >&2
+  exit 1
+fi
+if COLD_WARM_VUS=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "COLD_WARM_VUS=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if COLD_WARM_429_RATE_THRESHOLD=1.5 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "COLD_WARM_429_RATE_THRESHOLD=1.5 unexpectedly succeeded" >&2
+  exit 1
+fi
+if COLD_WARM_FORCE_RECREATE=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "COLD_WARM_FORCE_RECREATE=maybe unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh
+++ b/tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh [--print-plan]
+
+Required runtime environment for actual runs:
+  K6_HOT_ACCOUNT_ID
+  K6_HOT_FROM
+  K6_HOT_TO
+  K6_COLD_ACCOUNT_ID
+  K6_COLD_FROM
+  K6_COLD_TO
+
+Optional environment:
+  COLD_WARM_NAME                         default transaction-100m-cold-warm-<timestamp>
+  COLD_WARM_BUILD_BACKEND                default true
+  COLD_WARM_FORCE_RECREATE               default true
+  COLD_WARM_COLD_START_DURATION          default 1m
+  COLD_WARM_WARMUP_DURATION              default 2m
+  COLD_WARM_WARM_READ_DURATION           default 1m
+  COLD_WARM_VUS                          default 8
+  COLD_WARM_LIMIT                        default 50
+  COLD_WARM_READINESS_TIMEOUT_SECONDS    default 120
+  COLD_WARM_HARD_THRESHOLD_ENABLED       default true
+  COLD_WARM_COLD_START_P95_THRESHOLD_MS  default 1000
+  COLD_WARM_WARM_HOT_P95_THRESHOLD_MS    default 350
+  COLD_WARM_WARM_COLD_P95_THRESHOLD_MS   default 750
+  COLD_WARM_429_RATE_THRESHOLD           default 0
+
+Examples:
+  tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh --print-plan
+  COLD_WARM_WARMUP_DURATION=5m tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${COLD_WARM_NAME:-transaction-100m-cold-warm-$(date +%Y-%m-%d-%H%M%S)}"
+build_backend="${COLD_WARM_BUILD_BACKEND:-true}"
+force_recreate="${COLD_WARM_FORCE_RECREATE:-true}"
+cold_start_duration="${COLD_WARM_COLD_START_DURATION:-1m}"
+warmup_duration="${COLD_WARM_WARMUP_DURATION:-2m}"
+warm_read_duration="${COLD_WARM_WARM_READ_DURATION:-1m}"
+vus="${COLD_WARM_VUS:-8}"
+limit="${COLD_WARM_LIMIT:-50}"
+readiness_timeout_seconds="${COLD_WARM_READINESS_TIMEOUT_SECONDS:-120}"
+hard_threshold_enabled="${COLD_WARM_HARD_THRESHOLD_ENABLED:-true}"
+cold_start_p95_threshold_ms="${COLD_WARM_COLD_START_P95_THRESHOLD_MS:-1000}"
+warm_hot_p95_threshold_ms="${COLD_WARM_WARM_HOT_P95_THRESHOLD_MS:-350}"
+warm_cold_p95_threshold_ms="${COLD_WARM_WARM_COLD_P95_THRESHOLD_MS:-750}"
+transaction_429_rate_threshold="${COLD_WARM_429_RATE_THRESHOLD:-0}"
+backend_health_url="${COLD_WARM_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
+prometheus_url="${PROMETHEUS_URL:-http://localhost:9090}"
+prometheus_base_url="${prometheus_url%/}"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+report_dir="build/reports/k6/${name}"
+summary_tsv="${report_dir}/cold-warm-summary.tsv"
+threshold_failed=false
+
+require_bool_value() {
+  local key="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${key} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${key} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_number_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${key} must be a positive number: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value > 0) }' \
+    || {
+      echo "${key} must be greater than zero: ${value}" >&2
+      exit 1
+    }
+}
+
+require_rate_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${key} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0 && value <= 1) }' \
+    || {
+      echo "${key} must be a rate between 0 and 1: ${value}" >&2
+      exit 1
+    }
+}
+
+require_duration_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*(s|m|h)$ ]]; then
+    echo "${key} must use a positive duration such as 60s, 30m, or 1h: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_env() {
+  local key="$1"
+  local value="${!key:-}"
+  if [[ -z "${value}" ]]; then
+    echo "${key} is required" >&2
+    exit 1
+  fi
+}
+
+require_bool_value "COLD_WARM_BUILD_BACKEND" "${build_backend}"
+require_bool_value "COLD_WARM_FORCE_RECREATE" "${force_recreate}"
+require_bool_value "COLD_WARM_HARD_THRESHOLD_ENABLED" "${hard_threshold_enabled}"
+require_duration_value "COLD_WARM_COLD_START_DURATION" "${cold_start_duration}"
+require_duration_value "COLD_WARM_WARMUP_DURATION" "${warmup_duration}"
+require_duration_value "COLD_WARM_WARM_READ_DURATION" "${warm_read_duration}"
+require_positive_integer_value "COLD_WARM_VUS" "${vus}"
+require_positive_integer_value "COLD_WARM_LIMIT" "${limit}"
+require_positive_integer_value "COLD_WARM_READINESS_TIMEOUT_SECONDS" "${readiness_timeout_seconds}"
+require_positive_number_value "COLD_WARM_COLD_START_P95_THRESHOLD_MS" "${cold_start_p95_threshold_ms}"
+require_positive_number_value "COLD_WARM_WARM_HOT_P95_THRESHOLD_MS" "${warm_hot_p95_threshold_ms}"
+require_positive_number_value "COLD_WARM_WARM_COLD_P95_THRESHOLD_MS" "${warm_cold_p95_threshold_ms}"
+require_rate_value "COLD_WARM_429_RATE_THRESHOLD" "${transaction_429_rate_threshold}"
+
+print_plan() {
+  echo "[transaction-100m-cold-warm] name=${name}"
+  echo "[transaction-100m-cold-warm] build_backend=${build_backend}"
+  echo "[transaction-100m-cold-warm] force_recreate=${force_recreate}"
+  echo "[transaction-100m-cold-warm] cold_start_duration=${cold_start_duration}"
+  echo "[transaction-100m-cold-warm] warmup_duration=${warmup_duration}"
+  echo "[transaction-100m-cold-warm] warm_read_duration=${warm_read_duration}"
+  echo "[transaction-100m-cold-warm] vus=${vus}"
+  echo "[transaction-100m-cold-warm] limit=${limit}"
+  echo "[transaction-100m-cold-warm] backend_health_url=${backend_health_url}"
+  echo "[transaction-100m-cold-warm] prometheus_url=${prometheus_url}"
+  echo "[transaction-100m-cold-warm] readiness_timeout_seconds=${readiness_timeout_seconds}"
+  echo "[transaction-100m-cold-warm] hard_thresholds=${hard_threshold_enabled}"
+  echo "[transaction-100m-cold-warm] cold_start_p95_threshold_ms=${cold_start_p95_threshold_ms}"
+  echo "[transaction-100m-cold-warm] warm_hot_p95_threshold_ms=${warm_hot_p95_threshold_ms}"
+  echo "[transaction-100m-cold-warm] warm_cold_p95_threshold_ms=${warm_cold_p95_threshold_ms}"
+  echo "[transaction-100m-cold-warm] transaction_429_rate_threshold=${transaction_429_rate_threshold}"
+  echo "[transaction-100m-cold-warm] runner=tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps"
+  echo "[transaction-100m-cold-warm] summary=${summary_tsv}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+require_env K6_HOT_ACCOUNT_ID
+require_env K6_HOT_FROM
+require_env K6_HOT_TO
+require_env K6_COLD_ACCOUNT_ID
+require_env K6_COLD_FROM
+require_env K6_COLD_TO
+
+mkdir -p "${report_dir}" build/reports/k6
+
+metric_from_json() {
+  local json_path="$1"
+  local metric="$2"
+  local value_name="$3"
+  if [[ ! -f "${json_path}" ]] || ! command -v jq >/dev/null 2>&1; then
+    echo "n/a"
+    return 0
+  fi
+  jq -r --arg metric "${metric}" --arg value_name "${value_name}" \
+    '.metrics[$metric].values[$value_name] // "n/a"' "${json_path}"
+}
+
+wait_for_backend_readiness() {
+  local deadline=$((SECONDS + readiness_timeout_seconds))
+  local body=""
+  echo "[transaction-100m-cold-warm] waiting backend readiness: ${backend_health_url}"
+  while ((SECONDS < deadline)); do
+    body="$(curl -sS --max-time 2 "${backend_health_url}" 2>/dev/null || true)"
+    # 전체 health는 optional runtime 때문에 DOWN일 수 있어 readinessState만 확인합니다.
+    if grep -F '"readinessState":{"status":"UP"}' <<<"${body}" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "backend readiness timeout: ${backend_health_url}" >&2
+  [[ -z "${body}" ]] || echo "${body}" >&2
+  exit 1
+}
+
+wait_for_prometheus_readiness() {
+  local deadline=$((SECONDS + readiness_timeout_seconds))
+  echo "[transaction-100m-cold-warm] waiting prometheus readiness: ${prometheus_base_url}/-/ready"
+  while ((SECONDS < deadline)); do
+    if curl -fsS --max-time 2 "${prometheus_base_url}/-/ready" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "prometheus readiness timeout: ${prometheus_base_url}/-/ready" >&2
+  exit 1
+}
+
+write_header() {
+  printf "phase\tstatus\tvus\tduration\tlimit\thttp_failed_rate\thttp_reqs\ttransaction_429_rate\thot_first_p95_ms\thot_cursor_p95_ms\tcold_first_p95_ms\tcold_cursor_p95_ms\tlog_path\tsummary_json\n" >"${summary_tsv}"
+}
+
+append_summary() {
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$@" >>"${summary_tsv}"
+}
+
+is_numeric_value() {
+  [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+}
+
+number_greater_than() {
+  local value="$1"
+  local threshold="$2"
+  awk -v value="${value}" -v threshold="${threshold}" 'BEGIN { exit !(value > threshold) }'
+}
+
+record_threshold_violation() {
+  local phase="$1"
+  local metric="$2"
+  local value="$3"
+  local threshold="$4"
+  echo "[transaction-100m-cold-warm] threshold violation phase=${phase} metric=${metric} value=${value} threshold=${threshold}" >&2
+  threshold_failed=true
+}
+
+check_metric_lte() {
+  local phase="$1"
+  local metric="$2"
+  local value="$3"
+  local threshold="$4"
+
+  if ! is_numeric_value "${value}"; then
+    record_threshold_violation "${phase}" "${metric}" "${value}" "${threshold}"
+    return 0
+  fi
+  if number_greater_than "${value}" "${threshold}"; then
+    record_threshold_violation "${phase}" "${metric}" "${value}" "${threshold}"
+  fi
+}
+
+check_phase_thresholds() {
+  local phase="$1"
+  local status="$2"
+  local transaction_429_rate="$3"
+  local hot_first_p95="$4"
+  local hot_cursor_p95="$5"
+  local cold_first_p95="$6"
+  local cold_cursor_p95="$7"
+
+  if [[ "${hard_threshold_enabled}" != "true" ]]; then
+    return 0
+  fi
+
+  if [[ "${status}" -ne 0 ]]; then
+    record_threshold_violation "${phase}" "k6_status" "${status}" "0"
+  fi
+
+  check_metric_lte "${phase}" "transaction_429_rate" "${transaction_429_rate}" "${transaction_429_rate_threshold}"
+  if [[ "${phase}" == "cold-start" ]]; then
+    check_metric_lte "${phase}" "hot_first_p95_ms" "${hot_first_p95}" "${cold_start_p95_threshold_ms}"
+    check_metric_lte "${phase}" "hot_cursor_p95_ms" "${hot_cursor_p95}" "${cold_start_p95_threshold_ms}"
+    check_metric_lte "${phase}" "cold_first_p95_ms" "${cold_first_p95}" "${cold_start_p95_threshold_ms}"
+    check_metric_lte "${phase}" "cold_cursor_p95_ms" "${cold_cursor_p95}" "${cold_start_p95_threshold_ms}"
+  else
+    check_metric_lte "${phase}" "hot_first_p95_ms" "${hot_first_p95}" "${warm_hot_p95_threshold_ms}"
+    check_metric_lte "${phase}" "hot_cursor_p95_ms" "${hot_cursor_p95}" "${warm_hot_p95_threshold_ms}"
+    check_metric_lte "${phase}" "cold_first_p95_ms" "${cold_first_p95}" "${warm_cold_p95_threshold_ms}"
+    check_metric_lte "${phase}" "cold_cursor_p95_ms" "${cold_cursor_p95}" "${warm_cold_p95_threshold_ms}"
+  fi
+}
+
+start_loadtest_services() {
+  local args
+  args=(docker compose "${compose_files[@]}" --profile loadtest up -d)
+  if [[ "${force_recreate}" == "true" ]]; then
+    args+=(--force-recreate)
+  fi
+  args+=(postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter)
+  "${args[@]}"
+}
+
+run_k6_phase() {
+  local phase="$1"
+  local duration="$2"
+  local report_name="${name}-${phase}"
+  local log_path="${report_dir}/${report_name}.log"
+  local summary_json="build/reports/k6/${report_name}-summary.json"
+  local status http_failed_rate http_reqs transaction_429_rate
+  local hot_first_p95 hot_cursor_p95 cold_first_p95 cold_cursor_p95
+
+  echo "[transaction-100m-cold-warm] running phase=${phase} duration=${duration}"
+  set +e
+  K6_REPORT_NAME="${report_name}" \
+  K6_VUS="${vus}" \
+  K6_DURATION="${duration}" \
+  K6_LIMIT="${limit}" \
+  K6_OVERLOAD_MODE=false \
+  K6_ARCHIVE_RESULTS=false \
+    tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${log_path}" 2>&1
+  status=$?
+  set -e
+
+  http_failed_rate="$(metric_from_json "${summary_json}" "http_req_failed" "rate")"
+  http_reqs="$(metric_from_json "${summary_json}" "http_reqs" "count")"
+  transaction_429_rate="$(metric_from_json "${summary_json}" "aquila_transaction_429_rate" "rate")"
+  hot_first_p95="$(metric_from_json "${summary_json}" "aquila_transaction_hot_first_ms" "p(95)")"
+  hot_cursor_p95="$(metric_from_json "${summary_json}" "aquila_transaction_hot_cursor_ms" "p(95)")"
+  cold_first_p95="$(metric_from_json "${summary_json}" "aquila_transaction_cold_first_ms" "p(95)")"
+  cold_cursor_p95="$(metric_from_json "${summary_json}" "aquila_transaction_cold_cursor_ms" "p(95)")"
+
+  append_summary \
+    "${phase}" "${status}" "${vus}" "${duration}" "${limit}" \
+    "${http_failed_rate}" "${http_reqs}" "${transaction_429_rate}" \
+    "${hot_first_p95}" "${hot_cursor_p95}" "${cold_first_p95}" "${cold_cursor_p95}" \
+    "${log_path}" "${summary_json}"
+
+  check_phase_thresholds \
+    "${phase}" "${status}" "${transaction_429_rate}" \
+    "${hot_first_p95}" "${hot_cursor_p95}" "${cold_first_p95}" "${cold_cursor_p95}"
+}
+
+run_warmup() {
+  local report_name="${name}-warmup"
+  local log_path="${report_dir}/${report_name}.log"
+  local status
+
+  echo "[transaction-100m-cold-warm] running phase=warmup duration=${warmup_duration}"
+  set +e
+  K6_REPORT_NAME="${report_name}" \
+  K6_VUS="${vus}" \
+  K6_DURATION="${warmup_duration}" \
+  K6_LIMIT="${limit}" \
+  K6_OVERLOAD_MODE=false \
+  K6_ARCHIVE_RESULTS=false \
+    tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${log_path}" 2>&1
+  status=$?
+  set -e
+
+  if [[ "${hard_threshold_enabled}" == "true" && "${status}" -ne 0 ]]; then
+    record_threshold_violation "warmup" "k6_status" "${status}" "0"
+  fi
+}
+
+if [[ "${build_backend}" == "true" ]]; then
+  echo "[transaction-100m-cold-warm] building backend bootJar"
+  tools/test/with-resource-lock.sh back-gradle-loadtest-bootjar ./back/gradlew -p back bootJar
+fi
+
+start_loadtest_services
+wait_for_backend_readiness
+wait_for_prometheus_readiness
+
+write_header
+run_k6_phase "cold-start" "${cold_start_duration}"
+run_warmup
+run_k6_phase "warm-read" "${warm_read_duration}"
+
+echo "[transaction-100m-cold-warm] summary=${summary_tsv}"
+if [[ "${threshold_failed}" == "true" ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #402

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction 100m read에 cold-start와 cache-warm 이후 warm-read를 분리 측정하는 SLO gate runner를 추가했습니다.
- 재기동 직후 cold p95와 warm 이후 hot/cold p95, 429 rate를 TSV로 고정하고 threshold 초과 시 실패합니다.

## 🛠 Changes
- `run-transaction-100m-cold-start-cache-warm-gate.sh` 신규 추가
- `cold-warm-summary.tsv` 생성 및 k6 summary JSON metric 추출 추가
- runner 계약/invalid input checker 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-cold-start-cache-warm-gate.sh`
- `bash -n tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 실제 1억 fixture 환경에서 cold-start threshold 기본값 1000ms가 환경에 따라 조정이 필요할 수 있습니다.
- 롤백 방법: 이 PR revert 후 기존 capacity/k6 runner만 사용합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?