### PR TITLE
[Perf] transaction read JDBC mapper low-allocation 최적화

### DIFF
--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionArchiveReadRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionArchiveReadRepository.java
@@ -1,15 +1,10 @@
 package com.aquilabank.global.persistence.transaction;
 
 import com.aquilabank.domain.transaction.model.TransactionCursor;
-import com.aquilabank.domain.transaction.model.TransactionDirection;
 import com.aquilabank.domain.transaction.model.TransactionQuery;
 import com.aquilabank.domain.transaction.model.TransactionSlice;
-import com.aquilabank.domain.transaction.model.TransactionStatus;
 import com.aquilabank.domain.transaction.model.TransactionSummary;
 import com.aquilabank.domain.transaction.port.TransactionArchiveReadPort;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -22,7 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public class JdbcTransactionArchiveReadRepository implements TransactionArchiveReadPort {
 
-  private static final RowMapper<TransactionSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
+  private static final RowMapper<TransactionSummary> ROW_MAPPER =
+      TransactionSummaryRowMapper.INSTANCE;
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -44,22 +40,6 @@ public class JdbcTransactionArchiveReadRepository implements TransactionArchiveR
         hasNext ? new ArrayList<>(rows.subList(0, query.limit())) : rows;
     TransactionCursor nextCursor = hasNext ? toCursor(items.getLast()) : null;
     return new TransactionSlice(items, nextCursor, hasNext, query.limit());
-  }
-
-  private static TransactionSummary mapRow(ResultSet rs) throws SQLException {
-    OffsetDateTime bookedAt = rs.getObject("booked_at", OffsetDateTime.class);
-    return new TransactionSummary(
-        rs.getLong("id"),
-        rs.getLong("account_id"),
-        rs.getString("transaction_reference"),
-        TransactionDirection.valueOf(rs.getString("direction")),
-        TransactionStatus.valueOf(rs.getString("transaction_status")),
-        rs.getLong("amount_minor"),
-        rs.getLong("balance_after_minor"),
-        rs.getString("currency_code"),
-        rs.getString("summary"),
-        rs.getString("counterparty_masked_name"),
-        bookedAt.toInstant());
   }
 
   private static TransactionCursor toCursor(TransactionSummary item) {

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/JdbcTransactionReadRepository.java
@@ -1,17 +1,12 @@
 package com.aquilabank.global.persistence.transaction;
 
 import com.aquilabank.domain.transaction.model.TransactionCursor;
-import com.aquilabank.domain.transaction.model.TransactionDirection;
 import com.aquilabank.domain.transaction.model.TransactionQuery;
 import com.aquilabank.domain.transaction.model.TransactionSlice;
-import com.aquilabank.domain.transaction.model.TransactionStatus;
 import com.aquilabank.domain.transaction.model.TransactionSummary;
 import com.aquilabank.domain.transaction.port.TransactionReadPort;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -24,7 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public class JdbcTransactionReadRepository implements TransactionReadPort {
 
-  private static final RowMapper<TransactionSummary> ROW_MAPPER = (rs, rowNum) -> mapRow(rs);
+  private static final RowMapper<TransactionSummary> ROW_MAPPER =
+      TransactionSummaryRowMapper.INSTANCE;
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
   private final MeterRegistry meterRegistry;
@@ -63,22 +59,6 @@ public class JdbcTransactionReadRepository implements TransactionReadPort {
               "outcome",
               outcome));
     }
-  }
-
-  private static TransactionSummary mapRow(ResultSet rs) throws SQLException {
-    OffsetDateTime bookedAt = rs.getObject("booked_at", OffsetDateTime.class);
-    return new TransactionSummary(
-        rs.getLong("id"),
-        rs.getLong("account_id"),
-        rs.getString("transaction_reference"),
-        TransactionDirection.valueOf(rs.getString("direction")),
-        TransactionStatus.valueOf(rs.getString("transaction_status")),
-        rs.getLong("amount_minor"),
-        rs.getLong("balance_after_minor"),
-        rs.getString("currency_code"),
-        rs.getString("summary"),
-        rs.getString("counterparty_masked_name"),
-        bookedAt.toInstant());
   }
 
   private static TransactionCursor toCursor(TransactionSummary item) {

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionSummaryRowMapper.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionSummaryRowMapper.java
@@ -1,0 +1,52 @@
+package com.aquilabank.global.persistence.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.model.TransactionSummary;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import org.springframework.jdbc.core.RowMapper;
+
+/** 1억 row read path에서 enum directory HashMap lookup을 피하는 bounded mapper */
+final class TransactionSummaryRowMapper implements RowMapper<TransactionSummary> {
+
+  static final TransactionSummaryRowMapper INSTANCE = new TransactionSummaryRowMapper();
+
+  private TransactionSummaryRowMapper() {}
+
+  @Override
+  public TransactionSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
+    OffsetDateTime bookedAt = rs.getObject("booked_at", OffsetDateTime.class);
+    return new TransactionSummary(
+        rs.getLong("id"),
+        rs.getLong("account_id"),
+        rs.getString("transaction_reference"),
+        direction(rs.getString("direction")),
+        status(rs.getString("transaction_status")),
+        rs.getLong("amount_minor"),
+        rs.getLong("balance_after_minor"),
+        rs.getString("currency_code"),
+        rs.getString("summary"),
+        rs.getString("counterparty_masked_name"),
+        bookedAt.toInstant());
+  }
+
+  private static TransactionDirection direction(String value) throws SQLException {
+    return switch (value) {
+      case "DEBIT" -> TransactionDirection.DEBIT;
+      case "CREDIT" -> TransactionDirection.CREDIT;
+      default -> throw new SQLException("Unknown transaction direction: " + value);
+    };
+  }
+
+  private static TransactionStatus status(String value) throws SQLException {
+    return switch (value) {
+      case "PENDING" -> TransactionStatus.PENDING;
+      case "BOOKED" -> TransactionStatus.BOOKED;
+      case "PARTIALLY_REVERSED" -> TransactionStatus.PARTIALLY_REVERSED;
+      case "REVERSED" -> TransactionStatus.REVERSED;
+      default -> throw new SQLException("Unknown transaction status: " + value);
+    };
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/TransactionSummaryRowMapperTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/TransactionSummaryRowMapperTest.java
@@ -1,0 +1,71 @@
+package com.aquilabank.global.persistence.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.transaction.model.TransactionDirection;
+import com.aquilabank.domain.transaction.model.TransactionStatus;
+import com.aquilabank.domain.transaction.model.TransactionSummary;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class TransactionSummaryRowMapperTest {
+
+  @Test
+  void mapsTransactionSummaryWithoutEnumValueOfLookup() throws Exception {
+    ResultSet rs = resultSet("CREDIT", "BOOKED");
+
+    TransactionSummary item = TransactionSummaryRowMapper.INSTANCE.mapRow(rs, 0);
+
+    assertThat(item.id()).isEqualTo(11L);
+    assertThat(item.accountId()).isEqualTo(101L);
+    assertThat(item.transactionReference()).isEqualTo("TRX-11");
+    assertThat(item.direction()).isEqualTo(TransactionDirection.CREDIT);
+    assertThat(item.status()).isEqualTo(TransactionStatus.BOOKED);
+    assertThat(item.amountMinor()).isEqualTo(12_300L);
+    assertThat(item.balanceAfterMinor()).isEqualTo(45_600L);
+    assertThat(item.currencyCode()).isEqualTo("KRW");
+    assertThat(item.summary()).isEqualTo("salary");
+    assertThat(item.counterpartyMaskedName()).isEqualTo("A***");
+    assertThat(item.bookedAt()).isEqualTo(OffsetDateTime.parse("2026-04-26T10:15:30Z").toInstant());
+  }
+
+  @Test
+  void rejectsUnknownDirection() throws Exception {
+    ResultSet rs = resultSet("UNKNOWN", "BOOKED");
+
+    assertThatThrownBy(() -> TransactionSummaryRowMapper.INSTANCE.mapRow(rs, 0))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("Unknown transaction direction");
+  }
+
+  @Test
+  void rejectsUnknownStatus() throws Exception {
+    ResultSet rs = resultSet("CREDIT", "UNKNOWN");
+
+    assertThatThrownBy(() -> TransactionSummaryRowMapper.INSTANCE.mapRow(rs, 0))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("Unknown transaction status");
+  }
+
+  private static ResultSet resultSet(String direction, String status) throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getLong("id")).thenReturn(11L);
+    when(rs.getLong("account_id")).thenReturn(101L);
+    when(rs.getString("transaction_reference")).thenReturn("TRX-11");
+    when(rs.getString("direction")).thenReturn(direction);
+    when(rs.getString("transaction_status")).thenReturn(status);
+    when(rs.getLong("amount_minor")).thenReturn(12_300L);
+    when(rs.getLong("balance_after_minor")).thenReturn(45_600L);
+    when(rs.getString("currency_code")).thenReturn("KRW");
+    when(rs.getString("summary")).thenReturn("salary");
+    when(rs.getString("counterparty_masked_name")).thenReturn("A***");
+    when(rs.getObject("booked_at", OffsetDateTime.class))
+        .thenReturn(OffsetDateTime.parse("2026-04-26T10:15:30Z"));
+    return rs;
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #406

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction read/archive repository의 중복 row mapper를 공통 `TransactionSummaryRowMapper`로 분리했습니다.
- row마다 반복되던 direction/status `Enum.valueOf` lookup을 bounded switch로 바꿔 mapper hot path allocation/lookup 비용을 줄였습니다.

## 🛠 Changes
- 공통 `TransactionSummaryRowMapper` 추가
- timeline/archive repository가 공통 mapper를 사용하도록 변경
- unknown direction/status 실패 테스트 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-test-mapper ./back/gradlew -p back test --tests com.aquilabank.global.persistence.transaction.TransactionSummaryRowMapperTest`
- `tools/test/with-resource-lock.sh back-check ./back/gradlew -p back check`
- commit hook: `./back/gradlew -p back check`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: DB에 domain enum과 다른 값이 들어 있으면 기존 `Enum.valueOf`와 동일하게 실패하지만 예외 타입/메시지는 `SQLException`으로 바뀝니다. 정상 데이터 경로의 API schema는 변경 없습니다.
- 롤백 방법: 이 PR revert 후 repository별 기존 mapper로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?