### PR TITLE
[Build] Kafka loadtest 및 interference gate 재현성 보정

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -25,7 +25,7 @@ services:
       start_period: 10s
 
   kafka:
-    image: bitnami/kafka:4.2
+    image: ${KAFKA_IMAGE:-bitnamilegacy/kafka:4.0.0-debian-12-r10}
     container_name: aquila-bank-kafka
     restart: unless-stopped
     ports:

--- a/tools/test/check-transaction-100m-read-write-interference-gate.sh
+++ b/tools/test/check-transaction-100m-read-write-interference-gate.sh
@@ -25,16 +25,36 @@ grep -F "write_vus=2" <<<"${plan}" >/dev/null
 grep -F "write_amount_minor=1" <<<"${plan}" >/dev/null
 grep -F "read_hot_p95_threshold_ms=350" <<<"${plan}" >/dev/null
 grep -F "read_cold_p95_threshold_ms=750" <<<"${plan}" >/dev/null
+grep -F "read_overload_mode=false" <<<"${plan}" >/dev/null
 grep -F "read_429_rate_threshold=0" <<<"${plan}" >/dev/null
+grep -F "read_overload_429_rate_threshold=0.05" <<<"${plan}" >/dev/null
 grep -F "write_429_rate_threshold=0.05" <<<"${plan}" >/dev/null
 grep -F "services=postgres,kafka,aquila-bank-backend,prometheus,grafana,alertmanager,postgres-exporter" <<<"${plan}" >/dev/null
+grep -F "write_fixture_enabled=true" <<<"${plan}" >/dev/null
+grep -F "write_fixture_cleanup=true" <<<"${plan}" >/dev/null
+grep -F "write_source_account_id=920000001" <<<"${plan}" >/dev/null
+grep -F "write_target_account_id=920000002" <<<"${plan}" >/dev/null
 grep -F "summary=build/reports/k6/transaction-interference-check/read-write-interference-summary.tsv" <<<"${plan}" >/dev/null
 
+overload_plan="$(
+  INTERFERENCE_NAME=transaction-interference-overload-check \
+  INTERFERENCE_READ_OVERLOAD_MODE=true \
+    "${runner}" --print-plan
+)"
+grep -F "read_overload_mode=true" <<<"${overload_plan}" >/dev/null
+grep -F "read_429_rate_threshold=0.05" <<<"${overload_plan}" >/dev/null
+
 echo "[transaction-read-write-interference] runner contract"
+grep -F "bootstrap_write_fixture" "${runner}" >/dev/null
+grep -F "cleanup_write_fixture" "${runner}" >/dev/null
+grep -F "OVERRIDING SYSTEM VALUE" "${runner}" >/dev/null
+grep -F "INTERFERENCE_WRITE_FIXTURE_ENABLED" "${runner}" >/dev/null
 grep -F "KAFKA_ADVERTISED_HOST=kafka" "${runner}" >/dev/null
 grep -F "OUTBOX_KAFKA_ENABLED=true" "${runner}" >/dev/null
 grep -F "NOTIFICATION_INBOX_CONSUMER_ENABLED=true" "${runner}" >/dev/null
 grep -F "KAFKA_TOPIC_PROVISIONING_ENABLED=true" "${runner}" >/dev/null
+grep -F 'K6_OVERLOAD_MODE="${read_overload_mode}"' "${runner}" >/dev/null
+grep -F 'K6_OVERLOAD_429_RATE_THRESHOLD="${read_overload_429_rate_threshold}"' "${runner}" >/dev/null
 grep -F "run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${runner}" >/dev/null
 grep -F "transfer-write-interference.js" "${runner}" >/dev/null
 grep -F "read-write-interference-summary.tsv" "${runner}" >/dev/null
@@ -68,5 +88,13 @@ if INTERFERENCE_WRITE_VUS=0 "${runner}" --print-plan >/dev/null 2>&1; then
 fi
 if INTERFERENCE_WRITE_429_RATE_THRESHOLD=1.5 "${runner}" --print-plan >/dev/null 2>&1; then
   echo "INTERFERENCE_WRITE_429_RATE_THRESHOLD=1.5 unexpectedly succeeded" >&2
+  exit 1
+fi
+if INTERFERENCE_READ_OVERLOAD_MODE=maybe "${runner}" --print-plan >/dev/null 2>&1; then
+  echo "INTERFERENCE_READ_OVERLOAD_MODE=maybe unexpectedly succeeded" >&2
+  exit 1
+fi
+if INTERFERENCE_READ_OVERLOAD_429_RATE_THRESHOLD=1.5 "${runner}" --print-plan >/dev/null 2>&1; then
+  echo "INTERFERENCE_READ_OVERLOAD_429_RATE_THRESHOLD=1.5 unexpectedly succeeded" >&2
   exit 1
 fi

--- a/tools/test/check-transaction-100m-read-write-interference-gate.sh
+++ b/tools/test/check-transaction-100m-read-write-interference-gate.sh
@@ -52,6 +52,7 @@ grep -F "aquila_transfer_write_duration_ms" "${write_script}" >/dev/null
 grep -F "Retry-After" "${write_script}" >/dev/null
 
 echo "[transaction-read-write-interference] compose kafka override"
+grep -F 'image: ${KAFKA_IMAGE:-bitnamilegacy/kafka:4.0.0-debian-12-r10}' compose.yml >/dev/null
 grep -F 'KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://${KAFKA_ADVERTISED_HOST:-localhost}:${KAFKA_PORT:-9092}' compose.yml >/dev/null
 grep -F 'OUTBOX_KAFKA_BOOTSTRAP_SERVERS: ${OUTBOX_KAFKA_BOOTSTRAP_SERVERS:-}' compose.loadtest.yml >/dev/null
 grep -F 'NOTIFICATION_INBOX_CONSUMER_BOOTSTRAP_SERVERS: ${NOTIFICATION_INBOX_CONSUMER_BOOTSTRAP_SERVERS:-}' compose.loadtest.yml >/dev/null

--- a/tools/test/run-transaction-100m-read-write-interference-gate.sh
+++ b/tools/test/run-transaction-100m-read-write-interference-gate.sh
@@ -12,8 +12,8 @@ Required runtime environment for actual runs:
   K6_COLD_ACCOUNT_ID
   K6_COLD_FROM
   K6_COLD_TO
-  INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID
-  INTERFERENCE_WRITE_TARGET_ACCOUNT_ID
+  INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID  required only when INTERFERENCE_WRITE_FIXTURE_ENABLED=false
+  INTERFERENCE_WRITE_TARGET_ACCOUNT_ID  required only when INTERFERENCE_WRITE_FIXTURE_ENABLED=false
 
 Optional environment:
   INTERFERENCE_NAME                     default transaction-100m-read-write-interference-<timestamp>
@@ -26,9 +26,18 @@ Optional environment:
   INTERFERENCE_WRITE_AMOUNT_MINOR       default 1
   INTERFERENCE_READ_HOT_P95_THRESHOLD_MS default 350
   INTERFERENCE_READ_COLD_P95_THRESHOLD_MS default 750
-  INTERFERENCE_READ_429_RATE_THRESHOLD  default 0
+  INTERFERENCE_READ_OVERLOAD_MODE        default false
+  INTERFERENCE_READ_429_RATE_THRESHOLD  default 0, or 0.05 when read overload mode is true
+  INTERFERENCE_READ_OVERLOAD_429_RATE_THRESHOLD default 0.05
   INTERFERENCE_WRITE_429_RATE_THRESHOLD default 0.05
   INTERFERENCE_WRITE_SUCCESS_RATE_THRESHOLD default 0.95
+  INTERFERENCE_WRITE_FIXTURE_ENABLED    default true
+  INTERFERENCE_WRITE_FIXTURE_CLEANUP    default true
+  INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID  default 920000001 when fixture enabled
+  INTERFERENCE_WRITE_TARGET_ACCOUNT_ID  default 920000002 when fixture enabled
+  INTERFERENCE_WRITE_SOURCE_BALANCE_MINOR default 1000000000
+  INTERFERENCE_WRITE_TARGET_BALANCE_MINOR default 1000000000
+  INTERFERENCE_WRITE_CURRENCY_CODE      default KRW
   INTERFERENCE_READINESS_TIMEOUT_SECONDS default 120
 USAGE
 }
@@ -61,14 +70,34 @@ limit="${INTERFERENCE_LIMIT:-50}"
 write_amount_minor="${INTERFERENCE_WRITE_AMOUNT_MINOR:-1}"
 read_hot_p95_threshold_ms="${INTERFERENCE_READ_HOT_P95_THRESHOLD_MS:-350}"
 read_cold_p95_threshold_ms="${INTERFERENCE_READ_COLD_P95_THRESHOLD_MS:-750}"
-read_429_rate_threshold="${INTERFERENCE_READ_429_RATE_THRESHOLD:-0}"
+read_overload_mode="${INTERFERENCE_READ_OVERLOAD_MODE:-false}"
+if [[ "${read_overload_mode}" == "true" ]]; then
+  read_429_rate_threshold="${INTERFERENCE_READ_429_RATE_THRESHOLD:-0.05}"
+else
+  read_429_rate_threshold="${INTERFERENCE_READ_429_RATE_THRESHOLD:-0}"
+fi
+if [[ -n "${INTERFERENCE_READ_OVERLOAD_429_RATE_THRESHOLD:-}" ]]; then
+  read_overload_429_rate_threshold="${INTERFERENCE_READ_OVERLOAD_429_RATE_THRESHOLD}"
+elif [[ "${read_overload_mode}" == "true" ]]; then
+  read_overload_429_rate_threshold="${read_429_rate_threshold}"
+else
+  read_overload_429_rate_threshold="0.05"
+fi
 write_429_rate_threshold="${INTERFERENCE_WRITE_429_RATE_THRESHOLD:-0.05}"
 write_success_rate_threshold="${INTERFERENCE_WRITE_SUCCESS_RATE_THRESHOLD:-0.95}"
+write_fixture_enabled="${INTERFERENCE_WRITE_FIXTURE_ENABLED:-true}"
+write_fixture_cleanup="${INTERFERENCE_WRITE_FIXTURE_CLEANUP:-true}"
+write_source_account_id="${INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID:-920000001}"
+write_target_account_id="${INTERFERENCE_WRITE_TARGET_ACCOUNT_ID:-920000002}"
+write_source_balance_minor="${INTERFERENCE_WRITE_SOURCE_BALANCE_MINOR:-1000000000}"
+write_target_balance_minor="${INTERFERENCE_WRITE_TARGET_BALANCE_MINOR:-1000000000}"
+write_currency_code="${INTERFERENCE_WRITE_CURRENCY_CODE:-KRW}"
 readiness_timeout_seconds="${INTERFERENCE_READINESS_TIMEOUT_SECONDS:-120}"
 backend_health_url="${INTERFERENCE_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
 prometheus_url="${PROMETHEUS_URL:-http://localhost:9090}"
 prometheus_base_url="${prometheus_url%/}"
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
 report_dir="build/reports/k6/${name}"
 summary_tsv="${report_dir}/read-write-interference-summary.tsv"
 read_report_name="${name}-read"
@@ -126,6 +155,15 @@ require_rate_value() {
     }
 }
 
+require_currency_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[A-Z]{3}$ ]]; then
+    echo "${key} must be a 3-letter uppercase currency code: ${value}" >&2
+    exit 1
+  fi
+}
+
 require_duration_value() {
   local key="$1"
   local value="$2"
@@ -146,17 +184,36 @@ require_env() {
 
 require_bool_value "INTERFERENCE_BUILD_BACKEND" "${build_backend}"
 require_bool_value "INTERFERENCE_FORCE_RECREATE" "${force_recreate}"
+require_bool_value "INTERFERENCE_READ_OVERLOAD_MODE" "${read_overload_mode}"
+require_bool_value "INTERFERENCE_WRITE_FIXTURE_ENABLED" "${write_fixture_enabled}"
+require_bool_value "INTERFERENCE_WRITE_FIXTURE_CLEANUP" "${write_fixture_cleanup}"
 require_duration_value "INTERFERENCE_DURATION" "${duration}"
 require_positive_integer_value "INTERFERENCE_READ_VUS" "${read_vus}"
 require_positive_integer_value "INTERFERENCE_WRITE_VUS" "${write_vus}"
 require_positive_integer_value "INTERFERENCE_LIMIT" "${limit}"
 require_positive_integer_value "INTERFERENCE_WRITE_AMOUNT_MINOR" "${write_amount_minor}"
+require_positive_integer_value "INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID" "${write_source_account_id}"
+require_positive_integer_value "INTERFERENCE_WRITE_TARGET_ACCOUNT_ID" "${write_target_account_id}"
+require_positive_integer_value "INTERFERENCE_WRITE_SOURCE_BALANCE_MINOR" "${write_source_balance_minor}"
+require_positive_integer_value "INTERFERENCE_WRITE_TARGET_BALANCE_MINOR" "${write_target_balance_minor}"
 require_positive_integer_value "INTERFERENCE_READINESS_TIMEOUT_SECONDS" "${readiness_timeout_seconds}"
 require_positive_number_value "INTERFERENCE_READ_HOT_P95_THRESHOLD_MS" "${read_hot_p95_threshold_ms}"
 require_positive_number_value "INTERFERENCE_READ_COLD_P95_THRESHOLD_MS" "${read_cold_p95_threshold_ms}"
 require_rate_value "INTERFERENCE_READ_429_RATE_THRESHOLD" "${read_429_rate_threshold}"
+require_rate_value "INTERFERENCE_READ_OVERLOAD_429_RATE_THRESHOLD" "${read_overload_429_rate_threshold}"
 require_rate_value "INTERFERENCE_WRITE_429_RATE_THRESHOLD" "${write_429_rate_threshold}"
 require_rate_value "INTERFERENCE_WRITE_SUCCESS_RATE_THRESHOLD" "${write_success_rate_threshold}"
+require_currency_value "INTERFERENCE_WRITE_CURRENCY_CODE" "${write_currency_code}"
+
+if [[ "${write_source_account_id}" == "${write_target_account_id}" ]]; then
+  echo "INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID and INTERFERENCE_WRITE_TARGET_ACCOUNT_ID must differ" >&2
+  exit 1
+fi
+
+if [[ "${write_fixture_enabled}" == "false" ]]; then
+  require_env INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID
+  require_env INTERFERENCE_WRITE_TARGET_ACCOUNT_ID
+fi
 
 print_plan() {
   echo "[transaction-read-write-interference] name=${name}"
@@ -169,9 +226,18 @@ print_plan() {
   echo "[transaction-read-write-interference] write_amount_minor=${write_amount_minor}"
   echo "[transaction-read-write-interference] read_hot_p95_threshold_ms=${read_hot_p95_threshold_ms}"
   echo "[transaction-read-write-interference] read_cold_p95_threshold_ms=${read_cold_p95_threshold_ms}"
+  echo "[transaction-read-write-interference] read_overload_mode=${read_overload_mode}"
   echo "[transaction-read-write-interference] read_429_rate_threshold=${read_429_rate_threshold}"
+  echo "[transaction-read-write-interference] read_overload_429_rate_threshold=${read_overload_429_rate_threshold}"
   echo "[transaction-read-write-interference] write_429_rate_threshold=${write_429_rate_threshold}"
   echo "[transaction-read-write-interference] write_success_rate_threshold=${write_success_rate_threshold}"
+  echo "[transaction-read-write-interference] write_fixture_enabled=${write_fixture_enabled}"
+  echo "[transaction-read-write-interference] write_fixture_cleanup=${write_fixture_cleanup}"
+  echo "[transaction-read-write-interference] write_source_account_id=${write_source_account_id}"
+  echo "[transaction-read-write-interference] write_target_account_id=${write_target_account_id}"
+  echo "[transaction-read-write-interference] write_source_balance_minor=${write_source_balance_minor}"
+  echo "[transaction-read-write-interference] write_target_balance_minor=${write_target_balance_minor}"
+  echo "[transaction-read-write-interference] write_currency_code=${write_currency_code}"
   echo "[transaction-read-write-interference] services=postgres,kafka,aquila-bank-backend,prometheus,grafana,alertmanager,postgres-exporter"
   echo "[transaction-read-write-interference] read_runner=tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps"
   echo "[transaction-read-write-interference] write_script=ops/k6/transfer-write-interference.js"
@@ -238,6 +304,248 @@ wait_for_prometheus_readiness() {
   exit 1
 }
 
+psql_sql() {
+  "${psql_base[@]}" --command "$1"
+}
+
+cleanup_write_fixture() {
+  echo "[transaction-read-write-interference] cleaning write fixture accounts"
+  psql_sql "
+    DELETE FROM notification_channel_outbox
+    WHERE account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM notification_inbox
+    WHERE account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM auth_status_change_audit
+    WHERE target_account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM account_status_change_audit
+    WHERE target_account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM user_account_membership
+    WHERE account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM outbox_event
+    WHERE aggregate_id IN (
+      SELECT transaction_reference
+      FROM ledger_entry
+      WHERE account_id IN (
+        SELECT id
+        FROM bank_account
+        WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+           OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+      )
+    )
+       OR payload->>'sourceAccountId' IN ('${write_source_account_id}', '${write_target_account_id}')
+       OR payload->>'targetAccountId' IN ('${write_source_account_id}', '${write_target_account_id}');
+    DELETE FROM command_idempotency
+    WHERE idempotency_key LIKE 'interference-${write_source_account_id}-%'
+      AND EXISTS (
+        SELECT 1
+        FROM bank_account
+        WHERE id = ${write_source_account_id}
+          AND account_number = 'IFX${write_source_account_id}'
+      );
+    DELETE FROM transfer_reversal
+    WHERE source_account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    )
+       OR target_account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM transaction_read_model
+    WHERE account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM transaction_read_model_archive
+    WHERE account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM account_balance_snapshot
+    WHERE account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM ledger_entry
+    WHERE account_id IN (
+      SELECT id
+      FROM bank_account
+      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
+    );
+    DELETE FROM bank_account
+    WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
+       OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}');
+  "
+}
+
+bootstrap_write_fixture() {
+  cleanup_write_fixture
+  echo "[transaction-read-write-interference] bootstrapping write fixture accounts"
+  psql_sql "
+    DO \$\$
+    DECLARE
+      item record;
+      ledger_id bigint;
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM bank_account
+        WHERE id IN (${write_source_account_id}, ${write_target_account_id})
+          AND account_number NOT IN ('IFX${write_source_account_id}', 'IFX${write_target_account_id}')
+      ) THEN
+        RAISE EXCEPTION 'interference fixture account id already exists with non-fixture account_number';
+      END IF;
+
+      FOR item IN
+        SELECT ${write_source_account_id}::bigint AS account_id,
+               'IFX${write_source_account_id}'::text AS account_number,
+               'interference write source'::text AS display_name,
+               ${write_source_balance_minor}::bigint AS balance_minor
+        UNION ALL
+        SELECT ${write_target_account_id}::bigint,
+               'IFX${write_target_account_id}'::text,
+               'interference write target'::text,
+               ${write_target_balance_minor}::bigint
+      LOOP
+        INSERT INTO bank_account (
+            id,
+            account_number,
+            display_name,
+            account_status,
+            currency_code,
+            created_at,
+            updated_at
+        )
+        OVERRIDING SYSTEM VALUE
+        VALUES (
+            item.account_id,
+            item.account_number,
+            item.display_name,
+            'ACTIVE',
+            '${write_currency_code}',
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        );
+
+        -- write fixture도 opening ledger와 snapshot을 같이 맞춰 transfer source of truth를 보존합니다.
+        INSERT INTO ledger_entry (
+            account_id,
+            transaction_reference,
+            entry_reference,
+            direction,
+            entry_status,
+            amount_minor,
+            currency_code,
+            booked_at,
+            occurred_at,
+            description,
+            metadata,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            item.account_id,
+            'IFX-OPEN-' || item.account_id,
+            'IFX-OPEN-ENTRY-' || item.account_id,
+            'CREDIT',
+            'BOOKED',
+            item.balance_minor,
+            '${write_currency_code}',
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP,
+            'interference write fixture',
+            '{\"fixture\":\"transaction-read-write-interference\"}'::jsonb,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        )
+        RETURNING id INTO ledger_id;
+
+        INSERT INTO transaction_read_model (
+            ledger_entry_id,
+            account_id,
+            transaction_reference,
+            direction,
+            transaction_status,
+            amount_minor,
+            balance_after_minor,
+            currency_code,
+            summary,
+            counterparty_masked_name,
+            booked_at,
+            created_at
+        )
+        VALUES (
+            ledger_id,
+            item.account_id,
+            'IFX-OPEN-' || item.account_id,
+            'CREDIT',
+            'BOOKED',
+            item.balance_minor,
+            item.balance_minor,
+            '${write_currency_code}',
+            'interference write fixture',
+            'fixture',
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        );
+
+        INSERT INTO account_balance_snapshot (
+            account_id,
+            last_applied_ledger_entry_id,
+            available_balance_minor,
+            pending_balance_minor,
+            currency_code,
+            updated_at
+        )
+        VALUES (
+            item.account_id,
+            ledger_id,
+            item.balance_minor,
+            0,
+            '${write_currency_code}',
+            CURRENT_TIMESTAMP
+        );
+      END LOOP;
+    END \$\$;
+  "
+}
+
 start_loadtest_services() {
   local args
   args=(docker compose "${compose_files[@]}" --profile loadtest up -d)
@@ -274,9 +582,10 @@ start_write_pressure() {
     -e K6_PROMETHEUS_RW_SERVER_URL=http://prometheus:9090/api/v1/write \
     -e K6_PROMETHEUS_RW_TREND_STATS="p(50),p(90),p(95),p(99),min,max,avg" \
     -e K6_REPORT_NAME="${write_report_name}" \
-    -e K6_WRITE_SOURCE_ACCOUNT_ID="${INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID}" \
-    -e K6_WRITE_TARGET_ACCOUNT_ID="${INTERFERENCE_WRITE_TARGET_ACCOUNT_ID}" \
+    -e K6_WRITE_SOURCE_ACCOUNT_ID="${write_source_account_id}" \
+    -e K6_WRITE_TARGET_ACCOUNT_ID="${write_target_account_id}" \
     -e K6_WRITE_AMOUNT_MINOR="${write_amount_minor}" \
+    -e K6_WRITE_CURRENCY_CODE="${write_currency_code}" \
     -e K6_WRITE_VUS="${write_vus}" \
     -e K6_WRITE_DURATION="${duration}" \
     -e K6_WRITE_429_RATE_THRESHOLD="${write_429_rate_threshold}" \
@@ -294,6 +603,13 @@ stop_write_pressure() {
     kill "${WRITE_PID}" >/dev/null 2>&1 || true
     wait "${WRITE_PID}" >/dev/null 2>&1 || true
     WRITE_PID=""
+  fi
+}
+
+on_exit() {
+  stop_write_pressure
+  if [[ "${write_fixture_enabled}" == "true" && "${write_fixture_cleanup}" == "true" ]]; then
+    cleanup_write_fixture >/dev/null 2>&1 || true
   fi
 }
 
@@ -382,11 +698,15 @@ if [[ "${build_backend}" == "true" ]]; then
   tools/test/with-resource-lock.sh back-gradle-interference-bootjar ./back/gradlew -p back bootJar
 fi
 
-trap stop_write_pressure EXIT
+trap on_exit EXIT
 
 start_loadtest_services
 wait_for_backend_readiness
 wait_for_prometheus_readiness
+
+if [[ "${write_fixture_enabled}" == "true" ]]; then
+  bootstrap_write_fixture
+fi
 
 start_write_pressure
 
@@ -395,7 +715,8 @@ K6_REPORT_NAME="${read_report_name}" \
 K6_VUS="${read_vus}" \
 K6_DURATION="${duration}" \
 K6_LIMIT="${limit}" \
-K6_OVERLOAD_MODE=false \
+K6_OVERLOAD_MODE="${read_overload_mode}" \
+K6_OVERLOAD_429_RATE_THRESHOLD="${read_overload_429_rate_threshold}" \
 K6_ARCHIVE_RESULTS=false \
   tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${read_log_path}" 2>&1
 read_status=$?


### PR DESCRIPTION
## 🔗 Related Issue
- close #412
- close #413

## 🌿 Base Branch
- `main`

## 📝 Summary
- Kafka loadtest compose의 미해결 `bitnami/kafka:4.2` tag를 `bitnamilegacy/kafka:4.0.0-debian-12-r10` 기본값으로 pin하고 `KAFKA_IMAGE` override를 열었습니다.
- transaction read/write interference gate가 write source/target fixture를 직접 bootstrap/cleanup하고, read overload 429 ratio를 strict mode와 분리해 옵션화합니다.

## 🛠 Changes
- `compose.yml` Kafka image를 env override 가능한 고정 tag로 변경했습니다.
- `run-transaction-100m-read-write-interference-gate.sh`에 write fixture account bootstrap/cleanup, fixture account/balance/currency env, read overload mode/env threshold 전달을 추가했습니다.
- `check-transaction-100m-read-write-interference-gate.sh`가 image override, fixture 계약, read overload 계약, invalid input을 검증합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-read-write-interference-gate.sh`
- `bash -n tools/test/run-transaction-100m-read-write-interference-gate.sh`
- `docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/dev/null`
- `INTERFERENCE_READ_OVERLOAD_MODE=true INTERFERENCE_READ_429_RATE_THRESHOLD=0.2 tools/test/run-transaction-100m-read-write-interference-gate.sh --print-plan`
- `INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID=1 INTERFERENCE_WRITE_TARGET_ACCOUNT_ID=1 tools/test/run-transaction-100m-read-write-interference-gate.sh --print-plan >/dev/null` 실패 확인
- `INTERFERENCE_WRITE_FIXTURE_ENABLED=false tools/test/run-transaction-100m-read-write-interference-gate.sh --print-plan >/dev/null` 실패 확인
- `git diff --check`
- `git rev-list --count origin/main..HEAD` → `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Bitnami legacy image는 장기 지원 경로가 아니므로 운영 장기 고정값은 사내 mirror 또는 보안 이미지로 승격해야 합니다. fixture cleanup SQL 범위 오류가 있으면 gate 데이터가 훼손될 수 있어 fixture account number와 account id가 모두 맞는 행만 삭제하도록 제한했습니다.
- 롤백 방법: 이 PR의 두 commit을 revert하면 기존 compose image와 interference runner 계약으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?