### PR TITLE
[Perf] transaction 100m adaptive strict runner fail-fast guard 추가

### DIFF
--- a/tools/test/check-transaction-100m-capacity-gates.sh
+++ b/tools/test/check-transaction-100m-capacity-gates.sh
@@ -16,6 +16,7 @@ grep -F "capacity=transaction-capacity-check" <<<"${plan}" >/dev/null
 grep -F "single_host_profiles=single-host-default,single-host-high-traffic" <<<"${plan}" >/dev/null
 grep -F "cpu_split_profiles=cpu-backend040-postgres060,cpu-backend100-postgres060" <<<"${plan}" >/dev/null
 grep -F "long_soak_profile=long-soak-high-traffic duration=30m" <<<"${plan}" >/dev/null
+grep -F "adaptive_enabled=true" <<<"${plan}" >/dev/null
 grep -F "hard_thresholds=true" <<<"${plan}" >/dev/null
 grep -F "hot_p95_threshold_ms=350" <<<"${plan}" >/dev/null
 grep -F "cold_p95_threshold_ms=750" <<<"${plan}" >/dev/null
@@ -35,6 +36,9 @@ grep -F "CAPACITY_OVERLOAD_429_RATE_THRESHOLD" "${script}" >/dev/null
 grep -F "CAPACITY_BACKEND_CPU_THRESHOLD_PERCENT" "${script}" >/dev/null
 grep -F "CAPACITY_POSTGRES_CPU_THRESHOLD_PERCENT" "${script}" >/dev/null
 grep -F "CAPACITY_HIKARI_PENDING_THRESHOLD" "${script}" >/dev/null
+grep -F "CAPACITY_ADAPTIVE_ENABLED" "${script}" >/dev/null
+grep -F "assert_adaptive_strict_guard" "${script}" >/dev/null
+grep -F "strict profile uses overload mode or VU <= admission" "${script}" >/dev/null
 grep -F "check_capacity_thresholds" "${script}" >/dev/null
 grep -F "T3MICRO_BACKEND_CPUS" "${script}" >/dev/null
 grep -F "T3MICRO_POSTGRES_CPUS" "${script}" >/dev/null
@@ -64,5 +68,9 @@ if CAPACITY_HOT_P95_THRESHOLD_MS=bad "${script}" --print-plan >/dev/null 2>&1; t
 fi
 if CAPACITY_OVERLOAD_429_RATE_THRESHOLD=1.5 "${script}" --print-plan >/dev/null 2>&1; then
   echo "CAPACITY_OVERLOAD_429_RATE_THRESHOLD=1.5 unexpectedly succeeded" >&2
+  exit 1
+fi
+if CAPACITY_SINGLE_HOST_PROFILES=bad-strict:3:8:0.40:512m:0.60:384m:4:false:1m "${script}" --print-plan >/dev/null 2>&1; then
+  echo "adaptive strict profile without overload unexpectedly succeeded" >&2
   exit 1
 fi

--- a/tools/test/run-transaction-100m-capacity-gates.sh
+++ b/tools/test/run-transaction-100m-capacity-gates.sh
@@ -24,6 +24,7 @@ Optional environment:
   CAPACITY_READINESS_TIMEOUT_SECONDS default 120
   CAPACITY_METRIC_SCRAPE_WAIT_SECONDS default 6
   CAPACITY_CPU_SAMPLE_INTERVAL_SECONDS default 5
+  CAPACITY_ADAPTIVE_ENABLED default true
   CAPACITY_HARD_THRESHOLD_ENABLED default true
   CAPACITY_HOT_P95_THRESHOLD_MS default 350
   CAPACITY_COLD_P95_THRESHOLD_MS default 750
@@ -72,6 +73,7 @@ long_soak_duration="${CAPACITY_LONG_SOAK_DURATION:-30m}"
 readiness_timeout_seconds="${CAPACITY_READINESS_TIMEOUT_SECONDS:-120}"
 metric_scrape_wait_seconds="${CAPACITY_METRIC_SCRAPE_WAIT_SECONDS:-6}"
 cpu_sample_interval_seconds="${CAPACITY_CPU_SAMPLE_INTERVAL_SECONDS:-5}"
+adaptive_enabled="${CAPACITY_ADAPTIVE_ENABLED:-${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_ENABLED:-true}}"
 hard_threshold_enabled="${CAPACITY_HARD_THRESHOLD_ENABLED:-true}"
 hot_p95_threshold_ms="${CAPACITY_HOT_P95_THRESHOLD_MS:-350}"
 cold_p95_threshold_ms="${CAPACITY_COLD_P95_THRESHOLD_MS:-750}"
@@ -217,6 +219,32 @@ validate_profiles() {
   done
 }
 
+assert_adaptive_strict_guard() {
+  local group="$1"
+  local profile="$2"
+  IFS=':' read -r name admission vus _backend_cpus _backend_memory _postgres_cpus _postgres_memory _db_pool overload_mode _duration <<<"${profile}"
+  if [[ "${adaptive_enabled}" != "true" || "${overload_mode}" == "true" ]]; then
+    return 0
+  fi
+  if ((vus <= admission)); then
+    return 0
+  fi
+  # adaptive strict profile은 첫 429 이후 min limit으로 내려가므로 overload/backoff 없이 실행하지 않습니다.
+  echo "${group} strict profile uses overload mode or VU <= admission: profile=${name} admission=${admission} vus=${vus}" >&2
+  echo "Set overload_mode=true for protected 429 ratio testing, reduce vus to ${admission}, or set CAPACITY_ADAPTIVE_ENABLED=false only for a non-adaptive baseline." >&2
+  exit 1
+}
+
+assert_adaptive_strict_guards() {
+  local group="$1"
+  local csv="$2"
+  IFS=',' read -r -a profiles <<<"${csv}"
+  local profile
+  for profile in "${profiles[@]}"; do
+    assert_adaptive_strict_guard "${group}" "${profile}"
+  done
+}
+
 profile_names() {
   local csv="$1"
   IFS=',' read -r -a profiles <<<"${csv}"
@@ -246,6 +274,7 @@ require_bool "CAPACITY_RUN_SINGLE_HOST" "${run_single_host}"
 require_bool "CAPACITY_RUN_CPU_SPLIT" "${run_cpu_split}"
 require_bool "CAPACITY_RUN_LONG_SOAK" "${run_long_soak}"
 require_bool "CAPACITY_CONTINUE_ON_FAILURE" "${continue_on_failure}"
+require_bool "CAPACITY_ADAPTIVE_ENABLED" "${adaptive_enabled}"
 require_bool "CAPACITY_HARD_THRESHOLD_ENABLED" "${hard_threshold_enabled}"
 require_duration_value "CAPACITY_LONG_SOAK_DURATION" "${long_soak_duration}"
 require_positive_integer_value "CAPACITY_READINESS_TIMEOUT_SECONDS" "${readiness_timeout_seconds}"
@@ -261,6 +290,9 @@ require_non_negative_integer_value "CAPACITY_HIKARI_PENDING_THRESHOLD" "${hikari
 validate_profiles "CAPACITY_SINGLE_HOST_PROFILES" "${single_host_profiles}"
 validate_profiles "CAPACITY_CPU_SPLIT_PROFILES" "${cpu_split_profiles}"
 validate_profile "CAPACITY_LONG_SOAK_PROFILE" "${long_soak_profile}"
+assert_adaptive_strict_guards "CAPACITY_SINGLE_HOST_PROFILES" "${single_host_profiles}"
+assert_adaptive_strict_guards "CAPACITY_CPU_SPLIT_PROFILES" "${cpu_split_profiles}"
+assert_adaptive_strict_guard "CAPACITY_LONG_SOAK_PROFILE" "${long_soak_profile}"
 
 print_plan() {
   echo "[transaction-100m-capacity] capacity=${capacity_name}"
@@ -277,6 +309,7 @@ print_plan() {
   echo "[transaction-100m-capacity] readiness_timeout_seconds=${readiness_timeout_seconds}"
   echo "[transaction-100m-capacity] metric_scrape_wait_seconds=${metric_scrape_wait_seconds}"
   echo "[transaction-100m-capacity] cpu_sample_interval_seconds=${cpu_sample_interval_seconds}"
+  echo "[transaction-100m-capacity] adaptive_enabled=${adaptive_enabled}"
   echo "[transaction-100m-capacity] hard_thresholds=${hard_threshold_enabled}"
   echo "[transaction-100m-capacity] hot_p95_threshold_ms=${hot_p95_threshold_ms}"
   echo "[transaction-100m-capacity] cold_p95_threshold_ms=${cold_p95_threshold_ms}"
@@ -514,6 +547,7 @@ run_profile() {
   T3MICRO_POSTGRES_MEMORY="${postgres_memory}" \
   T3MICRO_POSTGRES_MEMORY_SWAP="${postgres_memory}" \
   OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX="${admission}" \
+  OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_ENABLED="${adaptive_enabled}" \
   DB_POOL_MAX_SIZE="${db_pool}" \
     docker compose "${compose_files[@]}" --profile loadtest up -d --force-recreate \
       postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter


### PR DESCRIPTION
## 🔗 Related Issue
- close #415

## 🌿 Base Branch
- `main`

## 📝 Summary
- adaptive admission이 켜진 capacity runner에서 strict/no-backoff profile이 `VU > admission` 조합으로 실행되는 것을 k6 실행 전에 차단합니다.
- guard 메시지는 overload mode 사용, VU 축소, 또는 비 adaptive baseline 의도 명시를 안내합니다.

## 🛠 Changes
- `CAPACITY_ADAPTIVE_ENABLED` runner env를 추가하고 backend compose 실행에도 전달합니다.
- capacity profile validation 뒤 `assert_adaptive_strict_guard`를 추가해 strict profile의 위험 조합을 fail-fast 처리합니다.
- checker에 print-plan, guard marker, invalid adaptive strict 조합 실패 검증을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-capacity-gates.sh`
- `bash -n tools/test/run-transaction-100m-capacity-gates.sh`
- `CAPACITY_SINGLE_HOST_PROFILES=bad-strict:3:8:0.40:512m:0.60:384m:4:false:1m tools/test/run-transaction-100m-capacity-gates.sh --print-plan` 실패 확인
- `CAPACITY_ADAPTIVE_ENABLED=false CAPACITY_SINGLE_HOST_PROFILES=bad-strict:3:8:0.40:512m:0.60:384m:4:false:1m tools/test/run-transaction-100m-capacity-gates.sh --print-plan`
- `git diff --check`
- `git rev-list --count origin/main..HEAD` → `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: guard 조건이 과하면 의도한 strict baseline 실행도 막을 수 있습니다. 비 adaptive baseline은 `CAPACITY_ADAPTIVE_ENABLED=false`로 명시해야 합니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 capacity runner 계약으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?