### PR TITLE
[Fix] transaction read/write interference fixture cleanup 보정

### DIFF
--- a/tools/test/check-transaction-100m-read-write-interference-gate.sh
+++ b/tools/test/check-transaction-100m-read-write-interference-gate.sh
@@ -61,6 +61,25 @@ grep -F "read-write-interference-summary.tsv" "${runner}" >/dev/null
 grep -F "check_interference_thresholds" "${runner}" >/dev/null
 grep -F "aquila_transaction_429_rate" "${runner}" >/dev/null
 grep -F "aquila_transfer_write_429_rate" "${runner}" >/dev/null
+source_require_count="$(grep -c '^[[:space:]]*require_env INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID$' "${runner}")"
+target_require_count="$(grep -c '^[[:space:]]*require_env INTERFERENCE_WRITE_TARGET_ACCOUNT_ID$' "${runner}")"
+if [[ "${source_require_count}" -ne 1 ]]; then
+  echo "INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID must be required only when fixture is disabled" >&2
+  exit 1
+fi
+if [[ "${target_require_count}" -ne 1 ]]; then
+  echo "INTERFERENCE_WRITE_TARGET_ACCOUNT_ID must be required only when fixture is disabled" >&2
+  exit 1
+fi
+if grep -F "cleanup_write_fixture >/dev/null 2>&1 || true" "${runner}" >/dev/null; then
+  echo "cleanup_write_fixture must not suppress cleanup failures silently" >&2
+  exit 1
+fi
+grep -F "cleanup failed; fixture rows may remain" "${runner}" >/dev/null
+grep -F "interference_fixture_account_ids" "${runner}" >/dev/null
+grep -F "interference_fixture_transaction_references" "${runner}" >/dev/null
+grep -F "payload->>'transactionReference'" "${runner}" >/dev/null
+grep -F "idempotency_key LIKE 'interference-\${write_target_account_id}-%'" "${runner}" >/dev/null
 
 echo "[transaction-read-write-interference] k6 write contract"
 grep -F "K6_WRITE_SOURCE_ACCOUNT_ID" "${write_script}" >/dev/null

--- a/tools/test/run-transaction-100m-read-write-interference-gate.sh
+++ b/tools/test/run-transaction-100m-read-write-interference-gate.sh
@@ -257,8 +257,6 @@ require_env K6_HOT_TO
 require_env K6_COLD_ACCOUNT_ID
 require_env K6_COLD_FROM
 require_env K6_COLD_TO
-require_env INTERFERENCE_WRITE_SOURCE_ACCOUNT_ID
-require_env INTERFERENCE_WRITE_TARGET_ACCOUNT_ID
 
 mkdir -p "${report_dir}" build/reports/k6
 
@@ -311,106 +309,71 @@ psql_sql() {
 cleanup_write_fixture() {
   echo "[transaction-read-write-interference] cleaning write fixture accounts"
   psql_sql "
-    DELETE FROM notification_channel_outbox
-    WHERE account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM notification_inbox
-    WHERE account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM auth_status_change_audit
-    WHERE target_account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM account_status_change_audit
-    WHERE target_account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM user_account_membership
-    WHERE account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM outbox_event
-    WHERE aggregate_id IN (
-      SELECT transaction_reference
-      FROM ledger_entry
-      WHERE account_id IN (
-        SELECT id
-        FROM bank_account
-        WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-           OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-      )
-    )
-       OR payload->>'sourceAccountId' IN ('${write_source_account_id}', '${write_target_account_id}')
-       OR payload->>'targetAccountId' IN ('${write_source_account_id}', '${write_target_account_id}');
-    DELETE FROM command_idempotency
-    WHERE idempotency_key LIKE 'interference-${write_source_account_id}-%'
-      AND EXISTS (
-        SELECT 1
-        FROM bank_account
-        WHERE id = ${write_source_account_id}
-          AND account_number = 'IFX${write_source_account_id}'
-      );
-    DELETE FROM transfer_reversal
-    WHERE source_account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    )
-       OR target_account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM transaction_read_model
-    WHERE account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM transaction_read_model_archive
-    WHERE account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM account_balance_snapshot
-    WHERE account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM ledger_entry
-    WHERE account_id IN (
-      SELECT id
-      FROM bank_account
-      WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
-         OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}')
-    );
-    DELETE FROM bank_account
+    BEGIN;
+
+    -- fixture marker 계좌만 삭제 후보로 고정해 운영 계좌 오삭제를 막습니다.
+    CREATE TEMP TABLE interference_fixture_account_ids ON COMMIT DROP AS
+    SELECT id
+    FROM bank_account
     WHERE (id = ${write_source_account_id} AND account_number = 'IFX${write_source_account_id}')
        OR (id = ${write_target_account_id} AND account_number = 'IFX${write_target_account_id}');
+
+    CREATE TEMP TABLE interference_fixture_transaction_references ON COMMIT DROP AS
+    SELECT DISTINCT transaction_reference
+    FROM ledger_entry
+    WHERE account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM notification_channel_outbox
+    WHERE account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM notification_inbox
+    WHERE account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM auth_status_change_audit
+    WHERE target_account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM account_status_change_audit
+    WHERE target_account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM user_account_membership
+    WHERE account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM outbox_event
+    WHERE aggregate_id IN (SELECT transaction_reference FROM interference_fixture_transaction_references)
+       OR payload->>'transactionReference' IN (SELECT transaction_reference FROM interference_fixture_transaction_references)
+       OR payload->>'sourceAccountId' IN (SELECT id::text FROM interference_fixture_account_ids)
+       OR payload->>'targetAccountId' IN (SELECT id::text FROM interference_fixture_account_ids);
+
+    DELETE FROM command_idempotency
+    WHERE (
+        idempotency_key LIKE 'interference-${write_source_account_id}-%'
+        AND EXISTS (SELECT 1 FROM interference_fixture_account_ids WHERE id = ${write_source_account_id})
+      )
+       OR (
+        idempotency_key LIKE 'interference-${write_target_account_id}-%'
+        AND EXISTS (SELECT 1 FROM interference_fixture_account_ids WHERE id = ${write_target_account_id})
+      );
+
+    DELETE FROM transfer_reversal
+    WHERE source_account_id IN (SELECT id FROM interference_fixture_account_ids)
+       OR target_account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM transaction_read_model
+    WHERE account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM transaction_read_model_archive
+    WHERE account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM account_balance_snapshot
+    WHERE account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM ledger_entry
+    WHERE account_id IN (SELECT id FROM interference_fixture_account_ids);
+
+    DELETE FROM bank_account
+    WHERE id IN (SELECT id FROM interference_fixture_account_ids);
+
+    COMMIT;
   "
 }
 
@@ -607,10 +570,17 @@ stop_write_pressure() {
 }
 
 on_exit() {
+  local status=$?
   stop_write_pressure
   if [[ "${write_fixture_enabled}" == "true" && "${write_fixture_cleanup}" == "true" ]]; then
-    cleanup_write_fixture >/dev/null 2>&1 || true
+    if ! cleanup_write_fixture; then
+      echo "[transaction-read-write-interference] cleanup failed; fixture rows may remain" >&2
+      if [[ "${status}" -eq 0 ]]; then
+        status=1
+      fi
+    fi
   fi
+  exit "${status}"
 }
 
 write_header() {


### PR DESCRIPTION
## 🔗 Related Issue
- close #420

## 🌿 Base Branch
- `main`

## 📝 Summary
- read/write interference gate의 fixture cleanup이 transfer 실행 후 남긴 ledger/read model/outbox/idempotency/notification row를 정리하도록 보정합니다.
- fixture enabled 기본 실행에서 write source/target env를 다시 요구하던 중복 검증을 제거하고, cleanup 실패가 조용히 묻히지 않게 합니다.

## 🛠 Changes
- fixture marker 계좌를 temp table로 고정한 뒤 관련 notification, audit, outbox, idempotency, reversal, read model, snapshot, ledger, account row를 같은 cleanup transaction에서 삭제합니다.
- outbox cleanup에 `transactionReference` payload 조건과 fixture transaction reference 조건을 추가했습니다.
- EXIT trap에서 cleanup 실패를 로그로 남기고, 성공 실행 중 cleanup이 실패하면 runner를 실패 처리합니다.
- contract check에 fixture env validation, cleanup failure visibility, cleanup 범위 회귀 검사를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-read-write-interference-gate.sh`
- `bash -n tools/test/run-transaction-100m-read-write-interference-gate.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: cleanup SQL 범위 변경으로 실제 interference gate 실행 시 psql cleanup 단계에서 새 FK 의존성이 발견될 수 있습니다. 삭제 범위는 `IFX<id>` fixture marker 계좌로 제한했습니다.
- 롤백 방법: PR revert 후 기존 runner로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?