### PR TITLE
[Perf] 100m fixture recovery-safe rerun 경로 추가

### DIFF
--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -89,6 +89,8 @@ tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only
 - `tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only` 실행 전 hot/cold account와 기간 값
 - hot/cold account와 기간 기본값이 테스트 의도와 맞는지 여부
 
+volume이 `OOMKilled=true` 또는 recovery loop 상태로 남으면 [Transaction Read Volume Corruption Runbook](../transaction-read-volume-corruption-runbook.md)을 기준으로 복구/폐기/재생성을 판단합니다.
+
 수동 보관이 필요하면 아래 명령을 사용합니다.
 
 ```bash

--- a/docs/transaction-read-volume-corruption-runbook.md
+++ b/docs/transaction-read-volume-corruption-runbook.md
@@ -1,0 +1,74 @@
+# Transaction Read Volume Corruption Runbook
+
+100m transaction read fixture volume이 crash recovery loop에 빠졌을 때의 복구 기준입니다. 운영 RDS 절차가 아니라 local Docker 100m performance fixture 전용입니다.
+
+## 복구 기준
+
+- `docker inspect aquila-bank-postgres --format '{{.State.OOMKilled}}'`가 `false`이고 container가 `running`이다.
+- `tools/test/run-transaction-100m-fixture-restore.sh`의 recovery preflight가 `pg_is_in_recovery()=false`를 확인한다.
+- schema/index preflight가 통과하고 read model sample row가 의도한 fixture account에서 조회된다.
+- 이 조건이면 기존 volume을 유지하고 아래 순서로 검증한다.
+
+```bash
+FIXTURE_MODE=verify \
+FIXTURE_VERIFY_MIN_ROWS=1000 \
+tools/test/run-transaction-100m-fixture-restore.sh
+```
+
+## 폐기 기준
+
+- `OOMKilled=true`가 남아 있다.
+- container status가 `restarting`, `dead`, `exited` 중 하나이고 짧은 재시작 후에도 닫히지 않는다.
+- `pg_is_in_recovery()` 확인이 connection failure 또는 startup/recovery loop 메시지로 반복 실패한다.
+- 대량 cleanup 직후 PostgreSQL signal 9 또는 Docker Desktop memory pressure가 확인됐다.
+
+이 조건에서는 mutable volume을 신뢰하지 않고 dump artifact 기준 fresh restore로 전환한다.
+
+```bash
+tools/test/run-transaction-100m-fresh-volume-restore-k6.sh --dry-run
+
+FRESH_VOLUME_CONFIRM=erase-postgres-volume \
+FIXTURE_NAME=transaction-100m-fixture \
+tools/test/run-transaction-100m-fresh-volume-restore-k6.sh
+```
+
+## 재생성 기준
+
+- `build/fixtures/<name>.dump`가 없거나 0 byte다.
+- fresh restore가 `fixture dump not found`로 실패한다.
+- schema migration이 바뀌어 기존 dump가 현재 Flyway schema와 맞지 않는다.
+
+이 조건에서는 fixture 생성 phase를 다시 실행하고 dump artifact를 먼저 만든다.
+
+```bash
+SEED_TOTAL_ROWS=100000000 \
+SEED_BATCH_SIZE=250000 \
+SEED_TRUNCATE=true \
+FIXTURE_POSTGRES_MEMORY=2g \
+tools/test/prepare-transaction-read-model-100m-fixture.sh
+
+FIXTURE_MODE=dump \
+FIXTURE_NAME=transaction-100m-fixture \
+tools/test/run-transaction-100m-fixture-restore.sh
+```
+
+## Cleanup 기준
+
+100m fixture cleanup은 큰 `TRUNCATE`/`DELETE` 한 번으로 처리하지 않는다. WAL budget을 두고 account 범위 chunk delete로 정리한다.
+
+```bash
+tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh --print-plan
+
+CLEANUP_CONFIRM=delete-100m-fixture \
+CLEANUP_CHUNK_SIZE=50000 \
+CLEANUP_WAL_MAX_BYTES=1073741824 \
+tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh
+```
+
+cleanup 중 `WAL budget exceeded`가 나면 즉시 중단하고 volume 상태를 다시 확인한다. 이때 남은 row를 더 큰 batch로 밀어붙이지 않는다.
+
+## 금지
+
+- dump artifact 없이 손상 volume을 반복 재시작하며 k6를 실행하지 않는다.
+- PostgreSQL recovery loop 상태에서 cleanup 또는 restore를 실행하지 않는다.
+- 운영 URL, token, RDS 접속 정보는 성능 결과 문서나 runbook 명령에 남기지 않는다.

--- a/tools/test/check-transaction-100m-fixture-cleanup-wal-budget.sh
+++ b/tools/test/check-transaction-100m-fixture-cleanup-wal-budget.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh"
+runbook="docs/transaction-read-volume-corruption-runbook.md"
+
+echo "[transaction-100m-cleanup-wal] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-100m-cleanup-wal] print plan"
+plan="$(
+  CLEANUP_CHUNK_SIZE=1000 \
+  CLEANUP_MAX_CHUNKS=3 \
+  CLEANUP_WAL_MAX_BYTES=1048576 \
+    "${script}" --print-plan
+)"
+grep -F "mode=print-plan" <<<"${plan}" >/dev/null
+grep -F "confirm=delete-100m-fixture required for run" <<<"${plan}" >/dev/null
+grep -F "accounts=910000001,910000002" <<<"${plan}" >/dev/null
+grep -F "chunk_size=1000" <<<"${plan}" >/dev/null
+grep -F "max_chunks=3" <<<"${plan}" >/dev/null
+grep -F "wal_max_bytes=1048576" <<<"${plan}" >/dev/null
+grep -F "tables=transaction_read_model,transaction_read_model_archive" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-cleanup-wal] dry-run command"
+dry_run="$("${script}" --dry-run)"
+grep -F "FIXTURE_MODE=verify" <<<"${dry_run}" >/dev/null
+grep -F "DELETE FROM public.transaction_read_model" <<<"${dry_run}" >/dev/null
+grep -F "DELETE FROM public.transaction_read_model_archive" <<<"${dry_run}" >/dev/null
+grep -F "pg_wal_lsn_diff" <<<"${dry_run}" >/dev/null
+
+echo "[transaction-100m-cleanup-wal] runner contract"
+grep -F "delete-100m-fixture" "${script}" >/dev/null
+grep -F "CLEANUP_CHUNK_SIZE" "${script}" >/dev/null
+grep -F "CLEANUP_WAL_MAX_BYTES" "${script}" >/dev/null
+grep -F "FIXTURE_MODE=verify" "${script}" >/dev/null
+grep -F "ctid" "${script}" >/dev/null
+grep -F "pg_current_wal_lsn()" "${script}" >/dev/null
+grep -F "pg_wal_lsn_diff" "${script}" >/dev/null
+grep -F "WAL budget exceeded" "${script}" >/dev/null
+
+echo "[transaction-100m-cleanup-wal] runbook contract"
+test -f "${runbook}"
+grep -F "복구 기준" "${runbook}" >/dev/null
+grep -F "폐기 기준" "${runbook}" >/dev/null
+grep -F "재생성 기준" "${runbook}" >/dev/null
+grep -F "run-transaction-100m-fresh-volume-restore-k6.sh" "${runbook}" >/dev/null
+grep -F "run-transaction-100m-fixture-cleanup-wal-budget.sh" "${runbook}" >/dev/null
+grep -F "OOMKilled=true" "${runbook}" >/dev/null
+
+echo "[transaction-100m-cleanup-wal] invalid input fails"
+if CLEANUP_CHUNK_SIZE=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "CLEANUP_CHUNK_SIZE=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if CLEANUP_MAX_CHUNKS=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "CLEANUP_MAX_CHUNKS=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if CLEANUP_WAL_MAX_BYTES=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "CLEANUP_WAL_MAX_BYTES=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if CLEANUP_CONFIRM=bad "${script}" >/dev/null 2>&1; then
+  echo "CLEANUP_CONFIRM=bad unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/check-transaction-100m-fixture-restore.sh
+++ b/tools/test/check-transaction-100m-fixture-restore.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-fixture-restore.sh"
+
+echo "[transaction-fixture-restore] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-fixture-restore] compose config"
+docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/dev/null
+
+echo "[transaction-fixture-restore] print plan"
+plan="$(
+  FIXTURE_MODE=verify \
+  FIXTURE_NAME=transaction-100m-check \
+  FIXTURE_REQUIRE_DUMP=true \
+  FIXTURE_VERIFY_MIN_ROWS=1000 \
+    "${script}" --print-plan
+)"
+grep -F "fixture=transaction-100m-check" <<<"${plan}" >/dev/null
+grep -F "mode=verify" <<<"${plan}" >/dev/null
+grep -F "dump=build/fixtures/transaction-100m-check.dump" <<<"${plan}" >/dev/null
+grep -F "recovery_preflight=true" <<<"${plan}" >/dev/null
+grep -F "require_dump=true" <<<"${plan}" >/dev/null
+grep -F "verify_min_rows=1000" <<<"${plan}" >/dev/null
+grep -F "modes=verify,dump,restore" <<<"${plan}" >/dev/null
+
+echo "[transaction-fixture-restore] runner contract"
+grep -F "FIXTURE_RECOVERY_PREFLIGHT" "${script}" >/dev/null
+grep -F "FIXTURE_REQUIRE_DUMP" "${script}" >/dev/null
+grep -F "FIXTURE_VERIFY_MIN_ROWS" "${script}" >/dev/null
+grep -F "assert_postgres_recovery_safe" "${script}" >/dev/null
+grep -F "assert_fixture_dump_present" "${script}" >/dev/null
+grep -F "OOMKilled" "${script}" >/dev/null
+grep -F "Restarting" "${script}" >/dev/null
+grep -F "pg_is_in_recovery()" "${script}" >/dev/null
+grep -F "fixture dump not found" "${script}" >/dev/null
+grep -F "transaction_read_model rows" "${script}" >/dev/null
+
+echo "[transaction-fixture-restore] invalid input fails"
+if FIXTURE_MODE=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "FIXTURE_MODE=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if FIXTURE_RECOVERY_PREFLIGHT=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "FIXTURE_RECOVERY_PREFLIGHT=maybe unexpectedly succeeded" >&2
+  exit 1
+fi
+if FIXTURE_REQUIRE_DUMP=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "FIXTURE_REQUIRE_DUMP=maybe unexpectedly succeeded" >&2
+  exit 1
+fi
+if FIXTURE_VERIFY_MIN_ROWS=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "FIXTURE_VERIFY_MIN_ROWS=bad unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/check-transaction-100m-fresh-volume-restore-k6.sh
+++ b/tools/test/check-transaction-100m-fresh-volume-restore-k6.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-fresh-volume-restore-k6.sh"
+
+echo "[transaction-100m-fresh-volume] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-100m-fresh-volume] compose config"
+docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/dev/null
+
+echo "[transaction-100m-fresh-volume] print plan"
+plan="$(
+  FRESH_VOLUME_NAME=aquila-bank-postgres-data \
+  FIXTURE_NAME=transaction-100m-check \
+  K6_REPORT_NAME=transaction-100m-fresh-check \
+  FRESH_VOLUME_RESTORE_VERIFY_MIN_ROWS=1000 \
+    "${script}" --print-plan
+)"
+grep -F "mode=print-plan" <<<"${plan}" >/dev/null
+grep -F "volume=aquila-bank-postgres-data" <<<"${plan}" >/dev/null
+grep -F "confirm=erase-postgres-volume required for run" <<<"${plan}" >/dev/null
+grep -F "fixture=transaction-100m-check" <<<"${plan}" >/dev/null
+grep -F "restore_verify_min_rows=1000" <<<"${plan}" >/dev/null
+grep -F "restore_runner=tools/test/run-transaction-100m-fixture-restore.sh" <<<"${plan}" >/dev/null
+grep -F "k6_runner=tools/test/run-k6-transaction-100m-loadtest.sh --no-up" <<<"${plan}" >/dev/null
+grep -F "k6_enabled=true" <<<"${plan}" >/dev/null
+grep -F "hot account=910000001" <<<"${plan}" >/dev/null
+grep -F "cold account=910000002" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-fresh-volume] dry-run command"
+dry_run="$(
+  FRESH_VOLUME_NAME=aquila-bank-postgres-data \
+  FIXTURE_NAME=transaction-100m-check \
+  K6_REPORT_NAME=transaction-100m-fresh-check \
+    "${script}" --dry-run
+)"
+grep -F "docker volume rm aquila-bank-postgres-data" <<<"${dry_run}" >/dev/null
+grep -F "FIXTURE_MODE=restore" <<<"${dry_run}" >/dev/null
+grep -F "FIXTURE_RESTORE_TRUNCATE=true" <<<"${dry_run}" >/dev/null
+grep -F "run-k6-transaction-100m-loadtest.sh --no-up" <<<"${dry_run}" >/dev/null
+
+echo "[transaction-100m-fresh-volume] runner contract"
+grep -F "erase-postgres-volume" "${script}" >/dev/null
+grep -F "docker volume rm" "${script}" >/dev/null
+grep -F "wait_for_schema" "${script}" >/dev/null
+grep -F "assert_flyway_latest" "${script}" >/dev/null
+grep -F "FIXTURE_MODE=restore" "${script}" >/dev/null
+grep -F "FIXTURE_RESTORE_TRUNCATE=true" "${script}" >/dev/null
+grep -F "FIXTURE_VERIFY_MIN_ROWS" "${script}" >/dev/null
+grep -F "run-k6-transaction-100m-loadtest.sh --no-up" "${script}" >/dev/null
+
+echo "[transaction-100m-fresh-volume] invalid input fails"
+if FRESH_VOLUME_K6_ENABLED=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "FRESH_VOLUME_K6_ENABLED=maybe unexpectedly succeeded" >&2
+  exit 1
+fi
+if FRESH_VOLUME_RESTORE_VERIFY_MIN_ROWS=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "FRESH_VOLUME_RESTORE_VERIFY_MIN_ROWS=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if FRESH_VOLUME_CONFIRM=bad "${script}" >/dev/null 2>&1; then
+  echo "FRESH_VOLUME_CONFIRM=bad unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh
+++ b/tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh [--print-plan|--dry-run]
+
+Environment:
+  CLEANUP_CONFIRM        must be delete-100m-fixture for actual run
+  CLEANUP_HOT_ACCOUNT_ID default 910000001
+  CLEANUP_COLD_ACCOUNT_ID default 910000002
+  CLEANUP_CHUNK_SIZE     default 50000
+  CLEANUP_MAX_CHUNKS     default 4000
+  CLEANUP_WAL_MAX_BYTES  default 1073741824
+
+Examples:
+  tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh --print-plan
+  tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh --dry-run
+  CLEANUP_CONFIRM=delete-100m-fixture tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_positive_integer_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${key} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+hot_account_id="${CLEANUP_HOT_ACCOUNT_ID:-910000001}"
+cold_account_id="${CLEANUP_COLD_ACCOUNT_ID:-910000002}"
+chunk_size="${CLEANUP_CHUNK_SIZE:-50000}"
+max_chunks="${CLEANUP_MAX_CHUNKS:-4000}"
+wal_max_bytes="${CLEANUP_WAL_MAX_BYTES:-1073741824}"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
+wal_start_lsn=""
+
+require_positive_integer_value "CLEANUP_HOT_ACCOUNT_ID" "${hot_account_id}"
+require_positive_integer_value "CLEANUP_COLD_ACCOUNT_ID" "${cold_account_id}"
+require_positive_integer_value "CLEANUP_CHUNK_SIZE" "${chunk_size}"
+require_positive_integer_value "CLEANUP_MAX_CHUNKS" "${max_chunks}"
+require_positive_integer_value "CLEANUP_WAL_MAX_BYTES" "${wal_max_bytes}"
+if [[ "${hot_account_id}" == "${cold_account_id}" ]]; then
+  echo "CLEANUP_HOT_ACCOUNT_ID and CLEANUP_COLD_ACCOUNT_ID must differ" >&2
+  exit 1
+fi
+
+print_plan() {
+  echo "[transaction-100m-cleanup-wal] mode=${mode}"
+  echo "[transaction-100m-cleanup-wal] confirm=delete-100m-fixture required for run"
+  echo "[transaction-100m-cleanup-wal] accounts=${hot_account_id},${cold_account_id}"
+  echo "[transaction-100m-cleanup-wal] chunk_size=${chunk_size}"
+  echo "[transaction-100m-cleanup-wal] max_chunks=${max_chunks}"
+  echo "[transaction-100m-cleanup-wal] wal_max_bytes=${wal_max_bytes}"
+  echo "[transaction-100m-cleanup-wal] tables=transaction_read_model,transaction_read_model_archive"
+  echo "[transaction-100m-cleanup-wal] recovery_preflight=tools/test/run-transaction-100m-fixture-restore.sh verify"
+}
+
+print_dry_run() {
+  echo "FIXTURE_MODE=verify FIXTURE_VERIFY_MIN_ROWS=0 tools/test/run-transaction-100m-fixture-restore.sh"
+  echo "WITH candidates AS (SELECT ctid FROM public.transaction_read_model WHERE account_id IN (${hot_account_id}, ${cold_account_id}) LIMIT ${chunk_size}), deleted AS (DELETE FROM public.transaction_read_model item USING candidates WHERE item.ctid = candidates.ctid RETURNING 1) SELECT count(*) FROM deleted;"
+  echo "WITH candidates AS (SELECT ctid FROM public.transaction_read_model_archive WHERE account_id IN (${hot_account_id}, ${cold_account_id}) LIMIT ${chunk_size}), deleted AS (DELETE FROM public.transaction_read_model_archive item USING candidates WHERE item.ctid = candidates.ctid RETURNING 1) SELECT count(*) FROM deleted;"
+  echo "SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), '<start_lsn>'::pg_lsn)::bigint;"
+}
+
+run_recovery_preflight() {
+  FIXTURE_MODE=verify \
+  FIXTURE_VERIFY_MIN_ROWS=0 \
+    tools/test/run-transaction-100m-fixture-restore.sh >/dev/null
+}
+
+capture_wal_start() {
+  wal_start_lsn="$("${psql_base[@]}" --no-align --tuples-only --command "SELECT pg_current_wal_lsn();")"
+  wal_start_lsn="$(tr -d '[:space:]' <<<"${wal_start_lsn}")"
+  if [[ -z "${wal_start_lsn}" ]]; then
+    echo "failed to capture PostgreSQL WAL start LSN" >&2
+    exit 1
+  fi
+  echo "[transaction-100m-cleanup-wal] wal_start_lsn=${wal_start_lsn}"
+}
+
+current_wal_bytes() {
+  local bytes
+  bytes="$(
+    "${psql_base[@]}" --no-align --tuples-only --command "
+      SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), '${wal_start_lsn}'::pg_lsn)::bigint;
+    "
+  )"
+  tr -d '[:space:]' <<<"${bytes}"
+}
+
+check_wal_budget() {
+  local table="$1"
+  local chunk="$2"
+  local wal_bytes
+  wal_bytes="$(current_wal_bytes)"
+  echo "[transaction-100m-cleanup-wal] table=${table} chunk=${chunk} wal_bytes=${wal_bytes}/${wal_max_bytes}"
+  if ! [[ "${wal_bytes}" =~ ^[0-9]+$ ]]; then
+    echo "WAL budget check returned invalid value: ${wal_bytes}" >&2
+    exit 1
+  fi
+  if ((wal_bytes > wal_max_bytes)); then
+    echo "WAL budget exceeded table=${table} chunk=${chunk} wal_bytes=${wal_bytes} max=${wal_max_bytes}" >&2
+    exit 1
+  fi
+}
+
+delete_chunk() {
+  local table="$1"
+  local deleted
+  deleted="$(
+    "${psql_base[@]}" --no-align --tuples-only --command "
+      WITH candidates AS (
+        SELECT ctid
+        FROM public.${table}
+        WHERE account_id IN (${hot_account_id}, ${cold_account_id})
+        LIMIT ${chunk_size}
+      ),
+      deleted AS (
+        DELETE FROM public.${table} item
+        USING candidates
+        WHERE item.ctid = candidates.ctid
+        RETURNING 1
+      )
+      SELECT count(*) FROM deleted;
+    "
+  )"
+  tr -d '[:space:]' <<<"${deleted}"
+}
+
+cleanup_table() {
+  local table="$1"
+  local chunk deleted
+  for chunk in $(seq 1 "${max_chunks}"); do
+    # 큰 DELETE 한 번 대신 ctid chunk로 나눠 recovery loop를 만든 WAL spike를 피합니다.
+    deleted="$(delete_chunk "${table}")"
+    if ! [[ "${deleted}" =~ ^[0-9]+$ ]]; then
+      echo "cleanup delete returned invalid count table=${table}: ${deleted}" >&2
+      exit 1
+    fi
+    echo "[transaction-100m-cleanup-wal] table=${table} chunk=${chunk} deleted=${deleted}"
+    check_wal_budget "${table}" "${chunk}"
+    if [[ "${deleted}" -eq 0 ]]; then
+      return 0
+    fi
+  done
+
+  echo "cleanup stopped after CLEANUP_MAX_CHUNKS=${max_chunks}; table may still contain fixture rows: ${table}" >&2
+  exit 1
+}
+
+print_plan
+
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  print_dry_run
+  exit 0
+fi
+if [[ "${CLEANUP_CONFIRM:-}" != "delete-100m-fixture" ]]; then
+  echo "CLEANUP_CONFIRM=delete-100m-fixture is required for 100m fixture cleanup" >&2
+  exit 1
+fi
+
+run_recovery_preflight
+capture_wal_start
+cleanup_table "transaction_read_model"
+cleanup_table "transaction_read_model_archive"

--- a/tools/test/run-transaction-100m-fixture-restore.sh
+++ b/tools/test/run-transaction-100m-fixture-restore.sh
@@ -8,6 +8,9 @@ usage: tools/test/run-transaction-100m-fixture-restore.sh [--print-plan]
 Environment:
   FIXTURE_MODE              verify|dump|restore, default verify
   FIXTURE_NAME              default transaction-100m-fixture
+  FIXTURE_RECOVERY_PREFLIGHT default true
+  FIXTURE_REQUIRE_DUMP      require local dump artifact before mode, default false; restore always requires it
+  FIXTURE_VERIFY_MIN_ROWS   sampled minimum rows for verify, default 0
   FIXTURE_RESTORE_TRUNCATE  must be true for restore
 USAGE
 }
@@ -27,6 +30,10 @@ fixture_mode="${FIXTURE_MODE:-verify}"
 fixture_name="${FIXTURE_NAME:-transaction-100m-fixture}"
 fixture_dir="${FIXTURE_DIR:-build/fixtures}"
 fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
+fixture_recovery_preflight="${FIXTURE_RECOVERY_PREFLIGHT:-true}"
+fixture_require_dump="${FIXTURE_REQUIRE_DUMP:-false}"
+fixture_verify_min_rows="${FIXTURE_VERIFY_MIN_ROWS:-0}"
+postgres_container_name="${FIXTURE_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres}"
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
 container_dump_path="/tmp/${fixture_name}.dump"
 
@@ -34,10 +41,28 @@ case "${fixture_mode}" in
   verify|dump|restore) ;;
   *) echo "FIXTURE_MODE must be verify, dump, or restore" >&2; exit 1 ;;
 esac
+case "${fixture_recovery_preflight}" in
+  true|false) ;;
+  *) echo "FIXTURE_RECOVERY_PREFLIGHT must be true or false" >&2; exit 1 ;;
+esac
+case "${fixture_require_dump}" in
+  true|false) ;;
+  *) echo "FIXTURE_REQUIRE_DUMP must be true or false" >&2; exit 1 ;;
+esac
+if ! [[ "${fixture_verify_min_rows}" =~ ^[0-9]+$ ]]; then
+  echo "FIXTURE_VERIFY_MIN_ROWS must be zero or a positive integer" >&2
+  exit 1
+fi
+if [[ "${fixture_mode}" == "restore" ]]; then
+  fixture_require_dump="true"
+fi
 
 echo "[transaction-fixture-restore] fixture=${fixture_name}"
 echo "[transaction-fixture-restore] mode=${fixture_mode}"
 echo "[transaction-fixture-restore] dump=${fixture_path}"
+echo "[transaction-fixture-restore] recovery_preflight=${fixture_recovery_preflight}"
+echo "[transaction-fixture-restore] require_dump=${fixture_require_dump}"
+echo "[transaction-fixture-restore] verify_min_rows=${fixture_verify_min_rows}"
 echo "[transaction-fixture-restore] modes=verify,dump,restore"
 
 if [[ "${print_plan}" == "true" ]]; then
@@ -51,7 +76,49 @@ fi
 
 mkdir -p "${fixture_dir}"
 
-if [[ "${fixture_mode}" == "verify" ]]; then
+assert_fixture_dump_present() {
+  test -s "${fixture_path}" || { echo "fixture dump not found: ${fixture_path}" >&2; exit 1; }
+}
+
+assert_postgres_recovery_safe() {
+  if [[ "${fixture_recovery_preflight}" != "true" ]]; then
+    echo "[transaction-fixture-restore] recovery preflight skipped"
+    return 0
+  fi
+
+  local state running restarting oom_killed status
+  if ! state="$(docker inspect "${postgres_container_name}" --format '{{.State.Running}} {{.State.Restarting}} {{.State.OOMKilled}} {{.State.Status}}' 2>/dev/null)"; then
+    echo "PostgreSQL container not found for recovery preflight: ${postgres_container_name}" >&2
+    exit 1
+  fi
+  read -r running restarting oom_killed status <<<"${state}"
+  if [[ "${oom_killed}" == "true" ]]; then
+    echo "PostgreSQL container has OOMKilled=true. Recreate or restore from fixture dump before retry." >&2
+    exit 1
+  fi
+  if [[ "${restarting}" == "true" || "${status}" != "running" || "${running}" != "true" ]]; then
+    echo "PostgreSQL container is not ready. Running=${running} Restarting=${restarting} Status=${status}" >&2
+    exit 1
+  fi
+
+  local in_recovery
+  if ! in_recovery="$(
+    docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 \
+      -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}" \
+      --no-align --tuples-only --command "SELECT pg_is_in_recovery();" 2>&1
+  )"; then
+    echo "PostgreSQL recovery preflight query failed; database may still be starting or in recovery loop." >&2
+    echo "${in_recovery}" >&2
+    exit 1
+  fi
+  in_recovery="$(tr -d '[:space:]' <<<"${in_recovery}")"
+  if [[ "${in_recovery}" == "t" ]]; then
+    echo "PostgreSQL reports pg_is_in_recovery()=true. Do not run fixture restore/k6 until recovery is closed." >&2
+    exit 1
+  fi
+}
+
+verify_fixture_schema() {
   docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 \
     -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}" \
     --no-align --tuples-only --command "
@@ -59,6 +126,48 @@ if [[ "${fixture_mode}" == "verify" ]]; then
           AND to_regclass('public.transaction_read_model_archive') IS NOT NULL
           AND to_regclass('public.idx_transaction_read_model_account_cursor') IS NOT NULL
           AND to_regclass('public.idx_transaction_read_model_archive_account_cursor') IS NOT NULL;"
+}
+
+verify_fixture_rows() {
+  if [[ "${fixture_verify_min_rows}" -eq 0 ]]; then
+    return 0
+  fi
+
+  local sampled_rows
+  sampled_rows="$(
+    docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 \
+      -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}" \
+      --no-align --tuples-only --command "
+        SELECT count(*)
+        FROM (
+          SELECT 1 FROM public.transaction_read_model
+          UNION ALL
+          SELECT 1 FROM public.transaction_read_model_archive
+          LIMIT ${fixture_verify_min_rows}
+        ) rows;"
+  )"
+  sampled_rows="$(tr -d '[:space:]' <<<"${sampled_rows}")"
+  echo "[transaction-fixture-restore] transaction_read_model rows sampled=${sampled_rows} min=${fixture_verify_min_rows}"
+  if ! [[ "${sampled_rows}" =~ ^[0-9]+$ ]] || ((sampled_rows < fixture_verify_min_rows)); then
+    echo "transaction_read_model rows below fixture verify minimum: sampled=${sampled_rows} min=${fixture_verify_min_rows}" >&2
+    exit 1
+  fi
+}
+
+if [[ "${fixture_require_dump}" == "true" ]]; then
+  assert_fixture_dump_present
+fi
+
+assert_postgres_recovery_safe
+
+if [[ "${fixture_mode}" == "verify" ]]; then
+  schema_ready="$(verify_fixture_schema)"
+  echo "${schema_ready}"
+  if [[ "$(tr -d '[:space:]' <<<"${schema_ready}")" != "t" ]]; then
+    echo "transaction read fixture schema/index preflight failed" >&2
+    exit 1
+  fi
+  verify_fixture_rows
 elif [[ "${fixture_mode}" == "dump" ]]; then
   docker compose "${compose_files[@]}" exec -T postgres pg_dump \
     -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}" \
@@ -67,8 +176,9 @@ elif [[ "${fixture_mode}" == "dump" ]]; then
     --table=public.transaction_read_model \
     --table=public.transaction_read_model_archive
   docker cp "aquila-bank-postgres:${container_dump_path}" "${fixture_path}"
+  assert_fixture_dump_present
 else
-  test -s "${fixture_path}" || { echo "fixture dump not found: ${fixture_path}" >&2; exit 1; }
+  assert_fixture_dump_present
   docker cp "${fixture_path}" "aquila-bank-postgres:${container_dump_path}"
   docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 \
     -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}" \

--- a/tools/test/run-transaction-100m-fresh-volume-restore-k6.sh
+++ b/tools/test/run-transaction-100m-fresh-volume-restore-k6.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-fresh-volume-restore-k6.sh [--print-plan|--dry-run]
+
+Environment:
+  FRESH_VOLUME_CONFIRM              must be erase-postgres-volume for actual run
+  FRESH_VOLUME_NAME                 default aquila-bank-postgres-data
+  FRESH_VOLUME_BUILD_BACKEND        default true
+  FRESH_VOLUME_K6_ENABLED           default true
+  FRESH_VOLUME_RESTORE_VERIFY_MIN_ROWS default 1000
+  FRESH_VOLUME_READINESS_TIMEOUT_SECONDS default 120
+  FIXTURE_NAME                      default transaction-100m-fixture
+  FIXTURE_PATH                      default build/fixtures/<FIXTURE_NAME>.dump
+  K6_REPORT_NAME                    default transaction-100m-fresh-volume-<timestamp>
+
+Examples:
+  tools/test/run-transaction-100m-fresh-volume-restore-k6.sh --print-plan
+  tools/test/run-transaction-100m-fresh-volume-restore-k6.sh --dry-run
+  FRESH_VOLUME_CONFIRM=erase-postgres-volume tools/test/run-transaction-100m-fresh-volume-restore-k6.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_bool_value() {
+  local key="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${key} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_non_negative_integer_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${key} must be zero or a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+fixture_name="${FIXTURE_NAME:-transaction-100m-fixture}"
+fixture_dir="${FIXTURE_DIR:-build/fixtures}"
+fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
+volume_name="${FRESH_VOLUME_NAME:-aquila-bank-postgres-data}"
+build_backend="${FRESH_VOLUME_BUILD_BACKEND:-true}"
+k6_enabled="${FRESH_VOLUME_K6_ENABLED:-true}"
+restore_verify_min_rows="${FRESH_VOLUME_RESTORE_VERIFY_MIN_ROWS:-1000}"
+readiness_timeout_seconds="${FRESH_VOLUME_READINESS_TIMEOUT_SECONDS:-120}"
+k6_report_name="${K6_REPORT_NAME:-transaction-100m-fresh-volume-$(date +%Y-%m-%d-%H%M%S)}"
+hot_account_id="${K6_HOT_ACCOUNT_ID:-${SEED_HOT_ACCOUNT_ID:-910000001}}"
+cold_account_id="${K6_COLD_ACCOUNT_ID:-${SEED_COLD_ACCOUNT_ID:-910000002}}"
+hot_from="${K6_HOT_FROM:-${SEED_HOT_FROM:-2026-04-01T00:00:00Z}}"
+hot_to="${K6_HOT_TO:-${SEED_HOT_TO:-2026-04-30T00:00:00Z}}"
+cold_from="${K6_COLD_FROM:-${SEED_COLD_FROM:-2026-01-01T00:00:00Z}}"
+cold_to="${K6_COLD_TO:-${SEED_COLD_TO:-2026-01-31T00:00:00Z}}"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
+
+require_bool_value "FRESH_VOLUME_BUILD_BACKEND" "${build_backend}"
+require_bool_value "FRESH_VOLUME_K6_ENABLED" "${k6_enabled}"
+require_non_negative_integer_value "FRESH_VOLUME_RESTORE_VERIFY_MIN_ROWS" "${restore_verify_min_rows}"
+require_non_negative_integer_value "FRESH_VOLUME_READINESS_TIMEOUT_SECONDS" "${readiness_timeout_seconds}"
+
+print_plan() {
+  echo "[transaction-100m-fresh-volume] mode=${mode}"
+  echo "[transaction-100m-fresh-volume] volume=${volume_name}"
+  echo "[transaction-100m-fresh-volume] confirm=erase-postgres-volume required for run"
+  echo "[transaction-100m-fresh-volume] fixture=${fixture_name}"
+  echo "[transaction-100m-fresh-volume] dump=${fixture_path}"
+  echo "[transaction-100m-fresh-volume] build_backend=${build_backend}"
+  echo "[transaction-100m-fresh-volume] restore_verify_min_rows=${restore_verify_min_rows}"
+  echo "[transaction-100m-fresh-volume] readiness_timeout_seconds=${readiness_timeout_seconds}"
+  echo "[transaction-100m-fresh-volume] restore_runner=tools/test/run-transaction-100m-fixture-restore.sh"
+  echo "[transaction-100m-fresh-volume] k6_runner=tools/test/run-k6-transaction-100m-loadtest.sh --no-up"
+  echo "[transaction-100m-fresh-volume] k6_enabled=${k6_enabled}"
+  echo "[transaction-100m-fresh-volume] k6 report=${k6_report_name}"
+  echo "[transaction-100m-fresh-volume] hot account=${hot_account_id} window=${hot_from}..${hot_to}"
+  echo "[transaction-100m-fresh-volume] cold account=${cold_account_id} window=${cold_from}..${cold_to}"
+  echo "[transaction-100m-fresh-volume] steps=stop-runtime,remove-postgres-volume,start-runtime,restore,verify,k6"
+}
+
+print_dry_run() {
+  echo "docker compose ${compose_files[*]} --profile loadtest stop aquila-bank-backend postgres prometheus grafana alertmanager postgres-exporter"
+  echo "docker compose ${compose_files[*]} --profile loadtest rm -f -s postgres"
+  echo "docker volume rm ${volume_name}"
+  echo "docker compose ${compose_files[*]} --profile loadtest up -d postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter"
+  echo "FIXTURE_MODE=restore FIXTURE_RESTORE_TRUNCATE=true FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} tools/test/run-transaction-100m-fixture-restore.sh"
+  echo "FIXTURE_MODE=verify FIXTURE_VERIFY_MIN_ROWS=${restore_verify_min_rows} FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} tools/test/run-transaction-100m-fixture-restore.sh"
+  echo "K6_REPORT_NAME=${k6_report_name} K6_HOT_ACCOUNT_ID=${hot_account_id} K6_COLD_ACCOUNT_ID=${cold_account_id} tools/test/run-k6-transaction-100m-loadtest.sh --no-up"
+}
+
+latest_local_flyway_version() {
+  local version
+  version="$(
+    find back/src/main/resources/db/migration -maxdepth 1 -type f -name 'V*__*.sql' \
+      | sed -E 's#^.*/V([0-9]+)__.*$#\1#' \
+      | sort -n \
+      | tail -1
+  )"
+  if [[ -z "${version}" ]]; then
+    echo "no local Flyway migrations found" >&2
+    exit 1
+  fi
+  echo "${version}"
+}
+
+wait_for_schema() {
+  local deadline=$((SECONDS + readiness_timeout_seconds))
+  local exists
+  while ((SECONDS < deadline)); do
+    if exists="$("${psql_base[@]}" --no-align --tuples-only --command "SELECT to_regclass('public.transaction_read_model') IS NOT NULL;" 2>/dev/null)"; then
+      if [[ "$(tr -d '[:space:]' <<<"${exists}")" == "t" ]]; then
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  echo "transaction_read_model schema was not created in time" >&2
+  exit 1
+}
+
+assert_flyway_latest() {
+  local required_version applied_version
+  required_version="$(latest_local_flyway_version)"
+  applied_version="$(
+    "${psql_base[@]}" --no-align --tuples-only --command "
+      SELECT COALESCE(MAX(version::integer), 0)
+      FROM flyway_schema_history
+      WHERE success
+        AND version ~ '^[0-9]+$';
+    "
+  )"
+  if ! [[ "${applied_version}" =~ ^[0-9]+$ ]]; then
+    echo "Flyway latest version check returned invalid value: ${applied_version}" >&2
+    exit 1
+  fi
+  echo "[transaction-100m-fresh-volume] flyway latest applied=${applied_version} required=${required_version}"
+  if ((applied_version < required_version)); then
+    echo "Flyway schema is stale after fresh volume recreate." >&2
+    exit 1
+  fi
+}
+
+reset_postgres_volume() {
+  echo "[transaction-100m-fresh-volume] stopping runtime before volume reset"
+  docker compose "${compose_files[@]}" --profile loadtest stop \
+    aquila-bank-backend postgres prometheus grafana alertmanager postgres-exporter >/dev/null 2>&1 || true
+  docker compose "${compose_files[@]}" --profile loadtest rm -f -s postgres >/dev/null 2>&1 || true
+
+  if docker volume inspect "${volume_name}" >/dev/null 2>&1; then
+    # fresh restore는 손상 volume 재사용을 피하기 위해 named volume을 명시 삭제합니다.
+    docker volume rm "${volume_name}"
+  else
+    echo "[transaction-100m-fresh-volume] volume already absent: ${volume_name}"
+  fi
+}
+
+start_runtime() {
+  if [[ "${build_backend}" == "true" ]]; then
+    echo "[transaction-100m-fresh-volume] building backend bootJar"
+    tools/test/with-resource-lock.sh back-gradle-fresh-volume-bootjar ./back/gradlew -p back bootJar
+  fi
+
+  echo "[transaction-100m-fresh-volume] starting runtime for restore"
+  docker compose "${compose_files[@]}" --profile loadtest up -d \
+    postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter
+  wait_for_schema
+  assert_flyway_latest
+}
+
+restore_fixture() {
+  FIXTURE_MODE=restore \
+  FIXTURE_RESTORE_TRUNCATE=true \
+  FIXTURE_NAME="${fixture_name}" \
+  FIXTURE_PATH="${fixture_path}" \
+    tools/test/run-transaction-100m-fixture-restore.sh
+}
+
+verify_fixture() {
+  FIXTURE_MODE=verify \
+  FIXTURE_VERIFY_MIN_ROWS="${restore_verify_min_rows}" \
+  FIXTURE_NAME="${fixture_name}" \
+  FIXTURE_PATH="${fixture_path}" \
+    tools/test/run-transaction-100m-fixture-restore.sh
+}
+
+run_k6() {
+  if [[ "${k6_enabled}" != "true" ]]; then
+    echo "[transaction-100m-fresh-volume] k6 skipped"
+    return 0
+  fi
+
+  K6_REPORT_NAME="${k6_report_name}" \
+  K6_HOT_ACCOUNT_ID="${hot_account_id}" \
+  K6_HOT_FROM="${hot_from}" \
+  K6_HOT_TO="${hot_to}" \
+  K6_COLD_ACCOUNT_ID="${cold_account_id}" \
+  K6_COLD_FROM="${cold_from}" \
+  K6_COLD_TO="${cold_to}" \
+    tools/test/run-k6-transaction-100m-loadtest.sh --no-up
+}
+
+print_plan
+
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  print_dry_run
+  exit 0
+fi
+if [[ "${FRESH_VOLUME_CONFIRM:-}" != "erase-postgres-volume" ]]; then
+  echo "FRESH_VOLUME_CONFIRM=erase-postgres-volume is required for fresh volume restore" >&2
+  exit 1
+fi
+
+reset_postgres_volume
+start_runtime
+restore_fixture
+verify_fixture
+run_k6


### PR DESCRIPTION
## 🔗 Related Issue
- close #431

## 🌿 Base Branch
- `main`

## 📝 Summary
- 100m transaction read fixture를 dump artifact 기준으로 검증/restore하고, PostgreSQL OOM/recovery 상태를 k6 전 fail-fast 하도록 보강합니다.
- crash volume 폐기 후 clean restore -> preflight -> k6 재실행 runner와 chunked cleanup/WAL budget, corruption runbook을 추가합니다.

## 🛠 Changes
- `run-transaction-100m-fixture-restore.sh`에 `FIXTURE_RECOVERY_PREFLIGHT`, `FIXTURE_REQUIRE_DUMP`, `FIXTURE_VERIFY_MIN_ROWS` 계약을 추가했습니다.
- `run-transaction-100m-fresh-volume-restore-k6.sh`로 named volume 삭제 confirm 후 restore/verify/k6 순서를 제공합니다.
- `run-transaction-100m-fixture-cleanup-wal-budget.sh`로 account 범위 chunk cleanup과 WAL budget guard를 제공합니다.
- `docs/transaction-read-volume-corruption-runbook.md`에 복구/폐기/재생성 기준을 문서화했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-fixture-restore.sh`
- `tools/test/check-transaction-100m-fresh-volume-restore-k6.sh`
- `tools/test/check-transaction-100m-fixture-cleanup-wal-budget.sh`
- `bash -n tools/test/run-transaction-100m-fixture-restore.sh`
- `bash -n tools/test/run-transaction-100m-fresh-volume-restore-k6.sh`
- `bash -n tools/test/run-transaction-100m-fixture-cleanup-wal-budget.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: fresh-volume runner는 confirm 후 PostgreSQL named volume을 삭제합니다. 기본 실행은 confirm 없이는 실패하며, `--dry-run`으로 명령을 먼저 확인할 수 있습니다.
- 롤백 방법: PR revert 후 기존 fixture restore/read runner 경로로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?