### PR TITLE
[Perf] defensive 100m k6 admission 경량 smoke 추가

### DIFF
--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -97,6 +97,16 @@ tools/test/archive-k6-transaction-100m-result.sh \
   build/reports/k6/<name>-summary.json
 ```
 
+## Admission guard telemetry
+
+방어형 HTTP admission smoke 결과는 summary TSV와 raw TSV를 Markdown으로 보관합니다. token, Authorization header, 운영 URL은 결과 문서에 남기지 않습니다.
+
+```bash
+tools/test/archive-admission-guard-telemetry-snapshot.sh \
+  build/reports/admission/<name>/http-admission-summary.tsv \
+  build/reports/admission/<name>/http-admission-raw.tsv
+```
+
 ## 월별 chunk lifecycle
 
 월별 partition 선생성, archive detach/drop guard, partition별 `ANALYZE`/`VACUUM` 절차는 [Transaction Read Model Chunk Lifecycle Runbook](../transaction-read-model-chunk-lifecycle.md)을 기준으로 실행합니다.

--- a/ops/k6/transaction-read-100m.js
+++ b/ops/k6/transaction-read-100m.js
@@ -33,6 +33,7 @@ const hotMaxThresholdMs = Number(__ENV.K6_HOT_MAX_THRESHOLD_MS || "3000");
 const coldMaxThresholdMs = Number(__ENV.K6_COLD_MAX_THRESHOLD_MS || "5000");
 const failedRate = Number(__ENV.K6_HTTP_FAILED_RATE || "0.01");
 const reportName = __ENV.K6_REPORT_NAME || "transaction-100m";
+const observabilityMode = __ENV.K6_OBSERVABILITY_MODE || "prometheus";
 const overloadMode = booleanEnv(__ENV.K6_OVERLOAD_MODE);
 const overload429RateThreshold = nonNegativeNumberEnv(__ENV.K6_OVERLOAD_429_RATE_THRESHOLD, 0.05);
 const maxRetryAfterSleepSeconds = nonNegativeNumberEnv(__ENV.K6_MAX_RETRY_AFTER_SLEEP_SECONDS, 1);
@@ -280,6 +281,7 @@ function markdownSummary(data) {
 - vus: ${vus}
 - duration: ${duration}
 - limit: ${limit}
+- observability mode: ${observabilityMode}
 - overload mode: ${overloadMode}
 - max retry-after sleep seconds: ${maxRetryAfterSleepSeconds}
 - hot account id: ${hotAccountId}
@@ -316,7 +318,7 @@ function markdownSummary(data) {
 - 이 결과는 k6 HTTP replay 기준입니다.
 - overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
 - 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
-- Prometheus remote write 대상은 \`K6_PROMETHEUS_RW_SERVER_URL\`입니다.
+- observability mode가 \`summary-only\`이면 Prometheus remote write 없이 summary 파일만 남깁니다.
 `;
 }
 

--- a/tools/test/archive-admission-guard-telemetry-snapshot.sh
+++ b/tools/test/archive-admission-guard-telemetry-snapshot.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/archive-admission-guard-telemetry-snapshot.sh <summary-tsv> [raw-tsv]
+
+Environment:
+  ADMISSION_TELEMETRY_RESULT_NAME   output basename without .md, default summary-tsv basename
+
+Examples:
+  tools/test/archive-admission-guard-telemetry-snapshot.sh \
+    build/reports/admission/<name>/http-admission-summary.tsv \
+    build/reports/admission/<name>/http-admission-raw.tsv
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+summary_tsv="$1"
+raw_tsv="${2:-}"
+if [[ ! -f "${summary_tsv}" ]]; then
+  echo "admission telemetry summary not found: ${summary_tsv}" >&2
+  exit 1
+fi
+if [[ -n "${raw_tsv}" && ! -f "${raw_tsv}" ]]; then
+  echo "admission telemetry raw sample not found: ${raw_tsv}" >&2
+  exit 1
+fi
+
+base_name="${ADMISSION_TELEMETRY_RESULT_NAME:-$(basename "${summary_tsv}" .tsv)}"
+output_dir="docs/performance-results"
+output_path="${output_dir}/${base_name}.md"
+mkdir -p "${output_dir}"
+
+{
+  echo "# ${base_name}"
+  echo
+  echo "## Admission Guard Telemetry"
+  echo
+  echo "- archivedAt: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "- sourceSummary: ${summary_tsv}"
+  if [[ -n "${raw_tsv}" ]]; then
+    echo "- sourceRaw: ${raw_tsv}"
+  fi
+  echo "- secretPolicy: token, Authorization header, 운영 URL은 기록하지 않음"
+  echo
+  echo "## Summary"
+  echo
+  echo '```tsv'
+  cat "${summary_tsv}"
+  echo '```'
+  if [[ -n "${raw_tsv}" ]]; then
+    echo
+    echo "## Raw Sample"
+    echo
+    echo '```tsv'
+    head -50 "${raw_tsv}"
+    echo '```'
+  fi
+} >"${output_path}"
+
+echo "${output_path}"

--- a/tools/test/check-admission-guard-telemetry-archive.sh
+++ b/tools/test/check-admission-guard-telemetry-archive.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/archive-admission-guard-telemetry-snapshot.sh"
+
+echo "[admission-telemetry-archive] shell syntax"
+bash -n "${script}"
+
+echo "[admission-telemetry-archive] archive sample"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+summary_tsv="${temp_dir}/http-admission-summary.tsv"
+raw_tsv="${temp_dir}/http-admission-raw.tsv"
+{
+  printf "requests\tsuccess_count\trejected_count\tfailed_count\tfailed_rate\tretry_after_count\traw_path\n"
+  printf "16\t8\t8\t0\t0.000000\t8\t%s\n" "${raw_tsv}"
+} >"${summary_tsv}"
+{
+  printf "request_id\tstatus\tduration_seconds\tretry_after\n"
+  printf "1\t429\t0.012\t1\n"
+} >"${raw_tsv}"
+
+output="$(
+  ADMISSION_TELEMETRY_RESULT_NAME=admission-telemetry-check \
+    "${script}" "${summary_tsv}" "${raw_tsv}"
+)"
+test "${output}" = "docs/performance-results/admission-telemetry-check.md"
+grep -F "# admission-telemetry-check" "${output}" >/dev/null
+grep -F "sourceSummary: ${summary_tsv}" "${output}" >/dev/null
+grep -F "sourceRaw: ${raw_tsv}" "${output}" >/dev/null
+grep -F $'16\t8\t8\t0\t0.000000\t8' "${output}" >/dev/null
+grep -F "429" "${output}" >/dev/null
+rm -f "${output}"
+
+echo "[admission-telemetry-archive] contract"
+grep -F "ADMISSION_TELEMETRY_RESULT_NAME" "${script}" >/dev/null
+grep -F "docs/performance-results" "${script}" >/dev/null
+grep -F "sourceSummary" "${script}" >/dev/null
+grep -F "Admission Guard Telemetry" "${script}" >/dev/null
+grep -F "secret" "${script}" >/dev/null
+grep -F "archive-admission-guard-telemetry-snapshot.sh" docs/performance-results/README.md >/dev/null
+
+echo "[admission-telemetry-archive] invalid input fails"
+if "${script}" "${temp_dir}/missing.tsv" >/dev/null 2>&1; then
+  echo "missing summary unexpectedly succeeded" >&2
+  exit 1
+fi
+if "${script}" "${summary_tsv}" "${temp_dir}/missing-raw.tsv" >/dev/null 2>&1; then
+  echo "missing raw unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/check-defensive-runtime-http-admission-smoke.sh
+++ b/tools/test/check-defensive-runtime-http-admission-smoke.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-defensive-runtime-http-admission-smoke.sh"
+
+echo "[defensive-http-admission] shell syntax"
+bash -n "${script}"
+
+echo "[defensive-http-admission] print plan"
+plan="$(
+  ADMISSION_NAME=admission-check \
+  ADMISSION_REQUESTS=12 \
+  ADMISSION_CONCURRENCY=4 \
+  ADMISSION_EXPECT_429=true \
+    "${script}" --print-plan
+)"
+grep -F "name=admission-check" <<<"${plan}" >/dev/null
+grep -F "base_url=http://localhost:8080" <<<"${plan}" >/dev/null
+grep -F "requests=12" <<<"${plan}" >/dev/null
+grep -F "concurrency=4" <<<"${plan}" >/dev/null
+grep -F "expect_429=true" <<<"${plan}" >/dev/null
+grep -F "summary=build/reports/admission/admission-check/http-admission-summary.tsv" <<<"${plan}" >/dev/null
+
+echo "[defensive-http-admission] dry-run command"
+dry_run="$("${script}" --dry-run)"
+grep -F "curl" <<<"${dry_run}" >/dev/null
+grep -F "X-Account-Id:" <<<"${dry_run}" >/dev/null
+grep -F "Authorization: Bearer ***" <<<"${dry_run}" >/dev/null
+grep -F "/api/v1/transactions" <<<"${dry_run}" >/dev/null
+
+echo "[defensive-http-admission] runner contract"
+grep -F "ADMISSION_EXPECT_429" "${script}" >/dev/null
+grep -F "ADMISSION_MAX_FAILED_RATE" "${script}" >/dev/null
+grep -F "http-admission-summary.tsv" "${script}" >/dev/null
+grep -F "Retry-After" "${script}" >/dev/null
+grep -F "rejected_count" "${script}" >/dev/null
+grep -F "failed_rate" "${script}" >/dev/null
+grep -F "Authorization: Bearer ***" "${script}" >/dev/null
+
+echo "[defensive-http-admission] invalid input fails"
+if ADMISSION_REQUESTS=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "ADMISSION_REQUESTS=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if ADMISSION_CONCURRENCY=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "ADMISSION_CONCURRENCY=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if ADMISSION_EXPECT_429=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "ADMISSION_EXPECT_429=maybe unexpectedly succeeded" >&2
+  exit 1
+fi
+if ADMISSION_MAX_FAILED_RATE=1.5 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "ADMISSION_MAX_FAILED_RATE=1.5 unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -26,14 +26,24 @@ grep -F "overload mode=false max retry-after sleep seconds=1" <<<"${plan}" >/dev
 grep -F "overload 429 rate threshold=0.05" <<<"${plan}" >/dev/null
 grep -F "generator mode=local" <<<"${plan}" >/dev/null
 grep -F "generator runner=docker compose service k6-transaction-read-100m" <<<"${plan}" >/dev/null
+grep -F "observability mode=prometheus" <<<"${plan}" >/dev/null
 grep -F "preflight=true" <<<"${plan}" >/dev/null
+
+summary_only_plan="$(
+  K6_REPORT_NAME=transaction-100m-summary-only-check \
+  K6_OBSERVABILITY_MODE=summary-only \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "k6 report name: transaction-100m-summary-only-check" <<<"${summary_only_plan}" >/dev/null
+grep -F "observability mode=summary-only" <<<"${summary_only_plan}" >/dev/null
+grep -F "generator runner=docker compose service k6-transaction-read-100m without prometheus remote-write" <<<"${summary_only_plan}" >/dev/null
 
 remote_plan="$(
   K6_REPORT_NAME=transaction-100m-remote-check \
+  K6_OBSERVABILITY_MODE=summary-only \
   K6_GENERATOR_MODE=docker-context \
   K6_DOCKER_CONTEXT=transaction-k6-remote \
   K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
-  K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.10:9090/api/v1/write \
   K6_REMOTE_WORKDIR=/srv/aquila-bank \
     tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
 )"
@@ -41,7 +51,7 @@ grep -F "k6 report name: transaction-100m-remote-check" <<<"${remote_plan}" >/de
 grep -F "generator mode=docker-context" <<<"${remote_plan}" >/dev/null
 grep -F "generator runner=docker --context transaction-k6-remote run grafana/k6:0.54.0" <<<"${remote_plan}" >/dev/null
 grep -F "remote base url=http://192.0.2.10:8080" <<<"${remote_plan}" >/dev/null
-grep -F "remote prometheus rw=http://192.0.2.10:9090/api/v1/write" <<<"${remote_plan}" >/dev/null
+grep -F "remote prometheus rw=disabled" <<<"${remote_plan}" >/dev/null
 grep -F "remote workdir=/srv/aquila-bank" <<<"${remote_plan}" >/dev/null
 
 overload_plan="$(
@@ -84,6 +94,10 @@ grep -F "K6_HOT_MAX_THRESHOLD_MS" tools/test/run-k6-transaction-100m-loadtest.sh
 grep -F "K6_COLD_MAX_THRESHOLD_MS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_OVERLOAD_429_RATE_THRESHOLD" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_GENERATOR_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_OBSERVABILITY_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "require_observability_mode" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "experimental-prometheus-rw" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "without prometheus remote-write" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_DOCKER_CONTEXT" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_REMOTE_BASE_URL" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_REMOTE_PROMETHEUS_RW_SERVER_URL" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
@@ -104,8 +118,12 @@ if K6_GENERATOR_MODE=unknown tools/test/run-k6-transaction-100m-loadtest.sh --pr
   echo "K6_GENERATOR_MODE=unknown unexpectedly succeeded" >&2
   exit 1
 fi
-if K6_GENERATOR_MODE=docker-context tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
-  echo "K6_GENERATOR_MODE=docker-context without remote inputs unexpectedly succeeded" >&2
+if K6_OBSERVABILITY_MODE=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_OBSERVABILITY_MODE=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_OBSERVABILITY_MODE=prometheus K6_GENERATOR_MODE=docker-context tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "prometheus docker-context without remote prometheus unexpectedly succeeded" >&2
   exit 1
 fi
 

--- a/tools/test/run-defensive-runtime-http-admission-smoke.sh
+++ b/tools/test/run-defensive-runtime-http-admission-smoke.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-defensive-runtime-http-admission-smoke.sh [--print-plan|--dry-run]
+
+Environment:
+  ADMISSION_NAME             default defensive-http-admission-<timestamp>
+  ADMISSION_BASE_URL         default http://localhost:8080
+  ADMISSION_REQUESTS         default 16
+  ADMISSION_CONCURRENCY      default 8
+  ADMISSION_EXPECT_429       default true
+  ADMISSION_MAX_FAILED_RATE  default 0
+  ADMISSION_ACCOUNT_ID       default 910000001
+  ADMISSION_FROM             default 2026-04-01T00:00:00Z
+  ADMISSION_TO               default 2026-04-30T00:00:00Z
+  ADMISSION_LIMIT            default 50
+  ADMISSION_AUTH_TOKEN       optional bearer token, not printed
+
+Examples:
+  tools/test/run-defensive-runtime-http-admission-smoke.sh --print-plan
+  tools/test/run-defensive-runtime-http-admission-smoke.sh --dry-run
+  ADMISSION_BASE_URL=http://localhost:8080 tools/test/run-defensive-runtime-http-admission-smoke.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_bool_value() {
+  local key="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${key} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${key} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_rate_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${key} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0 && value <= 1) }' \
+    || {
+      echo "${key} must be a rate between 0 and 1: ${value}" >&2
+      exit 1
+    }
+}
+
+number_greater_than() {
+  local value="$1"
+  local threshold="$2"
+  awk -v value="${value}" -v threshold="${threshold}" 'BEGIN { exit !(value > threshold) }'
+}
+
+name="${ADMISSION_NAME:-defensive-http-admission-$(date +%Y-%m-%d-%H%M%S)}"
+base_url="${ADMISSION_BASE_URL:-http://localhost:8080}"
+base_url="${base_url%/}"
+requests="${ADMISSION_REQUESTS:-16}"
+concurrency="${ADMISSION_CONCURRENCY:-8}"
+expect_429="${ADMISSION_EXPECT_429:-true}"
+max_failed_rate="${ADMISSION_MAX_FAILED_RATE:-0}"
+account_id="${ADMISSION_ACCOUNT_ID:-910000001}"
+from="${ADMISSION_FROM:-2026-04-01T00:00:00Z}"
+to="${ADMISSION_TO:-2026-04-30T00:00:00Z}"
+limit="${ADMISSION_LIMIT:-50}"
+auth_token="${ADMISSION_AUTH_TOKEN:-}"
+report_dir="build/reports/admission/${name}"
+raw_tsv="${report_dir}/http-admission-raw.tsv"
+summary_tsv="${report_dir}/http-admission-summary.tsv"
+request_dir="${report_dir}/requests"
+
+require_positive_integer_value "ADMISSION_REQUESTS" "${requests}"
+require_positive_integer_value "ADMISSION_CONCURRENCY" "${concurrency}"
+require_positive_integer_value "ADMISSION_ACCOUNT_ID" "${account_id}"
+require_positive_integer_value "ADMISSION_LIMIT" "${limit}"
+require_bool_value "ADMISSION_EXPECT_429" "${expect_429}"
+require_rate_value "ADMISSION_MAX_FAILED_RATE" "${max_failed_rate}"
+
+print_plan() {
+  echo "[defensive-http-admission] name=${name}"
+  echo "[defensive-http-admission] base_url=${base_url}"
+  echo "[defensive-http-admission] requests=${requests}"
+  echo "[defensive-http-admission] concurrency=${concurrency}"
+  echo "[defensive-http-admission] expect_429=${expect_429}"
+  echo "[defensive-http-admission] max_failed_rate=${max_failed_rate}"
+  echo "[defensive-http-admission] account=${account_id} window=${from}..${to} limit=${limit}"
+  echo "[defensive-http-admission] summary=${summary_tsv}"
+}
+
+print_dry_run() {
+  echo "curl --get ${base_url}/api/v1/transactions -H 'X-Account-Id: ${account_id}' -H 'X-Subject: admission-smoke' -H 'Authorization: Bearer ***' --data-urlencode accountId=${account_id} --data-urlencode from=${from} --data-urlencode to=${to} --data-urlencode limit=${limit}"
+}
+
+run_request() {
+  local request_id="$1"
+  local header_path="${request_dir}/${request_id}.headers"
+  local result_path="${request_dir}/${request_id}.tsv"
+  local error_path="${request_dir}/${request_id}.err"
+  local curl_output status duration retry_after
+  local curl_args
+
+  curl_args=(
+    -sS
+    -o /dev/null
+    -D "${header_path}"
+    -w "%{http_code}\t%{time_total}"
+    --get "${base_url}/api/v1/transactions"
+    -H "X-Account-Id: ${account_id}"
+    -H "X-Subject: admission-smoke"
+    --data-urlencode "accountId=${account_id}"
+    --data-urlencode "from=${from}"
+    --data-urlencode "to=${to}"
+    --data-urlencode "limit=${limit}"
+  )
+  if [[ -n "${auth_token}" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${auth_token}")
+  fi
+
+  if curl_output="$(curl "${curl_args[@]}" 2>"${error_path}")"; then
+    status="${curl_output%%$'\t'*}"
+    duration="${curl_output#*$'\t'}"
+  else
+    status="000"
+    duration="0"
+  fi
+  retry_after="$(awk 'BEGIN {IGNORECASE=1} /^Retry-After:/ {gsub("\r", "", $2); print $2}' "${header_path}" 2>/dev/null | tail -1)"
+  printf "%s\t%s\t%s\t%s\n" "${request_id}" "${status}" "${duration}" "${retry_after}" >"${result_path}"
+  return 0
+}
+
+run_requests() {
+  mkdir -p "${request_dir}"
+  local active=0
+  local request_id
+  for request_id in $(seq 1 "${requests}"); do
+    run_request "${request_id}" &
+    active=$((active + 1))
+    if ((active >= concurrency)); then
+      wait
+      active=0
+    fi
+  done
+  wait
+}
+
+write_raw() {
+  printf "request_id\tstatus\tduration_seconds\tretry_after\n" >"${raw_tsv}"
+  local request_id
+  for request_id in $(seq 1 "${requests}"); do
+    cat "${request_dir}/${request_id}.tsv" >>"${raw_tsv}"
+  done
+}
+
+write_summary() {
+  local success_count rejected_count failed_count retry_after_count failed_rate
+  success_count="$(awk -F '\t' 'NR > 1 && $2 ~ /^2/ {count++} END {print count + 0}' "${raw_tsv}")"
+  rejected_count="$(awk -F '\t' 'NR > 1 && $2 == "429" {count++} END {print count + 0}' "${raw_tsv}")"
+  failed_count="$(awk -F '\t' 'NR > 1 && $2 !~ /^2/ && $2 != "429" {count++} END {print count + 0}' "${raw_tsv}")"
+  retry_after_count="$(awk -F '\t' 'NR > 1 && $4 != "" {count++} END {print count + 0}' "${raw_tsv}")"
+  failed_rate="$(awk -v failed="${failed_count}" -v total="${requests}" 'BEGIN {printf "%.6f", failed / total}')"
+
+  {
+    printf "requests\tsuccess_count\trejected_count\tfailed_count\tfailed_rate\tretry_after_count\traw_path\n"
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+      "${requests}" "${success_count}" "${rejected_count}" "${failed_count}" "${failed_rate}" "${retry_after_count}" "${raw_tsv}"
+  } >"${summary_tsv}"
+
+  echo "[defensive-http-admission] summary=${summary_tsv}"
+  if [[ "${expect_429}" == "true" && "${rejected_count}" -eq 0 ]]; then
+    echo "expected at least one HTTP 429 admission rejection, but rejected_count=0" >&2
+    exit 1
+  fi
+  if number_greater_than "${failed_rate}" "${max_failed_rate}"; then
+    echo "failed_rate exceeded threshold: failed_rate=${failed_rate} max=${max_failed_rate}" >&2
+    exit 1
+  fi
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  print_dry_run
+  exit 0
+fi
+
+mkdir -p "${report_dir}"
+run_requests
+write_raw
+write_summary

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -25,6 +25,7 @@ Optional environment:
   K6_AUTH_TOKEN        bearer token, optional when bootstrap header auth is enabled
   K6_ARCHIVE_RESULTS   copy markdown summary to docs/performance-results, default true
   K6_PREFLIGHT         check PostgreSQL OOM/index readiness before k6, default true
+  K6_OBSERVABILITY_MODE prometheus|summary-only, default prometheus
   K6_OVERLOAD_MODE     treat 429 as expected rejected samples, default false
   K6_OVERLOAD_429_RATE_THRESHOLD
                        max 429 rate in overload mode, default 0.05
@@ -110,6 +111,17 @@ require_generator_mode() {
   esac
 }
 
+require_observability_mode() {
+  case "${K6_OBSERVABILITY_MODE}" in
+    prometheus|summary-only)
+      ;;
+    *)
+      echo "K6_OBSERVABILITY_MODE must be prometheus or summary-only" >&2
+      exit 1
+      ;;
+  esac
+}
+
 mode="run"
 run_dependencies="true"
 while [[ "$#" -gt 0 ]]; do
@@ -146,6 +158,7 @@ K6_COLD_MAX_THRESHOLD_MS="${K6_COLD_MAX_THRESHOLD_MS:-5000}"
 K6_HTTP_FAILED_RATE="${K6_HTTP_FAILED_RATE:-0.01}"
 K6_ARCHIVE_RESULTS="${K6_ARCHIVE_RESULTS:-true}"
 K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
+K6_OBSERVABILITY_MODE="${K6_OBSERVABILITY_MODE:-prometheus}"
 K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE:-false}"
 K6_OVERLOAD_429_RATE_THRESHOLD="${K6_OVERLOAD_429_RATE_THRESHOLD:-0.05}"
 K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${K6_MAX_RETRY_AFTER_SLEEP_SECONDS:-1}"
@@ -155,7 +168,7 @@ K6_REMOTE_BASE_URL="${K6_REMOTE_BASE_URL:-}"
 K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-}"
 K6_REMOTE_WORKDIR="${K6_REMOTE_WORKDIR:-$(pwd)}"
 K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-$(date +%Y-%m-%d-%H%M%S)}"
-export K6_VUS K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
+export K6_VUS K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
 
 require_positive_integer K6_VUS
 require_positive_integer K6_LIMIT
@@ -169,11 +182,14 @@ require_rate K6_HTTP_FAILED_RATE
 require_non_negative_integer K6_MAX_RETRY_AFTER_SLEEP_SECONDS
 require_rate K6_OVERLOAD_429_RATE_THRESHOLD
 require_generator_mode
+require_observability_mode
 
 if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
   require_env K6_DOCKER_CONTEXT
   require_env K6_REMOTE_BASE_URL
-  require_env K6_REMOTE_PROMETHEUS_RW_SERVER_URL
+  if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
+    require_env K6_REMOTE_PROMETHEUS_RW_SERVER_URL
+  fi
 fi
 
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
@@ -185,7 +201,12 @@ psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERRO
 print_plan() {
   echo "[k6-transaction-100m] compose files: ${compose_files[*]}"
   echo "[k6-transaction-100m] backend: aquila-bank-backend:8080 with t3.micro budget"
-  echo "[k6-transaction-100m] observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-exporter:9187"
+  if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
+    echo "[k6-transaction-100m] observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-exporter:9187"
+  else
+    echo "[k6-transaction-100m] observability: summary-only local markdown/json"
+  fi
+  echo "[k6-transaction-100m] observability mode=${K6_OBSERVABILITY_MODE}"
   echo "[k6-transaction-100m] k6 report name: ${K6_REPORT_NAME}"
   echo "[k6-transaction-100m] k6 vus=${K6_VUS} duration=${K6_DURATION:-1m} limit=${K6_LIMIT}"
   echo "[k6-transaction-100m] hot p95 threshold ms=${K6_HOT_P95_THRESHOLD_MS}"
@@ -201,10 +222,18 @@ print_plan() {
   if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
     echo "[k6-transaction-100m] generator runner=docker --context ${K6_DOCKER_CONTEXT} run grafana/k6:0.54.0"
     echo "[k6-transaction-100m] remote base url=${K6_REMOTE_BASE_URL}"
-    echo "[k6-transaction-100m] remote prometheus rw=${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}"
+    if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
+      echo "[k6-transaction-100m] remote prometheus rw=${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}"
+    else
+      echo "[k6-transaction-100m] remote prometheus rw=disabled"
+    fi
     echo "[k6-transaction-100m] remote workdir=${K6_REMOTE_WORKDIR}"
   else
-    echo "[k6-transaction-100m] generator runner=docker compose service k6-transaction-read-100m"
+    if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
+      echo "[k6-transaction-100m] generator runner=docker compose service k6-transaction-read-100m"
+    else
+      echo "[k6-transaction-100m] generator runner=docker compose service k6-transaction-read-100m without prometheus remote-write"
+    fi
   fi
   echo "[k6-transaction-100m] preflight=${K6_PREFLIGHT}"
   if [[ "${run_dependencies}" == "true" ]]; then
@@ -268,21 +297,32 @@ if [[ "${mode}" != "no-up" ]]; then
   tools/test/with-resource-lock.sh back-gradle-loadtest-bootjar ./back/gradlew -p back bootJar
 
   echo "[k6-transaction-100m] starting loadtest services"
-  docker compose "${compose_files[@]}" --profile loadtest up -d \
-    postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter
+  services=(postgres aquila-bank-backend)
+  if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
+    services+=(prometheus grafana alertmanager postgres-exporter)
+  fi
+  docker compose "${compose_files[@]}" --profile loadtest up -d "${services[@]}"
 fi
 
 assert_k6_preflight
 
 run_k6_local() {
   local run_args
+  local k6_command
   run_args=(--rm)
   if [[ "${run_dependencies}" != "true" ]]; then
     run_args+=(--no-deps)
   fi
+  k6_command=(run)
+  if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
+    k6_command+=(--out experimental-prometheus-rw)
+  fi
+  k6_command+=(/scripts/transaction-read-100m.js)
 
+  # summary-only는 k6 결과 파일만 남겨 same-host observability 비용을 제외합니다.
   docker compose "${compose_files[@]}" --profile loadtest run "${run_args[@]}" \
     -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
+    -e K6_OBSERVABILITY_MODE="${K6_OBSERVABILITY_MODE}" \
     -e K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
     -e K6_HOT_FROM="${K6_HOT_FROM}" \
     -e K6_HOT_TO="${K6_HOT_TO}" \
@@ -303,11 +343,18 @@ run_k6_local() {
     -e K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE}" \
     -e K6_OVERLOAD_429_RATE_THRESHOLD="${K6_OVERLOAD_429_RATE_THRESHOLD}" \
     -e K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${K6_MAX_RETRY_AFTER_SLEEP_SECONDS}" \
-    k6-transaction-read-100m
+    k6-transaction-read-100m \
+    "${k6_command[@]}"
 }
 
 run_k6_docker_context() {
   local remote_report_dir="${K6_REMOTE_WORKDIR}/build/reports/k6"
+  local k6_command
+  k6_command=(run)
+  if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
+    k6_command+=(--out experimental-prometheus-rw)
+  fi
+  k6_command+=(/scripts/transaction-read-100m.js)
 
   # backend/PostgreSQL CPU와 k6 CPU를 분리하기 위한 별도 Docker context 실행 경로.
   echo "[k6-transaction-100m] running remote k6 generator on docker context ${K6_DOCKER_CONTEXT}"
@@ -318,6 +365,7 @@ run_k6_docker_context() {
     -e K6_PROMETHEUS_RW_SERVER_URL="${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" \
     -e K6_PROMETHEUS_RW_TREND_STATS="p(50),p(90),p(95),p(99),min,max,avg" \
     -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
+    -e K6_OBSERVABILITY_MODE="${K6_OBSERVABILITY_MODE}" \
     -e K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
     -e K6_HOT_FROM="${K6_HOT_FROM}" \
     -e K6_HOT_TO="${K6_HOT_TO}" \
@@ -341,10 +389,7 @@ run_k6_docker_context() {
     -v "${K6_REMOTE_WORKDIR}/ops/k6:/scripts:ro" \
     -v "${remote_report_dir}:/reports" \
     grafana/k6:0.54.0 \
-    run \
-    --out \
-    experimental-prometheus-rw \
-    /scripts/transaction-read-100m.js
+    "${k6_command[@]}"
 }
 
 set +e


### PR DESCRIPTION
## 🔗 Related Issue
- close #432

## 🌿 Base Branch
- `main`

## 📝 Summary
- 100m transaction k6 runner에 Prometheus/Grafana 없이 summary만 남기는 `K6_OBSERVABILITY_MODE=summary-only` 경로를 추가합니다.
- 실제 backend에 burst HTTP 요청을 보내 admission 429/failed rate를 TSV로 남기고, 해당 telemetry를 Markdown 결과로 아카이브할 수 있게 합니다.

## 🛠 Changes
- `run-k6-transaction-100m-loadtest.sh`에 `prometheus|summary-only` observability mode를 추가했습니다.
- `run-defensive-runtime-http-admission-smoke.sh`로 HTTP 2xx/429/failed/Retry-After snapshot을 생성합니다.
- `archive-admission-guard-telemetry-snapshot.sh`로 admission summary/raw TSV를 `docs/performance-results` Markdown으로 보관합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `tools/test/check-defensive-runtime-http-admission-smoke.sh`
- `tools/test/check-admission-guard-telemetry-archive.sh`
- `bash -n tools/test/run-k6-transaction-100m-loadtest.sh`
- `bash -n tools/test/run-defensive-runtime-http-admission-smoke.sh`
- `bash -n tools/test/archive-admission-guard-telemetry-snapshot.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: summary-only mode는 k6 remote-write를 생략하므로 Prometheus 기반 대시보드에는 해당 실행 지표가 남지 않습니다. Markdown/JSON summary 보관 경로로 대체합니다.
- 롤백 방법: PR revert 후 기존 Prometheus remote-write k6 runner만 사용합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?