### PR TITLE
[Perf] t3.micro defensive runtime gate 결과 아카이브 추가

### DIFF
--- a/tools/test/check-docker-t3micro-capacity-smoke-script.sh
+++ b/tools/test/check-docker-t3micro-capacity-smoke-script.sh
@@ -20,6 +20,7 @@ grep -F "source=tools/test/run-production-t3micro-capacity-smoke.sh" <<<"${plan}
 grep -F "image=local-java21" <<<"${plan}" >/dev/null
 grep -F "cpus=2 memory=1024m memory-swap=1024m pids-limit=384" <<<"${plan}" >/dev/null
 grep -F "prepare-test-classes=true" <<<"${plan}" >/dev/null
+grep -F "archive-result=true" <<<"${plan}" >/dev/null
 grep -F "repeat=2" <<<"${plan}" >/dev/null
 grep -F "DB_POOL_MAX_SIZE=4" <<<"${plan}" >/dev/null
 grep -F "SERVER_THREADS_MAX=16" <<<"${plan}" >/dev/null
@@ -39,6 +40,12 @@ grep -F -- "--memory-swap 1024m" <<<"${dry_run}" >/dev/null
 grep -F -- "--pids-limit 384" <<<"${dry_run}" >/dev/null
 grep -F "local-java21 bash -lc tools/test/run-production-t3micro-capacity-smoke.sh" <<<"${dry_run}" >/dev/null
 
+echo "[docker-t3micro-capacity-script] archive contract"
+grep -F "DOCKER_T3MICRO_ARCHIVE_RESULT" "${script}" >/dev/null
+grep -F "archive_capacity_result" "${script}" >/dev/null
+grep -F "docs/performance-results" "${script}" >/dev/null
+grep -F "capacity smoke status" "${script}" >/dev/null
+
 echo "[docker-t3micro-capacity-script] compose override is valid"
 docker compose -f compose.yml -f compose.t3micro.yml config >/dev/null
 
@@ -57,5 +64,9 @@ if DOCKER_T3MICRO_PIDS_LIMIT=abc "${script}" --print-plan >/dev/null 2>&1; then
 fi
 if DOCKER_T3MICRO_PREPARE_TEST_CLASSES=maybe "${script}" --print-plan >/dev/null 2>&1; then
   echo "DOCKER_T3MICRO_PREPARE_TEST_CLASSES=maybe unexpectedly succeeded" >&2
+  exit 1
+fi
+if DOCKER_T3MICRO_ARCHIVE_RESULT=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "DOCKER_T3MICRO_ARCHIVE_RESULT=maybe unexpectedly succeeded" >&2
   exit 1
 fi

--- a/tools/test/check-outbox-provider-small-batch-backlog-gate.sh
+++ b/tools/test/check-outbox-provider-small-batch-backlog-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-outbox-provider-small-batch-backlog-gate.sh"
+
+echo "[outbox-provider-backlog] shell syntax"
+bash -n "${script}"
+
+echo "[outbox-provider-backlog] print plan"
+plan="$(
+  OUTBOX_BACKLOG_NAME=outbox-backlog-check \
+  OUTBOX_BACKLOG_BASE_URL=http://localhost:8080 \
+  OUTBOX_BACKLOG_MAX_LAG_SECONDS=30 \
+    "${script}" --print-plan
+)"
+grep -F "name=outbox-backlog-check" <<<"${plan}" >/dev/null
+grep -F "base_url=http://localhost:8080" <<<"${plan}" >/dev/null
+grep -F "max_lag_seconds=30" <<<"${plan}" >/dev/null
+grep -F "summary=build/reports/outbox/outbox-backlog-check/outbox-provider-backlog-summary.tsv" <<<"${plan}" >/dev/null
+
+echo "[outbox-provider-backlog] dry-run command"
+dry_run="$("${script}" --dry-run)"
+grep -F "/internal/api/v1/outbox/summary" <<<"${dry_run}" >/dev/null
+grep -F "/internal/api/v1/outbox/notification/summary" <<<"${dry_run}" >/dev/null
+grep -F "/internal/api/v1/outbox/notification-channel/quarantined-events" <<<"${dry_run}" >/dev/null
+grep -F "Authorization: Bearer ***" <<<"${dry_run}" >/dev/null
+
+echo "[outbox-provider-backlog] contract"
+grep -F "OUTBOX_BACKLOG_TOKEN" "${script}" >/dev/null
+grep -F "outbox-provider-backlog-summary.tsv" "${script}" >/dev/null
+grep -F "failedCount" "${script}" >/dev/null
+grep -F "quarantinedCount" "${script}" >/dev/null
+grep -F "staleSendingCount" "${script}" >/dev/null
+grep -F "lagCount" "${script}" >/dev/null
+grep -F "dlqCount" "${script}" >/dev/null
+grep -F "channel_quarantined_count" "${script}" >/dev/null
+
+echo "[outbox-provider-backlog] invalid input fails"
+if OUTBOX_BACKLOG_MAX_LAG_SECONDS=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad OUTBOX_BACKLOG_MAX_LAG_SECONDS unexpectedly succeeded" >&2
+  exit 1
+fi
+if OUTBOX_BACKLOG_MAX_FAILED_COUNT=-1 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "negative OUTBOX_BACKLOG_MAX_FAILED_COUNT unexpectedly succeeded" >&2
+  exit 1
+fi
+if OUTBOX_BACKLOG_CHANNEL_LIMIT=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "OUTBOX_BACKLOG_CHANNEL_LIMIT=0 unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/check-sse-reconnect-storm-t3micro-gate.sh
+++ b/tools/test/check-sse-reconnect-storm-t3micro-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-sse-reconnect-storm-t3micro-gate.sh"
+
+echo "[sse-reconnect-t3micro] shell syntax"
+bash -n "${script}"
+
+echo "[sse-reconnect-t3micro] print plan"
+plan="$(
+  SSE_T3MICRO_IMAGE=local-java21 \
+  SSE_T3MICRO_CPUS=2 \
+  SSE_T3MICRO_MEMORY=1024m \
+  SSE_T3MICRO_MEMORY_SWAP=1024m \
+  SSE_T3MICRO_PIDS_LIMIT=384 \
+    "${script}" --print-plan
+)"
+grep -F "source=tools/test/run-sse-reconnect-storm-smoke.sh" <<<"${plan}" >/dev/null
+grep -F "image=local-java21" <<<"${plan}" >/dev/null
+grep -F "cpus=2 memory=1024m memory-swap=1024m pids-limit=384" <<<"${plan}" >/dev/null
+grep -F "archive-result=true" <<<"${plan}" >/dev/null
+
+echo "[sse-reconnect-t3micro] dry-run command"
+dry_run="$(
+  SSE_T3MICRO_IMAGE=local-java21 \
+    "${script}" --dry-run
+)"
+grep -F -- "--cpus 2" <<<"${dry_run}" >/dev/null
+grep -F -- "--memory 1024m" <<<"${dry_run}" >/dev/null
+grep -F "local-java21 bash -lc tools/test/run-sse-reconnect-storm-smoke.sh" <<<"${dry_run}" >/dev/null
+
+echo "[sse-reconnect-t3micro] contract"
+grep -F "run-sse-reconnect-storm-smoke.sh" "${script}" >/dev/null
+grep -F "SSE_T3MICRO_ARCHIVE_RESULT" "${script}" >/dev/null
+grep -F "archive_sse_result" "${script}" >/dev/null
+grep -F "docs/performance-results" "${script}" >/dev/null
+
+echo "[sse-reconnect-t3micro] invalid input fails"
+if SSE_T3MICRO_CPUS=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "SSE_T3MICRO_CPUS=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if SSE_T3MICRO_MEMORY=0m "${script}" --print-plan >/dev/null 2>&1; then
+  echo "SSE_T3MICRO_MEMORY=0m unexpectedly succeeded" >&2
+  exit 1
+fi
+if SSE_T3MICRO_ARCHIVE_RESULT=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "SSE_T3MICRO_ARCHIVE_RESULT=maybe unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-docker-t3micro-capacity-smoke.sh
+++ b/tools/test/run-docker-t3micro-capacity-smoke.sh
@@ -13,6 +13,8 @@ Environment:
   DOCKER_T3MICRO_PIDS_LIMIT        Docker pids limit, default 384
   DOCKER_T3MICRO_GRADLE_USER_HOME  Host Gradle cache mount, default $HOME/.gradle
   DOCKER_T3MICRO_PREPARE_TEST_CLASSES  compile test classes on host before Docker run, default true
+  DOCKER_T3MICRO_ARCHIVE_RESULT     write Markdown result to docs/performance-results, default true
+  DOCKER_T3MICRO_RESULT_NAME        output basename, default docker-t3micro-capacity-<timestamp>
   SOAK_REPEAT                      repeat count passed to production smoke, default 1
 
 Examples:
@@ -89,6 +91,8 @@ server_threads_max="${PRODUCTION_T3MICRO_SERVER_THREADS_MAX:-16}"
 sse_max_total_sessions="${PRODUCTION_T3MICRO_SSE_MAX_TOTAL_SESSIONS:-64}"
 notification_stream_max="${PRODUCTION_T3MICRO_NOTIFICATION_STREAM_MAX:-4}"
 prepare_test_classes="${DOCKER_T3MICRO_PREPARE_TEST_CLASSES:-true}"
+archive_result="${DOCKER_T3MICRO_ARCHIVE_RESULT:-true}"
+result_name="${DOCKER_T3MICRO_RESULT_NAME:-docker-t3micro-capacity-$(date +%Y-%m-%d-%H%M%S)}"
 
 require_positive_number "DOCKER_T3MICRO_CPUS" "${cpus}"
 require_memory_value "DOCKER_T3MICRO_MEMORY" "${memory}"
@@ -100,6 +104,7 @@ require_positive_integer "PRODUCTION_T3MICRO_SERVER_THREADS_MAX" "${server_threa
 require_positive_integer "PRODUCTION_T3MICRO_SSE_MAX_TOTAL_SESSIONS" "${sse_max_total_sessions}"
 require_positive_integer "PRODUCTION_T3MICRO_NOTIFICATION_STREAM_MAX" "${notification_stream_max}"
 require_boolean "DOCKER_T3MICRO_PREPARE_TEST_CLASSES" "${prepare_test_classes}"
+require_boolean "DOCKER_T3MICRO_ARCHIVE_RESULT" "${archive_result}"
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 host_gradle_home="${DOCKER_T3MICRO_GRADLE_USER_HOME:-${HOME}/.gradle}"
@@ -112,6 +117,7 @@ print_plan() {
   echo "[docker-t3micro-capacity] image=${image}"
   echo "[docker-t3micro-capacity] docker limit: cpus=${cpus} memory=${memory} memory-swap=${memory_swap} pids-limit=${pids_limit}"
   echo "[docker-t3micro-capacity] prepare-test-classes=${prepare_test_classes}"
+  echo "[docker-t3micro-capacity] archive-result=${archive_result}"
   echo "[docker-t3micro-capacity] gradle cache=${host_gradle_home}"
   echo "[docker-t3micro-capacity] caveat: Docker cgroup은 CPU credit, EBS latency, 실제 AWS network를 재현하지 않습니다."
   SOAK_REPEAT="${repeat}" \
@@ -151,6 +157,42 @@ print_command() {
   printf '\n'
 }
 
+archive_capacity_result() {
+  local status="$1"
+  if [[ "${archive_result}" != "true" ]]; then
+    return 0
+  fi
+
+  local output_dir="docs/performance-results"
+  local output_path="${output_dir}/${result_name}.md"
+  mkdir -p "${output_dir}"
+  {
+    echo "# ${result_name}"
+    echo
+    echo "## Docker t3.micro Capacity Smoke"
+    echo
+    echo "- archivedAt: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "- capacity smoke status: ${status}"
+    echo "- source: tools/test/run-docker-t3micro-capacity-smoke.sh"
+    echo "- image: ${image}"
+    echo "- cpus: ${cpus}"
+    echo "- memory: ${memory}"
+    echo "- memorySwap: ${memory_swap}"
+    echo "- pidsLimit: ${pids_limit}"
+    echo "- repeat: ${repeat}"
+    echo "- dbPoolMaxSize: ${db_pool_max_size}"
+    echo "- serverThreadsMax: ${server_threads_max}"
+    echo "- sseMaxTotalSessions: ${sse_max_total_sessions}"
+    echo "- notificationStreamMax: ${notification_stream_max}"
+    echo
+    echo "## Notes"
+    echo
+    echo "- Docker cgroup은 CPU credit, EBS latency, 실제 AWS network를 재현하지 않습니다."
+    echo "- 실패한 실행도 status와 budget 값을 남겨 다음 재실행 기준으로 사용합니다."
+  } >"${output_path}"
+  echo "[docker-t3micro-capacity] archived=${output_path}"
+}
+
 print_plan
 
 if [[ "${mode}" == "print-plan" ]]; then
@@ -176,4 +218,9 @@ if [[ "${prepare_test_classes}" == "true" ]]; then
   tools/test/with-resource-lock.sh back-gradle-docker-t3micro-testclasses ./back/gradlew -p back testClasses
 fi
 
+set +e
 docker "${docker_args[@]}" "${image}" bash -lc "${container_command}"
+status=$?
+set -e
+archive_capacity_result "${status}"
+exit "${status}"

--- a/tools/test/run-outbox-provider-small-batch-backlog-gate.sh
+++ b/tools/test/run-outbox-provider-small-batch-backlog-gate.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-outbox-provider-small-batch-backlog-gate.sh [--print-plan|--dry-run]
+
+Environment:
+  OUTBOX_BACKLOG_NAME                 default outbox-provider-backlog-<timestamp>
+  OUTBOX_BACKLOG_BASE_URL             default http://localhost:8080
+  OUTBOX_BACKLOG_TOKEN                bearer token for internal outbox ops
+  OUTBOX_BACKLOG_MAX_LAG_SECONDS      default 30
+  OUTBOX_BACKLOG_MAX_FAILED_COUNT     default 0
+  OUTBOX_BACKLOG_MAX_QUARANTINED_COUNT default 0
+  OUTBOX_BACKLOG_MAX_STALE_SENDING_COUNT default 0
+  OUTBOX_BACKLOG_MAX_NOTIFICATION_LAG_COUNT default 0
+  OUTBOX_BACKLOG_MAX_DLQ_COUNT        default 0
+  OUTBOX_BACKLOG_CHANNEL_LIMIT        default 20
+
+Examples:
+  tools/test/run-outbox-provider-small-batch-backlog-gate.sh --print-plan
+  OUTBOX_BACKLOG_TOKEN=... tools/test/run-outbox-provider-small-batch-backlog-gate.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_non_negative_integer_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${key} must be zero or a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${key} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+name="${OUTBOX_BACKLOG_NAME:-outbox-provider-backlog-$(date +%Y-%m-%d-%H%M%S)}"
+base_url="${OUTBOX_BACKLOG_BASE_URL:-http://localhost:8080}"
+base_url="${base_url%/}"
+token="${OUTBOX_BACKLOG_TOKEN:-}"
+max_lag_seconds="${OUTBOX_BACKLOG_MAX_LAG_SECONDS:-30}"
+max_failed_count="${OUTBOX_BACKLOG_MAX_FAILED_COUNT:-0}"
+max_quarantined_count="${OUTBOX_BACKLOG_MAX_QUARANTINED_COUNT:-0}"
+max_stale_sending_count="${OUTBOX_BACKLOG_MAX_STALE_SENDING_COUNT:-0}"
+max_notification_lag_count="${OUTBOX_BACKLOG_MAX_NOTIFICATION_LAG_COUNT:-0}"
+max_dlq_count="${OUTBOX_BACKLOG_MAX_DLQ_COUNT:-0}"
+channel_limit="${OUTBOX_BACKLOG_CHANNEL_LIMIT:-20}"
+report_dir="build/reports/outbox/${name}"
+summary_tsv="${report_dir}/outbox-provider-backlog-summary.tsv"
+outbox_json="${report_dir}/outbox-summary.json"
+notification_json="${report_dir}/notification-summary.json"
+channel_json="${report_dir}/channel-quarantined-events.json"
+
+require_non_negative_integer_value "OUTBOX_BACKLOG_MAX_LAG_SECONDS" "${max_lag_seconds}"
+require_non_negative_integer_value "OUTBOX_BACKLOG_MAX_FAILED_COUNT" "${max_failed_count}"
+require_non_negative_integer_value "OUTBOX_BACKLOG_MAX_QUARANTINED_COUNT" "${max_quarantined_count}"
+require_non_negative_integer_value "OUTBOX_BACKLOG_MAX_STALE_SENDING_COUNT" "${max_stale_sending_count}"
+require_non_negative_integer_value "OUTBOX_BACKLOG_MAX_NOTIFICATION_LAG_COUNT" "${max_notification_lag_count}"
+require_non_negative_integer_value "OUTBOX_BACKLOG_MAX_DLQ_COUNT" "${max_dlq_count}"
+require_positive_integer_value "OUTBOX_BACKLOG_CHANNEL_LIMIT" "${channel_limit}"
+
+print_plan() {
+  echo "[outbox-provider-backlog] name=${name}"
+  echo "[outbox-provider-backlog] base_url=${base_url}"
+  echo "[outbox-provider-backlog] max_lag_seconds=${max_lag_seconds}"
+  echo "[outbox-provider-backlog] max_failed_count=${max_failed_count}"
+  echo "[outbox-provider-backlog] max_quarantined_count=${max_quarantined_count}"
+  echo "[outbox-provider-backlog] max_stale_sending_count=${max_stale_sending_count}"
+  echo "[outbox-provider-backlog] max_notification_lag_count=${max_notification_lag_count}"
+  echo "[outbox-provider-backlog] max_dlq_count=${max_dlq_count}"
+  echo "[outbox-provider-backlog] channel_limit=${channel_limit}"
+  echo "[outbox-provider-backlog] summary=${summary_tsv}"
+}
+
+print_dry_run() {
+  echo "curl ${base_url}/internal/api/v1/outbox/summary -H 'Authorization: Bearer ***'"
+  echo "curl ${base_url}/internal/api/v1/outbox/notification/summary -H 'Authorization: Bearer ***'"
+  echo "curl '${base_url}/internal/api/v1/outbox/notification-channel/quarantined-events?limit=${channel_limit}' -H 'Authorization: Bearer ***'"
+}
+
+require_runtime() {
+  command -v curl >/dev/null 2>&1 || { echo "curl command is required" >&2; exit 1; }
+  command -v jq >/dev/null 2>&1 || { echo "jq command is required" >&2; exit 1; }
+  if [[ -z "${token}" ]]; then
+    echo "OUTBOX_BACKLOG_TOKEN is required for internal outbox ops HTTP gate" >&2
+    exit 1
+  fi
+}
+
+fetch_json() {
+  local path="$1"
+  local output="$2"
+  curl -fsS "${base_url}${path}" \
+    -H "Authorization: Bearer ${token}" \
+    -o "${output}"
+}
+
+jq_number() {
+  local file="$1"
+  local expression="$2"
+  jq -r "${expression} // 0" "${file}"
+}
+
+check_lte() {
+  local metric="$1"
+  local value="$2"
+  local threshold="$3"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${metric} returned invalid value: ${value}" >&2
+    exit 1
+  fi
+  if ((value > threshold)); then
+    echo "${metric} exceeded threshold: value=${value} threshold=${threshold}" >&2
+    exit 1
+  fi
+}
+
+write_summary() {
+  local lag_seconds failed_count quarantined_count stale_sending_count
+  local notification_lag_count dlq_count channel_quarantined_count
+  lag_seconds="$(jq_number "${outbox_json}" ".lagSeconds")"
+  failed_count="$(jq_number "${outbox_json}" ".failedCount")"
+  quarantined_count="$(jq_number "${outbox_json}" ".quarantinedCount")"
+  stale_sending_count="$(jq_number "${outbox_json}" ".staleSendingCount")"
+  notification_lag_count="$(jq_number "${notification_json}" ".lagCount")"
+  dlq_count="$(jq_number "${notification_json}" ".dlqCount")"
+  channel_quarantined_count="$(jq_number "${channel_json}" ".items | length")"
+
+  {
+    printf "lag_seconds\tfailed_count\tquarantined_count\tstale_sending_count\tnotification_lag_count\tdlq_count\tchannel_quarantined_count\toutbox_json\tnotification_json\tchannel_json\n"
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+      "${lag_seconds}" "${failed_count}" "${quarantined_count}" "${stale_sending_count}" \
+      "${notification_lag_count}" "${dlq_count}" "${channel_quarantined_count}" \
+      "${outbox_json}" "${notification_json}" "${channel_json}"
+  } >"${summary_tsv}"
+
+  check_lte "lagSeconds" "${lag_seconds}" "${max_lag_seconds}"
+  check_lte "failedCount" "${failed_count}" "${max_failed_count}"
+  check_lte "quarantinedCount" "${quarantined_count}" "${max_quarantined_count}"
+  check_lte "staleSendingCount" "${stale_sending_count}" "${max_stale_sending_count}"
+  check_lte "lagCount" "${notification_lag_count}" "${max_notification_lag_count}"
+  check_lte "dlqCount" "${dlq_count}" "${max_dlq_count}"
+  check_lte "channel_quarantined_count" "${channel_quarantined_count}" "${max_quarantined_count}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  print_dry_run
+  exit 0
+fi
+
+require_runtime
+mkdir -p "${report_dir}"
+fetch_json "/internal/api/v1/outbox/summary" "${outbox_json}"
+fetch_json "/internal/api/v1/outbox/notification/summary" "${notification_json}"
+fetch_json "/internal/api/v1/outbox/notification-channel/quarantined-events?limit=${channel_limit}" "${channel_json}"
+write_summary
+echo "[outbox-provider-backlog] summary=${summary_tsv}"

--- a/tools/test/run-sse-reconnect-storm-t3micro-gate.sh
+++ b/tools/test/run-sse-reconnect-storm-t3micro-gate.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-sse-reconnect-storm-t3micro-gate.sh [--print-plan|--dry-run]
+
+Environment:
+  SSE_T3MICRO_IMAGE             Java 21 JDK image, default eclipse-temurin:21-jdk
+  SSE_T3MICRO_CPUS              Docker CPU quota, default 2
+  SSE_T3MICRO_MEMORY            Docker memory limit, default 1024m
+  SSE_T3MICRO_MEMORY_SWAP       Docker memory+swap limit, default 1024m
+  SSE_T3MICRO_PIDS_LIMIT        Docker pids limit, default 384
+  SSE_T3MICRO_GRADLE_USER_HOME  Host Gradle cache mount, default $HOME/.gradle
+  SSE_T3MICRO_ARCHIVE_RESULT    write Markdown result to docs/performance-results, default true
+  SSE_T3MICRO_RESULT_NAME       output basename, default sse-reconnect-t3micro-<timestamp>
+
+Examples:
+  tools/test/run-sse-reconnect-storm-t3micro-gate.sh --print-plan
+  tools/test/run-sse-reconnect-storm-t3micro-gate.sh --dry-run
+  tools/test/run-sse-reconnect-storm-t3micro-gate.sh
+USAGE
+}
+
+require_positive_number() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*([.][0-9]+)?$ ]]; then
+    echo "${name} must be a positive number" >&2
+    exit 1
+  fi
+}
+
+require_memory_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*[kKmMgG]?$ ]]; then
+    echo "${name} must be a positive Docker memory value" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer" >&2
+    exit 1
+  fi
+}
+
+require_boolean() {
+  local name="$1"
+  local value="$2"
+  case "${value}" in
+    true | false) ;;
+    *) echo "${name} must be true or false" >&2; exit 1 ;;
+  esac
+}
+
+mode="run"
+if [[ "${1:-}" == "--print-plan" ]]; then
+  mode="print-plan"
+  shift
+elif [[ "${1:-}" == "--dry-run" ]]; then
+  mode="dry-run"
+  shift
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+if [[ $# -ne 0 ]]; then
+  usage
+  exit 1
+fi
+
+image="${SSE_T3MICRO_IMAGE:-eclipse-temurin:21-jdk}"
+cpus="${SSE_T3MICRO_CPUS:-2}"
+memory="${SSE_T3MICRO_MEMORY:-1024m}"
+memory_swap="${SSE_T3MICRO_MEMORY_SWAP:-1024m}"
+pids_limit="${SSE_T3MICRO_PIDS_LIMIT:-384}"
+archive_result="${SSE_T3MICRO_ARCHIVE_RESULT:-true}"
+result_name="${SSE_T3MICRO_RESULT_NAME:-sse-reconnect-t3micro-$(date +%Y-%m-%d-%H%M%S)}"
+
+require_positive_number "SSE_T3MICRO_CPUS" "${cpus}"
+require_memory_value "SSE_T3MICRO_MEMORY" "${memory}"
+require_memory_value "SSE_T3MICRO_MEMORY_SWAP" "${memory_swap}"
+require_positive_integer "SSE_T3MICRO_PIDS_LIMIT" "${pids_limit}"
+require_boolean "SSE_T3MICRO_ARCHIVE_RESULT" "${archive_result}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+host_gradle_home="${SSE_T3MICRO_GRADLE_USER_HOME:-${HOME}/.gradle}"
+container_workdir="/workspace"
+container_name="aquila-bank-sse-reconnect-t3micro-${USER:-local}-$$"
+container_command="tools/test/run-sse-reconnect-storm-smoke.sh"
+
+print_plan() {
+  echo "[sse-reconnect-t3micro] source=${container_command}"
+  echo "[sse-reconnect-t3micro] image=${image}"
+  echo "[sse-reconnect-t3micro] docker limit: cpus=${cpus} memory=${memory} memory-swap=${memory_swap} pids-limit=${pids_limit}"
+  echo "[sse-reconnect-t3micro] archive-result=${archive_result}"
+  echo "[sse-reconnect-t3micro] gradle cache=${host_gradle_home}"
+}
+
+docker_args=(
+  run
+  --rm
+  --name "${container_name}"
+  --cpus "${cpus}"
+  --memory "${memory}"
+  --memory-swap "${memory_swap}"
+  --pids-limit "${pids_limit}"
+  --workdir "${container_workdir}"
+  --user "$(id -u):$(id -g)"
+  -e "HOME=/tmp"
+  -e "GRADLE_USER_HOME=/tmp/.gradle"
+  -e "JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:--XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=40}"
+  -e "GRADLE_OPTS=${GRADLE_OPTS:--Dorg.gradle.jvmargs=-Xmx512m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false}"
+  -v "${repo_root}:${container_workdir}"
+  -v "${host_gradle_home}:/tmp/.gradle"
+)
+
+print_command() {
+  printf '[sse-reconnect-t3micro] docker command: docker'
+  printf ' %q' "${docker_args[@]}" "${image}" bash -lc "${container_command}"
+  printf '\n'
+}
+
+archive_sse_result() {
+  local status="$1"
+  if [[ "${archive_result}" != "true" ]]; then
+    return 0
+  fi
+  local output_dir="docs/performance-results"
+  local output_path="${output_dir}/${result_name}.md"
+  mkdir -p "${output_dir}"
+  {
+    echo "# ${result_name}"
+    echo
+    echo "## SSE Reconnect Storm t3.micro Gate"
+    echo
+    echo "- archivedAt: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "- status: ${status}"
+    echo "- source: ${container_command}"
+    echo "- cpus: ${cpus}"
+    echo "- memory: ${memory}"
+    echo "- memorySwap: ${memory_swap}"
+    echo "- pidsLimit: ${pids_limit}"
+  } >"${output_path}"
+  echo "[sse-reconnect-t3micro] archived=${output_path}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+print_command
+if [[ "${mode}" == "dry-run" ]]; then
+  exit 0
+fi
+
+mkdir -p "${host_gradle_home}"
+set +e
+docker "${docker_args[@]}" "${image}" bash -lc "${container_command}"
+status=$?
+set -e
+archive_sse_result "${status}"
+exit "${status}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #433

## 🌿 Base Branch
- `main`

## 📝 Summary
- Docker t3.micro capacity smoke가 실행 budget/status를 Markdown 결과로 남기도록 archive 옵션을 추가합니다.
- SSE reconnect storm cgroup gate와 outbox/provider backlog HTTP gate를 추가해 작은 인프라 방어 경로를 독립 실행할 수 있게 합니다.

## 🛠 Changes
- `run-docker-t3micro-capacity-smoke.sh`에 `DOCKER_T3MICRO_ARCHIVE_RESULT` 결과 보관 옵션을 추가했습니다.
- `run-sse-reconnect-storm-t3micro-gate.sh`로 기존 SSE reconnect smoke를 Docker cgroup budget에서 실행합니다.
- `run-outbox-provider-small-batch-backlog-gate.sh`로 outbox/notification/channel ops summary를 HTTP로 조회하고 backlog threshold를 검증합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-docker-t3micro-capacity-smoke-script.sh`
- `tools/test/check-sse-reconnect-storm-t3micro-gate.sh`
- `tools/test/check-outbox-provider-small-batch-backlog-gate.sh`
- `bash -n tools/test/run-docker-t3micro-capacity-smoke.sh`
- `bash -n tools/test/run-sse-reconnect-storm-t3micro-gate.sh`
- `bash -n tools/test/run-outbox-provider-small-batch-backlog-gate.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 새 gate들은 wrapper/ops script이며 실제 실행 시 Docker image, Gradle cache, internal outbox ops token 같은 런타임 준비가 필요합니다. token 값은 출력하지 않습니다.
- 롤백 방법: PR revert 후 기존 smoke scripts만 사용합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?