### PR TITLE
[Perf] 100m read staging RDS gp3 smoke 추가

### DIFF
--- a/docs/performance-results/README.md
+++ b/docs/performance-results/README.md
@@ -109,6 +109,10 @@ tools/test/archive-admission-guard-telemetry-snapshot.sh \
   build/reports/admission/<name>/http-admission-raw.tsv
 ```
 
+## Staging RDS gp3 smoke
+
+RDS db.t4g.small + gp3 staging read-only smoke는 [Transaction 100m Staging RDS gp3 Smoke](../transaction-100m-staging-rds-gp3-smoke.md)를 기준으로 실행합니다.
+
 ## 월별 chunk lifecycle
 
 월별 partition 선생성, archive detach/drop guard, partition별 `ANALYZE`/`VACUUM` 절차는 [Transaction Read Model Chunk Lifecycle Runbook](../transaction-read-model-chunk-lifecycle.md)을 기준으로 실행합니다.

--- a/docs/transaction-100m-staging-rds-gp3-smoke.md
+++ b/docs/transaction-100m-staging-rds-gp3-smoke.md
@@ -1,0 +1,57 @@
+# Transaction 100m Staging RDS gp3 Smoke
+
+RDS db.t4g.small + gp3 staging 환경에서 100m transaction read path를 read-only로 확인하는 절차입니다. Docker local smoke는 RDS recovery, gp3 IO, CPU credit, network latency를 재현하지 못하므로 staging smoke는 별도 runner로 분리합니다.
+
+## Guard
+
+- staging backend URL은 `https://`를 기본으로 요구합니다.
+- `localhost`, `127.0.0.1`, `0.0.0.0`, `::1` URL은 기본 차단합니다.
+- 실행 전 `STAGING_RDS_CONFIRM=read-only-staging-rds`를 요구합니다.
+- RDS 접속 secret, 운영 URL, bearer token은 저장소와 결과 문서에 기록하지 않습니다.
+- runner는 k6 read scenario만 실행하며 restore, cleanup, write traffic을 수행하지 않습니다.
+
+## Dry Run
+
+```bash
+STAGING_RDS_BASE_URL=https://staging.example.invalid \
+STAGING_RDS_HOT_ACCOUNT_ID=910000001 \
+STAGING_RDS_HOT_FROM=2026-04-01T00:00:00Z \
+STAGING_RDS_HOT_TO=2026-04-30T00:00:00Z \
+STAGING_RDS_COLD_ACCOUNT_ID=910000002 \
+STAGING_RDS_COLD_FROM=2026-01-01T00:00:00Z \
+STAGING_RDS_COLD_TO=2026-01-31T00:00:00Z \
+tools/test/run-transaction-100m-staging-rds-gp3-smoke.sh --dry-run
+```
+
+## Run
+
+```bash
+STAGING_RDS_CONFIRM=read-only-staging-rds \
+STAGING_RDS_BASE_URL=<staging-backend-url> \
+STAGING_RDS_AUTH_TOKEN=<token-from-secret-store> \
+STAGING_RDS_HOT_ACCOUNT_ID=<hot-account-id> \
+STAGING_RDS_HOT_FROM=<from> \
+STAGING_RDS_HOT_TO=<to> \
+STAGING_RDS_COLD_ACCOUNT_ID=<cold-account-id> \
+STAGING_RDS_COLD_FROM=<from> \
+STAGING_RDS_COLD_TO=<to> \
+STAGING_RDS_VUS=4 \
+STAGING_RDS_DURATION=2m \
+tools/test/run-transaction-100m-staging-rds-gp3-smoke.sh
+```
+
+## Result
+
+기본값은 `STAGING_RDS_ARCHIVE_RESULTS=true`입니다. k6 summary는 `build/reports/k6`에 생성되고 Markdown 사본은 `docs/performance-results`에 보관됩니다.
+
+확인값:
+
+- hot/cold p95, p99, max latency
+- transaction 429 rate
+- failed request rate
+- RDS CPU credit, FreeableMemory, ReadIOPS/WriteIOPS, queue depth
+- backend CPU/memory와 DB pool pending 여부
+
+## Rollback
+
+이 smoke는 read-only traffic만 발생시키므로 application rollback은 필요하지 않습니다. staging latency나 RDS credit 소진이 보이면 실행을 중단하고 같은 SHA의 staging 배포 상태를 유지한 채 VU/duration을 낮춰 재측정합니다.

--- a/tools/test/check-transaction-100m-staging-rds-gp3-smoke.sh
+++ b/tools/test/check-transaction-100m-staging-rds-gp3-smoke.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-staging-rds-gp3-smoke.sh"
+runbook="docs/transaction-100m-staging-rds-gp3-smoke.md"
+
+echo "[transaction-100m-staging-rds] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-100m-staging-rds] print plan"
+plan="$(
+  STAGING_RDS_BASE_URL=https://staging.example.invalid \
+  STAGING_RDS_HOT_ACCOUNT_ID=910000001 \
+  STAGING_RDS_COLD_ACCOUNT_ID=910000002 \
+  STAGING_RDS_HOT_FROM=2026-04-01T00:00:00Z \
+  STAGING_RDS_HOT_TO=2026-04-30T00:00:00Z \
+  STAGING_RDS_COLD_FROM=2026-01-01T00:00:00Z \
+  STAGING_RDS_COLD_TO=2026-01-31T00:00:00Z \
+    "${script}" --print-plan
+)"
+grep -F "base_url=https://staging.example.invalid" <<<"${plan}" >/dev/null
+grep -F "confirm=read-only-staging-rds required for run" <<<"${plan}" >/dev/null
+grep -F "observability=summary-only" <<<"${plan}" >/dev/null
+grep -F "generator=docker run grafana/k6:0.54.0" <<<"${plan}" >/dev/null
+grep -F "archive_results=true" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-staging-rds] dry-run command"
+dry_run="$(
+  STAGING_RDS_BASE_URL=https://staging.example.invalid \
+  STAGING_RDS_HOT_ACCOUNT_ID=910000001 \
+  STAGING_RDS_COLD_ACCOUNT_ID=910000002 \
+  STAGING_RDS_HOT_FROM=2026-04-01T00:00:00Z \
+  STAGING_RDS_HOT_TO=2026-04-30T00:00:00Z \
+  STAGING_RDS_COLD_FROM=2026-01-01T00:00:00Z \
+  STAGING_RDS_COLD_TO=2026-01-31T00:00:00Z \
+    "${script}" --dry-run
+)"
+grep -F "docker run --rm" <<<"${dry_run}" >/dev/null
+grep -F "BASE_URL=https://staging.example.invalid" <<<"${dry_run}" >/dev/null
+grep -F "K6_OBSERVABILITY_MODE=summary-only" <<<"${dry_run}" >/dev/null
+grep -F "Authorization token is passed only through env" <<<"${dry_run}" >/dev/null
+
+echo "[transaction-100m-staging-rds] contract"
+grep -F "STAGING_RDS_CONFIRM" "${script}" >/dev/null
+grep -F "read-only-staging-rds" "${script}" >/dev/null
+grep -F "STAGING_RDS_ALLOW_LOCAL_URL" "${script}" >/dev/null
+grep -F "STAGING_RDS_REQUIRE_HTTPS" "${script}" >/dev/null
+grep -F "K6_OBSERVABILITY_MODE=summary-only" "${script}" >/dev/null
+grep -F "archive-k6-transaction-100m-result.sh" "${script}" >/dev/null
+test -f "${runbook}"
+grep -F "RDS db.t4g.small + gp3" "${runbook}" >/dev/null
+grep -F "secret" "${runbook}" >/dev/null
+grep -F "read-only-staging-rds" "${runbook}" >/dev/null
+
+echo "[transaction-100m-staging-rds] invalid input fails"
+if STAGING_RDS_BASE_URL=http://localhost:8080 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "localhost URL unexpectedly succeeded" >&2
+  exit 1
+fi
+if STAGING_RDS_BASE_URL=http://staging.example.invalid "${script}" --print-plan >/dev/null 2>&1; then
+  echo "non-HTTPS URL unexpectedly succeeded" >&2
+  exit 1
+fi
+if STAGING_RDS_BASE_URL=https://staging.example.invalid STAGING_RDS_HOT_ACCOUNT_ID=1 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "missing required windows unexpectedly succeeded" >&2
+  exit 1
+fi
+if STAGING_RDS_BASE_URL=https://staging.example.invalid STAGING_RDS_HOT_ACCOUNT_ID=1 STAGING_RDS_COLD_ACCOUNT_ID=1 STAGING_RDS_HOT_FROM=2026-04-01T00:00:00Z STAGING_RDS_HOT_TO=2026-04-30T00:00:00Z STAGING_RDS_COLD_FROM=2026-01-01T00:00:00Z STAGING_RDS_COLD_TO=2026-01-31T00:00:00Z "${script}" --print-plan >/dev/null 2>&1; then
+  echo "same hot/cold account unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-100m-staging-rds-gp3-smoke.sh
+++ b/tools/test/run-transaction-100m-staging-rds-gp3-smoke.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-staging-rds-gp3-smoke.sh [--print-plan|--dry-run]
+
+Required environment:
+  STAGING_RDS_BASE_URL
+  STAGING_RDS_HOT_ACCOUNT_ID
+  STAGING_RDS_HOT_FROM
+  STAGING_RDS_HOT_TO
+  STAGING_RDS_COLD_ACCOUNT_ID
+  STAGING_RDS_COLD_FROM
+  STAGING_RDS_COLD_TO
+
+Required for actual run:
+  STAGING_RDS_CONFIRM=read-only-staging-rds
+
+Optional environment:
+  STAGING_RDS_REQUIRE_HTTPS     default true
+  STAGING_RDS_ALLOW_LOCAL_URL   default false
+  STAGING_RDS_AUTH_TOKEN        optional bearer token, not printed
+  STAGING_RDS_REPORT_NAME       default transaction-100m-staging-rds-gp3-<timestamp>
+  STAGING_RDS_VUS               default 4
+  STAGING_RDS_DURATION          default 2m
+  STAGING_RDS_LIMIT             default 50
+  STAGING_RDS_ARCHIVE_RESULTS   default true
+
+Examples:
+  tools/test/run-transaction-100m-staging-rds-gp3-smoke.sh --print-plan
+  STAGING_RDS_CONFIRM=read-only-staging-rds tools/test/run-transaction-100m-staging-rds-gp3-smoke.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_env() {
+  local key="$1"
+  local value="${!key:-}"
+  if [[ -z "${value}" ]]; then
+    echo "${key} is required" >&2
+    exit 1
+  fi
+}
+
+require_bool_value() {
+  local key="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${key} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${key} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_env STAGING_RDS_BASE_URL
+require_env STAGING_RDS_HOT_ACCOUNT_ID
+require_env STAGING_RDS_HOT_FROM
+require_env STAGING_RDS_HOT_TO
+require_env STAGING_RDS_COLD_ACCOUNT_ID
+require_env STAGING_RDS_COLD_FROM
+require_env STAGING_RDS_COLD_TO
+
+base_url="${STAGING_RDS_BASE_URL%/}"
+hot_account_id="${STAGING_RDS_HOT_ACCOUNT_ID}"
+hot_from="${STAGING_RDS_HOT_FROM}"
+hot_to="${STAGING_RDS_HOT_TO}"
+cold_account_id="${STAGING_RDS_COLD_ACCOUNT_ID}"
+cold_from="${STAGING_RDS_COLD_FROM}"
+cold_to="${STAGING_RDS_COLD_TO}"
+require_https="${STAGING_RDS_REQUIRE_HTTPS:-true}"
+allow_local_url="${STAGING_RDS_ALLOW_LOCAL_URL:-false}"
+auth_token="${STAGING_RDS_AUTH_TOKEN:-}"
+report_name="${STAGING_RDS_REPORT_NAME:-transaction-100m-staging-rds-gp3-$(date +%Y-%m-%d-%H%M%S)}"
+vus="${STAGING_RDS_VUS:-4}"
+duration="${STAGING_RDS_DURATION:-2m}"
+limit="${STAGING_RDS_LIMIT:-50}"
+archive_results="${STAGING_RDS_ARCHIVE_RESULTS:-true}"
+report_dir="build/reports/k6"
+summary_md="${report_dir}/${report_name}-summary.md"
+summary_json="${report_dir}/${report_name}-summary.json"
+
+require_bool_value "STAGING_RDS_REQUIRE_HTTPS" "${require_https}"
+require_bool_value "STAGING_RDS_ALLOW_LOCAL_URL" "${allow_local_url}"
+require_bool_value "STAGING_RDS_ARCHIVE_RESULTS" "${archive_results}"
+require_positive_integer_value "STAGING_RDS_HOT_ACCOUNT_ID" "${hot_account_id}"
+require_positive_integer_value "STAGING_RDS_COLD_ACCOUNT_ID" "${cold_account_id}"
+require_positive_integer_value "STAGING_RDS_VUS" "${vus}"
+require_positive_integer_value "STAGING_RDS_LIMIT" "${limit}"
+
+if [[ "${hot_account_id}" == "${cold_account_id}" ]]; then
+  echo "STAGING_RDS_HOT_ACCOUNT_ID and STAGING_RDS_COLD_ACCOUNT_ID must differ" >&2
+  exit 1
+fi
+if [[ "${require_https}" == "true" && ! "${base_url}" =~ ^https:// ]]; then
+  echo "STAGING_RDS_BASE_URL must use https unless STAGING_RDS_REQUIRE_HTTPS=false" >&2
+  exit 1
+fi
+if [[ "${allow_local_url}" != "true" && "${base_url}" =~ ^https?://(localhost|127\.|0\.0\.0\.0|\[::1\]|::1) ]]; then
+  echo "local URL is not allowed for staging RDS smoke unless STAGING_RDS_ALLOW_LOCAL_URL=true" >&2
+  exit 1
+fi
+
+print_plan() {
+  echo "[transaction-100m-staging-rds] base_url=${base_url}"
+  echo "[transaction-100m-staging-rds] confirm=read-only-staging-rds required for run"
+  echo "[transaction-100m-staging-rds] observability=summary-only"
+  echo "[transaction-100m-staging-rds] generator=docker run grafana/k6:0.54.0"
+  echo "[transaction-100m-staging-rds] report=${report_name}"
+  echo "[transaction-100m-staging-rds] vus=${vus} duration=${duration} limit=${limit}"
+  echo "[transaction-100m-staging-rds] hot account=${hot_account_id} window=${hot_from}..${hot_to}"
+  echo "[transaction-100m-staging-rds] cold account=${cold_account_id} window=${cold_from}..${cold_to}"
+  echo "[transaction-100m-staging-rds] archive_results=${archive_results}"
+}
+
+print_dry_run() {
+  echo "docker run --rm -e BASE_URL=${base_url} -e K6_OBSERVABILITY_MODE=summary-only -e K6_REPORT_NAME=${report_name} -v $(pwd)/ops/k6:/scripts:ro -v $(pwd)/build/reports/k6:/reports grafana/k6:0.54.0 run /scripts/transaction-read-100m.js"
+  echo "Authorization token is passed only through env when STAGING_RDS_AUTH_TOKEN is set"
+}
+
+run_k6() {
+  mkdir -p "${report_dir}"
+  docker run --rm \
+    -e BASE_URL="${base_url}" \
+    -e K6_OBSERVABILITY_MODE=summary-only \
+    -e K6_REPORT_NAME="${report_name}" \
+    -e K6_HOT_ACCOUNT_ID="${hot_account_id}" \
+    -e K6_HOT_FROM="${hot_from}" \
+    -e K6_HOT_TO="${hot_to}" \
+    -e K6_COLD_ACCOUNT_ID="${cold_account_id}" \
+    -e K6_COLD_FROM="${cold_from}" \
+    -e K6_COLD_TO="${cold_to}" \
+    -e K6_AUTH_TOKEN="${auth_token}" \
+    -e K6_VUS="${vus}" \
+    -e K6_DURATION="${duration}" \
+    -e K6_LIMIT="${limit}" \
+    -v "$(pwd)/ops/k6:/scripts:ro" \
+    -v "$(pwd)/build/reports/k6:/reports" \
+    grafana/k6:0.54.0 \
+    run \
+    /scripts/transaction-read-100m.js
+}
+
+archive_result() {
+  if [[ "${archive_results}" != "true" ]]; then
+    return 0
+  fi
+  if [[ -f "${summary_md}" ]]; then
+    PERFORMANCE_RESULT_NAME="${report_name}" \
+      tools/test/archive-k6-transaction-100m-result.sh "${summary_md}" "${summary_json}"
+  else
+    echo "k6 summary markdown was not produced: ${summary_md}" >&2
+  fi
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  print_dry_run
+  exit 0
+fi
+if [[ "${STAGING_RDS_CONFIRM:-}" != "read-only-staging-rds" ]]; then
+  echo "STAGING_RDS_CONFIRM=read-only-staging-rds is required for staging RDS smoke" >&2
+  exit 1
+fi
+
+set +e
+run_k6
+status=$?
+set -e
+archive_result
+exit "${status}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #434

## 🌿 Base Branch
- `main`

## 📝 Summary
- RDS db.t4g.small + gp3 staging 환경에서 100m transaction read path를 read-only로 확인하는 summary-only k6 runner를 추가합니다.
- HTTPS/local URL guard, read-only confirm, secret 기록 금지 기준을 runbook으로 문서화했습니다.

## 🛠 Changes
- `run-transaction-100m-staging-rds-gp3-smoke.sh`를 추가해 staging backend URL 대상 k6 read-only smoke를 실행합니다.
- `check-transaction-100m-staging-rds-gp3-smoke.sh`로 필수 env, URL guard, dry-run, contract를 검증합니다.
- `docs/transaction-100m-staging-rds-gp3-smoke.md`에 실행/비용/secret/rollback 기준을 정리했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-staging-rds-gp3-smoke.sh`
- `bash -n tools/test/run-transaction-100m-staging-rds-gp3-smoke.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 실제 실행은 staging URL, token, fixture account/window, RDS credit 상태에 의존합니다. runner는 read-only k6만 수행하고 secret 값을 출력하지 않습니다.
- 롤백 방법: PR revert 후 staging RDS smoke runner/runbook을 제거합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?