### PR TITLE
[Perf] 100m fixture artifact export 및 k6 evidence 통합

### DIFF
--- a/ops/k6/transaction-read-100m.js
+++ b/ops/k6/transaction-read-100m.js
@@ -25,6 +25,13 @@ const authToken = __ENV.K6_AUTH_TOKEN || "";
 const limit = Number(__ENV.K6_LIMIT || "50");
 const vus = Number(__ENV.K6_VUS || "8");
 const duration = __ENV.K6_DURATION || "1m";
+const scenarioMode = __ENV.K6_SCENARIO_MODE || "constant-vus";
+const rate = Number(__ENV.K6_RATE || "8");
+const timeUnit = __ENV.K6_TIME_UNIT || "1s";
+const preAllocatedVUs = Number(__ENV.K6_PRE_ALLOCATED_VUS || String(vus));
+const maxVUs = Number(__ENV.K6_MAX_VUS || String(preAllocatedVUs));
+const burstRate = Number(__ENV.K6_BURST_RATE || "16");
+const burstDuration = __ENV.K6_BURST_DURATION || "20s";
 const hotP95ThresholdMs = Number(__ENV.K6_HOT_P95_THRESHOLD_MS || "350");
 const coldP95ThresholdMs = Number(__ENV.K6_COLD_P95_THRESHOLD_MS || "750");
 const hotP99ThresholdMs = Number(__ENV.K6_HOT_P99_THRESHOLD_MS || "750");
@@ -80,14 +87,42 @@ function thresholds() {
   return result;
 }
 
-export const options = {
-  scenarios: {
+function scenarios() {
+  if (scenarioMode === "constant-arrival-rate") {
+    return {
+      transaction_read_100m_arrival: {
+        executor: "constant-arrival-rate",
+        rate,
+        timeUnit,
+        duration,
+        preAllocatedVUs,
+        maxVUs,
+      },
+    };
+  }
+  if (scenarioMode === "burst") {
+    return {
+      burst_admission: {
+        executor: "constant-arrival-rate",
+        rate: burstRate,
+        timeUnit: "1s",
+        duration: burstDuration,
+        preAllocatedVUs,
+        maxVUs,
+      },
+    };
+  }
+  return {
     transaction_read_100m: {
       executor: "constant-vus",
       vus,
       duration,
     },
-  },
+  };
+}
+
+export const options = {
+  scenarios: scenarios(),
   thresholds: thresholds(),
   tags: {
     service: "aquila-bank",
@@ -280,6 +315,12 @@ function markdownSummary(data) {
 - baseUrl: ${baseUrl}
 - vus: ${vus}
 - duration: ${duration}
+- scenario mode: ${scenarioMode}
+- arrival rate: ${rate}/${timeUnit}
+- burst rate: ${burstRate}/1s
+- burst duration: ${burstDuration}
+- pre allocated VUs: ${preAllocatedVUs}
+- max VUs: ${maxVUs}
 - limit: ${limit}
 - observability mode: ${observabilityMode}
 - overload mode: ${overloadMode}

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -28,6 +28,7 @@ grep -F "generator mode=local" <<<"${plan}" >/dev/null
 grep -F "generator runner=docker compose service k6-transaction-read-100m" <<<"${plan}" >/dev/null
 grep -F "observability mode=prometheus" <<<"${plan}" >/dev/null
 grep -F "preflight=true" <<<"${plan}" >/dev/null
+grep -F "scenario mode=constant-vus" <<<"${plan}" >/dev/null
 
 summary_only_plan="$(
   K6_REPORT_NAME=transaction-100m-summary-only-check \
@@ -64,6 +65,18 @@ grep -F "k6 report name: transaction-100m-overload-check" <<<"${overload_plan}" 
 grep -F "overload mode=true max retry-after sleep seconds=2" <<<"${overload_plan}" >/dev/null
 grep -F "overload 429 rate threshold=0.05" <<<"${overload_plan}" >/dev/null
 
+burst_plan="$(
+  K6_REPORT_NAME=transaction-100m-burst-check \
+  K6_SCENARIO_MODE=burst \
+  K6_BURST_RATE=16 \
+  K6_BURST_DURATION=20s \
+  K6_PRE_ALLOCATED_VUS=8 \
+  K6_MAX_VUS=32 \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "scenario mode=burst" <<<"${burst_plan}" >/dev/null
+grep -F "burst rate=16 duration=20s preAllocatedVUs=8 maxVUs=32" <<<"${burst_plan}" >/dev/null
+
 echo "[k6-transaction-100m] k6 script contract"
 grep -F "experimental-prometheus-rw" compose.loadtest.yml >/dev/null
 grep -F "K6_PROMETHEUS_RW_SERVER_URL" compose.loadtest.yml >/dev/null
@@ -82,12 +95,17 @@ grep -F "K6_COLD_MAX_THRESHOLD_MS" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "p(99)<" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "max<" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "K6_OVERLOAD_MODE" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "K6_SCENARIO_MODE" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "constant-arrival-rate" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "burst_admission" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "K6_OVERLOAD_429_RATE_THRESHOLD" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "K6_MAX_RETRY_AFTER_SLEEP_SECONDS" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "aquila_transaction_429_rate" ops/k6/transaction-read-100m.js >/dev/null
 grep -F 'rate<${overload429RateThreshold}' ops/k6/transaction-read-100m.js >/dev/null
 grep -F "Retry-After" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "K6_OVERLOAD_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_SCENARIO_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "require_scenario_mode" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_HOT_P99_THRESHOLD_MS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_COLD_P99_THRESHOLD_MS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_HOT_MAX_THRESHOLD_MS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
@@ -120,6 +138,10 @@ if K6_GENERATOR_MODE=unknown tools/test/run-k6-transaction-100m-loadtest.sh --pr
 fi
 if K6_OBSERVABILITY_MODE=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
   echo "K6_OBSERVABILITY_MODE=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_SCENARIO_MODE=unknown tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_SCENARIO_MODE=unknown unexpectedly succeeded" >&2
   exit 1
 fi
 if K6_OBSERVABILITY_MODE=prometheus K6_GENERATOR_MODE=docker-context tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then

--- a/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
@@ -13,6 +13,7 @@ capacity="${temp_dir}/capacity.md"
 sse="${temp_dir}/sse.md"
 admission="${temp_dir}/admission.tsv"
 outbox="${temp_dir}/outbox.tsv"
+k6="${temp_dir}/k6-summary.md"
 
 cat >"${capacity}" <<'MD'
 # capacity
@@ -33,6 +34,14 @@ MD
 
 printf "requests\tsuccess_count\trejected_count\tfailed_count\tfailed_rate\tretry_after_count\traw_path\n16\t12\t4\t0\t0.000000\t4\traw.tsv\n" >"${admission}"
 printf "lag_seconds\tfailed_count\tquarantined_count\tstale_sending_count\tnotification_lag_count\tdlq_count\tchannel_quarantined_count\toutbox_json\tnotification_json\tchannel_json\n1\t0\t0\t0\t0\t0\t0\toutbox.json\tnotification.json\tchannel.json\n" >"${outbox}"
+cat >"${k6}" <<'MD'
+# k6
+- transaction 429 rate: 0.125
+- hot first p95 ms: 220
+- hot cursor p95 ms: 240
+- cold first p95 ms: 640
+- cold cursor p95 ms: 680
+MD
 
 echo "[t3micro-defensive-aggregate] plan"
 plan="$(
@@ -42,11 +51,13 @@ plan="$(
   T3MICRO_SSE_RESULT_MD="${sse}" \
   T3MICRO_ADMISSION_SUMMARY_TSV="${admission}" \
   T3MICRO_OUTBOX_SUMMARY_TSV="${outbox}" \
+  T3MICRO_K6_SUMMARY_MD="${k6}" \
     "${script}" --print-plan
 )"
 grep -F "output=${temp_dir}/aggregate-check.md" <<<"${plan}" >/dev/null
 grep -F "capacity=${capacity}" <<<"${plan}" >/dev/null
 grep -F "admission=${admission}" <<<"${plan}" >/dev/null
+grep -F "k6=${k6}" <<<"${plan}" >/dev/null
 
 echo "[t3micro-defensive-aggregate] report"
 output="$(
@@ -56,6 +67,7 @@ output="$(
   T3MICRO_SSE_RESULT_MD="${sse}" \
   T3MICRO_ADMISSION_SUMMARY_TSV="${admission}" \
   T3MICRO_OUTBOX_SUMMARY_TSV="${outbox}" \
+  T3MICRO_K6_SUMMARY_MD="${k6}" \
     "${script}"
 )"
 output="$(tail -1 <<<"${output}")"
@@ -64,3 +76,4 @@ grep -F "| capacity | 0 | 82.50 | 712.00 | repeat=3 | ${capacity} |" "${output}"
 grep -F "| sse reconnect | 0 | 61.00 | 512.00 | clients=8 rounds=3 | ${sse} |" "${output}" >/dev/null
 grep -F "rejected=4 failed_rate=0.000000" "${output}" >/dev/null
 grep -F "lag=1 failed=0 dlq=0" "${output}" >/dev/null
+grep -F "hotFirstP95=220 hotCursorP95=240 coldFirstP95=640 coldCursorP95=680 429Rate=0.125" "${output}" >/dev/null

--- a/tools/test/check-transaction-100m-existing-volume-fixture-export.sh
+++ b/tools/test/check-transaction-100m-existing-volume-fixture-export.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-existing-volume-fixture-export.sh"
+
+echo "[transaction-100m-existing-export] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-100m-existing-export] dry-run contract"
+plan="$(
+  FIXTURE_NAME=transaction-100m-check \
+  FIXTURE_DIR=build/fixtures/check \
+    "${script}" --dry-run
+)"
+grep -F "FIXTURE_MODE=dump" <<<"${plan}" >/dev/null
+grep -F "FIXTURE_NAME=transaction-100m-check" <<<"${plan}" >/dev/null
+grep -F "FIXTURE_PATH=build/fixtures/check/transaction-100m-check.dump" <<<"${plan}" >/dev/null
+grep -F "tools/test/run-transaction-100m-fixture-restore.sh" <<<"${plan}" >/dev/null
+grep -F "tools/test/validate-transaction-100m-fixture-artifact.sh --verify" <<<"${plan}" >/dev/null
+grep -F "manifest=build/fixtures/check/transaction-100m-check.dump.manifest" <<<"${plan}" >/dev/null
+grep -F "checksum=build/fixtures/check/transaction-100m-check.dump.sha256" <<<"${plan}" >/dev/null

--- a/tools/test/check-transaction-100m-k6-explain-snapshot.sh
+++ b/tools/test/check-transaction-100m-k6-explain-snapshot.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-k6-explain-snapshot.sh"
+
+echo "[transaction-100m-k6-explain] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-100m-k6-explain] dry-run contract"
+plan="$(
+  K6_REPORT_NAME=transaction-100m-explain-check \
+  K6_HOT_ACCOUNT_ID=910000001 \
+  K6_HOT_FROM=2026-04-01T00:00:00Z \
+  K6_HOT_TO=2026-04-30T00:00:00Z \
+  K6_COLD_ACCOUNT_ID=910000002 \
+  K6_COLD_FROM=2026-01-01T00:00:00Z \
+  K6_COLD_TO=2026-01-31T00:00:00Z \
+    "${script}" --dry-run
+)"
+grep -F "hot-first=build/reports/k6/transaction-100m-explain-check-explain/manual-hot-first.txt" <<<"${plan}" >/dev/null
+grep -F "hot-cursor=build/reports/k6/transaction-100m-explain-check-explain/manual-hot-cursor.txt" <<<"${plan}" >/dev/null
+grep -F "cold-first=build/reports/k6/transaction-100m-explain-check-explain/manual-cold-first.txt" <<<"${plan}" >/dev/null
+grep -F "cold-cursor=build/reports/k6/transaction-100m-explain-check-explain/manual-cold-cursor.txt" <<<"${plan}" >/dev/null
+
+sql="$(
+  K6_HOT_ACCOUNT_ID=910000001 \
+  K6_HOT_FROM=2026-04-01T00:00:00Z \
+  K6_HOT_TO=2026-04-30T00:00:00Z \
+  K6_COLD_ACCOUNT_ID=910000002 \
+  K6_COLD_FROM=2026-01-01T00:00:00Z \
+  K6_COLD_TO=2026-01-31T00:00:00Z \
+    "${script}" --print-sql
+)"
+grep -F "EXPLAIN (FORMAT TEXT)" <<<"${sql}" >/dev/null
+grep -F "FROM public.transaction_read_model" <<<"${sql}" >/dev/null
+grep -F "FROM public.transaction_read_model_archive" <<<"${sql}" >/dev/null
+grep -F "(booked_at, id) <" <<<"${sql}" >/dev/null
+
+k6_plan="$(tools/test/run-k6-transaction-100m-loadtest.sh --print-plan)"
+grep -F "explain_snapshot=true" <<<"${k6_plan}" >/dev/null
+grep -F "run_explain_snapshot pre" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "run_explain_snapshot post" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -34,6 +34,7 @@ Optional environment:
   K6_PREFLIGHT         check PostgreSQL OOM/index readiness before k6, default true
   K6_OUTBOX_PREFLIGHT  run local outbox backlog gate before k6, default false
   K6_OUTBOX_PREFLIGHT_BASE_URL default http://localhost:${LOADTEST_BACKEND_PORT:-18080}
+  K6_EXPLAIN_SNAPSHOT  write pre/post hot/cold query plans, default true
   K6_OBSERVABILITY_MODE prometheus|summary-only, default prometheus
   K6_OVERLOAD_MODE     treat 429 as expected rejected samples, default false
   K6_OVERLOAD_429_RATE_THRESHOLD
@@ -187,6 +188,7 @@ K6_ARCHIVE_RESULTS="${K6_ARCHIVE_RESULTS:-true}"
 K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
 K6_OUTBOX_PREFLIGHT="${K6_OUTBOX_PREFLIGHT:-false}"
 K6_OUTBOX_PREFLIGHT_BASE_URL="${K6_OUTBOX_PREFLIGHT_BASE_URL:-http://localhost:${LOADTEST_BACKEND_PORT:-18080}}"
+K6_EXPLAIN_SNAPSHOT="${K6_EXPLAIN_SNAPSHOT:-true}"
 K6_OBSERVABILITY_MODE="${K6_OBSERVABILITY_MODE:-prometheus}"
 K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE:-false}"
 K6_OVERLOAD_429_RATE_THRESHOLD="${K6_OVERLOAD_429_RATE_THRESHOLD:-0.05}"
@@ -205,7 +207,7 @@ loadtest_alertmanager_port="${LOADTEST_ALERTMANAGER_PORT:-19093}"
 loadtest_postgres_exporter_port="${LOADTEST_POSTGRES_EXPORTER_PORT:-19187}"
 loadtest_postgres_container="${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}"
 loadtest_backend_container="${LOADTEST_BACKEND_CONTAINER_NAME:-aquila-bank-backend-loadtest}"
-export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
+export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
 
 require_positive_integer K6_VUS
 require_positive_integer K6_RATE
@@ -229,6 +231,7 @@ require_bool_value() {
   fi
 }
 require_bool_value K6_OUTBOX_PREFLIGHT
+require_bool_value K6_EXPLAIN_SNAPSHOT
 require_non_negative_integer K6_MAX_RETRY_AFTER_SLEEP_SECONDS
 require_rate K6_OVERLOAD_429_RATE_THRESHOLD
 require_generator_mode
@@ -294,6 +297,7 @@ print_plan() {
   echo "[k6-transaction-100m] preflight=${K6_PREFLIGHT}"
   echo "[k6-transaction-100m] outbox_preflight=${K6_OUTBOX_PREFLIGHT}"
   echo "[k6-transaction-100m] outbox_preflight_base_url=${K6_OUTBOX_PREFLIGHT_BASE_URL}"
+  echo "[k6-transaction-100m] explain_snapshot=${K6_EXPLAIN_SNAPSHOT}"
   if [[ "${run_dependencies}" == "true" ]]; then
     echo "[k6-transaction-100m] dependencies=compose-default"
   else
@@ -360,6 +364,15 @@ run_outbox_preflight() {
     tools/test/run-outbox-provider-backlog-local-gate.sh
 }
 
+run_explain_snapshot() {
+  local phase="$1"
+  if [[ "${K6_EXPLAIN_SNAPSHOT}" != "true" ]]; then
+    echo "[k6-transaction-100m] explain snapshot skipped phase=${phase}"
+    return 0
+  fi
+  K6_EXPLAIN_PHASE="${phase}" tools/test/run-transaction-100m-k6-explain-snapshot.sh
+}
+
 if [[ "${mode}" != "no-up" ]]; then
   echo "[k6-transaction-100m] building backend bootJar"
   tools/test/with-resource-lock.sh back-gradle-loadtest-bootjar ./back/gradlew -p back bootJar
@@ -374,6 +387,7 @@ fi
 
 assert_k6_preflight
 run_outbox_preflight
+run_explain_snapshot pre
 
 run_k6_local() {
   local run_args
@@ -483,6 +497,8 @@ else
 fi
 status=$?
 set -e
+
+run_explain_snapshot post
 
 if [[ "${K6_ARCHIVE_RESULTS}" == "true" && -f "${summary_md}" ]]; then
   tools/test/archive-k6-transaction-100m-result.sh "${summary_md}" "${summary_json}"

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -17,6 +17,13 @@ Optional environment:
   K6_REPORT_NAME       default transaction-100m-<timestamp>
   K6_VUS               default 8
   K6_DURATION          default 1m
+  K6_SCENARIO_MODE     constant-vus|constant-arrival-rate|burst, default constant-vus
+  K6_RATE              iterations per K6_TIME_UNIT for constant-arrival-rate, default 8
+  K6_TIME_UNIT         default 1s
+  K6_PRE_ALLOCATED_VUS default K6_VUS
+  K6_MAX_VUS           default K6_PRE_ALLOCATED_VUS
+  K6_BURST_RATE        iterations per second for burst mode, default 16
+  K6_BURST_DURATION    default 20s
   K6_LIMIT             default 50
   K6_HOT_P99_THRESHOLD_MS default 750
   K6_COLD_P99_THRESHOLD_MS default 1500
@@ -124,6 +131,17 @@ require_observability_mode() {
   esac
 }
 
+require_scenario_mode() {
+  case "${K6_SCENARIO_MODE}" in
+    constant-vus|constant-arrival-rate|burst)
+      ;;
+    *)
+      echo "K6_SCENARIO_MODE must be constant-vus, constant-arrival-rate, or burst" >&2
+      exit 1
+      ;;
+  esac
+}
+
 mode="run"
 run_dependencies="true"
 while [[ "$#" -gt 0 ]]; do
@@ -150,6 +168,13 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 K6_VUS="${K6_VUS:-8}"
+K6_SCENARIO_MODE="${K6_SCENARIO_MODE:-constant-vus}"
+K6_RATE="${K6_RATE:-8}"
+K6_TIME_UNIT="${K6_TIME_UNIT:-1s}"
+K6_PRE_ALLOCATED_VUS="${K6_PRE_ALLOCATED_VUS:-${K6_VUS}}"
+K6_MAX_VUS="${K6_MAX_VUS:-${K6_PRE_ALLOCATED_VUS}}"
+K6_BURST_RATE="${K6_BURST_RATE:-16}"
+K6_BURST_DURATION="${K6_BURST_DURATION:-20s}"
 K6_LIMIT="${K6_LIMIT:-50}"
 K6_HOT_P95_THRESHOLD_MS="${K6_HOT_P95_THRESHOLD_MS:-350}"
 K6_COLD_P95_THRESHOLD_MS="${K6_COLD_P95_THRESHOLD_MS:-750}"
@@ -180,9 +205,13 @@ loadtest_alertmanager_port="${LOADTEST_ALERTMANAGER_PORT:-19093}"
 loadtest_postgres_exporter_port="${LOADTEST_POSTGRES_EXPORTER_PORT:-19187}"
 loadtest_postgres_container="${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}"
 loadtest_backend_container="${LOADTEST_BACKEND_CONTAINER_NAME:-aquila-bank-backend-loadtest}"
-export K6_VUS K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
+export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
 
 require_positive_integer K6_VUS
+require_positive_integer K6_RATE
+require_positive_integer K6_PRE_ALLOCATED_VUS
+require_positive_integer K6_MAX_VUS
+require_positive_integer K6_BURST_RATE
 require_positive_integer K6_LIMIT
 require_positive_number K6_HOT_P95_THRESHOLD_MS
 require_positive_number K6_COLD_P95_THRESHOLD_MS
@@ -204,6 +233,7 @@ require_non_negative_integer K6_MAX_RETRY_AFTER_SLEEP_SECONDS
 require_rate K6_OVERLOAD_429_RATE_THRESHOLD
 require_generator_mode
 require_observability_mode
+require_scenario_mode
 
 if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
   require_env K6_DOCKER_CONTEXT
@@ -232,6 +262,9 @@ print_plan() {
   echo "[k6-transaction-100m] observability mode=${K6_OBSERVABILITY_MODE}"
   echo "[k6-transaction-100m] k6 report name: ${K6_REPORT_NAME}"
   echo "[k6-transaction-100m] k6 vus=${K6_VUS} duration=${K6_DURATION:-1m} limit=${K6_LIMIT}"
+  echo "[k6-transaction-100m] scenario mode=${K6_SCENARIO_MODE}"
+  echo "[k6-transaction-100m] arrival rate=${K6_RATE} timeUnit=${K6_TIME_UNIT} preAllocatedVUs=${K6_PRE_ALLOCATED_VUS} maxVUs=${K6_MAX_VUS}"
+  echo "[k6-transaction-100m] burst rate=${K6_BURST_RATE} duration=${K6_BURST_DURATION} preAllocatedVUs=${K6_PRE_ALLOCATED_VUS} maxVUs=${K6_MAX_VUS}"
   echo "[k6-transaction-100m] hot p95 threshold ms=${K6_HOT_P95_THRESHOLD_MS}"
   echo "[k6-transaction-100m] cold p95 threshold ms=${K6_COLD_P95_THRESHOLD_MS}"
   echo "[k6-transaction-100m] hot p99 threshold ms=${K6_HOT_P99_THRESHOLD_MS}"
@@ -359,6 +392,13 @@ run_k6_local() {
   docker compose "${compose_files[@]}" --profile loadtest run "${run_args[@]}" \
     -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
     -e K6_OBSERVABILITY_MODE="${K6_OBSERVABILITY_MODE}" \
+    -e K6_SCENARIO_MODE="${K6_SCENARIO_MODE}" \
+    -e K6_RATE="${K6_RATE}" \
+    -e K6_TIME_UNIT="${K6_TIME_UNIT}" \
+    -e K6_PRE_ALLOCATED_VUS="${K6_PRE_ALLOCATED_VUS}" \
+    -e K6_MAX_VUS="${K6_MAX_VUS}" \
+    -e K6_BURST_RATE="${K6_BURST_RATE}" \
+    -e K6_BURST_DURATION="${K6_BURST_DURATION}" \
     -e K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
     -e K6_HOT_FROM="${K6_HOT_FROM}" \
     -e K6_HOT_TO="${K6_HOT_TO}" \
@@ -402,6 +442,13 @@ run_k6_docker_context() {
     -e K6_PROMETHEUS_RW_TREND_STATS="p(50),p(90),p(95),p(99),min,max,avg" \
     -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
     -e K6_OBSERVABILITY_MODE="${K6_OBSERVABILITY_MODE}" \
+    -e K6_SCENARIO_MODE="${K6_SCENARIO_MODE}" \
+    -e K6_RATE="${K6_RATE}" \
+    -e K6_TIME_UNIT="${K6_TIME_UNIT}" \
+    -e K6_PRE_ALLOCATED_VUS="${K6_PRE_ALLOCATED_VUS}" \
+    -e K6_MAX_VUS="${K6_MAX_VUS}" \
+    -e K6_BURST_RATE="${K6_BURST_RATE}" \
+    -e K6_BURST_DURATION="${K6_BURST_DURATION}" \
     -e K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
     -e K6_HOT_FROM="${K6_HOT_FROM}" \
     -e K6_HOT_TO="${K6_HOT_TO}" \

--- a/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
@@ -12,6 +12,7 @@ Environment:
   T3MICRO_SSE_RESULT_MD        optional SSE reconnect archive markdown
   T3MICRO_ADMISSION_SUMMARY_TSV optional admission summary TSV
   T3MICRO_OUTBOX_SUMMARY_TSV   optional outbox summary TSV
+  T3MICRO_K6_SUMMARY_MD        optional k6 transaction 100m summary markdown
 
 Examples:
   tools/test/run-t3micro-defensive-gates-aggregate-report.sh --print-plan
@@ -48,6 +49,7 @@ capacity_result="${T3MICRO_CAPACITY_RESULT_MD:-}"
 sse_result="${T3MICRO_SSE_RESULT_MD:-}"
 admission_summary="${T3MICRO_ADMISSION_SUMMARY_TSV:-}"
 outbox_summary="${T3MICRO_OUTBOX_SUMMARY_TSV:-}"
+k6_summary="${T3MICRO_K6_SUMMARY_MD:-}"
 
 print_plan() {
   echo "[t3micro-defensive-aggregate] mode=${mode}"
@@ -56,6 +58,7 @@ print_plan() {
   echo "[t3micro-defensive-aggregate] sse=${sse_result:-missing}"
   echo "[t3micro-defensive-aggregate] admission=${admission_summary:-missing}"
   echo "[t3micro-defensive-aggregate] outbox=${outbox_summary:-missing}"
+  echo "[t3micro-defensive-aggregate] k6=${k6_summary:-missing}"
 }
 
 md_value() {
@@ -99,6 +102,7 @@ write_report() {
     echo "- sseResult: ${sse_result:-missing}"
     echo "- admissionSummary: ${admission_summary:-missing}"
     echo "- outboxSummary: ${outbox_summary:-missing}"
+    echo "- k6Summary: ${k6_summary:-missing}"
     echo
     echo "## Gate Summary"
     echo
@@ -108,6 +112,7 @@ write_report() {
     echo "| sse reconnect | $(md_value "${sse_result}" "status") | $(md_value "${sse_result}" "peakCpuPercent") | $(md_value "${sse_result}" "peakMemoryMiB") | clients=$(md_value "${sse_result}" "reconnectClients") rounds=$(md_value "${sse_result}" "reconnectRounds") | ${sse_result:-missing} |"
     echo "| http admission | n/a | n/a | n/a | rejected=$(tsv_value "${admission_summary}" "rejected_count") failed_rate=$(tsv_value "${admission_summary}" "failed_rate") | ${admission_summary:-missing} |"
     echo "| outbox backlog | n/a | n/a | n/a | lag=$(tsv_value "${outbox_summary}" "lag_seconds") failed=$(tsv_value "${outbox_summary}" "failed_count") dlq=$(tsv_value "${outbox_summary}" "dlq_count") | ${outbox_summary:-missing} |"
+    echo "| k6 transaction 100m | n/a | n/a | n/a | hotFirstP95=$(md_value "${k6_summary}" "hot first p95 ms") hotCursorP95=$(md_value "${k6_summary}" "hot cursor p95 ms") coldFirstP95=$(md_value "${k6_summary}" "cold first p95 ms") coldCursorP95=$(md_value "${k6_summary}" "cold cursor p95 ms") 429Rate=$(md_value "${k6_summary}" "transaction 429 rate") | ${k6_summary:-missing} |"
     echo
     echo "## Notes"
     echo

--- a/tools/test/run-transaction-100m-existing-volume-fixture-export.sh
+++ b/tools/test/run-transaction-100m-existing-volume-fixture-export.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-existing-volume-fixture-export.sh [--print-plan|--dry-run]
+
+Environment:
+  FIXTURE_NAME                 default transaction-100m-fixture
+  FIXTURE_DIR                  default build/fixtures
+  FIXTURE_PATH                 default <FIXTURE_DIR>/<FIXTURE_NAME>.dump
+  FIXTURE_EXPORT_VERIFY        true|false, default true
+  FIXTURE_RECOVERY_PREFLIGHT   true|false, default true
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_bool_value() {
+  local key="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${key} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+fixture_name="${FIXTURE_NAME:-transaction-100m-fixture}"
+fixture_dir="${FIXTURE_DIR:-build/fixtures}"
+fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
+manifest_path="${FIXTURE_MANIFEST_PATH:-${fixture_path}.manifest}"
+checksum_path="${FIXTURE_CHECKSUM_PATH:-${fixture_path}.sha256}"
+verify_after_dump="${FIXTURE_EXPORT_VERIFY:-true}"
+recovery_preflight="${FIXTURE_RECOVERY_PREFLIGHT:-true}"
+
+require_bool_value "FIXTURE_EXPORT_VERIFY" "${verify_after_dump}"
+require_bool_value "FIXTURE_RECOVERY_PREFLIGHT" "${recovery_preflight}"
+
+print_plan() {
+  echo "[transaction-100m-existing-export] mode=${mode}"
+  echo "[transaction-100m-existing-export] fixture=${fixture_name}"
+  echo "[transaction-100m-existing-export] dump=${fixture_path}"
+  echo "[transaction-100m-existing-export] manifest=${manifest_path}"
+  echo "[transaction-100m-existing-export] checksum=${checksum_path}"
+  echo "[transaction-100m-existing-export] verify_after_dump=${verify_after_dump}"
+  echo "[transaction-100m-existing-export] recovery_preflight=${recovery_preflight}"
+}
+
+print_dry_run() {
+  echo "FIXTURE_MODE=dump FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} FIXTURE_WRITE_MANIFEST=true FIXTURE_RECOVERY_PREFLIGHT=${recovery_preflight} tools/test/run-transaction-100m-fixture-restore.sh"
+  if [[ "${verify_after_dump}" == "true" ]]; then
+    echo "FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} tools/test/validate-transaction-100m-fixture-artifact.sh --verify"
+  fi
+  echo "manifest=${manifest_path}"
+  echo "checksum=${checksum_path}"
+}
+
+run_export() {
+  mkdir -p "${fixture_dir}"
+  FIXTURE_MODE=dump \
+  FIXTURE_NAME="${fixture_name}" \
+  FIXTURE_PATH="${fixture_path}" \
+  FIXTURE_WRITE_MANIFEST=true \
+  FIXTURE_RECOVERY_PREFLIGHT="${recovery_preflight}" \
+    tools/test/run-transaction-100m-fixture-restore.sh
+
+  if [[ "${verify_after_dump}" == "true" ]]; then
+    FIXTURE_NAME="${fixture_name}" \
+    FIXTURE_PATH="${fixture_path}" \
+      tools/test/validate-transaction-100m-fixture-artifact.sh --verify
+  fi
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  print_dry_run
+  exit 0
+fi
+
+run_export

--- a/tools/test/run-transaction-100m-k6-explain-snapshot.sh
+++ b/tools/test/run-transaction-100m-k6-explain-snapshot.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-k6-explain-snapshot.sh [--print-plan|--dry-run|--print-sql]
+
+Required environment:
+  K6_HOT_ACCOUNT_ID
+  K6_HOT_FROM
+  K6_HOT_TO
+  K6_COLD_ACCOUNT_ID
+  K6_COLD_FROM
+  K6_COLD_TO
+
+Optional environment:
+  K6_REPORT_NAME         default transaction-100m
+  K6_EXPLAIN_PHASE       default manual
+  K6_EXPLAIN_DIR         default build/reports/k6/<K6_REPORT_NAME>-explain
+  K6_LIMIT               default 50
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    --print-sql)
+      mode="print-sql"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_env() {
+  local key="$1"
+  local value="${!key:-}"
+  if [[ -z "${value}" ]]; then
+    echo "${key} is required" >&2
+    exit 1
+  fi
+}
+
+K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m}"
+K6_EXPLAIN_PHASE="${K6_EXPLAIN_PHASE:-manual}"
+K6_LIMIT="${K6_LIMIT:-50}"
+K6_EXPLAIN_DIR="${K6_EXPLAIN_DIR:-build/reports/k6/${K6_REPORT_NAME}-explain}"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
+
+if ! [[ "${K6_LIMIT}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "K6_LIMIT must be a positive integer" >&2
+  exit 1
+fi
+
+hot_first_path="${K6_EXPLAIN_DIR}/${K6_EXPLAIN_PHASE}-hot-first.txt"
+hot_cursor_path="${K6_EXPLAIN_DIR}/${K6_EXPLAIN_PHASE}-hot-cursor.txt"
+cold_first_path="${K6_EXPLAIN_DIR}/${K6_EXPLAIN_PHASE}-cold-first.txt"
+cold_cursor_path="${K6_EXPLAIN_DIR}/${K6_EXPLAIN_PHASE}-cold-cursor.txt"
+
+print_plan() {
+  echo "[transaction-100m-k6-explain] mode=${mode}"
+  echo "[transaction-100m-k6-explain] report=${K6_REPORT_NAME}"
+  echo "[transaction-100m-k6-explain] phase=${K6_EXPLAIN_PHASE}"
+  echo "[transaction-100m-k6-explain] dir=${K6_EXPLAIN_DIR}"
+  echo "[transaction-100m-k6-explain] hot-first=${hot_first_path}"
+  echo "[transaction-100m-k6-explain] hot-cursor=${hot_cursor_path}"
+  echo "[transaction-100m-k6-explain] cold-first=${cold_first_path}"
+  echo "[transaction-100m-k6-explain] cold-cursor=${cold_cursor_path}"
+}
+
+query_sql() {
+  local table="$1"
+  local account_id="$2"
+  local from="$3"
+  local to="$4"
+  local cursor="$5"
+  local cursor_predicate=""
+  if [[ "${cursor}" == "true" ]]; then
+    cursor_predicate="
+  AND (booked_at, id) < (
+    SELECT booked_at, id
+    FROM public.${table}
+    WHERE account_id = '${account_id}'
+      AND booked_at >= '${from}'::timestamptz
+      AND booked_at < '${to}'::timestamptz
+    ORDER BY booked_at DESC, id DESC
+    OFFSET $((K6_LIMIT - 1))
+    LIMIT 1
+  )"
+  fi
+  cat <<SQL
+EXPLAIN (FORMAT TEXT)
+SELECT id, account_id, transaction_reference, booked_at
+FROM public.${table}
+WHERE account_id = '${account_id}'
+  AND booked_at >= '${from}'::timestamptz
+  AND booked_at < '${to}'::timestamptz${cursor_predicate}
+ORDER BY booked_at DESC, id DESC
+LIMIT ${K6_LIMIT};
+SQL
+}
+
+print_sql() {
+  query_sql "transaction_read_model" "${K6_HOT_ACCOUNT_ID}" "${K6_HOT_FROM}" "${K6_HOT_TO}" false
+  query_sql "transaction_read_model" "${K6_HOT_ACCOUNT_ID}" "${K6_HOT_FROM}" "${K6_HOT_TO}" true
+  query_sql "transaction_read_model_archive" "${K6_COLD_ACCOUNT_ID}" "${K6_COLD_FROM}" "${K6_COLD_TO}" false
+  query_sql "transaction_read_model_archive" "${K6_COLD_ACCOUNT_ID}" "${K6_COLD_FROM}" "${K6_COLD_TO}" true
+}
+
+write_explain() {
+  local table="$1"
+  local account_id="$2"
+  local from="$3"
+  local to="$4"
+  local cursor="$5"
+  local output="$6"
+  query_sql "${table}" "${account_id}" "${from}" "${to}" "${cursor}" \
+    | "${psql_base[@]}" --output "${output}"
+}
+
+require_inputs() {
+  require_env K6_HOT_ACCOUNT_ID
+  require_env K6_HOT_FROM
+  require_env K6_HOT_TO
+  require_env K6_COLD_ACCOUNT_ID
+  require_env K6_COLD_FROM
+  require_env K6_COLD_TO
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+require_inputs
+if [[ "${mode}" == "dry-run" ]]; then
+  echo "mkdir -p ${K6_EXPLAIN_DIR}"
+  echo "write hot-first ${hot_first_path}"
+  echo "write hot-cursor ${hot_cursor_path}"
+  echo "write cold-first ${cold_first_path}"
+  echo "write cold-cursor ${cold_cursor_path}"
+  exit 0
+fi
+if [[ "${mode}" == "print-sql" ]]; then
+  print_sql
+  exit 0
+fi
+
+mkdir -p "${K6_EXPLAIN_DIR}"
+write_explain "transaction_read_model" "${K6_HOT_ACCOUNT_ID}" "${K6_HOT_FROM}" "${K6_HOT_TO}" false "${hot_first_path}"
+write_explain "transaction_read_model" "${K6_HOT_ACCOUNT_ID}" "${K6_HOT_FROM}" "${K6_HOT_TO}" true "${hot_cursor_path}"
+write_explain "transaction_read_model_archive" "${K6_COLD_ACCOUNT_ID}" "${K6_COLD_FROM}" "${K6_COLD_TO}" false "${cold_first_path}"
+write_explain "transaction_read_model_archive" "${K6_COLD_ACCOUNT_ID}" "${K6_COLD_FROM}" "${K6_COLD_TO}" true "${cold_cursor_path}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #447

## 🌿 Base Branch
- `main`

## 📝 Summary
- 기존 local 100m volume을 dump/manifest/checksum artifact로 export하는 wrapper를 추가했습니다.
- k6 burst admission scenario, pre/post EXPLAIN snapshot, aggregate report의 k6/admission/outbox 상태 통합을 한 리뷰 단위로 묶었습니다.

## 🛠 Changes
- `run-transaction-100m-existing-volume-fixture-export.sh`로 existing volume dump export와 artifact verify 경로 제공
- `K6_SCENARIO_MODE=burst|constant-arrival-rate` 및 관련 rate/VU 옵션 추가
- k6 실행 전후 hot/cold first/cursor EXPLAIN snapshot runner 추가 및 기본 연결
- aggregate report에 k6 p95/429 rate 입력을 추가해 admission/outbox와 같은 표로 표시

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-existing-volume-fixture-export.sh`
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `tools/test/check-transaction-100m-k6-explain-snapshot.sh`
- `tools/test/check-t3micro-defensive-gates-aggregate-report.sh`
- `tools/test/run-transaction-100m-existing-volume-fixture-export.sh --dry-run`
- `tools/test/run-k6-transaction-100m-loadtest.sh --print-plan`
- `tools/test/run-transaction-100m-k6-explain-snapshot.sh --print-plan`
- `tools/test/run-t3micro-defensive-gates-aggregate-report.sh --print-plan`
- `tools/test/with-resource-lock.sh back-check-100m-artifact-evidence ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `K6_EXPLAIN_SNAPSHOT` 기본값이 true라 k6 실행 시 EXPLAIN 파일 8개(pre/post x 4 shape)가 추가로 생성됩니다. 실제 쿼리는 실행하지 않는 `EXPLAIN (FORMAT TEXT)`라 DB 부하는 낮습니다.
- 롤백 방법: 이 PR revert 후 기존 k6/fixture/report runner로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?