### PR TITLE
[Fix] outbox health indicator null status 복구

### DIFF
--- a/back/src/main/java/com/aquilabank/global/notification/OutboxHealthIndicator.java
+++ b/back/src/main/java/com/aquilabank/global/notification/OutboxHealthIndicator.java
@@ -41,9 +41,12 @@ public final class OutboxHealthIndicator implements HealthIndicator {
       }
       Health.Builder builder =
           reasons.isEmpty() ? Health.up() : Health.status(Status.OUT_OF_SERVICE);
+      Object oldestDispatchableAt =
+          summary.oldestDispatchableAt() == null ? "none" : summary.oldestDispatchableAt();
       return builder
           .withDetail("observedAt", summary.observedAt())
-          .withDetail("oldestDispatchableAt", summary.oldestDispatchableAt())
+          // backlog 없음은 정상 상태이므로 actuator detail에는 null 대신 sentinel을 남깁니다.
+          .withDetail("oldestDispatchableAt", oldestDispatchableAt)
           .withDetail("lagSeconds", lagSeconds)
           .withDetail("failedCount", summary.failedCount())
           .withDetail("quarantinedCount", summary.quarantinedCount())

--- a/back/src/test/java/com/aquilabank/global/notification/OutboxHealthIndicatorTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/OutboxHealthIndicatorTest.java
@@ -1,0 +1,68 @@
+package com.aquilabank.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.notification.model.OutboxFailedEvent;
+import com.aquilabank.domain.notification.model.OutboxOpsSummary;
+import com.aquilabank.domain.notification.usecase.OutboxOpsQueryUseCase;
+import com.aquilabank.global.config.OutboxOpsProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+final class OutboxHealthIndicatorTest {
+
+  @Test
+  void healthIsUpWhenNoDispatchableBacklogExists() {
+    Instant observedAt = Instant.parse("2026-04-27T00:00:00Z");
+    OutboxHealthIndicator indicator =
+        new OutboxHealthIndicator(
+            queryUseCase(new OutboxOpsSummary(observedAt, null, Duration.ZERO, 0, 0, 0, 0)),
+            new OutboxOpsProperties.Health(120, 0, 0));
+
+    Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails())
+        .containsEntry("observedAt", observedAt)
+        .containsEntry("oldestDispatchableAt", "none")
+        .containsEntry("lagSeconds", 0L);
+  }
+
+  @Test
+  void healthIsOutOfServiceWhenLagThresholdIsExceeded() {
+    Instant observedAt = Instant.parse("2026-04-27T00:00:00Z");
+    Instant oldestDispatchableAt = observedAt.minusSeconds(121);
+    OutboxHealthIndicator indicator =
+        new OutboxHealthIndicator(
+            queryUseCase(
+                new OutboxOpsSummary(
+                    observedAt, oldestDispatchableAt, Duration.ofSeconds(121), 0, 0, 0, 0)),
+            new OutboxOpsProperties.Health(120, 0, 0));
+
+    Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+    assertThat(health.getDetails())
+        .containsEntry("oldestDispatchableAt", oldestDispatchableAt)
+        .containsEntry("lagSeconds", 121L)
+        .containsEntry("reasons", List.of("lag"));
+  }
+
+  private static OutboxOpsQueryUseCase queryUseCase(OutboxOpsSummary summary) {
+    return new OutboxOpsQueryUseCase() {
+      @Override
+      public List<OutboxFailedEvent> getFailedEvents(int limit) {
+        throw new UnsupportedOperationException("not used");
+      }
+
+      @Override
+      public OutboxOpsSummary getSummary() {
+        return summary;
+      }
+    };
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #453

## 🌿 Base Branch
- `main`

## 📝 Summary
- outbox backlog가 없는 정상 상태에서 `oldestDispatchableAt=null` 때문에 actuator health가 DOWN으로 바뀌는 문제를 복구했습니다.
- health detail에는 null을 직접 넣지 않고 `"none"` sentinel을 남겨 readiness/health 503 오탐을 막습니다.

## 🛠 Changes
- `OutboxHealthIndicator`가 `oldestDispatchableAt` null을 정상 backlog 없음 상태로 처리합니다.
- `OutboxHealthIndicatorTest`를 추가해 null backlog UP 상태와 lag threshold OUT_OF_SERVICE 상태를 함께 고정했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back test --tests com.aquilabank.global.notification.OutboxHealthIndicatorTest`
- `tools/test/with-resource-lock.sh back-check-outbox-health-null ./back/gradlew -p back check` 실패: transaction integration query timeout 및 Flyway V52 statement timeout 계열로 실패했습니다. 타깃 outbox health test는 통과했고, 실패 지점은 이번 변경 파일과 무관한 integration test context/query timeout입니다.

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: actuator health detail의 `oldestDispatchableAt` 값이 backlog 없음 상태에서 null 대신 `"none"` 문자열로 표시됩니다.
- 롤백 방법: 이 PR revert 후 기존 health detail 처리로 복구합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
