### PR TITLE
[Perf] loadtest runtime evidence capacity profile 정합성

### DIFF
--- a/compose.loadtest.yml
+++ b/compose.loadtest.yml
@@ -110,6 +110,10 @@ services:
     profiles:
       - loadtest
     restart: unless-stopped
+    cpus: "${LOADTEST_PROMETHEUS_CPUS:-0.25}"
+    mem_limit: "${LOADTEST_PROMETHEUS_MEMORY:-256m}"
+    memswap_limit: "${LOADTEST_PROMETHEUS_MEMORY_SWAP:-256m}"
+    pids_limit: ${LOADTEST_PROMETHEUS_PIDS_LIMIT:-128}
     ports:
       - "${LOADTEST_PROMETHEUS_PORT:-19090}:9090"
     volumes:
@@ -131,6 +135,10 @@ services:
     profiles:
       - loadtest
     restart: unless-stopped
+    cpus: "${LOADTEST_GRAFANA_CPUS:-0.20}"
+    mem_limit: "${LOADTEST_GRAFANA_MEMORY:-256m}"
+    memswap_limit: "${LOADTEST_GRAFANA_MEMORY_SWAP:-256m}"
+    pids_limit: ${LOADTEST_GRAFANA_PIDS_LIMIT:-128}
     ports:
       - "${LOADTEST_GRAFANA_PORT:-13001}:3000"
     environment:
@@ -152,6 +160,10 @@ services:
     profiles:
       - loadtest
     restart: unless-stopped
+    cpus: "${LOADTEST_ALERTMANAGER_CPUS:-0.10}"
+    mem_limit: "${LOADTEST_ALERTMANAGER_MEMORY:-128m}"
+    memswap_limit: "${LOADTEST_ALERTMANAGER_MEMORY_SWAP:-128m}"
+    pids_limit: ${LOADTEST_ALERTMANAGER_PIDS_LIMIT:-64}
     ports:
       - "${LOADTEST_ALERTMANAGER_PORT:-19093}:9093"
     volumes:
@@ -165,6 +177,10 @@ services:
     profiles:
       - loadtest
     restart: unless-stopped
+    cpus: "${LOADTEST_POSTGRES_EXPORTER_CPUS:-0.10}"
+    mem_limit: "${LOADTEST_POSTGRES_EXPORTER_MEMORY:-128m}"
+    memswap_limit: "${LOADTEST_POSTGRES_EXPORTER_MEMORY_SWAP:-128m}"
+    pids_limit: ${LOADTEST_POSTGRES_EXPORTER_PIDS_LIMIT:-64}
     ports:
       - "${LOADTEST_POSTGRES_EXPORTER_PORT:-19187}:9187"
     environment:

--- a/compose.loadtest.yml
+++ b/compose.loadtest.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     container_name: ${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}
-    ports:
+    ports: !override
       - "${LOADTEST_DB_PORT:-15432}:5432"
     command:
       [

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -17,6 +17,7 @@ plan="$(
 )"
 grep -F "backend: aquila-bank-backend:8080 with t3.micro budget" <<<"${plan}" >/dev/null
 grep -F "observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-exporter:9187" <<<"${plan}" >/dev/null
+grep -F "observability resources: prometheus=0.25/256m grafana=0.20/256m alertmanager=0.10/128m postgres-exporter=0.10/128m" <<<"${plan}" >/dev/null
 grep -F "k6 report name: transaction-100m-check" <<<"${plan}" >/dev/null
 grep -F "hot p99 threshold ms=750" <<<"${plan}" >/dev/null
 grep -F "cold p99 threshold ms=1500" <<<"${plan}" >/dev/null
@@ -147,6 +148,10 @@ grep -F "K6_OVERLOAD_429_RATE_THRESHOLD" tools/test/run-k6-transaction-100m-load
 grep -F "K6_OVERLOAD_503_RATE_THRESHOLD" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_GENERATOR_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_OBSERVABILITY_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "LOADTEST_PROMETHEUS_CPUS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "LOADTEST_GRAFANA_MEMORY" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "LOADTEST_ALERTMANAGER_CPUS" compose.loadtest.yml >/dev/null
+grep -F "LOADTEST_POSTGRES_EXPORTER_MEMORY" compose.loadtest.yml >/dev/null
 grep -F "require_observability_mode" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "experimental-prometheus-rw" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "without prometheus remote-write" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null

--- a/tools/test/check-loadtest-compose-port-isolation.sh
+++ b/tools/test/check-loadtest-compose-port-isolation.sh
@@ -17,6 +17,10 @@ grep -F '${LOADTEST_PROMETHEUS_PORT:-19090}:9090' compose.loadtest.yml >/dev/nul
 grep -F '${LOADTEST_GRAFANA_PORT:-13001}:3000' compose.loadtest.yml >/dev/null
 grep -F '${LOADTEST_ALERTMANAGER_PORT:-19093}:9093' compose.loadtest.yml >/dev/null
 grep -F '${LOADTEST_POSTGRES_EXPORTER_PORT:-19187}:9187' compose.loadtest.yml >/dev/null
+grep -F 'cpus: "${LOADTEST_PROMETHEUS_CPUS:-0.25}"' compose.loadtest.yml >/dev/null
+grep -F 'mem_limit: "${LOADTEST_GRAFANA_MEMORY:-256m}"' compose.loadtest.yml >/dev/null
+grep -F 'pids_limit: ${LOADTEST_ALERTMANAGER_PIDS_LIMIT:-64}' compose.loadtest.yml >/dev/null
+grep -F 'memswap_limit: "${LOADTEST_POSTGRES_EXPORTER_MEMORY_SWAP:-128m}"' compose.loadtest.yml >/dev/null
 grep -F 'BASE_URL: ${K6_BASE_URL:-http://aquila-bank-backend:8080}' compose.loadtest.yml >/dev/null
 
 plan="$(
@@ -27,7 +31,16 @@ plan="$(
   LOADTEST_GRAFANA_PORT=23001 \
   LOADTEST_ALERTMANAGER_PORT=29093 \
   LOADTEST_POSTGRES_EXPORTER_PORT=29187 \
+  LOADTEST_PROMETHEUS_CPUS=0.15 \
+  LOADTEST_PROMETHEUS_MEMORY=192m \
+  LOADTEST_GRAFANA_CPUS=0.12 \
+  LOADTEST_GRAFANA_MEMORY=160m \
+  LOADTEST_ALERTMANAGER_CPUS=0.05 \
+  LOADTEST_ALERTMANAGER_MEMORY=96m \
+  LOADTEST_POSTGRES_EXPORTER_CPUS=0.05 \
+  LOADTEST_POSTGRES_EXPORTER_MEMORY=96m \
     tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
 )"
 grep -F "ports: db=25432 backend=28080 prometheus=29090 grafana=23001 alertmanager=29093 postgres-exporter=29187" <<<"${plan}" >/dev/null
 grep -F "containers: postgres=aquila-bank-postgres-loadtest backend=aquila-bank-backend-loadtest" <<<"${plan}" >/dev/null
+grep -F "observability resources: prometheus=0.15/192m grafana=0.12/160m alertmanager=0.05/96m postgres-exporter=0.05/96m" <<<"${plan}" >/dev/null

--- a/tools/test/check-loadtest-compose-port-isolation.sh
+++ b/tools/test/check-loadtest-compose-port-isolation.sh
@@ -2,7 +2,12 @@
 set -euo pipefail
 
 echo "[loadtest-compose-port-isolation] compose contract"
-docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/dev/null
+compose_config="$(docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config)"
+grep -F 'published: "15432"' <<<"${compose_config}" >/dev/null
+if grep -F 'published: "5432"' <<<"${compose_config}" >/dev/null; then
+  echo "loadtest postgres still publishes the dev DB port 5432" >&2
+  exit 1
+fi
 
 grep -F 'container_name: ${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}' compose.loadtest.yml >/dev/null
 grep -F '${LOADTEST_DB_PORT:-15432}:5432' compose.loadtest.yml >/dev/null

--- a/tools/test/check-transaction-100m-capacity-gates.sh
+++ b/tools/test/check-transaction-100m-capacity-gates.sh
@@ -10,6 +10,10 @@ echo "[transaction-100m-capacity] print plan"
 plan="$(
   CAPACITY_NAME=transaction-capacity-check \
   CAPACITY_LONG_SOAK_DURATION=30m \
+  CAPACITY_K6_DOCKER_CONTEXT=capacity-k6-remote \
+  CAPACITY_K6_REMOTE_BASE_URL=http://192.0.2.20:8080 \
+  CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.20:9090/api/v1/write \
+  CAPACITY_K6_REMOTE_WORKDIR=/srv/aquila-bank \
     "${script}" --print-plan
 )"
 grep -F "capacity=transaction-capacity-check" <<<"${plan}" >/dev/null
@@ -25,9 +29,17 @@ grep -F "overload_429_rate_threshold=0.20" <<<"${plan}" >/dev/null
 grep -F "backend_cpu_threshold_percent=120" <<<"${plan}" >/dev/null
 grep -F "postgres_cpu_threshold_percent=90" <<<"${plan}" >/dev/null
 grep -F "hikari_pending_threshold=0" <<<"${plan}" >/dev/null
+grep -F "k6_generator_mode=docker-context" <<<"${plan}" >/dev/null
+grep -F "allow_local_k6_generator=false" <<<"${plan}" >/dev/null
+grep -F "k6_docker_context=capacity-k6-remote" <<<"${plan}" >/dev/null
+grep -F "k6_remote_base_url=http://192.0.2.20:8080" <<<"${plan}" >/dev/null
+grep -F "k6_remote_workdir=/srv/aquila-bank" <<<"${plan}" >/dev/null
 grep -F "summary=build/reports/k6/transaction-capacity-check/capacity-summary.tsv" <<<"${plan}" >/dev/null
 
 echo "[transaction-100m-capacity] runner contract"
+grep -F "CAPACITY_K6_GENERATOR_MODE" "${script}" >/dev/null
+grep -F "CAPACITY_ALLOW_LOCAL_K6_GENERATOR" "${script}" >/dev/null
+grep -F "K6_GENERATOR_MODE=\"\${capacity_k6_generator_mode}\"" "${script}" >/dev/null
 grep -F "CAPACITY_HARD_THRESHOLD_ENABLED" "${script}" >/dev/null
 grep -F "CAPACITY_HOT_P95_THRESHOLD_MS" "${script}" >/dev/null
 grep -F "CAPACITY_COLD_P95_THRESHOLD_MS" "${script}" >/dev/null
@@ -72,5 +84,14 @@ if CAPACITY_OVERLOAD_429_RATE_THRESHOLD=1.5 "${script}" --print-plan >/dev/null 
 fi
 if CAPACITY_SINGLE_HOST_PROFILES=bad-strict:3:8:0.40:512m:0.60:384m:4:false:1m "${script}" --print-plan >/dev/null 2>&1; then
   echo "adaptive strict profile without overload unexpectedly succeeded" >&2
+  exit 1
+fi
+if CAPACITY_K6_GENERATOR_MODE=local "${script}" --print-plan >/dev/null 2>&1; then
+  echo "local k6 generator without explicit allowance unexpectedly succeeded" >&2
+  exit 1
+fi
+CAPACITY_K6_GENERATOR_MODE=local CAPACITY_ALLOW_LOCAL_K6_GENERATOR=true "${script}" --print-plan >/dev/null
+if CAPACITY_K6_GENERATOR_MODE=docker-context "${script}" --print-plan >/dev/null 2>&1; then
+  echo "docker-context k6 generator without remote runtime unexpectedly succeeded" >&2
   exit 1
 fi

--- a/tools/test/check-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/check-transaction-100m-fixture-dataset-probe.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-fixture-dataset-probe.sh"
+
+echo "[transaction-100m-dataset-probe] shell syntax"
+bash -n "${script}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+dump_path="${temp_dir}/transaction-100m-check.dump"
+manifest_path="${dump_path}.manifest"
+env_path="${temp_dir}/transaction-100m-check.dataset.env"
+printf "sample-dump\n" >"${dump_path}"
+{
+  echo "fixture_name=transaction-100m-check"
+  echo "dump_path=${dump_path}"
+  echo "sha256=dummy"
+  echo "flyway_version=999"
+  echo "total_rows=1000"
+  echo "hot_rows=600"
+  echo "archive_rows=400"
+  echo "hot_account_id=910000001"
+  echo "hot_from=2026-04-01T00:00:00Z"
+  echo "hot_to=2026-04-30T00:00:00Z"
+  echo "cold_account_id=910000002"
+  echo "cold_from=2026-01-01T00:00:00Z"
+  echo "cold_to=2026-01-31T00:00:00Z"
+  echo "generated_at=2026-04-27T00:00:00Z"
+} >"${manifest_path}"
+
+echo "[transaction-100m-dataset-probe] print plan"
+plan="$(
+  FIXTURE_PATH="${dump_path}" \
+  FIXTURE_MANIFEST_PATH="${manifest_path}" \
+  FIXTURE_DATASET_ENV_PATH="${env_path}" \
+    "${script}" --print-plan
+)"
+grep -F "mode=print-plan" <<<"${plan}" >/dev/null
+grep -F "manifest=${manifest_path}" <<<"${plan}" >/dev/null
+grep -F "dataset_env=${env_path}" <<<"${plan}" >/dev/null
+grep -F "db_fallback=false" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-dataset-probe] manifest probe writes k6 env"
+FIXTURE_PATH="${dump_path}" \
+FIXTURE_MANIFEST_PATH="${manifest_path}" \
+FIXTURE_DATASET_ENV_PATH="${env_path}" \
+  "${script}" >/dev/null
+grep -F "K6_HOT_ACCOUNT_ID=910000001" "${env_path}" >/dev/null
+grep -F "K6_HOT_FROM=2026-04-01T00:00:00Z" "${env_path}" >/dev/null
+grep -F "K6_HOT_TO=2026-04-30T00:00:00Z" "${env_path}" >/dev/null
+grep -F "K6_COLD_ACCOUNT_ID=910000002" "${env_path}" >/dev/null
+grep -F "K6_COLD_FROM=2026-01-01T00:00:00Z" "${env_path}" >/dev/null
+grep -F "K6_COLD_TO=2026-01-31T00:00:00Z" "${env_path}" >/dev/null
+
+echo "[transaction-100m-dataset-probe] missing metadata fails without db fallback"
+sed -i.bak '/hot_account_id=/d' "${manifest_path}"
+if FIXTURE_PATH="${dump_path}" \
+  FIXTURE_MANIFEST_PATH="${manifest_path}" \
+  FIXTURE_DATASET_ENV_PATH="${env_path}" \
+    "${script}" >/dev/null 2>&1; then
+  echo "missing manifest metadata unexpectedly passed without explicit DB fallback" >&2
+  exit 1
+fi
+
+echo "[transaction-100m-dataset-probe] wrapper contract"
+grep -F "run-transaction-100m-fixture-dataset-probe.sh" tools/test/run-transaction-100m-artifact-ready-k6.sh >/dev/null
+grep -F "run-transaction-100m-fixture-dataset-probe.sh" tools/test/run-transaction-100m-fresh-volume-restore-k6.sh >/dev/null

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -49,6 +49,10 @@ Optional environment:
   K6_REMOTE_PROMETHEUS_RW_SERVER_URL
                        Prometheus remote-write URL reachable from remote k6, required when mode=docker-context
   K6_REMOTE_WORKDIR   repo path visible from docker context host, default current working directory
+  LOADTEST_PROMETHEUS_CPUS/MEMORY default 0.25/256m
+  LOADTEST_GRAFANA_CPUS/MEMORY default 0.20/256m
+  LOADTEST_ALERTMANAGER_CPUS/MEMORY default 0.10/128m
+  LOADTEST_POSTGRES_EXPORTER_CPUS/MEMORY default 0.10/128m
 
 Examples:
   K6_HOT_ACCOUNT_ID=101 K6_HOT_FROM=2026-04-01T00:00:00Z K6_HOT_TO=2026-04-30T00:00:00Z \
@@ -208,6 +212,14 @@ loadtest_prometheus_port="${LOADTEST_PROMETHEUS_PORT:-19090}"
 loadtest_grafana_port="${LOADTEST_GRAFANA_PORT:-13001}"
 loadtest_alertmanager_port="${LOADTEST_ALERTMANAGER_PORT:-19093}"
 loadtest_postgres_exporter_port="${LOADTEST_POSTGRES_EXPORTER_PORT:-19187}"
+loadtest_prometheus_cpus="${LOADTEST_PROMETHEUS_CPUS:-0.25}"
+loadtest_prometheus_memory="${LOADTEST_PROMETHEUS_MEMORY:-256m}"
+loadtest_grafana_cpus="${LOADTEST_GRAFANA_CPUS:-0.20}"
+loadtest_grafana_memory="${LOADTEST_GRAFANA_MEMORY:-256m}"
+loadtest_alertmanager_cpus="${LOADTEST_ALERTMANAGER_CPUS:-0.10}"
+loadtest_alertmanager_memory="${LOADTEST_ALERTMANAGER_MEMORY:-128m}"
+loadtest_postgres_exporter_cpus="${LOADTEST_POSTGRES_EXPORTER_CPUS:-0.10}"
+loadtest_postgres_exporter_memory="${LOADTEST_POSTGRES_EXPORTER_MEMORY:-128m}"
 loadtest_postgres_container="${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}"
 loadtest_backend_container="${LOADTEST_BACKEND_CONTAINER_NAME:-aquila-bank-backend-loadtest}"
 export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
@@ -266,6 +278,7 @@ print_plan() {
   else
     echo "[k6-transaction-100m] observability: summary-only local markdown/json"
   fi
+  echo "[k6-transaction-100m] observability resources: prometheus=${loadtest_prometheus_cpus}/${loadtest_prometheus_memory} grafana=${loadtest_grafana_cpus}/${loadtest_grafana_memory} alertmanager=${loadtest_alertmanager_cpus}/${loadtest_alertmanager_memory} postgres-exporter=${loadtest_postgres_exporter_cpus}/${loadtest_postgres_exporter_memory}"
   echo "[k6-transaction-100m] observability mode=${K6_OBSERVABILITY_MODE}"
   echo "[k6-transaction-100m] k6 report name: ${K6_REPORT_NAME}"
   echo "[k6-transaction-100m] k6 vus=${K6_VUS} duration=${K6_DURATION:-1m} limit=${K6_LIMIT}"

--- a/tools/test/run-transaction-100m-artifact-ready-k6.sh
+++ b/tools/test/run-transaction-100m-artifact-ready-k6.sh
@@ -6,12 +6,7 @@ usage() {
 usage: tools/test/run-transaction-100m-artifact-ready-k6.sh [--print-plan|--dry-run]
 
 Required environment:
-  K6_HOT_ACCOUNT_ID
-  K6_HOT_FROM
-  K6_HOT_TO
-  K6_COLD_ACCOUNT_ID
-  K6_COLD_FROM
-  K6_COLD_TO
+  K6_HOT_ACCOUNT_ID/K6_HOT_FROM/... or fixture manifest dataset metadata
 
 Optional environment:
   FIXTURE_NAME              default transaction-100m-fixture
@@ -61,6 +56,7 @@ require_bool_value() {
 fixture_name="${FIXTURE_NAME:-transaction-100m-fixture}"
 fixture_dir="${FIXTURE_DIR:-build/fixtures}"
 fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
+dataset_env_path="${FIXTURE_DATASET_ENV_PATH:-${fixture_path}.dataset.env}"
 k6_no_deps="${ARTIFACT_READY_K6_NO_DEPS:-true}"
 K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-artifact-ready-$(date +%Y-%m-%d-%H%M%S)}"
 export K6_REPORT_NAME
@@ -72,6 +68,8 @@ print_plan() {
   echo "[transaction-100m-artifact-ready-k6] fixture=${fixture_name}"
   echo "[transaction-100m-artifact-ready-k6] dump=${fixture_path}"
   echo "[transaction-100m-artifact-ready-k6] artifact_gate=tools/test/validate-transaction-100m-fixture-artifact.sh --verify"
+  echo "[transaction-100m-artifact-ready-k6] dataset_probe=tools/test/run-transaction-100m-fixture-dataset-probe.sh"
+  echo "[transaction-100m-artifact-ready-k6] dataset_env=${dataset_env_path}"
   echo "[transaction-100m-artifact-ready-k6] k6_runner=tools/test/run-k6-transaction-100m-loadtest.sh --no-up"
   echo "[transaction-100m-artifact-ready-k6] k6_no_deps=${k6_no_deps}"
   echo "[transaction-100m-artifact-ready-k6] k6 report=${K6_REPORT_NAME}"
@@ -79,6 +77,7 @@ print_plan() {
 
 print_dry_run() {
   echo "FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} tools/test/validate-transaction-100m-fixture-artifact.sh --verify"
+  echo "FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} FIXTURE_DATASET_ENV_PATH=${dataset_env_path} tools/test/run-transaction-100m-fixture-dataset-probe.sh"
   if [[ "${k6_no_deps}" == "true" ]]; then
     echo "K6_REPORT_NAME=${K6_REPORT_NAME} tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps"
   else
@@ -91,6 +90,10 @@ run_k6() {
   if [[ "${k6_no_deps}" == "true" ]]; then
     args+=(--no-deps)
   fi
+  set -a
+  # manifest 기반 probe 결과만 k6 입력으로 노출해 1억 row 탐색을 피합니다.
+  source "${dataset_env_path}"
+  set +a
   tools/test/run-k6-transaction-100m-loadtest.sh "${args[@]}"
 }
 
@@ -106,4 +109,8 @@ fi
 FIXTURE_NAME="${fixture_name}" \
 FIXTURE_PATH="${fixture_path}" \
   tools/test/validate-transaction-100m-fixture-artifact.sh --verify
+FIXTURE_NAME="${fixture_name}" \
+FIXTURE_PATH="${fixture_path}" \
+FIXTURE_DATASET_ENV_PATH="${dataset_env_path}" \
+  tools/test/run-transaction-100m-fixture-dataset-probe.sh
 run_k6

--- a/tools/test/run-transaction-100m-capacity-gates.sh
+++ b/tools/test/run-transaction-100m-capacity-gates.sh
@@ -24,6 +24,12 @@ Optional environment:
   CAPACITY_READINESS_TIMEOUT_SECONDS default 120
   CAPACITY_METRIC_SCRAPE_WAIT_SECONDS default 6
   CAPACITY_CPU_SAMPLE_INTERVAL_SECONDS default 5
+  CAPACITY_K6_GENERATOR_MODE default docker-context
+  CAPACITY_ALLOW_LOCAL_K6_GENERATOR default false
+  CAPACITY_K6_DOCKER_CONTEXT docker context for off-host k6, required when generator mode=docker-context
+  CAPACITY_K6_REMOTE_BASE_URL backend URL reachable from off-host k6
+  CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL Prometheus remote-write URL reachable from off-host k6
+  CAPACITY_K6_REMOTE_WORKDIR repo path visible from docker context host, default current working directory
   CAPACITY_ADAPTIVE_ENABLED default true
   CAPACITY_HARD_THRESHOLD_ENABLED default true
   CAPACITY_HOT_P95_THRESHOLD_MS default 350
@@ -73,6 +79,12 @@ long_soak_duration="${CAPACITY_LONG_SOAK_DURATION:-30m}"
 readiness_timeout_seconds="${CAPACITY_READINESS_TIMEOUT_SECONDS:-120}"
 metric_scrape_wait_seconds="${CAPACITY_METRIC_SCRAPE_WAIT_SECONDS:-6}"
 cpu_sample_interval_seconds="${CAPACITY_CPU_SAMPLE_INTERVAL_SECONDS:-5}"
+capacity_k6_generator_mode="${CAPACITY_K6_GENERATOR_MODE:-docker-context}"
+allow_local_k6_generator="${CAPACITY_ALLOW_LOCAL_K6_GENERATOR:-false}"
+capacity_k6_docker_context="${CAPACITY_K6_DOCKER_CONTEXT:-${K6_DOCKER_CONTEXT:-}}"
+capacity_k6_remote_base_url="${CAPACITY_K6_REMOTE_BASE_URL:-${K6_REMOTE_BASE_URL:-}}"
+capacity_k6_remote_prometheus_rw_server_url="${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-${K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-}}"
+capacity_k6_remote_workdir="${CAPACITY_K6_REMOTE_WORKDIR:-${K6_REMOTE_WORKDIR:-$(pwd)}}"
 adaptive_enabled="${CAPACITY_ADAPTIVE_ENABLED:-${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_ENABLED:-true}}"
 hard_threshold_enabled="${CAPACITY_HARD_THRESHOLD_ENABLED:-true}"
 hot_p95_threshold_ms="${CAPACITY_HOT_P95_THRESHOLD_MS:-350}"
@@ -269,11 +281,26 @@ require_env() {
   fi
 }
 
+require_generator_mode_value() {
+  local name="$1"
+  local value="$2"
+  case "${value}" in
+    local|docker-context)
+      ;;
+    *)
+      echo "${name} must be local or docker-context: ${value}" >&2
+      exit 1
+      ;;
+  esac
+}
+
 require_bool "CAPACITY_BUILD_BACKEND" "${build_backend}"
 require_bool "CAPACITY_RUN_SINGLE_HOST" "${run_single_host}"
 require_bool "CAPACITY_RUN_CPU_SPLIT" "${run_cpu_split}"
 require_bool "CAPACITY_RUN_LONG_SOAK" "${run_long_soak}"
 require_bool "CAPACITY_CONTINUE_ON_FAILURE" "${continue_on_failure}"
+require_bool "CAPACITY_ALLOW_LOCAL_K6_GENERATOR" "${allow_local_k6_generator}"
+require_generator_mode_value "CAPACITY_K6_GENERATOR_MODE" "${capacity_k6_generator_mode}"
 require_bool "CAPACITY_ADAPTIVE_ENABLED" "${adaptive_enabled}"
 require_bool "CAPACITY_HARD_THRESHOLD_ENABLED" "${hard_threshold_enabled}"
 require_duration_value "CAPACITY_LONG_SOAK_DURATION" "${long_soak_duration}"
@@ -294,6 +321,26 @@ assert_adaptive_strict_guards "CAPACITY_SINGLE_HOST_PROFILES" "${single_host_pro
 assert_adaptive_strict_guards "CAPACITY_CPU_SPLIT_PROFILES" "${cpu_split_profiles}"
 assert_adaptive_strict_guard "CAPACITY_LONG_SOAK_PROFILE" "${long_soak_profile}"
 
+if [[ "${capacity_k6_generator_mode}" == "local" && "${allow_local_k6_generator}" != "true" ]]; then
+  echo "CAPACITY_K6_GENERATOR_MODE=local requires CAPACITY_ALLOW_LOCAL_K6_GENERATOR=true" >&2
+  exit 1
+fi
+
+if [[ "${capacity_k6_generator_mode}" == "docker-context" ]]; then
+  [[ -n "${capacity_k6_docker_context}" ]] || {
+    echo "CAPACITY_K6_DOCKER_CONTEXT is required when CAPACITY_K6_GENERATOR_MODE=docker-context" >&2
+    exit 1
+  }
+  [[ -n "${capacity_k6_remote_base_url}" ]] || {
+    echo "CAPACITY_K6_REMOTE_BASE_URL is required when CAPACITY_K6_GENERATOR_MODE=docker-context" >&2
+    exit 1
+  }
+  [[ -n "${capacity_k6_remote_prometheus_rw_server_url}" ]] || {
+    echo "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL is required when CAPACITY_K6_GENERATOR_MODE=docker-context" >&2
+    exit 1
+  }
+fi
+
 print_plan() {
   echo "[transaction-100m-capacity] capacity=${capacity_name}"
   echo "[transaction-100m-capacity] build_backend=${build_backend}"
@@ -309,6 +356,11 @@ print_plan() {
   echo "[transaction-100m-capacity] readiness_timeout_seconds=${readiness_timeout_seconds}"
   echo "[transaction-100m-capacity] metric_scrape_wait_seconds=${metric_scrape_wait_seconds}"
   echo "[transaction-100m-capacity] cpu_sample_interval_seconds=${cpu_sample_interval_seconds}"
+  echo "[transaction-100m-capacity] k6_generator_mode=${capacity_k6_generator_mode}"
+  echo "[transaction-100m-capacity] allow_local_k6_generator=${allow_local_k6_generator}"
+  echo "[transaction-100m-capacity] k6_docker_context=${capacity_k6_docker_context:-missing}"
+  echo "[transaction-100m-capacity] k6_remote_base_url=${capacity_k6_remote_base_url:-missing}"
+  echo "[transaction-100m-capacity] k6_remote_workdir=${capacity_k6_remote_workdir}"
   echo "[transaction-100m-capacity] adaptive_enabled=${adaptive_enabled}"
   echo "[transaction-100m-capacity] hard_thresholds=${hard_threshold_enabled}"
   echo "[transaction-100m-capacity] hot_p95_threshold_ms=${hot_p95_threshold_ms}"
@@ -562,6 +614,11 @@ run_profile() {
   K6_DURATION="${duration}" \
   K6_OVERLOAD_MODE="${overload_mode}" \
   K6_ARCHIVE_RESULTS=false \
+  K6_GENERATOR_MODE="${capacity_k6_generator_mode}" \
+  K6_DOCKER_CONTEXT="${capacity_k6_docker_context}" \
+  K6_REMOTE_BASE_URL="${capacity_k6_remote_base_url}" \
+  K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${capacity_k6_remote_prometheus_rw_server_url}" \
+  K6_REMOTE_WORKDIR="${capacity_k6_remote_workdir}" \
     tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${log_path}" 2>&1
   status=$?
   set -e

--- a/tools/test/run-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/run-transaction-100m-fixture-dataset-probe.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-fixture-dataset-probe.sh [--print-plan|--dry-run]
+
+Environment:
+  FIXTURE_NAME                         default transaction-100m-fixture
+  FIXTURE_PATH                         default build/fixtures/<FIXTURE_NAME>.dump
+  FIXTURE_MANIFEST_PATH                default <FIXTURE_PATH>.manifest
+  FIXTURE_DATASET_ENV_PATH             default <FIXTURE_PATH>.dataset.env
+  FIXTURE_DATASET_PROBE_DB_FALLBACK    true|false, default false
+
+Manifest keys:
+  hot_account_id hot_from hot_to cold_account_id cold_from cold_to
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_bool_value() {
+  local key="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${key} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+fixture_name="${FIXTURE_NAME:-transaction-100m-fixture}"
+fixture_dir="${FIXTURE_DIR:-build/fixtures}"
+fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
+manifest_path="${FIXTURE_MANIFEST_PATH:-${fixture_path}.manifest}"
+dataset_env_path="${FIXTURE_DATASET_ENV_PATH:-${fixture_path}.dataset.env}"
+db_fallback="${FIXTURE_DATASET_PROBE_DB_FALLBACK:-false}"
+compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
+
+require_bool_value "FIXTURE_DATASET_PROBE_DB_FALLBACK" "${db_fallback}"
+
+manifest_value() {
+  local key="$1"
+  if [[ ! -s "${manifest_path}" ]]; then
+    return 0
+  fi
+  awk -F '=' -v key="${key}" '$1 == key {print $2}' "${manifest_path}" | tail -1
+}
+
+require_value() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "dataset probe ${key} is missing" >&2
+    exit 1
+  fi
+}
+
+resolve_manifest_or_env() {
+  local manifest_key="$1"
+  local env_key="$2"
+  local value
+  value="$(manifest_value "${manifest_key}")"
+  if [[ -n "${value}" ]]; then
+    echo "${value}"
+    return 0
+  fi
+  echo "${!env_key:-}"
+}
+
+probe_from_db() {
+  local table="$1"
+  local account_id="$2"
+  local from_to
+  from_to="$(
+    "${psql_base[@]}" --no-align --tuples-only --field-separator='|' --command "
+      SELECT MIN(booked_at), MAX(booked_at)
+      FROM public.${table}
+      WHERE account_id = '${account_id}';
+    "
+  )"
+  tr -d '[:space:]' <<<"${from_to}"
+}
+
+write_dataset_env() {
+  local hot_account_id="$1"
+  local hot_from="$2"
+  local hot_to="$3"
+  local cold_account_id="$4"
+  local cold_from="$5"
+  local cold_to="$6"
+  mkdir -p "$(dirname "${dataset_env_path}")"
+  {
+    echo "K6_HOT_ACCOUNT_ID=${hot_account_id}"
+    echo "K6_HOT_FROM=${hot_from}"
+    echo "K6_HOT_TO=${hot_to}"
+    echo "K6_COLD_ACCOUNT_ID=${cold_account_id}"
+    echo "K6_COLD_FROM=${cold_from}"
+    echo "K6_COLD_TO=${cold_to}"
+  } >"${dataset_env_path}"
+  echo "[transaction-100m-dataset-probe] dataset env written=${dataset_env_path}"
+}
+
+print_plan() {
+  echo "[transaction-100m-dataset-probe] mode=${mode}"
+  echo "[transaction-100m-dataset-probe] fixture=${fixture_name}"
+  echo "[transaction-100m-dataset-probe] dump=${fixture_path}"
+  echo "[transaction-100m-dataset-probe] manifest=${manifest_path}"
+  echo "[transaction-100m-dataset-probe] dataset_env=${dataset_env_path}"
+  echo "[transaction-100m-dataset-probe] db_fallback=${db_fallback}"
+  echo "[transaction-100m-dataset-probe] source_order=manifest,env,db-fallback"
+}
+
+run_probe() {
+  local hot_account_id hot_from hot_to cold_account_id cold_from cold_to
+  hot_account_id="$(resolve_manifest_or_env hot_account_id K6_HOT_ACCOUNT_ID)"
+  hot_from="$(resolve_manifest_or_env hot_from K6_HOT_FROM)"
+  hot_to="$(resolve_manifest_or_env hot_to K6_HOT_TO)"
+  cold_account_id="$(resolve_manifest_or_env cold_account_id K6_COLD_ACCOUNT_ID)"
+  cold_from="$(resolve_manifest_or_env cold_from K6_COLD_FROM)"
+  cold_to="$(resolve_manifest_or_env cold_to K6_COLD_TO)"
+
+  if [[ "${db_fallback}" == "true" ]]; then
+    if [[ -n "${hot_account_id}" && ( -z "${hot_from}" || -z "${hot_to}" ) ]]; then
+      IFS='|' read -r hot_from hot_to <<<"$(probe_from_db transaction_read_model "${hot_account_id}")"
+    fi
+    if [[ -n "${cold_account_id}" && ( -z "${cold_from}" || -z "${cold_to}" ) ]]; then
+      IFS='|' read -r cold_from cold_to <<<"$(probe_from_db transaction_read_model_archive "${cold_account_id}")"
+    fi
+  fi
+
+  require_value hot_account_id "${hot_account_id}"
+  require_value hot_from "${hot_from}"
+  require_value hot_to "${hot_to}"
+  require_value cold_account_id "${cold_account_id}"
+  require_value cold_from "${cold_from}"
+  require_value cold_to "${cold_to}"
+  write_dataset_env "${hot_account_id}" "${hot_from}" "${hot_to}" "${cold_account_id}" "${cold_from}" "${cold_to}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  echo "write ${dataset_env_path} from manifest/env metadata"
+  if [[ "${db_fallback}" == "true" ]]; then
+    echo "db fallback enabled for missing windows"
+  fi
+  exit 0
+fi
+
+run_probe

--- a/tools/test/run-transaction-100m-fresh-volume-restore-k6.sh
+++ b/tools/test/run-transaction-100m-fresh-volume-restore-k6.sh
@@ -17,6 +17,7 @@ Environment:
   FRESH_VOLUME_READINESS_TIMEOUT_SECONDS default 120
   FIXTURE_NAME                      default transaction-100m-fixture
   FIXTURE_PATH                      default build/fixtures/<FIXTURE_NAME>.dump
+  FIXTURE_DATASET_ENV_PATH          default <FIXTURE_PATH>.dataset.env
   K6_REPORT_NAME                    default transaction-100m-fresh-volume-<timestamp>
 
 Examples:
@@ -68,6 +69,7 @@ require_non_negative_integer_value() {
 fixture_name="${FIXTURE_NAME:-transaction-100m-fixture}"
 fixture_dir="${FIXTURE_DIR:-build/fixtures}"
 fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
+dataset_env_path="${FIXTURE_DATASET_ENV_PATH:-${fixture_path}.dataset.env}"
 volume_name="${FRESH_VOLUME_NAME:-aquila-bank-postgres-data}"
 build_backend="${FRESH_VOLUME_BUILD_BACKEND:-true}"
 k6_enabled="${FRESH_VOLUME_K6_ENABLED:-true}"
@@ -103,6 +105,8 @@ print_plan() {
   echo "[transaction-100m-fresh-volume] confirm=erase-postgres-volume required for run"
   echo "[transaction-100m-fresh-volume] fixture=${fixture_name}"
   echo "[transaction-100m-fresh-volume] dump=${fixture_path}"
+  echo "[transaction-100m-fresh-volume] dataset_probe=tools/test/run-transaction-100m-fixture-dataset-probe.sh"
+  echo "[transaction-100m-fresh-volume] dataset_env=${dataset_env_path}"
   echo "[transaction-100m-fresh-volume] build_backend=${build_backend}"
   echo "[transaction-100m-fresh-volume] artifact_preflight=${artifact_preflight}"
   echo "[transaction-100m-fresh-volume] dump_missing_mode=${dump_missing_mode}"
@@ -129,6 +133,7 @@ print_dry_run() {
   echo "docker compose ${compose_files[*]} --profile loadtest up -d postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter"
   echo "FIXTURE_MODE=restore FIXTURE_RESTORE_TRUNCATE=true FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} tools/test/run-transaction-100m-fixture-restore.sh"
   echo "FIXTURE_MODE=verify FIXTURE_VERIFY_MIN_ROWS=${restore_verify_min_rows} FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} tools/test/run-transaction-100m-fixture-restore.sh"
+  echo "FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} FIXTURE_DATASET_ENV_PATH=${dataset_env_path} tools/test/run-transaction-100m-fixture-dataset-probe.sh"
   if [[ "${dump_missing_mode}" == "seed-only" ]]; then
     echo "if fixture dump is absent: tools/test/prepare-transaction-read-model-100m-fixture.sh"
   fi
@@ -258,6 +263,23 @@ verify_fixture() {
     tools/test/run-transaction-100m-fixture-restore.sh
 }
 
+load_dataset_probe() {
+  FIXTURE_NAME="${fixture_name}" \
+  FIXTURE_PATH="${fixture_path}" \
+  FIXTURE_DATASET_ENV_PATH="${dataset_env_path}" \
+    tools/test/run-transaction-100m-fixture-dataset-probe.sh
+  set -a
+  # restore 이후 k6 계정/window는 manifest metadata에서 받아 DB full scan을 피합니다.
+  source "${dataset_env_path}"
+  set +a
+  hot_account_id="${K6_HOT_ACCOUNT_ID:-${hot_account_id}}"
+  hot_from="${K6_HOT_FROM:-${hot_from}}"
+  hot_to="${K6_HOT_TO:-${hot_to}}"
+  cold_account_id="${K6_COLD_ACCOUNT_ID:-${cold_account_id}}"
+  cold_from="${K6_COLD_FROM:-${cold_from}}"
+  cold_to="${K6_COLD_TO:-${cold_to}}"
+}
+
 seed_fixture() {
   seed_fallback_used="true"
   tools/test/prepare-transaction-read-model-100m-fixture.sh
@@ -303,6 +325,7 @@ if [[ "${artifact_ready}" == "true" ]]; then
   start_runtime
   restore_fixture
   verify_fixture
+  load_dataset_probe
 else
   seed_fixture
 fi

--- a/tools/test/validate-transaction-100m-fixture-artifact.sh
+++ b/tools/test/validate-transaction-100m-fixture-artifact.sh
@@ -153,11 +153,18 @@ write_manifest() {
   mkdir -p "$(dirname "${manifest_path}")" "$(dirname "${checksum_path}")"
 
   local checksum flyway_version hot_rows archive_rows total_rows
+  local hot_account_id hot_from hot_to cold_account_id cold_from cold_to
   checksum="$(sha256_file "${fixture_path}")"
   flyway_version="$(applied_flyway_version)"
   hot_rows="$(table_count transaction_read_model)"
   archive_rows="$(table_count transaction_read_model_archive)"
   total_rows=$((hot_rows + archive_rows))
+  hot_account_id="${FIXTURE_HOT_ACCOUNT_ID:-${K6_HOT_ACCOUNT_ID:-${SEED_HOT_ACCOUNT_ID:-910000001}}}"
+  hot_from="${FIXTURE_HOT_FROM:-${K6_HOT_FROM:-${SEED_HOT_FROM:-2026-04-01T00:00:00Z}}}"
+  hot_to="${FIXTURE_HOT_TO:-${K6_HOT_TO:-${SEED_HOT_TO:-2026-04-30T00:00:00Z}}}"
+  cold_account_id="${FIXTURE_COLD_ACCOUNT_ID:-${K6_COLD_ACCOUNT_ID:-${SEED_COLD_ACCOUNT_ID:-910000002}}}"
+  cold_from="${FIXTURE_COLD_FROM:-${K6_COLD_FROM:-${SEED_COLD_FROM:-2026-01-01T00:00:00Z}}}"
+  cold_to="${FIXTURE_COLD_TO:-${K6_COLD_TO:-${SEED_COLD_TO:-2026-01-31T00:00:00Z}}}"
 
   printf "%s  %s\n" "${checksum}" "$(basename "${fixture_path}")" >"${checksum_path}"
   {
@@ -168,6 +175,12 @@ write_manifest() {
     echo "total_rows=${total_rows}"
     echo "hot_rows=${hot_rows}"
     echo "archive_rows=${archive_rows}"
+    echo "hot_account_id=${hot_account_id}"
+    echo "hot_from=${hot_from}"
+    echo "hot_to=${hot_to}"
+    echo "cold_account_id=${cold_account_id}"
+    echo "cold_from=${cold_from}"
+    echo "cold_to=${cold_to}"
     echo "generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   } >"${manifest_path}"
   echo "[transaction-100m-artifact] manifest written=${manifest_path}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #455

## 🌿 Base Branch
- `main`

## 📝 Summary
- loadtest runtime evidence 신뢰도를 낮추던 PostgreSQL host port 이중 binding, 100m dataset probe의 DB scan 의존, same-host k6 generator 오염, observability 리소스 미분리를 한 PR 단위로 정리합니다.
- 실제 거래/원장 도메인 동작은 변경하지 않고, loadtest compose/runner/check 계약만 보강합니다.

## 🛠 Changes
- PostgreSQL loadtest compose port를 `LOADTEST_DB_PORT` 단일 binding으로 override합니다.
- 100m fixture manifest metadata 기반 dataset probe를 추가하고, DB fallback은 명시 opt-in으로 제한합니다.
- capacity gate 기본 k6 generator를 `docker-context`로 전환하고, local generator는 `CAPACITY_ALLOW_LOCAL_K6_GENERATOR=true`일 때만 허용합니다.
- Prometheus/Grafana/Alertmanager/postgres-exporter에 별도 CPU/memory/pids resource profile을 추가하고 runner plan에 표시합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-loadtest-compose-port-isolation.sh`
- `tools/test/check-transaction-100m-fixture-dataset-probe.sh`
- `tools/test/check-transaction-100m-artifact-readiness.sh`
- `tools/test/check-transaction-100m-fresh-volume-restore-k6.sh`
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `tools/test/check-transaction-100m-capacity-gates.sh`
- `tools/test/run-transaction-100m-fixture-dataset-probe.sh --print-plan`
- `tools/test/run-k6-transaction-100m-loadtest.sh --print-plan`
- `tools/test/with-resource-lock.sh back-check-loadtest-runtime-profile ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: capacity gate 기본값이 off-host k6를 요구하므로 로컬 단독 실행은 `CAPACITY_ALLOW_LOCAL_K6_GENERATOR=true` 명시가 필요합니다.
- 롤백 방법: 이 PR revert 후 기존 local generator/compose profile로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
