### PR TITLE
[Perf] 100m defensive post-gate-reliability latest-main 병목 재검증

### DIFF
--- a/docs/performance-results/100m-defensive-post-gate-reliability-latest-main-20260427-bottleneck.md
+++ b/docs/performance-results/100m-defensive-post-gate-reliability-latest-main-20260427-bottleneck.md
@@ -1,0 +1,89 @@
+# 100m defensive post-gate-reliability latest-main bottleneck
+
+## 기준
+
+- 날짜: 2026-04-27
+- branch: `perf/100m-defensive-post-gate-reliability-retest`
+- base: `main @ efccba6`
+- 연결 issue: #465
+- 목적: #464 병합 이후 로컬 Docker t3.micro 1억 row 조회 부하와 대용량 트래픽 방어 경로를 다시 검증하고, 이미 완료된 작업을 제외한 남은 병목 후보를 PR/issue 단위로 정리한다.
+- 제외 범위: #462/#464에서 이미 닫은 k6 summary parser, backend readiness gate 추가, warmup/measured phase 추가, dropped_iterations hard fail 추가, aggregate required input 추가, postgres-exporter config mount 자체는 신규 후보에서 제외한다.
+
+## 환경
+
+- Docker stack: `compose.yml`, `compose.t3micro.yml`, `compose.loadtest.yml`
+- PostgreSQL: `aquila-bank-postgres-loadtest`, host port `15432`
+- Backend: `aquila-bank-backend-loadtest`, host port `18080`
+- Observability: Prometheus `19090`, Grafana `13001`, postgres-exporter `19187`
+- Fixture estimate: `transaction_read_model=50,000,000`, `transaction_read_model_archive=50,000,028`
+- Dataset env: `K6_HOT_ACCOUNT_ID=910000001`, `K6_COLD_ACCOUNT_ID=910000002`
+- Hot window: `2026-04-01T00:00:00Z` ~ `2026-04-30T00:00:00Z`
+- Cold window: `2026-01-01T00:00:00Z` ~ `2026-01-31T00:00:00Z`
+
+## 실행 결과
+
+| Run | Result | 핵심 수치 | 판단 |
+| --- | --- | --- | --- |
+| fixture dataset probe | failed | `total_estimate=99,999,884`, `min=100,000,000` | #464 DB gate는 동작하지만 `reltuples` estimate 기준이라 116 row 차이로 실패했다. manifest 파일도 없어 fallback min 100m이 적용됐다. |
+| exact count 분리 실험 | crashed DB | 100m `count(*)` 중 server connection lost, PostgreSQL backend `signal 9`, crash recovery 약 70초 | t3.micro PostgreSQL 384MiB에서 full exact count는 검증 방식 자체가 OOM/crash 병목이다. |
+| VU3 baseline | passed | `http_req_failed=0`, `checks=1`, p95 약 3.1~3.3ms, max 67~234ms | readiness gate, warmup 분리, summary parser는 정상 동작했다. 조회 plan 병목은 재발하지 않았다. |
+| VU16 overload | failed | `429=1.1089%`, `503 count=1`, p95 약 4.4~5.1ms, max 294~589ms | 대다수 요청은 방어됐지만 503=0 hard gate를 1건 위반했다. |
+| burst 256/s 20s | failed | `429=8.7308%`, `503=0`, `dropped_iterations=2488`, `Insufficient VUs` | #464의 dropped/insufficient hard fail은 정상 동작한다. 병목은 generator capacity와 burst 목표/정책 불일치다. |
+| Prometheus VU3 | passed | `http_req_failed=0`, `checks=1`, p95 약 3.3~3.4ms | Prometheus remote-write와 Grafana/Prometheus health는 정상이다. |
+| capacity runner | blocked | `CAPACITY_K6_DOCKER_CONTEXT is required` | 로컬 Docker context는 `default`, `desktop-linux`뿐이라 off-host k6 capacity runner prerequisite이 아직 없다. |
+| aggregate required input | passed as guard | `required aggregate input is missing: capacity`로 dry-run fail-fast | required gate 자체는 동작한다. 남은 문제는 capacity/SSE/admission/outbox/memory 입력을 실제로 채우는 실행 체계다. |
+
+## 리소스와 로그
+
+- post-run memory snapshot: backend `398.4MiB`, PostgreSQL `184.9MiB`, Prometheus `78.0MiB`, Grafana `79.1MiB`, postgres-exporter `20.7MiB`
+- aggregate memory total: `761.08MiB / 900MiB`, status `pass`
+- exact count 후 PostgreSQL 로그: `client backend ... terminated by signal 9`, `database system was interrupted`, `automatic recovery in progress`
+- postgres-exporter는 config missing warn은 사라졌고, DB crash/recovery 동안 connection error만 남았다.
+
+## 남은 병목 판단
+
+1억 row 조회 API 자체는 월별 chunk/index/keyset 경로에서 p95 3~5ms로 안정적이다. 현재 병목은 “실제 1억 row를 안전하게 검증하는 방식”, “t3.micro에서 503=0 보장”, “burst/high-traffic generator와 capacity runner 분리”에 있다. 특히 이번 실행에서는 검증용 exact count가 PostgreSQL을 OOM/crash시켜 이후 부하 테스트에도 간섭할 수 있음을 확인했다.
+
+## 다음 PR/issue 후보
+
+모두 issue 제목 = PR 제목, issue 1개 = PR 1개 기준이다.
+
+1. `[Perf] 100m fixture DB gate를 OOM-safe estimate 검증으로 전환` / 템플릿 `performance_request.yml` / 브랜치 `perf/100m-fixture-oom-safe-db-gate`
+   - 현재 DB gate는 `reltuples` estimate가 100m보다 116 낮으면 실패하고, exact count로 확인하면 PostgreSQL 384MiB에서 OOM/crash가 난다. partition별 `reltuples` 허용 오차, manifest 보강, bounded sample/window count 조합으로 바꿔야 한다.
+
+2. `[Perf] transaction read overload 503 원인 추적 및 zero-503 안정화` / 템플릿 `performance_request.yml` / 브랜치 `perf/transaction-read-overload-zero-503`
+   - VU16 overload에서 503이 1건 발생해 hard gate가 실패했다. DB crash 직후 간섭 가능성을 포함해 datasource timeout, admission guard, exception mapping을 분리해 503=0 계약을 복구한다.
+
+3. `[Perf] burst 256/s generator capacity를 off-host 기준으로 재보정` / 템플릿 `performance_request.yml` / 브랜치 `perf/burst-offhost-generator-calibration`
+   - burst에서 `dropped_iterations=2488`와 `Insufficient VUs`가 발생했다. local generator 한계를 제거하고 off-host generator 기준으로 preAllocated/max VUs와 target rate를 다시 잡는다.
+
+4. `[Chore] off-host k6 docker context capacity runner 구성` / 템플릿 `task_request.yml` / 브랜치 `chore/offhost-k6-capacity-runner`
+   - capacity runner는 여전히 `CAPACITY_K6_DOCKER_CONTEXT` 없이는 시작하지 않는다. app stack과 k6 generator를 다른 Docker context로 분리해야 capacity 결과가 host 간섭을 제거한다.
+
+5. `[Perf] capacity runner remote URL/prometheus 계약 검증 추가` / 템플릿 `performance_request.yml` / 브랜치 `perf/capacity-runner-remote-contract`
+   - docker context 외에도 `CAPACITY_K6_REMOTE_BASE_URL`, `CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL`이 필요하다. off-host runner가 app/prometheus에 실제 도달 가능한지 preflight로 닫는다.
+
+6. `[Perf] PostgreSQL crash recovery state preflight 추가` / 템플릿 `performance_request.yml` / 브랜치 `perf/postgres-recovery-state-preflight`
+   - exact count OOM 이후 DB는 약 70초간 recovery를 수행했다. 부하 테스트 전 `pg_is_in_recovery=false`, health=healthy, exporter 안정화 구간을 확인해 이전 crash가 측정에 섞이지 않게 한다.
+
+7. `[Perf] t3.micro read admission 429/latency 정책 재보정` / 템플릿 `performance_request.yml` / 브랜치 `perf/read-admission-policy-calibration`
+   - VU16은 429 1.1%였고 burst는 429 8.7%였다. 503=0을 보장하면서 p99.9/max spike를 줄이려면 admission threshold, retry-after, queue 정책을 실제 SLO 기준으로 재보정해야 한다.
+
+8. `[Perf] burst hot-first p99.9 spike profile 추가` / 템플릿 `performance_request.yml` / 브랜치 `perf/burst-hot-first-spike-profile`
+   - burst hot-first p99.9가 1123ms, max가 1292ms까지 상승했다. DB index plan은 정상이라 JDBC mapping, serialization, pool wait, CPU steal을 profile로 분리한다.
+
+9. `[Chore] defensive aggregate capacity/SSE/admission/outbox 입력 연결` / 템플릿 `task_request.yml` / 브랜치 `chore/defensive-aggregate-full-inputs`
+   - required gate는 동작하지만 이번 aggregate는 k6/memory만 채웠다. capacity, SSE reconnect, HTTP admission, outbox backlog 산출물을 한 실행에서 연결해야 “대용량 트래픽 방어” 전체 판정이 가능하다.
+
+10. `[Perf] DB 검증 쿼리 statement_timeout/memory budget guard 추가` / 템플릿 `performance_request.yml` / 브랜치 `perf/db-verification-query-resource-guard`
+    - full count 같은 검증 쿼리가 운영형 t3.micro DB를 죽이면 테스트가 아니라 장애 주입이 된다. 검증 쿼리별 timeout, `work_mem`, read-only transaction, concurrency cap을 명시한다.
+
+## 산출물
+
+- `docs/performance-results/transaction-100m-post-gate-reliability-vu3-20260427-summary.md`
+- `docs/performance-results/transaction-100m-post-gate-reliability-vu16-overload-20260427-summary.md`
+- `docs/performance-results/transaction-100m-post-gate-reliability-burst-20260427-summary.md`
+- `docs/performance-results/transaction-100m-post-gate-reliability-prom-vu3-20260427-summary.md`
+- `docs/performance-results/t3micro-defensive-gates-post-gate-reliability-20260427.md`
+- `build/reports/k6/transaction-100m-post-gate-reliability-burst-20260427-runner.log`
+- `build/reports/t3micro/post-gate-reliability-memory-summary.tsv`

--- a/docs/performance-results/t3micro-defensive-gates-post-gate-reliability-20260427.md
+++ b/docs/performance-results/t3micro-defensive-gates-post-gate-reliability-20260427.md
@@ -1,0 +1,26 @@
+# t3micro-defensive-gates-post-gate-reliability-20260427
+
+## Inputs
+
+- capacityResult: missing
+- sseResult: missing
+- admissionSummary: missing
+- outboxSummary: missing
+- k6Summary: docs/performance-results/transaction-100m-post-gate-reliability-vu3-20260427-summary.md
+- memorySummary: build/reports/t3micro/post-gate-reliability-memory-summary.tsv
+
+## Gate Summary
+
+| Gate | Status | Peak CPU % | Peak Memory MiB | Backlog / Reject Signal | Source |
+| --- | --- | ---: | ---: | --- | --- |
+| capacity | missing | missing | missing | repeat=missing | missing |
+| sse reconnect | missing | missing | missing | clients=missing rounds=missing | missing |
+| http admission | n/a | n/a | n/a | rejected=missing failed_rate=missing | missing |
+| outbox backlog | n/a | n/a | n/a | lag=missing failed=missing dlq=missing | missing |
+| k6 transaction 100m | n/a | n/a | n/a | hotFirstP95=3.1063249999999982 hotCursorP95=3.3210085999999985 coldFirstP95=3.153784 coldCursorP95=3.310249999999999 429Rate=0 | docs/performance-results/transaction-100m-post-gate-reliability-vu3-20260427-summary.md |
+| total memory | pass | n/a | 761.08 | budget=900 source=build/reports/t3micro/post-gate-reliability-memory-summary.tsv | build/reports/t3micro/post-gate-reliability-memory-summary.tsv |
+
+## Notes
+
+- missing 값은 해당 gate가 아직 같은 aggregate run에 연결되지 않았음을 뜻합니다.
+- token, 운영 URL, raw Authorization header는 기록하지 않습니다.

--- a/docs/performance-results/transaction-100m-post-gate-reliability-burst-20260427-summary.md
+++ b/docs/performance-results/transaction-100m-post-gate-reliability-burst-20260427-summary.md
@@ -1,0 +1,64 @@
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 16
+- duration: 20s
+- warmup duration: 10s
+- scenario mode: burst
+- arrival rate: 8/1s
+- burst rate: 256/1s
+- burst duration: 20s
+- pre allocated VUs: 64
+- max VUs: 64
+- limit: 50
+- observability mode: summary-only
+- overload mode: true
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: disabled in overload mode
+- overload 429 rate threshold: 0.02
+- overload 503 rate threshold: 0
+
+## Results
+
+- http_req_failed rate: 0.07283236994219654
+- checks rate: 1
+- transaction 429 rate: 0.08730800323362975
+- transaction 503 rate: 0
+- transaction 503 count: 0
+- hot first p95 ms: 22.501231099999927
+- hot first p99 ms: 481.0704898699999
+- hot first p99.9 ms: 1123.7619915240095
+- hot first max ms: 1292.579001
+- hot cursor p95 ms: 10.018908299999964
+- hot cursor p99 ms: 88.57033323999983
+- hot cursor p99.9 ms: 665.7824797080591
+- hot cursor max ms: 934.60725
+- cold first p95 ms: 8.394133399999998
+- cold first p99 ms: 54.69290199999999
+- cold first p99.9 ms: 156.31181014401585
+- cold first max ms: 311.673375
+- cold cursor p95 ms: 7.328677399999996
+- cold cursor p99 ms: 60.988711359999954
+- cold cursor p99.9 ms: 145.46916466400157
+- cold cursor max ms: 1009.606917
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `summary-only`이면 Prometheus remote write 없이 summary 파일만 남깁니다.

--- a/docs/performance-results/transaction-100m-post-gate-reliability-prom-vu3-20260427-summary.md
+++ b/docs/performance-results/transaction-100m-post-gate-reliability-prom-vu3-20260427-summary.md
@@ -1,0 +1,72 @@
+# transaction-100m-post-gate-reliability-prom-vu3-20260427-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-27T07:52:18Z
+- sourceMarkdown: build/reports/k6/transaction-100m-post-gate-reliability-prom-vu3-20260427-summary.md
+- sourceJson: build/reports/k6/transaction-100m-post-gate-reliability-prom-vu3-20260427-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 3
+- duration: 15s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 20s
+- pre allocated VUs: 3
+- max VUs: 3
+- limit: 50
+- observability mode: prometheus
+- overload mode: false
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: 0.01
+- overload 429 rate threshold: disabled outside overload mode
+- overload 503 rate threshold: disabled outside overload mode
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- transaction 503 count: n/a
+- hot first p95 ms: 3.4440874999999984
+- hot first p99 ms: 8.468144019999999
+- hot first p99.9 ms: 37.853040727001805
+- hot first max ms: 96.4945
+- hot cursor p95 ms: 3.3545848999999985
+- hot cursor p99 ms: 8.316615209999997
+- hot cursor p99.9 ms: 31.667297954001448
+- hot cursor max ms: 65.601375
+- cold first p95 ms: 3.3286268999999993
+- cold first p99 ms: 9.022943999999997
+- cold first p99.9 ms: 20.9116386250014
+- cold first max ms: 96.52625
+- cold cursor p95 ms: 3.445641849999998
+- cold cursor p99 ms: 9.224071019999998
+- cold cursor p99.9 ms: 40.41661495400592
+- cold cursor max ms: 125.962208
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `prometheus`이면 Prometheus remote write와 summary 파일을 함께 남깁니다.

--- a/docs/performance-results/transaction-100m-post-gate-reliability-vu16-overload-20260427-summary.md
+++ b/docs/performance-results/transaction-100m-post-gate-reliability-vu16-overload-20260427-summary.md
@@ -1,0 +1,64 @@
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 16
+- duration: 30s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 20s
+- pre allocated VUs: 16
+- max VUs: 16
+- limit: 50
+- observability mode: summary-only
+- overload mode: true
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: disabled in overload mode
+- overload 429 rate threshold: 0.02
+- overload 503 rate threshold: 0
+
+## Results
+
+- http_req_failed rate: 0.009255725190839694
+- checks rate: 0.9999880167765128
+- transaction 429 rate: 0.011089460714081036
+- transaction 503 rate: 0.000028654937245687433
+- transaction 503 count: 1
+- hot first p95 ms: 5.060158199999997
+- hot first p99 ms: 18.908498079999998
+- hot first p99.9 ms: 137.91598818400038
+- hot first max ms: 589.387667
+- hot cursor p95 ms: 4.7200955
+- hot cursor p99 ms: 14.078892319999989
+- hot cursor p99.9 ms: 65.46773020700161
+- hot cursor max ms: 583.709208
+- cold first p95 ms: 4.3815415999999985
+- cold first p99 ms: 12.503834439999995
+- cold first p99.9 ms: 57.18032700000414
+- cold first max ms: 499.934666
+- cold cursor p95 ms: 4.406666
+- cold cursor p99 ms: 13.472349999999995
+- cold cursor p99.9 ms: 60.005484500003085
+- cold cursor max ms: 294.352375
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `summary-only`이면 Prometheus remote write 없이 summary 파일만 남깁니다.

--- a/docs/performance-results/transaction-100m-post-gate-reliability-vu3-20260427-summary.md
+++ b/docs/performance-results/transaction-100m-post-gate-reliability-vu3-20260427-summary.md
@@ -1,0 +1,72 @@
+# transaction-100m-post-gate-reliability-vu3-20260427-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-27T07:44:51Z
+- sourceMarkdown: build/reports/k6/transaction-100m-post-gate-reliability-vu3-20260427-summary.md
+- sourceJson: build/reports/k6/transaction-100m-post-gate-reliability-vu3-20260427-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 3
+- duration: 30s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 20s
+- pre allocated VUs: 3
+- max VUs: 3
+- limit: 50
+- observability mode: summary-only
+- overload mode: false
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: 0.01
+- overload 429 rate threshold: disabled outside overload mode
+- overload 503 rate threshold: disabled outside overload mode
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- transaction 503 count: n/a
+- hot first p95 ms: 3.1063249999999982
+- hot first p99 ms: 9.18535472
+- hot first p99.9 ms: 40.291712672000294
+- hot first max ms: 156.762625
+- hot cursor p95 ms: 3.3210085999999985
+- hot cursor p99 ms: 9.374386719999984
+- hot cursor p99.9 ms: 36.797224312001596
+- hot cursor max ms: 233.83325
+- cold first p95 ms: 3.153784
+- cold first p99 ms: 9.218228839999998
+- cold first p99.9 ms: 34.81756565600038
+- cold first max ms: 84.803625
+- cold cursor p95 ms: 3.310249999999999
+- cold cursor p99 ms: 9.654490999999993
+- cold cursor p99.9 ms: 41.93293000000087
+- cold cursor max ms: 67.62275
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `summary-only`이면 Prometheus remote write 없이 summary 파일만 남깁니다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #465

## 🌿 Base Branch
- `main`

## 📝 Summary
- 최신 `main @ efccba6` 기준으로 #464 gate reliability 병합 이후 로컬 Docker t3.micro 1억 row 조회/방어 부하 테스트를 재실행했습니다.
- 실제 측정값과 남은 병목 후보를 `docs/performance-results`에 문서화하고, 이미 병합된 #462/#464 범위는 후보에서 제외했습니다.

## 🛠 Changes
- post-gate-reliability 1억 row 재검증 병목 보고서 추가
- VU3 baseline, VU16 overload, burst, Prometheus smoke summary archive 추가
- t3.micro defensive aggregate report 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml --profile loadtest up -d --force-recreate postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter`
- `tools/test/run-transaction-100m-fixture-dataset-probe.sh`
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-deps` with VU3 baseline
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps` with VU16 overload, burst, Prometheus smoke
- `tools/test/run-transaction-100m-capacity-gates.sh --print-plan`
- `tools/test/run-t3micro-defensive-gates-aggregate-report.sh --dry-run`
- `tools/test/run-t3micro-defensive-gates-aggregate-report.sh`
- `git diff --check`
- `git diff --cached --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 문서/측정 결과만 추가하므로 런타임 영향은 없음.
- 롤백 방법: 이 PR의 문서 커밋 revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
