### PR TITLE
[Perf] 100m fixture DB gate OOM-safe 검증 전환

### DIFF
--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -32,6 +32,9 @@ grep -F "warmup duration=10s" <<<"${plan}" >/dev/null
 grep -F "run purpose=smoke" <<<"${plan}" >/dev/null
 grep -F "summary gate=true" <<<"${plan}" >/dev/null
 grep -F "backend readiness gate=true path=/actuator/health/readiness timeout=120" <<<"${plan}" >/dev/null
+grep -F "postgres health gate=true required_status=healthy" <<<"${plan}" >/dev/null
+grep -F "postgres recovery gate=true stable_seconds=10" <<<"${plan}" >/dev/null
+grep -F "postgres exporter stable gate=true timeout=60" <<<"${plan}" >/dev/null
 grep -F "generator mode=local" <<<"${plan}" >/dev/null
 grep -F "generator runner=docker compose service k6-transaction-read-100m" <<<"${plan}" >/dev/null
 grep -F "observability mode=prometheus" <<<"${plan}" >/dev/null
@@ -107,6 +110,11 @@ grep -F "auth_modules:" ops/prometheus/postgres-exporter/postgres_exporter.yml >
 grep -F "max_wal_size" compose.loadtest.yml >/dev/null
 grep -F "checkpoint_timeout" compose.loadtest.yml >/dev/null
 grep -F "assert_k6_preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "assert_postgres_recovery_preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "wait_for_postgres_exporter_stability" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "pg_is_in_recovery()" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "postgres health status must be healthy" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "pg_up" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "idx_transaction_read_model_account_cursor" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "OOMKilled" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "stop_backend_before_bootjar" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
@@ -275,6 +283,22 @@ if K6_SCENARIO_MODE=unknown tools/test/run-k6-transaction-100m-loadtest.sh --pri
 fi
 if K6_WARMUP_DURATION=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
   echo "K6_WARMUP_DURATION=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_POSTGRES_HEALTH_GATE=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_POSTGRES_HEALTH_GATE=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_POSTGRES_RECOVERY_STABLE_SECONDS=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_POSTGRES_RECOVERY_STABLE_SECONDS=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_POSTGRES_EXPORTER_STABLE_GATE=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_POSTGRES_EXPORTER_STABLE_GATE=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS=0 tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS=0 unexpectedly succeeded" >&2
   exit 1
 fi
 if K6_RUN_PURPOSE=unknown tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then

--- a/tools/test/check-loadtest-readiness-recovery.sh
+++ b/tools/test/check-loadtest-readiness-recovery.sh
@@ -29,4 +29,10 @@ k6_plan="$(
     tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
 )"
 grep -F "backend readiness gate=true path=/actuator/health/readiness timeout=120" <<<"${k6_plan}" >/dev/null
+grep -F "postgres health gate=true required_status=healthy" <<<"${k6_plan}" >/dev/null
+grep -F "postgres recovery gate=true stable_seconds=10" <<<"${k6_plan}" >/dev/null
+grep -F "postgres exporter stable gate=true timeout=60" <<<"${k6_plan}" >/dev/null
 grep -F "wait_for_backend_readiness" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "assert_postgres_recovery_preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "pg_is_in_recovery()=false" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "wait_for_postgres_exporter_stability" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null

--- a/tools/test/check-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/check-transaction-100m-fixture-dataset-probe.sh
@@ -43,7 +43,28 @@ grep -F "dataset_env=${env_path}" <<<"${plan}" >/dev/null
 grep -F "db_gate=true" <<<"${plan}" >/dev/null
 grep -F "db_fallback=false" <<<"${plan}" >/dev/null
 grep -F "min_window_rows=51" <<<"${plan}" >/dev/null
-grep -F "db_gate_checks=estimate,window-count,monthly-partition" <<<"${plan}" >/dev/null
+grep -F "estimate_tolerance_rows=1000" <<<"${plan}" >/dev/null
+grep -F "db_report=${dump_path}.db-gate.env" <<<"${plan}" >/dev/null
+grep -F "query_statement_timeout_ms=3000" <<<"${plan}" >/dev/null
+grep -F "query_lock_timeout_ms=1000" <<<"${plan}" >/dev/null
+grep -F "query_work_mem=2MB" <<<"${plan}" >/dev/null
+grep -F "query_read_only=true" <<<"${plan}" >/dev/null
+grep -F "db_gate_checks=partition-estimate-tolerance,bounded-window-count,monthly-partition" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-dataset-probe] estimate tolerance contract"
+FIXTURE_DATASET_ASSERT_LABEL=total_estimate \
+FIXTURE_DATASET_ASSERT_ACTUAL=99999884 \
+FIXTURE_DATASET_ASSERT_MINIMUM=100000000 \
+FIXTURE_DATASET_ESTIMATE_TOLERANCE_ROWS=1000 \
+  "${script}" --assert-estimate >/dev/null
+if FIXTURE_DATASET_ASSERT_LABEL=total_estimate \
+  FIXTURE_DATASET_ASSERT_ACTUAL=99900000 \
+  FIXTURE_DATASET_ASSERT_MINIMUM=100000000 \
+  FIXTURE_DATASET_ESTIMATE_TOLERANCE_ROWS=1000 \
+    "${script}" --assert-estimate >/dev/null 2>&1; then
+  echo "estimate outside tolerance unexpectedly passed" >&2
+  exit 1
+fi
 
 echo "[transaction-100m-dataset-probe] manifest probe writes k6 env"
 FIXTURE_PATH="${dump_path}" \
@@ -74,6 +95,12 @@ grep -F "assert_dataset_db_gate" "${script}" >/dev/null
 grep -F "partition_name_for_month" "${script}" >/dev/null
 grep -F "assert_partition_exists transaction_read_model" "${script}" >/dev/null
 grep -F "assert_partition_exists transaction_read_model_archive" "${script}" >/dev/null
+grep -F "assert_estimate_at_least" "${script}" >/dev/null
+grep -F "write_db_gate_report" "${script}" >/dev/null
+grep -F "BEGIN READ ONLY" "${script}" >/dev/null
+grep -F "SET LOCAL statement_timeout" "${script}" >/dev/null
+grep -F "SET LOCAL lock_timeout" "${script}" >/dev/null
+grep -F "SET LOCAL work_mem" "${script}" >/dev/null
 grep -F "FIXTURE_DATASET_MIN_WINDOW_ROWS" "${script}" >/dev/null
 grep -F "run-transaction-100m-fixture-dataset-probe.sh" tools/test/run-transaction-100m-artifact-ready-k6.sh >/dev/null
 grep -F "run-transaction-100m-fixture-dataset-probe.sh" tools/test/run-transaction-100m-fresh-volume-restore-k6.sh >/dev/null

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -35,6 +35,11 @@ Optional environment:
   K6_AUTH_TOKEN        bearer token, optional when bootstrap header auth is enabled
   K6_ARCHIVE_RESULTS   copy markdown summary to docs/performance-results, default true
   K6_PREFLIGHT         check PostgreSQL OOM/index readiness before k6, default true
+  K6_POSTGRES_HEALTH_GATE require PostgreSQL Docker health=healthy before k6, default true
+  K6_POSTGRES_RECOVERY_GATE require pg_is_in_recovery()=false before k6, default true
+  K6_POSTGRES_RECOVERY_STABLE_SECONDS re-check non-recovery after this delay, default 10
+  K6_POSTGRES_EXPORTER_STABLE_GATE require pg_up=1 before k6 when prometheus mode, default true
+  K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS default 60
   K6_OUTBOX_PREFLIGHT  run local outbox backlog gate before k6, default false
   K6_OUTBOX_PREFLIGHT_BASE_URL default http://localhost:${LOADTEST_BACKEND_PORT:-18080}
   K6_EXPLAIN_SNAPSHOT  write pre/post hot/cold query plans, default true
@@ -244,6 +249,11 @@ K6_COLD_MAX_THRESHOLD_MS="${K6_COLD_MAX_THRESHOLD_MS:-5000}"
 K6_HTTP_FAILED_RATE="${K6_HTTP_FAILED_RATE:-0.01}"
 K6_ARCHIVE_RESULTS="${K6_ARCHIVE_RESULTS:-true}"
 K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
+K6_POSTGRES_HEALTH_GATE="${K6_POSTGRES_HEALTH_GATE:-true}"
+K6_POSTGRES_RECOVERY_GATE="${K6_POSTGRES_RECOVERY_GATE:-true}"
+K6_POSTGRES_RECOVERY_STABLE_SECONDS="${K6_POSTGRES_RECOVERY_STABLE_SECONDS:-10}"
+K6_POSTGRES_EXPORTER_STABLE_GATE="${K6_POSTGRES_EXPORTER_STABLE_GATE:-true}"
+K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS="${K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS:-60}"
 K6_OUTBOX_PREFLIGHT="${K6_OUTBOX_PREFLIGHT:-false}"
 K6_OUTBOX_PREFLIGHT_BASE_URL="${K6_OUTBOX_PREFLIGHT_BASE_URL:-http://localhost:${LOADTEST_BACKEND_PORT:-18080}}"
 K6_EXPLAIN_SNAPSHOT="${K6_EXPLAIN_SNAPSHOT:-true}"
@@ -279,7 +289,7 @@ loadtest_postgres_exporter_cpus="${LOADTEST_POSTGRES_EXPORTER_CPUS:-0.10}"
 loadtest_postgres_exporter_memory="${LOADTEST_POSTGRES_EXPORTER_MEMORY:-128m}"
 loadtest_postgres_container="${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}"
 loadtest_backend_container="${LOADTEST_BACKEND_CONTAINER_NAME:-aquila-bank-backend-loadtest}"
-export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_WARMUP_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
+export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_WARMUP_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
 
 require_positive_integer K6_VUS
 require_positive_integer K6_RATE
@@ -312,7 +322,12 @@ require_bool_value K6_OUTBOX_PREFLIGHT
 require_bool_value K6_EXPLAIN_SNAPSHOT
 require_bool_value K6_SUMMARY_GATE
 require_bool_value K6_BACKEND_READINESS_GATE
+require_bool_value K6_POSTGRES_HEALTH_GATE
+require_bool_value K6_POSTGRES_RECOVERY_GATE
+require_bool_value K6_POSTGRES_EXPORTER_STABLE_GATE
 require_positive_integer K6_BACKEND_READINESS_TIMEOUT_SECONDS
+require_non_negative_integer K6_POSTGRES_RECOVERY_STABLE_SECONDS
+require_positive_integer K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS
 require_non_negative_integer K6_MAX_RETRY_AFTER_SLEEP_SECONDS
 require_rate K6_OVERLOAD_429_RATE_THRESHOLD
 require_rate K6_OVERLOAD_503_RATE_THRESHOLD
@@ -448,6 +463,9 @@ print_plan() {
   echo "[k6-transaction-100m] run purpose=${K6_RUN_PURPOSE}"
   echo "[k6-transaction-100m] summary gate=${K6_SUMMARY_GATE}"
   echo "[k6-transaction-100m] backend readiness gate=${K6_BACKEND_READINESS_GATE} path=${K6_BACKEND_READINESS_PATH} timeout=${K6_BACKEND_READINESS_TIMEOUT_SECONDS}"
+  echo "[k6-transaction-100m] postgres health gate=${K6_POSTGRES_HEALTH_GATE} required_status=healthy"
+  echo "[k6-transaction-100m] postgres recovery gate=${K6_POSTGRES_RECOVERY_GATE} stable_seconds=${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
+  echo "[k6-transaction-100m] postgres exporter stable gate=${K6_POSTGRES_EXPORTER_STABLE_GATE} timeout=${K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS}"
   echo "[k6-transaction-100m] generator mode=${K6_GENERATOR_MODE}"
   if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
     echo "[k6-transaction-100m] generator runner=docker --context ${K6_DOCKER_CONTEXT} run grafana/k6:0.54.0"
@@ -510,6 +528,9 @@ assert_k6_preflight() {
     exit 1
   fi
 
+  assert_postgres_health_preflight
+  assert_postgres_recovery_preflight
+
   local missing_indexes
   missing_indexes="$("${psql_base[@]}" --no-align --tuples-only --command "
     WITH required(index_name) AS (
@@ -527,6 +548,86 @@ assert_k6_preflight() {
     echo "${missing_indexes}" >&2
     exit 1
   fi
+
+  wait_for_postgres_exporter_stability
+}
+
+assert_postgres_health_preflight() {
+  if [[ "${K6_POSTGRES_HEALTH_GATE}" != "true" ]]; then
+    echo "[k6-transaction-100m] postgres health gate skipped"
+    return 0
+  fi
+
+  local health_status
+  health_status="$(docker inspect "${loadtest_postgres_container}" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' 2>/dev/null || echo missing)"
+  if [[ "${health_status}" != "healthy" ]]; then
+    echo "postgres health status must be healthy: actual=${health_status}" >&2
+    exit 1
+  fi
+}
+
+query_postgres_recovery_state() {
+  local output
+  if ! output="$("${psql_base[@]}" --no-align --tuples-only --command "SELECT pg_is_in_recovery();" 2>&1)"; then
+    echo "${output}"
+    return 1
+  fi
+  tr -d '[:space:]' <<<"${output}"
+}
+
+assert_postgres_recovery_preflight() {
+  if [[ "${K6_POSTGRES_RECOVERY_GATE}" != "true" ]]; then
+    echo "[k6-transaction-100m] postgres recovery gate skipped"
+    return 0
+  fi
+
+  local in_recovery
+  if ! in_recovery="$(query_postgres_recovery_state)"; then
+    echo "PostgreSQL recovery preflight query failed: ${in_recovery}" >&2
+    exit 1
+  fi
+  if [[ "${in_recovery}" != "f" ]]; then
+    echo "pg_is_in_recovery()=false required before k6: actual=${in_recovery}" >&2
+    exit 1
+  fi
+  if ((K6_POSTGRES_RECOVERY_STABLE_SECONDS > 0)); then
+    sleep "${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
+    if ! in_recovery="$(query_postgres_recovery_state)"; then
+      echo "PostgreSQL recovery preflight recheck failed: ${in_recovery}" >&2
+      exit 1
+    fi
+    if [[ "${in_recovery}" != "f" ]]; then
+      echo "pg_is_in_recovery()=false required after stable wait: actual=${in_recovery}" >&2
+      exit 1
+    fi
+  fi
+  echo "[k6-transaction-100m] pg_is_in_recovery()=false stable_seconds=${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
+}
+
+wait_for_postgres_exporter_stability() {
+  if [[ "${K6_OBSERVABILITY_MODE}" != "prometheus" ]]; then
+    echo "[k6-transaction-100m] postgres exporter stable gate skipped for summary-only"
+    return 0
+  fi
+  if [[ "${K6_POSTGRES_EXPORTER_STABLE_GATE}" != "true" ]]; then
+    echo "[k6-transaction-100m] postgres exporter stable gate skipped"
+    return 0
+  fi
+
+  require_command curl
+  local url="http://localhost:${loadtest_postgres_exporter_port}/metrics"
+  local deadline=$((SECONDS + K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS))
+  local metrics
+  echo "[k6-transaction-100m] waiting postgres exporter stability: ${url}"
+  while ((SECONDS < deadline)); do
+    if metrics="$(curl -fsS --max-time 2 "${url}" 2>/dev/null)" \
+      && awk '$1 ~ /^pg_up/ && $2 == 1 {found=1} END {exit !found}' <<<"${metrics}"; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "postgres exporter pg_up did not become stable: ${url}" >&2
+  exit 1
 }
 
 run_outbox_preflight() {

--- a/tools/test/run-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/run-transaction-100m-fixture-dataset-probe.sh
@@ -3,19 +3,24 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE' >&2
-usage: tools/test/run-transaction-100m-fixture-dataset-probe.sh [--print-plan|--dry-run]
+usage: tools/test/run-transaction-100m-fixture-dataset-probe.sh [--print-plan|--dry-run|--assert-estimate]
 
 Environment:
   FIXTURE_NAME                         default transaction-100m-fixture
   FIXTURE_PATH                         default build/fixtures/<FIXTURE_NAME>.dump
   FIXTURE_MANIFEST_PATH                default <FIXTURE_PATH>.manifest
   FIXTURE_DATASET_ENV_PATH             default <FIXTURE_PATH>.dataset.env
+  FIXTURE_DATASET_DB_REPORT_PATH       default <FIXTURE_PATH>.db-gate.env
   FIXTURE_DATASET_DB_GATE              true|false, default true
   FIXTURE_DATASET_PROBE_DB_FALLBACK    true|false, default false
   FIXTURE_DATASET_MIN_TOTAL_ROWS       default manifest total_rows or 100000000
   FIXTURE_DATASET_MIN_HOT_ROWS         default manifest hot_rows or 1
   FIXTURE_DATASET_MIN_ARCHIVE_ROWS     default manifest archive_rows or 1
   FIXTURE_DATASET_MIN_WINDOW_ROWS      default 51
+  FIXTURE_DATASET_ESTIMATE_TOLERANCE_ROWS default 1000
+  FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS default 3000
+  FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS default 1000
+  FIXTURE_DATASET_QUERY_WORK_MEM       default 2MB
 
 Manifest keys:
   hot_account_id hot_from hot_to cold_account_id cold_from cold_to
@@ -30,6 +35,9 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --dry-run)
       mode="dry-run"
+      ;;
+    --assert-estimate)
+      mode="assert-estimate"
       ;;
     -h|--help)
       usage
@@ -57,14 +65,22 @@ fixture_dir="${FIXTURE_DIR:-build/fixtures}"
 fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
 manifest_path="${FIXTURE_MANIFEST_PATH:-${fixture_path}.manifest}"
 dataset_env_path="${FIXTURE_DATASET_ENV_PATH:-${fixture_path}.dataset.env}"
+db_report_path="${FIXTURE_DATASET_DB_REPORT_PATH:-${fixture_path}.db-gate.env}"
 db_gate="${FIXTURE_DATASET_DB_GATE:-true}"
 db_fallback="${FIXTURE_DATASET_PROBE_DB_FALLBACK:-false}"
 min_total_rows="${FIXTURE_DATASET_MIN_TOTAL_ROWS:-}"
 min_hot_rows="${FIXTURE_DATASET_MIN_HOT_ROWS:-}"
 min_archive_rows="${FIXTURE_DATASET_MIN_ARCHIVE_ROWS:-}"
 min_window_rows="${FIXTURE_DATASET_MIN_WINDOW_ROWS:-51}"
+estimate_tolerance_rows="${FIXTURE_DATASET_ESTIMATE_TOLERANCE_ROWS:-1000}"
+query_statement_timeout_ms="${FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS:-3000}"
+query_lock_timeout_ms="${FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS:-1000}"
+query_work_mem="${FIXTURE_DATASET_QUERY_WORK_MEM:-2MB}"
+assert_estimate_label="${FIXTURE_DATASET_ASSERT_LABEL:-estimate}"
+assert_estimate_actual="${FIXTURE_DATASET_ASSERT_ACTUAL:-}"
+assert_estimate_minimum="${FIXTURE_DATASET_ASSERT_MINIMUM:-}"
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
-psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
+psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql --quiet -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
 
 require_bool_value "FIXTURE_DATASET_DB_GATE" "${db_gate}"
 require_bool_value "FIXTURE_DATASET_PROBE_DB_FALLBACK" "${db_fallback}"
@@ -91,6 +107,13 @@ require_non_negative_integer_value "FIXTURE_DATASET_MIN_TOTAL_ROWS" "${min_total
 require_non_negative_integer_value "FIXTURE_DATASET_MIN_HOT_ROWS" "${min_hot_rows}"
 require_non_negative_integer_value "FIXTURE_DATASET_MIN_ARCHIVE_ROWS" "${min_archive_rows}"
 require_positive_integer_value "FIXTURE_DATASET_MIN_WINDOW_ROWS" "${min_window_rows}"
+require_non_negative_integer_value "FIXTURE_DATASET_ESTIMATE_TOLERANCE_ROWS" "${estimate_tolerance_rows}"
+require_positive_integer_value "FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS" "${query_statement_timeout_ms}"
+require_positive_integer_value "FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS" "${query_lock_timeout_ms}"
+if ! [[ "${query_work_mem}" =~ ^[1-9][0-9]*(kB|KB|MB|GB)$ ]]; then
+  echo "FIXTURE_DATASET_QUERY_WORK_MEM must use PostgreSQL memory units such as 2048kB or 2MB: ${query_work_mem}" >&2
+  exit 1
+fi
 
 manifest_value() {
   local key="$1"
@@ -125,13 +148,11 @@ probe_from_db() {
   local table="$1"
   local account_id="$2"
   local from_to
-  from_to="$(
-    "${psql_base[@]}" --no-align --tuples-only --field-separator='|' --command "
+  from_to="$(db_tuple "
       SELECT MIN(booked_at), MAX(booked_at)
       FROM public.${table}
       WHERE account_id = '${account_id}';
-    "
-  )"
+    ")"
   tr -d '[:space:]' <<<"${from_to}"
 }
 
@@ -147,9 +168,27 @@ manifest_integer_or_default() {
   echo "${fallback}"
 }
 
+guarded_sql() {
+  local sql="$1"
+  printf "BEGIN READ ONLY;\nSET LOCAL statement_timeout = '%sms';\nSET LOCAL lock_timeout = '%sms';\nSET LOCAL work_mem = '%s';\n%s\nCOMMIT;\n" \
+    "${query_statement_timeout_ms}" \
+    "${query_lock_timeout_ms}" \
+    "${query_work_mem}" \
+    "${sql}"
+}
+
 db_scalar() {
   local sql="$1"
-  "${psql_base[@]}" --no-align --tuples-only --command "${sql}" | tr -d '[:space:]'
+  local output
+  output="$("${psql_base[@]}" --no-align --tuples-only --command "$(guarded_sql "${sql}")")"
+  awk 'NF {line=$0} END {gsub(/[[:space:]]/, "", line); print line}' <<<"${output}"
+}
+
+db_tuple() {
+  local sql="$1"
+  local output
+  output="$("${psql_base[@]}" --no-align --tuples-only --field-separator='|' --command "$(guarded_sql "${sql}")")"
+  awk 'NF {line=$0} END {gsub(/[[:space:]]/, "", line); print line}' <<<"${output}"
 }
 
 table_estimate() {
@@ -202,6 +241,7 @@ assert_partition_exists() {
     echo "dataset probe monthly partition is missing: ${partition}" >&2
     exit 1
   fi
+  echo "${partition}"
 }
 
 assert_integer_at_least() {
@@ -218,6 +258,66 @@ assert_integer_at_least() {
   fi
 }
 
+assert_estimate_at_least() {
+  local label="$1"
+  local actual="$2"
+  local minimum="$3"
+  local tolerance="${estimate_tolerance_rows}"
+  local allowed_min
+  if ! [[ "${actual}" =~ ^[0-9]+$ ]]; then
+    echo "dataset probe ${label} returned invalid estimate: ${actual}" >&2
+    exit 1
+  fi
+  if ((minimum <= tolerance)); then
+    tolerance=0
+  fi
+  allowed_min=$((minimum - tolerance))
+  if ((allowed_min < 0)); then
+    allowed_min=0
+  fi
+  if ((actual < allowed_min)); then
+    echo "dataset probe ${label} below estimate tolerance: actual=${actual} min=${minimum} tolerance_rows=${tolerance} allowed_min=${allowed_min}" >&2
+    exit 1
+  fi
+  if ((actual < minimum)); then
+    echo "[transaction-100m-dataset-probe] ${label} accepted within estimate tolerance: actual=${actual} min=${minimum} tolerance_rows=${tolerance}"
+  fi
+}
+
+write_db_gate_report() {
+  local hot_min="$1"
+  local archive_min="$2"
+  local total_min="$3"
+  local hot_estimate="$4"
+  local archive_estimate="$5"
+  local total_estimate="$6"
+  local hot_count="$7"
+  local cold_count="$8"
+  local hot_partition="$9"
+  local cold_partition="${10}"
+  mkdir -p "$(dirname "${db_report_path}")"
+  {
+    echo "FIXTURE_DATASET_DB_GATE=passed"
+    echo "FIXTURE_DATASET_TOTAL_MIN=${total_min}"
+    echo "FIXTURE_DATASET_HOT_MIN=${hot_min}"
+    echo "FIXTURE_DATASET_ARCHIVE_MIN=${archive_min}"
+    echo "FIXTURE_DATASET_TOTAL_ESTIMATE=${total_estimate}"
+    echo "FIXTURE_DATASET_HOT_ESTIMATE=${hot_estimate}"
+    echo "FIXTURE_DATASET_ARCHIVE_ESTIMATE=${archive_estimate}"
+    echo "FIXTURE_DATASET_ESTIMATE_TOLERANCE_ROWS=${estimate_tolerance_rows}"
+    echo "FIXTURE_DATASET_HOT_WINDOW_COUNT=${hot_count}"
+    echo "FIXTURE_DATASET_COLD_WINDOW_COUNT=${cold_count}"
+    echo "FIXTURE_DATASET_MIN_WINDOW_ROWS=${min_window_rows}"
+    echo "FIXTURE_DATASET_HOT_PARTITION=${hot_partition}"
+    echo "FIXTURE_DATASET_COLD_PARTITION=${cold_partition}"
+    echo "FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS=${query_statement_timeout_ms}"
+    echo "FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS=${query_lock_timeout_ms}"
+    echo "FIXTURE_DATASET_QUERY_WORK_MEM=${query_work_mem}"
+    echo "FIXTURE_DATASET_QUERY_READ_ONLY=true"
+  } >"${db_report_path}"
+  echo "[transaction-100m-dataset-probe] db gate report written=${db_report_path}"
+}
+
 assert_dataset_db_gate() {
   local hot_account_id="$1"
   local hot_from="$2"
@@ -231,7 +331,7 @@ assert_dataset_db_gate() {
   fi
 
   local total_min hot_min archive_min
-  local hot_estimate archive_estimate total_estimate hot_count cold_count
+  local hot_estimate archive_estimate total_estimate hot_count cold_count hot_partition cold_partition
   total_min="${min_total_rows:-$(manifest_integer_or_default total_rows 100000000)}"
   hot_min="${min_hot_rows:-$(manifest_integer_or_default hot_rows 1)}"
   archive_min="${min_archive_rows:-$(manifest_integer_or_default archive_rows 1)}"
@@ -242,18 +342,19 @@ assert_dataset_db_gate() {
   assert_integer_at_least hot_estimate "${hot_estimate}" 0
   assert_integer_at_least archive_estimate "${archive_estimate}" 0
   total_estimate=$((hot_estimate + archive_estimate))
-  assert_integer_at_least hot_estimate "${hot_estimate}" "${hot_min}"
-  assert_integer_at_least archive_estimate "${archive_estimate}" "${archive_min}"
-  assert_integer_at_least total_estimate "${total_estimate}" "${total_min}"
+  assert_estimate_at_least hot_estimate "${hot_estimate}" "${hot_min}"
+  assert_estimate_at_least archive_estimate "${archive_estimate}" "${archive_min}"
+  assert_estimate_at_least total_estimate "${total_estimate}" "${total_min}"
 
   hot_count="$(window_count transaction_read_model "${hot_account_id}" "${hot_from}" "${hot_to}")"
   cold_count="$(window_count transaction_read_model_archive "${cold_account_id}" "${cold_from}" "${cold_to}")"
   assert_integer_at_least hot_window_count "${hot_count}" "${min_window_rows}"
   assert_integer_at_least cold_window_count "${cold_count}" "${min_window_rows}"
-  assert_partition_exists transaction_read_model "${hot_from}"
-  assert_partition_exists transaction_read_model_archive "${cold_from}"
+  hot_partition="$(assert_partition_exists transaction_read_model "${hot_from}")"
+  cold_partition="$(assert_partition_exists transaction_read_model_archive "${cold_from}")"
+  write_db_gate_report "${hot_min}" "${archive_min}" "${total_min}" "${hot_estimate}" "${archive_estimate}" "${total_estimate}" "${hot_count}" "${cold_count}" "${hot_partition}" "${cold_partition}"
 
-  echo "[transaction-100m-dataset-probe] db gate hot_estimate=${hot_estimate} archive_estimate=${archive_estimate} hot_window_count=${hot_count} cold_window_count=${cold_count}"
+  echo "[transaction-100m-dataset-probe] db gate hot_estimate=${hot_estimate} archive_estimate=${archive_estimate} total_estimate=${total_estimate} hot_window_count=${hot_count} cold_window_count=${cold_count}"
 }
 
 write_dataset_env() {
@@ -281,13 +382,19 @@ print_plan() {
   echo "[transaction-100m-dataset-probe] dump=${fixture_path}"
   echo "[transaction-100m-dataset-probe] manifest=${manifest_path}"
   echo "[transaction-100m-dataset-probe] dataset_env=${dataset_env_path}"
+  echo "[transaction-100m-dataset-probe] db_report=${db_report_path}"
   echo "[transaction-100m-dataset-probe] db_gate=${db_gate}"
   echo "[transaction-100m-dataset-probe] db_fallback=${db_fallback}"
   echo "[transaction-100m-dataset-probe] min_total_rows=${min_total_rows:-manifest-total_rows-or-100000000}"
   echo "[transaction-100m-dataset-probe] min_hot_rows=${min_hot_rows:-manifest-hot_rows-or-1}"
   echo "[transaction-100m-dataset-probe] min_archive_rows=${min_archive_rows:-manifest-archive_rows-or-1}"
   echo "[transaction-100m-dataset-probe] min_window_rows=${min_window_rows}"
-  echo "[transaction-100m-dataset-probe] db_gate_checks=estimate,window-count,monthly-partition"
+  echo "[transaction-100m-dataset-probe] estimate_tolerance_rows=${estimate_tolerance_rows}"
+  echo "[transaction-100m-dataset-probe] query_statement_timeout_ms=${query_statement_timeout_ms}"
+  echo "[transaction-100m-dataset-probe] query_lock_timeout_ms=${query_lock_timeout_ms}"
+  echo "[transaction-100m-dataset-probe] query_work_mem=${query_work_mem}"
+  echo "[transaction-100m-dataset-probe] query_read_only=true"
+  echo "[transaction-100m-dataset-probe] db_gate_checks=partition-estimate-tolerance,bounded-window-count,monthly-partition"
   echo "[transaction-100m-dataset-probe] source_order=manifest,env,db-fallback"
 }
 
@@ -328,6 +435,12 @@ if [[ "${mode}" == "dry-run" ]]; then
   if [[ "${db_fallback}" == "true" ]]; then
     echo "db fallback enabled for missing windows"
   fi
+  exit 0
+fi
+if [[ "${mode}" == "assert-estimate" ]]; then
+  require_value FIXTURE_DATASET_ASSERT_ACTUAL "${assert_estimate_actual}"
+  require_value FIXTURE_DATASET_ASSERT_MINIMUM "${assert_estimate_minimum}"
+  assert_estimate_at_least "${assert_estimate_label}" "${assert_estimate_actual}" "${assert_estimate_minimum}"
   exit 0
 fi
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #467

## 🌿 Base Branch
- `main`

## 📝 Summary
- 100m fixture DB gate가 reltuples estimate를 exact count처럼 취급해 false-negative를 내던 경로를 tolerance 기반 검증으로 바꿨습니다.
- full count 대신 partition estimate, bounded window count, monthly partition 존재 확인만 사용하고, k6 전 PostgreSQL recovery/exporter 안정 preflight를 추가했습니다.

## 🛠 Changes
- fixture DB gate에 estimate tolerance, guarded query(statement_timeout/lock_timeout/work_mem/read-only), DB gate sidecar report를 추가했습니다.
- k6 preflight에 PostgreSQL health=healthy, OOMKilled=false, pg_is_in_recovery()=false 안정 구간, postgres-exporter pg_up 확인을 추가했습니다.
- fixture/k6/loadtest recovery contract test를 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-fixture-dataset-probe.sh`
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `tools/test/check-loadtest-readiness-recovery.sh`
- `docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: estimate tolerance 기본값(1000 rows)이 fixture 품질 문제를 과도하게 허용하지 않는지 실제 artifact report와 함께 확인이 필요합니다.
- 롤백 방법: 이 PR의 두 커밋을 revert하면 기존 strict estimate gate와 k6 preflight 동작으로 복구됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
