### PR TITLE
[Perf] off-host k6 capacity runner 및 burst generator 재보정

### DIFF
--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -115,6 +115,21 @@ burst_plan="$(
 grep -F "scenario mode=burst" <<<"${burst_plan}" >/dev/null
 grep -F "burst rate=16 duration=20s preAllocatedVUs=8 maxVUs=32" <<<"${burst_plan}" >/dev/null
 
+burst_offhost_plan="$(
+  K6_REPORT_NAME=transaction-100m-burst-offhost-check \
+  K6_SCENARIO_MODE=burst \
+  K6_BURST_RATE=256 \
+  K6_BURST_DURATION=20s \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=transaction-k6-remote \
+  K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+  K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.10:9090/api/v1/write \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "k6 report name: transaction-100m-burst-offhost-check" <<<"${burst_offhost_plan}" >/dev/null
+grep -F "generator mode=docker-context" <<<"${burst_offhost_plan}" >/dev/null
+grep -F "burst rate=256 duration=20s preAllocatedVUs=512 maxVUs=1024" <<<"${burst_offhost_plan}" >/dev/null
+
 echo "[k6-transaction-100m] k6 script contract"
 grep -F "experimental-prometheus-rw" compose.loadtest.yml >/dev/null
 grep -F "K6_PROMETHEUS_RW_SERVER_URL" compose.loadtest.yml >/dev/null

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -65,6 +65,22 @@ grep -F "generator runner=docker --context transaction-k6-remote run grafana/k6:
 grep -F "remote base url=http://192.0.2.10:8080" <<<"${remote_plan}" >/dev/null
 grep -F "remote prometheus rw=disabled" <<<"${remote_plan}" >/dev/null
 grep -F "remote workdir=/srv/aquila-bank" <<<"${remote_plan}" >/dev/null
+grep -F "remote preflight=true timeout=30 readiness_path=/actuator/health/readiness" <<<"${remote_plan}" >/dev/null
+grep -F "remote preflight image=curlimages/curl:8.11.1" <<<"${remote_plan}" >/dev/null
+
+remote_prometheus_plan="$(
+  K6_REPORT_NAME=transaction-100m-remote-prometheus-check \
+  K6_OBSERVABILITY_MODE=prometheus \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=transaction-k6-remote \
+  K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+  K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.10:9090/api/v1/write \
+  K6_REMOTE_WORKDIR=/srv/aquila-bank \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "k6 report name: transaction-100m-remote-prometheus-check" <<<"${remote_prometheus_plan}" >/dev/null
+grep -F "remote prometheus rw=http://192.0.2.10:9090/api/v1/write" <<<"${remote_prometheus_plan}" >/dev/null
+grep -F "remote prometheus preflight=enabled" <<<"${remote_prometheus_plan}" >/dev/null
 
 overload_plan="$(
   K6_REPORT_NAME=transaction-100m-overload-check \
@@ -200,6 +216,12 @@ grep -F "without prometheus remote-write" tools/test/run-k6-transaction-100m-loa
 grep -F "K6_DOCKER_CONTEXT" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_REMOTE_BASE_URL" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_REMOTE_PROMETHEUS_RW_SERVER_URL" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_REMOTE_PREFLIGHT" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_REMOTE_READINESS_PATH" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "assert_remote_k6_preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "docker --context \"\${K6_DOCKER_CONTEXT}\" info" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "remote prometheus remote-write preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_REMOTE_WORKDIR" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_RUN_PURPOSE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "assert_k6_summary_gate" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
@@ -299,6 +321,14 @@ if K6_POSTGRES_EXPORTER_STABLE_GATE=bad tools/test/run-k6-transaction-100m-loadt
 fi
 if K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS=0 tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
   echo "K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS=0 unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_REMOTE_PREFLIGHT=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_REMOTE_PREFLIGHT=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS=0 tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS=0 unexpectedly succeeded" >&2
   exit 1
 fi
 if K6_RUN_PURPOSE=unknown tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then

--- a/tools/test/check-transaction-100m-capacity-gates.sh
+++ b/tools/test/check-transaction-100m-capacity-gates.sh
@@ -33,15 +33,19 @@ grep -F "k6_generator_mode=docker-context" <<<"${plan}" >/dev/null
 grep -F "allow_local_k6_generator=false" <<<"${plan}" >/dev/null
 grep -F "k6_docker_context=capacity-k6-remote" <<<"${plan}" >/dev/null
 grep -F "k6_remote_base_url=http://192.0.2.20:8080" <<<"${plan}" >/dev/null
+grep -F "k6_remote_prometheus_rw_server_url=http://192.0.2.20:9090/api/v1/write" <<<"${plan}" >/dev/null
 grep -F "k6_remote_workdir=/srv/aquila-bank" <<<"${plan}" >/dev/null
+grep -F "k6_remote_preflight=delegated-to-k6-runner" <<<"${plan}" >/dev/null
 grep -F "summary=build/reports/k6/transaction-capacity-check/capacity-summary.tsv" <<<"${plan}" >/dev/null
 
 echo "[transaction-100m-capacity] runner contract"
 grep -F "CAPACITY_K6_GENERATOR_MODE" "${script}" >/dev/null
 grep -F "CAPACITY_ALLOW_LOCAL_K6_GENERATOR" "${script}" >/dev/null
 grep -F "CAPACITY_K6_DOCKER_CONTEXT is required" "${script}" >/dev/null
+grep -F "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL is required" "${script}" >/dev/null
 grep -F "K6_GENERATOR_MODE=\"\${capacity_k6_generator_mode}\"" "${script}" >/dev/null
 grep -F "K6_RUN_PURPOSE=capacity" "${script}" >/dev/null
+grep -F "K6_REMOTE_PREFLIGHT=true" "${script}" >/dev/null
 grep -F "stop_backend_before_bootjar" "${script}" >/dev/null
 grep -F "docker compose \"\${compose_files[@]}\" --profile loadtest stop aquila-bank-backend" "${script}" >/dev/null
 grep -F -- "up -d --force-recreate" "${script}" >/dev/null

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -220,10 +220,15 @@ K6_RATE="${K6_RATE:-8}"
 K6_TIME_UNIT="${K6_TIME_UNIT:-1s}"
 K6_BURST_RATE="${K6_BURST_RATE:-16}"
 K6_BURST_DURATION="${K6_BURST_DURATION:-20s}"
+K6_GENERATOR_MODE="${K6_GENERATOR_MODE:-local}"
 K6_PRE_ALLOCATED_VUS="${K6_PRE_ALLOCATED_VUS:-}"
 if [[ -z "${K6_PRE_ALLOCATED_VUS}" ]]; then
   if [[ "${K6_SCENARIO_MODE}" == "burst" ]]; then
-    K6_PRE_ALLOCATED_VUS="${K6_BURST_RATE}"
+    if [[ "${K6_GENERATOR_MODE}" == "docker-context" && "${K6_BURST_RATE}" =~ ^[1-9][0-9]*$ ]]; then
+      K6_PRE_ALLOCATED_VUS="$((K6_BURST_RATE * 2))"
+    else
+      K6_PRE_ALLOCATED_VUS="${K6_BURST_RATE}"
+    fi
   else
     K6_PRE_ALLOCATED_VUS="${K6_VUS}"
   fi
@@ -232,7 +237,11 @@ K6_MAX_VUS="${K6_MAX_VUS:-}"
 if [[ -z "${K6_MAX_VUS}" ]]; then
   if [[ "${K6_SCENARIO_MODE}" == "burst" ]]; then
     if [[ "${K6_BURST_RATE}" =~ ^[1-9][0-9]*$ ]]; then
-      K6_MAX_VUS="$((K6_BURST_RATE * 2))"
+      if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
+        K6_MAX_VUS="$((K6_BURST_RATE * 4))"
+      else
+        K6_MAX_VUS="$((K6_BURST_RATE * 2))"
+      fi
     else
       K6_MAX_VUS="${K6_BURST_RATE}"
     fi
@@ -271,7 +280,6 @@ K6_SUMMARY_GATE="${K6_SUMMARY_GATE:-true}"
 K6_BACKEND_READINESS_GATE="${K6_BACKEND_READINESS_GATE:-true}"
 K6_BACKEND_READINESS_PATH="${K6_BACKEND_READINESS_PATH:-/actuator/health/readiness}"
 K6_BACKEND_READINESS_TIMEOUT_SECONDS="${K6_BACKEND_READINESS_TIMEOUT_SECONDS:-120}"
-K6_GENERATOR_MODE="${K6_GENERATOR_MODE:-local}"
 K6_DOCKER_CONTEXT="${K6_DOCKER_CONTEXT:-}"
 K6_REMOTE_BASE_URL="${K6_REMOTE_BASE_URL:-}"
 K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-}"

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -62,6 +62,10 @@ Optional environment:
   K6_REMOTE_PROMETHEUS_RW_SERVER_URL
                        Prometheus remote-write URL reachable from remote k6, required when mode=docker-context
   K6_REMOTE_WORKDIR   repo path visible from docker context host, default current working directory
+  K6_REMOTE_PREFLIGHT validate remote context/backend/prometheus reachability, default true
+  K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS default 30
+  K6_REMOTE_PREFLIGHT_IMAGE default curlimages/curl:8.11.1
+  K6_REMOTE_READINESS_PATH default /actuator/health/readiness
   LOADTEST_PROMETHEUS_CPUS/MEMORY default 0.25/256m
   LOADTEST_GRAFANA_CPUS/MEMORY default 0.20/256m
   LOADTEST_ALERTMANAGER_CPUS/MEMORY default 0.10/128m
@@ -272,6 +276,10 @@ K6_DOCKER_CONTEXT="${K6_DOCKER_CONTEXT:-}"
 K6_REMOTE_BASE_URL="${K6_REMOTE_BASE_URL:-}"
 K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-}"
 K6_REMOTE_WORKDIR="${K6_REMOTE_WORKDIR:-$(pwd)}"
+K6_REMOTE_PREFLIGHT="${K6_REMOTE_PREFLIGHT:-true}"
+K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS="${K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS:-30}"
+K6_REMOTE_PREFLIGHT_IMAGE="${K6_REMOTE_PREFLIGHT_IMAGE:-curlimages/curl:8.11.1}"
+K6_REMOTE_READINESS_PATH="${K6_REMOTE_READINESS_PATH:-/actuator/health/readiness}"
 K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-$(date +%Y-%m-%d-%H%M%S)}"
 loadtest_db_port="${LOADTEST_DB_PORT:-15432}"
 loadtest_backend_port="${LOADTEST_BACKEND_PORT:-18080}"
@@ -289,7 +297,7 @@ loadtest_postgres_exporter_cpus="${LOADTEST_POSTGRES_EXPORTER_CPUS:-0.10}"
 loadtest_postgres_exporter_memory="${LOADTEST_POSTGRES_EXPORTER_MEMORY:-128m}"
 loadtest_postgres_container="${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}"
 loadtest_backend_container="${LOADTEST_BACKEND_CONTAINER_NAME:-aquila-bank-backend-loadtest}"
-export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_WARMUP_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REPORT_NAME
+export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_WARMUP_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REMOTE_PREFLIGHT K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS K6_REMOTE_PREFLIGHT_IMAGE K6_REMOTE_READINESS_PATH K6_REPORT_NAME
 
 require_positive_integer K6_VUS
 require_positive_integer K6_RATE
@@ -328,6 +336,8 @@ require_bool_value K6_POSTGRES_EXPORTER_STABLE_GATE
 require_positive_integer K6_BACKEND_READINESS_TIMEOUT_SECONDS
 require_non_negative_integer K6_POSTGRES_RECOVERY_STABLE_SECONDS
 require_positive_integer K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS
+require_bool_value K6_REMOTE_PREFLIGHT
+require_positive_integer K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS
 require_non_negative_integer K6_MAX_RETRY_AFTER_SLEEP_SECONDS
 require_rate K6_OVERLOAD_429_RATE_THRESHOLD
 require_rate K6_OVERLOAD_503_RATE_THRESHOLD
@@ -476,6 +486,13 @@ print_plan() {
       echo "[k6-transaction-100m] remote prometheus rw=disabled"
     fi
     echo "[k6-transaction-100m] remote workdir=${K6_REMOTE_WORKDIR}"
+    echo "[k6-transaction-100m] remote preflight=${K6_REMOTE_PREFLIGHT} timeout=${K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS} readiness_path=${K6_REMOTE_READINESS_PATH}"
+    echo "[k6-transaction-100m] remote preflight image=${K6_REMOTE_PREFLIGHT_IMAGE}"
+    if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
+      echo "[k6-transaction-100m] remote prometheus preflight=enabled"
+    else
+      echo "[k6-transaction-100m] remote prometheus preflight=disabled"
+    fi
   else
     if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
       echo "[k6-transaction-100m] generator runner=docker compose service k6-transaction-read-100m"
@@ -660,6 +677,30 @@ wait_for_backend_readiness() {
   exit 1
 }
 
+assert_remote_k6_preflight() {
+  if [[ "${K6_GENERATOR_MODE}" != "docker-context" ]]; then
+    return 0
+  fi
+  if [[ "${K6_REMOTE_PREFLIGHT}" != "true" ]]; then
+    echo "[k6-transaction-100m] remote k6 preflight skipped"
+    return 0
+  fi
+
+  local readiness_url="${K6_REMOTE_BASE_URL%/}${K6_REMOTE_READINESS_PATH}"
+  echo "[k6-transaction-100m] remote docker context preflight: ${K6_DOCKER_CONTEXT}"
+  docker --context "${K6_DOCKER_CONTEXT}" info >/dev/null
+  echo "[k6-transaction-100m] remote backend readiness preflight: ${readiness_url}"
+  docker --context "${K6_DOCKER_CONTEXT}" run --rm "${K6_REMOTE_PREFLIGHT_IMAGE}" \
+    -fsS --max-time "${K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS}" "${readiness_url}" >/dev/null
+
+  if [[ "${K6_OBSERVABILITY_MODE}" == "prometheus" ]]; then
+    echo "[k6-transaction-100m] remote prometheus remote-write preflight: ${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}"
+    docker --context "${K6_DOCKER_CONTEXT}" run --rm --entrypoint sh "${K6_REMOTE_PREFLIGHT_IMAGE}" \
+      -c 'status="$(curl -sS -o /dev/null -w "%{http_code}" --max-time "$1" -X POST "$2" || echo 000)"; case "${status}" in 2*|3*|4*) exit 0 ;; *) echo "remote prometheus remote-write preflight failed: status=${status}" >&2; exit 1 ;; esac' \
+      sh "${K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS}" "${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}"
+  fi
+}
+
 run_explain_snapshot() {
   local phase="$1"
   if [[ "${K6_EXPLAIN_SNAPSHOT}" != "true" ]]; then
@@ -692,6 +733,7 @@ fi
 wait_for_backend_readiness
 assert_k6_preflight
 run_outbox_preflight
+assert_remote_k6_preflight
 run_explain_snapshot pre
 
 run_k6_local() {

--- a/tools/test/run-transaction-100m-capacity-gates.sh
+++ b/tools/test/run-transaction-100m-capacity-gates.sh
@@ -365,7 +365,9 @@ print_plan() {
   echo "[transaction-100m-capacity] allow_local_k6_generator=${allow_local_k6_generator}"
   echo "[transaction-100m-capacity] k6_docker_context=${capacity_k6_docker_context:-missing}"
   echo "[transaction-100m-capacity] k6_remote_base_url=${capacity_k6_remote_base_url:-missing}"
+  echo "[transaction-100m-capacity] k6_remote_prometheus_rw_server_url=${capacity_k6_remote_prometheus_rw_server_url:-missing}"
   echo "[transaction-100m-capacity] k6_remote_workdir=${capacity_k6_remote_workdir}"
+  echo "[transaction-100m-capacity] k6_remote_preflight=delegated-to-k6-runner"
   echo "[transaction-100m-capacity] adaptive_enabled=${adaptive_enabled}"
   echo "[transaction-100m-capacity] hard_thresholds=${hard_threshold_enabled}"
   echo "[transaction-100m-capacity] hot_p95_threshold_ms=${hot_p95_threshold_ms}"
@@ -627,6 +629,7 @@ run_profile() {
   K6_REMOTE_BASE_URL="${capacity_k6_remote_base_url}" \
   K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${capacity_k6_remote_prometheus_rw_server_url}" \
   K6_REMOTE_WORKDIR="${capacity_k6_remote_workdir}" \
+  K6_REMOTE_PREFLIGHT=true \
     tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${log_path}" 2>&1
   status=$?
   set -e


### PR DESCRIPTION
## 🔗 Related Issue
- close #469

## 🌿 Base Branch
- `main`

## 📝 Summary
- capacity 목적 k6 실행에서 off-host Docker context, remote backend URL, remote Prometheus remote-write URL 계약을 preflight로 검증합니다.
- burst 256/s off-host generator 기본 sizing을 preAllocatedVUs=512, maxVUs=1024로 재보정해 generator 부족을 hard gate 전에 줄입니다.

## 🛠 Changes
- `K6_REMOTE_PREFLIGHT`와 timeout/image/readiness path 설정을 추가하고 docker context/backend/prometheus reachability를 검증합니다.
- capacity gate runner가 remote prometheus URL과 k6 remote preflight 위임을 plan에 명시하고 k6 runner에 `K6_REMOTE_PREFLIGHT=true`를 전달합니다.
- docker-context burst 기본 VU sizing을 rate의 2배/4배로 조정하고 contract test를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `tools/test/check-transaction-100m-capacity-gates.sh`
- `tools/test/check-docker-t3micro-capacity-smoke-script.sh`
- `docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: remote preflight는 `curlimages/curl:8.11.1` 이미지를 off-host Docker context에서 사용할 수 있어야 합니다.
- 롤백 방법: 이 PR의 두 커밋을 revert하면 기존 remote runner 및 burst sizing 기본값으로 복구됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
