### PR TITLE
[Perf] 100m defensive post-overload-profile latest-main 병목 재검증

### DIFF
--- a/docs/performance-results/100m-defensive-post-overload-profile-latest-main-20260427-bottleneck.md
+++ b/docs/performance-results/100m-defensive-post-overload-profile-latest-main-20260427-bottleneck.md
@@ -1,0 +1,86 @@
+# 100m defensive post-overload-profile latest-main 병목 재검증
+
+## 기준
+
+- 실행일: 2026-04-27
+- 기준 브랜치: `main`
+- 기준 SHA: `686d178`
+- 작업 브랜치: `perf/100m-defensive-post-overload-profile-retest`
+- 연결 이슈: `#475`
+- 목표: 로컬 Docker t3.micro 제약에서 1억 row 거래 조회와 대용량 트래픽 방어 병목 재확인
+- 제외: 이미 main에 반영된 `#466`, `#470`, `#472`, `#474` 범위의 gate 안정화, overload 429/503 분리, burst hot-first spike gate, zero-503 admission profile
+
+## 환경
+
+- Docker compose: `compose.yml`, `compose.t3micro.yml`, `compose.loadtest.yml`
+- PostgreSQL 컨테이너: `aquila-bank-postgres-loadtest`, memory limit `384MiB`
+- Backend 컨테이너: `aquila-bank-backend-loadtest`, memory limit `1GiB`
+- Observability: Prometheus, Grafana, Alertmanager, postgres-exporter
+- Dataset account: hot `910000001`, cold `910000002`
+- Dataset estimate: fixture probe 기준 `99,999,884` rows, tolerance `1,000` rows로 1억 row 조건 수용
+- k6 공통 limit: `50`
+
+## 실행 결과
+
+| 항목 | 결과 | 핵심 수치 | 판단 |
+| --- | --- | --- | --- |
+| fixture dataset probe | 실패 | estimate는 통과, hot/cold window count 중 statement timeout 및 PostgreSQL backend `signal 9` 종료 | DB gate 쿼리가 t3.micro에서 아직 위험 |
+| VU3 baseline | 통과 | failed `0`, 429 `0`, 503 `0`, hot/cold p95 약 `1.18~1.24ms` | read API smoke 기준 양호 |
+| VU16 overload | 통과 | failed `0.0035115521`, 429 `0.0039591095`, 503 `0`, p95 약 `1.16~1.25ms` | admission guard가 503 없이 방어 |
+| burst 256/s | 통과 | failed `0`, 429 `0`, 503 `0`, hot first p95 `0.919959ms` | 짧은 burst smoke 기준 양호 |
+| Prometheus mode | 통과 | failed `0`, 429 `0`, 503 `0`, p95 약 `1.15~1.28ms` | remote write 경로 동작 |
+| Prometheus/Grafana health | 통과 | Prometheus `/-/ready` 200, Grafana `/api/health` 200 | 관측 스택 기동 정상 |
+| capacity runner | 차단 | `CAPACITY_K6_DOCKER_CONTEXT is required`, Docker context는 `default`, `desktop-linux`만 존재 | off-host k6 context 미구성 |
+| aggregate required capacity | 실패 의도 확인 | capacity input missing일 때 fail-fast | capacity 누락을 성공으로 오판하지 않음 |
+| aggregate k6+memory | 통과 | total memory `743.13MiB`, budget `900MiB` | smoke 집계는 통과 |
+
+## 리소스 스냅샷
+
+| 컨테이너 | CPU | Memory |
+| --- | ---: | ---: |
+| backend | `0.38%` | `394.7MiB / 1GiB` |
+| PostgreSQL | `0.87%` | `184.1MiB / 384MiB` |
+| Prometheus | `0.38%` | `63.65MiB / 256MiB` |
+| Grafana | `0.05%` | `86.09MiB / 256MiB` |
+| postgres-exporter | `0.00%` | `14.59MiB / 128MiB` |
+
+## 병목 판단
+
+현재 read API 자체는 최신 main 기준으로 smoke, overload, burst에서 병목이 크게 완화됐다. 특히 `#474` 이후 overload의 503은 재현되지 않았고, 429도 VU16 overload에서 `0.3959%`로 gate 안에 들어왔다.
+
+남은 1순위 병목은 API가 아니라 1억 row fixture 검증 DB gate다. estimate는 통과하지만 window count가 t3.micro PostgreSQL `384MiB`에서 timeout과 backend kill을 유발한다. 이 상태에서는 부하 테스트 본 실행 전 검증 단계가 DB를 recovery 상태로 만들 수 있어, 실제 capacity 결과와 fixture 검증 장애가 섞인다.
+
+2순위 병목은 capacity runner의 실행 환경이다. 로컬 Docker 컨텍스트만 있어 off-host k6 capacity runner가 실행되지 못했고, full defensive aggregate는 capacity 입력 없이 완료로 볼 수 없다.
+
+## 다음 병목 후보 PR/이슈
+
+모두 issue 제목 = PR 제목, issue 1개 = PR 1개 기준이다. 이미 main에 반영된 gate 안정화, overload 429/503 분리, burst hot-first spike gate, zero-503 admission profile 작업은 제외했다.
+
+1. `[Perf] fixture DB window count를 index-only bounded probe로 전환` / 브랜치 `perf/fixture-db-window-index-only-probe`
+   - 현재 window count가 timeout과 PostgreSQL backend kill을 유발한다. full count 성격의 검증을 index-only sample/range probe로 바꿔야 한다.
+2. `[Perf] fixture DB gate crash-safe timeout/connection recovery 처리 추가` / 브랜치 `perf/fixture-db-gate-crash-safe-recovery`
+   - 검증 쿼리 실패 시 DB recovery와 후속 k6 결과가 섞이지 않도록 fail-fast, recovery wait, artifact 분리를 추가한다.
+3. `[Perf] transaction 100m fixture manifest/db-gate artifact 복구` / 브랜치 `perf/transaction-100m-fixture-manifest-gate-artifact`
+   - 준비된 fixture manifest와 db-gate env를 우선 사용해 런타임 DB count 의존도를 낮춘다.
+4. `[Chore] off-host k6 docker context capacity runner 구성` / 브랜치 `chore/offhost-k6-capacity-runner`
+   - `CAPACITY_K6_DOCKER_CONTEXT`가 없어 실제 capacity runner가 차단된다.
+5. `[Perf] capacity runner remote URL/prometheus preflight 실환경 연결` / 브랜치 `perf/capacity-runner-remote-preflight-connectivity`
+   - remote base URL과 Prometheus remote write URL을 preflight로 검증해 capacity 실행 전 환경 오류를 닫는다.
+6. `[Perf] capacity gate를 실제 off-host 1억 row 결과로 baseline 확정` / 브랜치 `perf/offhost-capacity-baseline-100m`
+   - 로컬 smoke 통과와 별개로 off-host k6 capacity 수치를 baseline으로 고정해야 한다.
+7. `[Chore] defensive aggregate capacity input 자동 연결` / 브랜치 `chore/defensive-aggregate-capacity-input`
+   - capacity 결과가 생성되면 aggregate가 자동으로 최신 capacity input을 연결하고 누락 시 실패하도록 고정한다.
+8. `[Perf] PostgreSQL t3.micro 검증 쿼리 memory/IO SLO 추가` / 브랜치 `perf/postgres-verification-query-slo`
+   - fixture 검증 쿼리가 앱 부하보다 DB를 먼저 죽이는 문제를 막기 위해 검증 쿼리 자체의 memory/IO budget을 둔다.
+9. `[Perf] transaction read local smoke와 capacity 결과 분리 리포트 추가` / 브랜치 `perf/transaction-read-smoke-capacity-report-split`
+   - smoke 결과를 capacity 결과로 오판하지 않도록 리포트와 gate status를 분리한다.
+10. `[Perf] post-crash recovery noise를 loadtest 결과에서 자동 격리` / 브랜치 `perf/loadtest-post-crash-noise-isolation`
+    - DB crash/recovery 뒤 exporter/log noise가 후속 측정에 섞이지 않도록 run id와 recovery window 기준으로 격리한다.
+
+## 생성 아티팩트
+
+- `docs/performance-results/transaction-100m-post-overload-profile-vu3-20260427-summary.md`
+- `docs/performance-results/transaction-100m-post-overload-profile-vu16-overload-20260427-summary.md`
+- `docs/performance-results/transaction-100m-post-overload-profile-burst-20260427-summary.md`
+- `docs/performance-results/transaction-100m-post-overload-profile-prom-vu3-20260427-summary.md`
+- `docs/performance-results/t3micro-defensive-gates-post-overload-profile-20260427.md`

--- a/docs/performance-results/t3micro-defensive-gates-post-overload-profile-20260427.md
+++ b/docs/performance-results/t3micro-defensive-gates-post-overload-profile-20260427.md
@@ -1,0 +1,26 @@
+# t3micro-defensive-gates-post-overload-profile-20260427
+
+## Inputs
+
+- capacityResult: missing
+- sseResult: missing
+- admissionSummary: missing
+- outboxSummary: missing
+- k6Summary: docs/performance-results/transaction-100m-post-overload-profile-vu16-overload-20260427-summary.md
+- memorySummary: build/reports/t3micro/post-overload-profile-memory-summary.tsv
+
+## Gate Summary
+
+| Gate | Status | Peak CPU % | Peak Memory MiB | Backlog / Reject Signal | Source |
+| --- | --- | ---: | ---: | --- | --- |
+| capacity | missing | missing | missing | repeat=missing | missing |
+| sse reconnect | missing | missing | missing | clients=missing rounds=missing | missing |
+| http admission | n/a | n/a | n/a | rejected=missing failed_rate=missing | missing |
+| outbox backlog | n/a | n/a | n/a | lag=missing failed=missing dlq=missing | missing |
+| k6 transaction 100m | n/a | n/a | n/a | hotFirstP95=1.2469707999999997 hotCursorP95=1.2110400999999988 coldFirstP95=1.1627785499999999 coldCursorP95=1.169051499999999 429Rate=0.003959109504908281 | docs/performance-results/transaction-100m-post-overload-profile-vu16-overload-20260427-summary.md |
+| total memory | pass | n/a | 743.13 | budget=900 source=build/reports/t3micro/post-overload-profile-memory-summary.tsv | build/reports/t3micro/post-overload-profile-memory-summary.tsv |
+
+## Notes
+
+- missing 값은 해당 gate가 아직 같은 aggregate run에 연결되지 않았음을 뜻합니다.
+- token, 운영 URL, raw Authorization header는 기록하지 않습니다.

--- a/docs/performance-results/transaction-100m-post-overload-profile-burst-20260427-summary.md
+++ b/docs/performance-results/transaction-100m-post-overload-profile-burst-20260427-summary.md
@@ -1,0 +1,74 @@
+# transaction-100m-post-overload-profile-burst-20260427-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-27T13:09:27Z
+- sourceMarkdown: build/reports/k6/transaction-100m-post-overload-profile-burst-20260427-summary.md
+- sourceJson: build/reports/k6/transaction-100m-post-overload-profile-burst-20260427-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 16
+- duration: 20s
+- warmup duration: 10s
+- scenario mode: burst
+- arrival rate: 8/1s
+- burst rate: 256/1s
+- burst duration: 20s
+- pre allocated VUs: 64
+- max VUs: 64
+- limit: 50
+- observability mode: summary-only
+- overload mode: true
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: disabled in overload mode
+- overload 429 rate threshold: 0.015
+- burst 429 rate threshold: 0.1
+- effective overload 429 rate threshold: 0.1
+- overload 503 rate threshold: 0
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- transaction 503 count: 0
+- hot first p95 ms: 0.919959
+- hot first p99 ms: 1.8210999999999997
+- hot first p99.9 ms: 3.744924920000238
+- hot first max ms: 6.551834
+- hot cursor p95 ms: 0.795709
+- hot cursor p99 ms: 1.4162665999999986
+- hot cursor p99.9 ms: 2.9357780000000204
+- hot cursor max ms: 5.003875
+- cold first p95 ms: 0.741875
+- cold first p99 ms: 1.5110909999999982
+- cold first p99.9 ms: 2.654407040000069
+- cold first max ms: 4.022125
+- cold cursor p95 ms: 0.765
+- cold cursor p99 ms: 1.6537245999999992
+- cold cursor p99.9 ms: 3.166315000000064
+- cold cursor max ms: 4.275208
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `summary-only`이면 Prometheus remote write 없이 summary 파일만 남깁니다.

--- a/docs/performance-results/transaction-100m-post-overload-profile-prom-vu3-20260427-summary.md
+++ b/docs/performance-results/transaction-100m-post-overload-profile-prom-vu3-20260427-summary.md
@@ -1,0 +1,74 @@
+# transaction-100m-post-overload-profile-prom-vu3-20260427-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-27T13:10:11Z
+- sourceMarkdown: build/reports/k6/transaction-100m-post-overload-profile-prom-vu3-20260427-summary.md
+- sourceJson: build/reports/k6/transaction-100m-post-overload-profile-prom-vu3-20260427-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 3
+- duration: 15s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 20s
+- pre allocated VUs: 3
+- max VUs: 3
+- limit: 50
+- observability mode: prometheus
+- overload mode: false
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: 0.01
+- overload 429 rate threshold: disabled outside overload mode
+- burst 429 rate threshold: disabled outside overload mode
+- effective overload 429 rate threshold: disabled outside overload mode
+- overload 503 rate threshold: disabled outside overload mode
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- transaction 503 count: n/a
+- hot first p95 ms: 1.2773019999999997
+- hot first p99 ms: 3.0316168999999964
+- hot first p99.9 ms: 14.608174760000159
+- hot first max ms: 43.30225
+- hot cursor p95 ms: 1.2025524999999995
+- hot cursor p99 ms: 3.7609352999999786
+- hot cursor p99.9 ms: 15.566960495000481
+- hot cursor max ms: 42.727917
+- cold first p95 ms: 1.1483539999999974
+- cold first p99 ms: 2.82745
+- cold first p99.9 ms: 13.033798120000286
+- cold first max ms: 36.748167
+- cold cursor p95 ms: 1.28031275
+- cold cursor p99 ms: 3.2148255499999987
+- cold cursor p99.9 ms: 15.518841890000003
+- cold cursor max ms: 42.026583
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `prometheus`이면 Prometheus remote write와 summary 파일을 함께 남깁니다.

--- a/docs/performance-results/transaction-100m-post-overload-profile-vu16-overload-20260427-summary.md
+++ b/docs/performance-results/transaction-100m-post-overload-profile-vu16-overload-20260427-summary.md
@@ -1,0 +1,74 @@
+# transaction-100m-post-overload-profile-vu16-overload-20260427-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-27T13:06:50Z
+- sourceMarkdown: build/reports/k6/transaction-100m-post-overload-profile-vu16-overload-20260427-summary.md
+- sourceJson: build/reports/k6/transaction-100m-post-overload-profile-vu16-overload-20260427-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 16
+- duration: 30s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 20s
+- pre allocated VUs: 16
+- max VUs: 16
+- limit: 50
+- observability mode: summary-only
+- overload mode: true
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: disabled in overload mode
+- overload 429 rate threshold: 0.015
+- burst 429 rate threshold: 0.1
+- effective overload 429 rate threshold: 0.015
+- overload 503 rate threshold: 0
+
+## Results
+
+- http_req_failed rate: 0.0035115521060308658
+- checks rate: 1
+- transaction 429 rate: 0.003959109504908281
+- transaction 503 rate: 0
+- transaction 503 count: 0
+- hot first p95 ms: 1.2469707999999997
+- hot first p99 ms: 3.5181605599999988
+- hot first p99.9 ms: 12.691568750000195
+- hot first max ms: 44.580709
+- hot cursor p95 ms: 1.2110400999999988
+- hot cursor p99 ms: 2.9920076799999973
+- hot cursor p99.9 ms: 13.998792918000175
+- hot cursor max ms: 56.253625
+- cold first p95 ms: 1.1627785499999999
+- cold first p99 ms: 2.805119789999999
+- cold first p99.9 ms: 13.728642821000262
+- cold first max ms: 55.933709
+- cold cursor p95 ms: 1.169051499999999
+- cold cursor p99 ms: 2.830197999999997
+- cold cursor p99.9 ms: 13.549271975000021
+- cold cursor max ms: 53.407458
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `summary-only`이면 Prometheus remote write 없이 summary 파일만 남깁니다.

--- a/docs/performance-results/transaction-100m-post-overload-profile-vu3-20260427-summary.md
+++ b/docs/performance-results/transaction-100m-post-overload-profile-vu3-20260427-summary.md
@@ -1,0 +1,74 @@
+# transaction-100m-post-overload-profile-vu3-20260427-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-27T13:05:29Z
+- sourceMarkdown: build/reports/k6/transaction-100m-post-overload-profile-vu3-20260427-summary.md
+- sourceJson: build/reports/k6/transaction-100m-post-overload-profile-vu3-20260427-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- vus: 3
+- duration: 30s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 20s
+- pre allocated VUs: 3
+- max VUs: 3
+- limit: 50
+- observability mode: summary-only
+- overload mode: false
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: 0.01
+- overload 429 rate threshold: disabled outside overload mode
+- burst 429 rate threshold: disabled outside overload mode
+- effective overload 429 rate threshold: disabled outside overload mode
+- overload 503 rate threshold: disabled outside overload mode
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- transaction 503 count: n/a
+- hot first p95 ms: 1.187999599999999
+- hot first p99 ms: 2.4908886399999974
+- hot first p99.9 ms: 12.544145136000854
+- hot first max ms: 41.390709
+- hot cursor p95 ms: 1.1993251999999999
+- hot cursor p99 ms: 2.639366999999998
+- hot cursor p99.9 ms: 12.461267228000574
+- hot cursor max ms: 38.631833
+- cold first p95 ms: 1.2362831999999992
+- cold first p99 ms: 2.5518852799999996
+- cold first p99.9 ms: 13.555647864000811
+- cold first max ms: 36.461792
+- cold cursor p95 ms: 1.2361917999999985
+- cold cursor p99 ms: 2.6588627199999966
+- cold cursor p99.9 ms: 12.874571908000092
+- cold cursor max ms: 42.823709
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `summary-only`이면 Prometheus remote write 없이 summary 파일만 남깁니다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #475

## 🌿 Base Branch
- `main`

## 📝 Summary
- 최신 `main@686d178` 기준으로 로컬 Docker t3.micro 1억 row 거래 조회와 대용량 트래픽 방어 재검증 결과를 문서화합니다.
- fixture DB gate, k6 baseline/overload/burst/Prometheus, aggregate gate 결과를 분리해 남은 병목 후보를 PR/issue 단위로 정리합니다.

## 🛠 Changes
- 100m post-overload-profile 재검증 병목 리포트 추가
- k6 baseline, overload, burst, Prometheus mode summary 문서 보존
- t3.micro defensive aggregate k6+memory 결과 문서 보존

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-transaction-100m-fixture-dataset-probe.sh`
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-deps` baseline VU3
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-deps` overload VU16
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-deps` burst 256/s
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-deps` Prometheus mode
- `tools/test/run-transaction-100m-capacity-gates.sh --print-plan`
- `tools/test/run-t3micro-defensive-gates-aggregate-report.sh`
- `git diff --cached --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 문서 PR이라 런타임 영향 없음. capacity runner는 off-host Docker context 미구성으로 실행 차단 상태를 기록했습니다.
- 롤백 방법: 이 PR의 문서 커밋 revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
