### PR TITLE
[Perf] fixture DB gate index-only probe 및 crash-safe recovery

### DIFF
--- a/ops/k6/transaction-read-100m.js
+++ b/ops/k6/transaction-read-100m.js
@@ -44,6 +44,7 @@ const hotMaxThresholdMs = Number(__ENV.K6_HOT_MAX_THRESHOLD_MS || "3000");
 const coldMaxThresholdMs = Number(__ENV.K6_COLD_MAX_THRESHOLD_MS || "5000");
 const failedRate = Number(__ENV.K6_HTTP_FAILED_RATE || "0.01");
 const reportName = __ENV.K6_REPORT_NAME || "transaction-100m";
+const runId = __ENV.K6_RUN_ID || reportName;
 const observabilityMode = __ENV.K6_OBSERVABILITY_MODE || "prometheus";
 const overloadMode = booleanEnv(__ENV.K6_OVERLOAD_MODE);
 const overload429RateThreshold = nonNegativeNumberEnv(__ENV.K6_OVERLOAD_429_RATE_THRESHOLD, 0.015);
@@ -188,6 +189,7 @@ export const options = {
   tags: {
     service: "aquila-bank",
     workload: "transaction-read-100m",
+    run_id: runId,
   },
 };
 
@@ -399,6 +401,7 @@ function markdownSummary(data) {
 ## Environment
 
 - baseUrl: ${baseUrl}
+- run id: ${runId}
 - vus: ${vus}
 - duration: ${duration}
 - warmup duration: ${warmupDuration}

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -19,6 +19,8 @@ grep -F "backend: aquila-bank-backend:8080 with t3.micro budget" <<<"${plan}" >/
 grep -F "observability: prometheus:9090 grafana:3000 alertmanager:9093 postgres-exporter:9187" <<<"${plan}" >/dev/null
 grep -F "observability resources: prometheus=0.25/256m grafana=0.20/256m alertmanager=0.10/128m postgres-exporter=0.10/128m" <<<"${plan}" >/dev/null
 grep -F "k6 report name: transaction-100m-check" <<<"${plan}" >/dev/null
+grep -F "run id=transaction-100m-check" <<<"${plan}" >/dev/null
+grep -F "run context=build/reports/k6/transaction-100m-check-run-context.env" <<<"${plan}" >/dev/null
 grep -F "hot p99 threshold ms=750" <<<"${plan}" >/dev/null
 grep -F "cold p99 threshold ms=1500" <<<"${plan}" >/dev/null
 grep -F "hot p99.9 threshold ms=1200" <<<"${plan}" >/dev/null
@@ -35,6 +37,7 @@ grep -F "summary gate=true" <<<"${plan}" >/dev/null
 grep -F "backend readiness gate=true path=/actuator/health/readiness timeout=120" <<<"${plan}" >/dev/null
 grep -F "postgres health gate=true required_status=healthy" <<<"${plan}" >/dev/null
 grep -F "postgres recovery gate=true stable_seconds=10" <<<"${plan}" >/dev/null
+grep -F "postgres recovery noise window seconds=30" <<<"${plan}" >/dev/null
 grep -F "postgres exporter stable gate=true timeout=60" <<<"${plan}" >/dev/null
 grep -F "generator mode=local" <<<"${plan}" >/dev/null
 grep -F "generator runner=docker compose service k6-transaction-read-100m" <<<"${plan}" >/dev/null
@@ -165,6 +168,8 @@ grep -F "p(99)<" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "p(99.9)<" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "max<" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "K6_OVERLOAD_MODE" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "K6_RUN_ID" ops/k6/transaction-read-100m.js >/dev/null
+grep -F "run_id: runId" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "AQUILA_K6_SCENARIO_MODE" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "AQUILA_K6_VUS" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "AQUILA_K6_DURATION" ops/k6/transaction-read-100m.js >/dev/null
@@ -224,6 +229,10 @@ grep -F "K6_OVERLOAD_503_RATE_THRESHOLD" tools/test/run-k6-transaction-100m-load
 grep -F "K6_GENERATOR_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_OBSERVABILITY_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_BACKEND_READINESS_GATE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_RUN_ID" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "write_run_context" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "RECOVERY_NOISE_WINDOW_SECONDS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "wait_for_backend_readiness" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "LOADTEST_PROMETHEUS_CPUS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "LOADTEST_GRAFANA_MEMORY" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
@@ -336,6 +345,10 @@ if K6_POSTGRES_HEALTH_GATE=bad tools/test/run-k6-transaction-100m-loadtest.sh --
 fi
 if K6_POSTGRES_RECOVERY_STABLE_SECONDS=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
   echo "K6_POSTGRES_RECOVERY_STABLE_SECONDS=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS=bad unexpectedly succeeded" >&2
   exit 1
 fi
 if K6_POSTGRES_EXPORTER_STABLE_GATE=bad tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then

--- a/tools/test/check-transaction-100m-artifact-readiness.sh
+++ b/tools/test/check-transaction-100m-artifact-readiness.sh
@@ -74,6 +74,8 @@ k6_plan="$(
     "${runner}" --print-plan
 )"
 grep -F "artifact_gate=tools/test/validate-transaction-100m-fixture-artifact.sh --verify" <<<"${k6_plan}" >/dev/null
+grep -F "db_gate_artifact=${dump_path}.db-gate.env" <<<"${k6_plan}" >/dev/null
+grep -F "dataset_source=existing-artifact-or-probe" <<<"${k6_plan}" >/dev/null
 grep -F "k6_no_deps=true" <<<"${k6_plan}" >/dev/null
 
 echo "[transaction-100m-artifact] fresh-volume dry-run preflight order"
@@ -89,6 +91,16 @@ if [[ -z "${preflight_line}" || -z "${volume_line}" || "${preflight_line}" -ge "
   echo "artifact preflight must be planned before docker volume rm" >&2
   exit 1
 fi
+grep -F "db gate artifact: ${dump_path}.db-gate.env" <<<"${dry_run}" >/dev/null
+grep -F "source existing dataset env when db gate artifact passed" <<<"${dry_run}" >/dev/null
+
+echo "[transaction-100m-artifact] wrapper artifact reuse contract"
+grep -F "dataset_artifacts_ready" "${runner}" >/dev/null
+grep -F "load_dataset_env_or_probe" "${runner}" >/dev/null
+grep -F "FIXTURE_DATASET_DB_GATE_STATUS=passed" "${runner}" >/dev/null
+grep -F "dataset_artifacts_ready" "${fresh_runner}" >/dev/null
+grep -F "load_dataset_env_or_probe" "${fresh_runner}" >/dev/null
+grep -F "FIXTURE_DATASET_DB_GATE_STATUS=passed" "${fresh_runner}" >/dev/null
 
 echo "[transaction-100m-artifact] invalid input fails"
 if FRESH_VOLUME_DUMP_MISSING_MODE=bad "${fresh_runner}" --print-plan >/dev/null 2>&1; then

--- a/tools/test/check-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/check-transaction-100m-fixture-dataset-probe.sh
@@ -35,6 +35,7 @@ plan="$(
   FIXTURE_PATH="${dump_path}" \
   FIXTURE_MANIFEST_PATH="${manifest_path}" \
   FIXTURE_DATASET_ENV_PATH="${env_path}" \
+  FIXTURE_DATASET_RUN_ID=dataset-probe-check \
     "${script}" --print-plan
 )"
 grep -F "mode=print-plan" <<<"${plan}" >/dev/null
@@ -42,6 +43,7 @@ grep -F "manifest=${manifest_path}" <<<"${plan}" >/dev/null
 grep -F "dataset_env=${env_path}" <<<"${plan}" >/dev/null
 grep -F "db_gate=true" <<<"${plan}" >/dev/null
 grep -F "db_fallback=false" <<<"${plan}" >/dev/null
+grep -F "run_id=dataset-probe-check" <<<"${plan}" >/dev/null
 grep -F "min_window_rows=51" <<<"${plan}" >/dev/null
 grep -F "estimate_tolerance_rows=1000" <<<"${plan}" >/dev/null
 grep -F "db_report=${dump_path}.db-gate.env" <<<"${plan}" >/dev/null
@@ -50,6 +52,9 @@ grep -F "query_lock_timeout_ms=1000" <<<"${plan}" >/dev/null
 grep -F "query_work_mem=2MB" <<<"${plan}" >/dev/null
 grep -F "query_temp_file_limit=8MB" <<<"${plan}" >/dev/null
 grep -F "query_read_only=true" <<<"${plan}" >/dev/null
+grep -F "db_failure_report=${dump_path}.db-gate-dataset-probe-check.failure.env" <<<"${plan}" >/dev/null
+grep -F "recovery_on_failure=true" <<<"${plan}" >/dev/null
+grep -F "recovery_wait_seconds=90" <<<"${plan}" >/dev/null
 grep -F "window_probe_mode=index-only-bounded" <<<"${plan}" >/dev/null
 grep -F "window_probe_limit=51" <<<"${plan}" >/dev/null
 grep -F "db_gate_checks=partition-estimate-tolerance,index-only-bounded-window-probe,monthly-partition" <<<"${plan}" >/dev/null
@@ -103,6 +108,10 @@ grep -F "index_only_window_probe" "${script}" >/dev/null
 grep -F "ORDER BY booked_at DESC, id DESC" "${script}" >/dev/null
 grep -F "LIMIT \${min_window_rows}" "${script}" >/dev/null
 grep -F "write_db_gate_report" "${script}" >/dev/null
+grep -F "write_db_gate_failure_report" "${script}" >/dev/null
+grep -F "wait_for_postgres_recovery_after_failure" "${script}" >/dev/null
+grep -F "FIXTURE_DATASET_DB_GATE_STATUS=failed" "${script}" >/dev/null
+grep -F "FIXTURE_DATASET_DB_FAILURE_STAGE" "${script}" >/dev/null
 grep -F "BEGIN READ ONLY" "${script}" >/dev/null
 grep -F "SET LOCAL statement_timeout" "${script}" >/dev/null
 grep -F "SET LOCAL lock_timeout" "${script}" >/dev/null
@@ -119,5 +128,13 @@ grep -F "run-transaction-100m-fixture-dataset-probe.sh" tools/test/run-transacti
 echo "[transaction-100m-dataset-probe] invalid input fails"
 if FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT=bad "${script}" --print-plan >/dev/null 2>&1; then
   echo "FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if FIXTURE_DATASET_RECOVERY_ON_FAILURE=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "FIXTURE_DATASET_RECOVERY_ON_FAILURE=bad unexpectedly succeeded" >&2
+  exit 1
+fi
+if FIXTURE_DATASET_RECOVERY_WAIT_SECONDS=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "FIXTURE_DATASET_RECOVERY_WAIT_SECONDS=bad unexpectedly succeeded" >&2
   exit 1
 fi

--- a/tools/test/check-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/check-transaction-100m-fixture-dataset-probe.sh
@@ -48,8 +48,11 @@ grep -F "db_report=${dump_path}.db-gate.env" <<<"${plan}" >/dev/null
 grep -F "query_statement_timeout_ms=3000" <<<"${plan}" >/dev/null
 grep -F "query_lock_timeout_ms=1000" <<<"${plan}" >/dev/null
 grep -F "query_work_mem=2MB" <<<"${plan}" >/dev/null
+grep -F "query_temp_file_limit=8MB" <<<"${plan}" >/dev/null
 grep -F "query_read_only=true" <<<"${plan}" >/dev/null
-grep -F "db_gate_checks=partition-estimate-tolerance,bounded-window-count,monthly-partition" <<<"${plan}" >/dev/null
+grep -F "window_probe_mode=index-only-bounded" <<<"${plan}" >/dev/null
+grep -F "window_probe_limit=51" <<<"${plan}" >/dev/null
+grep -F "db_gate_checks=partition-estimate-tolerance,index-only-bounded-window-probe,monthly-partition" <<<"${plan}" >/dev/null
 
 echo "[transaction-100m-dataset-probe] estimate tolerance contract"
 FIXTURE_DATASET_ASSERT_LABEL=total_estimate \
@@ -96,11 +99,25 @@ grep -F "partition_name_for_month" "${script}" >/dev/null
 grep -F "assert_partition_exists transaction_read_model" "${script}" >/dev/null
 grep -F "assert_partition_exists transaction_read_model_archive" "${script}" >/dev/null
 grep -F "assert_estimate_at_least" "${script}" >/dev/null
+grep -F "index_only_window_probe" "${script}" >/dev/null
+grep -F "ORDER BY booked_at DESC, id DESC" "${script}" >/dev/null
+grep -F "LIMIT \${min_window_rows}" "${script}" >/dev/null
 grep -F "write_db_gate_report" "${script}" >/dev/null
 grep -F "BEGIN READ ONLY" "${script}" >/dev/null
 grep -F "SET LOCAL statement_timeout" "${script}" >/dev/null
 grep -F "SET LOCAL lock_timeout" "${script}" >/dev/null
 grep -F "SET LOCAL work_mem" "${script}" >/dev/null
+grep -F "SET LOCAL temp_file_limit" "${script}" >/dev/null
 grep -F "FIXTURE_DATASET_MIN_WINDOW_ROWS" "${script}" >/dev/null
+if grep -F "bounded-window-count" "${script}" >/dev/null; then
+  echo "dataset probe still reports bounded-window-count instead of index-only bounded probe" >&2
+  exit 1
+fi
 grep -F "run-transaction-100m-fixture-dataset-probe.sh" tools/test/run-transaction-100m-artifact-ready-k6.sh >/dev/null
 grep -F "run-transaction-100m-fixture-dataset-probe.sh" tools/test/run-transaction-100m-fresh-volume-restore-k6.sh >/dev/null
+
+echo "[transaction-100m-dataset-probe] invalid input fails"
+if FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT=bad unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -15,6 +15,7 @@ Required environment:
 
 Optional environment:
   K6_REPORT_NAME       default transaction-100m-<timestamp>
+  K6_RUN_ID            default K6_REPORT_NAME; propagated to k6 tags and run context
   K6_VUS               default 8
   K6_DURATION          default 1m
   K6_SCENARIO_MODE     constant-vus|constant-arrival-rate|burst, default constant-vus
@@ -38,6 +39,7 @@ Optional environment:
   K6_POSTGRES_HEALTH_GATE require PostgreSQL Docker health=healthy before k6, default true
   K6_POSTGRES_RECOVERY_GATE require pg_is_in_recovery()=false before k6, default true
   K6_POSTGRES_RECOVERY_STABLE_SECONDS re-check non-recovery after this delay, default 10
+  K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS wait after recovery gate before measured run, default 30
   K6_POSTGRES_EXPORTER_STABLE_GATE require pg_up=1 before k6 when prometheus mode, default true
   K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS default 60
   K6_OUTBOX_PREFLIGHT  run local outbox backlog gate before k6, default false
@@ -267,6 +269,7 @@ K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
 K6_POSTGRES_HEALTH_GATE="${K6_POSTGRES_HEALTH_GATE:-true}"
 K6_POSTGRES_RECOVERY_GATE="${K6_POSTGRES_RECOVERY_GATE:-true}"
 K6_POSTGRES_RECOVERY_STABLE_SECONDS="${K6_POSTGRES_RECOVERY_STABLE_SECONDS:-10}"
+K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS="${K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS:-30}"
 K6_POSTGRES_EXPORTER_STABLE_GATE="${K6_POSTGRES_EXPORTER_STABLE_GATE:-true}"
 K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS="${K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS:-60}"
 K6_OUTBOX_PREFLIGHT="${K6_OUTBOX_PREFLIGHT:-false}"
@@ -292,6 +295,7 @@ K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS="${K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS:-30}"
 K6_REMOTE_PREFLIGHT_IMAGE="${K6_REMOTE_PREFLIGHT_IMAGE:-curlimages/curl:8.11.1}"
 K6_REMOTE_READINESS_PATH="${K6_REMOTE_READINESS_PATH:-/actuator/health/readiness}"
 K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-$(date +%Y-%m-%d-%H%M%S)}"
+K6_RUN_ID="${K6_RUN_ID:-${K6_REPORT_NAME}}"
 loadtest_db_port="${LOADTEST_DB_PORT:-15432}"
 loadtest_backend_port="${LOADTEST_BACKEND_PORT:-18080}"
 loadtest_prometheus_port="${LOADTEST_PROMETHEUS_PORT:-19090}"
@@ -308,7 +312,7 @@ loadtest_postgres_exporter_cpus="${LOADTEST_POSTGRES_EXPORTER_CPUS:-0.10}"
 loadtest_postgres_exporter_memory="${LOADTEST_POSTGRES_EXPORTER_MEMORY:-128m}"
 loadtest_postgres_container="${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}"
 loadtest_backend_container="${LOADTEST_BACKEND_CONTAINER_NAME:-aquila-bank-backend-loadtest}"
-export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_WARMUP_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_BURST_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REMOTE_PREFLIGHT K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS K6_REMOTE_PREFLIGHT_IMAGE K6_REMOTE_READINESS_PATH K6_REPORT_NAME
+export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_WARMUP_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_BURST_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REMOTE_PREFLIGHT K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS K6_REMOTE_PREFLIGHT_IMAGE K6_REMOTE_READINESS_PATH K6_REPORT_NAME K6_RUN_ID
 
 require_positive_integer K6_VUS
 require_positive_integer K6_RATE
@@ -346,6 +350,7 @@ require_bool_value K6_POSTGRES_RECOVERY_GATE
 require_bool_value K6_POSTGRES_EXPORTER_STABLE_GATE
 require_positive_integer K6_BACKEND_READINESS_TIMEOUT_SECONDS
 require_non_negative_integer K6_POSTGRES_RECOVERY_STABLE_SECONDS
+require_non_negative_integer K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS
 require_positive_integer K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS
 require_bool_value K6_REMOTE_PREFLIGHT
 require_positive_integer K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS
@@ -376,6 +381,7 @@ report_dir="build/reports/k6"
 summary_md="${report_dir}/${K6_REPORT_NAME}-summary.md"
 summary_json="${report_dir}/${K6_REPORT_NAME}-summary.json"
 k6_runner_log="${report_dir}/${K6_REPORT_NAME}-runner.log"
+run_context_env="${report_dir}/${K6_REPORT_NAME}-run-context.env"
 psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
 
 require_command() {
@@ -465,6 +471,8 @@ print_plan() {
   echo "[k6-transaction-100m] observability resources: prometheus=${loadtest_prometheus_cpus}/${loadtest_prometheus_memory} grafana=${loadtest_grafana_cpus}/${loadtest_grafana_memory} alertmanager=${loadtest_alertmanager_cpus}/${loadtest_alertmanager_memory} postgres-exporter=${loadtest_postgres_exporter_cpus}/${loadtest_postgres_exporter_memory}"
   echo "[k6-transaction-100m] observability mode=${K6_OBSERVABILITY_MODE}"
   echo "[k6-transaction-100m] k6 report name: ${K6_REPORT_NAME}"
+  echo "[k6-transaction-100m] run id=${K6_RUN_ID}"
+  echo "[k6-transaction-100m] run context=${run_context_env}"
   echo "[k6-transaction-100m] k6 vus=${K6_VUS} duration=${K6_DURATION:-1m} limit=${K6_LIMIT}"
   echo "[k6-transaction-100m] scenario mode=${K6_SCENARIO_MODE}"
   echo "[k6-transaction-100m] arrival rate=${K6_RATE} timeUnit=${K6_TIME_UNIT} preAllocatedVUs=${K6_PRE_ALLOCATED_VUS} maxVUs=${K6_MAX_VUS}"
@@ -488,6 +496,7 @@ print_plan() {
   echo "[k6-transaction-100m] backend readiness gate=${K6_BACKEND_READINESS_GATE} path=${K6_BACKEND_READINESS_PATH} timeout=${K6_BACKEND_READINESS_TIMEOUT_SECONDS}"
   echo "[k6-transaction-100m] postgres health gate=${K6_POSTGRES_HEALTH_GATE} required_status=healthy"
   echo "[k6-transaction-100m] postgres recovery gate=${K6_POSTGRES_RECOVERY_GATE} stable_seconds=${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
+  echo "[k6-transaction-100m] postgres recovery noise window seconds=${K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS}"
   echo "[k6-transaction-100m] postgres exporter stable gate=${K6_POSTGRES_EXPORTER_STABLE_GATE} timeout=${K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS}"
   echo "[k6-transaction-100m] generator mode=${K6_GENERATOR_MODE}"
   if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
@@ -544,6 +553,24 @@ require_env K6_COLD_FROM
 require_env K6_COLD_TO
 
 mkdir -p "${report_dir}"
+
+write_run_context() {
+  {
+    echo "K6_RUN_ID=${K6_RUN_ID}"
+    echo "K6_REPORT_NAME=${K6_REPORT_NAME}"
+    echo "K6_RUN_PURPOSE=${K6_RUN_PURPOSE}"
+    echo "K6_SCENARIO_MODE=${K6_SCENARIO_MODE}"
+    echo "RECOVERY_GATE=${K6_POSTGRES_RECOVERY_GATE}"
+    echo "RECOVERY_STABLE_SECONDS=${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
+    echo "RECOVERY_NOISE_WINDOW_SECONDS=${K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS}"
+    echo "POSTGRES_CONTAINER=${loadtest_postgres_container}"
+    echo "SUMMARY_JSON=${summary_json}"
+    echo "RUNNER_LOG=${k6_runner_log}"
+  } >"${run_context_env}"
+  echo "[k6-transaction-100m] run context written=${run_context_env}"
+}
+
+write_run_context
 
 assert_k6_preflight() {
   if [[ "${K6_PREFLIGHT}" != "true" ]]; then
@@ -632,6 +659,14 @@ assert_postgres_recovery_preflight() {
     fi
   fi
   echo "[k6-transaction-100m] pg_is_in_recovery()=false stable_seconds=${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
+}
+
+wait_for_postgres_recovery_noise_window() {
+  if [[ "${K6_POSTGRES_RECOVERY_GATE}" != "true" || "${K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS}" -eq 0 ]]; then
+    return 0
+  fi
+  echo "[k6-transaction-100m] isolating post-crash recovery noise window seconds=${K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS}"
+  sleep "${K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS}"
 }
 
 wait_for_postgres_exporter_stability() {
@@ -745,6 +780,7 @@ fi
 
 wait_for_backend_readiness
 assert_k6_preflight
+wait_for_postgres_recovery_noise_window
 run_outbox_preflight
 assert_remote_k6_preflight
 run_explain_snapshot pre
@@ -765,6 +801,7 @@ run_k6_local() {
   # summary-only는 k6 결과 파일만 남겨 same-host observability 비용을 제외합니다.
   docker compose "${compose_files[@]}" --profile loadtest run "${run_args[@]}" \
     -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
+    -e K6_RUN_ID="${K6_RUN_ID}" \
     -e K6_OBSERVABILITY_MODE="${K6_OBSERVABILITY_MODE}" \
     -e K6_PROMETHEUS_RW_TREND_STATS="p(50),p(90),p(95),p(99),p(99.9),min,max,avg" \
     -e AQUILA_K6_SCENARIO_MODE="${K6_SCENARIO_MODE}" \
@@ -821,6 +858,7 @@ run_k6_docker_context() {
     -e K6_PROMETHEUS_RW_SERVER_URL="${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" \
     -e K6_PROMETHEUS_RW_TREND_STATS="p(50),p(90),p(95),p(99),p(99.9),min,max,avg" \
     -e K6_REPORT_NAME="${K6_REPORT_NAME}" \
+    -e K6_RUN_ID="${K6_RUN_ID}" \
     -e K6_OBSERVABILITY_MODE="${K6_OBSERVABILITY_MODE}" \
     -e AQUILA_K6_SCENARIO_MODE="${K6_SCENARIO_MODE}" \
     -e AQUILA_K6_RATE="${K6_RATE}" \

--- a/tools/test/run-transaction-100m-artifact-ready-k6.sh
+++ b/tools/test/run-transaction-100m-artifact-ready-k6.sh
@@ -57,6 +57,7 @@ fixture_name="${FIXTURE_NAME:-transaction-100m-fixture}"
 fixture_dir="${FIXTURE_DIR:-build/fixtures}"
 fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
 dataset_env_path="${FIXTURE_DATASET_ENV_PATH:-${fixture_path}.dataset.env}"
+db_gate_artifact_path="${FIXTURE_DATASET_DB_REPORT_PATH:-${fixture_path}.db-gate.env}"
 k6_no_deps="${ARTIFACT_READY_K6_NO_DEPS:-true}"
 K6_REPORT_NAME="${K6_REPORT_NAME:-transaction-100m-artifact-ready-$(date +%Y-%m-%d-%H%M%S)}"
 export K6_REPORT_NAME
@@ -70,6 +71,8 @@ print_plan() {
   echo "[transaction-100m-artifact-ready-k6] artifact_gate=tools/test/validate-transaction-100m-fixture-artifact.sh --verify"
   echo "[transaction-100m-artifact-ready-k6] dataset_probe=tools/test/run-transaction-100m-fixture-dataset-probe.sh"
   echo "[transaction-100m-artifact-ready-k6] dataset_env=${dataset_env_path}"
+  echo "[transaction-100m-artifact-ready-k6] db_gate_artifact=${db_gate_artifact_path}"
+  echo "[transaction-100m-artifact-ready-k6] dataset_source=existing-artifact-or-probe"
   echo "[transaction-100m-artifact-ready-k6] k6_runner=tools/test/run-k6-transaction-100m-loadtest.sh --no-up"
   echo "[transaction-100m-artifact-ready-k6] k6_no_deps=${k6_no_deps}"
   echo "[transaction-100m-artifact-ready-k6] k6 report=${K6_REPORT_NAME}"
@@ -77,6 +80,8 @@ print_plan() {
 
 print_dry_run() {
   echo "FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} tools/test/validate-transaction-100m-fixture-artifact.sh --verify"
+  echo "db gate artifact: ${db_gate_artifact_path}"
+  echo "source existing dataset env when db gate artifact passed"
   echo "FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} FIXTURE_DATASET_ENV_PATH=${dataset_env_path} tools/test/run-transaction-100m-fixture-dataset-probe.sh"
   if [[ "${k6_no_deps}" == "true" ]]; then
     echo "K6_REPORT_NAME=${K6_REPORT_NAME} tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps"
@@ -85,15 +90,33 @@ print_dry_run() {
   fi
 }
 
+dataset_artifacts_ready() {
+  [[ -s "${dataset_env_path}" && -s "${db_gate_artifact_path}" ]] || return 1
+  grep -F "FIXTURE_DATASET_DB_GATE_STATUS=passed" "${db_gate_artifact_path}" >/dev/null \
+    || grep -F "FIXTURE_DATASET_DB_GATE=passed" "${db_gate_artifact_path}" >/dev/null
+}
+
+load_dataset_env_or_probe() {
+  if dataset_artifacts_ready; then
+    echo "[transaction-100m-artifact-ready-k6] using existing dataset env and db gate artifact"
+  else
+    FIXTURE_NAME="${fixture_name}" \
+    FIXTURE_PATH="${fixture_path}" \
+    FIXTURE_DATASET_ENV_PATH="${dataset_env_path}" \
+    FIXTURE_DATASET_DB_REPORT_PATH="${db_gate_artifact_path}" \
+      tools/test/run-transaction-100m-fixture-dataset-probe.sh
+  fi
+  set -a
+  # manifest/db-gate artifact가 준비되어 있으면 runtime DB probe 없이 k6 입력만 노출합니다.
+  source "${dataset_env_path}"
+  set +a
+}
+
 run_k6() {
   local args=(--no-up)
   if [[ "${k6_no_deps}" == "true" ]]; then
     args+=(--no-deps)
   fi
-  set -a
-  # manifest 기반 probe 결과만 k6 입력으로 노출해 1억 row 탐색을 피합니다.
-  source "${dataset_env_path}"
-  set +a
   tools/test/run-k6-transaction-100m-loadtest.sh "${args[@]}"
 }
 
@@ -109,8 +132,5 @@ fi
 FIXTURE_NAME="${fixture_name}" \
 FIXTURE_PATH="${fixture_path}" \
   tools/test/validate-transaction-100m-fixture-artifact.sh --verify
-FIXTURE_NAME="${fixture_name}" \
-FIXTURE_PATH="${fixture_path}" \
-FIXTURE_DATASET_ENV_PATH="${dataset_env_path}" \
-  tools/test/run-transaction-100m-fixture-dataset-probe.sh
+load_dataset_env_or_probe
 run_k6

--- a/tools/test/run-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/run-transaction-100m-fixture-dataset-probe.sh
@@ -21,6 +21,7 @@ Environment:
   FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS default 3000
   FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS default 1000
   FIXTURE_DATASET_QUERY_WORK_MEM       default 2MB
+  FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT default 8MB
 
 Manifest keys:
   hot_account_id hot_from hot_to cold_account_id cold_from cold_to
@@ -76,6 +77,7 @@ estimate_tolerance_rows="${FIXTURE_DATASET_ESTIMATE_TOLERANCE_ROWS:-1000}"
 query_statement_timeout_ms="${FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS:-3000}"
 query_lock_timeout_ms="${FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS:-1000}"
 query_work_mem="${FIXTURE_DATASET_QUERY_WORK_MEM:-2MB}"
+query_temp_file_limit="${FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT:-8MB}"
 assert_estimate_label="${FIXTURE_DATASET_ASSERT_LABEL:-estimate}"
 assert_estimate_actual="${FIXTURE_DATASET_ASSERT_ACTUAL:-}"
 assert_estimate_minimum="${FIXTURE_DATASET_ASSERT_MINIMUM:-}"
@@ -110,10 +112,17 @@ require_positive_integer_value "FIXTURE_DATASET_MIN_WINDOW_ROWS" "${min_window_r
 require_non_negative_integer_value "FIXTURE_DATASET_ESTIMATE_TOLERANCE_ROWS" "${estimate_tolerance_rows}"
 require_positive_integer_value "FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS" "${query_statement_timeout_ms}"
 require_positive_integer_value "FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS" "${query_lock_timeout_ms}"
-if ! [[ "${query_work_mem}" =~ ^[1-9][0-9]*(kB|KB|MB|GB)$ ]]; then
-  echo "FIXTURE_DATASET_QUERY_WORK_MEM must use PostgreSQL memory units such as 2048kB or 2MB: ${query_work_mem}" >&2
-  exit 1
-fi
+require_postgres_memory_value() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*(kB|KB|MB|GB)$ ]]; then
+    echo "${key} must use PostgreSQL memory units such as 2048kB or 2MB: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_postgres_memory_value "FIXTURE_DATASET_QUERY_WORK_MEM" "${query_work_mem}"
+require_postgres_memory_value "FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT" "${query_temp_file_limit}"
 
 manifest_value() {
   local key="$1"
@@ -170,10 +179,11 @@ manifest_integer_or_default() {
 
 guarded_sql() {
   local sql="$1"
-  printf "BEGIN READ ONLY;\nSET LOCAL statement_timeout = '%sms';\nSET LOCAL lock_timeout = '%sms';\nSET LOCAL work_mem = '%s';\n%s\nCOMMIT;\n" \
+  printf "BEGIN READ ONLY;\nSET LOCAL statement_timeout = '%sms';\nSET LOCAL lock_timeout = '%sms';\nSET LOCAL work_mem = '%s';\nSET LOCAL temp_file_limit = '%s';\n%s\nCOMMIT;\n" \
     "${query_statement_timeout_ms}" \
     "${query_lock_timeout_ms}" \
     "${query_work_mem}" \
+    "${query_temp_file_limit}" \
     "${sql}"
 }
 
@@ -205,17 +215,23 @@ table_estimate() {
   "
 }
 
-window_count() {
+index_only_window_probe() {
   local table="$1"
   local account_id="$2"
   local from="$3"
   local to="$4"
+  # account cursor index 순서로 필요한 최소 sample까지만 읽어 full window count를 피합니다.
   db_scalar "
     SELECT count(*)
-    FROM public.${table}
-    WHERE account_id = '${account_id}'
-      AND booked_at >= '${from}'::timestamptz
-      AND booked_at < '${to}'::timestamptz;
+    FROM (
+      SELECT 1
+      FROM public.${table}
+      WHERE account_id = '${account_id}'
+        AND booked_at >= '${from}'::timestamptz
+        AND booked_at < '${to}'::timestamptz
+      ORDER BY booked_at DESC, id DESC
+      LIMIT ${min_window_rows}
+    ) sample;
   "
 }
 
@@ -313,7 +329,10 @@ write_db_gate_report() {
     echo "FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS=${query_statement_timeout_ms}"
     echo "FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS=${query_lock_timeout_ms}"
     echo "FIXTURE_DATASET_QUERY_WORK_MEM=${query_work_mem}"
+    echo "FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT=${query_temp_file_limit}"
     echo "FIXTURE_DATASET_QUERY_READ_ONLY=true"
+    echo "FIXTURE_DATASET_WINDOW_PROBE_MODE=index-only-bounded"
+    echo "FIXTURE_DATASET_WINDOW_PROBE_LIMIT=${min_window_rows}"
   } >"${db_report_path}"
   echo "[transaction-100m-dataset-probe] db gate report written=${db_report_path}"
 }
@@ -346,8 +365,8 @@ assert_dataset_db_gate() {
   assert_estimate_at_least archive_estimate "${archive_estimate}" "${archive_min}"
   assert_estimate_at_least total_estimate "${total_estimate}" "${total_min}"
 
-  hot_count="$(window_count transaction_read_model "${hot_account_id}" "${hot_from}" "${hot_to}")"
-  cold_count="$(window_count transaction_read_model_archive "${cold_account_id}" "${cold_from}" "${cold_to}")"
+  hot_count="$(index_only_window_probe transaction_read_model "${hot_account_id}" "${hot_from}" "${hot_to}")"
+  cold_count="$(index_only_window_probe transaction_read_model_archive "${cold_account_id}" "${cold_from}" "${cold_to}")"
   assert_integer_at_least hot_window_count "${hot_count}" "${min_window_rows}"
   assert_integer_at_least cold_window_count "${cold_count}" "${min_window_rows}"
   hot_partition="$(assert_partition_exists transaction_read_model "${hot_from}")"
@@ -393,8 +412,11 @@ print_plan() {
   echo "[transaction-100m-dataset-probe] query_statement_timeout_ms=${query_statement_timeout_ms}"
   echo "[transaction-100m-dataset-probe] query_lock_timeout_ms=${query_lock_timeout_ms}"
   echo "[transaction-100m-dataset-probe] query_work_mem=${query_work_mem}"
+  echo "[transaction-100m-dataset-probe] query_temp_file_limit=${query_temp_file_limit}"
   echo "[transaction-100m-dataset-probe] query_read_only=true"
-  echo "[transaction-100m-dataset-probe] db_gate_checks=partition-estimate-tolerance,bounded-window-count,monthly-partition"
+  echo "[transaction-100m-dataset-probe] window_probe_mode=index-only-bounded"
+  echo "[transaction-100m-dataset-probe] window_probe_limit=${min_window_rows}"
+  echo "[transaction-100m-dataset-probe] db_gate_checks=partition-estimate-tolerance,index-only-bounded-window-probe,monthly-partition"
   echo "[transaction-100m-dataset-probe] source_order=manifest,env,db-fallback"
 }
 

--- a/tools/test/run-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/run-transaction-100m-fixture-dataset-probe.sh
@@ -22,6 +22,10 @@ Environment:
   FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS default 1000
   FIXTURE_DATASET_QUERY_WORK_MEM       default 2MB
   FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT default 8MB
+  FIXTURE_DATASET_RUN_ID               default timestamp
+  FIXTURE_DATASET_DB_FAILURE_REPORT_PATH default <FIXTURE_PATH>.db-gate-<run-id>.failure.env
+  FIXTURE_DATASET_RECOVERY_ON_FAILURE  true|false, default true
+  FIXTURE_DATASET_RECOVERY_WAIT_SECONDS default 90
 
 Manifest keys:
   hot_account_id hot_from hot_to cold_account_id cold_from cold_to
@@ -78,6 +82,11 @@ query_statement_timeout_ms="${FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS:-3000}"
 query_lock_timeout_ms="${FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS:-1000}"
 query_work_mem="${FIXTURE_DATASET_QUERY_WORK_MEM:-2MB}"
 query_temp_file_limit="${FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT:-8MB}"
+run_id="${FIXTURE_DATASET_RUN_ID:-$(date +%Y-%m-%d-%H%M%S)}"
+db_failure_report_path="${FIXTURE_DATASET_DB_FAILURE_REPORT_PATH:-${fixture_path}.db-gate-${run_id}.failure.env}"
+recovery_on_failure="${FIXTURE_DATASET_RECOVERY_ON_FAILURE:-true}"
+recovery_wait_seconds="${FIXTURE_DATASET_RECOVERY_WAIT_SECONDS:-90}"
+postgres_container_name="${FIXTURE_POSTGRES_CONTAINER_NAME:-${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}}"
 assert_estimate_label="${FIXTURE_DATASET_ASSERT_LABEL:-estimate}"
 assert_estimate_actual="${FIXTURE_DATASET_ASSERT_ACTUAL:-}"
 assert_estimate_minimum="${FIXTURE_DATASET_ASSERT_MINIMUM:-}"
@@ -86,6 +95,7 @@ psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql --quiet -v
 
 require_bool_value "FIXTURE_DATASET_DB_GATE" "${db_gate}"
 require_bool_value "FIXTURE_DATASET_PROBE_DB_FALLBACK" "${db_fallback}"
+require_bool_value "FIXTURE_DATASET_RECOVERY_ON_FAILURE" "${recovery_on_failure}"
 
 require_non_negative_integer_value() {
   local key="$1"
@@ -112,6 +122,7 @@ require_positive_integer_value "FIXTURE_DATASET_MIN_WINDOW_ROWS" "${min_window_r
 require_non_negative_integer_value "FIXTURE_DATASET_ESTIMATE_TOLERANCE_ROWS" "${estimate_tolerance_rows}"
 require_positive_integer_value "FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS" "${query_statement_timeout_ms}"
 require_positive_integer_value "FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS" "${query_lock_timeout_ms}"
+require_non_negative_integer_value "FIXTURE_DATASET_RECOVERY_WAIT_SECONDS" "${recovery_wait_seconds}"
 require_postgres_memory_value() {
   local key="$1"
   local value="$2"
@@ -123,6 +134,10 @@ require_postgres_memory_value() {
 
 require_postgres_memory_value "FIXTURE_DATASET_QUERY_WORK_MEM" "${query_work_mem}"
 require_postgres_memory_value "FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT" "${query_temp_file_limit}"
+
+sanitize_report_value() {
+  tr '\n\r' '  ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//'
+}
 
 manifest_value() {
   local key="$1"
@@ -161,7 +176,7 @@ probe_from_db() {
       SELECT MIN(booked_at), MAX(booked_at)
       FROM public.${table}
       WHERE account_id = '${account_id}';
-    ")"
+    " "db_fallback_window:${table}")"
   tr -d '[:space:]' <<<"${from_to}"
 }
 
@@ -189,16 +204,104 @@ guarded_sql() {
 
 db_scalar() {
   local sql="$1"
+  local stage="${2:-db_scalar}"
   local output
-  output="$("${psql_base[@]}" --no-align --tuples-only --command "$(guarded_sql "${sql}")")"
+  local status
+  set +e
+  output="$("${psql_base[@]}" --no-align --tuples-only --command "$(guarded_sql "${sql}")" 2>&1)"
+  status=$?
+  set -e
+  if ((status != 0)); then
+    handle_db_gate_query_failure "${stage}" "${status}" "${output}"
+  fi
   awk 'NF {line=$0} END {gsub(/[[:space:]]/, "", line); print line}' <<<"${output}"
 }
 
 db_tuple() {
   local sql="$1"
+  local stage="${2:-db_tuple}"
   local output
-  output="$("${psql_base[@]}" --no-align --tuples-only --field-separator='|' --command "$(guarded_sql "${sql}")")"
+  local status
+  set +e
+  output="$("${psql_base[@]}" --no-align --tuples-only --field-separator='|' --command "$(guarded_sql "${sql}")" 2>&1)"
+  status=$?
+  set -e
+  if ((status != 0)); then
+    handle_db_gate_query_failure "${stage}" "${status}" "${output}"
+  fi
   awk 'NF {line=$0} END {gsub(/[[:space:]]/, "", line); print line}' <<<"${output}"
+}
+
+write_db_gate_failure_report() {
+  local stage="$1"
+  local status="$2"
+  local message="$3"
+  mkdir -p "$(dirname "${db_failure_report_path}")"
+  {
+    echo "FIXTURE_DATASET_DB_GATE_STATUS=failed"
+    echo "FIXTURE_DATASET_RUN_ID=${run_id}"
+    echo "FIXTURE_DATASET_DB_FAILURE_STAGE=${stage}"
+    echo "FIXTURE_DATASET_DB_FAILURE_EXIT_STATUS=${status}"
+    echo "FIXTURE_DATASET_DB_FAILURE_MESSAGE=$(sanitize_report_value <<<"${message}")"
+    echo "FIXTURE_DATASET_DB_REPORT_PATH=${db_report_path}"
+    echo "FIXTURE_DATASET_DB_FAILURE_REPORT_PATH=${db_failure_report_path}"
+    echo "FIXTURE_DATASET_QUERY_STATEMENT_TIMEOUT_MS=${query_statement_timeout_ms}"
+    echo "FIXTURE_DATASET_QUERY_LOCK_TIMEOUT_MS=${query_lock_timeout_ms}"
+    echo "FIXTURE_DATASET_QUERY_WORK_MEM=${query_work_mem}"
+    echo "FIXTURE_DATASET_QUERY_TEMP_FILE_LIMIT=${query_temp_file_limit}"
+    echo "FIXTURE_DATASET_RECOVERY_ON_FAILURE=${recovery_on_failure}"
+    echo "FIXTURE_DATASET_RECOVERY_WAIT_SECONDS=${recovery_wait_seconds}"
+  } >"${db_failure_report_path}"
+  echo "[transaction-100m-dataset-probe] db gate failure report written=${db_failure_report_path}" >&2
+}
+
+wait_for_postgres_recovery_after_failure() {
+  if [[ "${recovery_on_failure}" != "true" ]]; then
+    echo "[transaction-100m-dataset-probe] recovery wait after failure skipped" >&2
+    return 0
+  fi
+
+  local deadline=$((SECONDS + recovery_wait_seconds))
+  local state running restarting oom_killed status in_recovery last_error
+  while ((SECONDS <= deadline)); do
+    if ! state="$(docker inspect "${postgres_container_name}" --format '{{.State.Running}} {{.State.Restarting}} {{.State.OOMKilled}} {{.State.Status}}' 2>/dev/null)"; then
+      last_error="PostgreSQL container not found: ${postgres_container_name}"
+    else
+      read -r running restarting oom_killed status <<<"${state}"
+      if [[ "${oom_killed}" == "true" ]]; then
+        echo "[transaction-100m-dataset-probe] PostgreSQL OOMKilled=true after DB gate failure" >&2
+        return 1
+      fi
+      if [[ "${running}" == "true" && "${restarting}" == "false" && "${status}" == "running" ]]; then
+        if in_recovery="$("${psql_base[@]}" --no-align --tuples-only --command "SELECT pg_is_in_recovery();" 2>/dev/null)"; then
+          in_recovery="$(tr -d '[:space:]' <<<"${in_recovery}")"
+          if [[ "${in_recovery}" != "t" ]]; then
+            echo "[transaction-100m-dataset-probe] postgres recovery closed after DB gate failure" >&2
+            return 0
+          fi
+          last_error="pg_is_in_recovery()=true"
+        else
+          last_error="pg_is_in_recovery query failed"
+        fi
+      else
+        last_error="Running=${running:-unknown} Restarting=${restarting:-unknown} Status=${status:-unknown}"
+      fi
+    fi
+    echo "[transaction-100m-dataset-probe] waiting postgres recovery after DB gate failure: ${last_error}" >&2
+    sleep 5
+  done
+  echo "[transaction-100m-dataset-probe] PostgreSQL recovery wait exceeded after DB gate failure: seconds=${recovery_wait_seconds}" >&2
+  return 1
+}
+
+handle_db_gate_query_failure() {
+  local stage="$1"
+  local status="$2"
+  local output="$3"
+  write_db_gate_failure_report "${stage}" "${status}" "${output}"
+  wait_for_postgres_recovery_after_failure || true
+  echo "dataset probe DB gate query failed: stage=${stage} status=${status} failure_report=${db_failure_report_path}" >&2
+  exit 1
 }
 
 table_estimate() {
@@ -212,7 +315,7 @@ table_estimate() {
     SELECT COALESCE(SUM(GREATEST(item.reltuples, 0))::bigint, 0)
     FROM leaf
     JOIN pg_class item ON item.oid = leaf.relid;
-  "
+  " "table_estimate:${table}"
 }
 
 index_only_window_probe() {
@@ -232,7 +335,7 @@ index_only_window_probe() {
       ORDER BY booked_at DESC, id DESC
       LIMIT ${min_window_rows}
     ) sample;
-  "
+  " "index_only_window_probe:${table}"
 }
 
 partition_name_for_month() {
@@ -252,7 +355,7 @@ assert_partition_exists() {
   local timestamp="$2"
   local partition exists
   partition="$(partition_name_for_month "${table}" "${timestamp}")"
-  exists="$(db_scalar "SELECT to_regclass('public.${partition}') IS NOT NULL;")"
+  exists="$(db_scalar "SELECT to_regclass('public.${partition}') IS NOT NULL;" "partition_exists:${partition}")"
   if [[ "${exists}" != "t" ]]; then
     echo "dataset probe monthly partition is missing: ${partition}" >&2
     exit 1
@@ -314,6 +417,8 @@ write_db_gate_report() {
   mkdir -p "$(dirname "${db_report_path}")"
   {
     echo "FIXTURE_DATASET_DB_GATE=passed"
+    echo "FIXTURE_DATASET_DB_GATE_STATUS=passed"
+    echo "FIXTURE_DATASET_RUN_ID=${run_id}"
     echo "FIXTURE_DATASET_TOTAL_MIN=${total_min}"
     echo "FIXTURE_DATASET_HOT_MIN=${hot_min}"
     echo "FIXTURE_DATASET_ARCHIVE_MIN=${archive_min}"
@@ -402,8 +507,10 @@ print_plan() {
   echo "[transaction-100m-dataset-probe] manifest=${manifest_path}"
   echo "[transaction-100m-dataset-probe] dataset_env=${dataset_env_path}"
   echo "[transaction-100m-dataset-probe] db_report=${db_report_path}"
+  echo "[transaction-100m-dataset-probe] db_failure_report=${db_failure_report_path}"
   echo "[transaction-100m-dataset-probe] db_gate=${db_gate}"
   echo "[transaction-100m-dataset-probe] db_fallback=${db_fallback}"
+  echo "[transaction-100m-dataset-probe] run_id=${run_id}"
   echo "[transaction-100m-dataset-probe] min_total_rows=${min_total_rows:-manifest-total_rows-or-100000000}"
   echo "[transaction-100m-dataset-probe] min_hot_rows=${min_hot_rows:-manifest-hot_rows-or-1}"
   echo "[transaction-100m-dataset-probe] min_archive_rows=${min_archive_rows:-manifest-archive_rows-or-1}"
@@ -414,6 +521,8 @@ print_plan() {
   echo "[transaction-100m-dataset-probe] query_work_mem=${query_work_mem}"
   echo "[transaction-100m-dataset-probe] query_temp_file_limit=${query_temp_file_limit}"
   echo "[transaction-100m-dataset-probe] query_read_only=true"
+  echo "[transaction-100m-dataset-probe] recovery_on_failure=${recovery_on_failure}"
+  echo "[transaction-100m-dataset-probe] recovery_wait_seconds=${recovery_wait_seconds}"
   echo "[transaction-100m-dataset-probe] window_probe_mode=index-only-bounded"
   echo "[transaction-100m-dataset-probe] window_probe_limit=${min_window_rows}"
   echo "[transaction-100m-dataset-probe] db_gate_checks=partition-estimate-tolerance,index-only-bounded-window-probe,monthly-partition"

--- a/tools/test/run-transaction-100m-fresh-volume-restore-k6.sh
+++ b/tools/test/run-transaction-100m-fresh-volume-restore-k6.sh
@@ -70,6 +70,7 @@ fixture_name="${FIXTURE_NAME:-transaction-100m-fixture}"
 fixture_dir="${FIXTURE_DIR:-build/fixtures}"
 fixture_path="${FIXTURE_PATH:-${fixture_dir}/${fixture_name}.dump}"
 dataset_env_path="${FIXTURE_DATASET_ENV_PATH:-${fixture_path}.dataset.env}"
+db_gate_artifact_path="${FIXTURE_DATASET_DB_REPORT_PATH:-${fixture_path}.db-gate.env}"
 volume_name="${FRESH_VOLUME_NAME:-aquila-bank-postgres-data}"
 build_backend="${FRESH_VOLUME_BUILD_BACKEND:-true}"
 k6_enabled="${FRESH_VOLUME_K6_ENABLED:-true}"
@@ -107,6 +108,8 @@ print_plan() {
   echo "[transaction-100m-fresh-volume] dump=${fixture_path}"
   echo "[transaction-100m-fresh-volume] dataset_probe=tools/test/run-transaction-100m-fixture-dataset-probe.sh"
   echo "[transaction-100m-fresh-volume] dataset_env=${dataset_env_path}"
+  echo "[transaction-100m-fresh-volume] db_gate_artifact=${db_gate_artifact_path}"
+  echo "[transaction-100m-fresh-volume] dataset_source=existing-artifact-or-probe"
   echo "[transaction-100m-fresh-volume] build_backend=${build_backend}"
   echo "[transaction-100m-fresh-volume] artifact_preflight=${artifact_preflight}"
   echo "[transaction-100m-fresh-volume] dump_missing_mode=${dump_missing_mode}"
@@ -133,6 +136,8 @@ print_dry_run() {
   echo "docker compose ${compose_files[*]} --profile loadtest up -d postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter"
   echo "FIXTURE_MODE=restore FIXTURE_RESTORE_TRUNCATE=true FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} tools/test/run-transaction-100m-fixture-restore.sh"
   echo "FIXTURE_MODE=verify FIXTURE_VERIFY_MIN_ROWS=${restore_verify_min_rows} FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} tools/test/run-transaction-100m-fixture-restore.sh"
+  echo "db gate artifact: ${db_gate_artifact_path}"
+  echo "source existing dataset env when db gate artifact passed"
   echo "FIXTURE_NAME=${fixture_name} FIXTURE_PATH=${fixture_path} FIXTURE_DATASET_ENV_PATH=${dataset_env_path} tools/test/run-transaction-100m-fixture-dataset-probe.sh"
   if [[ "${dump_missing_mode}" == "seed-only" ]]; then
     echo "if fixture dump is absent: tools/test/prepare-transaction-read-model-100m-fixture.sh"
@@ -263,13 +268,24 @@ verify_fixture() {
     tools/test/run-transaction-100m-fixture-restore.sh
 }
 
-load_dataset_probe() {
-  FIXTURE_NAME="${fixture_name}" \
-  FIXTURE_PATH="${fixture_path}" \
-  FIXTURE_DATASET_ENV_PATH="${dataset_env_path}" \
-    tools/test/run-transaction-100m-fixture-dataset-probe.sh
+dataset_artifacts_ready() {
+  [[ -s "${dataset_env_path}" && -s "${db_gate_artifact_path}" ]] || return 1
+  grep -F "FIXTURE_DATASET_DB_GATE_STATUS=passed" "${db_gate_artifact_path}" >/dev/null \
+    || grep -F "FIXTURE_DATASET_DB_GATE=passed" "${db_gate_artifact_path}" >/dev/null
+}
+
+load_dataset_env_or_probe() {
+  if dataset_artifacts_ready; then
+    echo "[transaction-100m-fresh-volume] using existing dataset env and db gate artifact"
+  else
+    FIXTURE_NAME="${fixture_name}" \
+    FIXTURE_PATH="${fixture_path}" \
+    FIXTURE_DATASET_ENV_PATH="${dataset_env_path}" \
+    FIXTURE_DATASET_DB_REPORT_PATH="${db_gate_artifact_path}" \
+      tools/test/run-transaction-100m-fixture-dataset-probe.sh
+  fi
   set -a
-  # restore 이후 k6 계정/window는 manifest metadata에서 받아 DB full scan을 피합니다.
+  # restore 이후 k6 계정/window는 준비된 artifact에서 받아 DB 검증 쿼리 반복을 피합니다.
   source "${dataset_env_path}"
   set +a
   hot_account_id="${K6_HOT_ACCOUNT_ID:-${hot_account_id}}"
@@ -325,7 +341,7 @@ if [[ "${artifact_ready}" == "true" ]]; then
   start_runtime
   restore_fixture
   verify_fixture
-  load_dataset_probe
+  load_dataset_env_or_probe
 else
   seed_fixture
 fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #477

## 🌿 Base Branch
- `main`

## 📝 Summary
- fixture DB window count를 full count 성격에서 index key 순서의 bounded probe로 전환했습니다.
- DB gate 실패 시 failure artifact와 recovery wait를 남기고, 준비된 manifest/db-gate artifact가 있으면 wrapper가 우선 사용하도록 했습니다.
- k6 run id와 recovery noise window를 artifact/tag로 남겨 post-crash noise와 후속 측정을 분리합니다.

## 🛠 Changes
- `run-transaction-100m-fixture-dataset-probe.sh`에 `index_only_window_probe`, `temp_file_limit`, failure report/recovery wait를 추가했습니다.
- artifact-ready/fresh-volume wrapper가 `*.dataset.env` + `*.db-gate.env` passed marker를 우선 사용합니다.
- k6 runner가 `K6_RUN_ID`, `K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS`, run context env를 기록하고 k6 tag에 run id를 전달합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-fixture-dataset-probe.sh`
- `tools/test/check-transaction-100m-artifact-readiness.sh`
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS=30` 기본값으로 실제 k6 시작 전 recovery noise isolation 대기 시간이 추가됩니다.
- 롤백 방법: 이 PR의 merge commit 또는 개별 커밋 revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
