### PR TITLE
[Perf] off-host capacity runner preflight 및 report 분리

### DIFF
--- a/tools/test/archive-k6-transaction-100m-result.sh
+++ b/tools/test/archive-k6-transaction-100m-result.sh
@@ -7,6 +7,8 @@ usage: tools/test/archive-k6-transaction-100m-result.sh <summary-md> [summary-js
 
 Environment:
   PERFORMANCE_RESULT_NAME   output basename without .md, default summary-md basename
+  PERFORMANCE_RESULT_OUTPUT_DIR default docs/performance-results
+  PERFORMANCE_RESULT_PURPOSE default ${K6_RUN_PURPOSE:-smoke}
 
 Examples:
   tools/test/archive-k6-transaction-100m-result.sh build/reports/k6/transaction-100m-summary.md
@@ -36,7 +38,8 @@ if [[ -n "${summary_json}" && ! -f "${summary_json}" ]]; then
 fi
 
 base_name="${PERFORMANCE_RESULT_NAME:-$(basename "${summary_md}" .md)}"
-output_dir="docs/performance-results"
+output_dir="${PERFORMANCE_RESULT_OUTPUT_DIR:-docs/performance-results}"
+purpose="${PERFORMANCE_RESULT_PURPOSE:-${K6_RUN_PURPOSE:-smoke}}"
 output_path="${output_dir}/${base_name}.md"
 mkdir -p "${output_dir}"
 
@@ -46,6 +49,8 @@ mkdir -p "${output_dir}"
   echo "## Archive Metadata"
   echo
   echo "- archivedAt: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "- resultPurpose: ${purpose}"
+  echo "- reportClass: transaction-100m-${purpose}"
   echo "- sourceMarkdown: ${summary_md}"
   if [[ -n "${summary_json}" ]]; then
     echo "- sourceJson: ${summary_json}"

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -33,6 +33,7 @@ grep -F "burst 429 rate threshold=0.1" <<<"${plan}" >/dev/null
 grep -F "overload 503 rate threshold=0" <<<"${plan}" >/dev/null
 grep -F "warmup duration=10s" <<<"${plan}" >/dev/null
 grep -F "run purpose=smoke" <<<"${plan}" >/dev/null
+grep -F "archive output dir=docs/performance-results/k6-smoke" <<<"${plan}" >/dev/null
 grep -F "summary gate=true" <<<"${plan}" >/dev/null
 grep -F "backend readiness gate=true path=/actuator/health/readiness timeout=120" <<<"${plan}" >/dev/null
 grep -F "postgres health gate=true required_status=healthy" <<<"${plan}" >/dev/null
@@ -85,6 +86,18 @@ remote_prometheus_plan="$(
 grep -F "k6 report name: transaction-100m-remote-prometheus-check" <<<"${remote_prometheus_plan}" >/dev/null
 grep -F "remote prometheus rw=http://192.0.2.10:9090/api/v1/write" <<<"${remote_prometheus_plan}" >/dev/null
 grep -F "remote prometheus preflight=enabled" <<<"${remote_prometheus_plan}" >/dev/null
+
+capacity_archive_plan="$(
+  K6_REPORT_NAME=transaction-100m-capacity-archive-check \
+  K6_RUN_PURPOSE=capacity \
+  K6_OBSERVABILITY_MODE=summary-only \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=transaction-k6-remote \
+  K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "run purpose=capacity" <<<"${capacity_archive_plan}" >/dev/null
+grep -F "archive output dir=docs/performance-results/k6-capacity" <<<"${capacity_archive_plan}" >/dev/null
 
 overload_plan="$(
   K6_REPORT_NAME=transaction-100m-overload-check \
@@ -252,6 +265,10 @@ grep -F "docker --context \"\${K6_DOCKER_CONTEXT}\" info" tools/test/run-k6-tran
 grep -F "remote prometheus remote-write preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_REMOTE_WORKDIR" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_RUN_PURPOSE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "PERFORMANCE_RESULT_PURPOSE=\"\${K6_RUN_PURPOSE}\"" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "PERFORMANCE_RESULT_OUTPUT_DIR=\"\${archive_output_dir}\"" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "resultPurpose" tools/test/archive-k6-transaction-100m-result.sh >/dev/null
+grep -F "reportClass" tools/test/archive-k6-transaction-100m-result.sh >/dev/null
 grep -F "assert_k6_summary_gate" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "interrupted_iterations" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "dropped_iterations" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
@@ -384,14 +401,31 @@ echo "[k6-transaction-100m] archive script"
 echo "# sample" >"${temp_dir}/transaction-100m-summary.md"
 echo "{}" >"${temp_dir}/transaction-100m-summary.json"
 output="$(
+  PERFORMANCE_RESULT_OUTPUT_DIR="${temp_dir}/k6-smoke" \
+  PERFORMANCE_RESULT_PURPOSE=smoke \
   PERFORMANCE_RESULT_NAME=transaction-100m-check-result \
     tools/test/archive-k6-transaction-100m-result.sh \
     "${temp_dir}/transaction-100m-summary.md" \
     "${temp_dir}/transaction-100m-summary.json"
 )"
-test "${output}" = "docs/performance-results/transaction-100m-check-result.md"
+test "${output}" = "${temp_dir}/k6-smoke/transaction-100m-check-result.md"
+grep -F "resultPurpose: smoke" "${output}" >/dev/null
+grep -F "reportClass: transaction-100m-smoke" "${output}" >/dev/null
 grep -F "sourceMarkdown: ${temp_dir}/transaction-100m-summary.md" "${output}" >/dev/null
 rm -f "${output}"
+
+capacity_output="$(
+  PERFORMANCE_RESULT_OUTPUT_DIR="${temp_dir}/k6-capacity" \
+  PERFORMANCE_RESULT_PURPOSE=capacity \
+  PERFORMANCE_RESULT_NAME=transaction-100m-capacity-check-result \
+    tools/test/archive-k6-transaction-100m-result.sh \
+    "${temp_dir}/transaction-100m-summary.md" \
+    "${temp_dir}/transaction-100m-summary.json"
+)"
+test "${capacity_output}" = "${temp_dir}/k6-capacity/transaction-100m-capacity-check-result.md"
+grep -F "resultPurpose: capacity" "${capacity_output}" >/dev/null
+grep -F "reportClass: transaction-100m-capacity" "${capacity_output}" >/dev/null
+rm -f "${capacity_output}"
 
 echo "[k6-transaction-100m] optional k6 inspect"
 if docker image inspect grafana/k6:0.54.0 >/dev/null 2>&1; then

--- a/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
@@ -10,6 +10,8 @@ temp_dir="$(mktemp -d)"
 trap 'rm -rf "${temp_dir}"' EXIT
 
 capacity="${temp_dir}/capacity.md"
+capacity_summary="${temp_dir}/capacity-summary.tsv"
+capacity_context="${temp_dir}/capacity-run-context.env"
 sse="${temp_dir}/sse.md"
 admission="${temp_dir}/admission.tsv"
 outbox="${temp_dir}/outbox.tsv"
@@ -23,6 +25,14 @@ cat >"${capacity}" <<'MD'
 - peakCpuPercent: 82.50
 - peakMemoryMiB: 712.00
 MD
+cat >"${capacity_context}" <<'ENV'
+CAPACITY_RUN_PURPOSE=capacity
+CAPACITY_GENERATOR_MODE=docker-context
+CAPACITY_K6_DOCKER_CONTEXT=capacity-k6-remote
+CAPACITY_K6_REMOTE_BASE_URL=http://192.0.2.20:8080
+CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.20:9090/api/v1/write
+ENV
+printf "phase\tprofile\tstatus\tadmission\tvus\tbackend_cpus\tbackend_memory\tpostgres_cpus\tpostgres_memory\tdb_pool\toverload_mode\tduration\thttp_failed_rate\thttp_reqs\ttransaction_429_rate\thot_first_p95_ms\thot_cursor_p95_ms\tcold_first_p95_ms\tcold_cursor_p95_ms\tbackend_cpu_percent\tpostgres_cpu_percent\thikari_active\thikari_pending\thikari_max\tlog_path\tsummary_json\nsingle-host\tsingle-host-default\t0\t3\t8\t0.40\t512m\t0.60\t384m\t4\ttrue\t1m\t0\t1200\t0.010000\t210\t220\t610\t640\t82.50\t41.00\t3\t0\t4\tcapacity.log\tcapacity-summary.json\n" >"${capacity_summary}"
 
 cat >"${sse}" <<'MD'
 # sse
@@ -50,6 +60,8 @@ plan="$(
   T3MICRO_AGGREGATE_NAME=aggregate-check \
   T3MICRO_AGGREGATE_OUTPUT_DIR="${temp_dir}" \
   T3MICRO_CAPACITY_RESULT_MD="${capacity}" \
+  T3MICRO_CAPACITY_SUMMARY_TSV="${capacity_summary}" \
+  T3MICRO_CAPACITY_RUN_CONTEXT_ENV="${capacity_context}" \
   T3MICRO_SSE_RESULT_MD="${sse}" \
   T3MICRO_ADMISSION_SUMMARY_TSV="${admission}" \
   T3MICRO_OUTBOX_SUMMARY_TSV="${outbox}" \
@@ -60,6 +72,8 @@ plan="$(
 )"
 grep -F "output=${temp_dir}/aggregate-check.md" <<<"${plan}" >/dev/null
 grep -F "capacity=${capacity}" <<<"${plan}" >/dev/null
+grep -F "capacity_summary=${capacity_summary}" <<<"${plan}" >/dev/null
+grep -F "capacity_run_context=${capacity_context}" <<<"${plan}" >/dev/null
 grep -F "admission=${admission}" <<<"${plan}" >/dev/null
 grep -F "k6=${k6}" <<<"${plan}" >/dev/null
 grep -F "memory=${memory}" <<<"${plan}" >/dev/null
@@ -70,12 +84,18 @@ grep -F "total_memory_budget_mib=900" <<<"${plan}" >/dev/null
 auto_root="${temp_dir}/auto"
 mkdir -p "${auto_root}/docs/performance-results" "${auto_root}/build/reports/admission/run" "${auto_root}/build/reports/outbox/run" "${auto_root}/build/reports/k6" "${auto_root}/build/reports/t3micro"
 auto_capacity="${auto_root}/docs/performance-results/docker-t3micro-capacity-auto.md"
+auto_capacity_dir="${auto_root}/build/reports/k6/transaction-100m-capacity-auto"
+auto_capacity_summary="${auto_capacity_dir}/capacity-summary.tsv"
+auto_capacity_context="${auto_capacity_dir}/capacity-run-context.env"
 auto_sse="${auto_root}/docs/performance-results/sse-reconnect-auto.md"
 auto_admission="${auto_root}/build/reports/admission/run/http-admission-summary.tsv"
 auto_outbox="${auto_root}/build/reports/outbox/run/outbox-provider-backlog-summary.tsv"
 auto_k6="${auto_root}/build/reports/k6/transaction-100m-auto-summary.md"
 auto_memory="${auto_root}/build/reports/t3micro/t3micro-memory-summary.tsv"
 cp "${capacity}" "${auto_capacity}"
+mkdir -p "${auto_capacity_dir}"
+cp "${capacity_summary}" "${auto_capacity_summary}"
+cp "${capacity_context}" "${auto_capacity_context}"
 cp "${sse}" "${auto_sse}"
 cp "${admission}" "${auto_admission}"
 cp "${outbox}" "${auto_outbox}"
@@ -90,6 +110,8 @@ auto_plan="$(
     "${script}" --print-plan
 )"
 grep -F "capacity=${auto_capacity}" <<<"${auto_plan}" >/dev/null
+grep -F "capacity_summary=${auto_capacity_summary}" <<<"${auto_plan}" >/dev/null
+grep -F "capacity_run_context=${auto_capacity_context}" <<<"${auto_plan}" >/dev/null
 grep -F "sse=${auto_sse}" <<<"${auto_plan}" >/dev/null
 grep -F "admission=${auto_admission}" <<<"${auto_plan}" >/dev/null
 grep -F "outbox=${auto_outbox}" <<<"${auto_plan}" >/dev/null
@@ -103,6 +125,26 @@ if T3MICRO_AGGREGATE_NAME=aggregate-required-check \
   T3MICRO_AGGREGATE_REQUIRED_GATES=capacity \
     "${script}" --print-plan >/dev/null 2>&1; then
   echo "required capacity input unexpectedly passed when missing" >&2
+  exit 1
+fi
+if T3MICRO_AGGREGATE_NAME=aggregate-required-smoke-only-check \
+  T3MICRO_AGGREGATE_OUTPUT_DIR="${temp_dir}" \
+  T3MICRO_AGGREGATE_AUTO_INPUTS=false \
+  T3MICRO_CAPACITY_RESULT_MD="${capacity}" \
+  T3MICRO_AGGREGATE_REQUIRED_GATES=capacity \
+    "${script}" --print-plan >/dev/null 2>&1; then
+  echo "required capacity input unexpectedly accepted local smoke markdown" >&2
+  exit 1
+fi
+bad_context="${temp_dir}/bad-capacity-run-context.env"
+sed 's/CAPACITY_GENERATOR_MODE=docker-context/CAPACITY_GENERATOR_MODE=local/' "${capacity_context}" >"${bad_context}"
+if T3MICRO_AGGREGATE_NAME=aggregate-required-local-context-check \
+  T3MICRO_AGGREGATE_OUTPUT_DIR="${temp_dir}" \
+  T3MICRO_CAPACITY_SUMMARY_TSV="${capacity_summary}" \
+  T3MICRO_CAPACITY_RUN_CONTEXT_ENV="${bad_context}" \
+  T3MICRO_AGGREGATE_REQUIRED_GATES=capacity \
+    "${script}" --print-plan >/dev/null 2>&1; then
+  echo "required capacity input unexpectedly accepted local generator context" >&2
   exit 1
 fi
 
@@ -121,6 +163,8 @@ output="$(
   T3MICRO_AGGREGATE_NAME=aggregate-check \
   T3MICRO_AGGREGATE_OUTPUT_DIR="${temp_dir}" \
   T3MICRO_CAPACITY_RESULT_MD="${capacity}" \
+  T3MICRO_CAPACITY_SUMMARY_TSV="${capacity_summary}" \
+  T3MICRO_CAPACITY_RUN_CONTEXT_ENV="${capacity_context}" \
   T3MICRO_SSE_RESULT_MD="${sse}" \
   T3MICRO_ADMISSION_SUMMARY_TSV="${admission}" \
   T3MICRO_OUTBOX_SUMMARY_TSV="${outbox}" \
@@ -131,7 +175,7 @@ output="$(
 )"
 output="$(tail -1 <<<"${output}")"
 test "${output}" = "${temp_dir}/aggregate-check.md"
-grep -F "| capacity | 0 | 82.50 | 712.00 | repeat=3 | ${capacity} |" "${output}" >/dev/null
+grep -F "| capacity | pass | 82.50 | n/a | 429Rate=0.010000 hikariPending=0 profiles=1 | ${capacity_summary} |" "${output}" >/dev/null
 grep -F "| sse reconnect | 0 | 61.00 | 512.00 | clients=8 rounds=3 | ${sse} |" "${output}" >/dev/null
 grep -F "rejected=4 failed_rate=0.000000" "${output}" >/dev/null
 grep -F "lag=1 failed=0 dlq=0" "${output}" >/dev/null

--- a/tools/test/check-transaction-100m-capacity-gates.sh
+++ b/tools/test/check-transaction-100m-capacity-gates.sh
@@ -35,17 +35,29 @@ grep -F "k6_docker_context=capacity-k6-remote" <<<"${plan}" >/dev/null
 grep -F "k6_remote_base_url=http://192.0.2.20:8080" <<<"${plan}" >/dev/null
 grep -F "k6_remote_prometheus_rw_server_url=http://192.0.2.20:9090/api/v1/write" <<<"${plan}" >/dev/null
 grep -F "k6_remote_workdir=/srv/aquila-bank" <<<"${plan}" >/dev/null
-grep -F "k6_remote_preflight=delegated-to-k6-runner" <<<"${plan}" >/dev/null
+grep -F "capacity_remote_preflight=true timeout=30 readiness_path=/actuator/health/readiness image=curlimages/curl:8.11.1" <<<"${plan}" >/dev/null
 grep -F "summary=build/reports/k6/transaction-capacity-check/capacity-summary.tsv" <<<"${plan}" >/dev/null
+grep -F "run_context=build/reports/k6/transaction-capacity-check/capacity-run-context.env" <<<"${plan}" >/dev/null
 
 echo "[transaction-100m-capacity] runner contract"
 grep -F "CAPACITY_K6_GENERATOR_MODE" "${script}" >/dev/null
 grep -F "CAPACITY_ALLOW_LOCAL_K6_GENERATOR" "${script}" >/dev/null
+grep -F "CAPACITY_REMOTE_PREFLIGHT" "${script}" >/dev/null
+grep -F "CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS" "${script}" >/dev/null
+grep -F "CAPACITY_REMOTE_READINESS_PATH" "${script}" >/dev/null
+grep -F "CAPACITY_REMOTE_PREFLIGHT_IMAGE" "${script}" >/dev/null
 grep -F "CAPACITY_K6_DOCKER_CONTEXT is required" "${script}" >/dev/null
 grep -F "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL is required" "${script}" >/dev/null
 grep -F "K6_GENERATOR_MODE=\"\${capacity_k6_generator_mode}\"" "${script}" >/dev/null
 grep -F "K6_RUN_PURPOSE=capacity" "${script}" >/dev/null
-grep -F "K6_REMOTE_PREFLIGHT=true" "${script}" >/dev/null
+grep -F "K6_REMOTE_PREFLIGHT=\"\${capacity_remote_preflight}\"" "${script}" >/dev/null
+grep -F "K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS=\"\${capacity_remote_preflight_timeout_seconds}\"" "${script}" >/dev/null
+grep -F "K6_REMOTE_PREFLIGHT_IMAGE=\"\${capacity_remote_preflight_image}\"" "${script}" >/dev/null
+grep -F "K6_REMOTE_READINESS_PATH=\"\${capacity_remote_readiness_path}\"" "${script}" >/dev/null
+grep -F "assert_capacity_remote_preflight" "${script}" >/dev/null
+grep -F "remote backend readiness preflight" "${script}" >/dev/null
+grep -F "remote prometheus remote-write preflight" "${script}" >/dev/null
+grep -F "capacity-run-context.env" "${script}" >/dev/null
 grep -F "stop_backend_before_bootjar" "${script}" >/dev/null
 grep -F "docker compose \"\${compose_files[@]}\" --profile loadtest stop aquila-bank-backend" "${script}" >/dev/null
 grep -F -- "up -d --force-recreate" "${script}" >/dev/null

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -35,6 +35,7 @@ Optional environment:
   K6_COLD_MAX_THRESHOLD_MS default 5000
   K6_AUTH_TOKEN        bearer token, optional when bootstrap header auth is enabled
   K6_ARCHIVE_RESULTS   copy markdown summary to docs/performance-results, default true
+  K6_ARCHIVE_OUTPUT_ROOT default docs/performance-results
   K6_PREFLIGHT         check PostgreSQL OOM/index readiness before k6, default true
   K6_POSTGRES_HEALTH_GATE require PostgreSQL Docker health=healthy before k6, default true
   K6_POSTGRES_RECOVERY_GATE require pg_is_in_recovery()=false before k6, default true
@@ -265,6 +266,7 @@ K6_HOT_MAX_THRESHOLD_MS="${K6_HOT_MAX_THRESHOLD_MS:-3000}"
 K6_COLD_MAX_THRESHOLD_MS="${K6_COLD_MAX_THRESHOLD_MS:-5000}"
 K6_HTTP_FAILED_RATE="${K6_HTTP_FAILED_RATE:-0.01}"
 K6_ARCHIVE_RESULTS="${K6_ARCHIVE_RESULTS:-true}"
+K6_ARCHIVE_OUTPUT_ROOT="${K6_ARCHIVE_OUTPUT_ROOT:-docs/performance-results}"
 K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
 K6_POSTGRES_HEALTH_GATE="${K6_POSTGRES_HEALTH_GATE:-true}"
 K6_POSTGRES_RECOVERY_GATE="${K6_POSTGRES_RECOVERY_GATE:-true}"
@@ -382,6 +384,7 @@ summary_md="${report_dir}/${K6_REPORT_NAME}-summary.md"
 summary_json="${report_dir}/${K6_REPORT_NAME}-summary.json"
 k6_runner_log="${report_dir}/${K6_REPORT_NAME}-runner.log"
 run_context_env="${report_dir}/${K6_REPORT_NAME}-run-context.env"
+archive_output_dir="${K6_ARCHIVE_OUTPUT_ROOT%/}/k6-${K6_RUN_PURPOSE}"
 psql_base=(docker compose "${compose_files[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U "${DB_USERNAME:-postgres}" -d "${DB_NAME:-aquila_bank}")
 
 require_command() {
@@ -533,6 +536,7 @@ print_plan() {
   fi
   echo "[k6-transaction-100m] required dataset: prepared 100m transaction read model hot/cold accounts"
   echo "[k6-transaction-100m] archive results: ${K6_ARCHIVE_RESULTS}"
+  echo "[k6-transaction-100m] archive output dir=${archive_output_dir}"
 }
 
 print_plan
@@ -912,7 +916,9 @@ status=$?
 run_explain_snapshot post
 
 if [[ "${K6_ARCHIVE_RESULTS}" == "true" && -f "${summary_md}" ]]; then
-  tools/test/archive-k6-transaction-100m-result.sh "${summary_md}" "${summary_json}"
+  PERFORMANCE_RESULT_PURPOSE="${K6_RUN_PURPOSE}" \
+  PERFORMANCE_RESULT_OUTPUT_DIR="${archive_output_dir}" \
+    tools/test/archive-k6-transaction-100m-result.sh "${summary_md}" "${summary_json}"
 elif [[ "${K6_ARCHIVE_RESULTS}" == "true" ]]; then
   echo "k6 summary markdown was not produced: ${summary_md}" >&2
   if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then

--- a/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
@@ -9,6 +9,8 @@ Environment:
   T3MICRO_AGGREGATE_NAME       default t3micro-defensive-gates-aggregate-<timestamp>
   T3MICRO_AGGREGATE_OUTPUT_DIR default docs/performance-results
   T3MICRO_CAPACITY_RESULT_MD   optional Docker capacity archive markdown
+  T3MICRO_CAPACITY_SUMMARY_TSV optional off-host transaction 100m capacity summary TSV
+  T3MICRO_CAPACITY_RUN_CONTEXT_ENV optional run context next to capacity summary TSV
   T3MICRO_SSE_RESULT_MD        optional SSE reconnect archive markdown
   T3MICRO_ADMISSION_SUMMARY_TSV optional admission summary TSV
   T3MICRO_OUTBOX_SUMMARY_TSV   optional outbox summary TSV
@@ -51,6 +53,8 @@ name="${T3MICRO_AGGREGATE_NAME:-t3micro-defensive-gates-aggregate-$(date +%Y-%m-
 output_dir="${T3MICRO_AGGREGATE_OUTPUT_DIR:-docs/performance-results}"
 output_path="${output_dir}/${name}.md"
 capacity_result="${T3MICRO_CAPACITY_RESULT_MD:-}"
+capacity_summary="${T3MICRO_CAPACITY_SUMMARY_TSV:-}"
+capacity_run_context="${T3MICRO_CAPACITY_RUN_CONTEXT_ENV:-}"
 sse_result="${T3MICRO_SSE_RESULT_MD:-}"
 admission_summary="${T3MICRO_ADMISSION_SUMMARY_TSV:-}"
 outbox_summary="${T3MICRO_OUTBOX_SUMMARY_TSV:-}"
@@ -96,11 +100,51 @@ latest_file() {
   ls -t "${matches[@]}" 2>/dev/null | head -1
 }
 
+capacity_context_for_summary() {
+  local summary="$1"
+  local dir
+  dir="$(dirname "${summary}")"
+  echo "${dir}/capacity-run-context.env"
+}
+
+capacity_context_is_offhost() {
+  local context="$1"
+  [[ -f "${context}" ]] || return 1
+  grep -Fx "CAPACITY_RUN_PURPOSE=capacity" "${context}" >/dev/null \
+    && grep -Fx "CAPACITY_GENERATOR_MODE=docker-context" "${context}" >/dev/null \
+    && grep -E '^CAPACITY_K6_DOCKER_CONTEXT=.' "${context}" >/dev/null \
+    && grep -E '^CAPACITY_K6_REMOTE_BASE_URL=.' "${context}" >/dev/null \
+    && grep -E '^CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=.' "${context}" >/dev/null
+}
+
+latest_capacity_summary() {
+  local matches=()
+  local root path context
+  for root in ${search_roots}; do
+    if [[ -d "${root}" ]]; then
+      while IFS= read -r path; do
+        context="$(capacity_context_for_summary "${path}")"
+        if capacity_context_is_offhost "${context}"; then
+          matches+=("${path}")
+        fi
+      done < <(find "${root}" -type f -name "capacity-summary.tsv" 2>/dev/null)
+    fi
+  done
+  if [[ "${#matches[@]}" -eq 0 ]]; then
+    return 0
+  fi
+  ls -t "${matches[@]}" 2>/dev/null | head -1
+}
+
 resolve_auto_inputs() {
   if [[ "${auto_inputs}" != "true" ]]; then
     return 0
   fi
-  capacity_result="${capacity_result:-$(latest_file '*capacity*.md')}"
+  capacity_summary="${capacity_summary:-$(latest_capacity_summary)}"
+  if [[ -z "${capacity_run_context}" && -n "${capacity_summary}" ]]; then
+    capacity_run_context="$(capacity_context_for_summary "${capacity_summary}")"
+  fi
+  capacity_result="${capacity_result:-$(latest_file 'docker-t3micro-capacity*.md')}"
   sse_result="${sse_result:-$(latest_file '*sse*.md')}"
   admission_summary="${admission_summary:-$(latest_file 'http-admission-summary.tsv')}"
   outbox_summary="${outbox_summary:-$(latest_file 'outbox-provider-backlog-summary.tsv')}"
@@ -115,7 +159,7 @@ resolve_auto_inputs
 gate_path() {
   local gate="$1"
   case "${gate}" in
-    capacity) echo "${capacity_result}" ;;
+    capacity) echo "${capacity_summary}" ;;
     sse) echo "${sse_result}" ;;
     admission) echo "${admission_summary}" ;;
     outbox) echo "${outbox_summary}" ;;
@@ -149,6 +193,8 @@ print_plan() {
   echo "[t3micro-defensive-aggregate] auto_inputs=${auto_inputs}"
   echo "[t3micro-defensive-aggregate] search_roots=${search_roots}"
   echo "[t3micro-defensive-aggregate] capacity=${capacity_result:-missing}"
+  echo "[t3micro-defensive-aggregate] capacity_summary=${capacity_summary:-missing}"
+  echo "[t3micro-defensive-aggregate] capacity_run_context=${capacity_run_context:-missing}"
   echo "[t3micro-defensive-aggregate] sse=${sse_result:-missing}"
   echo "[t3micro-defensive-aggregate] admission=${admission_summary:-missing}"
   echo "[t3micro-defensive-aggregate] outbox=${outbox_summary:-missing}"
@@ -168,6 +214,155 @@ md_value() {
   local value
   value="$(awk -F ': ' -v key="- ${key}" '$1 == key {print $2}' "${file}" | tail -1)"
   printf "%s" "${value:-missing}"
+}
+
+capacity_summary_status() {
+  local file="$1"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "missing"
+    return 0
+  fi
+  awk -F '\t' '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "status") status_column = i
+      }
+      next
+    }
+    status_column {
+      rows += 1
+      if ($status_column != "0") failed = 1
+    }
+    END {
+      if (!status_column || rows == 0) {
+        print "invalid"
+      } else if (failed) {
+        print "fail"
+      } else {
+        print "pass"
+      }
+    }
+  ' "${file}"
+}
+
+capacity_profile_count() {
+  local file="$1"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "missing"
+    return 0
+  fi
+  awk 'NR > 1 {count += 1} END {print count + 0}' "${file}"
+}
+
+capacity_tsv_column_max() {
+  local file="$1"
+  local key="$2"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "n/a"
+    return 0
+  fi
+  awk -F '\t' -v key="${key}" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == key) column = i
+      }
+      next
+    }
+    column && $column ~ /^[0-9]+([.][0-9]+)?$/ {
+      value = $column + 0
+      if (!found || value > max) {
+        max = value
+        text = $column
+      }
+      found = 1
+    }
+    END {
+      if (found) {
+        print text
+      } else {
+        print "n/a"
+      }
+    }
+  ' "${file}"
+}
+
+capacity_cpu_peak() {
+  local file="$1"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "n/a"
+    return 0
+  fi
+  awk -F '\t' '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "backend_cpu_percent") backend_column = i
+        if ($i == "postgres_cpu_percent") postgres_column = i
+      }
+      next
+    }
+    {
+      for (i = 1; i <= NF; i++) {
+        if ((i == backend_column || i == postgres_column) && $i ~ /^[0-9]+([.][0-9]+)?$/) {
+          value = $i + 0
+          if (!found || value > max) {
+            max = value
+            text = $i
+          }
+          found = 1
+        }
+      }
+    }
+    END {
+      if (found) {
+        print text
+      } else {
+        print "n/a"
+      }
+    }
+  ' "${file}"
+}
+
+capacity_status_value() {
+  if [[ -n "${capacity_summary}" ]]; then
+    capacity_summary_status "${capacity_summary}"
+  else
+    md_value "${capacity_result}" "capacity smoke status"
+  fi
+}
+
+capacity_cpu_value() {
+  if [[ -n "${capacity_summary}" ]]; then
+    capacity_cpu_peak "${capacity_summary}"
+  else
+    md_value "${capacity_result}" "peakCpuPercent"
+  fi
+}
+
+capacity_memory_value() {
+  if [[ -n "${capacity_summary}" ]]; then
+    printf "n/a"
+  else
+    md_value "${capacity_result}" "peakMemoryMiB"
+  fi
+}
+
+capacity_signal_value() {
+  if [[ -n "${capacity_summary}" ]]; then
+    printf "429Rate=%s hikariPending=%s profiles=%s" \
+      "$(capacity_tsv_column_max "${capacity_summary}" "transaction_429_rate")" \
+      "$(capacity_tsv_column_max "${capacity_summary}" "hikari_pending")" \
+      "$(capacity_profile_count "${capacity_summary}")"
+  else
+    printf "repeat=%s" "$(md_value "${capacity_result}" "repeat")"
+  fi
+}
+
+capacity_source_value() {
+  if [[ -n "${capacity_summary}" ]]; then
+    printf "%s" "${capacity_summary}"
+  else
+    printf "%s" "${capacity_result:-missing}"
+  fi
 }
 
 tsv_value() {
@@ -245,6 +440,34 @@ assert_memory_budget() {
   fi
 }
 
+assert_capacity_summary() {
+  if [[ -z "${capacity_summary}" ]]; then
+    return 0
+  fi
+  if [[ ! -f "${capacity_summary}" ]]; then
+    echo "capacity summary not found: ${capacity_summary}" >&2
+    exit 1
+  fi
+  if [[ -z "${capacity_run_context}" ]]; then
+    capacity_run_context="$(capacity_context_for_summary "${capacity_summary}")"
+  fi
+  if ! capacity_context_is_offhost "${capacity_run_context}"; then
+    echo "capacity summary requires off-host docker-context run context: ${capacity_run_context}" >&2
+    exit 1
+  fi
+  case "$(capacity_summary_status "${capacity_summary}")" in
+    pass) ;;
+    fail)
+      echo "capacity summary contains failed profiles: ${capacity_summary}" >&2
+      exit 1
+      ;;
+    *)
+      echo "capacity summary is invalid: ${capacity_summary}" >&2
+      exit 1
+      ;;
+  esac
+}
+
 write_report() {
   mkdir -p "${output_dir}"
   {
@@ -253,6 +476,8 @@ write_report() {
     echo "## Inputs"
     echo
     echo "- capacityResult: ${capacity_result:-missing}"
+    echo "- capacitySummary: ${capacity_summary:-missing}"
+    echo "- capacityRunContext: ${capacity_run_context:-missing}"
     echo "- sseResult: ${sse_result:-missing}"
     echo "- admissionSummary: ${admission_summary:-missing}"
     echo "- outboxSummary: ${outbox_summary:-missing}"
@@ -263,7 +488,7 @@ write_report() {
     echo
     echo "| Gate | Status | Peak CPU % | Peak Memory MiB | Backlog / Reject Signal | Source |"
     echo "| --- | --- | ---: | ---: | --- | --- |"
-    echo "| capacity | $(md_value "${capacity_result}" "capacity smoke status") | $(md_value "${capacity_result}" "peakCpuPercent") | $(md_value "${capacity_result}" "peakMemoryMiB") | repeat=$(md_value "${capacity_result}" "repeat") | ${capacity_result:-missing} |"
+    echo "| capacity | $(capacity_status_value) | $(capacity_cpu_value) | $(capacity_memory_value) | $(capacity_signal_value) | $(capacity_source_value) |"
     echo "| sse reconnect | $(md_value "${sse_result}" "status") | $(md_value "${sse_result}" "peakCpuPercent") | $(md_value "${sse_result}" "peakMemoryMiB") | clients=$(md_value "${sse_result}" "reconnectClients") rounds=$(md_value "${sse_result}" "reconnectRounds") | ${sse_result:-missing} |"
     echo "| http admission | n/a | n/a | n/a | rejected=$(tsv_value "${admission_summary}" "rejected_count") failed_rate=$(tsv_value "${admission_summary}" "failed_rate") | ${admission_summary:-missing} |"
     echo "| outbox backlog | n/a | n/a | n/a | lag=$(tsv_value "${outbox_summary}" "lag_seconds") failed=$(tsv_value "${outbox_summary}" "failed_count") dlq=$(tsv_value "${outbox_summary}" "dlq_count") | ${outbox_summary:-missing} |"
@@ -281,6 +506,7 @@ write_report() {
 }
 
 print_plan
+assert_capacity_summary
 assert_required_gates
 assert_memory_budget
 if [[ "${mode}" == "print-plan" ]]; then

--- a/tools/test/run-transaction-100m-capacity-gates.sh
+++ b/tools/test/run-transaction-100m-capacity-gates.sh
@@ -30,6 +30,10 @@ Optional environment:
   CAPACITY_K6_REMOTE_BASE_URL backend URL reachable from off-host k6
   CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL Prometheus remote-write URL reachable from off-host k6
   CAPACITY_K6_REMOTE_WORKDIR repo path visible from docker context host, default current working directory
+  CAPACITY_REMOTE_PREFLIGHT default true
+  CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS default 30
+  CAPACITY_REMOTE_PREFLIGHT_IMAGE default curlimages/curl:8.11.1
+  CAPACITY_REMOTE_READINESS_PATH default /actuator/health/readiness
   CAPACITY_ADAPTIVE_ENABLED default true
   CAPACITY_HARD_THRESHOLD_ENABLED default true
   CAPACITY_HOT_P95_THRESHOLD_MS default 350
@@ -85,6 +89,10 @@ capacity_k6_docker_context="${CAPACITY_K6_DOCKER_CONTEXT:-${K6_DOCKER_CONTEXT:-}
 capacity_k6_remote_base_url="${CAPACITY_K6_REMOTE_BASE_URL:-${K6_REMOTE_BASE_URL:-}}"
 capacity_k6_remote_prometheus_rw_server_url="${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-${K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-}}"
 capacity_k6_remote_workdir="${CAPACITY_K6_REMOTE_WORKDIR:-${K6_REMOTE_WORKDIR:-$(pwd)}}"
+capacity_remote_preflight="${CAPACITY_REMOTE_PREFLIGHT:-true}"
+capacity_remote_preflight_timeout_seconds="${CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS:-30}"
+capacity_remote_preflight_image="${CAPACITY_REMOTE_PREFLIGHT_IMAGE:-curlimages/curl:8.11.1}"
+capacity_remote_readiness_path="${CAPACITY_REMOTE_READINESS_PATH:-/actuator/health/readiness}"
 adaptive_enabled="${CAPACITY_ADAPTIVE_ENABLED:-${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_ENABLED:-true}}"
 hard_threshold_enabled="${CAPACITY_HARD_THRESHOLD_ENABLED:-true}"
 hot_p95_threshold_ms="${CAPACITY_HOT_P95_THRESHOLD_MS:-350}"
@@ -99,6 +107,7 @@ prometheus_base_url="${prometheus_url%/}"
 backend_health_url="${CAPACITY_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
 report_dir="build/reports/k6/${capacity_name}"
 summary_tsv="${report_dir}/capacity-summary.tsv"
+run_context_path="${report_dir}/capacity-run-context.env"
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
 CPU_SAMPLER_PID=""
 threshold_failed=false
@@ -306,6 +315,8 @@ require_bool "CAPACITY_RUN_LONG_SOAK" "${run_long_soak}"
 require_bool "CAPACITY_CONTINUE_ON_FAILURE" "${continue_on_failure}"
 require_bool "CAPACITY_ALLOW_LOCAL_K6_GENERATOR" "${allow_local_k6_generator}"
 require_generator_mode_value "CAPACITY_K6_GENERATOR_MODE" "${capacity_k6_generator_mode}"
+require_bool "CAPACITY_REMOTE_PREFLIGHT" "${capacity_remote_preflight}"
+require_positive_integer_value "CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS" "${capacity_remote_preflight_timeout_seconds}"
 require_bool "CAPACITY_ADAPTIVE_ENABLED" "${adaptive_enabled}"
 require_bool "CAPACITY_HARD_THRESHOLD_ENABLED" "${hard_threshold_enabled}"
 require_duration_value "CAPACITY_LONG_SOAK_DURATION" "${long_soak_duration}"
@@ -367,7 +378,7 @@ print_plan() {
   echo "[transaction-100m-capacity] k6_remote_base_url=${capacity_k6_remote_base_url:-missing}"
   echo "[transaction-100m-capacity] k6_remote_prometheus_rw_server_url=${capacity_k6_remote_prometheus_rw_server_url:-missing}"
   echo "[transaction-100m-capacity] k6_remote_workdir=${capacity_k6_remote_workdir}"
-  echo "[transaction-100m-capacity] k6_remote_preflight=delegated-to-k6-runner"
+  echo "[transaction-100m-capacity] capacity_remote_preflight=${capacity_remote_preflight} timeout=${capacity_remote_preflight_timeout_seconds} readiness_path=${capacity_remote_readiness_path} image=${capacity_remote_preflight_image}"
   echo "[transaction-100m-capacity] adaptive_enabled=${adaptive_enabled}"
   echo "[transaction-100m-capacity] hard_thresholds=${hard_threshold_enabled}"
   echo "[transaction-100m-capacity] hot_p95_threshold_ms=${hot_p95_threshold_ms}"
@@ -378,6 +389,7 @@ print_plan() {
   echo "[transaction-100m-capacity] postgres_cpu_threshold_percent=${postgres_cpu_threshold_percent}"
   echo "[transaction-100m-capacity] hikari_pending_threshold=${hikari_pending_threshold}"
   echo "[transaction-100m-capacity] summary=${summary_tsv}"
+  echo "[transaction-100m-capacity] run_context=${run_context_path}"
 }
 
 print_plan
@@ -393,6 +405,25 @@ require_env K6_COLD_FROM
 require_env K6_COLD_TO
 
 mkdir -p "${report_dir}" build/reports/k6
+
+write_capacity_run_context() {
+  {
+    echo "CAPACITY_RUN_PURPOSE=capacity"
+    echo "CAPACITY_NAME=${capacity_name}"
+    echo "CAPACITY_GENERATOR_MODE=${capacity_k6_generator_mode}"
+    echo "CAPACITY_K6_DOCKER_CONTEXT=${capacity_k6_docker_context}"
+    echo "CAPACITY_K6_REMOTE_BASE_URL=${capacity_k6_remote_base_url}"
+    echo "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=${capacity_k6_remote_prometheus_rw_server_url}"
+    echo "CAPACITY_K6_REMOTE_WORKDIR=${capacity_k6_remote_workdir}"
+    echo "CAPACITY_REMOTE_PREFLIGHT=${capacity_remote_preflight}"
+    echo "CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS=${capacity_remote_preflight_timeout_seconds}"
+    echo "CAPACITY_REMOTE_READINESS_PATH=${capacity_remote_readiness_path}"
+    echo "CAPACITY_REMOTE_PREFLIGHT_IMAGE=${capacity_remote_preflight_image}"
+    echo "CAPACITY_SUMMARY_TSV=${summary_tsv}"
+  } >"${run_context_path}"
+}
+
+write_capacity_run_context
 
 if [[ "${build_backend}" == "true" ]]; then
   stop_backend_before_bootjar
@@ -453,6 +484,28 @@ wait_for_prometheus_readiness() {
   done
   echo "prometheus readiness timeout: ${prometheus_base_url}/-/ready" >&2
   exit 1
+}
+
+assert_capacity_remote_preflight() {
+  if [[ "${capacity_k6_generator_mode}" != "docker-context" ]]; then
+    return 0
+  fi
+  if [[ "${capacity_remote_preflight}" != "true" ]]; then
+    echo "[transaction-100m-capacity] remote preflight skipped"
+    return 0
+  fi
+
+  local readiness_url="${capacity_k6_remote_base_url%/}${capacity_remote_readiness_path}"
+  echo "[transaction-100m-capacity] remote docker context preflight: ${capacity_k6_docker_context}"
+  docker --context "${capacity_k6_docker_context}" info >/dev/null
+  echo "[transaction-100m-capacity] remote backend readiness preflight: ${readiness_url}"
+  docker --context "${capacity_k6_docker_context}" run --rm "${capacity_remote_preflight_image}" \
+    -fsS --max-time "${capacity_remote_preflight_timeout_seconds}" "${readiness_url}" >/dev/null
+
+  echo "[transaction-100m-capacity] remote prometheus remote-write preflight: ${capacity_k6_remote_prometheus_rw_server_url}"
+  docker --context "${capacity_k6_docker_context}" run --rm --entrypoint sh "${capacity_remote_preflight_image}" \
+    -c 'status="$(curl -sS -o /dev/null -w "%{http_code}" --max-time "$1" -X POST "$2" || echo 000)"; case "${status}" in 2*|3*|4*) exit 0 ;; *) echo "remote prometheus remote-write preflight failed: status=${status}" >&2; exit 1 ;; esac' \
+    sh "${capacity_remote_preflight_timeout_seconds}" "${capacity_k6_remote_prometheus_rw_server_url}"
 }
 
 start_cpu_sampler() {
@@ -615,6 +668,7 @@ run_profile() {
 
   wait_for_backend_readiness
   wait_for_prometheus_readiness
+  assert_capacity_remote_preflight
 
   start_cpu_sampler "${stats_path}"
   set +e
@@ -629,7 +683,10 @@ run_profile() {
   K6_REMOTE_BASE_URL="${capacity_k6_remote_base_url}" \
   K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${capacity_k6_remote_prometheus_rw_server_url}" \
   K6_REMOTE_WORKDIR="${capacity_k6_remote_workdir}" \
-  K6_REMOTE_PREFLIGHT=true \
+  K6_REMOTE_PREFLIGHT="${capacity_remote_preflight}" \
+  K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS="${capacity_remote_preflight_timeout_seconds}" \
+  K6_REMOTE_PREFLIGHT_IMAGE="${capacity_remote_preflight_image}" \
+  K6_REMOTE_READINESS_PATH="${capacity_remote_readiness_path}" \
     tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${log_path}" 2>&1
   status=$?
   set -e


### PR DESCRIPTION
## 🔗 Related Issue
close #479

## 🌿 Base Branch
- `main`

## 📝 Summary
- off-host k6 capacity runner가 Docker context/backend readiness/Prometheus remote-write preflight 계약과 run context artifact를 남기도록 강화했습니다.
- k6 transaction 100m archive를 smoke/capacity 목적별 디렉터리와 metadata로 분리하고, defensive aggregate가 off-host capacity summary를 우선 연결하도록 고정했습니다.
- actual off-host 1억 row 수치는 환경값 없이는 실행하지 않았고, local smoke markdown만으로 capacity required gate를 만족하지 못하게 막았습니다.

## 🛠 Changes
- `run-transaction-100m-capacity-gates.sh`에 capacity-level remote preflight와 `capacity-run-context.env` artifact 추가
- `archive-k6-transaction-100m-result.sh` / k6 runner에 `resultPurpose`, `reportClass`, purpose별 output dir 추가
- defensive aggregate에 `T3MICRO_CAPACITY_SUMMARY_TSV`, `T3MICRO_CAPACITY_RUN_CONTEXT_ENV` 입력과 off-host context 검증 추가
- aggregate auto input이 sibling `capacity-run-context.env`가 있는 `capacity-summary.tsv`만 capacity baseline으로 선택하도록 변경

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-capacity-gates.sh`
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `tools/test/check-t3micro-defensive-gates-aggregate-report.sh`
- `git diff --check`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 aggregate에서 `capacity` required gate를 local Docker smoke markdown만으로 만족시키던 실행은 실패합니다. 이 변경은 smoke/capacity 오판 방지가 목적입니다.
- 롤백 방법: 이 PR의 세 커밋을 revert하면 기존 archive/aggregate 선택 방식으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
