### PR TITLE
[Perf] 100m defensive latest-main 병목 재검증 20260428

### DIFF
--- a/docs/performance-results/100m-defensive-latest-main-20260428-bottleneck.md
+++ b/docs/performance-results/100m-defensive-latest-main-20260428-bottleneck.md
@@ -1,0 +1,90 @@
+# 100m defensive latest-main 병목 재검증 20260428
+
+## 기준
+
+- 실행일: 2026-04-28 KST
+- 기준 브랜치: `main`
+- 기준 SHA: `7a9805c`
+- 작업 브랜치: `perf/100m-defensive-latest-main-20260428-retest`
+- 연결 이슈: `#481`
+- 목표: 로컬 Docker t3.micro 제약에서 1억 row 거래 조회와 대용량 트래픽 방어 병목 재확인
+- 제외: 이미 main에 반영된 `#478` fixture DB gate index-only/crash-safe recovery, `#480` off-host capacity preflight/report split, `#476` post-overload-profile 재검증, `#474` zero-503 admission profile, `#472` aggregate full inputs, `#470` off-host runner/burst calibration
+
+## 환경
+
+- Docker compose: `compose.yml`, `compose.t3micro.yml`, `compose.loadtest.yml`
+- PostgreSQL 컨테이너: `aquila-bank-postgres-loadtest`, memory limit `384MiB`
+- Backend 컨테이너: `aquila-bank-backend-loadtest`, memory limit `1GiB`
+- Observability: Prometheus, Grafana, Alertmanager, postgres-exporter
+- Dataset account: hot `910000001`, cold `910000002`
+- Dataset estimate: total `99,999,884`, hot `49,999,856`, archive `50,000,028`
+- Window probe: `index-only-bounded`, limit `51`
+- k6 공통 limit: `50`
+
+## 실행 결과
+
+| 항목 | 결과 | 핵심 수치 | 판단 |
+| --- | --- | --- | --- |
+| stack health | 통과 | backend health 200, Prometheus ready 200, Grafana health 200 | 기본 실행 상태 정상 |
+| fixture dataset probe | 통과 | total estimate `99,999,884`, hot/cold window count `51/51`, PostgreSQL OOM `false` | 이전 DB gate 병목은 최신 main에서 해소 |
+| VU3 baseline | 통과 | failed `0`, 429 `0`, 503 `0`, p95 약 `1.74~1.80ms` | read API smoke 양호 |
+| VU16 overload | 통과 | failed `0.0052672096`, 429 `0.005702338`, 503 `0`, p95 약 `2.15~2.39ms` | admission guard가 503 없이 방어 |
+| burst 256/s | 통과 | failed `0.0021078782`, 429 `0.0027500859`, 503 `0`, hot first p95 `2.19317705ms` | 순간 부하 smoke 양호 |
+| Prometheus mode | 통과 | failed `0`, 429 `0`, 503 `0`, p95 약 `1.98~2.07ms` | remote-write 관측 경로 동작 |
+| capacity prerequisite | 실패 | `CAPACITY_K6_DOCKER_CONTEXT is required` | off-host capacity 실행 환경 미구성 |
+| aggregate required capacity | 실패 의도 확인 | `required aggregate input is missing: capacity` | capacity 누락을 성공으로 오판하지 않음 |
+| aggregate k6+memory | 통과 | total memory `644.45MiB`, budget `900MiB` | 이번 smoke 집계 기준 통과 |
+| aggregate auto input dry-run | 위험 확인 | 2026-04-27 capacity/SSE/admission artifact를 자동 선택 | run-id/date가 다른 stale artifact 혼입 가능 |
+
+## 리소스 스냅샷
+
+| 컨테이너 | CPU | Memory |
+| --- | ---: | ---: |
+| backend | `0.45%` | `394.00MiB / 1GiB` |
+| PostgreSQL | `0.02%` | `75.79MiB / 384MiB` |
+| Prometheus | `1.16%` | `74.45MiB / 256MiB` |
+| Grafana | `0.05%` | `86.62MiB / 256MiB` |
+| postgres-exporter | `0.00%` | `13.59MiB / 128MiB` |
+
+## 병목 판단
+
+최신 main 기준으로 read API와 fixture DB gate는 통과했다. VU3, VU16 overload, burst 256/s, Prometheus remote-write smoke 모두 503 없이 끝났고, 429는 overload/burst threshold 안에서 방어 신호로만 기록됐다. PostgreSQL은 실행 후 `healthy`, `pg_is_in_recovery()=false`, OOM `false` 상태다.
+
+남은 1순위 병목은 실제 capacity 실행 환경이다. 로컬 Docker context는 `default`, `desktop-linux`뿐이라 off-host k6 generator를 실행할 수 없고, `run-transaction-100m-capacity-gates.sh --print-plan`도 `CAPACITY_K6_DOCKER_CONTEXT` 누락에서 fail-fast된다. 따라서 이번 결과는 로컬 smoke 통과이지 실제 off-host capacity baseline 확정은 아니다.
+
+2순위 병목은 aggregate auto input의 run scope다. `T3MICRO_AGGREGATE_AUTO_INPUTS=true` dry-run이 2026-04-27 capacity/SSE/admission artifact와 2026-04-28 k6/memory artifact를 섞어 잡았다. required capacity gate는 실패하지만, required gate를 걸지 않은 리포트에서는 stale artifact 혼입 위험이 남는다.
+
+3순위 병목은 실행 계약 재현성이다. fixture probe는 기존 `dataset.env` 파일이 있어도 자동 source하지 않아 env를 직접 주지 않으면 `hot_account_id is missing`으로 중단된다. 실제 DB 병목은 아니지만 반복 측정 자동화에서는 불필요한 실패 지점이다.
+
+## 다음 병목 후보 PR/이슈
+
+모두 issue 제목 = PR 제목, issue 1개 = PR 1개 기준이다. 위 제외 목록의 완료 작업은 중복 등록하지 않았다.
+
+1. `[Perf] off-host 100m capacity 실행 환경 프로비저닝 추가` / 브랜치 `perf/offhost-100m-capacity-environment`
+   - runner 코드는 있지만 현재 로컬에는 `CAPACITY_K6_DOCKER_CONTEXT`, remote backend URL, remote Prometheus write URL이 없어 실제 capacity baseline을 못 닫는다.
+2. `[Perf] t3micro aggregate auto input을 run-id scope로 제한` / 브랜치 `perf/t3micro-aggregate-run-id-scoped-inputs`
+   - auto input이 2026-04-27 artifact와 2026-04-28 artifact를 섞어 잡는다. 같은 run id 또는 같은 aggregate name prefix만 자동 선택해야 한다.
+3. `[Perf] capacity prerequisite failure artifact 문서화` / 브랜치 `perf/capacity-prerequisite-failure-artifact`
+   - capacity env 누락은 현재 stderr로만 끝난다. 실패 artifact를 남겨 aggregate/report에서 원인을 추적 가능하게 한다.
+4. `[Perf] transaction 100m capacity long-soak baseline 확정` / 브랜치 `perf/transaction-100m-capacity-long-soak-baseline`
+   - smoke는 통과했지만 실제 목표에는 off-host generator 기반 장시간 soak baseline이 필요하다.
+5. `[Perf] fixture dataset env 자동 로드 추가` / 브랜치 `perf/fixture-dataset-env-auto-load`
+   - `build/fixtures/transaction-100m-fixture.dump.dataset.env`가 있어도 명시 env 없이는 probe가 중단된다. 반복 테스트 자동화의 재현성을 높인다.
+6. `[Perf] k6 multi-scenario runner 재기동 비용 제거` / 브랜치 `perf/k6-multi-scenario-service-reuse`
+   - VU3/VU16/burst/prometheus마다 backend를 재기동해 recovery/noise window 비용이 누적된다. 같은 stack에서 연속 시나리오를 실행하는 runner가 필요하다.
+7. `[Perf] transaction read p99.9 spike profile artifact 추가` / 브랜치 `perf/transaction-read-p999-spike-profile`
+   - p95는 낮지만 p99.9/max는 30~80ms까지 튄다. DB/GC/connection pool/HTTP thread 중 어느 경계인지 artifact로 분리해야 한다.
+8. `[Perf] burst 256/s 429 budget 회귀 gate 강화` / 브랜치 `perf/burst-256-429-budget-regression-gate`
+   - burst 429는 threshold 안이지만 0에서 0.275%로 관측됐다. generator/서버 변동성을 고려해 회귀선을 별도 고정한다.
+9. `[Perf] Prometheus remote-write 부하와 API latency 상관 리포트 추가` / 브랜치 `perf/prometheus-remote-write-latency-correlation`
+   - Prometheus mode p95가 baseline보다 약간 높다. 관측 비용이 API latency에 미치는 영향을 리포트로 분리한다.
+10. `[Perf] t3micro capacity와 smoke 결과 등급 분리 gate 추가` / 브랜치 `perf/t3micro-capacity-smoke-grade-separation`
+    - 로컬 smoke 통과가 off-host capacity 통과처럼 읽히지 않도록 `smoke`, `capacity`, `soak` 등급을 aggregate status에 명시한다.
+
+## 생성 아티팩트
+
+- `docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-vu3-summary.md`
+- `docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-vu16-overload-summary.md`
+- `docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-burst-summary.md`
+- `docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-prom-vu3-summary.md`
+- `docs/performance-results/t3micro-defensive-latest-main-20260428.md`

--- a/docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-burst-summary.md
+++ b/docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-burst-summary.md
@@ -1,0 +1,77 @@
+# transaction-100m-latest-main-20260428-burst-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-28T00:27:14Z
+- resultPurpose: smoke
+- reportClass: transaction-100m-smoke
+- sourceMarkdown: build/reports/k6/transaction-100m-latest-main-20260428-burst-summary.md
+- sourceJson: build/reports/k6/transaction-100m-latest-main-20260428-burst-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- run id: transaction-100m-latest-main-20260428-burst
+- vus: 16
+- duration: 20s
+- warmup duration: 10s
+- scenario mode: burst
+- arrival rate: 8/1s
+- burst rate: 256/1s
+- burst duration: 20s
+- pre allocated VUs: 64
+- max VUs: 64
+- limit: 50
+- observability mode: summary-only
+- overload mode: true
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: disabled in overload mode
+- overload 429 rate threshold: 0.015
+- burst 429 rate threshold: 0.1
+- effective overload 429 rate threshold: 0.1
+- overload 503 rate threshold: 0
+
+## Results
+
+- http_req_failed rate: 0.002107878194752889
+- checks rate: 1
+- transaction 429 rate: 0.002750085940185631
+- transaction 503 rate: 0
+- transaction 503 count: 0
+- hot first p95 ms: 2.19317705
+- hot first p99 ms: 6.370319499999999
+- hot first p99.9 ms: 31.049400947002407
+- hot first max ms: 80.837209
+- hot cursor p95 ms: 1.788246099999999
+- hot cursor p99 ms: 4.181691979999998
+- hot cursor p99.9 ms: 14.380868328000878
+- hot cursor max ms: 80.372917
+- cold first p95 ms: 1.6220209999999986
+- cold first p99 ms: 3.904516899999999
+- cold first p99.9 ms: 10.865901870000053
+- cold first max ms: 31.136208
+- cold cursor p95 ms: 1.7448754
+- cold cursor p99 ms: 3.6660187599999996
+- cold cursor p99.9 ms: 7.963168688000014
+- cold cursor max ms: 13.368166
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `summary-only`이면 Prometheus remote write 없이 summary 파일만 남깁니다.

--- a/docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-prom-vu3-summary.md
+++ b/docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-prom-vu3-summary.md
@@ -1,0 +1,77 @@
+# transaction-100m-latest-main-20260428-prom-vu3-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-28T00:29:28Z
+- resultPurpose: smoke
+- reportClass: transaction-100m-smoke
+- sourceMarkdown: build/reports/k6/transaction-100m-latest-main-20260428-prom-vu3-summary.md
+- sourceJson: build/reports/k6/transaction-100m-latest-main-20260428-prom-vu3-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- run id: transaction-100m-latest-main-20260428-prom-vu3
+- vus: 3
+- duration: 15s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 20s
+- pre allocated VUs: 3
+- max VUs: 3
+- limit: 50
+- observability mode: prometheus
+- overload mode: false
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: 0.01
+- overload 429 rate threshold: disabled outside overload mode
+- burst 429 rate threshold: disabled outside overload mode
+- effective overload 429 rate threshold: disabled outside overload mode
+- overload 503 rate threshold: disabled outside overload mode
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- transaction 503 count: n/a
+- hot first p95 ms: 1.9809579999999993
+- hot first p99 ms: 6.020474999999995
+- hot first p99.9 ms: 18.513766130001247
+- hot first max ms: 58.674958
+- hot cursor p95 ms: 2.0715624999999993
+- hot cursor p99 ms: 6.329795899999997
+- hot cursor p99.9 ms: 16.87824762000077
+- hot cursor max ms: 54.601042
+- cold first p95 ms: 1.9751869999999996
+- cold first p99 ms: 6.2832076999999975
+- cold first p99.9 ms: 23.372858870003608
+- cold first max ms: 63.690084
+- cold cursor p95 ms: 1.9959579999999997
+- cold cursor p99 ms: 7.0198369
+- cold cursor p99.9 ms: 20.30858927000059
+- cold cursor max ms: 34.784208
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `prometheus`이면 Prometheus remote write와 summary 파일을 함께 남깁니다.

--- a/docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-vu16-overload-summary.md
+++ b/docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-vu16-overload-summary.md
@@ -1,0 +1,77 @@
+# transaction-100m-latest-main-20260428-vu16-overload-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-28T00:23:38Z
+- resultPurpose: smoke
+- reportClass: transaction-100m-smoke
+- sourceMarkdown: build/reports/k6/transaction-100m-latest-main-20260428-vu16-overload-summary.md
+- sourceJson: build/reports/k6/transaction-100m-latest-main-20260428-vu16-overload-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- run id: transaction-100m-latest-main-20260428-vu16-overload
+- vus: 16
+- duration: 30s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 20s
+- pre allocated VUs: 16
+- max VUs: 16
+- limit: 50
+- observability mode: summary-only
+- overload mode: true
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: disabled in overload mode
+- overload 429 rate threshold: 0.015
+- burst 429 rate threshold: 0.1
+- effective overload 429 rate threshold: 0.015
+- overload 503 rate threshold: 0
+
+## Results
+
+- http_req_failed rate: 0.005267209594424861
+- checks rate: 1
+- transaction 429 rate: 0.005702337958563011
+- transaction 503 rate: 0
+- transaction 503 count: 0
+- hot first p95 ms: 2.3940358999999996
+- hot first p99 ms: 9.138222159999994
+- hot first p99.9 ms: 26.97497265800048
+- hot first max ms: 72.775
+- hot cursor p95 ms: 2.2502080999999996
+- hot cursor p99 ms: 7.546341239999997
+- hot cursor p99.9 ms: 29.44489662700048
+- hot cursor max ms: 60.862834
+- cold first p95 ms: 2.1458436999999986
+- cold first p99 ms: 6.343147499999979
+- cold first p99.9 ms: 22.596532208001733
+- cold first max ms: 56.498042
+- cold cursor p95 ms: 2.264982899999999
+- cold cursor p99 ms: 7.184074999999996
+- cold cursor p99.9 ms: 31.5724690260052
+- cold cursor max ms: 64.385334
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `summary-only`이면 Prometheus remote write 없이 summary 파일만 남깁니다.

--- a/docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-vu3-summary.md
+++ b/docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-vu3-summary.md
@@ -1,0 +1,77 @@
+# transaction-100m-latest-main-20260428-vu3-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-28T00:21:53Z
+- resultPurpose: smoke
+- reportClass: transaction-100m-smoke
+- sourceMarkdown: build/reports/k6/transaction-100m-latest-main-20260428-vu3-summary.md
+- sourceJson: build/reports/k6/transaction-100m-latest-main-20260428-vu3-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- run id: transaction-100m-latest-main-20260428-vu3
+- vus: 3
+- duration: 30s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 20s
+- pre allocated VUs: 3
+- max VUs: 3
+- limit: 50
+- observability mode: summary-only
+- overload mode: false
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: 0.01
+- overload 429 rate threshold: disabled outside overload mode
+- burst 429 rate threshold: disabled outside overload mode
+- effective overload 429 rate threshold: disabled outside overload mode
+- overload 503 rate threshold: disabled outside overload mode
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- transaction 503 count: n/a
+- hot first p95 ms: 1.7575621499999983
+- hot first p99 ms: 4.32791577
+- hot first p99.9 ms: 18.067606621000994
+- hot first max ms: 44.864501
+- hot cursor p95 ms: 1.7645666999999987
+- hot cursor p99 ms: 4.318272999999999
+- hot cursor p99.9 ms: 17.19225537100124
+- hot cursor max ms: 61.952334
+- cold first p95 ms: 1.7409874999999981
+- cold first p99 ms: 4.78609056
+- cold first p99.9 ms: 15.82058675400033
+- cold first max ms: 54.312834
+- cold cursor p95 ms: 1.79796105
+- cold cursor p99 ms: 4.543069519999998
+- cold cursor p99.9 ms: 15.04550775600045
+- cold cursor max ms: 58.738709
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `summary-only`이면 Prometheus remote write 없이 summary 파일만 남깁니다.

--- a/docs/performance-results/t3micro-defensive-latest-main-20260428.md
+++ b/docs/performance-results/t3micro-defensive-latest-main-20260428.md
@@ -1,0 +1,28 @@
+# t3micro-defensive-latest-main-20260428
+
+## Inputs
+
+- capacityResult: missing
+- capacitySummary: missing
+- capacityRunContext: missing
+- sseResult: missing
+- admissionSummary: missing
+- outboxSummary: missing
+- k6Summary: docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-vu16-overload-summary.md
+- memorySummary: build/reports/t3micro/latest-main-20260428-memory-summary.tsv
+
+## Gate Summary
+
+| Gate | Status | Peak CPU % | Peak Memory MiB | Backlog / Reject Signal | Source |
+| --- | --- | ---: | ---: | --- | --- |
+| capacity | missing | missing | missing | repeat=missing | missing |
+| sse reconnect | missing | missing | missing | clients=missing rounds=missing | missing |
+| http admission | n/a | n/a | n/a | rejected=missing failed_rate=missing | missing |
+| outbox backlog | n/a | n/a | n/a | lag=missing failed=missing dlq=missing | missing |
+| k6 transaction 100m | n/a | n/a | n/a | hotFirstP95=2.3940358999999996 hotCursorP95=2.2502080999999996 coldFirstP95=2.1458436999999986 coldCursorP95=2.264982899999999 429Rate=0.005702337958563011 | docs/performance-results/k6-smoke/transaction-100m-latest-main-20260428-vu16-overload-summary.md |
+| total memory | pass | n/a | 644.45 | budget=900 source=build/reports/t3micro/latest-main-20260428-memory-summary.tsv | build/reports/t3micro/latest-main-20260428-memory-summary.tsv |
+
+## Notes
+
+- missing 값은 해당 gate가 아직 같은 aggregate run에 연결되지 않았음을 뜻합니다.
+- token, 운영 URL, raw Authorization header는 기록하지 않습니다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #481

## 🌿 Base Branch
- `main`

## 📝 Summary
- 최신 `main@7a9805c` 기준으로 로컬 Docker t3.micro 1억 row 거래 조회와 대용량 트래픽 방어 재검증 결과를 문서화합니다.
- fixture DB gate, k6 baseline/overload/burst/Prometheus, capacity prerequisite, aggregate 결과를 분리해 남은 병목 후보를 PR/issue 단위로 정리합니다.

## 🛠 Changes
- 2026-04-28 latest-main 100m defensive 병목 리포트 추가
- k6 baseline, overload, burst, Prometheus mode summary 문서 보존
- t3.micro defensive aggregate k6+memory 결과 문서 보존

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `git pull --ff-only origin main`
- `tools/test/run-transaction-100m-fixture-dataset-probe.sh`
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-deps` baseline VU3
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-deps` overload VU16
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-deps` burst 256/s
- `tools/test/run-k6-transaction-100m-loadtest.sh --no-deps` Prometheus mode
- `tools/test/run-transaction-100m-capacity-gates.sh --print-plan`
- `tools/test/run-t3micro-defensive-gates-aggregate-report.sh --dry-run`
- `tools/test/run-t3micro-defensive-gates-aggregate-report.sh`
- `git diff --cached --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 문서 PR이라 런타임 영향 없음. off-host capacity context 미구성으로 실제 capacity baseline은 미확정 상태를 기록했습니다.
- 롤백 방법: 이 PR의 문서 커밋 revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
