### PR TITLE
[Perf] off-host 100m capacity 핵심 실행 경로 보강

### DIFF
--- a/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
@@ -27,12 +27,13 @@ cat >"${capacity}" <<'MD'
 MD
 cat >"${capacity_context}" <<'ENV'
 CAPACITY_RUN_PURPOSE=capacity
+CAPACITY_NAME=aggregate-check-capacity
 CAPACITY_GENERATOR_MODE=docker-context
 CAPACITY_K6_DOCKER_CONTEXT=capacity-k6-remote
 CAPACITY_K6_REMOTE_BASE_URL=http://192.0.2.20:8080
 CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.20:9090/api/v1/write
 ENV
-printf "phase\tprofile\tstatus\tadmission\tvus\tbackend_cpus\tbackend_memory\tpostgres_cpus\tpostgres_memory\tdb_pool\toverload_mode\tduration\thttp_failed_rate\thttp_reqs\ttransaction_429_rate\thot_first_p95_ms\thot_cursor_p95_ms\tcold_first_p95_ms\tcold_cursor_p95_ms\tbackend_cpu_percent\tpostgres_cpu_percent\thikari_active\thikari_pending\thikari_max\tlog_path\tsummary_json\nsingle-host\tsingle-host-default\t0\t3\t8\t0.40\t512m\t0.60\t384m\t4\ttrue\t1m\t0\t1200\t0.010000\t210\t220\t610\t640\t82.50\t41.00\t3\t0\t4\tcapacity.log\tcapacity-summary.json\n" >"${capacity_summary}"
+printf "phase\tprofile\tstatus\tadmission\tvus\tbackend_cpus\tbackend_memory\tpostgres_cpus\tpostgres_memory\tdb_pool\toverload_mode\tduration\thttp_failed_rate\thttp_reqs\ttransaction_429_rate\thot_first_p95_ms\thot_cursor_p95_ms\tcold_first_p95_ms\tcold_cursor_p95_ms\tbackend_cpu_percent\tpostgres_cpu_percent\thikari_active\thikari_pending\thikari_max\tlog_path\tsummary_json\nsingle-host\tsingle-host-default\t0\t3\t8\t0.40\t512m\t0.60\t384m\t4\ttrue\t1m\t0\t1200\t0.010000\t210\t220\t610\t640\t82.50\t41.00\t3\t0\t4\tcapacity.log\tcapacity-summary.json\nlong-soak\tlong-soak-high-traffic\t0\t8\t8\t0.80\t640m\t0.60\t384m\t6\tfalse\t30m\t0\t12000\t0.000000\t230\t240\t650\t680\t88.25\t45.00\t5\t0\t6\tsoak.log\tsoak-summary.json\n" >"${capacity_summary}"
 
 cat >"${sse}" <<'MD'
 # sse
@@ -78,22 +79,24 @@ grep -F "admission=${admission}" <<<"${plan}" >/dev/null
 grep -F "k6=${k6}" <<<"${plan}" >/dev/null
 grep -F "memory=${memory}" <<<"${plan}" >/dev/null
 grep -F "auto_inputs=true" <<<"${plan}" >/dev/null
+grep -F "auto_input_run_id=missing" <<<"${plan}" >/dev/null
+grep -F "auto_input_prefix=aggregate-check" <<<"${plan}" >/dev/null
 grep -F "required_gates=capacity,sse,admission,outbox,k6,memory" <<<"${plan}" >/dev/null
 grep -F "total_memory_budget_mib=900" <<<"${plan}" >/dev/null
 
 auto_root="${temp_dir}/auto"
 mkdir -p "${auto_root}/docs/performance-results" "${auto_root}/build/reports/admission/run" "${auto_root}/build/reports/outbox/run" "${auto_root}/build/reports/k6" "${auto_root}/build/reports/t3micro"
-auto_capacity="${auto_root}/docs/performance-results/docker-t3micro-capacity-auto.md"
-auto_capacity_dir="${auto_root}/build/reports/k6/transaction-100m-capacity-auto"
+auto_capacity="${auto_root}/docs/performance-results/docker-t3micro-capacity-aggregate-auto-check.md"
+auto_capacity_dir="${auto_root}/build/reports/k6/aggregate-auto-check-capacity"
 auto_capacity_summary="${auto_capacity_dir}/capacity-summary.tsv"
 auto_capacity_context="${auto_capacity_dir}/capacity-run-context.env"
-auto_sse="${auto_root}/docs/performance-results/sse-reconnect-auto.md"
-auto_admission="${auto_root}/build/reports/admission/run/http-admission-summary.tsv"
-auto_outbox="${auto_root}/build/reports/outbox/run/outbox-provider-backlog-summary.tsv"
-auto_k6="${auto_root}/build/reports/k6/transaction-100m-auto-summary.md"
-auto_memory="${auto_root}/build/reports/t3micro/t3micro-memory-summary.tsv"
+auto_sse="${auto_root}/docs/performance-results/aggregate-auto-check-sse-reconnect.md"
+auto_admission="${auto_root}/build/reports/admission/aggregate-auto-check-admission/http-admission-summary.tsv"
+auto_outbox="${auto_root}/build/reports/outbox/aggregate-auto-check-outbox/outbox-provider-backlog-summary.tsv"
+auto_k6="${auto_root}/build/reports/k6/transaction-100m-aggregate-auto-check-summary.md"
+auto_memory="${auto_root}/build/reports/t3micro/aggregate-auto-check-memory-summary.tsv"
 cp "${capacity}" "${auto_capacity}"
-mkdir -p "${auto_capacity_dir}"
+mkdir -p "${auto_capacity_dir}" "$(dirname "${auto_admission}")" "$(dirname "${auto_outbox}")"
 cp "${capacity_summary}" "${auto_capacity_summary}"
 cp "${capacity_context}" "${auto_capacity_context}"
 cp "${sse}" "${auto_sse}"
@@ -101,6 +104,18 @@ cp "${admission}" "${auto_admission}"
 cp "${outbox}" "${auto_outbox}"
 cp "${k6}" "${auto_k6}"
 cp "${memory}" "${auto_memory}"
+stale_capacity="${auto_root}/docs/performance-results/stale-20260427-docker-t3micro-capacity.md"
+stale_capacity_dir="${auto_root}/build/reports/k6/stale-20260427-capacity"
+stale_capacity_summary="${stale_capacity_dir}/capacity-summary.tsv"
+stale_capacity_context="${stale_capacity_dir}/capacity-run-context.env"
+stale_sse="${auto_root}/docs/performance-results/stale-20260427-sse-reconnect.md"
+stale_k6="${auto_root}/build/reports/k6/stale-20260427-k6-summary.md"
+mkdir -p "${stale_capacity_dir}"
+cp "${capacity}" "${stale_capacity}"
+cp "${capacity_summary}" "${stale_capacity_summary}"
+cp "${capacity_context}" "${stale_capacity_context}"
+cp "${sse}" "${stale_sse}"
+cp "${k6}" "${stale_k6}"
 
 echo "[t3micro-defensive-aggregate] auto inputs"
 auto_plan="$(
@@ -117,6 +132,10 @@ grep -F "admission=${auto_admission}" <<<"${auto_plan}" >/dev/null
 grep -F "outbox=${auto_outbox}" <<<"${auto_plan}" >/dev/null
 grep -F "k6=${auto_k6}" <<<"${auto_plan}" >/dev/null
 grep -F "memory=${auto_memory}" <<<"${auto_plan}" >/dev/null
+if grep -F "stale-20260427" <<<"${auto_plan}" >/dev/null; then
+  echo "auto input unexpectedly selected stale artifact outside aggregate prefix" >&2
+  exit 1
+fi
 
 echo "[t3micro-defensive-aggregate] required inputs"
 if T3MICRO_AGGREGATE_NAME=aggregate-required-check \
@@ -175,7 +194,9 @@ output="$(
 )"
 output="$(tail -1 <<<"${output}")"
 test "${output}" = "${temp_dir}/aggregate-check.md"
+grep -F "| capacity smoke | 0 | 82.50 | 712.00 | repeat=3 | ${capacity} |" "${output}" >/dev/null
 grep -F "| capacity | pass | 82.50 | n/a | 429Rate=0.010000 hikariPending=0 profiles=1 | ${capacity_summary} |" "${output}" >/dev/null
+grep -F "| capacity soak | pass | 88.25 | n/a | 429Rate=0.000000 hikariPending=0 profiles=1 | ${capacity_summary} |" "${output}" >/dev/null
 grep -F "| sse reconnect | 0 | 61.00 | 512.00 | clients=8 rounds=3 | ${sse} |" "${output}" >/dev/null
 grep -F "rejected=4 failed_rate=0.000000" "${output}" >/dev/null
 grep -F "lag=1 failed=0 dlq=0" "${output}" >/dev/null

--- a/tools/test/check-transaction-100m-capacity-gates.sh
+++ b/tools/test/check-transaction-100m-capacity-gates.sh
@@ -38,6 +38,7 @@ grep -F "k6_remote_workdir=/srv/aquila-bank" <<<"${plan}" >/dev/null
 grep -F "capacity_remote_preflight=true timeout=30 readiness_path=/actuator/health/readiness image=curlimages/curl:8.11.1" <<<"${plan}" >/dev/null
 grep -F "summary=build/reports/k6/transaction-capacity-check/capacity-summary.tsv" <<<"${plan}" >/dev/null
 grep -F "run_context=build/reports/k6/transaction-capacity-check/capacity-run-context.env" <<<"${plan}" >/dev/null
+grep -F "prerequisite_failure=build/reports/k6/transaction-capacity-check/capacity-prerequisite-failure.env" <<<"${plan}" >/dev/null
 
 echo "[transaction-100m-capacity] runner contract"
 grep -F "CAPACITY_K6_GENERATOR_MODE" "${script}" >/dev/null
@@ -46,8 +47,9 @@ grep -F "CAPACITY_REMOTE_PREFLIGHT" "${script}" >/dev/null
 grep -F "CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS" "${script}" >/dev/null
 grep -F "CAPACITY_REMOTE_READINESS_PATH" "${script}" >/dev/null
 grep -F "CAPACITY_REMOTE_PREFLIGHT_IMAGE" "${script}" >/dev/null
-grep -F "CAPACITY_K6_DOCKER_CONTEXT is required" "${script}" >/dev/null
-grep -F "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL is required" "${script}" >/dev/null
+grep -F "write_capacity_prerequisite_failure_report" "${script}" >/dev/null
+grep -F "fail_capacity_prerequisite" "${script}" >/dev/null
+grep -F "CAPACITY_PREREQUISITE_MISSING_VARS" "${script}" >/dev/null
 grep -F "K6_GENERATOR_MODE=\"\${capacity_k6_generator_mode}\"" "${script}" >/dev/null
 grep -F "K6_RUN_PURPOSE=capacity" "${script}" >/dev/null
 grep -F "K6_REMOTE_PREFLIGHT=\"\${capacity_remote_preflight}\"" "${script}" >/dev/null
@@ -115,7 +117,16 @@ if CAPACITY_K6_GENERATOR_MODE=local CAPACITY_ALLOW_LOCAL_K6_GENERATOR=true "${sc
   echo "capacity local k6 generator unexpectedly succeeded" >&2
   exit 1
 fi
-if CAPACITY_K6_GENERATOR_MODE=docker-context "${script}" --print-plan >/dev/null 2>&1; then
+prereq_name="transaction-capacity-prereq-missing-check"
+prereq_failure="build/reports/k6/${prereq_name}/capacity-prerequisite-failure.env"
+rm -f "${prereq_failure}"
+if CAPACITY_NAME="${prereq_name}" CAPACITY_K6_GENERATOR_MODE=docker-context "${script}" --print-plan >/dev/null 2>&1; then
   echo "docker-context k6 generator without remote runtime unexpectedly succeeded" >&2
   exit 1
 fi
+test -f "${prereq_failure}"
+grep -F "CAPACITY_PREREQUISITE_STATUS=failed" "${prereq_failure}" >/dev/null
+grep -F "CAPACITY_PREREQUISITE_FAILURE_REASON=missing-required-env" "${prereq_failure}" >/dev/null
+grep -F "CAPACITY_PREREQUISITE_MISSING_VARS=CAPACITY_K6_DOCKER_CONTEXT,CAPACITY_K6_REMOTE_BASE_URL,CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL" "${prereq_failure}" >/dev/null
+grep -F "CAPACITY_PREREQUISITE_GRADE=capacity" "${prereq_failure}" >/dev/null
+grep -F "CAPACITY_PREREQUISITE_FAILURE_REPORT=${prereq_failure}" "${prereq_failure}" >/dev/null

--- a/tools/test/check-transaction-100m-capacity-gates.sh
+++ b/tools/test/check-transaction-100m-capacity-gates.sh
@@ -39,9 +39,41 @@ grep -F "capacity_remote_preflight=true timeout=30 readiness_path=/actuator/heal
 grep -F "summary=build/reports/k6/transaction-capacity-check/capacity-summary.tsv" <<<"${plan}" >/dev/null
 grep -F "run_context=build/reports/k6/transaction-capacity-check/capacity-run-context.env" <<<"${plan}" >/dev/null
 grep -F "prerequisite_failure=build/reports/k6/transaction-capacity-check/capacity-prerequisite-failure.env" <<<"${plan}" >/dev/null
+grep -F "capacity_env_file=missing" <<<"${plan}" >/dev/null
+grep -F "offhost_required_env=CAPACITY_K6_DOCKER_CONTEXT,CAPACITY_K6_REMOTE_BASE_URL,CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL" <<<"${plan}" >/dev/null
+grep -F "long_soak_baseline=enabled grade=soak duration=30m" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-capacity] env template"
+env_template="$("${script}" --print-env-template)"
+grep -F "export CAPACITY_K6_GENERATOR_MODE=docker-context" <<<"${env_template}" >/dev/null
+grep -F "export CAPACITY_K6_DOCKER_CONTEXT=<remote-docker-context>" <<<"${env_template}" >/dev/null
+grep -F "export CAPACITY_K6_REMOTE_BASE_URL=http://<backend-host>:18080" <<<"${env_template}" >/dev/null
+grep -F "export CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://<prometheus-host>:9090/api/v1/write" <<<"${env_template}" >/dev/null
+grep -F "export CAPACITY_RUN_LONG_SOAK=true" <<<"${env_template}" >/dev/null
+grep -F "export CAPACITY_LONG_SOAK_DURATION=30m" <<<"${env_template}" >/dev/null
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+capacity_env_file="${temp_dir}/capacity.env"
+cat >"${capacity_env_file}" <<'ENV'
+CAPACITY_K6_DOCKER_CONTEXT=capacity-k6-file
+CAPACITY_K6_REMOTE_BASE_URL=http://192.0.2.40:18080
+CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.40:9090/api/v1/write
+CAPACITY_K6_REMOTE_WORKDIR=/srv/aquila-bank-file
+ENV
+env_file_plan="$(
+  CAPACITY_NAME=transaction-capacity-env-file-check \
+  CAPACITY_ENV_FILE="${capacity_env_file}" \
+    "${script}" --print-plan
+)"
+grep -F "capacity_env_file=${capacity_env_file}" <<<"${env_file_plan}" >/dev/null
+grep -F "k6_docker_context=capacity-k6-file" <<<"${env_file_plan}" >/dev/null
+grep -F "k6_remote_base_url=http://192.0.2.40:18080" <<<"${env_file_plan}" >/dev/null
+grep -F "k6_remote_prometheus_rw_server_url=http://192.0.2.40:9090/api/v1/write" <<<"${env_file_plan}" >/dev/null
 
 echo "[transaction-100m-capacity] runner contract"
 grep -F "CAPACITY_K6_GENERATOR_MODE" "${script}" >/dev/null
+grep -F "CAPACITY_ENV_FILE" "${script}" >/dev/null
 grep -F "CAPACITY_ALLOW_LOCAL_K6_GENERATOR" "${script}" >/dev/null
 grep -F "CAPACITY_REMOTE_PREFLIGHT" "${script}" >/dev/null
 grep -F "CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS" "${script}" >/dev/null
@@ -50,6 +82,7 @@ grep -F "CAPACITY_REMOTE_PREFLIGHT_IMAGE" "${script}" >/dev/null
 grep -F "write_capacity_prerequisite_failure_report" "${script}" >/dev/null
 grep -F "fail_capacity_prerequisite" "${script}" >/dev/null
 grep -F "CAPACITY_PREREQUISITE_MISSING_VARS" "${script}" >/dev/null
+grep -F "print_env_template" "${script}" >/dev/null
 grep -F "K6_GENERATOR_MODE=\"\${capacity_k6_generator_mode}\"" "${script}" >/dev/null
 grep -F "K6_RUN_PURPOSE=capacity" "${script}" >/dev/null
 grep -F "K6_REMOTE_PREFLIGHT=\"\${capacity_remote_preflight}\"" "${script}" >/dev/null

--- a/tools/test/check-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/check-transaction-100m-fixture-dataset-probe.sh
@@ -58,6 +58,7 @@ grep -F "recovery_wait_seconds=90" <<<"${plan}" >/dev/null
 grep -F "window_probe_mode=index-only-bounded" <<<"${plan}" >/dev/null
 grep -F "window_probe_limit=51" <<<"${plan}" >/dev/null
 grep -F "db_gate_checks=partition-estimate-tolerance,index-only-bounded-window-probe,monthly-partition" <<<"${plan}" >/dev/null
+grep -F "source_order=manifest,env,dataset-env,db-fallback" <<<"${plan}" >/dev/null
 
 echo "[transaction-100m-dataset-probe] estimate tolerance contract"
 FIXTURE_DATASET_ASSERT_LABEL=total_estimate \
@@ -87,16 +88,14 @@ grep -F "K6_COLD_ACCOUNT_ID=910000002" "${env_path}" >/dev/null
 grep -F "K6_COLD_FROM=2026-01-01T00:00:00Z" "${env_path}" >/dev/null
 grep -F "K6_COLD_TO=2026-01-31T00:00:00Z" "${env_path}" >/dev/null
 
-echo "[transaction-100m-dataset-probe] missing metadata fails without db fallback"
+echo "[transaction-100m-dataset-probe] existing dataset env fills missing manifest metadata"
 sed -i.bak '/hot_account_id=/d' "${manifest_path}"
-if FIXTURE_PATH="${dump_path}" \
-  FIXTURE_MANIFEST_PATH="${manifest_path}" \
-  FIXTURE_DATASET_ENV_PATH="${env_path}" \
-  FIXTURE_DATASET_DB_GATE=false \
-    "${script}" >/dev/null 2>&1; then
-  echo "missing manifest metadata unexpectedly passed without explicit DB fallback" >&2
-  exit 1
-fi
+FIXTURE_PATH="${dump_path}" \
+FIXTURE_MANIFEST_PATH="${manifest_path}" \
+FIXTURE_DATASET_ENV_PATH="${env_path}" \
+FIXTURE_DATASET_DB_GATE=false \
+  "${script}" >/dev/null
+grep -F "K6_HOT_ACCOUNT_ID=910000001" "${env_path}" >/dev/null
 
 echo "[transaction-100m-dataset-probe] wrapper contract"
 grep -F "assert_dataset_db_gate" "${script}" >/dev/null
@@ -118,6 +117,7 @@ grep -F "SET LOCAL lock_timeout" "${script}" >/dev/null
 grep -F "SET LOCAL work_mem" "${script}" >/dev/null
 grep -F "SET LOCAL temp_file_limit" "${script}" >/dev/null
 grep -F "FIXTURE_DATASET_MIN_WINDOW_ROWS" "${script}" >/dev/null
+grep -F "dataset_env_value" "${script}" >/dev/null
 if grep -F "bounded-window-count" "${script}" >/dev/null; then
   echo "dataset probe still reports bounded-window-count instead of index-only bounded probe" >&2
   exit 1

--- a/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
@@ -20,6 +20,8 @@ Environment:
   T3MICRO_TOTAL_MEMORY_BUDGET_MIB default 900
   T3MICRO_AGGREGATE_AUTO_INPUTS default true
   T3MICRO_AGGREGATE_SEARCH_ROOTS default "docs/performance-results build/reports"
+  T3MICRO_AGGREGATE_RUN_ID optional run id used to scope auto inputs
+  T3MICRO_AGGREGATE_AUTO_INPUT_PREFIX default <aggregate name>, used when run id is empty
 
 Examples:
   tools/test/run-t3micro-defensive-gates-aggregate-report.sh --print-plan
@@ -64,6 +66,8 @@ required_gates="${T3MICRO_AGGREGATE_REQUIRED_GATES:-}"
 total_memory_budget_mib="${T3MICRO_TOTAL_MEMORY_BUDGET_MIB:-900}"
 auto_inputs="${T3MICRO_AGGREGATE_AUTO_INPUTS:-true}"
 search_roots="${T3MICRO_AGGREGATE_SEARCH_ROOTS:-docs/performance-results build/reports}"
+aggregate_run_id="${T3MICRO_AGGREGATE_RUN_ID:-}"
+auto_input_prefix="${T3MICRO_AGGREGATE_AUTO_INPUT_PREFIX:-${name}}"
 
 require_bool() {
   local name="$1"
@@ -90,7 +94,9 @@ latest_file() {
   for root in ${search_roots}; do
     if [[ -d "${root}" ]]; then
       while IFS= read -r path; do
-        matches+=("${path}")
+        if file_matches_auto_scope "${path}"; then
+          matches+=("${path}")
+        fi
       done < <(find "${root}" -type f -name "${pattern}" 2>/dev/null)
     fi
   done
@@ -98,6 +104,31 @@ latest_file() {
     return 0
   fi
   ls -t "${matches[@]}" 2>/dev/null | head -1
+}
+
+file_matches_auto_scope() {
+  local path="$1"
+  if [[ -n "${aggregate_run_id}" ]]; then
+    [[ "${path}" == *"${aggregate_run_id}"* ]] && return 0
+    grep -F "${aggregate_run_id}" "${path}" >/dev/null 2>&1 && return 0
+    return 1
+  fi
+  if [[ -n "${auto_input_prefix}" ]]; then
+    [[ "${path}" == *"${auto_input_prefix}"* ]] && return 0
+    grep -F "${auto_input_prefix}" "${path}" >/dev/null 2>&1 && return 0
+    return 1
+  fi
+  return 0
+}
+
+capacity_summary_matches_auto_scope() {
+  local summary="$1"
+  local context="$2"
+  if file_matches_auto_scope "${summary}"; then
+    return 0
+  fi
+  [[ -f "${context}" ]] || return 1
+  file_matches_auto_scope "${context}"
 }
 
 capacity_context_for_summary() {
@@ -124,7 +155,7 @@ latest_capacity_summary() {
     if [[ -d "${root}" ]]; then
       while IFS= read -r path; do
         context="$(capacity_context_for_summary "${path}")"
-        if capacity_context_is_offhost "${context}"; then
+        if capacity_context_is_offhost "${context}" && capacity_summary_matches_auto_scope "${path}" "${context}"; then
           matches+=("${path}")
         fi
       done < <(find "${root}" -type f -name "capacity-summary.tsv" 2>/dev/null)
@@ -192,6 +223,8 @@ print_plan() {
   echo "[t3micro-defensive-aggregate] output=${output_path}"
   echo "[t3micro-defensive-aggregate] auto_inputs=${auto_inputs}"
   echo "[t3micro-defensive-aggregate] search_roots=${search_roots}"
+  echo "[t3micro-defensive-aggregate] auto_input_run_id=${aggregate_run_id:-missing}"
+  echo "[t3micro-defensive-aggregate] auto_input_prefix=${auto_input_prefix:-missing}"
   echo "[t3micro-defensive-aggregate] capacity=${capacity_result:-missing}"
   echo "[t3micro-defensive-aggregate] capacity_summary=${capacity_summary:-missing}"
   echo "[t3micro-defensive-aggregate] capacity_run_context=${capacity_run_context:-missing}"
@@ -245,6 +278,42 @@ capacity_summary_status() {
   ' "${file}"
 }
 
+capacity_summary_status_for_grade() {
+  local file="$1"
+  local grade="$2"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "missing"
+    return 0
+  fi
+  awk -F '\t' -v grade="${grade}" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "phase") phase_column = i
+        if ($i == "profile") profile_column = i
+        if ($i == "status") status_column = i
+      }
+      next
+    }
+    phase_column && profile_column && status_column {
+      is_soak = ($phase_column == "long-soak" || $profile_column ~ /soak/)
+      if ((grade == "soak" && !is_soak) || (grade == "capacity" && is_soak)) {
+        next
+      }
+      rows += 1
+      if ($status_column != "0") failed = 1
+    }
+    END {
+      if (!phase_column || !profile_column || !status_column || rows == 0) {
+        print "missing"
+      } else if (failed) {
+        print "fail"
+      } else {
+        print "pass"
+      }
+    }
+  ' "${file}"
+}
+
 capacity_profile_count() {
   local file="$1"
   if [[ -z "${file}" || ! -f "${file}" ]]; then
@@ -252,6 +321,31 @@ capacity_profile_count() {
     return 0
   fi
   awk 'NR > 1 {count += 1} END {print count + 0}' "${file}"
+}
+
+capacity_profile_count_for_grade() {
+  local file="$1"
+  local grade="$2"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "missing"
+    return 0
+  fi
+  awk -F '\t' -v grade="${grade}" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "phase") phase_column = i
+        if ($i == "profile") profile_column = i
+      }
+      next
+    }
+    phase_column && profile_column {
+      is_soak = ($phase_column == "long-soak" || $profile_column ~ /soak/)
+      if ((grade == "soak" && is_soak) || (grade == "capacity" && !is_soak)) {
+        count += 1
+      }
+    }
+    END { print count + 0 }
+  ' "${file}"
 }
 
 capacity_tsv_column_max() {
@@ -275,6 +369,47 @@ capacity_tsv_column_max() {
         text = $column
       }
       found = 1
+    }
+    END {
+      if (found) {
+        print text
+      } else {
+        print "n/a"
+      }
+    }
+  ' "${file}"
+}
+
+capacity_tsv_column_max_for_grade() {
+  local file="$1"
+  local key="$2"
+  local grade="$3"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "n/a"
+    return 0
+  fi
+  awk -F '\t' -v key="${key}" -v grade="${grade}" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == key) column = i
+        if ($i == "phase") phase_column = i
+        if ($i == "profile") profile_column = i
+      }
+      next
+    }
+    column && phase_column && profile_column {
+      is_soak = ($phase_column == "long-soak" || $profile_column ~ /soak/)
+      if ((grade == "soak" && !is_soak) || (grade == "capacity" && is_soak)) {
+        next
+      }
+      if ($column ~ /^[0-9]+([.][0-9]+)?$/) {
+        value = $column + 0
+        if (!found || value > max) {
+          max = value
+          text = $column
+        }
+        found = 1
+      }
     }
     END {
       if (found) {
@@ -322,20 +457,71 @@ capacity_cpu_peak() {
   ' "${file}"
 }
 
+capacity_cpu_peak_for_grade() {
+  local file="$1"
+  local grade="$2"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "n/a"
+    return 0
+  fi
+  awk -F '\t' -v grade="${grade}" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "phase") phase_column = i
+        if ($i == "profile") profile_column = i
+        if ($i == "backend_cpu_percent") backend_column = i
+        if ($i == "postgres_cpu_percent") postgres_column = i
+      }
+      next
+    }
+    phase_column && profile_column {
+      is_soak = ($phase_column == "long-soak" || $profile_column ~ /soak/)
+      if ((grade == "soak" && !is_soak) || (grade == "capacity" && is_soak)) {
+        next
+      }
+      for (i = 1; i <= NF; i++) {
+        if ((i == backend_column || i == postgres_column) && $i ~ /^[0-9]+([.][0-9]+)?$/) {
+          value = $i + 0
+          if (!found || value > max) {
+            max = value
+            text = $i
+          }
+          found = 1
+        }
+      }
+    }
+    END {
+      if (found) {
+        print text
+      } else {
+        print "n/a"
+      }
+    }
+  ' "${file}"
+}
+
 capacity_status_value() {
   if [[ -n "${capacity_summary}" ]]; then
-    capacity_summary_status "${capacity_summary}"
+    capacity_summary_status_for_grade "${capacity_summary}" capacity
   else
     md_value "${capacity_result}" "capacity smoke status"
   fi
 }
 
+capacity_soak_status_value() {
+  capacity_summary_status_for_grade "${capacity_summary}" soak
+}
+
 capacity_cpu_value() {
   if [[ -n "${capacity_summary}" ]]; then
-    capacity_cpu_peak "${capacity_summary}"
+    capacity_cpu_peak_for_grade "${capacity_summary}" capacity
   else
     md_value "${capacity_result}" "peakCpuPercent"
   fi
+}
+
+capacity_soak_cpu_value() {
+  capacity_cpu_peak_for_grade "${capacity_summary}" soak
 }
 
 capacity_memory_value() {
@@ -349,12 +535,19 @@ capacity_memory_value() {
 capacity_signal_value() {
   if [[ -n "${capacity_summary}" ]]; then
     printf "429Rate=%s hikariPending=%s profiles=%s" \
-      "$(capacity_tsv_column_max "${capacity_summary}" "transaction_429_rate")" \
-      "$(capacity_tsv_column_max "${capacity_summary}" "hikari_pending")" \
-      "$(capacity_profile_count "${capacity_summary}")"
+      "$(capacity_tsv_column_max_for_grade "${capacity_summary}" "transaction_429_rate" capacity)" \
+      "$(capacity_tsv_column_max_for_grade "${capacity_summary}" "hikari_pending" capacity)" \
+      "$(capacity_profile_count_for_grade "${capacity_summary}" capacity)"
   else
     printf "repeat=%s" "$(md_value "${capacity_result}" "repeat")"
   fi
+}
+
+capacity_soak_signal_value() {
+  printf "429Rate=%s hikariPending=%s profiles=%s" \
+    "$(capacity_tsv_column_max_for_grade "${capacity_summary}" "transaction_429_rate" soak)" \
+    "$(capacity_tsv_column_max_for_grade "${capacity_summary}" "hikari_pending" soak)" \
+    "$(capacity_profile_count_for_grade "${capacity_summary}" soak)"
 }
 
 capacity_source_value() {
@@ -488,7 +681,9 @@ write_report() {
     echo
     echo "| Gate | Status | Peak CPU % | Peak Memory MiB | Backlog / Reject Signal | Source |"
     echo "| --- | --- | ---: | ---: | --- | --- |"
+    echo "| capacity smoke | $(md_value "${capacity_result}" "capacity smoke status") | $(md_value "${capacity_result}" "peakCpuPercent") | $(md_value "${capacity_result}" "peakMemoryMiB") | repeat=$(md_value "${capacity_result}" "repeat") | ${capacity_result:-missing} |"
     echo "| capacity | $(capacity_status_value) | $(capacity_cpu_value) | $(capacity_memory_value) | $(capacity_signal_value) | $(capacity_source_value) |"
+    echo "| capacity soak | $(capacity_soak_status_value) | $(capacity_soak_cpu_value) | n/a | $(capacity_soak_signal_value) | ${capacity_summary:-missing} |"
     echo "| sse reconnect | $(md_value "${sse_result}" "status") | $(md_value "${sse_result}" "peakCpuPercent") | $(md_value "${sse_result}" "peakMemoryMiB") | clients=$(md_value "${sse_result}" "reconnectClients") rounds=$(md_value "${sse_result}" "reconnectRounds") | ${sse_result:-missing} |"
     echo "| http admission | n/a | n/a | n/a | rejected=$(tsv_value "${admission_summary}" "rejected_count") failed_rate=$(tsv_value "${admission_summary}" "failed_rate") | ${admission_summary:-missing} |"
     echo "| outbox backlog | n/a | n/a | n/a | lag=$(tsv_value "${outbox_summary}" "lag_seconds") failed=$(tsv_value "${outbox_summary}" "failed_count") dlq=$(tsv_value "${outbox_summary}" "dlq_count") | ${outbox_summary:-missing} |"

--- a/tools/test/run-transaction-100m-capacity-gates.sh
+++ b/tools/test/run-transaction-100m-capacity-gates.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE' >&2
-usage: tools/test/run-transaction-100m-capacity-gates.sh [--print-plan]
+usage: tools/test/run-transaction-100m-capacity-gates.sh [--print-plan|--print-env-template]
 
 Required runtime environment for actual runs:
   K6_HOT_ACCOUNT_ID
@@ -15,6 +15,7 @@ Required runtime environment for actual runs:
 
 Optional environment:
   CAPACITY_NAME              default transaction-100m-capacity-<timestamp>
+  CAPACITY_ENV_FILE          optional local env file for off-host capacity runtime
   CAPACITY_BUILD_BACKEND     default true
   CAPACITY_RUN_SINGLE_HOST   default true
   CAPACITY_RUN_CPU_SPLIT     default true
@@ -61,6 +62,9 @@ while [[ "$#" -gt 0 ]]; do
     --print-plan)
       mode="print-plan"
       ;;
+    --print-env-template)
+      mode="print-env-template"
+      ;;
     -h|--help)
       usage
       exit 0
@@ -72,6 +76,18 @@ while [[ "$#" -gt 0 ]]; do
   esac
   shift
 done
+
+capacity_env_file="${CAPACITY_ENV_FILE:-}"
+if [[ -n "${capacity_env_file}" ]]; then
+  if [[ ! -f "${capacity_env_file}" ]]; then
+    echo "CAPACITY_ENV_FILE not found: ${capacity_env_file}" >&2
+    exit 1
+  fi
+  set -a
+  # 로컬 전용 원격 실행 값을 shell env로만 주입해 secret/URL 저장소 기록을 피합니다.
+  source "${capacity_env_file}"
+  set +a
+fi
 
 capacity_name="${CAPACITY_NAME:-transaction-100m-capacity-$(date +%Y-%m-%d-%H%M%S)}"
 build_backend="${CAPACITY_BUILD_BACKEND:-true}"
@@ -312,6 +328,7 @@ write_capacity_prerequisite_failure_report() {
     echo "CAPACITY_PREREQUISITE_FAILURE_REASON=${reason}"
     echo "CAPACITY_PREREQUISITE_MISSING_VARS=${missing_vars}"
     echo "CAPACITY_GENERATOR_MODE=${capacity_k6_generator_mode}"
+    echo "CAPACITY_ENV_FILE_PRESENT=$(present_flag "${capacity_env_file}")"
     echo "CAPACITY_K6_DOCKER_CONTEXT_PRESENT=$(present_flag "${capacity_k6_docker_context}")"
     echo "CAPACITY_K6_REMOTE_BASE_URL_PRESENT=$(present_flag "${capacity_k6_remote_base_url}")"
     echo "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_PRESENT=$(present_flag "${capacity_k6_remote_prometheus_rw_server_url}")"
@@ -330,6 +347,30 @@ fail_capacity_prerequisite() {
   echo "${message}" >&2
   echo "capacity prerequisite failure report: ${prerequisite_failure_path}" >&2
   exit 1
+}
+
+print_env_template() {
+  cat <<'TEMPLATE'
+# Local-only off-host capacity env. Keep this file outside git.
+export CAPACITY_K6_GENERATOR_MODE=docker-context
+export CAPACITY_K6_DOCKER_CONTEXT=<remote-docker-context>
+export CAPACITY_K6_REMOTE_BASE_URL=http://<backend-host>:18080
+export CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://<prometheus-host>:9090/api/v1/write
+export CAPACITY_K6_REMOTE_WORKDIR=/srv/aquila-bank
+export CAPACITY_REMOTE_PREFLIGHT=true
+export CAPACITY_RUN_SINGLE_HOST=true
+export CAPACITY_RUN_CPU_SPLIT=true
+export CAPACITY_RUN_LONG_SOAK=true
+export CAPACITY_LONG_SOAK_DURATION=30m
+TEMPLATE
+}
+
+capacity_run_grades() {
+  if [[ "${run_long_soak}" == "true" ]]; then
+    echo "capacity,soak"
+  else
+    echo "capacity"
+  fi
 }
 
 stop_backend_before_bootjar() {
@@ -379,6 +420,11 @@ assert_adaptive_strict_guards "CAPACITY_SINGLE_HOST_PROFILES" "${single_host_pro
 assert_adaptive_strict_guards "CAPACITY_CPU_SPLIT_PROFILES" "${cpu_split_profiles}"
 assert_adaptive_strict_guard "CAPACITY_LONG_SOAK_PROFILE" "${long_soak_profile}"
 
+if [[ "${mode}" == "print-env-template" ]]; then
+  print_env_template
+  exit 0
+fi
+
 if [[ "${capacity_k6_generator_mode}" == "local" ]]; then
   fail_capacity_prerequisite \
     "local-generator-not-allowed" \
@@ -407,6 +453,7 @@ print_plan() {
   echo "[transaction-100m-capacity] run_cpu_split=${run_cpu_split}"
   echo "[transaction-100m-capacity] run_long_soak=${run_long_soak}"
   echo "[transaction-100m-capacity] continue_on_failure=${continue_on_failure}"
+  echo "[transaction-100m-capacity] capacity_env_file=${capacity_env_file:-missing}"
   echo "[transaction-100m-capacity] single_host_profiles=$(profile_names "${single_host_profiles}")"
   echo "[transaction-100m-capacity] cpu_split_profiles=$(profile_names "${cpu_split_profiles}")"
   echo "[transaction-100m-capacity] long_soak_profile=${long_soak_profile%%:*} duration=${long_soak_duration}"
@@ -434,6 +481,8 @@ print_plan() {
   echo "[transaction-100m-capacity] summary=${summary_tsv}"
   echo "[transaction-100m-capacity] run_context=${run_context_path}"
   echo "[transaction-100m-capacity] prerequisite_failure=${prerequisite_failure_path}"
+  echo "[transaction-100m-capacity] offhost_required_env=CAPACITY_K6_DOCKER_CONTEXT,CAPACITY_K6_REMOTE_BASE_URL,CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL"
+  echo "[transaction-100m-capacity] long_soak_baseline=$([[ "${run_long_soak}" == "true" ]] && echo enabled || echo disabled) grade=soak duration=${long_soak_duration}"
 }
 
 print_plan
@@ -454,6 +503,7 @@ write_capacity_run_context() {
   {
     echo "CAPACITY_RUN_PURPOSE=capacity"
     echo "CAPACITY_NAME=${capacity_name}"
+    echo "CAPACITY_RUN_GRADES=$(capacity_run_grades)"
     echo "CAPACITY_GENERATOR_MODE=${capacity_k6_generator_mode}"
     echo "CAPACITY_K6_DOCKER_CONTEXT=${capacity_k6_docker_context}"
     echo "CAPACITY_K6_REMOTE_BASE_URL=${capacity_k6_remote_base_url}"

--- a/tools/test/run-transaction-100m-capacity-gates.sh
+++ b/tools/test/run-transaction-100m-capacity-gates.sh
@@ -108,6 +108,8 @@ backend_health_url="${CAPACITY_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PO
 report_dir="build/reports/k6/${capacity_name}"
 summary_tsv="${report_dir}/capacity-summary.tsv"
 run_context_path="${report_dir}/capacity-run-context.env"
+prerequisite_failure_path="${CAPACITY_PREREQUISITE_FAILURE_REPORT_PATH:-${report_dir}/capacity-prerequisite-failure.env}"
+capacity_run_grade="${CAPACITY_RUN_GRADE:-capacity}"
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
 CPU_SAMPLER_PID=""
 threshold_failed=false
@@ -290,6 +292,46 @@ require_env() {
   fi
 }
 
+present_flag() {
+  if [[ -n "$1" ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+write_capacity_prerequisite_failure_report() {
+  local reason="$1"
+  local missing_vars="$2"
+  mkdir -p "$(dirname "${prerequisite_failure_path}")"
+  {
+    echo "CAPACITY_PREREQUISITE_STATUS=failed"
+    echo "CAPACITY_RUN_PURPOSE=capacity"
+    echo "CAPACITY_NAME=${capacity_name}"
+    echo "CAPACITY_PREREQUISITE_GRADE=${capacity_run_grade}"
+    echo "CAPACITY_PREREQUISITE_FAILURE_REASON=${reason}"
+    echo "CAPACITY_PREREQUISITE_MISSING_VARS=${missing_vars}"
+    echo "CAPACITY_GENERATOR_MODE=${capacity_k6_generator_mode}"
+    echo "CAPACITY_K6_DOCKER_CONTEXT_PRESENT=$(present_flag "${capacity_k6_docker_context}")"
+    echo "CAPACITY_K6_REMOTE_BASE_URL_PRESENT=$(present_flag "${capacity_k6_remote_base_url}")"
+    echo "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_PRESENT=$(present_flag "${capacity_k6_remote_prometheus_rw_server_url}")"
+    echo "CAPACITY_SUMMARY_TSV=${summary_tsv}"
+    echo "CAPACITY_RUN_CONTEXT_ENV=${run_context_path}"
+    echo "CAPACITY_PREREQUISITE_FAILURE_REPORT=${prerequisite_failure_path}"
+  } >"${prerequisite_failure_path}"
+  echo "[transaction-100m-capacity] prerequisite failure report written=${prerequisite_failure_path}" >&2
+}
+
+fail_capacity_prerequisite() {
+  local reason="$1"
+  local missing_vars="$2"
+  local message="$3"
+  write_capacity_prerequisite_failure_report "${reason}" "${missing_vars}"
+  echo "${message}" >&2
+  echo "capacity prerequisite failure report: ${prerequisite_failure_path}" >&2
+  exit 1
+}
+
 stop_backend_before_bootjar() {
   # host jar hot-swap 방지: bootJar 전 실행 중인 backend JVM만 내립니다.
   docker compose "${compose_files[@]}" --profile loadtest stop aquila-bank-backend >/dev/null 2>&1 || true
@@ -338,23 +380,24 @@ assert_adaptive_strict_guards "CAPACITY_CPU_SPLIT_PROFILES" "${cpu_split_profile
 assert_adaptive_strict_guard "CAPACITY_LONG_SOAK_PROFILE" "${long_soak_profile}"
 
 if [[ "${capacity_k6_generator_mode}" == "local" ]]; then
-  echo "CAPACITY_K6_GENERATOR_MODE=local is limited to smoke runners; capacity requires docker-context" >&2
-  exit 1
+  fail_capacity_prerequisite \
+    "local-generator-not-allowed" \
+    "" \
+    "CAPACITY_K6_GENERATOR_MODE=local is limited to smoke runners; capacity requires docker-context"
 fi
 
 if [[ "${capacity_k6_generator_mode}" == "docker-context" ]]; then
-  [[ -n "${capacity_k6_docker_context}" ]] || {
-    echo "CAPACITY_K6_DOCKER_CONTEXT is required when CAPACITY_K6_GENERATOR_MODE=docker-context" >&2
-    exit 1
-  }
-  [[ -n "${capacity_k6_remote_base_url}" ]] || {
-    echo "CAPACITY_K6_REMOTE_BASE_URL is required when CAPACITY_K6_GENERATOR_MODE=docker-context" >&2
-    exit 1
-  }
-  [[ -n "${capacity_k6_remote_prometheus_rw_server_url}" ]] || {
-    echo "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL is required when CAPACITY_K6_GENERATOR_MODE=docker-context" >&2
-    exit 1
-  }
+  missing_vars=()
+  [[ -n "${capacity_k6_docker_context}" ]] || missing_vars+=("CAPACITY_K6_DOCKER_CONTEXT")
+  [[ -n "${capacity_k6_remote_base_url}" ]] || missing_vars+=("CAPACITY_K6_REMOTE_BASE_URL")
+  [[ -n "${capacity_k6_remote_prometheus_rw_server_url}" ]] || missing_vars+=("CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL")
+  if [[ "${#missing_vars[@]}" -gt 0 ]]; then
+    missing_csv="$(IFS=,; echo "${missing_vars[*]}")"
+    fail_capacity_prerequisite \
+      "missing-required-env" \
+      "${missing_csv}" \
+      "${missing_csv} is required when CAPACITY_K6_GENERATOR_MODE=docker-context"
+  fi
 fi
 
 print_plan() {
@@ -390,6 +433,7 @@ print_plan() {
   echo "[transaction-100m-capacity] hikari_pending_threshold=${hikari_pending_threshold}"
   echo "[transaction-100m-capacity] summary=${summary_tsv}"
   echo "[transaction-100m-capacity] run_context=${run_context_path}"
+  echo "[transaction-100m-capacity] prerequisite_failure=${prerequisite_failure_path}"
 }
 
 print_plan

--- a/tools/test/run-transaction-100m-fixture-dataset-probe.sh
+++ b/tools/test/run-transaction-100m-fixture-dataset-probe.sh
@@ -147,6 +147,14 @@ manifest_value() {
   awk -F '=' -v key="${key}" '$1 == key {print $2}' "${manifest_path}" | tail -1
 }
 
+dataset_env_value() {
+  local key="$1"
+  if [[ ! -s "${dataset_env_path}" ]]; then
+    return 0
+  fi
+  awk -F '=' -v key="${key}" '$1 == key {print $2}' "${dataset_env_path}" | tail -1
+}
+
 require_value() {
   local key="$1"
   local value="$2"
@@ -165,7 +173,12 @@ resolve_manifest_or_env() {
     echo "${value}"
     return 0
   fi
-  echo "${!env_key:-}"
+  value="${!env_key:-}"
+  if [[ -n "${value}" ]]; then
+    echo "${value}"
+    return 0
+  fi
+  dataset_env_value "${env_key}"
 }
 
 probe_from_db() {
@@ -526,7 +539,7 @@ print_plan() {
   echo "[transaction-100m-dataset-probe] window_probe_mode=index-only-bounded"
   echo "[transaction-100m-dataset-probe] window_probe_limit=${min_window_rows}"
   echo "[transaction-100m-dataset-probe] db_gate_checks=partition-estimate-tolerance,index-only-bounded-window-probe,monthly-partition"
-  echo "[transaction-100m-dataset-probe] source_order=manifest,env,db-fallback"
+  echo "[transaction-100m-dataset-probe] source_order=manifest,env,dataset-env,db-fallback"
 }
 
 run_probe() {


### PR DESCRIPTION
## 🔗 Related Issue
close #483

## 🌿 Base Branch
- `main`

## 📝 Summary
- off-host 100m capacity 실행 전 prerequisite 누락을 artifact로 남기고, 로컬 전용 env 파일로 remote k6 실행 환경을 주입할 수 있게 했습니다.
- t3micro aggregate auto input을 run id 또는 aggregate prefix scope로 제한하고, smoke/capacity/soak 등급을 분리해 stale artifact 혼입을 줄였습니다.
- fixture dataset probe는 기존 `*.dataset.env`를 자동 fallback으로 사용해 반복 실행 재현성을 높였습니다.

## 🛠 Changes
- capacity runner에 `capacity-prerequisite-failure.env`, `CAPACITY_ENV_FILE`, `--print-env-template`, long-soak baseline plan 출력을 추가했습니다.
- t3micro aggregate runner에 `T3MICRO_AGGREGATE_RUN_ID`, `T3MICRO_AGGREGATE_AUTO_INPUT_PREFIX`, capacity smoke/capacity soak 분리 rows를 추가했습니다.
- fixture dataset probe가 manifest와 명시 env 다음에 기존 dataset env를 읽도록 변경했습니다.
- 각 runner checker에 regression contract를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-capacity-gates.sh`
- `tools/test/check-t3micro-defensive-gates-aggregate-report.sh`
- `tools/test/check-transaction-100m-fixture-dataset-probe.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` = `4`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: aggregate auto input scope가 엄격해져 prefix/run id가 맞지 않는 과거 artifact는 자동 선택되지 않습니다. 실제 off-host capacity baseline 수치는 remote Docker context와 URL 준비 뒤 별도 실행이 필요합니다.
- 롤백 방법: 이 PR의 4개 commit을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
