### PR TITLE
[Perf] transaction read 관측 gate 및 latency 상관 리포트 추가

### DIFF
--- a/tools/test/check-prometheus-remote-write-latency-correlation.sh
+++ b/tools/test/check-prometheus-remote-write-latency-correlation.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-prometheus-remote-write-latency-correlation.sh"
+
+echo "[prometheus-remote-write-correlation] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+baseline_json="${temp_dir}/baseline-summary.json"
+prometheus_json="${temp_dir}/prometheus-summary.json"
+remote_write_tsv="${temp_dir}/remote-write-snapshot.tsv"
+output_dir="${temp_dir}/correlation-output"
+
+cat >"${baseline_json}" <<'JSON'
+{
+  "metrics": {
+    "http_req_failed": {"values": {"rate": 0}},
+    "http_reqs": {"values": {"count": 1000}},
+    "aquila_transaction_429_rate": {"values": {"rate": 0}},
+    "aquila_transaction_hot_first_ms": {"values": {"p(95)": 2.0, "p(99)": 6.0, "p(99.9)": 20.0, "max": 40.0}},
+    "aquila_transaction_hot_cursor_ms": {"values": {"p(95)": 2.1, "p(99)": 6.2, "p(99.9)": 18.0, "max": 35.0}},
+    "aquila_transaction_cold_first_ms": {"values": {"p(95)": 2.3, "p(99)": 6.4, "p(99.9)": 21.0, "max": 39.0}},
+    "aquila_transaction_cold_cursor_ms": {"values": {"p(95)": 2.2, "p(99)": 6.3, "p(99.9)": 19.0, "max": 34.0}}
+  }
+}
+JSON
+
+cat >"${prometheus_json}" <<'JSON'
+{
+  "metrics": {
+    "http_req_failed": {"values": {"rate": 0}},
+    "http_reqs": {"values": {"count": 1000}},
+    "aquila_transaction_429_rate": {"values": {"rate": 0}},
+    "aquila_transaction_hot_first_ms": {"values": {"p(95)": 2.4, "p(99)": 7.1, "p(99.9)": 25.0, "max": 60.0}},
+    "aquila_transaction_hot_cursor_ms": {"values": {"p(95)": 2.3, "p(99)": 6.9, "p(99.9)": 22.0, "max": 44.0}},
+    "aquila_transaction_cold_first_ms": {"values": {"p(95)": 2.5, "p(99)": 7.0, "p(99.9)": 24.0, "max": 48.0}},
+    "aquila_transaction_cold_cursor_ms": {"values": {"p(95)": 2.4, "p(99)": 7.2, "p(99.9)": 26.0, "max": 52.0}}
+  }
+}
+JSON
+
+cat >"${remote_write_tsv}" <<'TSV'
+metric	value
+prometheus.remote_write.samples_total	12345
+prometheus.remote_write.failed_samples_total	0
+prometheus.remote_write.highest_latency_seconds	0.025
+TSV
+
+echo "[prometheus-remote-write-correlation] print plan"
+plan="$(
+  REMOTE_WRITE_CORRELATION_NAME=remote-write-check \
+  REMOTE_WRITE_BASELINE_SUMMARY_JSON="${baseline_json}" \
+  REMOTE_WRITE_PROMETHEUS_SUMMARY_JSON="${prometheus_json}" \
+  REMOTE_WRITE_SNAPSHOT_TSV="${remote_write_tsv}" \
+  REMOTE_WRITE_OUTPUT_DIR="${output_dir}" \
+  REMOTE_WRITE_P95_WARN_RATIO=1.10 \
+  REMOTE_WRITE_P95_FAIL_RATIO=1.50 \
+    "${runner}" --print-plan
+)"
+grep -F "correlation=remote-write-check" <<<"${plan}" >/dev/null
+grep -F "baseline_summary=${baseline_json}" <<<"${plan}" >/dev/null
+grep -F "prometheus_summary=${prometheus_json}" <<<"${plan}" >/dev/null
+grep -F "remote_write_snapshot=${remote_write_tsv}" <<<"${plan}" >/dev/null
+grep -F "p95_warn_ratio=1.10" <<<"${plan}" >/dev/null
+grep -F "p95_fail_ratio=1.50" <<<"${plan}" >/dev/null
+grep -F "result_tsv=${output_dir}/remote-write-check-remote-write-latency-correlation.tsv" <<<"${plan}" >/dev/null
+grep -F "report_md=${output_dir}/remote-write-check-remote-write-latency-correlation.md" <<<"${plan}" >/dev/null
+
+echo "[prometheus-remote-write-correlation] report"
+output="$(
+  REMOTE_WRITE_CORRELATION_NAME=remote-write-check \
+  REMOTE_WRITE_BASELINE_SUMMARY_JSON="${baseline_json}" \
+  REMOTE_WRITE_PROMETHEUS_SUMMARY_JSON="${prometheus_json}" \
+  REMOTE_WRITE_SNAPSHOT_TSV="${remote_write_tsv}" \
+  REMOTE_WRITE_OUTPUT_DIR="${output_dir}" \
+  REMOTE_WRITE_P95_WARN_RATIO=1.10 \
+  REMOTE_WRITE_P95_FAIL_RATIO=1.50 \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+result_tsv="${output_dir}/remote-write-check-remote-write-latency-correlation.tsv"
+test "${report_md}" = "${output_dir}/remote-write-check-remote-write-latency-correlation.md"
+grep -F $'metric\tbaseline\tprometheus\tdelta\tratio\tstatus' "${result_tsv}" >/dev/null
+grep -F $'p95_latency_ms\t2.3\t2.5\t0.200000\t1.086957\tpass' "${result_tsv}" >/dev/null
+grep -F $'max_latency_ms\t40.0\t60.0\t20.000000\t1.500000\twarn' "${result_tsv}" >/dev/null
+grep -F "correlation_status=warn" "${report_md}" >/dev/null
+grep -F "prometheus.remote_write.samples_total: 12345" "${report_md}" >/dev/null
+grep -F "prometheus.remote_write.failed_samples_total: 0" "${report_md}" >/dev/null
+grep -F "p95 latency ratio: 1.086957" "${report_md}" >/dev/null
+
+echo "[prometheus-remote-write-correlation] runner contract"
+grep -F "aquila_transaction_hot_first_ms" "${runner}" >/dev/null
+grep -F "aquila_transaction_cold_cursor_ms" "${runner}" >/dev/null
+grep -F "REMOTE_WRITE_P95_WARN_RATIO" "${runner}" >/dev/null
+grep -F "REMOTE_WRITE_P95_FAIL_RATIO" "${runner}" >/dev/null
+grep -F "prometheus.remote_write.samples_total" "${runner}" >/dev/null
+grep -F "remote-write-latency-correlation.tsv" "${runner}" >/dev/null
+
+echo "[prometheus-remote-write-correlation] invalid input fails"
+if REMOTE_WRITE_CORRELATION_NAME=bad-threshold \
+  REMOTE_WRITE_BASELINE_SUMMARY_JSON="${baseline_json}" \
+  REMOTE_WRITE_PROMETHEUS_SUMMARY_JSON="${prometheus_json}" \
+  REMOTE_WRITE_P95_WARN_RATIO=2 \
+  REMOTE_WRITE_P95_FAIL_RATIO=1.5 \
+    "${runner}" --print-plan >/dev/null 2>&1; then
+  echo "warn ratio greater than fail ratio unexpectedly succeeded" >&2
+  exit 1
+fi
+if REMOTE_WRITE_CORRELATION_NAME=missing-input "${runner}" >/dev/null 2>&1; then
+  echo "missing correlation input unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/check-transaction-read-burst-429-budget-gate.sh
+++ b/tools/test/check-transaction-read-burst-429-budget-gate.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-burst-429-budget-gate.sh"
+
+echo "[transaction-read-burst-429] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+summary_json="${temp_dir}/burst-summary.json"
+fail_json="${temp_dir}/burst-fail-summary.json"
+output_dir="${temp_dir}/burst-output"
+
+cat >"${summary_json}" <<'JSON'
+{
+  "metrics": {
+    "http_req_failed": {"values": {"rate": 0}},
+    "http_reqs": {"values": {"count": 4096}},
+    "dropped_iterations": {"values": {"count": 0}},
+    "interrupted_iterations": {"values": {"count": 0}},
+    "aquila_transaction_429_rate": {"values": {"rate": 0.00275}},
+    "aquila_transaction_503_rate": {"values": {"rate": 0}},
+    "aquila_transaction_503_count": {"values": {"count": 0}}
+  }
+}
+JSON
+
+cat >"${fail_json}" <<'JSON'
+{
+  "metrics": {
+    "http_req_failed": {"values": {"rate": 0}},
+    "http_reqs": {"values": {"count": 4096}},
+    "dropped_iterations": {"values": {"count": 0}},
+    "interrupted_iterations": {"values": {"count": 0}},
+    "aquila_transaction_429_rate": {"values": {"rate": 0.006}},
+    "aquila_transaction_503_rate": {"values": {"rate": 0}},
+    "aquila_transaction_503_count": {"values": {"count": 0}}
+  }
+}
+JSON
+
+echo "[transaction-read-burst-429] print plan"
+plan="$(
+  BURST_429_GATE_NAME=burst-429-check \
+  BURST_429_SUMMARY_JSON="${summary_json}" \
+  BURST_429_OUTPUT_DIR="${output_dir}" \
+  BURST_429_WARN_RATE=0.001 \
+  BURST_429_FAIL_RATE=0.005 \
+  BURST_429_BURST_RATE=256 \
+    "${runner}" --print-plan
+)"
+grep -F "gate=burst-429-check" <<<"${plan}" >/dev/null
+grep -F "summary_json=${summary_json}" <<<"${plan}" >/dev/null
+grep -F "burst_rate=256" <<<"${plan}" >/dev/null
+grep -F "expected_rate=0" <<<"${plan}" >/dev/null
+grep -F "warn_rate=0.001" <<<"${plan}" >/dev/null
+grep -F "fail_rate=0.005" <<<"${plan}" >/dev/null
+grep -F "result_tsv=${output_dir}/burst-429-check-burst-429-budget.tsv" <<<"${plan}" >/dev/null
+grep -F "report_md=${output_dir}/burst-429-check-burst-429-budget.md" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-burst-429] warning report"
+output="$(
+  BURST_429_GATE_NAME=burst-429-check \
+  BURST_429_SUMMARY_JSON="${summary_json}" \
+  BURST_429_OUTPUT_DIR="${output_dir}" \
+  BURST_429_WARN_RATE=0.001 \
+  BURST_429_FAIL_RATE=0.005 \
+  BURST_429_BURST_RATE=256 \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+result_tsv="${output_dir}/burst-429-check-burst-429-budget.tsv"
+test "${report_md}" = "${output_dir}/burst-429-check-burst-429-budget.md"
+grep -F $'metric\tvalue\twarn_threshold\tfail_threshold\tstatus' "${result_tsv}" >/dev/null
+grep -F $'transaction_429_rate\t0.00275\t0.001\t0.005\twarn' "${result_tsv}" >/dev/null
+grep -F $'dropped_iterations\t0\t0\t0\tpass' "${result_tsv}" >/dev/null
+grep -F "gate_status=warn" "${report_md}" >/dev/null
+grep -F "burst rate: 256/s" "${report_md}" >/dev/null
+grep -F "transaction 429 rate: 0.00275" "${report_md}" >/dev/null
+
+echo "[transaction-read-burst-429] fail threshold"
+if BURST_429_GATE_NAME=burst-429-fail-check \
+  BURST_429_SUMMARY_JSON="${fail_json}" \
+  BURST_429_OUTPUT_DIR="${output_dir}" \
+  BURST_429_WARN_RATE=0.001 \
+  BURST_429_FAIL_RATE=0.005 \
+    "${runner}" >/dev/null 2>&1; then
+  echo "429 fail budget unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "[transaction-read-burst-429] runner contract"
+grep -F "aquila_transaction_429_rate" "${runner}" >/dev/null
+grep -F "dropped_iterations" "${runner}" >/dev/null
+grep -F "interrupted_iterations" "${runner}" >/dev/null
+grep -F "BURST_429_WARN_RATE" "${runner}" >/dev/null
+grep -F "BURST_429_FAIL_RATE" "${runner}" >/dev/null
+grep -F "K6_SCENARIO_MODE=burst" "${runner}" >/dev/null
+grep -F "K6_BURST_RATE" "${runner}" >/dev/null
+
+echo "[transaction-read-burst-429] invalid input fails"
+if BURST_429_GATE_NAME=bad-threshold \
+  BURST_429_SUMMARY_JSON="${summary_json}" \
+  BURST_429_WARN_RATE=0.01 \
+  BURST_429_FAIL_RATE=0.005 \
+    "${runner}" --print-plan >/dev/null 2>&1; then
+  echo "warn threshold greater than fail threshold unexpectedly succeeded" >&2
+  exit 1
+fi
+if BURST_429_GATE_NAME=missing-json "${runner}" >/dev/null 2>&1; then
+  echo "missing burst summary unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/check-transaction-read-p999-spike-profile.sh
+++ b/tools/test/check-transaction-read-p999-spike-profile.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-p999-spike-profile.sh"
+
+echo "[transaction-read-p999-spike] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+summary_json="${temp_dir}/transaction-summary.json"
+snapshot_tsv="${temp_dir}/prometheus-snapshot.tsv"
+output_dir="${temp_dir}/profile-output"
+
+cat >"${summary_json}" <<'JSON'
+{
+  "metrics": {
+    "http_req_failed": {"values": {"rate": 0}},
+    "http_reqs": {"values": {"count": 1200}},
+    "aquila_transaction_429_rate": {"values": {"rate": 0.00275}},
+    "aquila_transaction_503_rate": {"values": {"rate": 0}},
+    "aquila_transaction_hot_first_ms": {"values": {"p(95)": 2.1, "p(99)": 6.0, "p(99.9)": 42.5, "max": 81.2}},
+    "aquila_transaction_hot_cursor_ms": {"values": {"p(95)": 2.2, "p(99)": 6.2, "p(99.9)": 38.1, "max": 76.3}},
+    "aquila_transaction_cold_first_ms": {"values": {"p(95)": 2.4, "p(99)": 6.4, "p(99.9)": 44.3, "max": 79.9}},
+    "aquila_transaction_cold_cursor_ms": {"values": {"p(95)": 2.5, "p(99)": 6.8, "p(99.9)": 40.1, "max": 78.4}}
+  }
+}
+JSON
+
+cat >"${snapshot_tsv}" <<'TSV'
+metric	value
+db.hikari.pending.max	0
+db.hikari.active.max	5
+jvm.gc.pause.max.seconds	0.008
+tomcat.threads.busy.max	9
+http.server.requests.max.seconds	0.082
+postgres.cpu.max.percent	45.2
+backend.cpu.max.percent	88.1
+TSV
+
+echo "[transaction-read-p999-spike] print plan"
+plan="$(
+  P999_SPIKE_PROFILE_NAME=transaction-p999-check \
+  P999_SPIKE_K6_SUMMARY_JSON="${summary_json}" \
+  P999_SPIKE_PROMETHEUS_SNAPSHOT_TSV="${snapshot_tsv}" \
+  P999_SPIKE_OUTPUT_DIR="${output_dir}" \
+  P999_SPIKE_WARN_MS=30 \
+  P999_SPIKE_FAIL_MS=120 \
+    "${runner}" --print-plan
+)"
+grep -F "profile=transaction-p999-check" <<<"${plan}" >/dev/null
+grep -F "run_id=transaction-p999-check" <<<"${plan}" >/dev/null
+grep -F "k6_summary_json=${summary_json}" <<<"${plan}" >/dev/null
+grep -F "prometheus_snapshot=${snapshot_tsv}" <<<"${plan}" >/dev/null
+grep -F "warn_ms=30" <<<"${plan}" >/dev/null
+grep -F "fail_ms=120" <<<"${plan}" >/dev/null
+grep -F "boundary_tsv=${output_dir}/transaction-p999-check-p999-boundary.tsv" <<<"${plan}" >/dev/null
+grep -F "report_md=${output_dir}/transaction-p999-check-p999-spike-profile.md" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-p999-spike] report"
+output="$(
+  P999_SPIKE_PROFILE_NAME=transaction-p999-check \
+  P999_SPIKE_K6_SUMMARY_JSON="${summary_json}" \
+  P999_SPIKE_PROMETHEUS_SNAPSHOT_TSV="${snapshot_tsv}" \
+  P999_SPIKE_OUTPUT_DIR="${output_dir}" \
+  P999_SPIKE_WARN_MS=30 \
+  P999_SPIKE_FAIL_MS=120 \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+boundary_tsv="${output_dir}/transaction-p999-check-p999-boundary.tsv"
+test "${report_md}" = "${output_dir}/transaction-p999-check-p999-spike-profile.md"
+test -s "${boundary_tsv}"
+grep -F $'layer\tmetric\tvalue\tsource' "${boundary_tsv}" >/dev/null
+grep -F $'http\tmax_latency_ms\t81.2\tk6:aquila_transaction_hot_first_ms' "${boundary_tsv}" >/dev/null
+grep -F $'http\tp999_latency_ms\t44.3\tk6:aquila_transaction_cold_first_ms' "${boundary_tsv}" >/dev/null
+grep -F $'db\tconnection_pool_pending\t0\tprometheus-snapshot' "${boundary_tsv}" >/dev/null
+grep -F $'gc\tpause_max_seconds\t0.008\tprometheus-snapshot' "${boundary_tsv}" >/dev/null
+grep -F $'http-thread\tbusy_threads\t9\tprometheus-snapshot' "${boundary_tsv}" >/dev/null
+grep -F "tail_status=warn" "${report_md}" >/dev/null
+grep -F "max latency ms: 81.2" "${report_md}" >/dev/null
+grep -F "p99.9 latency ms: 44.3" "${report_md}" >/dev/null
+
+echo "[transaction-read-p999-spike] runner contract"
+grep -F "aquila_transaction_hot_first_ms" "${runner}" >/dev/null
+grep -F "aquila_transaction_cold_cursor_ms" "${runner}" >/dev/null
+grep -F "db.hikari.pending.max" "${runner}" >/dev/null
+grep -F "jvm.gc.pause.max.seconds" "${runner}" >/dev/null
+grep -F "tomcat.threads.busy.max" "${runner}" >/dev/null
+grep -F "http.server.requests.max.seconds" "${runner}" >/dev/null
+grep -F "p999-boundary.tsv" "${runner}" >/dev/null
+
+echo "[transaction-read-p999-spike] invalid input fails"
+if P999_SPIKE_PROFILE_NAME=bad-threshold \
+  P999_SPIKE_K6_SUMMARY_JSON="${summary_json}" \
+  P999_SPIKE_WARN_MS=100 \
+  P999_SPIKE_FAIL_MS=30 \
+    "${runner}" --print-plan >/dev/null 2>&1; then
+  echo "warn threshold greater than fail threshold unexpectedly succeeded" >&2
+  exit 1
+fi
+if P999_SPIKE_PROFILE_NAME=missing-json "${runner}" >/dev/null 2>&1; then
+  echo "missing k6 summary unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-prometheus-remote-write-latency-correlation.sh
+++ b/tools/test/run-prometheus-remote-write-latency-correlation.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-prometheus-remote-write-latency-correlation.sh [--print-plan]
+
+Environment:
+  REMOTE_WRITE_CORRELATION_NAME             default prometheus-remote-write-correlation-<timestamp>
+  REMOTE_WRITE_BASELINE_SUMMARY_JSON        required summary-only k6 summary JSON
+  REMOTE_WRITE_PROMETHEUS_SUMMARY_JSON      required prometheus-mode k6 summary JSON
+  REMOTE_WRITE_SNAPSHOT_TSV                 optional metric/value remote-write snapshot
+  REMOTE_WRITE_OUTPUT_DIR                   default build/reports/k6/<name>
+  REMOTE_WRITE_P95_WARN_RATIO               default 1.10
+  REMOTE_WRITE_P95_FAIL_RATIO               default 1.50
+  REMOTE_WRITE_TAIL_WARN_RATIO              default 1.25
+  REMOTE_WRITE_TAIL_FAIL_RATIO              default 2.00
+
+Snapshot metric keys:
+  prometheus.remote_write.samples_total
+  prometheus.remote_write.failed_samples_total
+  prometheus.remote_write.highest_latency_seconds
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${REMOTE_WRITE_CORRELATION_NAME:-prometheus-remote-write-correlation-$(date +%Y-%m-%d-%H%M%S)}"
+baseline_summary="${REMOTE_WRITE_BASELINE_SUMMARY_JSON:-}"
+prometheus_summary="${REMOTE_WRITE_PROMETHEUS_SUMMARY_JSON:-}"
+remote_write_snapshot="${REMOTE_WRITE_SNAPSHOT_TSV:-}"
+output_dir="${REMOTE_WRITE_OUTPUT_DIR:-build/reports/k6/${name}}"
+p95_warn_ratio="${REMOTE_WRITE_P95_WARN_RATIO:-1.10}"
+p95_fail_ratio="${REMOTE_WRITE_P95_FAIL_RATIO:-1.50}"
+tail_warn_ratio="${REMOTE_WRITE_TAIL_WARN_RATIO:-1.25}"
+tail_fail_ratio="${REMOTE_WRITE_TAIL_FAIL_RATIO:-2.00}"
+result_tsv="${output_dir}/${name}-remote-write-latency-correlation.tsv"
+report_md="${output_dir}/${name}-remote-write-latency-correlation.md"
+
+require_positive_number_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${name} must be a positive number: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value > 0) }' || {
+    echo "${name} must be greater than zero: ${value}" >&2
+    exit 1
+  }
+}
+
+number_greater_than() {
+  awk -v value="$1" -v threshold="$2" 'BEGIN { exit !(value > threshold) }'
+}
+
+require_positive_number_value "REMOTE_WRITE_P95_WARN_RATIO" "${p95_warn_ratio}"
+require_positive_number_value "REMOTE_WRITE_P95_FAIL_RATIO" "${p95_fail_ratio}"
+require_positive_number_value "REMOTE_WRITE_TAIL_WARN_RATIO" "${tail_warn_ratio}"
+require_positive_number_value "REMOTE_WRITE_TAIL_FAIL_RATIO" "${tail_fail_ratio}"
+if number_greater_than "${p95_warn_ratio}" "${p95_fail_ratio}"; then
+  echo "REMOTE_WRITE_P95_WARN_RATIO must be less than or equal to REMOTE_WRITE_P95_FAIL_RATIO" >&2
+  exit 1
+fi
+if number_greater_than "${tail_warn_ratio}" "${tail_fail_ratio}"; then
+  echo "REMOTE_WRITE_TAIL_WARN_RATIO must be less than or equal to REMOTE_WRITE_TAIL_FAIL_RATIO" >&2
+  exit 1
+fi
+
+print_plan() {
+  echo "[prometheus-remote-write-correlation] correlation=${name}"
+  echo "[prometheus-remote-write-correlation] baseline_summary=${baseline_summary:-missing}"
+  echo "[prometheus-remote-write-correlation] prometheus_summary=${prometheus_summary:-missing}"
+  echo "[prometheus-remote-write-correlation] remote_write_snapshot=${remote_write_snapshot:-missing}"
+  echo "[prometheus-remote-write-correlation] p95_warn_ratio=${p95_warn_ratio}"
+  echo "[prometheus-remote-write-correlation] p95_fail_ratio=${p95_fail_ratio}"
+  echo "[prometheus-remote-write-correlation] tail_warn_ratio=${tail_warn_ratio}"
+  echo "[prometheus-remote-write-correlation] tail_fail_ratio=${tail_fail_ratio}"
+  echo "[prometheus-remote-write-correlation] result_tsv=${result_tsv}"
+  echo "[prometheus-remote-write-correlation] report_md=${report_md}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+if [[ -z "${baseline_summary}" || ! -s "${baseline_summary}" ]]; then
+  echo "REMOTE_WRITE_BASELINE_SUMMARY_JSON is required: ${baseline_summary:-missing}" >&2
+  exit 1
+fi
+if [[ -z "${prometheus_summary}" || ! -s "${prometheus_summary}" ]]; then
+  echo "REMOTE_WRITE_PROMETHEUS_SUMMARY_JSON is required: ${prometheus_summary:-missing}" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+metric_value() {
+  local file="$1"
+  local metric="$2"
+  local field="$3"
+  jq -r --arg metric "${metric}" --arg field "${field}" \
+    '.metrics[$metric].values[$field] // "n/a"' "${file}"
+}
+
+max_metric_for_field() {
+  local file="$1"
+  local field="$2"
+  local best_value="n/a"
+  local metric value
+  for metric in \
+    aquila_transaction_hot_first_ms \
+    aquila_transaction_hot_cursor_ms \
+    aquila_transaction_cold_first_ms \
+    aquila_transaction_cold_cursor_ms
+  do
+    value="$(metric_value "${file}" "${metric}" "${field}")"
+    if [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+      if [[ "${best_value}" == "n/a" ]] || number_greater_than "${value}" "${best_value}"; then
+        best_value="${value}"
+      fi
+    fi
+  done
+  echo "${best_value}"
+}
+
+snapshot_value() {
+  local key="$1"
+  if [[ -z "${remote_write_snapshot}" || ! -s "${remote_write_snapshot}" ]]; then
+    echo "n/a"
+    return 0
+  fi
+  awk -F '\t' -v key="${key}" '$1 == key {value = $2; found = 1} END {print found ? value : "n/a"}' "${remote_write_snapshot}"
+}
+
+delta_value() {
+  awk -v baseline="$1" -v observed="$2" 'BEGIN { printf "%.6f", observed - baseline }'
+}
+
+ratio_value() {
+  awk -v baseline="$1" -v observed="$2" 'BEGIN {
+    if (baseline == 0) {
+      if (observed == 0) printf "1.000000"; else printf "inf";
+    } else {
+      printf "%.6f", observed / baseline;
+    }
+  }'
+}
+
+status_for_ratio() {
+  local ratio="$1"
+  local warn="$2"
+  local fail="$3"
+  if [[ "${ratio}" == "inf" ]]; then
+    echo "fail"
+  elif number_greater_than "${ratio}" "${fail}"; then
+    echo "fail"
+  elif number_greater_than "${ratio}" "${warn}"; then
+    echo "warn"
+  else
+    echo "pass"
+  fi
+}
+
+write_row() {
+  local metric="$1"
+  local baseline="$2"
+  local observed="$3"
+  local warn="$4"
+  local fail="$5"
+  local delta ratio status
+  delta="$(delta_value "${baseline}" "${observed}")"
+  ratio="$(ratio_value "${baseline}" "${observed}")"
+  status="$(status_for_ratio "${ratio}" "${warn}" "${fail}")"
+  printf "%s\t%s\t%s\t%s\t%s\t%s\n" "${metric}" "${baseline}" "${observed}" "${delta}" "${ratio}" "${status}" >>"${result_tsv}"
+}
+
+mkdir -p "${output_dir}"
+printf "metric\tbaseline\tprometheus\tdelta\tratio\tstatus\n" >"${result_tsv}"
+
+baseline_p95="$(max_metric_for_field "${baseline_summary}" "p(95)")"
+prometheus_p95="$(max_metric_for_field "${prometheus_summary}" "p(95)")"
+baseline_p99="$(max_metric_for_field "${baseline_summary}" "p(99)")"
+prometheus_p99="$(max_metric_for_field "${prometheus_summary}" "p(99)")"
+baseline_p999="$(max_metric_for_field "${baseline_summary}" "p(99.9)")"
+prometheus_p999="$(max_metric_for_field "${prometheus_summary}" "p(99.9)")"
+baseline_max="$(max_metric_for_field "${baseline_summary}" "max")"
+prometheus_max="$(max_metric_for_field "${prometheus_summary}" "max")"
+
+write_row "p95_latency_ms" "${baseline_p95}" "${prometheus_p95}" "${p95_warn_ratio}" "${p95_fail_ratio}"
+write_row "p99_latency_ms" "${baseline_p99}" "${prometheus_p99}" "${tail_warn_ratio}" "${tail_fail_ratio}"
+write_row "p999_latency_ms" "${baseline_p999}" "${prometheus_p999}" "${tail_warn_ratio}" "${tail_fail_ratio}"
+write_row "max_latency_ms" "${baseline_max}" "${prometheus_max}" "${tail_warn_ratio}" "${tail_fail_ratio}"
+write_row "transaction_429_rate" \
+  "$(metric_value "${baseline_summary}" aquila_transaction_429_rate rate)" \
+  "$(metric_value "${prometheus_summary}" aquila_transaction_429_rate rate)" \
+  "${tail_warn_ratio}" "${tail_fail_ratio}"
+write_row "http_failed_rate" \
+  "$(metric_value "${baseline_summary}" http_req_failed rate)" \
+  "$(metric_value "${prometheus_summary}" http_req_failed rate)" \
+  "${tail_warn_ratio}" "${tail_fail_ratio}"
+
+correlation_status="pass"
+if awk -F '\t' 'NR > 1 && $6 == "fail" {found = 1} END {exit !found}' "${result_tsv}"; then
+  correlation_status="fail"
+elif awk -F '\t' 'NR > 1 && $6 == "warn" {found = 1} END {exit !found}' "${result_tsv}"; then
+  correlation_status="warn"
+fi
+
+p95_ratio="$(awk -F '\t' '$1 == "p95_latency_ms" {print $5}' "${result_tsv}")"
+
+cat >"${report_md}" <<REPORT
+# Prometheus Remote-write Latency Correlation
+
+## Summary
+
+- correlation: ${name}
+- correlation_status=${correlation_status}
+- baseline summary JSON: ${baseline_summary}
+- prometheus summary JSON: ${prometheus_summary}
+- p95 latency ratio: ${p95_ratio}
+
+## Remote Write Snapshot
+
+- prometheus.remote_write.samples_total: $(snapshot_value prometheus.remote_write.samples_total)
+- prometheus.remote_write.failed_samples_total: $(snapshot_value prometheus.remote_write.failed_samples_total)
+- prometheus.remote_write.highest_latency_seconds: $(snapshot_value prometheus.remote_write.highest_latency_seconds)
+
+## Artifacts
+
+- result TSV: ${result_tsv}
+- remote-write snapshot TSV: ${remote_write_snapshot:-missing}
+
+## Notes
+
+- summary-only와 prometheus mode의 latency 차이만 비교하며, 원인 확정은 p99.9 spike artifact와 함께 판단합니다.
+- 운영 URL, token, Authorization header는 기록하지 않습니다.
+REPORT
+
+echo "${report_md}"
+
+if [[ "${correlation_status}" == "fail" ]]; then
+  echo "remote-write latency correlation exceeded fail threshold" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-read-burst-429-budget-gate.sh
+++ b/tools/test/run-transaction-read-burst-429-budget-gate.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-burst-429-budget-gate.sh [--print-plan]
+
+Environment:
+  BURST_429_GATE_NAME       default transaction-read-burst-429-<timestamp>
+  BURST_429_SUMMARY_JSON    required unless BURST_429_RUN_K6=true
+  BURST_429_OUTPUT_DIR      default build/reports/k6/<gate>
+  BURST_429_BURST_RATE      default 256
+  BURST_429_BURST_DURATION  default 20s
+  BURST_429_WARN_RATE       default 0.001
+  BURST_429_FAIL_RATE       default 0.005
+  BURST_429_EXPECTED_RATE   default 0
+  BURST_429_RUN_K6          true|false, default false
+  BURST_429_K6_DURATION     default 30s
+
+Required when BURST_429_RUN_K6=true:
+  K6_HOT_ACCOUNT_ID K6_HOT_FROM K6_HOT_TO K6_COLD_ACCOUNT_ID K6_COLD_FROM K6_COLD_TO
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+gate_name="${BURST_429_GATE_NAME:-transaction-read-burst-429-$(date +%Y-%m-%d-%H%M%S)}"
+summary_json="${BURST_429_SUMMARY_JSON:-}"
+output_dir="${BURST_429_OUTPUT_DIR:-build/reports/k6/${gate_name}}"
+burst_rate="${BURST_429_BURST_RATE:-256}"
+burst_duration="${BURST_429_BURST_DURATION:-20s}"
+warn_rate="${BURST_429_WARN_RATE:-0.001}"
+fail_rate="${BURST_429_FAIL_RATE:-0.005}"
+expected_rate="${BURST_429_EXPECTED_RATE:-0}"
+run_k6="${BURST_429_RUN_K6:-false}"
+k6_duration="${BURST_429_K6_DURATION:-30s}"
+result_tsv="${output_dir}/${gate_name}-burst-429-budget.tsv"
+report_md="${output_dir}/${gate_name}-burst-429-budget.md"
+k6_report_name="${gate_name}-k6"
+generated_summary_json="build/reports/k6/${k6_report_name}-summary.json"
+k6_runner="tools/test/run-k6-transaction-100m-loadtest.sh"
+
+require_bool_value() {
+  local name="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${name} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_rate_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${name} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0 && value <= 1) }' || {
+    echo "${name} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  }
+}
+
+require_positive_integer_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_duration_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*(s|m|h)$ ]]; then
+    echo "${name} must use a positive duration such as 20s, 1m, or 1h: ${value}" >&2
+    exit 1
+  fi
+}
+
+number_greater_than() {
+  awk -v value="$1" -v threshold="$2" 'BEGIN { exit !(value > threshold) }'
+}
+
+require_bool_value "BURST_429_RUN_K6" "${run_k6}"
+require_positive_integer_value "BURST_429_BURST_RATE" "${burst_rate}"
+require_duration_value "BURST_429_BURST_DURATION" "${burst_duration}"
+require_duration_value "BURST_429_K6_DURATION" "${k6_duration}"
+require_rate_value "BURST_429_WARN_RATE" "${warn_rate}"
+require_rate_value "BURST_429_FAIL_RATE" "${fail_rate}"
+require_rate_value "BURST_429_EXPECTED_RATE" "${expected_rate}"
+if number_greater_than "${warn_rate}" "${fail_rate}"; then
+  echo "BURST_429_WARN_RATE must be less than or equal to BURST_429_FAIL_RATE" >&2
+  exit 1
+fi
+
+print_plan() {
+  echo "[transaction-read-burst-429] gate=${gate_name}"
+  echo "[transaction-read-burst-429] summary_json=${summary_json:-missing}"
+  echo "[transaction-read-burst-429] output_dir=${output_dir}"
+  echo "[transaction-read-burst-429] burst_rate=${burst_rate}"
+  echo "[transaction-read-burst-429] burst_duration=${burst_duration}"
+  echo "[transaction-read-burst-429] expected_rate=${expected_rate}"
+  echo "[transaction-read-burst-429] warn_rate=${warn_rate}"
+  echo "[transaction-read-burst-429] fail_rate=${fail_rate}"
+  echo "[transaction-read-burst-429] run_k6=${run_k6}"
+  echo "[transaction-read-burst-429] k6_command=K6_SCENARIO_MODE=burst K6_BURST_RATE=${burst_rate} ${k6_runner}"
+  echo "[transaction-read-burst-429] result_tsv=${result_tsv}"
+  echo "[transaction-read-burst-429] report_md=${report_md}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+if [[ "${run_k6}" == "true" ]]; then
+  K6_REPORT_NAME="${k6_report_name}" \
+  K6_SCENARIO_MODE=burst \
+  K6_BURST_RATE="${burst_rate}" \
+  K6_BURST_DURATION="${burst_duration}" \
+  K6_DURATION="${k6_duration}" \
+  K6_OVERLOAD_MODE=true \
+  K6_BURST_429_RATE_THRESHOLD="${fail_rate}" \
+  K6_ARCHIVE_RESULTS=false \
+    "${k6_runner}"
+  summary_json="${generated_summary_json}"
+fi
+
+if [[ -z "${summary_json}" || ! -s "${summary_json}" ]]; then
+  echo "BURST_429_SUMMARY_JSON is required: ${summary_json:-missing}" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+metric_value() {
+  local metric="$1"
+  local field="$2"
+  jq -r --arg metric "${metric}" --arg field "${field}" \
+    '.metrics[$metric].values[$field] // "0"' "${summary_json}"
+}
+
+status_for_rate() {
+  local value="$1"
+  if number_greater_than "${value}" "${fail_rate}"; then
+    echo "fail"
+  elif number_greater_than "${value}" "${warn_rate}"; then
+    echo "warn"
+  else
+    echo "pass"
+  fi
+}
+
+status_for_zero() {
+  local value="$1"
+  if number_greater_than "${value}" "0"; then
+    echo "fail"
+  else
+    echo "pass"
+  fi
+}
+
+mkdir -p "${output_dir}"
+
+transaction_429_rate="$(metric_value aquila_transaction_429_rate rate)"
+transaction_503_rate="$(metric_value aquila_transaction_503_rate rate)"
+transaction_503_count="$(metric_value aquila_transaction_503_count count)"
+dropped_iterations="$(metric_value dropped_iterations count)"
+interrupted_iterations="$(metric_value interrupted_iterations count)"
+http_failed_rate="$(metric_value http_req_failed rate)"
+http_reqs="$(metric_value http_reqs count)"
+transaction_429_status="$(status_for_rate "${transaction_429_rate}")"
+dropped_status="$(status_for_zero "${dropped_iterations}")"
+interrupted_status="$(status_for_zero "${interrupted_iterations}")"
+status="pass"
+case "${transaction_429_status}:${dropped_status}:${interrupted_status}" in
+  *fail*) status="fail" ;;
+  *warn*) status="warn" ;;
+esac
+if number_greater_than "${transaction_503_rate}" "0" || number_greater_than "${transaction_503_count}" "0"; then
+  status="fail"
+fi
+
+{
+  printf "metric\tvalue\twarn_threshold\tfail_threshold\tstatus\n"
+  printf "transaction_429_rate\t%s\t%s\t%s\t%s\n" "${transaction_429_rate}" "${warn_rate}" "${fail_rate}" "${transaction_429_status}"
+  printf "transaction_503_rate\t%s\t0\t0\t%s\n" "${transaction_503_rate}" "$(status_for_zero "${transaction_503_rate}")"
+  printf "transaction_503_count\t%s\t0\t0\t%s\n" "${transaction_503_count}" "$(status_for_zero "${transaction_503_count}")"
+  printf "dropped_iterations\t%s\t0\t0\t%s\n" "${dropped_iterations}" "${dropped_status}"
+  printf "interrupted_iterations\t%s\t0\t0\t%s\n" "${interrupted_iterations}" "${interrupted_status}"
+  printf "http_failed_rate\t%s\tn/a\tn/a\tobserve\n" "${http_failed_rate}"
+  printf "http_reqs\t%s\tn/a\tn/a\tobserve\n" "${http_reqs}"
+} >"${result_tsv}"
+
+cat >"${report_md}" <<REPORT
+# Transaction Read Burst 429 Budget
+
+## Summary
+
+- gate: ${gate_name}
+- gate_status=${status}
+- burst rate: ${burst_rate}/s
+- burst duration: ${burst_duration}
+- expected 429 rate: ${expected_rate}
+- warning threshold: ${warn_rate}
+- fail threshold: ${fail_rate}
+- transaction 429 rate: ${transaction_429_rate}
+- transaction 503 rate: ${transaction_503_rate}
+- dropped iterations: ${dropped_iterations}
+- interrupted iterations: ${interrupted_iterations}
+
+## Artifacts
+
+- result TSV: ${result_tsv}
+- summary JSON: ${summary_json}
+
+## Notes
+
+- warning은 generator/server 변동성을 고려한 회귀 관측 신호입니다.
+- fail threshold, 503, dropped/interrupted iteration은 non-zero exit로 처리합니다.
+REPORT
+
+echo "${report_md}"
+
+if [[ "${status}" == "fail" ]]; then
+  echo "burst 429 budget failed: rate=${transaction_429_rate} fail=${fail_rate}" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-read-p999-spike-profile.sh
+++ b/tools/test/run-transaction-read-p999-spike-profile.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-p999-spike-profile.sh [--print-plan]
+
+Environment:
+  P999_SPIKE_PROFILE_NAME             default transaction-read-p999-spike-<timestamp>
+  P999_SPIKE_RUN_ID                   default P999_SPIKE_PROFILE_NAME
+  P999_SPIKE_K6_SUMMARY_JSON          required k6 summary JSON
+  P999_SPIKE_PROMETHEUS_SNAPSHOT_TSV  optional metric/value snapshot TSV
+  P999_SPIKE_OUTPUT_DIR               default build/reports/profiling/<profile>
+  P999_SPIKE_WARN_MS                  default 30
+  P999_SPIKE_FAIL_MS                  default 80
+
+Snapshot metric keys:
+  db.hikari.pending.max
+  db.hikari.active.max
+  jvm.gc.pause.max.seconds
+  tomcat.threads.busy.max
+  http.server.requests.max.seconds
+  postgres.cpu.max.percent
+  backend.cpu.max.percent
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+profile_name="${P999_SPIKE_PROFILE_NAME:-transaction-read-p999-spike-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${P999_SPIKE_RUN_ID:-${profile_name}}"
+k6_summary_json="${P999_SPIKE_K6_SUMMARY_JSON:-}"
+prometheus_snapshot_tsv="${P999_SPIKE_PROMETHEUS_SNAPSHOT_TSV:-}"
+output_dir="${P999_SPIKE_OUTPUT_DIR:-build/reports/profiling/${profile_name}}"
+warn_ms="${P999_SPIKE_WARN_MS:-30}"
+fail_ms="${P999_SPIKE_FAIL_MS:-80}"
+boundary_tsv="${output_dir}/${profile_name}-p999-boundary.tsv"
+report_md="${output_dir}/${profile_name}-p999-spike-profile.md"
+
+require_positive_number_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${name} must be a positive number: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value > 0) }' || {
+    echo "${name} must be greater than zero: ${value}" >&2
+    exit 1
+  }
+}
+
+number_greater_than() {
+  awk -v value="$1" -v threshold="$2" 'BEGIN { exit !(value > threshold) }'
+}
+
+require_positive_number_value "P999_SPIKE_WARN_MS" "${warn_ms}"
+require_positive_number_value "P999_SPIKE_FAIL_MS" "${fail_ms}"
+if number_greater_than "${warn_ms}" "${fail_ms}"; then
+  echo "P999_SPIKE_WARN_MS must be less than or equal to P999_SPIKE_FAIL_MS" >&2
+  exit 1
+fi
+
+print_plan() {
+  echo "[transaction-read-p999-spike] profile=${profile_name}"
+  echo "[transaction-read-p999-spike] run_id=${run_id}"
+  echo "[transaction-read-p999-spike] k6_summary_json=${k6_summary_json:-missing}"
+  echo "[transaction-read-p999-spike] prometheus_snapshot=${prometheus_snapshot_tsv:-missing}"
+  echo "[transaction-read-p999-spike] warn_ms=${warn_ms}"
+  echo "[transaction-read-p999-spike] fail_ms=${fail_ms}"
+  echo "[transaction-read-p999-spike] boundary_tsv=${boundary_tsv}"
+  echo "[transaction-read-p999-spike] report_md=${report_md}"
+  echo "[transaction-read-p999-spike] layers=http,db,gc,http-thread,backend"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+if [[ -z "${k6_summary_json}" || ! -s "${k6_summary_json}" ]]; then
+  echo "P999_SPIKE_K6_SUMMARY_JSON is required: ${k6_summary_json:-missing}" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+metric_value() {
+  local metric="$1"
+  local field="$2"
+  jq -r --arg metric "${metric}" --arg field "${field}" \
+    '.metrics[$metric].values[$field] // "n/a"' "${k6_summary_json}"
+}
+
+snapshot_value() {
+  local key="$1"
+  if [[ -z "${prometheus_snapshot_tsv}" || ! -s "${prometheus_snapshot_tsv}" ]]; then
+    echo "n/a"
+    return 0
+  fi
+  awk -F '\t' -v key="${key}" '$1 == key {value = $2; found = 1} END {print found ? value : "n/a"}' "${prometheus_snapshot_tsv}"
+}
+
+max_metric_for_field() {
+  local field="$1"
+  local best_value="n/a"
+  local best_metric="n/a"
+  local metric value
+  for metric in \
+    aquila_transaction_hot_first_ms \
+    aquila_transaction_hot_cursor_ms \
+    aquila_transaction_cold_first_ms \
+    aquila_transaction_cold_cursor_ms
+  do
+    value="$(metric_value "${metric}" "${field}")"
+    if [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+      if [[ "${best_value}" == "n/a" ]] || number_greater_than "${value}" "${best_value}"; then
+        best_value="${value}"
+        best_metric="${metric}"
+      fi
+    fi
+  done
+  printf "%s\t%s\n" "${best_value}" "${best_metric}"
+}
+
+mkdir -p "${output_dir}"
+
+read -r max_latency max_latency_metric <<<"$(max_metric_for_field "max")"
+read -r p999_latency p999_latency_metric <<<"$(max_metric_for_field "p(99.9)")"
+
+tail_status="pass"
+if [[ "${max_latency}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  if number_greater_than "${max_latency}" "${fail_ms}"; then
+    tail_status="fail"
+  elif number_greater_than "${max_latency}" "${warn_ms}"; then
+    tail_status="warn"
+  fi
+fi
+
+{
+  printf "layer\tmetric\tvalue\tsource\n"
+  printf "http\tmax_latency_ms\t%s\tk6:%s\n" "${max_latency}" "${max_latency_metric}"
+  printf "http\tp999_latency_ms\t%s\tk6:%s\n" "${p999_latency}" "${p999_latency_metric}"
+  printf "http\thttp_failed_rate\t%s\tk6:http_req_failed\n" "$(metric_value http_req_failed rate)"
+  printf "http\ttransaction_429_rate\t%s\tk6:aquila_transaction_429_rate\n" "$(metric_value aquila_transaction_429_rate rate)"
+  printf "http\ttransaction_503_rate\t%s\tk6:aquila_transaction_503_rate\n" "$(metric_value aquila_transaction_503_rate rate)"
+  printf "db\tconnection_pool_pending\t%s\tprometheus-snapshot\n" "$(snapshot_value db.hikari.pending.max)"
+  printf "db\tconnection_pool_active\t%s\tprometheus-snapshot\n" "$(snapshot_value db.hikari.active.max)"
+  printf "db\tpostgres_cpu_percent\t%s\tprometheus-snapshot\n" "$(snapshot_value postgres.cpu.max.percent)"
+  printf "gc\tpause_max_seconds\t%s\tprometheus-snapshot\n" "$(snapshot_value jvm.gc.pause.max.seconds)"
+  printf "http-thread\tbusy_threads\t%s\tprometheus-snapshot\n" "$(snapshot_value tomcat.threads.busy.max)"
+  printf "http-thread\tserver_request_max_seconds\t%s\tprometheus-snapshot\n" "$(snapshot_value http.server.requests.max.seconds)"
+  printf "backend\tcpu_percent\t%s\tprometheus-snapshot\n" "$(snapshot_value backend.cpu.max.percent)"
+} >"${boundary_tsv}"
+
+cat >"${report_md}" <<REPORT
+# Transaction Read p99.9 Spike Profile
+
+## Summary
+
+- profile: ${profile_name}
+- run id: ${run_id}
+- tail_status=${tail_status}
+- warn threshold ms: ${warn_ms}
+- fail threshold ms: ${fail_ms}
+- max latency ms: ${max_latency}
+- max latency source: ${max_latency_metric}
+- p99.9 latency ms: ${p999_latency}
+- p99.9 latency source: ${p999_latency_metric}
+
+## Boundary Artifacts
+
+- boundary TSV: ${boundary_tsv}
+- k6 summary JSON: ${k6_summary_json}
+- Prometheus snapshot TSV: ${prometheus_snapshot_tsv:-missing}
+
+## Notes
+
+- DB/GC/connection pool/HTTP thread 값은 Prometheus snapshot이 없으면 \`n/a\`로 남깁니다.
+- p99.9/max spike 원인 확정이 아니라 경계 분리를 위한 artifact입니다.
+- 운영 URL, token, Authorization header는 기록하지 않습니다.
+REPORT
+
+echo "${report_md}"
+
+if [[ "${tail_status}" == "fail" ]]; then
+  echo "p99.9 spike profile exceeded fail threshold: max=${max_latency} fail=${fail_ms}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
close #485

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction read p99.9/max spike를 k6 summary와 Prometheus snapshot 기준으로 분리하는 artifact runner를 추가했습니다.
- burst 256/s 429 회귀를 warning/fail budget으로 분리하고, Prometheus remote-write mode와 summary-only baseline의 latency 상관 리포트를 추가했습니다.

## 🛠 Changes
- `run-transaction-read-p999-spike-profile.sh`: p99.9/max, 429/503, DB/GC/Hikari/Tomcat boundary TSV 및 markdown 생성
- `run-transaction-read-burst-429-budget-gate.sh`: burst 429 warning/fail threshold, dropped/interrupted iteration hard gate
- `run-prometheus-remote-write-latency-correlation.sh`: summary-only vs prometheus mode p95/p99/p99.9/max delta/ratio report
- 각 runner별 checker와 invalid input regression contract 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-read-p999-spike-profile.sh`
- `tools/test/check-transaction-read-burst-429-budget-gate.sh`
- `tools/test/check-prometheus-remote-write-latency-correlation.sh`
- `bash -n tools/test/run-transaction-read-p999-spike-profile.sh && bash -n tools/test/run-transaction-read-burst-429-budget-gate.sh && bash -n tools/test/run-prometheus-remote-write-latency-correlation.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` = `3`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: 새 gate의 warning은 실패가 아니라 회귀 관측 신호입니다. Prometheus metric snapshot은 환경별 metric name 차이로 `n/a`가 남을 수 있습니다.
- 롤백 방법: 이 PR의 3개 commit을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
