### PR TITLE
[Perf] k6 burst capacity evidence gate 보강

### DIFF
--- a/tools/test/archive-k6-transaction-100m-result.sh
+++ b/tools/test/archive-k6-transaction-100m-result.sh
@@ -9,6 +9,7 @@ Environment:
   PERFORMANCE_RESULT_NAME   output basename without .md, default summary-md basename
   PERFORMANCE_RESULT_OUTPUT_DIR default docs/performance-results
   PERFORMANCE_RESULT_PURPOSE default ${K6_RUN_PURPOSE:-smoke}
+  PERFORMANCE_RESULT_STATUS  default unknown
 
 Examples:
   tools/test/archive-k6-transaction-100m-result.sh build/reports/k6/transaction-100m-summary.md
@@ -40,6 +41,7 @@ fi
 base_name="${PERFORMANCE_RESULT_NAME:-$(basename "${summary_md}" .md)}"
 output_dir="${PERFORMANCE_RESULT_OUTPUT_DIR:-docs/performance-results}"
 purpose="${PERFORMANCE_RESULT_PURPOSE:-${K6_RUN_PURPOSE:-smoke}}"
+status="${PERFORMANCE_RESULT_STATUS:-unknown}"
 output_path="${output_dir}/${base_name}.md"
 mkdir -p "${output_dir}"
 
@@ -50,6 +52,7 @@ mkdir -p "${output_dir}"
   echo
   echo "- archivedAt: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
   echo "- resultPurpose: ${purpose}"
+  echo "- resultStatus: ${status}"
   echo "- reportClass: transaction-100m-${purpose}"
   echo "- sourceMarkdown: ${summary_md}"
   if [[ -n "${summary_json}" ]]; then

--- a/tools/test/check-burst-first-second-spike-correlation.sh
+++ b/tools/test/check-burst-first-second-spike-correlation.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-burst-first-second-spike-correlation.sh"
+
+echo "[burst-first-second-spike] shell syntax"
+bash -n "${script}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+summary_json="${temp_dir}/burst-summary.json"
+runner_log="${temp_dir}/burst-runner.log"
+snapshot_tsv="${temp_dir}/burst-snapshot.tsv"
+output_dir="${temp_dir}/burst-output"
+
+cat >"${summary_json}" <<'JSON'
+{
+  "metrics": {
+    "http_reqs": {"values": {"count": 4096}},
+    "dropped_iterations": {"values": {"count": 10}},
+    "interrupted_iterations": {"values": {"count": 0}},
+    "aquila_transaction_429_rate": {"values": {"rate": 0.017}},
+    "aquila_transaction_503_rate": {"values": {"rate": 0}},
+    "aquila_transaction_hot_first_ms": {"values": {"p(99.9)": 1123.4, "max": 1292.6}}
+  }
+}
+JSON
+cat >"${runner_log}" <<'LOG'
+WARN[0010] Insufficient VUs, reached 128 active VUs and cannot initialize more
+LOG
+cat >"${snapshot_tsv}" <<'TSV'
+metric	value
+k6.vus.max	128
+k6.vus.active.max	128
+backend.cpu.max.percent	91.2
+postgres.cpu.max.percent	48.4
+db.hikari.pending.max	0
+TSV
+
+echo "[burst-first-second-spike] plan"
+plan="$(
+  BURST_SPIKE_NAME=burst-spike-check \
+  BURST_SPIKE_K6_SUMMARY_JSON="${summary_json}" \
+  BURST_SPIKE_RUNNER_LOG="${runner_log}" \
+  BURST_SPIKE_PROMETHEUS_SNAPSHOT_TSV="${snapshot_tsv}" \
+  BURST_SPIKE_OUTPUT_DIR="${output_dir}" \
+  BURST_SPIKE_WINDOW_SECONDS=3 \
+    "${script}" --print-plan
+)"
+grep -F "name=burst-spike-check" <<<"${plan}" >/dev/null
+grep -F "k6_summary_json=${summary_json}" <<<"${plan}" >/dev/null
+grep -F "runner_log=${runner_log}" <<<"${plan}" >/dev/null
+grep -F "prometheus_snapshot=${snapshot_tsv}" <<<"${plan}" >/dev/null
+grep -F "window_seconds=3" <<<"${plan}" >/dev/null
+grep -F "correlation_tsv=${output_dir}/burst-spike-check-first-3s-correlation.tsv" <<<"${plan}" >/dev/null
+
+echo "[burst-first-second-spike] report"
+output="$(
+  BURST_SPIKE_NAME=burst-spike-check \
+  BURST_SPIKE_K6_SUMMARY_JSON="${summary_json}" \
+  BURST_SPIKE_RUNNER_LOG="${runner_log}" \
+  BURST_SPIKE_PROMETHEUS_SNAPSHOT_TSV="${snapshot_tsv}" \
+  BURST_SPIKE_OUTPUT_DIR="${output_dir}" \
+  BURST_SPIKE_WINDOW_SECONDS=3 \
+    "${script}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+correlation_tsv="${output_dir}/burst-spike-check-first-3s-correlation.tsv"
+test "${report_md}" = "${output_dir}/burst-spike-check-first-3s-correlation.md"
+test -s "${correlation_tsv}"
+grep -F $'window_seconds\tmetric\tvalue\tsource' "${correlation_tsv}" >/dev/null
+grep -F $'3\tdropped_iterations\t10\tk6-summary' "${correlation_tsv}" >/dev/null
+grep -F $'3\tinsufficient_vus_detected\t1\trunner-log' "${correlation_tsv}" >/dev/null
+grep -F $'3\tk6_vus_max\t128\tprometheus-snapshot' "${correlation_tsv}" >/dev/null
+grep -F "dropped iterations: 10" "${report_md}" >/dev/null
+grep -F "insufficient VUs detected: 1" "${report_md}" >/dev/null
+grep -F "hot first p99.9 ms: 1123.4" "${report_md}" >/dev/null
+
+echo "[burst-first-second-spike] invalid input fails"
+if BURST_SPIKE_WINDOW_SECONDS=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "zero first window unexpectedly passed" >&2
+  exit 1
+fi
+if BURST_SPIKE_NAME=missing-summary "${script}" >/dev/null 2>&1; then
+  echo "missing burst summary unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "[burst-first-second-spike] runner contract"
+grep -F "Insufficient VUs" "${script}" >/dev/null
+grep -F "dropped_iterations" "${script}" >/dev/null
+grep -F "k6.vus.active.max" "${script}" >/dev/null
+grep -F "first-window 원인 확정값이 아니라" "${script}" >/dev/null

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -35,6 +35,7 @@ grep -F "warmup duration=10s" <<<"${plan}" >/dev/null
 grep -F "run purpose=smoke" <<<"${plan}" >/dev/null
 grep -F "archive output dir=docs/performance-results/k6-smoke" <<<"${plan}" >/dev/null
 grep -F "summary gate=true" <<<"${plan}" >/dev/null
+grep -F "archive failed summary=true" <<<"${plan}" >/dev/null
 grep -F "backend readiness gate=true path=/actuator/health/readiness timeout=120" <<<"${plan}" >/dev/null
 grep -F "postgres health gate=true required_status=healthy" <<<"${plan}" >/dev/null
 grep -F "postgres recovery gate=true stable_seconds=10" <<<"${plan}" >/dev/null
@@ -120,18 +121,29 @@ burst_default_plan="$(
 )"
 grep -F "scenario mode=burst" <<<"${burst_default_plan}" >/dev/null
 grep -F "burst rate=16 duration=20s preAllocatedVUs=16 maxVUs=32" <<<"${burst_default_plan}" >/dev/null
+grep -F "burst headroom preflight=true minVUs=16" <<<"${burst_default_plan}" >/dev/null
 
-burst_plan="$(
-  K6_REPORT_NAME=transaction-100m-burst-check \
+burst_valid_plan="$(
+  K6_REPORT_NAME=transaction-100m-burst-valid-check \
   K6_SCENARIO_MODE=burst \
   K6_BURST_RATE=16 \
   K6_BURST_DURATION=20s \
-  K6_PRE_ALLOCATED_VUS=8 \
+  K6_PRE_ALLOCATED_VUS=16 \
   K6_MAX_VUS=32 \
     tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
 )"
-grep -F "scenario mode=burst" <<<"${burst_plan}" >/dev/null
-grep -F "burst rate=16 duration=20s preAllocatedVUs=8 maxVUs=32" <<<"${burst_plan}" >/dev/null
+grep -F "scenario mode=burst" <<<"${burst_valid_plan}" >/dev/null
+grep -F "burst rate=16 duration=20s preAllocatedVUs=16 maxVUs=32" <<<"${burst_valid_plan}" >/dev/null
+
+if K6_REPORT_NAME=transaction-100m-burst-underheadroom-check \
+  K6_SCENARIO_MODE=burst \
+  K6_BURST_RATE=256 \
+  K6_PRE_ALLOCATED_VUS=128 \
+  K6_MAX_VUS=128 \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan >/dev/null 2>&1; then
+  echo "burst headroom preflight unexpectedly accepted VU128 for 256/s" >&2
+  exit 1
+fi
 
 burst_offhost_plan="$(
   K6_REPORT_NAME=transaction-100m-burst-offhost-check \
@@ -146,7 +158,8 @@ burst_offhost_plan="$(
 )"
 grep -F "k6 report name: transaction-100m-burst-offhost-check" <<<"${burst_offhost_plan}" >/dev/null
 grep -F "generator mode=docker-context" <<<"${burst_offhost_plan}" >/dev/null
-grep -F "burst rate=256 duration=20s preAllocatedVUs=512 maxVUs=1024" <<<"${burst_offhost_plan}" >/dev/null
+grep -F "burst rate=256 duration=20s preAllocatedVUs=256 maxVUs=256" <<<"${burst_offhost_plan}" >/dev/null
+grep -F "burst headroom preflight=true minVUs=256" <<<"${burst_offhost_plan}" >/dev/null
 
 echo "[k6-transaction-100m] k6 script contract"
 grep -F "experimental-prometheus-rw" compose.loadtest.yml >/dev/null
@@ -244,7 +257,10 @@ grep -F "K6_OBSERVABILITY_MODE" tools/test/run-k6-transaction-100m-loadtest.sh >
 grep -F "K6_BACKEND_READINESS_GATE" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_RUN_ID" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_BURST_HEADROOM_PREFLIGHT" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "K6_ARCHIVE_FAILED_SUMMARY" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "write_run_context" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "assert_burst_headroom_preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "RECOVERY_NOISE_WINDOW_SECONDS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "wait_for_backend_readiness" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "LOADTEST_PROMETHEUS_CPUS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
@@ -260,6 +276,7 @@ grep -F "K6_REMOTE_PROMETHEUS_RW_SERVER_URL" tools/test/run-k6-transaction-100m-
 grep -F "K6_REMOTE_PREFLIGHT" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "K6_REMOTE_READINESS_PATH" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F "PERFORMANCE_RESULT_STATUS" tools/test/archive-k6-transaction-100m-result.sh >/dev/null
 grep -F "assert_remote_k6_preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "docker --context \"\${K6_DOCKER_CONTEXT}\" info" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
 grep -F "remote prometheus remote-write preflight" tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null

--- a/tools/test/check-k6-transaction-100m-multi-scenario.sh
+++ b/tools/test/check-k6-transaction-100m-multi-scenario.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-k6-transaction-100m-multi-scenario.sh"
+
+echo "[k6-transaction-100m-multi] shell syntax"
+bash -n "${script}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+scenarios="baseline:constant-vus:3:30s:false:16:3:3,burst-256:burst:16:20s:true:256:256:256"
+
+echo "[k6-transaction-100m-multi] plan"
+plan="$(
+  K6_MULTI_NAME=multi-check \
+  K6_MULTI_RUN_ID=multi-run-check \
+  K6_MULTI_OUTPUT_DIR="${temp_dir}/multi" \
+  K6_MULTI_SCENARIOS="${scenarios}" \
+    "${script}" --print-plan
+)"
+grep -F "name=multi-check" <<<"${plan}" >/dev/null
+grep -F "run_id=multi-run-check" <<<"${plan}" >/dev/null
+grep -F "output_dir=${temp_dir}/multi" <<<"${plan}" >/dev/null
+grep -F "reuse_backend=true" <<<"${plan}" >/dev/null
+grep -F "post_first_recovery_noise_window_seconds=0" <<<"${plan}" >/dev/null
+grep -F "scenario_count=2" <<<"${plan}" >/dev/null
+grep -F "execution_plan=${temp_dir}/multi/multi-check-execution-plan.tsv" <<<"${plan}" >/dev/null
+
+echo "[k6-transaction-100m-multi] dry-run execution plan"
+output="$(
+  K6_MULTI_NAME=multi-check \
+  K6_MULTI_RUN_ID=multi-run-check \
+  K6_MULTI_OUTPUT_DIR="${temp_dir}/multi" \
+  K6_MULTI_SCENARIOS="${scenarios}" \
+    "${script}" --dry-run
+)"
+execution_plan="$(tail -1 <<<"${output}")"
+test "${execution_plan}" = "${temp_dir}/multi/multi-check-execution-plan.tsv"
+test -s "${execution_plan}"
+grep -F $'order\tname\tmode\tvus\tduration\toverload\tburst_rate\tpre_allocated_vus\tmax_vus\treport_name\trunner_args\trecovery_noise_window_seconds' "${execution_plan}" >/dev/null
+grep -F $'1\tbaseline\tconstant-vus\t3\t30s\tfalse\t16\t3\t3\tmulti-check-baseline\tdefault\t30' "${execution_plan}" >/dev/null
+grep -F $'2\tburst-256\tburst\t16\t20s\ttrue\t256\t256\t256\tmulti-check-burst-256\t--no-up --no-deps\t0' "${execution_plan}" >/dev/null
+
+echo "[k6-transaction-100m-multi] invalid input fails"
+if K6_MULTI_SCENARIOS=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad multi scenario unexpectedly passed" >&2
+  exit 1
+fi
+if K6_MULTI_REUSE_BACKEND=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad reuse flag unexpectedly passed" >&2
+  exit 1
+fi
+if K6_MULTI_POST_FIRST_RECOVERY_NOISE_WINDOW_SECONDS=bad "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad recovery noise window unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "[k6-transaction-100m-multi] runner contract"
+grep -F "run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${script}" >/dev/null
+grep -F "K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS=\"\${post_first_noise_window}\"" "${script}" >/dev/null
+grep -F "K6_PRE_ALLOCATED_VUS=\"\${pre_allocated}\"" "${script}" >/dev/null
+grep -F "K6_MAX_VUS=\"\${max_vus}\"" "${script}" >/dev/null

--- a/tools/test/check-offhost-capacity-env-doctor.sh
+++ b/tools/test/check-offhost-capacity-env-doctor.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-offhost-capacity-env-doctor.sh"
+template="tools/test/offhost-capacity.env.example"
+
+echo "[offhost-capacity-env-doctor] shell syntax"
+bash -n "${script}"
+
+echo "[offhost-capacity-env-doctor] template"
+test -f "${template}"
+grep -F "export CAPACITY_K6_GENERATOR_MODE=docker-context" "${template}" >/dev/null
+grep -F "export CAPACITY_K6_DOCKER_CONTEXT=<remote-docker-context>" "${template}" >/dev/null
+grep -F "export CAPACITY_K6_REMOTE_BASE_URL=http://<backend-host>:18080" "${template}" >/dev/null
+grep -F "export CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://<prometheus-host>:9090/api/v1/write" "${template}" >/dev/null
+
+echo "[offhost-capacity-env-doctor] print template"
+env_template="$("${script}" --print-env-template)"
+grep -F "CAPACITY_K6_DOCKER_CONTEXT=<remote-docker-context>" <<<"${env_template}" >/dev/null
+grep -F "CAPACITY_REMOTE_READINESS_PATH=/actuator/health/readiness" <<<"${env_template}" >/dev/null
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+env_file="${temp_dir}/offhost-capacity.env"
+cat >"${env_file}" <<'ENV'
+CAPACITY_K6_DOCKER_CONTEXT=capacity-k6-remote
+CAPACITY_K6_REMOTE_BASE_URL=http://192.0.2.20:18080
+CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.20:9090/api/v1/write
+CAPACITY_K6_REMOTE_WORKDIR=/srv/aquila-bank
+CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS=15
+CAPACITY_REMOTE_PREFLIGHT_IMAGE=curlimages/curl:8.11.1
+CAPACITY_REMOTE_READINESS_PATH=/actuator/health/readiness
+ENV
+
+echo "[offhost-capacity-env-doctor] plan"
+plan="$(
+  OFFHOST_CAPACITY_ENV_FILE="${env_file}" \
+  OFFHOST_CAPACITY_CHECK_CONNECTIVITY=false \
+    "${script}" --print-plan
+)"
+grep -F "env_file=${env_file}" <<<"${plan}" >/dev/null
+grep -F "docker_context=capacity-k6-remote" <<<"${plan}" >/dev/null
+grep -F "remote_base_url=http://192.0.2.20:18080" <<<"${plan}" >/dev/null
+grep -F "remote_prometheus_rw_url=http://192.0.2.20:9090/api/v1/write" <<<"${plan}" >/dev/null
+grep -F "remote_workdir=/srv/aquila-bank" <<<"${plan}" >/dev/null
+grep -F "readiness_url=http://192.0.2.20:18080/actuator/health/readiness" <<<"${plan}" >/dev/null
+grep -F "timeout_seconds=15" <<<"${plan}" >/dev/null
+grep -F "check_connectivity=false" <<<"${plan}" >/dev/null
+
+echo "[offhost-capacity-env-doctor] dry run"
+OFFHOST_CAPACITY_ENV_FILE="${env_file}" \
+OFFHOST_CAPACITY_CHECK_CONNECTIVITY=false \
+  "${script}" --dry-run >/dev/null
+
+echo "[offhost-capacity-env-doctor] invalid input fails"
+if "${script}" --print-plan >/dev/null 2>&1; then
+  echo "missing off-host capacity env unexpectedly passed" >&2
+  exit 1
+fi
+if OFFHOST_CAPACITY_ENV_FILE="${temp_dir}/missing.env" "${script}" --print-plan >/dev/null 2>&1; then
+  echo "missing env file unexpectedly passed" >&2
+  exit 1
+fi
+bad_env_file="${temp_dir}/bad.env"
+cat >"${bad_env_file}" <<'ENV'
+CAPACITY_K6_DOCKER_CONTEXT=capacity-k6-remote
+CAPACITY_K6_REMOTE_BASE_URL=not-a-url
+CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.20:9090/api/v1/write
+ENV
+if OFFHOST_CAPACITY_ENV_FILE="${bad_env_file}" "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad remote base url unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "[offhost-capacity-env-doctor] runner contract"
+grep -F "OFFHOST_CAPACITY_ENV_FILE" "${script}" >/dev/null
+grep -F "OFFHOST_CAPACITY_CHECK_CONNECTIVITY" "${script}" >/dev/null
+grep -F "docker context inspect" "${script}" >/dev/null
+grep -F "docker --context \"\${docker_context}\" info" "${script}" >/dev/null
+grep -F "docker --context \"\${docker_context}\" run --rm \"\${preflight_image}\"" "${script}" >/dev/null
+grep -F "remote prometheus remote-write preflight failed" "${script}" >/dev/null

--- a/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
@@ -17,6 +17,7 @@ admission="${temp_dir}/admission.tsv"
 outbox="${temp_dir}/outbox.tsv"
 k6="${temp_dir}/k6-summary.md"
 memory="${temp_dir}/memory.tsv"
+capacity_prereq="${temp_dir}/capacity-prerequisite-failure.env"
 
 cat >"${capacity}" <<'MD'
 # capacity
@@ -55,6 +56,12 @@ cat >"${k6}" <<'MD'
 - cold first p95 ms: 640
 - cold cursor p95 ms: 680
 MD
+cat >"${capacity_prereq}" <<'ENV'
+CAPACITY_PREREQUISITE_STATUS=failed
+CAPACITY_PREREQUISITE_FAILURE_REASON=missing-required-env
+CAPACITY_PREREQUISITE_MISSING_VARS=CAPACITY_K6_DOCKER_CONTEXT,CAPACITY_K6_REMOTE_BASE_URL,CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL
+CAPACITY_PREREQUISITE_GRADE=capacity
+ENV
 
 echo "[t3micro-defensive-aggregate] plan"
 plan="$(
@@ -63,6 +70,7 @@ plan="$(
   T3MICRO_CAPACITY_RESULT_MD="${capacity}" \
   T3MICRO_CAPACITY_SUMMARY_TSV="${capacity_summary}" \
   T3MICRO_CAPACITY_RUN_CONTEXT_ENV="${capacity_context}" \
+  T3MICRO_CAPACITY_PREREQUISITE_ENV="${capacity_prereq}" \
   T3MICRO_SSE_RESULT_MD="${sse}" \
   T3MICRO_ADMISSION_SUMMARY_TSV="${admission}" \
   T3MICRO_OUTBOX_SUMMARY_TSV="${outbox}" \
@@ -75,8 +83,10 @@ grep -F "output=${temp_dir}/aggregate-check.md" <<<"${plan}" >/dev/null
 grep -F "capacity=${capacity}" <<<"${plan}" >/dev/null
 grep -F "capacity_summary=${capacity_summary}" <<<"${plan}" >/dev/null
 grep -F "capacity_run_context=${capacity_context}" <<<"${plan}" >/dev/null
+grep -F "capacity_prerequisite=${capacity_prereq}" <<<"${plan}" >/dev/null
 grep -F "admission=${admission}" <<<"${plan}" >/dev/null
 grep -F "k6=${k6}" <<<"${plan}" >/dev/null
+grep -F "k6_profile_selector=representative" <<<"${plan}" >/dev/null
 grep -F "memory=${memory}" <<<"${plan}" >/dev/null
 grep -F "auto_inputs=true" <<<"${plan}" >/dev/null
 grep -F "auto_input_run_id=missing" <<<"${plan}" >/dev/null
@@ -93,7 +103,8 @@ auto_capacity_context="${auto_capacity_dir}/capacity-run-context.env"
 auto_sse="${auto_root}/docs/performance-results/aggregate-auto-check-sse-reconnect.md"
 auto_admission="${auto_root}/build/reports/admission/aggregate-auto-check-admission/http-admission-summary.tsv"
 auto_outbox="${auto_root}/build/reports/outbox/aggregate-auto-check-outbox/outbox-provider-backlog-summary.tsv"
-auto_k6="${auto_root}/build/reports/k6/transaction-100m-aggregate-auto-check-summary.md"
+auto_k6="${auto_root}/build/reports/k6/transaction-100m-aggregate-auto-check-vu3-summary.md"
+auto_k6_burst_failed="${auto_root}/build/reports/k6/transaction-100m-aggregate-auto-check-burst-vu128-summary.md"
 auto_memory="${auto_root}/build/reports/t3micro/aggregate-auto-check-memory-summary.tsv"
 cp "${capacity}" "${auto_capacity}"
 mkdir -p "${auto_capacity_dir}" "$(dirname "${auto_admission}")" "$(dirname "${auto_outbox}")"
@@ -102,8 +113,39 @@ cp "${capacity_context}" "${auto_capacity_context}"
 cp "${sse}" "${auto_sse}"
 cp "${admission}" "${auto_admission}"
 cp "${outbox}" "${auto_outbox}"
-cp "${k6}" "${auto_k6}"
+cat >"${auto_k6}" <<'MD'
+# k6 pass
+- resultPurpose: smoke
+- resultStatus: 0
+- run id: transaction-100m-aggregate-auto-check-vu3
+- scenario mode: constant-vus
+- checks rate: 1
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- hot first p95 ms: 220
+- hot cursor p95 ms: 240
+- cold first p95 ms: 640
+- cold cursor p95 ms: 680
+MD
+cat >"${auto_k6_burst_failed}" <<'MD'
+# k6 failed burst
+- resultPurpose: smoke
+- resultStatus: 1
+- run id: transaction-100m-aggregate-auto-check-burst-vu128
+- scenario mode: burst
+- burst rate: 256/1s
+- pre allocated VUs: 128
+- max VUs: 128
+- checks rate: 1
+- transaction 429 rate: 0.017
+- transaction 503 rate: 0
+- hot first p95 ms: 260
+- hot cursor p95 ms: 270
+- cold first p95 ms: 690
+- cold cursor p95 ms: 710
+MD
 cp "${memory}" "${auto_memory}"
+touch "${auto_k6}" "${auto_k6_burst_failed}"
 stale_capacity="${auto_root}/docs/performance-results/stale-20260427-docker-t3micro-capacity.md"
 stale_capacity_dir="${auto_root}/build/reports/k6/stale-20260427-capacity"
 stale_capacity_summary="${stale_capacity_dir}/capacity-summary.tsv"
@@ -132,10 +174,29 @@ grep -F "admission=${auto_admission}" <<<"${auto_plan}" >/dev/null
 grep -F "outbox=${auto_outbox}" <<<"${auto_plan}" >/dev/null
 grep -F "k6=${auto_k6}" <<<"${auto_plan}" >/dev/null
 grep -F "memory=${auto_memory}" <<<"${auto_plan}" >/dev/null
+if grep -F "burst-vu128" <<<"${auto_plan}" >/dev/null; then
+  echo "auto input unexpectedly selected failed burst k6 summary as representative" >&2
+  exit 1
+fi
 if grep -F "stale-20260427" <<<"${auto_plan}" >/dev/null; then
   echo "auto input unexpectedly selected stale artifact outside aggregate prefix" >&2
   exit 1
 fi
+
+alias_auto_root="${temp_dir}/alias-auto"
+mkdir -p "${alias_auto_root}/build/reports/t3micro" "${alias_auto_root}/build/reports/k6"
+alias_memory="${alias_auto_root}/build/reports/t3micro/post-observability-20260428-memory-summary.tsv"
+alias_k6="${alias_auto_root}/build/reports/k6/transaction-100m-post-observability-20260428-vu3-summary.md"
+cp "${memory}" "${alias_memory}"
+cp "${auto_k6}" "${alias_k6}"
+alias_plan="$(
+  T3MICRO_AGGREGATE_NAME=t3micro-defensive-post-observability-20260428 \
+  T3MICRO_AGGREGATE_OUTPUT_DIR="${temp_dir}" \
+  T3MICRO_AGGREGATE_SEARCH_ROOTS="${alias_auto_root}/build/reports" \
+    "${script}" --print-plan
+)"
+grep -F "k6=${alias_k6}" <<<"${alias_plan}" >/dev/null
+grep -F "memory=${alias_memory}" <<<"${alias_plan}" >/dev/null
 
 echo "[t3micro-defensive-aggregate] required inputs"
 if T3MICRO_AGGREGATE_NAME=aggregate-required-check \
@@ -184,6 +245,7 @@ output="$(
   T3MICRO_CAPACITY_RESULT_MD="${capacity}" \
   T3MICRO_CAPACITY_SUMMARY_TSV="${capacity_summary}" \
   T3MICRO_CAPACITY_RUN_CONTEXT_ENV="${capacity_context}" \
+  T3MICRO_CAPACITY_PREREQUISITE_ENV="${capacity_prereq}" \
   T3MICRO_SSE_RESULT_MD="${sse}" \
   T3MICRO_ADMISSION_SUMMARY_TSV="${admission}" \
   T3MICRO_OUTBOX_SUMMARY_TSV="${outbox}" \
@@ -195,6 +257,7 @@ output="$(
 output="$(tail -1 <<<"${output}")"
 test "${output}" = "${temp_dir}/aggregate-check.md"
 grep -F "| capacity smoke | 0 | 82.50 | 712.00 | repeat=3 | ${capacity} |" "${output}" >/dev/null
+grep -F "| capacity prerequisite | failed | n/a | n/a | reason=missing-required-env missing=CAPACITY_K6_DOCKER_CONTEXT,CAPACITY_K6_REMOTE_BASE_URL,CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL | ${capacity_prereq} |" "${output}" >/dev/null
 grep -F "| capacity | pass | 82.50 | n/a | 429Rate=0.010000 hikariPending=0 profiles=1 | ${capacity_summary} |" "${output}" >/dev/null
 grep -F "| capacity soak | pass | 88.25 | n/a | 429Rate=0.000000 hikariPending=0 profiles=1 | ${capacity_summary} |" "${output}" >/dev/null
 grep -F "| sse reconnect | 0 | 61.00 | 512.00 | clients=8 rounds=3 | ${sse} |" "${output}" >/dev/null

--- a/tools/test/check-transaction-100m-offhost-capacity-baseline-report.sh
+++ b/tools/test/check-transaction-100m-offhost-capacity-baseline-report.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-offhost-capacity-baseline-report.sh"
+
+echo "[transaction-100m-offhost-baseline] shell syntax"
+bash -n "${script}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+env_file="${temp_dir}/offhost-capacity.env"
+summary="${temp_dir}/capacity-summary.tsv"
+context="${temp_dir}/capacity-run-context.env"
+prereq="${temp_dir}/capacity-prerequisite-failure.env"
+cat >"${env_file}" <<'ENV'
+CAPACITY_K6_DOCKER_CONTEXT=capacity-k6-remote
+CAPACITY_K6_REMOTE_BASE_URL=http://192.0.2.20:18080
+CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.20:9090/api/v1/write
+CAPACITY_K6_REMOTE_WORKDIR=/srv/aquila-bank
+ENV
+printf "phase\tprofile\tstatus\tadmission\tvus\tbackend_cpus\tbackend_memory\tpostgres_cpus\tpostgres_memory\tdb_pool\toverload_mode\tduration\thttp_failed_rate\thttp_reqs\ttransaction_429_rate\thot_first_p95_ms\thot_cursor_p95_ms\tcold_first_p95_ms\tcold_cursor_p95_ms\tbackend_cpu_percent\tpostgres_cpu_percent\thikari_active\thikari_pending\thikari_max\tlog_path\tsummary_json\nsingle-host\tsingle-host-default\t0\t3\t8\t0.40\t512m\t0.60\t384m\t4\ttrue\t1m\t0\t1200\t0.010000\t210\t220\t610\t640\t82.50\t41.00\t3\t0\t4\tcapacity.log\tcapacity-summary.json\nlong-soak\tlong-soak-high-traffic\t0\t8\t8\t0.80\t640m\t0.60\t384m\t6\tfalse\t30m\t0\t12000\t0.000000\t230\t240\t650\t680\t88.25\t45.00\t5\t0\t6\tsoak.log\tsoak-summary.json\n" >"${summary}"
+cat >"${context}" <<'ENV'
+CAPACITY_RUN_PURPOSE=capacity
+CAPACITY_NAME=offhost-baseline-check
+CAPACITY_GENERATOR_MODE=docker-context
+ENV
+cat >"${prereq}" <<'ENV'
+CAPACITY_PREREQUISITE_STATUS=missing
+CAPACITY_PREREQUISITE_FAILURE_REASON=missing
+CAPACITY_PREREQUISITE_MISSING_VARS=missing
+ENV
+
+echo "[transaction-100m-offhost-baseline] plan"
+plan="$(
+  OFFHOST_BASELINE_NAME=offhost-baseline-check \
+  OFFHOST_BASELINE_OUTPUT_DIR="${temp_dir}" \
+  OFFHOST_BASELINE_ENV_FILE="${env_file}" \
+  OFFHOST_BASELINE_CAPACITY_SUMMARY_TSV="${summary}" \
+  OFFHOST_BASELINE_CAPACITY_RUN_CONTEXT_ENV="${context}" \
+  OFFHOST_BASELINE_CAPACITY_PREREQUISITE_ENV="${prereq}" \
+  OFFHOST_BASELINE_RUN_CAPACITY=false \
+  OFFHOST_BASELINE_DOCTOR_CONNECTIVITY=false \
+    "${script}" --print-plan
+)"
+grep -F "name=offhost-baseline-check" <<<"${plan}" >/dev/null
+grep -F "output=${temp_dir}/offhost-baseline-check.md" <<<"${plan}" >/dev/null
+grep -F "env_file=${env_file}" <<<"${plan}" >/dev/null
+grep -F "run_capacity=false" <<<"${plan}" >/dev/null
+grep -F "doctor_connectivity=false" <<<"${plan}" >/dev/null
+grep -F "capacity_summary=${summary}" <<<"${plan}" >/dev/null
+grep -F "capacity_run_context=${context}" <<<"${plan}" >/dev/null
+grep -F "capacity_prerequisite=${prereq}" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-offhost-baseline] dry-run report"
+output="$(
+  OFFHOST_BASELINE_NAME=offhost-baseline-check \
+  OFFHOST_BASELINE_OUTPUT_DIR="${temp_dir}" \
+  OFFHOST_BASELINE_ENV_FILE="${env_file}" \
+  OFFHOST_BASELINE_CAPACITY_SUMMARY_TSV="${summary}" \
+  OFFHOST_BASELINE_CAPACITY_RUN_CONTEXT_ENV="${context}" \
+  OFFHOST_BASELINE_CAPACITY_PREREQUISITE_ENV="${prereq}" \
+  OFFHOST_BASELINE_RUN_CAPACITY=false \
+  OFFHOST_BASELINE_DOCTOR_CONNECTIVITY=false \
+    "${script}" --dry-run
+)"
+output="$(tail -1 <<<"${output}")"
+test "${output}" = "${temp_dir}/offhost-baseline-check.md"
+grep -F "| capacity | pass | 82.50 | 0.010000 | 0 | ${summary} |" "${output}" >/dev/null
+grep -F "| soak | pass | 88.25 | 0.000000 | 0 | ${summary} |" "${output}" >/dev/null
+grep -F "| prerequisite | missing | n/a | n/a | n/a | reason=missing missing=missing |" "${output}" >/dev/null
+
+echo "[transaction-100m-offhost-baseline] invalid input fails"
+if OFFHOST_BASELINE_RUN_CAPACITY=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad OFFHOST_BASELINE_RUN_CAPACITY unexpectedly passed" >&2
+  exit 1
+fi
+if OFFHOST_BASELINE_LONG_SOAK_DURATION=0m "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad OFFHOST_BASELINE_LONG_SOAK_DURATION unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "[transaction-100m-offhost-baseline] runner contract"
+grep -F "run-offhost-capacity-env-doctor.sh" "${script}" >/dev/null
+grep -F "run-transaction-100m-capacity-gates.sh" "${script}" >/dev/null
+grep -F "OFFHOST_BASELINE_CAPACITY_SUMMARY_TSV" "${script}" >/dev/null
+grep -F "OFFHOST_BASELINE_CAPACITY_PREREQUISITE_ENV" "${script}" >/dev/null
+grep -F "OFFHOST_BASELINE_DOCTOR_CONNECTIVITY" "${script}" >/dev/null

--- a/tools/test/offhost-capacity.env.example
+++ b/tools/test/offhost-capacity.env.example
@@ -1,0 +1,10 @@
+# Local-only off-host capacity template. Copy outside git and fill runtime values.
+export CAPACITY_K6_GENERATOR_MODE=docker-context
+export CAPACITY_K6_DOCKER_CONTEXT=<remote-docker-context>
+export CAPACITY_K6_REMOTE_BASE_URL=http://<backend-host>:18080
+export CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://<prometheus-host>:9090/api/v1/write
+export CAPACITY_K6_REMOTE_WORKDIR=/srv/aquila-bank
+export CAPACITY_REMOTE_PREFLIGHT=true
+export CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS=30
+export CAPACITY_REMOTE_PREFLIGHT_IMAGE=curlimages/curl:8.11.1
+export CAPACITY_REMOTE_READINESS_PATH=/actuator/health/readiness

--- a/tools/test/run-burst-first-second-spike-correlation.sh
+++ b/tools/test/run-burst-first-second-spike-correlation.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-burst-first-second-spike-correlation.sh [--print-plan]
+
+Environment:
+  BURST_SPIKE_NAME default burst-first-second-spike-<timestamp>
+  BURST_SPIKE_RUN_ID default BURST_SPIKE_NAME
+  BURST_SPIKE_K6_SUMMARY_JSON required k6 summary JSON
+  BURST_SPIKE_RUNNER_LOG optional k6 runner log
+  BURST_SPIKE_PROMETHEUS_SNAPSHOT_TSV optional metric/value snapshot TSV
+  BURST_SPIKE_OUTPUT_DIR default build/reports/profiling/<name>
+  BURST_SPIKE_WINDOW_SECONDS default 3
+
+Snapshot metric keys:
+  k6.vus.max
+  k6.vus.active.max
+  backend.cpu.max.percent
+  postgres.cpu.max.percent
+  db.hikari.pending.max
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${BURST_SPIKE_NAME:-burst-first-second-spike-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${BURST_SPIKE_RUN_ID:-${name}}"
+k6_summary_json="${BURST_SPIKE_K6_SUMMARY_JSON:-}"
+runner_log="${BURST_SPIKE_RUNNER_LOG:-}"
+snapshot_tsv="${BURST_SPIKE_PROMETHEUS_SNAPSHOT_TSV:-}"
+output_dir="${BURST_SPIKE_OUTPUT_DIR:-build/reports/profiling/${name}}"
+window_seconds="${BURST_SPIKE_WINDOW_SECONDS:-3}"
+correlation_tsv="${output_dir}/${name}-first-${window_seconds}s-correlation.tsv"
+report_md="${output_dir}/${name}-first-${window_seconds}s-correlation.md"
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer "BURST_SPIKE_WINDOW_SECONDS" "${window_seconds}"
+
+print_plan() {
+  echo "[burst-first-second-spike] name=${name}"
+  echo "[burst-first-second-spike] run_id=${run_id}"
+  echo "[burst-first-second-spike] k6_summary_json=${k6_summary_json:-missing}"
+  echo "[burst-first-second-spike] runner_log=${runner_log:-missing}"
+  echo "[burst-first-second-spike] prometheus_snapshot=${snapshot_tsv:-missing}"
+  echo "[burst-first-second-spike] window_seconds=${window_seconds}"
+  echo "[burst-first-second-spike] correlation_tsv=${correlation_tsv}"
+  echo "[burst-first-second-spike] report_md=${report_md}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+if [[ -z "${k6_summary_json}" || ! -s "${k6_summary_json}" ]]; then
+  echo "BURST_SPIKE_K6_SUMMARY_JSON is required: ${k6_summary_json:-missing}" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+metric_value() {
+  local metric="$1"
+  local field="$2"
+  jq -r --arg metric "${metric}" --arg field "${field}" \
+    '.metrics[$metric].values[$field] // "n/a"' "${k6_summary_json}"
+}
+
+metric_count() {
+  local metric="$1"
+  jq -r --arg metric "${metric}" '
+    (.metrics[$metric].values // {}) as $values
+    | if $values.count != null then
+        $values.count
+      elif ($values.passes != null or $values.fails != null) then
+        (($values.passes // 0) + ($values.fails // 0))
+      else
+        0
+      end
+  ' "${k6_summary_json}"
+}
+
+snapshot_value() {
+  local key="$1"
+  if [[ -z "${snapshot_tsv}" || ! -s "${snapshot_tsv}" ]]; then
+    echo "n/a"
+    return 0
+  fi
+  awk -F '\t' -v key="${key}" '$1 == key {value = $2; found = 1} END {print found ? value : "n/a"}' "${snapshot_tsv}"
+}
+
+insufficient_vus_detected() {
+  if [[ -n "${runner_log}" && -s "${runner_log}" ]] && grep -Fi "Insufficient VUs" "${runner_log}" >/dev/null; then
+    echo "1"
+  else
+    echo "0"
+  fi
+}
+
+mkdir -p "${output_dir}"
+
+{
+  printf "window_seconds\tmetric\tvalue\tsource\n"
+  printf "%s\tdropped_iterations\t%s\tk6-summary\n" "${window_seconds}" "$(metric_count dropped_iterations)"
+  printf "%s\tinterrupted_iterations\t%s\tk6-summary\n" "${window_seconds}" "$(metric_count interrupted_iterations)"
+  printf "%s\thttp_reqs\t%s\tk6-summary\n" "${window_seconds}" "$(metric_count http_reqs)"
+  printf "%s\ttransaction_429_rate\t%s\tk6-summary\n" "${window_seconds}" "$(metric_value aquila_transaction_429_rate rate)"
+  printf "%s\ttransaction_503_rate\t%s\tk6-summary\n" "${window_seconds}" "$(metric_value aquila_transaction_503_rate rate)"
+  printf "%s\thot_first_p999_ms\t%s\tk6-summary\n" "${window_seconds}" "$(metric_value aquila_transaction_hot_first_ms "p(99.9)")"
+  printf "%s\thot_first_max_ms\t%s\tk6-summary\n" "${window_seconds}" "$(metric_value aquila_transaction_hot_first_ms max)"
+  printf "%s\tinsufficient_vus_detected\t%s\trunner-log\n" "${window_seconds}" "$(insufficient_vus_detected)"
+  printf "%s\tk6_vus_max\t%s\tprometheus-snapshot\n" "${window_seconds}" "$(snapshot_value k6.vus.max)"
+  printf "%s\tk6_vus_active_max\t%s\tprometheus-snapshot\n" "${window_seconds}" "$(snapshot_value k6.vus.active.max)"
+  printf "%s\tbackend_cpu_percent\t%s\tprometheus-snapshot\n" "${window_seconds}" "$(snapshot_value backend.cpu.max.percent)"
+  printf "%s\tpostgres_cpu_percent\t%s\tprometheus-snapshot\n" "${window_seconds}" "$(snapshot_value postgres.cpu.max.percent)"
+  printf "%s\thikari_pending\t%s\tprometheus-snapshot\n" "${window_seconds}" "$(snapshot_value db.hikari.pending.max)"
+} >"${correlation_tsv}"
+
+cat >"${report_md}" <<REPORT
+# Burst First-Second Spike Correlation
+
+## Summary
+
+- name: ${name}
+- run id: ${run_id}
+- first window seconds: ${window_seconds}
+- dropped iterations: $(metric_count dropped_iterations)
+- interrupted iterations: $(metric_count interrupted_iterations)
+- insufficient VUs detected: $(insufficient_vus_detected)
+- hot first p99.9 ms: $(metric_value aquila_transaction_hot_first_ms "p(99.9)")
+- hot first max ms: $(metric_value aquila_transaction_hot_first_ms max)
+
+## Artifacts
+
+- correlation TSV: ${correlation_tsv}
+- k6 summary JSON: ${k6_summary_json}
+- runner log: ${runner_log:-missing}
+- Prometheus snapshot TSV: ${snapshot_tsv:-missing}
+
+## Notes
+
+- k6 summary 값은 전체 measured phase 기준이므로 first-window 원인 확정값이 아니라 VU 포화/429/latency를 함께 보존하는 방어용 artifact입니다.
+- Prometheus snapshot이 있으면 첫 ${window_seconds}s 구간 query 결과를 같이 넣어 판단합니다.
+REPORT
+
+echo "${report_md}"

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -25,6 +25,8 @@ Optional environment:
   K6_MAX_VUS           default K6_PRE_ALLOCATED_VUS
   K6_BURST_RATE        iterations per second for burst mode, default 16
   K6_BURST_DURATION    default 20s
+  K6_BURST_HEADROOM_PREFLIGHT fail before k6 when burst VU headroom is too small, default true
+  K6_BURST_MIN_HEADROOM_VUS default K6_BURST_RATE
   K6_WARMUP_DURATION   warmup phase before measured phase, default 10s
   K6_LIMIT             default 50
   K6_HOT_P99_THRESHOLD_MS default 750
@@ -35,6 +37,7 @@ Optional environment:
   K6_COLD_MAX_THRESHOLD_MS default 5000
   K6_AUTH_TOKEN        bearer token, optional when bootstrap header auth is enabled
   K6_ARCHIVE_RESULTS   copy markdown summary to docs/performance-results, default true
+  K6_ARCHIVE_FAILED_SUMMARY archive summary even when hard gate fails, default true
   K6_ARCHIVE_OUTPUT_ROOT default docs/performance-results
   K6_PREFLIGHT         check PostgreSQL OOM/index readiness before k6, default true
   K6_POSTGRES_HEALTH_GATE require PostgreSQL Docker health=healthy before k6, default true
@@ -225,15 +228,13 @@ K6_RATE="${K6_RATE:-8}"
 K6_TIME_UNIT="${K6_TIME_UNIT:-1s}"
 K6_BURST_RATE="${K6_BURST_RATE:-16}"
 K6_BURST_DURATION="${K6_BURST_DURATION:-20s}"
+K6_BURST_HEADROOM_PREFLIGHT="${K6_BURST_HEADROOM_PREFLIGHT:-true}"
+K6_BURST_MIN_HEADROOM_VUS="${K6_BURST_MIN_HEADROOM_VUS:-${K6_BURST_RATE}}"
 K6_GENERATOR_MODE="${K6_GENERATOR_MODE:-local}"
 K6_PRE_ALLOCATED_VUS="${K6_PRE_ALLOCATED_VUS:-}"
 if [[ -z "${K6_PRE_ALLOCATED_VUS}" ]]; then
   if [[ "${K6_SCENARIO_MODE}" == "burst" ]]; then
-    if [[ "${K6_GENERATOR_MODE}" == "docker-context" && "${K6_BURST_RATE}" =~ ^[1-9][0-9]*$ ]]; then
-      K6_PRE_ALLOCATED_VUS="$((K6_BURST_RATE * 2))"
-    else
-      K6_PRE_ALLOCATED_VUS="${K6_BURST_RATE}"
-    fi
+    K6_PRE_ALLOCATED_VUS="${K6_BURST_MIN_HEADROOM_VUS}"
   else
     K6_PRE_ALLOCATED_VUS="${K6_VUS}"
   fi
@@ -243,9 +244,13 @@ if [[ -z "${K6_MAX_VUS}" ]]; then
   if [[ "${K6_SCENARIO_MODE}" == "burst" ]]; then
     if [[ "${K6_BURST_RATE}" =~ ^[1-9][0-9]*$ ]]; then
       if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
-        K6_MAX_VUS="$((K6_BURST_RATE * 4))"
+        K6_MAX_VUS="${K6_PRE_ALLOCATED_VUS}"
       else
-        K6_MAX_VUS="$((K6_BURST_RATE * 2))"
+        burst_local_max="$((K6_BURST_RATE * 2))"
+        if [[ "${K6_PRE_ALLOCATED_VUS}" =~ ^[1-9][0-9]*$ && "${K6_PRE_ALLOCATED_VUS}" -gt "${burst_local_max}" ]]; then
+          burst_local_max="${K6_PRE_ALLOCATED_VUS}"
+        fi
+        K6_MAX_VUS="${burst_local_max}"
       fi
     else
       K6_MAX_VUS="${K6_BURST_RATE}"
@@ -266,6 +271,7 @@ K6_HOT_MAX_THRESHOLD_MS="${K6_HOT_MAX_THRESHOLD_MS:-3000}"
 K6_COLD_MAX_THRESHOLD_MS="${K6_COLD_MAX_THRESHOLD_MS:-5000}"
 K6_HTTP_FAILED_RATE="${K6_HTTP_FAILED_RATE:-0.01}"
 K6_ARCHIVE_RESULTS="${K6_ARCHIVE_RESULTS:-true}"
+K6_ARCHIVE_FAILED_SUMMARY="${K6_ARCHIVE_FAILED_SUMMARY:-true}"
 K6_ARCHIVE_OUTPUT_ROOT="${K6_ARCHIVE_OUTPUT_ROOT:-docs/performance-results}"
 K6_PREFLIGHT="${K6_PREFLIGHT:-true}"
 K6_POSTGRES_HEALTH_GATE="${K6_POSTGRES_HEALTH_GATE:-true}"
@@ -314,13 +320,14 @@ loadtest_postgres_exporter_cpus="${LOADTEST_POSTGRES_EXPORTER_CPUS:-0.10}"
 loadtest_postgres_exporter_memory="${LOADTEST_POSTGRES_EXPORTER_MEMORY:-128m}"
 loadtest_postgres_container="${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}"
 loadtest_backend_container="${LOADTEST_BACKEND_CONTAINER_NAME:-aquila-bank-backend-loadtest}"
-export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_WARMUP_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_BURST_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REMOTE_PREFLIGHT K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS K6_REMOTE_PREFLIGHT_IMAGE K6_REMOTE_READINESS_PATH K6_REPORT_NAME K6_RUN_ID
+export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_BURST_HEADROOM_PREFLIGHT K6_BURST_MIN_HEADROOM_VUS K6_WARMUP_DURATION K6_LIMIT K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_ARCHIVE_FAILED_SUMMARY K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_BURST_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REMOTE_PREFLIGHT K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS K6_REMOTE_PREFLIGHT_IMAGE K6_REMOTE_READINESS_PATH K6_REPORT_NAME K6_RUN_ID
 
 require_positive_integer K6_VUS
 require_positive_integer K6_RATE
 require_positive_integer K6_PRE_ALLOCATED_VUS
 require_positive_integer K6_MAX_VUS
 require_positive_integer K6_BURST_RATE
+require_positive_integer K6_BURST_MIN_HEADROOM_VUS
 if ! [[ "${K6_WARMUP_DURATION}" =~ ^[0-9]+(s|m|h)$ ]]; then
   echo "K6_WARMUP_DURATION must use a duration such as 0s, 10s, or 1m" >&2
   exit 1
@@ -345,7 +352,10 @@ require_bool_value() {
 }
 require_bool_value K6_OUTBOX_PREFLIGHT
 require_bool_value K6_EXPLAIN_SNAPSHOT
+require_bool_value K6_ARCHIVE_RESULTS
+require_bool_value K6_ARCHIVE_FAILED_SUMMARY
 require_bool_value K6_SUMMARY_GATE
+require_bool_value K6_BURST_HEADROOM_PREFLIGHT
 require_bool_value K6_BACKEND_READINESS_GATE
 require_bool_value K6_POSTGRES_HEALTH_GATE
 require_bool_value K6_POSTGRES_RECOVERY_GATE
@@ -364,6 +374,22 @@ require_generator_mode
 require_observability_mode
 require_scenario_mode
 require_run_purpose
+
+assert_burst_headroom_preflight() {
+  if [[ "${K6_SCENARIO_MODE}" != "burst" || "${K6_BURST_HEADROOM_PREFLIGHT}" != "true" ]]; then
+    return 0
+  fi
+  if ((K6_PRE_ALLOCATED_VUS < K6_BURST_MIN_HEADROOM_VUS)); then
+    echo "burst headroom preflight failed: K6_PRE_ALLOCATED_VUS=${K6_PRE_ALLOCATED_VUS} min=${K6_BURST_MIN_HEADROOM_VUS}" >&2
+    exit 1
+  fi
+  if ((K6_MAX_VUS < K6_BURST_MIN_HEADROOM_VUS)); then
+    echo "burst headroom preflight failed: K6_MAX_VUS=${K6_MAX_VUS} min=${K6_BURST_MIN_HEADROOM_VUS}" >&2
+    exit 1
+  fi
+}
+
+assert_burst_headroom_preflight
 
 if [[ "${K6_GENERATOR_MODE}" == "local" && "${K6_RUN_PURPOSE}" != "smoke" ]]; then
   echo "K6_GENERATOR_MODE=local is limited to K6_RUN_PURPOSE=smoke" >&2
@@ -480,6 +506,7 @@ print_plan() {
   echo "[k6-transaction-100m] scenario mode=${K6_SCENARIO_MODE}"
   echo "[k6-transaction-100m] arrival rate=${K6_RATE} timeUnit=${K6_TIME_UNIT} preAllocatedVUs=${K6_PRE_ALLOCATED_VUS} maxVUs=${K6_MAX_VUS}"
   echo "[k6-transaction-100m] burst rate=${K6_BURST_RATE} duration=${K6_BURST_DURATION} preAllocatedVUs=${K6_PRE_ALLOCATED_VUS} maxVUs=${K6_MAX_VUS}"
+  echo "[k6-transaction-100m] burst headroom preflight=${K6_BURST_HEADROOM_PREFLIGHT} minVUs=${K6_BURST_MIN_HEADROOM_VUS}"
   echo "[k6-transaction-100m] warmup duration=${K6_WARMUP_DURATION}"
   echo "[k6-transaction-100m] hot p95 threshold ms=${K6_HOT_P95_THRESHOLD_MS}"
   echo "[k6-transaction-100m] cold p95 threshold ms=${K6_COLD_P95_THRESHOLD_MS}"
@@ -496,6 +523,7 @@ print_plan() {
   echo "[k6-transaction-100m] overload 503 rate threshold=${K6_OVERLOAD_503_RATE_THRESHOLD}"
   echo "[k6-transaction-100m] run purpose=${K6_RUN_PURPOSE}"
   echo "[k6-transaction-100m] summary gate=${K6_SUMMARY_GATE}"
+  echo "[k6-transaction-100m] archive failed summary=${K6_ARCHIVE_FAILED_SUMMARY}"
   echo "[k6-transaction-100m] backend readiness gate=${K6_BACKEND_READINESS_GATE} path=${K6_BACKEND_READINESS_PATH} timeout=${K6_BACKEND_READINESS_TIMEOUT_SECONDS}"
   echo "[k6-transaction-100m] postgres health gate=${K6_POSTGRES_HEALTH_GATE} required_status=healthy"
   echo "[k6-transaction-100m] postgres recovery gate=${K6_POSTGRES_RECOVERY_GATE} stable_seconds=${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
@@ -567,6 +595,8 @@ write_run_context() {
     echo "RECOVERY_GATE=${K6_POSTGRES_RECOVERY_GATE}"
     echo "RECOVERY_STABLE_SECONDS=${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
     echo "RECOVERY_NOISE_WINDOW_SECONDS=${K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS}"
+    echo "BURST_HEADROOM_PREFLIGHT=${K6_BURST_HEADROOM_PREFLIGHT}"
+    echo "BURST_MIN_HEADROOM_VUS=${K6_BURST_MIN_HEADROOM_VUS}"
     echo "POSTGRES_CONTAINER=${loadtest_postgres_container}"
     echo "SUMMARY_JSON=${summary_json}"
     echo "RUNNER_LOG=${k6_runner_log}"
@@ -910,16 +940,32 @@ else
 fi 2>&1 | tee "${k6_runner_log}"
 status=${PIPESTATUS[0]}
 set -e
+set +e
 assert_k6_summary_gate "${summary_json}" "${k6_runner_log}" "${status}"
 status=$?
+set -e
 
-run_explain_snapshot post
+if ! run_explain_snapshot post; then
+  echo "[k6-transaction-100m] post explain snapshot failed; preserving k6 status=${status}" >&2
+  if [[ "${status}" -eq 0 ]]; then
+    status=1
+  fi
+fi
 
-if [[ "${K6_ARCHIVE_RESULTS}" == "true" && -f "${summary_md}" ]]; then
+archive_requested=false
+if [[ "${K6_ARCHIVE_RESULTS}" == "true" ]]; then
+  archive_requested=true
+fi
+if [[ "${K6_ARCHIVE_FAILED_SUMMARY}" == "true" && "${status}" -ne 0 ]]; then
+  archive_requested=true
+fi
+
+if [[ "${archive_requested}" == "true" && -f "${summary_md}" ]]; then
+  PERFORMANCE_RESULT_STATUS="${status}" \
   PERFORMANCE_RESULT_PURPOSE="${K6_RUN_PURPOSE}" \
   PERFORMANCE_RESULT_OUTPUT_DIR="${archive_output_dir}" \
     tools/test/archive-k6-transaction-100m-result.sh "${summary_md}" "${summary_json}"
-elif [[ "${K6_ARCHIVE_RESULTS}" == "true" ]]; then
+elif [[ "${archive_requested}" == "true" ]]; then
   echo "k6 summary markdown was not produced: ${summary_md}" >&2
   if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
     echo "remote generator writes summaries under ${K6_REMOTE_WORKDIR}/build/reports/k6 on docker context ${K6_DOCKER_CONTEXT}" >&2

--- a/tools/test/run-k6-transaction-100m-multi-scenario.sh
+++ b/tools/test/run-k6-transaction-100m-multi-scenario.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-k6-transaction-100m-multi-scenario.sh [--print-plan|--dry-run]
+
+Environment:
+  K6_MULTI_NAME default transaction-100m-multi-scenario-<timestamp>
+  K6_MULTI_RUN_ID default K6_MULTI_NAME
+  K6_MULTI_OUTPUT_DIR default build/reports/k6/<name>
+  K6_MULTI_REUSE_BACKEND default true
+  K6_MULTI_POST_FIRST_RECOVERY_NOISE_WINDOW_SECONDS default 0
+  K6_MULTI_SCENARIOS comma list of name:mode:vus:duration:overload:burst_rate:preAllocated:max
+
+Default scenarios:
+  vu3:constant-vus:3:30s:false:16:3:3,vu16-overload:constant-vus:16:30s:true:16:16:16,burst-256:burst:16:20s:true:256:256:256
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${K6_MULTI_NAME:-transaction-100m-multi-scenario-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${K6_MULTI_RUN_ID:-${name}}"
+output_dir="${K6_MULTI_OUTPUT_DIR:-build/reports/k6/${name}}"
+reuse_backend="${K6_MULTI_REUSE_BACKEND:-true}"
+post_first_noise_window="${K6_MULTI_POST_FIRST_RECOVERY_NOISE_WINDOW_SECONDS:-0}"
+scenarios_csv="${K6_MULTI_SCENARIOS:-vu3:constant-vus:3:30s:false:16:3:3,vu16-overload:constant-vus:16:30s:true:16:16:16,burst-256:burst:16:20s:true:256:256:256}"
+execution_plan_tsv="${output_dir}/${name}-execution-plan.tsv"
+
+require_bool() {
+  local name="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${name} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_non_negative_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${name} must be zero or a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_duration() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*(s|m|h)$ ]]; then
+    echo "${name} must use a positive duration such as 30s or 1m: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_scenario_mode() {
+  local value="$1"
+  case "${value}" in
+    constant-vus|constant-arrival-rate|burst)
+      ;;
+    *)
+      echo "scenario mode must be constant-vus, constant-arrival-rate, or burst: ${value}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+validate_scenario() {
+  local scenario="$1"
+  local scenario_name scenario_mode vus duration overload burst_rate pre_allocated max_vus extra
+  IFS=':' read -r scenario_name scenario_mode vus duration overload burst_rate pre_allocated max_vus extra <<<"${scenario}"
+  if [[ -n "${extra:-}" || -z "${max_vus:-}" ]]; then
+    echo "K6_MULTI_SCENARIOS entry must have 8 fields: ${scenario}" >&2
+    exit 1
+  fi
+  if [[ ! "${scenario_name}" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "scenario name must be kebab-case: ${scenario_name}" >&2
+    exit 1
+  fi
+  require_scenario_mode "${scenario_mode}"
+  require_positive_integer "scenario.vus" "${vus}"
+  require_duration "scenario.duration" "${duration}"
+  require_bool "scenario.overload" "${overload}"
+  require_positive_integer "scenario.burst_rate" "${burst_rate}"
+  require_positive_integer "scenario.preAllocated" "${pre_allocated}"
+  require_positive_integer "scenario.max" "${max_vus}"
+}
+
+scenario_count() {
+  IFS=',' read -r -a scenarios <<<"${scenarios_csv}"
+  echo "${#scenarios[@]}"
+}
+
+validate_scenarios() {
+  IFS=',' read -r -a scenarios <<<"${scenarios_csv}"
+  if [[ "${#scenarios[@]}" -eq 0 ]]; then
+    echo "K6_MULTI_SCENARIOS must not be empty" >&2
+    exit 1
+  fi
+  local scenario
+  for scenario in "${scenarios[@]}"; do
+    validate_scenario "${scenario}"
+  done
+}
+
+require_bool "K6_MULTI_REUSE_BACKEND" "${reuse_backend}"
+require_non_negative_integer "K6_MULTI_POST_FIRST_RECOVERY_NOISE_WINDOW_SECONDS" "${post_first_noise_window}"
+validate_scenarios
+
+print_plan() {
+  echo "[k6-transaction-100m-multi] mode=${mode}"
+  echo "[k6-transaction-100m-multi] name=${name}"
+  echo "[k6-transaction-100m-multi] run_id=${run_id}"
+  echo "[k6-transaction-100m-multi] output_dir=${output_dir}"
+  echo "[k6-transaction-100m-multi] reuse_backend=${reuse_backend}"
+  echo "[k6-transaction-100m-multi] post_first_recovery_noise_window_seconds=${post_first_noise_window}"
+  echo "[k6-transaction-100m-multi] scenario_count=$(scenario_count)"
+  echo "[k6-transaction-100m-multi] scenarios=${scenarios_csv}"
+  echo "[k6-transaction-100m-multi] execution_plan=${execution_plan_tsv}"
+}
+
+runner_args_for_order() {
+  local order="$1"
+  if [[ "${reuse_backend}" == "true" && "${order}" -gt 1 ]]; then
+    echo "--no-up --no-deps"
+  else
+    echo "default"
+  fi
+}
+
+recovery_noise_for_order() {
+  local order="$1"
+  if [[ "${reuse_backend}" == "true" && "${order}" -gt 1 ]]; then
+    echo "${post_first_noise_window}"
+  else
+    echo "${K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS:-30}"
+  fi
+}
+
+write_execution_plan() {
+  mkdir -p "${output_dir}"
+  printf "order\tname\tmode\tvus\tduration\toverload\tburst_rate\tpre_allocated_vus\tmax_vus\treport_name\trunner_args\trecovery_noise_window_seconds\n" >"${execution_plan_tsv}"
+  IFS=',' read -r -a scenarios <<<"${scenarios_csv}"
+  local order=1
+  local scenario scenario_name scenario_mode vus duration overload burst_rate pre_allocated max_vus
+  for scenario in "${scenarios[@]}"; do
+    IFS=':' read -r scenario_name scenario_mode vus duration overload burst_rate pre_allocated max_vus <<<"${scenario}"
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s-%s\t%s\t%s\n" \
+      "${order}" "${scenario_name}" "${scenario_mode}" "${vus}" "${duration}" "${overload}" \
+      "${burst_rate}" "${pre_allocated}" "${max_vus}" "${name}" "${scenario_name}" \
+      "$(runner_args_for_order "${order}")" "$(recovery_noise_for_order "${order}")" >>"${execution_plan_tsv}"
+    order=$((order + 1))
+  done
+}
+
+run_scenarios() {
+  IFS=',' read -r -a scenarios <<<"${scenarios_csv}"
+  local order=1
+  local scenario scenario_name scenario_mode vus duration overload burst_rate pre_allocated max_vus report_name runner_args
+  for scenario in "${scenarios[@]}"; do
+    IFS=':' read -r scenario_name scenario_mode vus duration overload burst_rate pre_allocated max_vus <<<"${scenario}"
+    report_name="${name}-${scenario_name}"
+    runner_args="$(runner_args_for_order "${order}")"
+    echo "[k6-transaction-100m-multi] running order=${order} scenario=${scenario_name} runner_args=${runner_args}"
+    if [[ "${runner_args}" == "default" ]]; then
+      K6_REPORT_NAME="${report_name}" \
+      K6_RUN_ID="${run_id}" \
+      K6_SCENARIO_MODE="${scenario_mode}" \
+      K6_VUS="${vus}" \
+      K6_DURATION="${duration}" \
+      K6_OVERLOAD_MODE="${overload}" \
+      K6_BURST_RATE="${burst_rate}" \
+      K6_BURST_DURATION="${duration}" \
+      K6_PRE_ALLOCATED_VUS="${pre_allocated}" \
+      K6_MAX_VUS="${max_vus}" \
+        tools/test/run-k6-transaction-100m-loadtest.sh
+    else
+      K6_REPORT_NAME="${report_name}" \
+      K6_RUN_ID="${run_id}" \
+      K6_SCENARIO_MODE="${scenario_mode}" \
+      K6_VUS="${vus}" \
+      K6_DURATION="${duration}" \
+      K6_OVERLOAD_MODE="${overload}" \
+      K6_BURST_RATE="${burst_rate}" \
+      K6_BURST_DURATION="${duration}" \
+      K6_PRE_ALLOCATED_VUS="${pre_allocated}" \
+      K6_MAX_VUS="${max_vus}" \
+      K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS="${post_first_noise_window}" \
+        tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps
+    fi
+    order=$((order + 1))
+  done
+}
+
+print_plan
+write_execution_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  echo "${execution_plan_tsv}"
+  exit 0
+fi
+
+run_scenarios
+echo "${execution_plan_tsv}"

--- a/tools/test/run-offhost-capacity-env-doctor.sh
+++ b/tools/test/run-offhost-capacity-env-doctor.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-offhost-capacity-env-doctor.sh [--print-plan|--print-env-template|--dry-run]
+
+Environment:
+  OFFHOST_CAPACITY_ENV_FILE optional local env file to source
+  OFFHOST_CAPACITY_CHECK_CONNECTIVITY default true
+  CAPACITY_K6_DOCKER_CONTEXT required
+  CAPACITY_K6_REMOTE_BASE_URL required
+  CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL required
+  CAPACITY_K6_REMOTE_WORKDIR default current working directory
+  CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS default 30
+  CAPACITY_REMOTE_PREFLIGHT_IMAGE default curlimages/curl:8.11.1
+  CAPACITY_REMOTE_READINESS_PATH default /actuator/health/readiness
+
+Examples:
+  OFFHOST_CAPACITY_ENV_FILE=.env/offhost-capacity.env \
+    tools/test/run-offhost-capacity-env-doctor.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --print-env-template)
+      mode="print-env-template"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+print_env_template() {
+  cat tools/test/offhost-capacity.env.example
+}
+
+if [[ "${mode}" == "print-env-template" ]]; then
+  print_env_template
+  exit 0
+fi
+
+env_file="${OFFHOST_CAPACITY_ENV_FILE:-${CAPACITY_ENV_FILE:-}}"
+if [[ -n "${env_file}" ]]; then
+  if [[ ! -f "${env_file}" ]]; then
+    echo "OFFHOST_CAPACITY_ENV_FILE not found: ${env_file}" >&2
+    exit 1
+  fi
+  set -a
+  # 로컬 전용 원격 endpoint 값만 shell env로 주입하고 저장소에는 기록하지 않습니다.
+  source "${env_file}"
+  set +a
+fi
+
+docker_context="${CAPACITY_K6_DOCKER_CONTEXT:-${K6_DOCKER_CONTEXT:-}}"
+remote_base_url="${CAPACITY_K6_REMOTE_BASE_URL:-${K6_REMOTE_BASE_URL:-}}"
+remote_prometheus_rw_url="${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-${K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-}}"
+remote_workdir="${CAPACITY_K6_REMOTE_WORKDIR:-${K6_REMOTE_WORKDIR:-$(pwd)}}"
+check_connectivity="${OFFHOST_CAPACITY_CHECK_CONNECTIVITY:-true}"
+timeout_seconds="${CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS:-${K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS:-30}}"
+preflight_image="${CAPACITY_REMOTE_PREFLIGHT_IMAGE:-${K6_REMOTE_PREFLIGHT_IMAGE:-curlimages/curl:8.11.1}}"
+readiness_path="${CAPACITY_REMOTE_READINESS_PATH:-${K6_REMOTE_READINESS_PATH:-/actuator/health/readiness}}"
+readiness_url="${remote_base_url%/}${readiness_path}"
+
+require_bool() {
+  local name="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${name} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_env_value() {
+  local name="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "${name} is required" >&2
+    exit 1
+  fi
+}
+
+require_url() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^https?://[^[:space:]]+$ ]]; then
+    echo "${name} must be an http(s) URL: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_bool "OFFHOST_CAPACITY_CHECK_CONNECTIVITY" "${check_connectivity}"
+require_positive_integer "CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS" "${timeout_seconds}"
+require_env_value "CAPACITY_K6_DOCKER_CONTEXT" "${docker_context}"
+require_env_value "CAPACITY_K6_REMOTE_BASE_URL" "${remote_base_url}"
+require_env_value "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL" "${remote_prometheus_rw_url}"
+require_url "CAPACITY_K6_REMOTE_BASE_URL" "${remote_base_url}"
+require_url "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL" "${remote_prometheus_rw_url}"
+
+print_plan() {
+  echo "[offhost-capacity-env-doctor] mode=${mode}"
+  echo "[offhost-capacity-env-doctor] env_file=${env_file:-missing}"
+  echo "[offhost-capacity-env-doctor] docker_context=${docker_context}"
+  echo "[offhost-capacity-env-doctor] remote_base_url=${remote_base_url}"
+  echo "[offhost-capacity-env-doctor] remote_prometheus_rw_url=${remote_prometheus_rw_url}"
+  echo "[offhost-capacity-env-doctor] remote_workdir=${remote_workdir}"
+  echo "[offhost-capacity-env-doctor] readiness_url=${readiness_url}"
+  echo "[offhost-capacity-env-doctor] preflight_image=${preflight_image}"
+  echo "[offhost-capacity-env-doctor] timeout_seconds=${timeout_seconds}"
+  echo "[offhost-capacity-env-doctor] check_connectivity=${check_connectivity}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  echo "[offhost-capacity-env-doctor] dry-run passed"
+  exit 0
+fi
+
+if [[ "${check_connectivity}" != "true" ]]; then
+  echo "[offhost-capacity-env-doctor] connectivity check skipped"
+  exit 0
+fi
+
+docker context inspect "${docker_context}" >/dev/null
+docker --context "${docker_context}" info >/dev/null
+docker --context "${docker_context}" run --rm "${preflight_image}" \
+  -fsS --max-time "${timeout_seconds}" "${readiness_url}" >/dev/null
+docker --context "${docker_context}" run --rm --entrypoint sh "${preflight_image}" \
+  -c 'status="$(curl -sS -o /dev/null -w "%{http_code}" --max-time "$1" -X POST "$2" || echo 000)"; case "${status}" in 2*|3*|4*) exit 0 ;; *) echo "remote prometheus remote-write preflight failed: status=${status}" >&2; exit 1 ;; esac' \
+  sh "${timeout_seconds}" "${remote_prometheus_rw_url}"
+
+echo "[offhost-capacity-env-doctor] connectivity passed"

--- a/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
@@ -11,6 +11,7 @@ Environment:
   T3MICRO_CAPACITY_RESULT_MD   optional Docker capacity archive markdown
   T3MICRO_CAPACITY_SUMMARY_TSV optional off-host transaction 100m capacity summary TSV
   T3MICRO_CAPACITY_RUN_CONTEXT_ENV optional run context next to capacity summary TSV
+  T3MICRO_CAPACITY_PREREQUISITE_ENV optional capacity prerequisite failure env
   T3MICRO_SSE_RESULT_MD        optional SSE reconnect archive markdown
   T3MICRO_ADMISSION_SUMMARY_TSV optional admission summary TSV
   T3MICRO_OUTBOX_SUMMARY_TSV   optional outbox summary TSV
@@ -22,6 +23,7 @@ Environment:
   T3MICRO_AGGREGATE_SEARCH_ROOTS default "docs/performance-results build/reports"
   T3MICRO_AGGREGATE_RUN_ID optional run id used to scope auto inputs
   T3MICRO_AGGREGATE_AUTO_INPUT_PREFIX default <aggregate name>, used when run id is empty
+  T3MICRO_K6_PROFILE_SELECTOR representative|latest, default representative
 
 Examples:
   tools/test/run-t3micro-defensive-gates-aggregate-report.sh --print-plan
@@ -57,6 +59,7 @@ output_path="${output_dir}/${name}.md"
 capacity_result="${T3MICRO_CAPACITY_RESULT_MD:-}"
 capacity_summary="${T3MICRO_CAPACITY_SUMMARY_TSV:-}"
 capacity_run_context="${T3MICRO_CAPACITY_RUN_CONTEXT_ENV:-}"
+capacity_prerequisite="${T3MICRO_CAPACITY_PREREQUISITE_ENV:-}"
 sse_result="${T3MICRO_SSE_RESULT_MD:-}"
 admission_summary="${T3MICRO_ADMISSION_SUMMARY_TSV:-}"
 outbox_summary="${T3MICRO_OUTBOX_SUMMARY_TSV:-}"
@@ -68,6 +71,7 @@ auto_inputs="${T3MICRO_AGGREGATE_AUTO_INPUTS:-true}"
 search_roots="${T3MICRO_AGGREGATE_SEARCH_ROOTS:-docs/performance-results build/reports}"
 aggregate_run_id="${T3MICRO_AGGREGATE_RUN_ID:-}"
 auto_input_prefix="${T3MICRO_AGGREGATE_AUTO_INPUT_PREFIX:-${name}}"
+k6_profile_selector="${T3MICRO_K6_PROFILE_SELECTOR:-representative}"
 
 require_bool() {
   local name="$1"
@@ -85,6 +89,42 @@ require_non_negative_number() {
     echo "${name} must be zero or a positive number: ${value}" >&2
     exit 1
   fi
+}
+
+require_k6_profile_selector() {
+  case "${k6_profile_selector}" in
+    representative|latest)
+      ;;
+    *)
+      echo "T3MICRO_K6_PROFILE_SELECTOR must be representative or latest: ${k6_profile_selector}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+auto_scope_token_variants() {
+  local token="$1"
+  local variant
+  [[ -z "${token}" ]] && return 0
+  echo "${token}"
+  for variant in \
+    "${token#t3micro-defensive-}" \
+    "${token#t3micro-}" \
+    "${token#defensive-}" \
+    "${token#transaction-100m-}"; do
+    if [[ -n "${variant}" && "${variant}" != "${token}" ]]; then
+      echo "${variant}"
+    fi
+  done
+}
+
+file_matches_scope_token() {
+  local path="$1"
+  local token="$2"
+  [[ -z "${token}" ]] && return 1
+  [[ "${path}" == *"${token}"* ]] && return 0
+  grep -F "${token}" "${path}" >/dev/null 2>&1 && return 0
+  return 1
 }
 
 latest_file() {
@@ -108,17 +148,147 @@ latest_file() {
 
 file_matches_auto_scope() {
   local path="$1"
+  local token
   if [[ -n "${aggregate_run_id}" ]]; then
-    [[ "${path}" == *"${aggregate_run_id}"* ]] && return 0
-    grep -F "${aggregate_run_id}" "${path}" >/dev/null 2>&1 && return 0
+    while IFS= read -r token; do
+      file_matches_scope_token "${path}" "${token}" && return 0
+    done < <(auto_scope_token_variants "${aggregate_run_id}")
     return 1
   fi
   if [[ -n "${auto_input_prefix}" ]]; then
-    [[ "${path}" == *"${auto_input_prefix}"* ]] && return 0
-    grep -F "${auto_input_prefix}" "${path}" >/dev/null 2>&1 && return 0
+    while IFS= read -r token; do
+      file_matches_scope_token "${path}" "${token}" && return 0
+    done < <(auto_scope_token_variants "${auto_input_prefix}")
     return 1
   fi
   return 0
+}
+
+md_field_value() {
+  local file="$1"
+  local key="$2"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "missing"
+    return 0
+  fi
+  awk -F ': ' -v key="- ${key}" '$1 == key {print $2}' "${file}" | tail -1
+}
+
+number_is_gt_zero() {
+  local value="$1"
+  [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+  awk -v value="${value}" 'BEGIN { exit !(value > 0) }'
+}
+
+k6_json_metric_count() {
+  local json_path="$1"
+  local metric="$2"
+  [[ -f "${json_path}" ]] || {
+    echo "0"
+    return 0
+  }
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "0"
+    return 0
+  fi
+  jq -r --arg metric "${metric}" '
+    (.metrics[$metric].values // {}) as $values
+    | if $values.count != null then
+        $values.count
+      elif ($values.passes != null or $values.fails != null) then
+        (($values.passes // 0) + ($values.fails // 0))
+      else
+        0
+      end
+  ' "${json_path}" 2>/dev/null || echo "0"
+}
+
+k6_summary_score() {
+  local file="$1"
+  local purpose status scenario overload source_json checks_rate rate_503 count_503 burst_rate pre_allocated
+  local score=0
+  local failed=false
+
+  purpose="$(md_field_value "${file}" "resultPurpose")"
+  status="$(md_field_value "${file}" "resultStatus")"
+  scenario="$(md_field_value "${file}" "scenario mode")"
+  overload="$(md_field_value "${file}" "overload mode")"
+  source_json="$(md_field_value "${file}" "sourceJson")"
+  checks_rate="$(md_field_value "${file}" "checks rate")"
+  rate_503="$(md_field_value "${file}" "transaction 503 rate")"
+  count_503="$(md_field_value "${file}" "transaction 503 count")"
+  burst_rate="$(md_field_value "${file}" "burst rate")"
+  pre_allocated="$(md_field_value "${file}" "pre allocated VUs")"
+
+  if [[ "${status}" =~ ^[0-9]+$ && "${status}" -ne 0 ]]; then
+    failed=true
+  fi
+  if [[ "${checks_rate}" == "0" ]]; then
+    failed=true
+  fi
+  if number_is_gt_zero "${rate_503}" || number_is_gt_zero "${count_503}"; then
+    failed=true
+  fi
+  if [[ "${scenario}" == "burst" ]]; then
+    burst_rate="${burst_rate%%/*}"
+    if [[ "${burst_rate}" =~ ^[0-9]+$ && "${pre_allocated}" =~ ^[0-9]+$ && "${pre_allocated}" -lt "${burst_rate}" ]]; then
+      failed=true
+    fi
+  fi
+  if [[ -n "${source_json}" && "${source_json}" != "missing" && -f "${source_json}" ]]; then
+    if number_is_gt_zero "$(k6_json_metric_count "${source_json}" "dropped_iterations")" \
+      || number_is_gt_zero "$(k6_json_metric_count "${source_json}" "interrupted_iterations")"; then
+      failed=true
+    fi
+  fi
+
+  if [[ "${failed}" == "false" ]]; then
+    score=$((score + 10000))
+  fi
+  case "${purpose}" in
+    smoke) score=$((score + 3000)) ;;
+    capacity) score=$((score + 2500)) ;;
+    profile) score=$((score + 2000)) ;;
+    benchmark) score=$((score + 1500)) ;;
+    *) score=$((score + 1000)) ;;
+  esac
+  case "${scenario}" in
+    constant-vus) score=$((score + 300)) ;;
+    constant-arrival-rate) score=$((score + 250)) ;;
+    burst) score=$((score + 100)) ;;
+    *) score=$((score + 50)) ;;
+  esac
+  if [[ "${overload}" == "true" ]]; then
+    score=$((score - 50))
+  fi
+  echo "${score}"
+}
+
+latest_k6_summary() {
+  if [[ "${k6_profile_selector}" == "latest" ]]; then
+    latest_file '*transaction-100m*-summary.md'
+    return 0
+  fi
+
+  local matches=()
+  local root path
+  for root in ${search_roots}; do
+    if [[ -d "${root}" ]]; then
+      while IFS= read -r path; do
+        if file_matches_auto_scope "${path}"; then
+          matches+=("${path}")
+        fi
+      done < <(find "${root}" -type f -name '*transaction-100m*-summary.md' 2>/dev/null)
+    fi
+  done
+  if [[ "${#matches[@]}" -eq 0 ]]; then
+    return 0
+  fi
+  {
+    for path in "${matches[@]}"; do
+      printf "%08d\t%s\n" "$(k6_summary_score "${path}")" "${path}"
+    done
+  } | sort -r | head -1 | cut -f2-
 }
 
 capacity_summary_matches_auto_scope() {
@@ -175,22 +345,24 @@ resolve_auto_inputs() {
   if [[ -z "${capacity_run_context}" && -n "${capacity_summary}" ]]; then
     capacity_run_context="$(capacity_context_for_summary "${capacity_summary}")"
   fi
+  capacity_prerequisite="${capacity_prerequisite:-$(latest_file 'capacity-prerequisite-failure.env')}"
   capacity_result="${capacity_result:-$(latest_file 'docker-t3micro-capacity*.md')}"
   sse_result="${sse_result:-$(latest_file '*sse*.md')}"
   admission_summary="${admission_summary:-$(latest_file 'http-admission-summary.tsv')}"
   outbox_summary="${outbox_summary:-$(latest_file 'outbox-provider-backlog-summary.tsv')}"
-  k6_summary="${k6_summary:-$(latest_file '*transaction-100m*-summary.md')}"
+  k6_summary="${k6_summary:-$(latest_k6_summary)}"
   memory_summary="${memory_summary:-$(latest_file '*memory-summary.tsv')}"
 }
 
 require_bool "T3MICRO_AGGREGATE_AUTO_INPUTS" "${auto_inputs}"
 require_non_negative_number "T3MICRO_TOTAL_MEMORY_BUDGET_MIB" "${total_memory_budget_mib}"
+require_k6_profile_selector
 resolve_auto_inputs
 
 gate_path() {
   local gate="$1"
   case "${gate}" in
-    capacity) echo "${capacity_summary}" ;;
+    capacity) echo "${capacity_summary:-${capacity_prerequisite}}" ;;
     sse) echo "${sse_result}" ;;
     admission) echo "${admission_summary}" ;;
     outbox) echo "${outbox_summary}" ;;
@@ -228,11 +400,13 @@ print_plan() {
   echo "[t3micro-defensive-aggregate] capacity=${capacity_result:-missing}"
   echo "[t3micro-defensive-aggregate] capacity_summary=${capacity_summary:-missing}"
   echo "[t3micro-defensive-aggregate] capacity_run_context=${capacity_run_context:-missing}"
+  echo "[t3micro-defensive-aggregate] capacity_prerequisite=${capacity_prerequisite:-missing}"
   echo "[t3micro-defensive-aggregate] sse=${sse_result:-missing}"
   echo "[t3micro-defensive-aggregate] admission=${admission_summary:-missing}"
   echo "[t3micro-defensive-aggregate] outbox=${outbox_summary:-missing}"
   echo "[t3micro-defensive-aggregate] k6=${k6_summary:-missing}"
   echo "[t3micro-defensive-aggregate] memory=${memory_summary:-missing}"
+  echo "[t3micro-defensive-aggregate] k6_profile_selector=${k6_profile_selector}"
   echo "[t3micro-defensive-aggregate] required_gates=${required_gates:-none}"
   echo "[t3micro-defensive-aggregate] total_memory_budget_mib=${total_memory_budget_mib}"
 }
@@ -247,6 +421,26 @@ md_value() {
   local value
   value="$(awk -F ': ' -v key="- ${key}" '$1 == key {print $2}' "${file}" | tail -1)"
   printf "%s" "${value:-missing}"
+}
+
+env_value() {
+  local file="$1"
+  local key="$2"
+  if [[ -z "${file}" || ! -f "${file}" ]]; then
+    printf "missing"
+    return 0
+  fi
+  awk -F '=' -v key="${key}" '$1 == key {sub(/^[^=]*=/, ""); print; exit}' "${file}"
+}
+
+capacity_prerequisite_status_value() {
+  env_value "${capacity_prerequisite}" "CAPACITY_PREREQUISITE_STATUS"
+}
+
+capacity_prerequisite_signal_value() {
+  printf "reason=%s missing=%s" \
+    "$(env_value "${capacity_prerequisite}" "CAPACITY_PREREQUISITE_FAILURE_REASON")" \
+    "$(env_value "${capacity_prerequisite}" "CAPACITY_PREREQUISITE_MISSING_VARS")"
 }
 
 capacity_summary_status() {
@@ -671,6 +865,7 @@ write_report() {
     echo "- capacityResult: ${capacity_result:-missing}"
     echo "- capacitySummary: ${capacity_summary:-missing}"
     echo "- capacityRunContext: ${capacity_run_context:-missing}"
+    echo "- capacityPrerequisite: ${capacity_prerequisite:-missing}"
     echo "- sseResult: ${sse_result:-missing}"
     echo "- admissionSummary: ${admission_summary:-missing}"
     echo "- outboxSummary: ${outbox_summary:-missing}"
@@ -682,6 +877,7 @@ write_report() {
     echo "| Gate | Status | Peak CPU % | Peak Memory MiB | Backlog / Reject Signal | Source |"
     echo "| --- | --- | ---: | ---: | --- | --- |"
     echo "| capacity smoke | $(md_value "${capacity_result}" "capacity smoke status") | $(md_value "${capacity_result}" "peakCpuPercent") | $(md_value "${capacity_result}" "peakMemoryMiB") | repeat=$(md_value "${capacity_result}" "repeat") | ${capacity_result:-missing} |"
+    echo "| capacity prerequisite | $(capacity_prerequisite_status_value) | n/a | n/a | $(capacity_prerequisite_signal_value) | ${capacity_prerequisite:-missing} |"
     echo "| capacity | $(capacity_status_value) | $(capacity_cpu_value) | $(capacity_memory_value) | $(capacity_signal_value) | $(capacity_source_value) |"
     echo "| capacity soak | $(capacity_soak_status_value) | $(capacity_soak_cpu_value) | n/a | $(capacity_soak_signal_value) | ${capacity_summary:-missing} |"
     echo "| sse reconnect | $(md_value "${sse_result}" "status") | $(md_value "${sse_result}" "peakCpuPercent") | $(md_value "${sse_result}" "peakMemoryMiB") | clients=$(md_value "${sse_result}" "reconnectClients") rounds=$(md_value "${sse_result}" "reconnectRounds") | ${sse_result:-missing} |"

--- a/tools/test/run-transaction-100m-offhost-capacity-baseline-report.sh
+++ b/tools/test/run-transaction-100m-offhost-capacity-baseline-report.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-offhost-capacity-baseline-report.sh [--print-plan|--dry-run]
+
+Environment:
+  OFFHOST_BASELINE_NAME default transaction-100m-offhost-capacity-baseline-<timestamp>
+  OFFHOST_BASELINE_OUTPUT_DIR default docs/performance-results
+  OFFHOST_BASELINE_ENV_FILE optional local env file for off-host capacity
+  OFFHOST_BASELINE_RUN_CAPACITY default true
+  OFFHOST_BASELINE_DOCTOR_CONNECTIVITY default true
+  OFFHOST_BASELINE_LONG_SOAK_DURATION default 30m
+  OFFHOST_BASELINE_CAPACITY_SUMMARY_TSV optional existing capacity summary TSV
+  OFFHOST_BASELINE_CAPACITY_RUN_CONTEXT_ENV optional capacity run context env
+  OFFHOST_BASELINE_CAPACITY_PREREQUISITE_ENV optional prerequisite failure env
+
+Examples:
+  OFFHOST_BASELINE_ENV_FILE=.env/offhost-capacity.env \
+    tools/test/run-transaction-100m-offhost-capacity-baseline-report.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${OFFHOST_BASELINE_NAME:-transaction-100m-offhost-capacity-baseline-$(date +%Y-%m-%d-%H%M%S)}"
+output_dir="${OFFHOST_BASELINE_OUTPUT_DIR:-docs/performance-results}"
+output_path="${output_dir}/${name}.md"
+env_file="${OFFHOST_BASELINE_ENV_FILE:-${CAPACITY_ENV_FILE:-}}"
+run_capacity="${OFFHOST_BASELINE_RUN_CAPACITY:-true}"
+doctor_connectivity="${OFFHOST_BASELINE_DOCTOR_CONNECTIVITY:-true}"
+long_soak_duration="${OFFHOST_BASELINE_LONG_SOAK_DURATION:-30m}"
+capacity_name="${OFFHOST_BASELINE_CAPACITY_NAME:-${name}}"
+report_dir="build/reports/k6/${capacity_name}"
+capacity_summary="${OFFHOST_BASELINE_CAPACITY_SUMMARY_TSV:-${report_dir}/capacity-summary.tsv}"
+capacity_run_context="${OFFHOST_BASELINE_CAPACITY_RUN_CONTEXT_ENV:-${report_dir}/capacity-run-context.env}"
+capacity_prerequisite="${OFFHOST_BASELINE_CAPACITY_PREREQUISITE_ENV:-${report_dir}/capacity-prerequisite-failure.env}"
+
+require_bool() {
+  local name="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${name} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_duration() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*(s|m|h)$ ]]; then
+    echo "${name} must use a positive duration such as 30m: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_bool "OFFHOST_BASELINE_RUN_CAPACITY" "${run_capacity}"
+require_bool "OFFHOST_BASELINE_DOCTOR_CONNECTIVITY" "${doctor_connectivity}"
+require_duration "OFFHOST_BASELINE_LONG_SOAK_DURATION" "${long_soak_duration}"
+
+print_plan() {
+  echo "[transaction-100m-offhost-baseline] mode=${mode}"
+  echo "[transaction-100m-offhost-baseline] name=${name}"
+  echo "[transaction-100m-offhost-baseline] output=${output_path}"
+  echo "[transaction-100m-offhost-baseline] env_file=${env_file:-missing}"
+  echo "[transaction-100m-offhost-baseline] run_capacity=${run_capacity}"
+  echo "[transaction-100m-offhost-baseline] doctor_connectivity=${doctor_connectivity}"
+  echo "[transaction-100m-offhost-baseline] long_soak_duration=${long_soak_duration}"
+  echo "[transaction-100m-offhost-baseline] capacity_name=${capacity_name}"
+  echo "[transaction-100m-offhost-baseline] capacity_summary=${capacity_summary}"
+  echo "[transaction-100m-offhost-baseline] capacity_run_context=${capacity_run_context}"
+  echo "[transaction-100m-offhost-baseline] capacity_prerequisite=${capacity_prerequisite}"
+}
+
+capacity_status_for_grade() {
+  local file="$1"
+  local grade="$2"
+  if [[ ! -f "${file}" ]]; then
+    printf "missing"
+    return 0
+  fi
+  awk -F '\t' -v grade="${grade}" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "phase") phase_column = i
+        if ($i == "profile") profile_column = i
+        if ($i == "status") status_column = i
+      }
+      next
+    }
+    phase_column && profile_column && status_column {
+      is_soak = ($phase_column == "long-soak" || $profile_column ~ /soak/)
+      if ((grade == "soak" && !is_soak) || (grade == "capacity" && is_soak)) {
+        next
+      }
+      rows += 1
+      if ($status_column != "0") failed = 1
+    }
+    END {
+      if (!phase_column || !profile_column || !status_column || rows == 0) {
+        print "missing"
+      } else if (failed) {
+        print "fail"
+      } else {
+        print "pass"
+      }
+    }
+  ' "${file}"
+}
+
+capacity_column_max_for_grade() {
+  local file="$1"
+  local key="$2"
+  local grade="$3"
+  if [[ ! -f "${file}" ]]; then
+    printf "n/a"
+    return 0
+  fi
+  awk -F '\t' -v key="${key}" -v grade="${grade}" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == key) column = i
+        if ($i == "phase") phase_column = i
+        if ($i == "profile") profile_column = i
+      }
+      next
+    }
+    column && phase_column && profile_column {
+      is_soak = ($phase_column == "long-soak" || $profile_column ~ /soak/)
+      if ((grade == "soak" && !is_soak) || (grade == "capacity" && is_soak)) {
+        next
+      }
+      if ($column ~ /^[0-9]+([.][0-9]+)?$/) {
+        value = $column + 0
+        if (!found || value > max) {
+          max = value
+          text = $column
+        }
+        found = 1
+      }
+    }
+    END {
+      if (found) {
+        print text
+      } else {
+        print "n/a"
+      }
+    }
+  ' "${file}"
+}
+
+env_value() {
+  local file="$1"
+  local key="$2"
+  if [[ ! -f "${file}" ]]; then
+    printf "missing"
+    return 0
+  fi
+  awk -F '=' -v key="${key}" '$1 == key {sub(/^[^=]*=/, ""); print; exit}' "${file}"
+}
+
+run_doctor() {
+  if [[ "${mode}" == "dry-run" ]]; then
+    OFFHOST_CAPACITY_ENV_FILE="${env_file}" \
+    OFFHOST_CAPACITY_CHECK_CONNECTIVITY=false \
+      tools/test/run-offhost-capacity-env-doctor.sh --dry-run
+    return 0
+  fi
+  OFFHOST_CAPACITY_ENV_FILE="${env_file}" \
+  OFFHOST_CAPACITY_CHECK_CONNECTIVITY="${doctor_connectivity}" \
+    tools/test/run-offhost-capacity-env-doctor.sh
+}
+
+run_capacity_gates() {
+  if [[ "${run_capacity}" != "true" || "${mode}" == "dry-run" ]]; then
+    return 0
+  fi
+  CAPACITY_ENV_FILE="${env_file}" \
+  CAPACITY_NAME="${capacity_name}" \
+  CAPACITY_LONG_SOAK_DURATION="${long_soak_duration}" \
+    tools/test/run-transaction-100m-capacity-gates.sh
+}
+
+write_report() {
+  mkdir -p "${output_dir}"
+  {
+    echo "# ${name}"
+    echo
+    echo "## Inputs"
+    echo
+    echo "- envFile: ${env_file:-missing}"
+    echo "- capacitySummary: ${capacity_summary}"
+    echo "- capacityRunContext: ${capacity_run_context}"
+    echo "- capacityPrerequisite: ${capacity_prerequisite}"
+    echo "- doctorConnectivity: ${doctor_connectivity}"
+    echo
+    echo "## Baseline Status"
+    echo
+    echo "| Grade | Status | Peak CPU % | 429 Rate | Hikari Pending | Source |"
+    echo "| --- | --- | ---: | ---: | ---: | --- |"
+    echo "| capacity | $(capacity_status_for_grade "${capacity_summary}" capacity) | $(capacity_column_max_for_grade "${capacity_summary}" backend_cpu_percent capacity) | $(capacity_column_max_for_grade "${capacity_summary}" transaction_429_rate capacity) | $(capacity_column_max_for_grade "${capacity_summary}" hikari_pending capacity) | ${capacity_summary} |"
+    echo "| soak | $(capacity_status_for_grade "${capacity_summary}" soak) | $(capacity_column_max_for_grade "${capacity_summary}" backend_cpu_percent soak) | $(capacity_column_max_for_grade "${capacity_summary}" transaction_429_rate soak) | $(capacity_column_max_for_grade "${capacity_summary}" hikari_pending soak) | ${capacity_summary} |"
+    echo "| prerequisite | $(env_value "${capacity_prerequisite}" CAPACITY_PREREQUISITE_STATUS) | n/a | n/a | n/a | reason=$(env_value "${capacity_prerequisite}" CAPACITY_PREREQUISITE_FAILURE_REASON) missing=$(env_value "${capacity_prerequisite}" CAPACITY_PREREQUISITE_MISSING_VARS) |"
+    echo
+    echo "## Notes"
+    echo
+    echo "- 실제 목표 달성 판단은 off-host k6 generator 기준 capacity/soak summary가 있을 때만 확정합니다."
+    echo "- 운영 URL과 token은 리포트에 기록하지 않습니다."
+  } >"${output_path}"
+  echo "${output_path}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+run_doctor
+run_capacity_gates
+write_report


### PR DESCRIPTION
## 🔗 Related Issue
- close #489

## 🌿 Base Branch
- `main`

## 📝 Summary
- k6 burst 256/s 기본 VU headroom을 VU256 기준으로 재보정하고, 부족한 headroom은 실행 전 fail-fast로 막습니다.
- t3.micro aggregate가 failed burst summary나 missing memory를 대표 결과로 오판하지 않도록 k6/memory/capacity prerequisite evidence 선택을 강화합니다.
- off-host capacity env doctor, baseline report runner, burst first-window correlation, multi-scenario backend reuse runner를 추가합니다.

## 🛠 Changes
- burst mode headroom preflight와 실패 summary archive metadata 추가
- aggregate k6 representative selector, run-id/prefix alias memory discovery, capacity prerequisite row 추가
- off-host capacity env template/doctor 및 off-host baseline report runner 추가
- burst first 1~3초 spike correlation artifact runner 추가
- 같은 backend stack에서 여러 k6 scenario를 연속 실행하는 reuse runner 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `tools/test/check-t3micro-defensive-gates-aggregate-report.sh`
- `tools/test/check-transaction-100m-capacity-gates.sh`
- `tools/test/check-offhost-capacity-env-doctor.sh`
- `tools/test/check-transaction-100m-offhost-capacity-baseline-report.sh`
- `tools/test/check-burst-first-second-spike-correlation.sh`
- `tools/test/check-k6-transaction-100m-multi-scenario.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: aggregate auto selector가 기존 “latest file” 선택과 다른 대표 k6 summary를 고를 수 있습니다. `T3MICRO_K6_PROFILE_SELECTOR=latest`로 기존 선택 방식을 유지할 수 있습니다.
- 롤백 방법: 이 PR revert. off-host 실행은 새 runner opt-in 경로라 기존 loadtest API 계약에는 영향 없습니다.
- 실환경 메모: 현재 로컬에는 `CAPACITY_K6_DOCKER_CONTEXT`, remote backend URL, remote Prometheus URL이 없어 실제 off-host capacity baseline 수치는 실행하지 않았습니다. doctor/runner 계약만 검증했습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
