### PR TITLE
[Perf] 100m defensive post-burst-capacity-evidence latest-main 병목 재검증

### DIFF
--- a/docs/performance-results/100m-defensive-post-burst-capacity-evidence-latest-main-20260428-bottleneck.md
+++ b/docs/performance-results/100m-defensive-post-burst-capacity-evidence-latest-main-20260428-bottleneck.md
@@ -1,0 +1,91 @@
+# 100m defensive post-burst-capacity-evidence latest-main bottleneck
+
+## 기준
+
+- 기준 브랜치: `main`
+- 기준 SHA: `63a5e44`
+- issue: #491
+- 실행일: 2026-04-28
+- 환경: local Docker loadtest stack, t3.micro 근사 compose, PostgreSQL 18.3, k6, Prometheus, Grafana
+- 제외: 이미 main에 반영된 #490, #488, #486, #484, #472, #438, #435 작업은 후속 리스트에서 제외한다.
+
+## 준비 상태
+
+| 항목 | 결과 | 근거 |
+| --- | --- | --- |
+| backend readiness | 통과 | `GET /actuator/health/readiness` -> `UP` |
+| Prometheus readiness | 통과 | `/-/ready` -> ready |
+| Grafana health | 통과 | `/api/health` -> `ok` |
+| PostgreSQL recovery | 통과 | `pg_is_in_recovery() = f` |
+| postgres-exporter | 통과 | Prometheus `pg_up = 1` |
+| Docker OOMKilled | 통과 | backend/postgres/prometheus/grafana/alertmanager/exporter 모두 `OOM=false` |
+
+## 100m fixture probe
+
+| 항목 | 값 |
+| --- | ---: |
+| total estimate | `99,999,884` |
+| hot estimate | `49,999,856` |
+| archive estimate | `50,000,028` |
+| hot bounded window | `51` |
+| cold bounded window | `51` |
+| result | 통과 |
+
+## k6 multi-scenario
+
+Run id: `transaction-100m-post-burst-evidence-20260428`
+
+| 시나리오 | 결과 | 429 rate | 503 rate | dropped | interrupted | p95 hot first | p95 cold first | 판단 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| VU3 baseline | 통과 | `0` | `0` | `0` | `0` | `2.0797479ms` | `2.0774723ms` | 1억 row bounded read 자체는 여유 있음 |
+| VU16 overload | 통과 | `0.0088313218` | `0` | `0` | `0` | `4.4582295ms` | `4.1662498ms` | admission 429 예산 내, 503 없음 |
+| burst 256/s | 통과 | `0.0096446954` | `0` | `0` | `0` | `3.0585421ms` | `1.8525083ms` | #490 headroom 보강 후 generator sizing 병목 해소 |
+
+EXPLAIN snapshot은 hot/cold first/cursor 모두 월별 partition index scan 또는 cursor용 index-only scan 경로를 사용했다. `Seq Scan`과 `Sort`는 확인되지 않았다.
+
+## aggregate
+
+| 항목 | 결과 | 근거 |
+| --- | --- | --- |
+| capacity prerequisite | 실패 | `CAPACITY_K6_DOCKER_CONTEXT,CAPACITY_K6_REMOTE_BASE_URL,CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL` 누락 |
+| Docker context | 제한 | `default`, `desktop-linux`만 존재 |
+| aggregate auto k6 input | 통과 | run-id 기준 `vu3` 대표 summary 선택, stale failed burst summary 미선택 |
+| aggregate memory input | 통과 | `post-burst-evidence-20260428-memory-summary.tsv` 선택 |
+| aggregate total memory | 통과 | `663.61MiB / 900MiB` |
+| aggregate required gate 의미 | 미흡 | `required_gates=capacity,k6,memory`인데 capacity prerequisite `failed` 상태에서도 runner exit code는 `0` |
+
+## 병목 판단
+
+거래 조회 read path는 현재 병목이 아니다. 1억 row fixture에서 VU3, VU16 overload, 256/s burst 모두 index 기반으로 통과했고 503, dropped iteration, interrupted iteration이 모두 0이다.
+
+현재 1순위 병목은 실제 capacity 증거 공백이다. 로컬 Docker는 CPU credit, RDS recovery, gp3 IO, 실제 네트워크를 재현하지 못하며, 현재 로컬에는 off-host k6 실행에 필요한 Docker context와 remote endpoint 값이 없다.
+
+2순위 병목은 gate semantics다. aggregate는 capacity prerequisite 실패를 문서에는 표시하지만, required capacity gate로 지정해도 non-zero로 실패하지 않았다. 이 상태에서는 capacity가 실제로 막혀도 자동화가 성공으로 오인할 수 있다.
+
+3순위 병목은 burst spike 원인 상관 증거다. `run-burst-first-second-spike-correlation.sh` 결과는 dropped/interrupted/Insufficient VUs 0을 남겼지만 Prometheus first-window snapshot은 아직 `missing`이라 burst 초반 CPU/Hikari/DB 원인 확정에는 부족하다.
+
+## 다음 작업 리스트
+
+모두 issue 제목 = PR 제목, issue 1개 = PR 1개 기준이다. 아래 항목은 이번 최신 main 스캔에서 이미 merged 된 작업 제목과 중복되지 않도록 제외 확인했다.
+
+| 순서 | issue/PR 제목 | 템플릿 | 브랜치 | 목적 |
+| ---: | --- | --- | --- | --- |
+| 1 | `[Fix] t3micro aggregate required capacity prerequisite 실패를 non-zero 처리` | `bug_report.yml` | `fix/t3micro-aggregate-required-capacity-fail` | capacity가 required인데 prerequisite failed여도 exit 0인 현재 gate 의미를 바로잡는다. |
+| 2 | `[Perf] off-host 100m capacity baseline 최초 실행 결과 확정` | `performance_request.yml` | `perf/offhost-100m-capacity-baseline-evidence` | #490의 runner/doctor는 구현됐으므로, 실제 remote k6 context로 capacity/soak TSV를 생성해 목표 증거를 닫는다. |
+| 3 | `[Perf] staging RDS gp3 100m 30m soak baseline 확정` | `performance_request.yml` | `perf/staging-rds-gp3-100m-soak-baseline` | #438은 smoke runner라서 RDS `db.t4g.small` + gp3 장시간 SLO/CPU credit/IO 한계를 아직 닫지 못했다. |
+| 4 | `[Perf] transaction 100m burst 307/s 120% capacity probe 추가` | `performance_request.yml` | `perf/transaction-100m-burst-307-capacity-probe` | 256/s가 통과했으므로 120% 목표선인 약 307/s에서 429/503/dropped 한계를 빠르게 찾는다. |
+| 5 | `[Perf] burst first-window Prometheus snapshot 자동 수집` | `performance_request.yml` | `perf/burst-first-window-prometheus-snapshot` | correlation artifact는 생겼지만 CPU/Hikari/PostgreSQL first-window snapshot이 missing이라 spike 원인 확정이 안 된다. |
+| 6 | `[Perf] k6 multi-scenario peak CPU/memory sampling 통합` | `performance_request.yml` | `perf/k6-multi-scenario-peak-resource-sampling` | 현재 memory TSV는 수동 snapshot이다. VU3/VU16/burst 실행 중 peak resource를 자동 산출해야 t3.micro headroom을 신뢰할 수 있다. |
+| 7 | `[Perf] t3micro defensive full aggregate 실측 리포트 추가` | `performance_request.yml` | `perf/t3micro-defensive-full-aggregate-evidence` | runner는 있으나 이번 aggregate는 k6/memory/capacity prerequisite만 연결됐다. SSE/admission/outbox까지 같은 run으로 묶어 방어 목표를 닫는다. |
+| 8 | `[Perf] local Docker vs staging RDS 100m 최신 비교 결과 확정` | `performance_request.yml` | `perf/100m-local-staging-rds-comparison-evidence` | 비교 runner는 있으나 최신 local k6와 staging RDS 결과를 같은 표로 비교한 evidence가 없다. |
+| 9 | `[Perf] capacity runner CloudWatch CPU credit/gp3 IO snapshot 연동` | `performance_request.yml` | `perf/capacity-cloudwatch-credit-gp3-snapshot` | 실제 목표 병목인 CPU credit, FreeableMemory, gp3 IO/queue depth를 capacity 결과에 같이 남긴다. |
+| 10 | `[CI] off-host 100m capacity prerequisite required gate 추가` | `task_request.yml` | `ci/offhost-100m-capacity-prerequisite-gate` | remote k6 context/URL/Prometheus RW 누락을 PR 또는 수동 workflow에서 조기 fail-fast한다. |
+
+## 실행 산출물
+
+- `docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-vu3-summary.md`
+- `docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-vu16-overload-summary.md`
+- `docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-burst-256-summary.md`
+- `docs/performance-results/t3micro-defensive-post-burst-evidence-20260428.md`
+- `build/reports/k6/transaction-100m-post-burst-evidence-20260428-capacity/capacity-prerequisite-failure.env`
+- `build/reports/profiling/burst-first-second-post-burst-evidence-20260428/burst-first-second-post-burst-evidence-20260428-first-3s-correlation.md`

--- a/docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-burst-256-summary.md
+++ b/docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-burst-256-summary.md
@@ -1,0 +1,78 @@
+# transaction-100m-post-burst-evidence-20260428-burst-256-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-28T02:09:07Z
+- resultPurpose: smoke
+- resultStatus: 0
+- reportClass: transaction-100m-smoke
+- sourceMarkdown: build/reports/k6/transaction-100m-post-burst-evidence-20260428-burst-256-summary.md
+- sourceJson: build/reports/k6/transaction-100m-post-burst-evidence-20260428-burst-256-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- run id: transaction-100m-post-burst-evidence-20260428
+- vus: 16
+- duration: 20s
+- warmup duration: 10s
+- scenario mode: burst
+- arrival rate: 8/1s
+- burst rate: 256/1s
+- burst duration: 20s
+- pre allocated VUs: 256
+- max VUs: 256
+- limit: 50
+- observability mode: prometheus
+- overload mode: true
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: disabled in overload mode
+- overload 429 rate threshold: 0.015
+- burst 429 rate threshold: 0.1
+- effective overload 429 rate threshold: 0.1
+- overload 503 rate threshold: 0
+
+## Results
+
+- http_req_failed rate: 0.0067270826071802025
+- checks rate: 1
+- transaction 429 rate: 0.009644695417520364
+- transaction 503 rate: 0
+- transaction 503 count: 0
+- hot first p95 ms: 3.0585420999999964
+- hot first p99 ms: 10.346523309999998
+- hot first p99.9 ms: 94.3745919190033
+- hot first max ms: 112.250417
+- hot cursor p95 ms: 2.038731349999998
+- hot cursor p99 ms: 4.963151509999999
+- hot cursor p99.9 ms: 65.5250096250093
+- hot cursor max ms: 117.504084
+- cold first p95 ms: 1.8525082999999984
+- cold first p99 ms: 4.686722719999999
+- cold first p99.9 ms: 13.406779787001682
+- cold first max ms: 84.993167
+- cold cursor p95 ms: 1.8679437499999998
+- cold cursor p99 ms: 4.684766839999999
+- cold cursor p99.9 ms: 12.557088934000735
+- cold cursor max ms: 81.927291
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `prometheus`이면 Prometheus remote write와 summary 파일을 함께 남깁니다.

--- a/docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-vu16-overload-summary.md
+++ b/docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-vu16-overload-summary.md
@@ -1,0 +1,78 @@
+# transaction-100m-post-burst-evidence-20260428-vu16-overload-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-28T02:08:24Z
+- resultPurpose: smoke
+- resultStatus: 0
+- reportClass: transaction-100m-smoke
+- sourceMarkdown: build/reports/k6/transaction-100m-post-burst-evidence-20260428-vu16-overload-summary.md
+- sourceJson: build/reports/k6/transaction-100m-post-burst-evidence-20260428-vu16-overload-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- run id: transaction-100m-post-burst-evidence-20260428
+- vus: 16
+- duration: 30s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 30s
+- pre allocated VUs: 16
+- max VUs: 16
+- limit: 50
+- observability mode: prometheus
+- overload mode: true
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: disabled in overload mode
+- overload 429 rate threshold: 0.015
+- burst 429 rate threshold: 0.1
+- effective overload 429 rate threshold: 0.015
+- overload 503 rate threshold: 0
+
+## Results
+
+- http_req_failed rate: 0.007374491821877659
+- checks rate: 1
+- transaction 429 rate: 0.008831321754489255
+- transaction 503 rate: 0
+- transaction 503 count: 0
+- hot first p95 ms: 4.458229499999998
+- hot first p99 ms: 14.483657759999991
+- hot first p99.9 ms: 69.30988988801221
+- hot first max ms: 242.899376
+- hot cursor p95 ms: 4.1985874999999995
+- hot cursor p99 ms: 12.698629869999989
+- hot cursor p99.9 ms: 52.1499517690054
+- hot cursor max ms: 123.181542
+- cold first p95 ms: 4.166249799999998
+- cold first p99 ms: 14.096815039999989
+- cold first p99.9 ms: 55.00630229600262
+- cold first max ms: 243.024083
+- cold cursor p95 ms: 4.0405415
+- cold cursor p99 ms: 12.667896499999998
+- cold cursor p99.9 ms: 59.10028305000225
+- cold cursor max ms: 123.447708
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `prometheus`이면 Prometheus remote write와 summary 파일을 함께 남깁니다.

--- a/docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-vu3-summary.md
+++ b/docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-vu3-summary.md
@@ -1,0 +1,78 @@
+# transaction-100m-post-burst-evidence-20260428-vu3-summary
+
+## Archive Metadata
+
+- archivedAt: 2026-04-28T02:07:30Z
+- resultPurpose: smoke
+- resultStatus: 0
+- reportClass: transaction-100m-smoke
+- sourceMarkdown: build/reports/k6/transaction-100m-post-burst-evidence-20260428-vu3-summary.md
+- sourceJson: build/reports/k6/transaction-100m-post-burst-evidence-20260428-vu3-summary.json
+
+# k6 Transaction 100m Load Test
+
+## Environment
+
+- baseUrl: http://aquila-bank-backend:8080
+- run id: transaction-100m-post-burst-evidence-20260428
+- vus: 3
+- duration: 30s
+- warmup duration: 10s
+- scenario mode: constant-vus
+- arrival rate: 8/1s
+- burst rate: 16/1s
+- burst duration: 30s
+- pre allocated VUs: 3
+- max VUs: 3
+- limit: 50
+- observability mode: prometheus
+- overload mode: false
+- max retry-after sleep seconds: 1
+- hot account id: 910000001
+- cold account id: 910000002
+- hot p95 threshold ms: 350
+- cold p95 threshold ms: 750
+- hot p99 threshold ms: 750
+- cold p99 threshold ms: 1500
+- hot p99.9 threshold ms: 1200
+- cold p99.9 threshold ms: 2500
+- hot max threshold ms: 3000
+- cold max threshold ms: 5000
+- http failed rate threshold: 0.01
+- overload 429 rate threshold: disabled outside overload mode
+- burst 429 rate threshold: disabled outside overload mode
+- effective overload 429 rate threshold: disabled outside overload mode
+- overload 503 rate threshold: disabled outside overload mode
+
+## Results
+
+- http_req_failed rate: 0
+- checks rate: 1
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- transaction 503 count: n/a
+- hot first p95 ms: 2.0797479
+- hot first p99 ms: 7.468171689999977
+- hot first p99.9 ms: 22.535929394001634
+- hot first max ms: 53.148
+- hot cursor p95 ms: 2.13706425
+- hot cursor p99 ms: 8.852480909999992
+- hot cursor p99.9 ms: 29.6396252690018
+- hot cursor max ms: 62.258084
+- cold first p95 ms: 2.077472299999999
+- cold first p99 ms: 6.519134529999993
+- cold first p99.9 ms: 29.467779447002485
+- cold first max ms: 62.058375
+- cold cursor p95 ms: 2.1074309499999995
+- cold cursor p99 ms: 8.086593999999993
+- cold cursor p99.9 ms: 26.757853125005486
+- cold cursor max ms: 62.272333
+
+## Notes
+
+- 이 결과는 k6 HTTP replay 기준입니다.
+- overload mode에서는 admission guard 429를 rejected sample로 집계합니다.
+- overload mode에서도 503은 app/backend failure 신호라 hard fail로 분리합니다.
+- warmup phase는 endpoint/JVM/cache/pool 초기화를 분리하고, custom latency Trend는 measured phase만 기록합니다.
+- 1억 건 분포는 실행 전 DB에 준비되어 있어야 합니다.
+- observability mode가 `prometheus`이면 Prometheus remote write와 summary 파일을 함께 남깁니다.

--- a/docs/performance-results/t3micro-defensive-post-burst-evidence-20260428.md
+++ b/docs/performance-results/t3micro-defensive-post-burst-evidence-20260428.md
@@ -1,0 +1,32 @@
+# t3micro-defensive-post-burst-evidence-20260428
+
+## Inputs
+
+- capacityResult: missing
+- capacitySummary: missing
+- capacityRunContext: missing
+- capacityPrerequisite: build/reports/k6/transaction-100m-post-burst-evidence-20260428-capacity/capacity-prerequisite-failure.env
+- sseResult: missing
+- admissionSummary: missing
+- outboxSummary: missing
+- k6Summary: docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-vu3-summary.md
+- memorySummary: build/reports/t3micro/post-burst-evidence-20260428-memory-summary.tsv
+
+## Gate Summary
+
+| Gate | Status | Peak CPU % | Peak Memory MiB | Backlog / Reject Signal | Source |
+| --- | --- | ---: | ---: | --- | --- |
+| capacity smoke | missing | missing | missing | repeat=missing | missing |
+| capacity prerequisite | failed | n/a | n/a | reason=missing-required-env missing=CAPACITY_K6_DOCKER_CONTEXT,CAPACITY_K6_REMOTE_BASE_URL,CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL | build/reports/k6/transaction-100m-post-burst-evidence-20260428-capacity/capacity-prerequisite-failure.env |
+| capacity | missing | missing | missing | repeat=missing | missing |
+| capacity soak | missing | n/a | n/a | 429Rate=n/a hikariPending=n/a profiles=missing | missing |
+| sse reconnect | missing | missing | missing | clients=missing rounds=missing | missing |
+| http admission | n/a | n/a | n/a | rejected=missing failed_rate=missing | missing |
+| outbox backlog | n/a | n/a | n/a | lag=missing failed=missing dlq=missing | missing |
+| k6 transaction 100m | n/a | n/a | n/a | hotFirstP95=2.0797479 hotCursorP95=2.13706425 coldFirstP95=2.077472299999999 coldCursorP95=2.1074309499999995 429Rate=0 | docs/performance-results/k6-smoke/transaction-100m-post-burst-evidence-20260428-vu3-summary.md |
+| total memory | pass | n/a | 663.61 | budget=900 source=build/reports/t3micro/post-burst-evidence-20260428-memory-summary.tsv | build/reports/t3micro/post-burst-evidence-20260428-memory-summary.tsv |
+
+## Notes
+
+- missing 값은 해당 gate가 아직 같은 aggregate run에 연결되지 않았음을 뜻합니다.
+- token, 운영 URL, raw Authorization header는 기록하지 않습니다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #491

## 🌿 Base Branch
- `main`

## 📝 Summary
- 최신 `main @ 63a5e44` 기준으로 1억 row 거래 조회와 대용량 트래픽 방어 경로를 로컬 Docker t3.micro 환경에서 재검증했습니다.
- #490 이후 burst headroom과 aggregate selector가 실제 실행에서 동작하는지 확인하고, 이미 완료된 작업을 제외한 다음 병목 개선 issue/PR 후보 10개를 문서화했습니다.

## 🛠 Changes
- 100m fixture probe, k6 VU3/VU16/burst 256/s, capacity prerequisite, aggregate 결과를 `docs/performance-results`에 추가했습니다.
- 병목 판단을 `off-host capacity evidence 공백`, `required capacity prerequisite gate semantics`, `burst first-window snapshot missing`으로 정리했습니다.
- 완료된 #490/#488/#486/#484/#472/#438/#435 범위와 중복되지 않는 후속 작업 리스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `git pull --ff-only origin main`
- `docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml --profile loadtest up -d --force-recreate postgres aquila-bank-backend prometheus grafana alertmanager postgres-exporter`
- `tools/test/run-transaction-100m-fixture-dataset-probe.sh`
- `tools/test/run-k6-transaction-100m-multi-scenario.sh`
- `tools/test/run-transaction-100m-capacity-gates.sh --print-plan`
- `tools/test/run-t3micro-defensive-gates-aggregate-report.sh`
- `tools/test/run-burst-first-second-spike-correlation.sh`
- `git diff --cached --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 문서/성능 결과 추가만 포함하므로 런타임 리스크는 없습니다. 단, 결과는 로컬 Docker t3.micro 근사 환경 기준이며 실제 AWS CPU credit/RDS gp3 한계는 별도 off-host/staging 실행으로 확정해야 합니다.
- 롤백 방법: 이 PR의 문서 commit revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
