### PR TITLE
[CI] Jacoco PR 파일별 커버리지 요약 보강

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Java 21
         uses: actions/setup-java@v4
@@ -55,10 +57,14 @@ jobs:
         run: |
           summary_file="${RUNNER_TEMP}/jacoco-summary.md"
           comments_file="${RUNNER_TEMP}/pr-comments.json"
+          changed_files="${RUNNER_TEMP}/changed-files.txt"
+
+          git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" > "${changed_files}"
 
           python3 tools/ci/comment-jacoco-summary.py \
             back/build/reports/jacoco/full/jacocoFullTestReport.xml \
             back/config/jacoco-coverage-baseline-excludes.txt \
+            --changed-files "${changed_files}" \
             > "${summary_file}"
 
           gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate > "${comments_file}"
@@ -74,6 +80,16 @@ jobs:
           fi
 
           cat "${summary_file}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload Jacoco full report
+        if: always() && hashFiles('back/build/reports/jacoco/full/jacocoFullTestReport.xml') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-full-report
+          path: |
+            back/build/reports/jacoco/full/jacocoFullTestReport.xml
+            back/build/reports/jacoco/full/html
+          if-no-files-found: error
 
       - name: Run transaction query plan regression gate
         working-directory: ${{ github.workspace }}

--- a/tools/ci/comment-jacoco-summary.py
+++ b/tools/ci/comment-jacoco-summary.py
@@ -6,6 +6,9 @@ import xml.etree.ElementTree as ET
 
 
 MARKER = "<!-- aquila-bank:jacoco-coverage-summary -->"
+SOURCE_PREFIX = "back/src/main/java/"
+MAX_CHANGED_FILES = 30
+MAX_WORST_FILES = 20
 
 
 def coverage_bar(ratio):
@@ -13,8 +16,8 @@ def coverage_bar(ratio):
     return "█" * filled + "░" * (10 - filled)
 
 
-def read_counter(root, name):
-    counter = next((item for item in root.findall("counter") if item.get("type") == name), None)
+def read_counter(node, name):
+    counter = next((item for item in node.findall("counter") if item.get("type") == name), None)
     if counter is None:
         return 0, 0, 100.0
     missed = int(counter.get("missed"))
@@ -38,13 +41,77 @@ def format_counter(name, missed, covered, ratio):
     return f"| {name} | {covered} | {missed + covered} | {missed} | {ratio:.2f}% | `{coverage_bar(ratio)}` |"
 
 
-def build_summary(report_path, baseline_path):
+def display_path(path):
+    return path.removeprefix(SOURCE_PREFIX)
+
+
+def read_changed_files(path):
+    if path is None or not path.exists():
+        return []
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith(SOURCE_PREFIX) and line.strip().endswith(".java")
+    ]
+
+
+def source_file_rows(root):
+    rows = []
+    for item in root.findall("package"):
+        package_name = item.get("name")
+        for source in item.findall("sourcefile"):
+            line_missed, line_covered, line_ratio = read_counter(source, "LINE")
+            branch_missed, branch_covered, branch_ratio = read_counter(source, "BRANCH")
+            path = f"{SOURCE_PREFIX}{package_name}/{source.get('name')}"
+            rows.append(
+                {
+                    "path": path,
+                    "line_missed": line_missed,
+                    "line_covered": line_covered,
+                    "line_ratio": line_ratio,
+                    "branch_missed": branch_missed,
+                    "branch_covered": branch_covered,
+                    "branch_ratio": branch_ratio,
+                })
+    return rows
+
+
+def format_file_row(row):
+    return (
+        f"| `{display_path(row['path'])}` | {row['line_ratio']:.2f}% | {row['line_missed']} | "
+        f"{row['branch_ratio']:.2f}% | {row['branch_missed']} | `{coverage_bar(row['line_ratio'])}` |"
+    )
+
+
+def append_file_section(lines, title, rows, empty_message):
+    lines.extend(["", f"## {title}", ""])
+    if not rows:
+        lines.append(empty_message)
+        return
+    lines.extend(
+        [
+            "| 파일 | Line | 미커버 Line | Branch | 미커버 Branch | 그래프 |",
+            "| --- | ---: | ---: | ---: | ---: | --- |",
+        ])
+    lines.extend(format_file_row(row) for row in rows)
+
+
+def build_summary(report_path, baseline_path, changed_files_path=None):
     root = ET.parse(report_path).getroot()
     line_missed, line_covered, line_ratio = read_counter(root, "LINE")
     status = "통과" if line_missed == 0 and line_ratio >= 100.0 else "미달"
     baseline_count = count_baseline_exclusions(baseline_path)
     sha = os.environ.get("GITHUB_SHA", "")
     sha_line = f"- Commit: `{sha}`" if sha else ""
+    rows = source_file_rows(root)
+    row_by_path = {item["path"]: item for item in rows}
+    changed_files = read_changed_files(changed_files_path)
+    changed_rows = [row_by_path[path] for path in changed_files if path in row_by_path]
+    worst_rows = sorted(
+        (item for item in rows if item["line_missed"] > 0),
+        key=lambda item: (item["line_missed"], item["branch_missed"], item["path"]),
+        reverse=True,
+    )[:MAX_WORST_FILES]
 
     counters = [
         ("Instruction", *read_counter(root, "INSTRUCTION")),
@@ -73,10 +140,25 @@ def build_summary(report_path, baseline_path):
         ]
     )
     lines.extend(format_counter(*item) for item in counters)
+    append_file_section(
+        lines,
+        "변경 파일 커버리지",
+        changed_rows[:MAX_CHANGED_FILES],
+        "- 변경된 production Java 파일 없음",
+    )
+    append_file_section(
+        lines,
+        "Top 미커버 파일",
+        worst_rows,
+        "- 미커버 source file 없음",
+    )
     lines.extend(
         [
             "",
-            f"- XML: `{report_path}`",
+            "## 상세 report",
+            "",
+            "- Actions artifact: `jacoco-full-report`",
+            f"- XML path: `{report_path}`",
             f"- Baseline: `{baseline_path}`",
         ]
     )
@@ -87,12 +169,13 @@ def main():
     parser = argparse.ArgumentParser(description="Create a Jacoco coverage summary PR comment body.")
     parser.add_argument("report", type=Path)
     parser.add_argument("baseline", type=Path)
+    parser.add_argument("--changed-files", type=Path)
     args = parser.parse_args()
 
     if not args.report.exists():
         raise SystemExit(f"Jacoco report not found: {args.report}")
 
-    print(build_summary(args.report, args.baseline))
+    print(build_summary(args.report, args.baseline, args.changed_files))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔗 Related Issue
- close #499

## 🌿 Base Branch
- `main`

## 📝 Summary
- PR Jacoco 댓글을 전체 요약 + 변경 파일 coverage + Top 미커버 파일 중심으로 보강합니다.
- full Jacoco XML/HTML report를 Actions artifact로 업로드해 전체 상세는 artifact에서 확인하게 합니다.
- 기존 filtered Jacoco 100% gate는 유지합니다.

## 🛠 Changes
- `tools/ci/comment-jacoco-summary.py`: JaCoCo `sourcefile` counter를 파싱해 변경 파일/미커버 상위 파일 table 출력.
- `.github/workflows/backend-ci.yml`: PR changed files를 스크립트에 전달하고 `jacoco-full-report` artifact 업로드.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `python3 tools/ci/comment-jacoco-summary.py back/build/reports/jacoco/full/jacocoFullTestReport.xml back/config/jacoco-coverage-baseline-excludes.txt --changed-files /tmp/aquila-changed-files.txt`
- `python3 -m py_compile tools/ci/comment-jacoco-summary.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/backend-ci.yml"); puts "backend-ci yaml ok"'`
- `git diff --check`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back test jacocoFullTestReport check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: checkout fetch-depth 증가로 Backend CI checkout 시간이 소폭 늘 수 있음. 댓글/아티팩트 단계 실패 시 coverage 표시에만 영향.
- 롤백 방법: 이 PR의 단일 커밋 revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A