### PR TITLE
[Fix] t3micro aggregate required capacity prerequisite 실패를 non-zero 처리

### DIFF
--- a/.github/workflows/offhost-100m-capacity-prerequisite.yml
+++ b/.github/workflows/offhost-100m-capacity-prerequisite.yml
@@ -1,0 +1,59 @@
+name: off-host 100m capacity prerequisite
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_context:
+        description: "Remote Docker context name for off-host k6"
+        required: false
+        type: string
+      remote_base_url:
+        description: "Backend URL reachable from off-host k6"
+        required: false
+        type: string
+      remote_prometheus_rw_url:
+        description: "Prometheus remote-write URL reachable from off-host k6"
+        required: false
+        type: string
+      remote_workdir:
+        description: "Repository path on remote Docker context host"
+        required: false
+        default: "/srv/aquila-bank"
+        type: string
+  pull_request:
+    paths:
+      - ".github/workflows/offhost-100m-capacity-prerequisite.yml"
+      - "tools/test/run-transaction-100m-capacity-gates.sh"
+      - "tools/test/run-offhost-capacity-env-doctor.sh"
+      - "tools/test/run-transaction-100m-offhost-capacity-baseline-report.sh"
+      - "tools/test/run-t3micro-defensive-gates-aggregate-report.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  prerequisite:
+    name: required off-host capacity env
+    runs-on: ubuntu-latest
+    env:
+      CAPACITY_NAME: ci-offhost-100m-capacity-prerequisite
+      CAPACITY_K6_GENERATOR_MODE: docker-context
+      CAPACITY_REMOTE_PREFLIGHT: "false"
+      CAPACITY_K6_DOCKER_CONTEXT: ${{ inputs.docker_context || vars.CAPACITY_K6_DOCKER_CONTEXT }}
+      CAPACITY_K6_REMOTE_BASE_URL: ${{ inputs.remote_base_url || vars.CAPACITY_K6_REMOTE_BASE_URL }}
+      CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL: ${{ inputs.remote_prometheus_rw_url || vars.CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL }}
+      CAPACITY_K6_REMOTE_WORKDIR: ${{ inputs.remote_workdir || vars.CAPACITY_K6_REMOTE_WORKDIR || '/srv/aquila-bank' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Required prerequisite check
+        run: tools/test/run-transaction-100m-capacity-gates.sh --print-plan
+
+      - name: Upload prerequisite failure artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: offhost-capacity-prerequisite-failure
+          path: build/reports/k6/ci-offhost-100m-capacity-prerequisite/capacity-prerequisite-failure.env
+          if-no-files-found: ignore

--- a/.github/workflows/offhost-100m-capacity-prerequisite.yml
+++ b/.github/workflows/offhost-100m-capacity-prerequisite.yml
@@ -32,8 +32,20 @@ permissions:
   contents: read
 
 jobs:
+  contract:
+    name: off-host capacity prerequisite contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate workflow contract
+        run: tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+
   prerequisite:
     name: required off-host capacity env
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       CAPACITY_NAME: ci-offhost-100m-capacity-prerequisite

--- a/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+++ b/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/offhost-100m-capacity-prerequisite.yml"
+
+echo "[offhost-capacity-prerequisite] workflow exists"
+test -f "${workflow}"
+
+echo "[offhost-capacity-prerequisite] workflow contract"
+grep -F "name: off-host 100m capacity prerequisite" "${workflow}" >/dev/null
+grep -F "workflow_dispatch:" "${workflow}" >/dev/null
+grep -F "pull_request:" "${workflow}" >/dev/null
+grep -F "CAPACITY_K6_GENERATOR_MODE: docker-context" "${workflow}" >/dev/null
+grep -F "CAPACITY_REMOTE_PREFLIGHT: \"false\"" "${workflow}" >/dev/null
+grep -F "tools/test/run-transaction-100m-capacity-gates.sh --print-plan" "${workflow}" >/dev/null
+grep -F "capacity-prerequisite-failure.env" "${workflow}" >/dev/null
+grep -F "actions/upload-artifact@v4" "${workflow}" >/dev/null
+grep -F "offhost-capacity-prerequisite-failure" "${workflow}" >/dev/null
+
+echo "[offhost-capacity-prerequisite] local fail-fast contract"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+prereq="${temp_dir}/capacity-prerequisite-failure.env"
+if CAPACITY_NAME=ci-offhost-prereq-check \
+  CAPACITY_PREREQUISITE_FAILURE_REPORT_PATH="${prereq}" \
+  CAPACITY_K6_GENERATOR_MODE=docker-context \
+    tools/test/run-transaction-100m-capacity-gates.sh --print-plan >/dev/null 2>&1; then
+  echo "missing off-host capacity env unexpectedly passed local prerequisite check" >&2
+  exit 1
+fi
+test -f "${prereq}"
+grep -F "CAPACITY_PREREQUISITE_STATUS=failed" "${prereq}" >/dev/null
+grep -F "CAPACITY_PREREQUISITE_FAILURE_REASON=missing-required-env" "${prereq}" >/dev/null

--- a/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+++ b/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
@@ -10,6 +10,10 @@ echo "[offhost-capacity-prerequisite] workflow contract"
 grep -F "name: off-host 100m capacity prerequisite" "${workflow}" >/dev/null
 grep -F "workflow_dispatch:" "${workflow}" >/dev/null
 grep -F "pull_request:" "${workflow}" >/dev/null
+grep -F "off-host capacity prerequisite contract" "${workflow}" >/dev/null
+grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
+grep -F "tools/test/check-offhost-capacity-prerequisite-required-gate.sh" "${workflow}" >/dev/null
+grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "CAPACITY_K6_GENERATOR_MODE: docker-context" "${workflow}" >/dev/null
 grep -F "CAPACITY_REMOTE_PREFLIGHT: \"false\"" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-100m-capacity-gates.sh --print-plan" "${workflow}" >/dev/null

--- a/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/check-t3micro-defensive-gates-aggregate-report.sh
@@ -227,6 +227,17 @@ if T3MICRO_AGGREGATE_NAME=aggregate-required-local-context-check \
   echo "required capacity input unexpectedly accepted local generator context" >&2
   exit 1
 fi
+required_prereq_output="${temp_dir}/aggregate-required-prereq-failed-check.md"
+if T3MICRO_AGGREGATE_NAME=aggregate-required-prereq-failed-check \
+  T3MICRO_AGGREGATE_OUTPUT_DIR="${temp_dir}" \
+  T3MICRO_CAPACITY_PREREQUISITE_ENV="${capacity_prereq}" \
+  T3MICRO_AGGREGATE_REQUIRED_GATES=capacity \
+    "${script}" >/dev/null 2>&1; then
+  echo "required capacity prerequisite failure unexpectedly exited zero" >&2
+  exit 1
+fi
+test -f "${required_prereq_output}"
+grep -F "| capacity prerequisite | failed | n/a | n/a | reason=missing-required-env missing=CAPACITY_K6_DOCKER_CONTEXT,CAPACITY_K6_REMOTE_BASE_URL,CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL | ${capacity_prereq} |" "${required_prereq_output}" >/dev/null
 
 echo "[t3micro-defensive-aggregate] memory budget"
 if T3MICRO_AGGREGATE_NAME=aggregate-memory-fail-check \

--- a/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
+++ b/tools/test/run-t3micro-defensive-gates-aggregate-report.sh
@@ -390,6 +390,21 @@ assert_required_gates() {
   done
 }
 
+gate_is_required() {
+  local expected="$1"
+  local gate
+  if [[ -z "${required_gates}" ]]; then
+    return 1
+  fi
+  IFS=',' read -r -a gates <<<"${required_gates}"
+  for gate in "${gates[@]}"; do
+    if [[ "${gate}" == "${expected}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 print_plan() {
   echo "[t3micro-defensive-aggregate] mode=${mode}"
   echo "[t3micro-defensive-aggregate] output=${output_path}"
@@ -441,6 +456,20 @@ capacity_prerequisite_signal_value() {
   printf "reason=%s missing=%s" \
     "$(env_value "${capacity_prerequisite}" "CAPACITY_PREREQUISITE_FAILURE_REASON")" \
     "$(env_value "${capacity_prerequisite}" "CAPACITY_PREREQUISITE_MISSING_VARS")"
+}
+
+capacity_prerequisite_failed() {
+  [[ -n "${capacity_prerequisite}" && -f "${capacity_prerequisite}" ]] || return 1
+  [[ "$(env_value "${capacity_prerequisite}" "CAPACITY_PREREQUISITE_STATUS")" == "failed" ]]
+}
+
+assert_required_capacity_prerequisite_status() {
+  if gate_is_required capacity && [[ -z "${capacity_summary}" || ! -f "${capacity_summary}" ]] && capacity_prerequisite_failed; then
+    echo "required aggregate capacity prerequisite failed: $(capacity_prerequisite_signal_value)" >&2
+    echo "capacity prerequisite failure report: ${capacity_prerequisite}" >&2
+    return 1
+  fi
+  return 0
 }
 
 capacity_summary_status() {
@@ -905,6 +934,8 @@ if [[ "${mode}" == "print-plan" ]]; then
 fi
 if [[ "${mode}" == "dry-run" ]]; then
   echo "write ${output_path}"
+  assert_required_capacity_prerequisite_status
   exit 0
 fi
 write_report
+assert_required_capacity_prerequisite_status


### PR DESCRIPTION
## 🔗 Related Issue
- close #503

## 🌿 Base Branch
- `main`

## 📝 Summary
- required capacity gate에서 capacity summary 없이 prerequisite failure만 있는 경우 aggregate runner가 report를 남긴 뒤 non-zero로 종료하도록 수정합니다.
- off-host 100m capacity prerequisite 값을 PR path 변경 또는 수동 workflow에서 조기 검증하는 CI gate를 추가합니다.

## 🛠 Changes
- `T3MICRO_AGGREGATE_REQUIRED_GATES=capacity` + `CAPACITY_PREREQUISITE_STATUS=failed` 재현 체크 추가
- aggregate report 작성 후 required capacity prerequisite failure를 non-zero 처리
- `.github/workflows/offhost-100m-capacity-prerequisite.yml` 추가
- prerequisite failure artifact upload 계약 체크 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-t3micro-defensive-gates-aggregate-report.sh`
- `tools/test/check-offhost-capacity-prerequisite-required-gate.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: capacity summary 없이 prerequisite failure만 있는 required aggregate 실행은 이제 실패합니다. 실제 capacity summary가 있으면 stale prerequisite artifact만으로 실패하지 않게 제한했습니다.
- 롤백 방법: 이 PR revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
