### PR TITLE
[Perf] 100m capacity evidence collection 보강

### DIFF
--- a/tools/test/check-burst-first-window-prometheus-snapshot.sh
+++ b/tools/test/check-burst-first-window-prometheus-snapshot.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-burst-first-window-prometheus-snapshot.sh"
+
+echo "[burst-first-window-prometheus] shell syntax"
+bash -n "${script}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+echo "[burst-first-window-prometheus] plan"
+plan="$(
+  BURST_WINDOW_SNAPSHOT_NAME=burst-window-check \
+  BURST_WINDOW_RUN_ID=transaction-100m-burst-window-check \
+  BURST_WINDOW_PROMETHEUS_URL=http://127.0.0.1:9090 \
+  BURST_WINDOW_SECONDS=3 \
+  BURST_WINDOW_OUTPUT_DIR="${temp_dir}" \
+    "${script}" --print-plan
+)"
+grep -F "name=burst-window-check" <<<"${plan}" >/dev/null
+grep -F "run_id=transaction-100m-burst-window-check" <<<"${plan}" >/dev/null
+grep -F "prometheus_url=http://127.0.0.1:9090" <<<"${plan}" >/dev/null
+grep -F "window_seconds=3" <<<"${plan}" >/dev/null
+grep -F "snapshot_tsv=${temp_dir}/burst-window-check-prometheus-first-3s.tsv" <<<"${plan}" >/dev/null
+
+echo "[burst-first-window-prometheus] dry-run"
+dry_run="$(
+  BURST_WINDOW_SNAPSHOT_NAME=burst-window-check \
+  BURST_WINDOW_RUN_ID=transaction-100m-burst-window-check \
+  BURST_WINDOW_PROMETHEUS_URL=http://127.0.0.1:9090 \
+  BURST_WINDOW_SECONDS=3 \
+  BURST_WINDOW_OUTPUT_DIR="${temp_dir}" \
+    "${script}" --dry-run
+)"
+grep -F "max_over_time(k6_vus" <<<"${dry_run}" >/dev/null
+grep -F "run_id=\"transaction-100m-burst-window-check\"" <<<"${dry_run}" >/dev/null
+grep -F "db.hikari.pending.max" <<<"${dry_run}" >/dev/null
+
+echo "[burst-first-window-prometheus] invalid input fails"
+if BURST_WINDOW_SECONDS=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "zero window unexpectedly passed" >&2
+  exit 1
+fi
+if BURST_WINDOW_PROMETHEUS_URL=not-a-url "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad prometheus url unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "[burst-first-window-prometheus] runner contract"
+grep -F "k6.vus.max" "${script}" >/dev/null
+grep -F "k6.vus.active.max" "${script}" >/dev/null
+grep -F "backend.cpu.max.percent" "${script}" >/dev/null
+grep -F "postgres.cpu.max.percent" "${script}" >/dev/null
+grep -F "db.hikari.pending.max" "${script}" >/dev/null
+grep -F "/api/v1/query" "${script}" >/dev/null

--- a/tools/test/check-capacity-cloudwatch-credit-gp3-snapshot.sh
+++ b/tools/test/check-capacity-cloudwatch-credit-gp3-snapshot.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-capacity-cloudwatch-credit-gp3-snapshot.sh"
+
+echo "[capacity-cloudwatch] shell syntax"
+bash -n "${script}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+echo "[capacity-cloudwatch] plan"
+plan="$(
+  CAPACITY_CLOUDWATCH_NAME=cloudwatch-check \
+  CAPACITY_CLOUDWATCH_OUTPUT_DIR="${temp_dir}" \
+  CAPACITY_CLOUDWATCH_REGION=ap-northeast-2 \
+  CAPACITY_CLOUDWATCH_START_TIME=2026-04-28T00:00:00Z \
+  CAPACITY_CLOUDWATCH_END_TIME=2026-04-28T00:30:00Z \
+  CAPACITY_CLOUDWATCH_EC2_INSTANCE_ID=i-0123456789abcdef0 \
+  CAPACITY_CLOUDWATCH_RDS_IDENTIFIER=aquila-staging-rds \
+  CAPACITY_CLOUDWATCH_EBS_VOLUME_ID=vol-0123456789abcdef0 \
+    "${script}" --print-plan
+)"
+grep -F "name=cloudwatch-check" <<<"${plan}" >/dev/null
+grep -F "region=ap-northeast-2" <<<"${plan}" >/dev/null
+grep -F "ec2_instance_id=i-0123456789abcdef0" <<<"${plan}" >/dev/null
+grep -F "rds_identifier=aquila-staging-rds" <<<"${plan}" >/dev/null
+grep -F "ebs_volume_id=vol-0123456789abcdef0" <<<"${plan}" >/dev/null
+grep -F "snapshot_tsv=${temp_dir}/cloudwatch-check-cloudwatch-capacity-snapshot.tsv" <<<"${plan}" >/dev/null
+
+echo "[capacity-cloudwatch] dry-run metrics"
+dry_run="$(
+  CAPACITY_CLOUDWATCH_NAME=cloudwatch-check \
+  CAPACITY_CLOUDWATCH_OUTPUT_DIR="${temp_dir}" \
+  CAPACITY_CLOUDWATCH_REGION=ap-northeast-2 \
+  CAPACITY_CLOUDWATCH_START_TIME=2026-04-28T00:00:00Z \
+  CAPACITY_CLOUDWATCH_END_TIME=2026-04-28T00:30:00Z \
+  CAPACITY_CLOUDWATCH_EC2_INSTANCE_ID=i-0123456789abcdef0 \
+  CAPACITY_CLOUDWATCH_RDS_IDENTIFIER=aquila-staging-rds \
+  CAPACITY_CLOUDWATCH_EBS_VOLUME_ID=vol-0123456789abcdef0 \
+    "${script}" --dry-run
+)"
+grep -F $'AWS/EC2\tCPUCreditBalance\tInstanceId\ti-0123456789abcdef0' <<<"${dry_run}" >/dev/null
+grep -F $'AWS/RDS\tFreeableMemory\tDBInstanceIdentifier\taquila-staging-rds' <<<"${dry_run}" >/dev/null
+grep -F $'AWS/EBS\tVolumeQueueLength\tVolumeId\tvol-0123456789abcdef0' <<<"${dry_run}" >/dev/null
+
+echo "[capacity-cloudwatch] invalid input fails"
+if CAPACITY_CLOUDWATCH_PERIOD_SECONDS=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "zero period unexpectedly passed" >&2
+  exit 1
+fi
+if CAPACITY_CLOUDWATCH_START_TIME=bad CAPACITY_CLOUDWATCH_END_TIME=2026-04-28T00:30:00Z "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad start time unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "[capacity-cloudwatch] runner contract"
+grep -F "aws cloudwatch get-metric-statistics" "${script}" >/dev/null
+grep -F "CPUCreditBalance" "${script}" >/dev/null
+grep -F "FreeableMemory" "${script}" >/dev/null
+grep -F "VolumeQueueLength" "${script}" >/dev/null
+grep -F "capacity-cloudwatch" "${script}" >/dev/null

--- a/tools/test/check-k6-transaction-100m-multi-scenario.sh
+++ b/tools/test/check-k6-transaction-100m-multi-scenario.sh
@@ -24,6 +24,8 @@ grep -F "run_id=multi-run-check" <<<"${plan}" >/dev/null
 grep -F "output_dir=${temp_dir}/multi" <<<"${plan}" >/dev/null
 grep -F "reuse_backend=true" <<<"${plan}" >/dev/null
 grep -F "post_first_recovery_noise_window_seconds=0" <<<"${plan}" >/dev/null
+grep -F "resource_sampling=true" <<<"${plan}" >/dev/null
+grep -F "resource_summary=${temp_dir}/multi/multi-check-peak-resource-summary.tsv" <<<"${plan}" >/dev/null
 grep -F "scenario_count=2" <<<"${plan}" >/dev/null
 grep -F "execution_plan=${temp_dir}/multi/multi-check-execution-plan.tsv" <<<"${plan}" >/dev/null
 
@@ -38,9 +40,12 @@ output="$(
 execution_plan="$(tail -1 <<<"${output}")"
 test "${execution_plan}" = "${temp_dir}/multi/multi-check-execution-plan.tsv"
 test -s "${execution_plan}"
+resource_summary="${temp_dir}/multi/multi-check-peak-resource-summary.tsv"
+test -s "${resource_summary}"
 grep -F $'order\tname\tmode\tvus\tduration\toverload\tburst_rate\tpre_allocated_vus\tmax_vus\treport_name\trunner_args\trecovery_noise_window_seconds' "${execution_plan}" >/dev/null
 grep -F $'1\tbaseline\tconstant-vus\t3\t30s\tfalse\t16\t3\t3\tmulti-check-baseline\tdefault\t30' "${execution_plan}" >/dev/null
 grep -F $'2\tburst-256\tburst\t16\t20s\ttrue\t256\t256\t256\tmulti-check-burst-256\t--no-up --no-deps\t0' "${execution_plan}" >/dev/null
+grep -F $'scenario\tcontainer\tpeak_cpu_percent\tpeak_memory_mib\tsamples' "${resource_summary}" >/dev/null
 
 echo "[k6-transaction-100m-multi] invalid input fails"
 if K6_MULTI_SCENARIOS=bad "${script}" --print-plan >/dev/null 2>&1; then
@@ -55,9 +60,15 @@ if K6_MULTI_POST_FIRST_RECOVERY_NOISE_WINDOW_SECONDS=bad "${script}" --print-pla
   echo "bad recovery noise window unexpectedly passed" >&2
   exit 1
 fi
+if K6_MULTI_RESOURCE_SAMPLING=maybe "${script}" --print-plan >/dev/null 2>&1; then
+  echo "bad resource sampling flag unexpectedly passed" >&2
+  exit 1
+fi
 
 echo "[k6-transaction-100m-multi] runner contract"
 grep -F "run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${script}" >/dev/null
+grep -F "start_peak_resource_sampler" "${script}" >/dev/null
+grep -F "write_peak_resource_summary" "${script}" >/dev/null
 grep -F "K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS=\"\${post_first_noise_window}\"" "${script}" >/dev/null
 grep -F "K6_PRE_ALLOCATED_VUS=\"\${pre_allocated}\"" "${script}" >/dev/null
 grep -F "K6_MAX_VUS=\"\${max_vus}\"" "${script}" >/dev/null

--- a/tools/test/check-transaction-100m-burst-307-capacity-probe.sh
+++ b/tools/test/check-transaction-100m-burst-307-capacity-probe.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/test/run-transaction-100m-burst-307-capacity-probe.sh"
+
+echo "[transaction-100m-burst-307] shell syntax"
+bash -n "${script}"
+
+echo "[transaction-100m-burst-307] plan"
+plan="$(
+  BURST_307_PROBE_NAME=burst-307-check \
+  BURST_307_PROBE_DURATION=20s \
+  BURST_307_PROBE_VUS=307 \
+  BURST_307_PROBE_OVERLOAD_MODE=true \
+    "${script}" --print-plan
+)"
+grep -F "name=burst-307-check" <<<"${plan}" >/dev/null
+grep -F "rate=307" <<<"${plan}" >/dev/null
+grep -F "duration=20s" <<<"${plan}" >/dev/null
+grep -F "vus=307" <<<"${plan}" >/dev/null
+grep -F "overload_mode=true" <<<"${plan}" >/dev/null
+grep -F "k6_report_name=burst-307-check-burst-307" <<<"${plan}" >/dev/null
+grep -F "archive_output_dir=docs/performance-results/k6-profile" <<<"${plan}" >/dev/null
+
+echo "[transaction-100m-burst-307] dry-run"
+dry_run="$(
+  BURST_307_PROBE_NAME=burst-307-check \
+  BURST_307_PROBE_DURATION=20s \
+  BURST_307_PROBE_VUS=307 \
+  BURST_307_PROBE_OVERLOAD_MODE=true \
+    "${script}" --dry-run
+)"
+grep -F "K6_SCENARIO_MODE=burst" <<<"${dry_run}" >/dev/null
+grep -F "K6_BURST_RATE=307" <<<"${dry_run}" >/dev/null
+grep -F "K6_PRE_ALLOCATED_VUS=307" <<<"${dry_run}" >/dev/null
+grep -F "K6_MAX_VUS=307" <<<"${dry_run}" >/dev/null
+grep -F "K6_OVERLOAD_MODE=true" <<<"${dry_run}" >/dev/null
+grep -F "tools/test/run-k6-transaction-100m-loadtest.sh" <<<"${dry_run}" >/dev/null
+
+echo "[transaction-100m-burst-307] invalid input fails"
+if BURST_307_PROBE_RATE=0 "${script}" --print-plan >/dev/null 2>&1; then
+  echo "zero burst rate unexpectedly passed" >&2
+  exit 1
+fi
+if BURST_307_PROBE_DURATION=0s "${script}" --print-plan >/dev/null 2>&1; then
+  echo "zero duration unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "[transaction-100m-burst-307] runner contract"
+grep -F "BURST_307_PROBE_RATE" "${script}" >/dev/null
+grep -F "K6_BURST_RATE=\"\${rate}\"" "${script}" >/dev/null
+grep -F "K6_PRE_ALLOCATED_VUS=\"\${vus}\"" "${script}" >/dev/null
+grep -F "K6_MAX_VUS=\"\${vus}\"" "${script}" >/dev/null

--- a/tools/test/run-burst-first-window-prometheus-snapshot.sh
+++ b/tools/test/run-burst-first-window-prometheus-snapshot.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-burst-first-window-prometheus-snapshot.sh [--print-plan|--dry-run]
+
+Environment:
+  BURST_WINDOW_SNAPSHOT_NAME default burst-first-window-prometheus-<timestamp>
+  BURST_WINDOW_RUN_ID required for actual run
+  BURST_WINDOW_PROMETHEUS_URL default http://localhost:9090
+  BURST_WINDOW_SECONDS default 3
+  BURST_WINDOW_OUTPUT_DIR default build/reports/profiling/<name>
+
+Examples:
+  BURST_WINDOW_RUN_ID=transaction-100m-burst-256 \
+    tools/test/run-burst-first-window-prometheus-snapshot.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${BURST_WINDOW_SNAPSHOT_NAME:-burst-first-window-prometheus-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${BURST_WINDOW_RUN_ID:-}"
+prometheus_url="${BURST_WINDOW_PROMETHEUS_URL:-http://localhost:9090}"
+prometheus_url="${prometheus_url%/}"
+window_seconds="${BURST_WINDOW_SECONDS:-3}"
+output_dir="${BURST_WINDOW_OUTPUT_DIR:-build/reports/profiling/${name}}"
+snapshot_tsv="${output_dir}/${name}-prometheus-first-${window_seconds}s.tsv"
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_url() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^https?://[^[:space:]]+$ ]]; then
+    echo "${name} must be an http(s) URL: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer "BURST_WINDOW_SECONDS" "${window_seconds}"
+require_url "BURST_WINDOW_PROMETHEUS_URL" "${prometheus_url}"
+
+query_for_key() {
+  local key="$1"
+  case "${key}" in
+    k6.vus.max)
+      printf 'max(max_over_time(k6_vus{run_id="%s"}[%ss]))' "${run_id}" "${window_seconds}"
+      ;;
+    k6.vus.active.max)
+      printf 'max(max_over_time(k6_vus{run_id="%s"}[%ss]))' "${run_id}" "${window_seconds}"
+      ;;
+    backend.cpu.max.percent)
+      printf 'max(max_over_time(rate(container_cpu_usage_seconds_total{name=~"aquila-bank-backend.*"}[%ss])[%ss:1s])) * 100' "${window_seconds}" "${window_seconds}"
+      ;;
+    postgres.cpu.max.percent)
+      printf 'max(max_over_time(rate(container_cpu_usage_seconds_total{name=~"aquila-bank-postgres.*"}[%ss])[%ss:1s])) * 100' "${window_seconds}" "${window_seconds}"
+      ;;
+    db.hikari.pending.max)
+      printf 'max(max_over_time(hikaricp_connections_pending{pool="aquila-bank-pool"}[%ss]))' "${window_seconds}"
+      ;;
+    *)
+      echo "unknown snapshot key: ${key}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+snapshot_keys=(
+  k6.vus.max
+  k6.vus.active.max
+  backend.cpu.max.percent
+  postgres.cpu.max.percent
+  db.hikari.pending.max
+)
+
+print_plan() {
+  echo "[burst-first-window-prometheus] mode=${mode}"
+  echo "[burst-first-window-prometheus] name=${name}"
+  echo "[burst-first-window-prometheus] run_id=${run_id:-missing}"
+  echo "[burst-first-window-prometheus] prometheus_url=${prometheus_url}"
+  echo "[burst-first-window-prometheus] window_seconds=${window_seconds}"
+  echo "[burst-first-window-prometheus] snapshot_tsv=${snapshot_tsv}"
+}
+
+print_queries() {
+  local key
+  for key in "${snapshot_keys[@]}"; do
+    printf "%s\t%s\n" "${key}" "$(query_for_key "${key}")"
+  done
+}
+
+prometheus_value() {
+  local query="$1"
+  curl -fsS --get "${prometheus_url}/api/v1/query" \
+    --data-urlencode "query=${query}" \
+    | jq -r '.data.result[0].value[1] // "n/a"'
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ -z "${run_id}" ]]; then
+  echo "BURST_WINDOW_RUN_ID is required" >&2
+  exit 1
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  print_queries
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+{
+  printf "metric\tvalue\n"
+  for key in "${snapshot_keys[@]}"; do
+    printf "%s\t%s\n" "${key}" "$(prometheus_value "$(query_for_key "${key}")")"
+  done
+} >"${snapshot_tsv}"
+
+echo "${snapshot_tsv}"

--- a/tools/test/run-capacity-cloudwatch-credit-gp3-snapshot.sh
+++ b/tools/test/run-capacity-cloudwatch-credit-gp3-snapshot.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-capacity-cloudwatch-credit-gp3-snapshot.sh [--print-plan|--dry-run]
+
+Environment:
+  CAPACITY_CLOUDWATCH_NAME default capacity-cloudwatch-<timestamp>
+  CAPACITY_CLOUDWATCH_OUTPUT_DIR default build/reports/cloudwatch/<name>
+  CAPACITY_CLOUDWATCH_REGION default AWS_REGION
+  CAPACITY_CLOUDWATCH_START_TIME required ISO-8601 UTC
+  CAPACITY_CLOUDWATCH_END_TIME required ISO-8601 UTC
+  CAPACITY_CLOUDWATCH_PERIOD_SECONDS default 60
+  CAPACITY_CLOUDWATCH_EC2_INSTANCE_ID optional
+  CAPACITY_CLOUDWATCH_RDS_IDENTIFIER optional
+  CAPACITY_CLOUDWATCH_EBS_VOLUME_ID optional gp3 volume id
+
+Examples:
+  CAPACITY_CLOUDWATCH_START_TIME=2026-04-28T00:00:00Z \
+  CAPACITY_CLOUDWATCH_END_TIME=2026-04-28T00:30:00Z \
+    tools/test/run-capacity-cloudwatch-credit-gp3-snapshot.sh
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${CAPACITY_CLOUDWATCH_NAME:-capacity-cloudwatch-$(date +%Y-%m-%d-%H%M%S)}"
+output_dir="${CAPACITY_CLOUDWATCH_OUTPUT_DIR:-build/reports/cloudwatch/${name}}"
+region="${CAPACITY_CLOUDWATCH_REGION:-${AWS_REGION:-}}"
+start_time="${CAPACITY_CLOUDWATCH_START_TIME:-}"
+end_time="${CAPACITY_CLOUDWATCH_END_TIME:-}"
+period_seconds="${CAPACITY_CLOUDWATCH_PERIOD_SECONDS:-60}"
+ec2_instance_id="${CAPACITY_CLOUDWATCH_EC2_INSTANCE_ID:-}"
+rds_identifier="${CAPACITY_CLOUDWATCH_RDS_IDENTIFIER:-}"
+ebs_volume_id="${CAPACITY_CLOUDWATCH_EBS_VOLUME_ID:-}"
+snapshot_tsv="${output_dir}/${name}-cloudwatch-capacity-snapshot.tsv"
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_time() {
+  local name="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "${name} is required" >&2
+    exit 1
+  fi
+  if ! [[ "${value}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    echo "${name} must be UTC ISO-8601 such as 2026-04-28T00:00:00Z: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer "CAPACITY_CLOUDWATCH_PERIOD_SECONDS" "${period_seconds}"
+require_time "CAPACITY_CLOUDWATCH_START_TIME" "${start_time}"
+require_time "CAPACITY_CLOUDWATCH_END_TIME" "${end_time}"
+
+print_plan() {
+  echo "[capacity-cloudwatch] mode=${mode}"
+  echo "[capacity-cloudwatch] name=${name}"
+  echo "[capacity-cloudwatch] region=${region:-missing}"
+  echo "[capacity-cloudwatch] start_time=${start_time}"
+  echo "[capacity-cloudwatch] end_time=${end_time}"
+  echo "[capacity-cloudwatch] period_seconds=${period_seconds}"
+  echo "[capacity-cloudwatch] ec2_instance_id=${ec2_instance_id:-missing}"
+  echo "[capacity-cloudwatch] rds_identifier=${rds_identifier:-missing}"
+  echo "[capacity-cloudwatch] ebs_volume_id=${ebs_volume_id:-missing}"
+  echo "[capacity-cloudwatch] snapshot_tsv=${snapshot_tsv}"
+}
+
+emit_metric_plan() {
+  if [[ -n "${ec2_instance_id}" ]]; then
+    printf "AWS/EC2\tCPUCreditBalance\tInstanceId\t%s\tAverage,Maximum\n" "${ec2_instance_id}"
+    printf "AWS/EC2\tCPUCreditUsage\tInstanceId\t%s\tAverage,Maximum\n" "${ec2_instance_id}"
+    printf "AWS/EC2\tCPUUtilization\tInstanceId\t%s\tAverage,Maximum\n" "${ec2_instance_id}"
+  fi
+  if [[ -n "${rds_identifier}" ]]; then
+    printf "AWS/RDS\tCPUCreditBalance\tDBInstanceIdentifier\t%s\tAverage,Maximum\n" "${rds_identifier}"
+    printf "AWS/RDS\tFreeableMemory\tDBInstanceIdentifier\t%s\tAverage,Minimum\n" "${rds_identifier}"
+    printf "AWS/RDS\tReadIOPS\tDBInstanceIdentifier\t%s\tAverage,Maximum\n" "${rds_identifier}"
+    printf "AWS/RDS\tWriteIOPS\tDBInstanceIdentifier\t%s\tAverage,Maximum\n" "${rds_identifier}"
+    printf "AWS/RDS\tDiskQueueDepth\tDBInstanceIdentifier\t%s\tAverage,Maximum\n" "${rds_identifier}"
+  fi
+  if [[ -n "${ebs_volume_id}" ]]; then
+    printf "AWS/EBS\tVolumeReadOps\tVolumeId\t%s\tSum,Maximum\n" "${ebs_volume_id}"
+    printf "AWS/EBS\tVolumeWriteOps\tVolumeId\t%s\tSum,Maximum\n" "${ebs_volume_id}"
+    printf "AWS/EBS\tVolumeQueueLength\tVolumeId\t%s\tAverage,Maximum\n" "${ebs_volume_id}"
+  fi
+}
+
+cloudwatch_metric_value() {
+  local namespace="$1"
+  local metric="$2"
+  local dimension_name="$3"
+  local dimension_value="$4"
+  local statistic="$5"
+  aws cloudwatch get-metric-statistics \
+    --region "${region}" \
+    --namespace "${namespace}" \
+    --metric-name "${metric}" \
+    --dimensions "Name=${dimension_name},Value=${dimension_value}" \
+    --statistics "${statistic}" \
+    --start-time "${start_time}" \
+    --end-time "${end_time}" \
+    --period "${period_seconds}" \
+    | jq -r --arg statistic "${statistic}" '
+        [.Datapoints[]?[$statistic] // empty]
+        | if length == 0 then "n/a" else (add / length) end
+      '
+}
+
+write_metric_rows() {
+  mkdir -p "${output_dir}"
+  printf "namespace\tmetric\tdimension_name\tdimension_value\tstatistic\tvalue\n" >"${snapshot_tsv}"
+  while IFS=$'\t' read -r namespace metric dimension_name dimension_value statistics_csv; do
+    IFS=',' read -r -a statistics <<<"${statistics_csv}"
+    local statistic
+    for statistic in "${statistics[@]}"; do
+      printf "%s\t%s\t%s\t%s\t%s\t%s\n" \
+        "${namespace}" "${metric}" "${dimension_name}" "${dimension_value}" "${statistic}" \
+        "$(cloudwatch_metric_value "${namespace}" "${metric}" "${dimension_name}" "${dimension_value}" "${statistic}")" >>"${snapshot_tsv}"
+    done
+  done < <(emit_metric_plan)
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  emit_metric_plan
+  exit 0
+fi
+if [[ -z "${region}" ]]; then
+  echo "CAPACITY_CLOUDWATCH_REGION or AWS_REGION is required" >&2
+  exit 1
+fi
+if [[ -z "${ec2_instance_id}" && -z "${rds_identifier}" && -z "${ebs_volume_id}" ]]; then
+  echo "at least one CloudWatch dimension target is required" >&2
+  exit 1
+fi
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+write_metric_rows
+echo "${snapshot_tsv}"

--- a/tools/test/run-k6-transaction-100m-multi-scenario.sh
+++ b/tools/test/run-k6-transaction-100m-multi-scenario.sh
@@ -11,6 +11,9 @@ Environment:
   K6_MULTI_OUTPUT_DIR default build/reports/k6/<name>
   K6_MULTI_REUSE_BACKEND default true
   K6_MULTI_POST_FIRST_RECOVERY_NOISE_WINDOW_SECONDS default 0
+  K6_MULTI_RESOURCE_SAMPLING default true
+  K6_MULTI_RESOURCE_CONTAINERS default aquila-bank-backend-loadtest,aquila-bank-postgres,prometheus,postgres-exporter
+  K6_MULTI_RESOURCE_SAMPLE_INTERVAL_SECONDS default 2
   K6_MULTI_SCENARIOS comma list of name:mode:vus:duration:overload:burst_rate:preAllocated:max
 
 Default scenarios:
@@ -44,8 +47,12 @@ run_id="${K6_MULTI_RUN_ID:-${name}}"
 output_dir="${K6_MULTI_OUTPUT_DIR:-build/reports/k6/${name}}"
 reuse_backend="${K6_MULTI_REUSE_BACKEND:-true}"
 post_first_noise_window="${K6_MULTI_POST_FIRST_RECOVERY_NOISE_WINDOW_SECONDS:-0}"
+resource_sampling="${K6_MULTI_RESOURCE_SAMPLING:-true}"
+resource_containers="${K6_MULTI_RESOURCE_CONTAINERS:-aquila-bank-backend-loadtest,aquila-bank-postgres,prometheus,postgres-exporter}"
+resource_sample_interval_seconds="${K6_MULTI_RESOURCE_SAMPLE_INTERVAL_SECONDS:-2}"
 scenarios_csv="${K6_MULTI_SCENARIOS:-vu3:constant-vus:3:30s:false:16:3:3,vu16-overload:constant-vus:16:30s:true:16:16:16,burst-256:burst:16:20s:true:256:256:256}"
 execution_plan_tsv="${output_dir}/${name}-execution-plan.tsv"
+resource_summary_tsv="${output_dir}/${name}-peak-resource-summary.tsv"
 
 require_bool() {
   local name="$1"
@@ -134,7 +141,9 @@ validate_scenarios() {
 }
 
 require_bool "K6_MULTI_REUSE_BACKEND" "${reuse_backend}"
+require_bool "K6_MULTI_RESOURCE_SAMPLING" "${resource_sampling}"
 require_non_negative_integer "K6_MULTI_POST_FIRST_RECOVERY_NOISE_WINDOW_SECONDS" "${post_first_noise_window}"
+require_positive_integer "K6_MULTI_RESOURCE_SAMPLE_INTERVAL_SECONDS" "${resource_sample_interval_seconds}"
 validate_scenarios
 
 print_plan() {
@@ -144,9 +153,13 @@ print_plan() {
   echo "[k6-transaction-100m-multi] output_dir=${output_dir}"
   echo "[k6-transaction-100m-multi] reuse_backend=${reuse_backend}"
   echo "[k6-transaction-100m-multi] post_first_recovery_noise_window_seconds=${post_first_noise_window}"
+  echo "[k6-transaction-100m-multi] resource_sampling=${resource_sampling}"
+  echo "[k6-transaction-100m-multi] resource_containers=${resource_containers}"
+  echo "[k6-transaction-100m-multi] resource_sample_interval_seconds=${resource_sample_interval_seconds}"
   echo "[k6-transaction-100m-multi] scenario_count=$(scenario_count)"
   echo "[k6-transaction-100m-multi] scenarios=${scenarios_csv}"
   echo "[k6-transaction-100m-multi] execution_plan=${execution_plan_tsv}"
+  echo "[k6-transaction-100m-multi] resource_summary=${resource_summary_tsv}"
 }
 
 runner_args_for_order() {
@@ -183,40 +196,155 @@ write_execution_plan() {
   done
 }
 
+memory_to_mib_awk='
+function to_mib(value) {
+  gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+  value = tolower(value)
+  gsub(/,/, ".", value)
+  gsub(/[[:space:]]+/, "", value)
+  if (value ~ /gib$/) { sub(/gib$/, "", value); return value * 1024 }
+  if (value ~ /gb$/) { sub(/gb$/, "", value); return value * 1024 }
+  if (value ~ /mib$/) { sub(/mib$/, "", value); return value + 0 }
+  if (value ~ /mb$/) { sub(/mb$/, "", value); return value + 0 }
+  if (value ~ /kib$/) { sub(/kib$/, "", value); return value / 1024 }
+  if (value ~ /kb$/) { sub(/kb$/, "", value); return value / 1024 }
+  if (value ~ /b$/) { sub(/b$/, "", value); return value / 1048576 }
+  return value + 0
+}'
+
+write_peak_resource_summary_header() {
+  mkdir -p "${output_dir}"
+  printf "scenario\tcontainer\tpeak_cpu_percent\tpeak_memory_mib\tsamples\n" >"${resource_summary_tsv}"
+}
+
+start_peak_resource_sampler() {
+  local scenario_name="$1"
+  local stats_path="$2"
+  local marker_path="$3"
+  IFS=',' read -r -a containers <<<"${resource_containers}"
+  : >"${stats_path}"
+  touch "${marker_path}"
+  (
+    printf "timestamp\tscenario\tcontainer\tcpu_percent\tmemory_usage\tmemory_limit\n" >>"${stats_path}"
+    while [[ -f "${marker_path}" ]]; do
+      local line container cpu memory memory_usage memory_limit
+      for container in "${containers[@]}"; do
+        if line="$(docker stats --no-stream --format '{{.Name}}	{{.CPUPerc}}	{{.MemUsage}}' "${container}" 2>/dev/null)"; then
+          cpu="$(awk -F '\t' '{print $2}' <<<"${line}")"
+          memory="$(awk -F '\t' '{print $3}' <<<"${line}")"
+          memory_usage="${memory%% / *}"
+          memory_limit="${memory##* / }"
+          printf "%s\t%s\t%s\t%s\t%s\t%s\n" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${scenario_name}" "${container}" \
+            "${cpu}" "${memory_usage}" "${memory_limit}" >>"${stats_path}"
+        fi
+      done
+      sleep "${resource_sample_interval_seconds}"
+    done
+  ) &
+  echo "$!"
+}
+
+stop_peak_resource_sampler() {
+  local marker_path="$1"
+  local sampler_pid="$2"
+  rm -f "${marker_path}"
+  if [[ -n "${sampler_pid}" ]]; then
+    wait "${sampler_pid}" 2>/dev/null || true
+  fi
+}
+
+write_peak_resource_summary() {
+  local scenario_name="$1"
+  local stats_path="$2"
+  if [[ ! -s "${stats_path}" ]]; then
+    return 0
+  fi
+  awk -F '\t' "${memory_to_mib_awk}"'
+    NR > 1 {
+      cpu = $4
+      gsub(/%$/, "", cpu)
+      memory = to_mib($5)
+      key = $2 "\t" $3
+      samples[key] += 1
+      if (!(key in peak_cpu) || cpu > peak_cpu[key]) peak_cpu[key] = cpu
+      if (!(key in peak_memory) || memory > peak_memory[key]) peak_memory[key] = memory
+    }
+    END {
+      for (key in samples) {
+        split(key, parts, "\t")
+        printf "%s\t%s\t%.2f\t%.2f\t%d\n", parts[1], parts[2], peak_cpu[key] + 0, peak_memory[key] + 0, samples[key]
+      }
+    }
+  ' "${stats_path}" >>"${resource_summary_tsv}"
+}
+
+run_one_scenario() {
+  local order="$1"
+  local scenario_name="$2"
+  local scenario_mode="$3"
+  local vus="$4"
+  local duration="$5"
+  local overload="$6"
+  local burst_rate="$7"
+  local pre_allocated="$8"
+  local max_vus="$9"
+  local report_name="${name}-${scenario_name}"
+  local runner_args
+  runner_args="$(runner_args_for_order "${order}")"
+  if [[ "${runner_args}" == "default" ]]; then
+    K6_REPORT_NAME="${report_name}" \
+    K6_RUN_ID="${run_id}" \
+    K6_SCENARIO_MODE="${scenario_mode}" \
+    K6_VUS="${vus}" \
+    K6_DURATION="${duration}" \
+    K6_OVERLOAD_MODE="${overload}" \
+    K6_BURST_RATE="${burst_rate}" \
+    K6_BURST_DURATION="${duration}" \
+    K6_PRE_ALLOCATED_VUS="${pre_allocated}" \
+    K6_MAX_VUS="${max_vus}" \
+      tools/test/run-k6-transaction-100m-loadtest.sh
+  else
+    K6_REPORT_NAME="${report_name}" \
+    K6_RUN_ID="${run_id}" \
+    K6_SCENARIO_MODE="${scenario_mode}" \
+    K6_VUS="${vus}" \
+    K6_DURATION="${duration}" \
+    K6_OVERLOAD_MODE="${overload}" \
+    K6_BURST_RATE="${burst_rate}" \
+    K6_BURST_DURATION="${duration}" \
+    K6_PRE_ALLOCATED_VUS="${pre_allocated}" \
+    K6_MAX_VUS="${max_vus}" \
+    K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS="${post_first_noise_window}" \
+      tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps
+  fi
+}
+
 run_scenarios() {
   IFS=',' read -r -a scenarios <<<"${scenarios_csv}"
   local order=1
-  local scenario scenario_name scenario_mode vus duration overload burst_rate pre_allocated max_vus report_name runner_args
+  local scenario scenario_name scenario_mode vus duration overload burst_rate pre_allocated max_vus runner_args
+  write_peak_resource_summary_header
   for scenario in "${scenarios[@]}"; do
     IFS=':' read -r scenario_name scenario_mode vus duration overload burst_rate pre_allocated max_vus <<<"${scenario}"
-    report_name="${name}-${scenario_name}"
     runner_args="$(runner_args_for_order "${order}")"
     echo "[k6-transaction-100m-multi] running order=${order} scenario=${scenario_name} runner_args=${runner_args}"
-    if [[ "${runner_args}" == "default" ]]; then
-      K6_REPORT_NAME="${report_name}" \
-      K6_RUN_ID="${run_id}" \
-      K6_SCENARIO_MODE="${scenario_mode}" \
-      K6_VUS="${vus}" \
-      K6_DURATION="${duration}" \
-      K6_OVERLOAD_MODE="${overload}" \
-      K6_BURST_RATE="${burst_rate}" \
-      K6_BURST_DURATION="${duration}" \
-      K6_PRE_ALLOCATED_VUS="${pre_allocated}" \
-      K6_MAX_VUS="${max_vus}" \
-        tools/test/run-k6-transaction-100m-loadtest.sh
-    else
-      K6_REPORT_NAME="${report_name}" \
-      K6_RUN_ID="${run_id}" \
-      K6_SCENARIO_MODE="${scenario_mode}" \
-      K6_VUS="${vus}" \
-      K6_DURATION="${duration}" \
-      K6_OVERLOAD_MODE="${overload}" \
-      K6_BURST_RATE="${burst_rate}" \
-      K6_BURST_DURATION="${duration}" \
-      K6_PRE_ALLOCATED_VUS="${pre_allocated}" \
-      K6_MAX_VUS="${max_vus}" \
-      K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS="${post_first_noise_window}" \
-        tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps
+    local stats_path="${output_dir}/${name}-${scenario_name}-resource-stats.tsv"
+    local marker_path="${output_dir}/${name}-${scenario_name}-resource-sampler.marker"
+    local sampler_pid=""
+    if [[ "${resource_sampling}" == "true" ]]; then
+      sampler_pid="$(start_peak_resource_sampler "${scenario_name}" "${stats_path}" "${marker_path}")"
+    fi
+    set +e
+    run_one_scenario "${order}" "${scenario_name}" "${scenario_mode}" "${vus}" "${duration}" "${overload}" "${burst_rate}" "${pre_allocated}" "${max_vus}"
+    local status=$?
+    set -e
+    if [[ "${resource_sampling}" == "true" ]]; then
+      stop_peak_resource_sampler "${marker_path}" "${sampler_pid}"
+      write_peak_resource_summary "${scenario_name}" "${stats_path}"
+    fi
+    if [[ "${status}" -ne 0 ]]; then
+      exit "${status}"
     fi
     order=$((order + 1))
   done
@@ -224,6 +352,7 @@ run_scenarios() {
 
 print_plan
 write_execution_plan
+write_peak_resource_summary_header
 if [[ "${mode}" == "print-plan" ]]; then
   exit 0
 fi

--- a/tools/test/run-transaction-100m-burst-307-capacity-probe.sh
+++ b/tools/test/run-transaction-100m-burst-307-capacity-probe.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-100m-burst-307-capacity-probe.sh [--print-plan|--dry-run]
+
+Environment:
+  BURST_307_PROBE_NAME default transaction-100m-burst-307-<timestamp>
+  BURST_307_PROBE_RATE default 307
+  BURST_307_PROBE_DURATION default 20s
+  BURST_307_PROBE_VUS default BURST_307_PROBE_RATE
+  BURST_307_PROBE_OVERLOAD_MODE default true
+  BURST_307_PROBE_RUN_PURPOSE default profile
+
+Examples:
+  tools/test/run-transaction-100m-burst-307-capacity-probe.sh --print-plan
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    --dry-run)
+      mode="dry-run"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${BURST_307_PROBE_NAME:-transaction-100m-burst-307-$(date +%Y-%m-%d-%H%M%S)}"
+rate="${BURST_307_PROBE_RATE:-307}"
+duration="${BURST_307_PROBE_DURATION:-20s}"
+vus="${BURST_307_PROBE_VUS:-${rate}}"
+overload_mode="${BURST_307_PROBE_OVERLOAD_MODE:-true}"
+run_purpose="${BURST_307_PROBE_RUN_PURPOSE:-profile}"
+k6_report_name="${name}-burst-307"
+archive_output_dir="docs/performance-results/k6-${run_purpose}"
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_duration() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*(s|m|h)$ ]]; then
+    echo "${name} must use a positive duration such as 20s: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_bool() {
+  local name="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${name} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer "BURST_307_PROBE_RATE" "${rate}"
+require_positive_integer "BURST_307_PROBE_VUS" "${vus}"
+require_duration "BURST_307_PROBE_DURATION" "${duration}"
+require_bool "BURST_307_PROBE_OVERLOAD_MODE" "${overload_mode}"
+
+print_plan() {
+  echo "[transaction-100m-burst-307] mode=${mode}"
+  echo "[transaction-100m-burst-307] name=${name}"
+  echo "[transaction-100m-burst-307] rate=${rate}"
+  echo "[transaction-100m-burst-307] duration=${duration}"
+  echo "[transaction-100m-burst-307] vus=${vus}"
+  echo "[transaction-100m-burst-307] overload_mode=${overload_mode}"
+  echo "[transaction-100m-burst-307] run_purpose=${run_purpose}"
+  echo "[transaction-100m-burst-307] k6_report_name=${k6_report_name}"
+  echo "[transaction-100m-burst-307] archive_output_dir=${archive_output_dir}"
+}
+
+print_command() {
+  echo "K6_REPORT_NAME=${k6_report_name} K6_RUN_PURPOSE=${run_purpose} K6_SCENARIO_MODE=burst K6_BURST_RATE=${rate} K6_BURST_DURATION=${duration} K6_PRE_ALLOCATED_VUS=${vus} K6_MAX_VUS=${vus} K6_OVERLOAD_MODE=${overload_mode} tools/test/run-k6-transaction-100m-loadtest.sh"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "dry-run" ]]; then
+  print_command
+  exit 0
+fi
+
+K6_REPORT_NAME="${k6_report_name}" \
+K6_RUN_PURPOSE="${run_purpose}" \
+K6_SCENARIO_MODE=burst \
+K6_BURST_RATE="${rate}" \
+K6_BURST_DURATION="${duration}" \
+K6_PRE_ALLOCATED_VUS="${vus}" \
+K6_MAX_VUS="${vus}" \
+K6_OVERLOAD_MODE="${overload_mode}" \
+  tools/test/run-k6-transaction-100m-loadtest.sh


### PR DESCRIPTION
## 🔗 Related Issue
- close #505

## 🌿 Base Branch
- `main`

## 📝 Summary
- 256/s 이후 120% 목표선인 307/s burst probe runner를 추가합니다.
- first-window Prometheus snapshot, multi-scenario peak resource sampling, CloudWatch CPU credit/gp3 IO snapshot collector를 추가해 capacity evidence 자동화를 보강합니다.

## 🛠 Changes
- `run-transaction-100m-burst-307-capacity-probe.sh` 추가
- `run-burst-first-window-prometheus-snapshot.sh` 추가
- `run-k6-transaction-100m-multi-scenario.sh`에 peak CPU/memory resource summary TSV 통합
- `run-capacity-cloudwatch-credit-gp3-snapshot.sh` 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-transaction-100m-burst-307-capacity-probe.sh`
- `tools/test/check-burst-first-window-prometheus-snapshot.sh`
- `tools/test/check-k6-transaction-100m-multi-scenario.sh`
- `tools/test/check-capacity-cloudwatch-credit-gp3-snapshot.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 실제 Prometheus/AWS metric 이름이 배포 환경과 다르면 snapshot 값이 `n/a`로 남을 수 있습니다. runner는 dry-run으로 query/metric plan을 노출합니다.
- 롤백 방법: 이 PR revert.
- 실환경 메모: 현재 로컬에는 off-host Docker context, staging RDS env, AWS target ids가 없어 실제 off-host/staging/CloudWatch evidence 수치는 실행하지 못했습니다. 이 PR은 collector/runner 계약을 닫습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
