### PR TITLE
[Chore] OCI Always Free A1 Flex Terraform 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,13 @@ docs/superpowers/plans/
 .aider*
 .windsurf/
 .ai/
+
+# Terraform local state
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+*.tfplan
+crash.log
+crash.*.log

--- a/docs/superpowers/specs/2026-04-28-oci-always-free-a1-flex-design.md
+++ b/docs/superpowers/specs/2026-04-28-oci-always-free-a1-flex-design.md
@@ -1,0 +1,50 @@
+# OCI Always Free A1 Flex Terraform Design
+
+## Goal
+- OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 단일 인스턴스를 Terraform으로 생성한다.
+- 목표 스펙은 4 OCPU, 24GB RAM, Boot Volume 150GB이다.
+
+## Selected Approach
+- 새 OCI VCN을 만들고, public subnet에 A1 Flex VM 1대를 배치한다.
+- Internet Gateway와 route table은 public SSH 접속에 필요한 최소 구성만 둔다.
+- Security List ingress는 SSH 22번만 허용하고, 허용 CIDR은 변수로 받는다.
+- NAT Gateway, Load Balancer, Database, 추가 Block Volume은 만들지 않는다.
+
+## Free Tier Boundary
+- Oracle 공식 Always Free 문서 기준 A1 Flex는 월 3,000 OCPU hours / 18,000 GB hours이며 Always Free 전용 계정에서는 4 OCPU / 24GB RAM에 해당한다.
+- Oracle 공식 Always Free 문서 기준 Block Volume은 홈 리전에서 boot volume과 block volume 합산 200GB이다.
+- 이번 구성은 Boot Volume 150GB만 생성하므로, 기존 OCI boot/block volume 합산 사용량이 50GB 이하일 때 무료 한도 안에 머문다.
+- Always Free volume은 홈 리전 전제가 중요하므로 `region`은 tenancy 홈 리전으로 설정해야 한다.
+
+## Terraform Structure
+- 경로: `infra/terraform/oci/always-free-a1-flex`
+- Provider: `oracle/oci`
+- 주요 파일:
+  - `versions.tf`: Terraform/provider 버전 제약
+  - `providers.tf`: OCI provider 인증 변수 연결
+  - `variables.tf`: OCID, region, SSH key, CIDR, 무료 한도 guardrail 변수
+  - `locals.tf`: shape, size, 공통 tag
+  - `network.tf`: VCN, Internet Gateway, Route Table, Security List, Subnet
+  - `compute.tf`: A1 Flex instance
+  - `outputs.tf`: instance, VCN, public IP 출력
+  - `terraform.tfvars.example`: 실값 없는 예시
+  - `README.md`: 실행 순서와 과금 방지 주의사항
+
+## Inputs
+- `tenancy_ocid`, `user_ocid`, `fingerprint`, `private_key_path`, `region`
+- `compartment_ocid`, `availability_domain`, `source_image_ocid`
+- `ssh_public_key`
+- `ssh_ingress_cidr`
+- `vcn_cidr`, `subnet_cidr`
+
+## Error And Risk Handling
+- A1 host capacity 부족은 Terraform 코드로 해결할 수 없으므로 apply 실패 시 availability domain 변경 또는 재시도 안내로 처리한다.
+- 이미지 OCID는 리전별로 다르므로 자동 추정하지 않고 사용자가 Always Free eligible Arm image OCID를 명시한다.
+- `ssh_ingress_cidr` 기본 예시는 넓게 열 수 있지만 README에서 운영자 IP `/32` 사용을 우선 안내한다.
+- Terraform state와 tfvars에는 민감 정보가 포함될 수 있으므로 `.gitignore`에 state/tfvars/plan 파일을 제외한다.
+
+## Validation
+- `terraform fmt -check`
+- `terraform init -backend=false`
+- `terraform validate`
+- 실제 `apply`는 OCI 계정/홈 리전/용량/이미지 OCID가 필요하므로 로컬 자동 검증 범위에서 제외한다.

--- a/infra/terraform/oci/always-free-a1-flex/.terraform.lock.hcl
+++ b/infra/terraform/oci/always-free-a1-flex/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/oracle/oci" {
+  version     = "8.10.0"
+  constraints = "~> 8.8"
+  hashes = [
+    "h1:ZF86BRM782SNsPwsiTOT1abNU6hnfb7q7KUWZFEko3g=",
+    "zh:0b22770a902ddd4d8cae218b046eba9e85fcda36a7ab2832a127af996d970ae6",
+    "zh:123272ea9a7b153c38390bd073bc347f2d657677349792f2e00071834d1d86fc",
+    "zh:1beda414966276fb2f24b22197f24fbb8aeb6eb44a4f2f8c5c18d7c1f31de1e8",
+    "zh:202d68bbd9d647943e241cf2c44f5220b21e1a80bb01befd0a83939f74cf3c8c",
+    "zh:2abb50a1a8ca46fdd8d9d6587284082ce4a5cfbb6dfb512fc735f6fa47cf0218",
+    "zh:3f0cc8ed8b0d46f9ac05e46fdf51e3e90253471e341987b38134ce5408ba2f9c",
+    "zh:3f1899e734b930eda94703f864f2fe7d2d08f36bcb481ea116c5173ad307f8fb",
+    "zh:59461f5620ef014ccf8a5b198c982e72fcee17d53ca3830f65c213d47351ee73",
+    "zh:65127b97c1d9cd0e95314e4f7a9375942396d9064e9e140a114f0ab249755c0e",
+    "zh:76904784b1b98759a9e74b6d790fe79a9a27f23e2d3a4363f4c39c08b8c43a01",
+    "zh:92f4d893670ee15850f42b3e9fac43c77c643aa666d705c19733ff3f15569c77",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a41a1077d3971eed0c83efb7629d06ba6b463fa209661aa7c751520203143957",
+    "zh:b81108061cf16b14ec368c609a6a8e10fd399c0838e792502694c6cdd43c2fa6",
+    "zh:df68e34805a354d85c6244671ff3354caf298eb1d5ca71942c23f23ba09bf504",
+  ]
+}

--- a/infra/terraform/oci/always-free-a1-flex/README.md
+++ b/infra/terraform/oci/always-free-a1-flex/README.md
@@ -1,0 +1,65 @@
+# OCI Always Free A1 Flex Terraform
+
+OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만든다.
+
+## 구성
+
+- Compute: `VM.Standard.A1.Flex`
+- OCPU: `4`
+- Memory: `24GB`
+- Boot Volume: `150GB`
+- Network: 새 VCN, public subnet, Internet Gateway, Route Table
+- Ingress: SSH `22/tcp`만 허용
+- 제외: NAT Gateway, Load Balancer, Database, 추가 Block Volume
+
+## 무료 한도 조건
+
+- A1 Flex Always Free 한도는 총 4 OCPU / 24GB RAM 범위다.
+- Block Volume Always Free 한도는 홈 리전의 boot volume과 block volume 합산 200GB다.
+- 이 스택은 Boot Volume 150GB를 생성한다. 기존 OCI boot/block volume 합산 사용량이 50GB를 넘으면 무료 한도 초과 가능성이 있다.
+- `region`은 tenancy 홈 리전으로 설정한다. 홈 리전 밖 volume은 무료 한도 적용에서 벗어날 수 있다.
+- `source_image_ocid`는 선택한 리전의 Always Free eligible Arm image OCID를 사용한다.
+
+## 준비 값
+
+- `tenancy_ocid`
+- `user_ocid`
+- `fingerprint`
+- `private_key_path`
+- `region`
+- `compartment_ocid`
+- `availability_domain`
+- `source_image_ocid`
+- `ssh_public_key`
+- `ssh_ingress_cidr`
+
+`ssh_ingress_cidr`는 운영자 현재 공인 IP의 `/32`를 우선 사용한다. `0.0.0.0/0`은 임시 테스트가 아니면 사용하지 않는다.
+
+## 실행
+
+```bash
+cd infra/terraform/oci/always-free-a1-flex
+cp terraform.tfvars.example terraform.tfvars
+```
+
+`terraform.tfvars`에 실제 값을 입력한다. 이 파일은 git에 커밋하지 않는다.
+
+```bash
+terraform init
+terraform fmt -check
+terraform validate
+terraform plan
+terraform apply
+```
+
+## 삭제
+
+```bash
+terraform destroy
+```
+
+`preserve_boot_volume = false`이므로 destroy 시 boot volume도 함께 제거된다. 수동으로 만든 volume backup이나 추가 volume은 별도로 확인한다.
+
+## 용량 부족 대응
+
+OCI A1 Always Free는 리전/AD별 capacity 부족으로 생성이 실패할 수 있다. 이 경우 `availability_domain`을 같은 홈 리전의 다른 AD로 바꾸거나, 시간을 두고 다시 `terraform apply`를 실행한다.

--- a/infra/terraform/oci/always-free-a1-flex/compute.tf
+++ b/infra/terraform/oci/always-free-a1-flex/compute.tf
@@ -1,0 +1,34 @@
+resource "oci_core_instance" "this" {
+  availability_domain  = var.availability_domain
+  compartment_id       = var.compartment_ocid
+  display_name         = var.name_prefix
+  freeform_tags        = local.common_tags
+  preserve_boot_volume = false
+  shape                = local.instance_shape
+
+  create_vnic_details {
+    assign_public_ip = true
+    display_name     = "${var.name_prefix}-primary-vnic"
+    hostname_label   = var.hostname_label
+    subnet_id        = oci_core_subnet.public.id
+  }
+
+  instance_options {
+    are_legacy_imds_endpoints_disabled = true
+  }
+
+  metadata = {
+    ssh_authorized_keys = trimspace(var.ssh_public_key)
+  }
+
+  shape_config {
+    memory_in_gbs = var.instance_memory_in_gbs
+    ocpus         = var.instance_ocpus
+  }
+
+  source_details {
+    boot_volume_size_in_gbs = var.boot_volume_size_in_gbs
+    source_id               = var.source_image_ocid
+    source_type             = "image"
+  }
+}

--- a/infra/terraform/oci/always-free-a1-flex/locals.tf
+++ b/infra/terraform/oci/always-free-a1-flex/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  instance_shape = "VM.Standard.A1.Flex"
+
+  common_tags = merge(
+    {
+      CostBoundary = "oci-always-free"
+      ManagedBy    = "terraform"
+      Project      = "aquila-bank"
+    },
+    var.freeform_tags
+  )
+}

--- a/infra/terraform/oci/always-free-a1-flex/network.tf
+++ b/infra/terraform/oci/always-free-a1-flex/network.tf
@@ -1,0 +1,67 @@
+resource "oci_core_vcn" "this" {
+  compartment_id = var.compartment_ocid
+  cidr_blocks    = [var.vcn_cidr]
+  display_name   = "${var.name_prefix}-vcn"
+  dns_label      = var.vcn_dns_label
+  freeform_tags  = local.common_tags
+}
+
+resource "oci_core_internet_gateway" "this" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name_prefix}-igw"
+  enabled        = true
+  freeform_tags  = local.common_tags
+  vcn_id         = oci_core_vcn.this.id
+}
+
+resource "oci_core_route_table" "public" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name_prefix}-public-rt"
+  freeform_tags  = local.common_tags
+  vcn_id         = oci_core_vcn.this.id
+
+  route_rules {
+    description       = "Public subnet outbound route"
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.this.id
+  }
+}
+
+resource "oci_core_security_list" "public_ssh" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name_prefix}-public-ssh-sl"
+  freeform_tags  = local.common_tags
+  vcn_id         = oci_core_vcn.this.id
+
+  egress_security_rules {
+    description      = "Allow outbound traffic from the instance"
+    destination      = "0.0.0.0/0"
+    destination_type = "CIDR_BLOCK"
+    protocol         = "all"
+  }
+
+  ingress_security_rules {
+    description = "SSH ingress only from operator CIDR"
+    protocol    = "6"
+    source      = var.ssh_ingress_cidr
+    source_type = "CIDR_BLOCK"
+
+    tcp_options {
+      max = 22
+      min = 22
+    }
+  }
+}
+
+resource "oci_core_subnet" "public" {
+  cidr_block                 = var.subnet_cidr
+  compartment_id             = var.compartment_ocid
+  display_name               = "${var.name_prefix}-public-subnet"
+  dns_label                  = var.subnet_dns_label
+  freeform_tags              = local.common_tags
+  prohibit_public_ip_on_vnic = false
+  route_table_id             = oci_core_route_table.public.id
+  security_list_ids          = [oci_core_security_list.public_ssh.id]
+  vcn_id                     = oci_core_vcn.this.id
+}

--- a/infra/terraform/oci/always-free-a1-flex/outputs.tf
+++ b/infra/terraform/oci/always-free-a1-flex/outputs.tf
@@ -1,0 +1,24 @@
+output "instance_id" {
+  description = "Created OCI compute instance OCID."
+  value       = oci_core_instance.this.id
+}
+
+output "instance_public_ip" {
+  description = "Public IPv4 address assigned to the instance VNIC."
+  value       = oci_core_instance.this.public_ip
+}
+
+output "instance_private_ip" {
+  description = "Private IPv4 address assigned to the instance VNIC."
+  value       = oci_core_instance.this.private_ip
+}
+
+output "vcn_id" {
+  description = "Created VCN OCID."
+  value       = oci_core_vcn.this.id
+}
+
+output "subnet_id" {
+  description = "Created public subnet OCID."
+  value       = oci_core_subnet.public.id
+}

--- a/infra/terraform/oci/always-free-a1-flex/providers.tf
+++ b/infra/terraform/oci/always-free-a1-flex/providers.tf
@@ -1,0 +1,7 @@
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+  region           = var.region
+}

--- a/infra/terraform/oci/always-free-a1-flex/terraform.tfvars.example
+++ b/infra/terraform/oci/always-free-a1-flex/terraform.tfvars.example
@@ -1,0 +1,24 @@
+tenancy_ocid     = "ocid1.tenancy.oc1..example"
+user_ocid        = "ocid1.user.oc1..example"
+fingerprint      = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+private_key_path = "~/.oci/oci_api_key.pem"
+region           = "ap-seoul-1"
+
+compartment_ocid    = "ocid1.compartment.oc1..example"
+availability_domain = "example:AP-SEOUL-1-AD-1"
+source_image_ocid   = "ocid1.image.oc1.ap-seoul-1.example"
+
+ssh_public_key   = "ssh-ed25519 example-public-key"
+ssh_ingress_cidr = "203.0.113.10/32"
+
+name_prefix    = "aquila-free-a1"
+hostname_label = "aquilafreea1"
+vcn_dns_label  = "aquilavcn"
+subnet_dns_label = "public"
+
+vcn_cidr    = "10.40.0.0/16"
+subnet_cidr = "10.40.1.0/24"
+
+instance_ocpus         = 4
+instance_memory_in_gbs = 24
+boot_volume_size_in_gbs = 150

--- a/infra/terraform/oci/always-free-a1-flex/variables.tf
+++ b/infra/terraform/oci/always-free-a1-flex/variables.tf
@@ -1,0 +1,227 @@
+variable "tenancy_ocid" {
+  description = "OCI tenancy OCID."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^ocid1\\.tenancy\\.", var.tenancy_ocid))
+    error_message = "tenancy_ocid must start with ocid1.tenancy."
+  }
+}
+
+variable "user_ocid" {
+  description = "OCI user OCID for API key authentication."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^ocid1\\.user\\.", var.user_ocid))
+    error_message = "user_ocid must start with ocid1.user."
+  }
+}
+
+variable "fingerprint" {
+  description = "OCI API key fingerprint."
+  type        = string
+  nullable    = false
+  sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.fingerprint)) > 0
+    error_message = "fingerprint must not be empty."
+  }
+}
+
+variable "private_key_path" {
+  description = "Local path to the OCI API private key. Do not commit the key."
+  type        = string
+  nullable    = false
+  sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.private_key_path)) > 0
+    error_message = "private_key_path must not be empty."
+  }
+}
+
+variable "region" {
+  description = "OCI home region for Always Free block volume eligibility."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[a-z]+-[a-z]+-[0-9]+$", var.region))
+    error_message = "region must look like ap-seoul-1 or us-ashburn-1."
+  }
+}
+
+variable "compartment_ocid" {
+  description = "Compartment OCID where the free-tier resources will be created."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^ocid1\\.compartment\\.", var.compartment_ocid)) || can(regex("^ocid1\\.tenancy\\.", var.compartment_ocid))
+    error_message = "compartment_ocid must start with ocid1.compartment or ocid1.tenancy."
+  }
+}
+
+variable "availability_domain" {
+  description = "Availability domain name for the A1 Flex instance, for example Uocm:AP-SEOUL-1-AD-1."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(trimspace(var.availability_domain)) > 0
+    error_message = "availability_domain must not be empty."
+  }
+}
+
+variable "source_image_ocid" {
+  description = "Always Free eligible Arm image OCID for the selected region."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^ocid1\\.image\\.", var.source_image_ocid))
+    error_message = "source_image_ocid must start with ocid1.image."
+  }
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key installed into the instance metadata."
+  type        = string
+  nullable    = false
+  sensitive   = true
+
+  validation {
+    condition     = can(regex("^(ssh-rsa|ssh-ed25519|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521) ", trimspace(var.ssh_public_key)))
+    error_message = "ssh_public_key must be a valid OpenSSH public key."
+  }
+}
+
+variable "ssh_ingress_cidr" {
+  description = "CIDR allowed to connect to SSH port 22. Prefer a single operator IP /32."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.ssh_ingress_cidr))
+    error_message = "ssh_ingress_cidr must be a valid IPv4 CIDR."
+  }
+}
+
+variable "name_prefix" {
+  description = "Name prefix for OCI resources."
+  type        = string
+  default     = "aquila-free-a1"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,30}[a-z0-9]$", var.name_prefix))
+    error_message = "name_prefix must be lowercase kebab-case, 3-32 characters."
+  }
+}
+
+variable "hostname_label" {
+  description = "DNS hostname label for the primary VNIC."
+  type        = string
+  default     = "aquilafreea1"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9]{1,13}[a-z0-9]$", var.hostname_label))
+    error_message = "hostname_label must be 3-15 lowercase alphanumeric characters."
+  }
+}
+
+variable "vcn_dns_label" {
+  description = "DNS label for the VCN."
+  type        = string
+  default     = "aquilavcn"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9]{1,13}[a-z0-9]$", var.vcn_dns_label))
+    error_message = "vcn_dns_label must be 3-15 lowercase alphanumeric characters."
+  }
+}
+
+variable "subnet_dns_label" {
+  description = "DNS label for the public subnet."
+  type        = string
+  default     = "public"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9]{1,13}[a-z0-9]$", var.subnet_dns_label))
+    error_message = "subnet_dns_label must be 3-15 lowercase alphanumeric characters."
+  }
+}
+
+variable "vcn_cidr" {
+  description = "IPv4 CIDR for the dedicated VCN."
+  type        = string
+  default     = "10.40.0.0/16"
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.vcn_cidr))
+    error_message = "vcn_cidr must be a valid IPv4 CIDR."
+  }
+}
+
+variable "subnet_cidr" {
+  description = "IPv4 CIDR for the public subnet."
+  type        = string
+  default     = "10.40.1.0/24"
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.subnet_cidr))
+    error_message = "subnet_cidr must be a valid IPv4 CIDR."
+  }
+}
+
+variable "instance_ocpus" {
+  description = "OCPU count for VM.Standard.A1.Flex. Always Free upper bound is 4."
+  type        = number
+  default     = 4
+  nullable    = false
+
+  validation {
+    condition     = var.instance_ocpus > 0 && var.instance_ocpus <= 4
+    error_message = "instance_ocpus must be greater than 0 and no more than 4 for Always Free."
+  }
+}
+
+variable "instance_memory_in_gbs" {
+  description = "Memory in GB for VM.Standard.A1.Flex. Always Free upper bound is 24."
+  type        = number
+  default     = 24
+  nullable    = false
+
+  validation {
+    condition     = var.instance_memory_in_gbs > 0 && var.instance_memory_in_gbs <= 24
+    error_message = "instance_memory_in_gbs must be greater than 0 and no more than 24 for Always Free."
+  }
+}
+
+variable "boot_volume_size_in_gbs" {
+  description = "Boot volume size in GB. This stack caps it at the requested 150GB."
+  type        = number
+  default     = 150
+  nullable    = false
+
+  validation {
+    condition     = var.boot_volume_size_in_gbs >= 50 && var.boot_volume_size_in_gbs <= 150
+    error_message = "boot_volume_size_in_gbs must be between 50 and 150."
+  }
+}
+
+variable "freeform_tags" {
+  description = "Additional free-form tags for created OCI resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/infra/terraform/oci/always-free-a1-flex/versions.tf
+++ b/infra/terraform/oci/always-free-a1-flex/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 8.8"
+    }
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #507

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI Always Free 한도 안에서 A1 Flex 4 OCPU / 24GB RAM / Boot Volume 150GB 인스턴스를 만들 수 있는 Terraform 스택을 추가했다.
- 기존 AWS/t3.micro 운영 경로와 분리된 `infra/terraform/oci/always-free-a1-flex` 독립 스택으로 구성했다.

## 🛠 Changes
- OCI provider 기반 Terraform root module 추가
- 새 VCN, public subnet, Internet Gateway, Route Table, SSH-only Security List 추가
- `VM.Standard.A1.Flex` instance, 4 OCPU, 24GB RAM, Boot Volume 150GB 설정 추가
- Terraform state/tfvars/plan 로컬 산출물 git ignore 추가
- Always Free 한도, 홈 리전 조건, SSH CIDR 주의사항 문서화

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex fmt -check`
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex init -backend=false`
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex validate`
- `git rev-list --count main..HEAD` → `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - OCI 홈 리전 밖에서 적용하거나 기존 boot/block volume 사용량이 50GB를 초과하면 150GB boot volume 생성 시 Always Free 200GB 합산 한도를 넘을 수 있다.
  - A1 Flex capacity 부족 시 `terraform apply`가 실패할 수 있다.
  - `ssh_ingress_cidr`를 넓게 열면 SSH 공격면이 커진다.
- 롤백 방법:
  - 아직 apply 전이면 PR revert만으로 종료한다.
  - apply 후에는 `terraform -chdir=infra/terraform/oci/always-free-a1-flex destroy`로 생성 리소스를 제거한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?