### PR TITLE
[Chore] OCI Terraform Ubuntu 이미지 자동 조회 전환

### DIFF
--- a/docs/superpowers/specs/2026-04-28-oci-always-free-a1-flex-design.md
+++ b/docs/superpowers/specs/2026-04-28-oci-always-free-a1-flex-design.md
@@ -22,8 +22,9 @@
 - 주요 파일:
   - `versions.tf`: Terraform/provider 버전 제약
   - `providers.tf`: OCI provider 인증 변수 연결
-  - `variables.tf`: OCID, region, SSH key, CIDR, 무료 한도 guardrail 변수
+  - `variables.tf`: OCID, region, SSH key, CIDR, 이미지 조회, 무료 한도 guardrail 변수
   - `locals.tf`: shape, size, 공통 tag
+  - `images.tf`: A1 Flex 호환 Ubuntu image data source
   - `network.tf`: VCN, Internet Gateway, Route Table, Security List, Subnet
   - `compute.tf`: A1 Flex instance
   - `outputs.tf`: instance, VCN, public IP 출력
@@ -32,14 +33,16 @@
 
 ## Inputs
 - `tenancy_ocid`, `user_ocid`, `fingerprint`, `private_key_path`, `region`
-- `compartment_ocid`, `availability_domain`, `source_image_ocid`
+- `compartment_ocid`, `availability_domain`
+- `image_operating_system`, `image_operating_system_version`, `source_image_ocid_override`
 - `ssh_public_key`
 - `ssh_ingress_cidr`
 - `vcn_cidr`, `subnet_cidr`
 
 ## Error And Risk Handling
 - A1 host capacity 부족은 Terraform 코드로 해결할 수 없으므로 apply 실패 시 availability domain 변경 또는 재시도 안내로 처리한다.
-- 이미지 OCID는 리전별로 다르므로 자동 추정하지 않고 사용자가 Always Free eligible Arm image OCID를 명시한다.
+- 기본 경로는 `oci_core_images` data source로 A1 Flex 호환 최신 Ubuntu 이미지를 조회한다.
+- Oracle 공식 문서 기준 image data source 결과는 시간에 따라 바뀔 수 있으므로, 재현성이 필요한 운영은 `source_image_ocid_override`로 특정 image OCID를 고정한다.
 - `ssh_ingress_cidr` 기본 예시는 넓게 열 수 있지만 README에서 운영자 IP `/32` 사용을 우선 안내한다.
 - Terraform state와 tfvars에는 민감 정보가 포함될 수 있으므로 `.gitignore`에 state/tfvars/plan 파일을 제외한다.
 

--- a/infra/terraform/oci/always-free-a1-flex/README.md
+++ b/infra/terraform/oci/always-free-a1-flex/README.md
@@ -18,7 +18,8 @@ OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만�
 - Block Volume Always Free 한도는 홈 리전의 boot volume과 block volume 합산 200GB다.
 - 이 스택은 Boot Volume 150GB를 생성한다. 기존 OCI boot/block volume 합산 사용량이 50GB를 넘으면 무료 한도 초과 가능성이 있다.
 - `region`은 tenancy 홈 리전으로 설정한다. 홈 리전 밖 volume은 무료 한도 적용에서 벗어날 수 있다.
-- `source_image_ocid`는 선택한 리전의 Always Free eligible Arm image OCID를 사용한다.
+- 기본 경로는 Terraform `oci_core_images` data source로 `VM.Standard.A1.Flex` 호환 최신 Ubuntu 이미지를 조회한다.
+- 최신 이미지 자동 조회는 다음 `terraform apply` 시점에 더 새 이미지가 잡힐 수 있다. 재현성이 필요하면 `source_image_ocid_override`에 특정 image OCID를 고정한다.
 
 ## 준비 값
 
@@ -29,9 +30,14 @@ OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만�
 - `region`
 - `compartment_ocid`
 - `availability_domain`
-- `source_image_ocid`
 - `ssh_public_key`
 - `ssh_ingress_cidr`
+
+선택 값:
+
+- `image_operating_system`: 기본값 `Canonical Ubuntu`
+- `image_operating_system_version`: 기본값 `null`
+- `source_image_ocid_override`: 기본값 `null`
 
 `ssh_ingress_cidr`는 운영자 현재 공인 IP의 `/32`를 우선 사용한다. `0.0.0.0/0`은 임시 테스트가 아니면 사용하지 않는다.
 
@@ -51,6 +57,8 @@ terraform validate
 terraform plan
 terraform apply
 ```
+
+`terraform apply` 후 output의 `selected_image_display_name`과 `selected_image_id`를 확인한다. 같은 이미지로 계속 재현해야 하면 해당 `selected_image_id`를 `source_image_ocid_override`에 넣고 다시 plan을 확인한다.
 
 ## 삭제
 

--- a/infra/terraform/oci/always-free-a1-flex/compute.tf
+++ b/infra/terraform/oci/always-free-a1-flex/compute.tf
@@ -28,7 +28,7 @@ resource "oci_core_instance" "this" {
 
   source_details {
     boot_volume_size_in_gbs = var.boot_volume_size_in_gbs
-    source_id               = var.source_image_ocid
+    source_id               = local.selected_image_id
     source_type             = "image"
   }
 }

--- a/infra/terraform/oci/always-free-a1-flex/images.tf
+++ b/infra/terraform/oci/always-free-a1-flex/images.tf
@@ -1,0 +1,12 @@
+# 최신 Ubuntu 추적용 조회. 재현성 우선 운영은 source_image_ocid_override로 image OCID를 고정한다.
+data "oci_core_images" "ubuntu_a1" {
+  count = var.source_image_ocid_override == null ? 1 : 0
+
+  compartment_id           = var.tenancy_ocid
+  operating_system         = var.image_operating_system
+  operating_system_version = var.image_operating_system_version
+  shape                    = local.instance_shape
+  sort_by                  = "TIMECREATED"
+  sort_order               = "DESC"
+  state                    = "AVAILABLE"
+}

--- a/infra/terraform/oci/always-free-a1-flex/locals.tf
+++ b/infra/terraform/oci/always-free-a1-flex/locals.tf
@@ -1,6 +1,11 @@
 locals {
   instance_shape = "VM.Standard.A1.Flex"
 
+  selected_image_id = var.source_image_ocid_override == null ? data.oci_core_images.ubuntu_a1[0].images[0].id : var.source_image_ocid_override
+
+  selected_image_display_name = var.source_image_ocid_override == null ? data.oci_core_images.ubuntu_a1[0].images[0].display_name : "source_image_ocid_override"
+  selected_image_time_created = var.source_image_ocid_override == null ? data.oci_core_images.ubuntu_a1[0].images[0].time_created : null
+
   common_tags = merge(
     {
       CostBoundary = "oci-always-free"

--- a/infra/terraform/oci/always-free-a1-flex/outputs.tf
+++ b/infra/terraform/oci/always-free-a1-flex/outputs.tf
@@ -22,3 +22,18 @@ output "subnet_id" {
   description = "Created public subnet OCID."
   value       = oci_core_subnet.public.id
 }
+
+output "selected_image_id" {
+  description = "Image OCID used to launch the instance."
+  value       = local.selected_image_id
+}
+
+output "selected_image_display_name" {
+  description = "Display name of the automatically selected image, or source_image_ocid_override when pinned."
+  value       = local.selected_image_display_name
+}
+
+output "selected_image_time_created" {
+  description = "Creation time of the automatically selected image. Null when source_image_ocid_override is used."
+  value       = local.selected_image_time_created
+}

--- a/infra/terraform/oci/always-free-a1-flex/terraform.tfvars.example
+++ b/infra/terraform/oci/always-free-a1-flex/terraform.tfvars.example
@@ -6,7 +6,10 @@ region           = "ap-seoul-1"
 
 compartment_ocid    = "ocid1.compartment.oc1..example"
 availability_domain = "example:AP-SEOUL-1-AD-1"
-source_image_ocid   = "ocid1.image.oc1.ap-seoul-1.example"
+
+image_operating_system         = "Canonical Ubuntu"
+image_operating_system_version = null
+source_image_ocid_override     = null
 
 ssh_public_key   = "ssh-ed25519 example-public-key"
 ssh_ingress_cidr = "203.0.113.10/32"

--- a/infra/terraform/oci/always-free-a1-flex/variables.tf
+++ b/infra/terraform/oci/always-free-a1-flex/variables.tf
@@ -77,14 +77,39 @@ variable "availability_domain" {
   }
 }
 
-variable "source_image_ocid" {
-  description = "Always Free eligible Arm image OCID for the selected region."
+variable "source_image_ocid_override" {
+  description = "Optional image OCID override. Use this when reproducible applies are more important than tracking the latest Ubuntu image."
   type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.source_image_ocid_override == null || can(regex("^ocid1\\.image\\.", var.source_image_ocid_override))
+    error_message = "source_image_ocid_override must be null or start with ocid1.image."
+  }
+}
+
+variable "image_operating_system" {
+  description = "Operating system filter used for automatic platform image lookup."
+  type        = string
+  default     = "Canonical Ubuntu"
   nullable    = false
 
   validation {
-    condition     = can(regex("^ocid1\\.image\\.", var.source_image_ocid))
-    error_message = "source_image_ocid must start with ocid1.image."
+    condition     = length(trimspace(var.image_operating_system)) > 0
+    error_message = "image_operating_system must not be empty."
+  }
+}
+
+variable "image_operating_system_version" {
+  description = "Optional operating system version filter for automatic platform image lookup. Leave null to track the latest Ubuntu version for the shape."
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.image_operating_system_version == null || length(trimspace(var.image_operating_system_version)) > 0
+    error_message = "image_operating_system_version must be null or a non-empty string."
   }
 }
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #509

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI A1 Flex Terraform 스택의 필수 `source_image_ocid` 입력을 제거하고, 기본 경로를 `oci_core_images` data source 기반 최신 Ubuntu Arm 이미지 조회로 바꿨다.
- Oracle 공식 문서상 image data source 결과는 시간이 지나면 달라질 수 있어, 재현성이 필요한 경우 `source_image_ocid_override`로 특정 image OCID를 고정할 수 있게 했다.

## 🛠 Changes
- `images.tf`에 `VM.Standard.A1.Flex` 호환 Ubuntu image 자동 조회 추가
- instance `source_details.source_id`를 `local.selected_image_id`로 변경
- `source_image_ocid_override`, `image_operating_system`, `image_operating_system_version` 변수 추가
- 선택된 image id/display name/time output 추가
- README, tfvars example, 설계 문서 갱신

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex fmt -check`
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex init -backend=false`
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex validate`
- `git rev-list --count main..HEAD` → `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크:
  - 자동 조회는 최신 이미지 추적에 유리하지만, 이후 apply 시 더 새 이미지가 선택되어 instance replacement가 발생할 수 있다.
  - Ubuntu 이미지 필터가 OCI 리전별 제공 상태와 맞지 않으면 plan 단계에서 image 조회 결과가 비어 실패할 수 있다.
- 롤백 방법:
  - `source_image_ocid_override`에 이전 `selected_image_id`를 넣어 특정 이미지로 고정한다.
  - 필요하면 이 PR commit을 revert한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?