### PR TITLE
[Chore] AWS EC2 RDS Terraform 구성

### DIFF
--- a/docs/superpowers/specs/2026-04-28-aws-ec2-rds-baseline-design.md
+++ b/docs/superpowers/specs/2026-04-28-aws-ec2-rds-baseline-design.md
@@ -1,0 +1,59 @@
+# AWS EC2/RDS Baseline Terraform Design
+
+## Goal
+- 1억 건 규모 테스트와 운영 근접 검증을 위해 AWS 기준 Terraform baseline을 추가한다.
+- 기본 스펙은 EC2 `t3.micro`, RDS PostgreSQL `db.t4g.small`, gp3 storage이다.
+
+## Selected Approach
+- 새 VPC를 만들고 public subnet에는 EC2 1대를, private DB subnet 2개에는 RDS subnet group을 둔다.
+- EC2는 SSH 접근만 외부 CIDR로 제한하고, RDS는 EC2 security group에서 오는 5432만 허용한다.
+- 비용 방어를 위해 NAT Gateway, ALB/NLB, Multi-AZ RDS, Performance Insights, Enhanced Monitoring, Elastic IP는 기본 구성에서 제외한다.
+- 실제 application 배포, Docker bootstrap, SSL 인증서, domain 연결은 이번 PR 범위에서 제외한다.
+
+## Alternatives Considered
+- EC2 only: 가장 저렴하지만 1억 건 조회의 RDS I/O, connection, gp3 특성을 검증할 수 없다.
+- EC2 + RDS baseline: 비용은 발생하지만 repo 운영 목표인 EC2/RDS 분리 구조를 가장 직접적으로 검증한다.
+- Full production-like stack: ALB, NAT, ACM, Route53, monitoring까지 포함할 수 있지만 비용과 범위가 커져 이번 목표에는 맞지 않는다.
+
+## Terraform Structure
+- 경로: `infra/terraform/aws/ec2-rds-baseline`
+- Provider: `hashicorp/aws`
+- 주요 파일:
+  - `versions.tf`: Terraform/provider 버전 제약
+  - `providers.tf`: AWS provider region 연결
+  - `variables.tf`: region, CIDR, key pair, AMI, DB credentials, RDS sizing 변수
+  - `locals.tf`: naming, tags
+  - `network.tf`: VPC, subnets, IGW, route table, DB subnet group
+  - `security.tf`: EC2/RDS security groups
+  - `compute.tf`: EC2 instance
+  - `database.tf`: RDS PostgreSQL instance
+  - `outputs.tf`: 접속/리소스 output
+  - `terraform.tfvars.example`: 실값 없는 예시
+  - `README.md`: 실행, 비용, destroy 절차
+
+## Inputs
+- `aws_region`
+- `name_prefix`
+- `ssh_ingress_cidr`
+- `ec2_key_name`
+- `ec2_ami_id`
+- `vpc_cidr`, `public_subnet_cidr`, `private_db_subnet_cidrs`
+- `db_name`, `db_username`, `db_password`
+- `db_engine_version`, `db_allocated_storage`, `db_max_allocated_storage`
+
+## Cost Boundary
+- EC2 `t3.micro`는 free tier/credit 대상 여부가 계정 생성 시점과 AWS Free Tier 조건에 따라 다르다.
+- RDS `db.t4g.small`과 gp3 storage는 무료가 아닐 수 있으며 1억 건 데이터 적재 시 storage, I/O, snapshot 비용이 발생한다.
+- 기본값은 비용 방어를 위해 `multi_az = false`, `backup_retention_period = 1`, `skip_final_snapshot = true`, `deletion_protection = false`로 둔다.
+
+## Error And Risk Handling
+- RDS PostgreSQL engine version은 리전별 지원 여부가 달라질 수 있으므로 실제 apply 전 AWS CLI 또는 console로 확인한다.
+- EC2 `t3.micro`는 CPU credit 고갈 시 성능이 급락할 수 있다.
+- RDS `db.t4g.small`은 1억 건 조회의 모든 병목을 해결하는 크기가 아니라 작은 운영 목표에서의 방어 기준이다.
+- RDS password와 SSH private key는 Terraform variable/local file로만 다루고 저장소에 기록하지 않는다.
+
+## Validation
+- `terraform fmt -check`
+- `terraform init -backend=false`
+- `terraform validate`
+- 실제 `plan/apply`는 AWS credentials, key pair, AMI ID, DB password가 필요하므로 로컬 자동 검증 범위에서 제외한다.

--- a/infra/terraform/aws/ec2-rds-baseline/.terraform.lock.hcl
+++ b/infra/terraform/aws/ec2-rds-baseline/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/aws/ec2-rds-baseline/README.md
+++ b/infra/terraform/aws/ec2-rds-baseline/README.md
@@ -1,0 +1,78 @@
+# AWS EC2/RDS Baseline Terraform
+
+AWS에서 1억 건 규모 테스트와 운영 근접 검증을 위한 최소 baseline을 만든다.
+
+## 구성
+
+- EC2: `t3.micro`
+- EC2 root EBS: gp3, 기본 30GiB
+- RDS: PostgreSQL, `db.t4g.small`
+- RDS storage: gp3, 기본 100GiB
+- Network: 새 VPC, public subnet 1개, private DB subnet 2개, Internet Gateway
+- Security:
+  - SSH `22/tcp`: `ssh_ingress_cidr`에서만 허용
+  - PostgreSQL `5432/tcp`: EC2 security group에서만 허용
+- 제외: NAT Gateway, ALB/NLB, Multi-AZ RDS, Elastic IP, Enhanced Monitoring, Performance Insights
+
+## 비용 주의
+
+- EC2 `t3.micro` free tier/credit 적용 여부는 계정 상태와 AWS Free Tier 조건에 따라 다르다.
+- RDS `db.t4g.small`과 gp3 storage는 무료가 아닐 수 있다.
+- 1억 건 데이터 적재는 RDS storage, I/O, snapshot 비용을 만들 수 있다.
+- 기본값은 테스트 비용 방어를 위해 `multi_az = false`, `backup_retention_period = 1`, `skip_final_snapshot = true`, `deletion_protection = false`다.
+- NAT Gateway와 Load Balancer는 고정 비용이 생기므로 기본 구성에서 제외한다.
+
+## 준비 값
+
+- AWS credentials: environment, shared config, SSO 중 하나
+- 기존 EC2 key pair name
+- 운영자 공인 IP `/32`
+- RDS master password
+- 필요 시 고정할 RDS PostgreSQL engine version
+
+기본값은 AWS가 리전에서 지원하는 PostgreSQL 기본 버전을 선택하도록 `db_engine_version = null`로 둔다. 특정 버전이 필요하면 적용 전 리전 지원 버전을 확인하고 고정한다.
+
+```bash
+aws rds describe-db-engine-versions \
+  --engine postgres \
+  --engine-version <major-or-minor-version> \
+  --region ap-northeast-2
+```
+
+## 실행
+
+```bash
+cd infra/terraform/aws/ec2-rds-baseline
+cp terraform.tfvars.example terraform.tfvars
+```
+
+`terraform.tfvars`에 실제 값을 입력한다. 이 파일은 git에 커밋하지 않는다.
+RDS password는 Terraform state에 저장될 수 있으므로 state 파일도 공개 저장소나 공유 채널에 올리지 않는다.
+
+```bash
+terraform init
+terraform fmt -check
+terraform validate
+terraform plan
+terraform apply
+```
+
+## 접속
+
+EC2 접속:
+
+```bash
+ssh -i ~/.ssh/<private-key> ec2-user@<ec2_public_ip>
+```
+
+RDS는 public 접근을 막고 EC2 security group에서만 접근한다. EC2에서 `psql` 또는 애플리케이션으로 `rds_endpoint:5432`에 접속한다.
+
+## 삭제
+
+테스트가 끝나면 비용 방지를 위해 destroy한다.
+
+```bash
+terraform destroy
+```
+
+`skip_final_snapshot = true`이므로 기본값에서는 삭제 시 final snapshot을 만들지 않는다. 데이터를 보존해야 하는 테스트에서는 destroy 전에 snapshot 정책을 별도로 정한다.

--- a/infra/terraform/aws/ec2-rds-baseline/compute.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/compute.tf
@@ -1,0 +1,24 @@
+resource "aws_instance" "app" {
+  ami                         = local.ec2_ami_id
+  associate_public_ip_address = true
+  instance_type               = var.ec2_instance_type
+  key_name                    = var.ec2_key_name
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.ec2.id]
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  root_block_device {
+    delete_on_termination = true
+    encrypted             = true
+    volume_size           = var.ec2_root_volume_size
+    volume_type           = "gp3"
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-ec2"
+  }
+}

--- a/infra/terraform/aws/ec2-rds-baseline/data.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/data.tf
@@ -1,0 +1,23 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}

--- a/infra/terraform/aws/ec2-rds-baseline/database.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/database.tf
@@ -1,0 +1,29 @@
+resource "aws_db_instance" "postgres" {
+  allocated_storage            = var.db_allocated_storage
+  auto_minor_version_upgrade   = true
+  backup_retention_period      = var.db_backup_retention_period
+  copy_tags_to_snapshot        = true
+  db_name                      = var.db_name
+  db_subnet_group_name         = aws_db_subnet_group.this.name
+  deletion_protection          = false
+  engine                       = "postgres"
+  engine_version               = var.db_engine_version
+  identifier                   = var.db_identifier
+  instance_class               = var.db_instance_class
+  max_allocated_storage        = var.db_max_allocated_storage
+  monitoring_interval          = 0
+  multi_az                     = false
+  password                     = var.db_password
+  performance_insights_enabled = false
+  port                         = 5432
+  publicly_accessible          = false
+  skip_final_snapshot          = true
+  storage_encrypted            = true
+  storage_type                 = "gp3"
+  username                     = var.db_username
+  vpc_security_group_ids       = [aws_security_group.rds.id]
+
+  tags = {
+    Name = var.db_identifier
+  }
+}

--- a/infra/terraform/aws/ec2-rds-baseline/locals.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  common_tags = merge(
+    {
+      CostBoundary = "aws-ec2-rds-baseline"
+      ManagedBy    = "terraform"
+      Project      = "aquila-bank"
+    },
+    var.freeform_tags
+  )
+
+  ec2_ami_id = var.ec2_ami_id == null ? data.aws_ami.amazon_linux_2023.id : var.ec2_ami_id
+}

--- a/infra/terraform/aws/ec2-rds-baseline/network.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/network.tf
@@ -1,0 +1,67 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.name_prefix}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-igw"
+  }
+}
+
+resource "aws_subnet" "public" {
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  cidr_block              = var.public_subnet_cidr
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-public-a"
+  }
+}
+
+resource "aws_subnet" "private_db" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = var.private_db_subnet_cidrs[count.index]
+  vpc_id            = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-private-db-${count.index + 1}"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public.id
+}
+
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.name_prefix}-db-subnet-group"
+  subnet_ids = aws_subnet.private_db[*].id
+
+  tags = {
+    Name = "${var.name_prefix}-db-subnet-group"
+  }
+}

--- a/infra/terraform/aws/ec2-rds-baseline/outputs.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/outputs.tf
@@ -1,0 +1,39 @@
+output "ec2_instance_id" {
+  description = "EC2 instance ID."
+  value       = aws_instance.app.id
+}
+
+output "ec2_public_dns" {
+  description = "EC2 public DNS name."
+  value       = aws_instance.app.public_dns
+}
+
+output "ec2_public_ip" {
+  description = "EC2 public IPv4 address."
+  value       = aws_instance.app.public_ip
+}
+
+output "rds_endpoint" {
+  description = "RDS PostgreSQL endpoint."
+  value       = aws_db_instance.postgres.endpoint
+}
+
+output "rds_address" {
+  description = "RDS PostgreSQL address."
+  value       = aws_db_instance.postgres.address
+}
+
+output "rds_port" {
+  description = "RDS PostgreSQL port."
+  value       = aws_db_instance.postgres.port
+}
+
+output "selected_ec2_ami_id" {
+  description = "AMI ID used by the EC2 instance."
+  value       = local.ec2_ami_id
+}
+
+output "vpc_id" {
+  description = "Created VPC ID."
+  value       = aws_vpc.this.id
+}

--- a/infra/terraform/aws/ec2-rds-baseline/providers.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/terraform/aws/ec2-rds-baseline/security.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/security.tf
@@ -1,0 +1,51 @@
+resource "aws_security_group" "ec2" {
+  description = "SSH access for the baseline EC2 instance"
+  name        = "${var.name_prefix}-ec2-sg"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    cidr_blocks = [var.ssh_ingress_cidr]
+    description = "SSH from operator CIDR"
+    from_port   = 22
+    protocol    = "tcp"
+    to_port     = 22
+  }
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Outbound internet access"
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-ec2-sg"
+  }
+}
+
+resource "aws_security_group" "rds" {
+  description = "PostgreSQL access from the baseline EC2 security group only"
+  name        = "${var.name_prefix}-rds-sg"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description     = "PostgreSQL from EC2"
+    from_port       = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2.id]
+    to_port         = 5432
+  }
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Outbound responses"
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-rds-sg"
+  }
+}

--- a/infra/terraform/aws/ec2-rds-baseline/terraform.tfvars.example
+++ b/infra/terraform/aws/ec2-rds-baseline/terraform.tfvars.example
@@ -1,0 +1,23 @@
+aws_region  = "ap-northeast-2"
+name_prefix = "aquila-bank-baseline"
+
+vpc_cidr                = "10.50.0.0/16"
+public_subnet_cidr      = "10.50.1.0/24"
+private_db_subnet_cidrs = ["10.50.11.0/24", "10.50.12.0/24"]
+
+ssh_ingress_cidr = "203.0.113.10/32"
+ec2_key_name     = "replace-with-existing-key-pair"
+ec2_ami_id       = null
+
+ec2_instance_type    = "t3.micro"
+ec2_root_volume_size = 30
+
+db_identifier              = "aquila-bank-baseline-postgres"
+db_name                    = "aquilabank"
+db_username                = "aquila_admin"
+db_password                = "replace-with-strong-password"
+db_engine_version          = null
+db_instance_class          = "db.t4g.small"
+db_allocated_storage       = 100
+db_max_allocated_storage   = null
+db_backup_retention_period = 1

--- a/infra/terraform/aws/ec2-rds-baseline/variables.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/variables.tf
@@ -1,0 +1,232 @@
+variable "aws_region" {
+  description = "AWS region for EC2 and RDS resources."
+  type        = string
+  default     = "ap-northeast-2"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]+$", var.aws_region))
+    error_message = "aws_region must look like ap-northeast-2."
+  }
+}
+
+variable "name_prefix" {
+  description = "Name prefix for AWS resources."
+  type        = string
+  default     = "aquila-bank-baseline"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,40}[a-z0-9]$", var.name_prefix))
+    error_message = "name_prefix must be lowercase kebab-case, 3-42 characters."
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the dedicated VPC."
+  type        = string
+  default     = "10.50.0.0/16"
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.vpc_cidr))
+    error_message = "vpc_cidr must be a valid IPv4 CIDR."
+  }
+}
+
+variable "public_subnet_cidr" {
+  description = "CIDR block for the public EC2 subnet."
+  type        = string
+  default     = "10.50.1.0/24"
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.public_subnet_cidr))
+    error_message = "public_subnet_cidr must be a valid IPv4 CIDR."
+  }
+}
+
+variable "private_db_subnet_cidrs" {
+  description = "Two private subnet CIDR blocks for the RDS subnet group."
+  type        = list(string)
+  default     = ["10.50.11.0/24", "10.50.12.0/24"]
+  nullable    = false
+
+  validation {
+    condition     = length(var.private_db_subnet_cidrs) == 2 && alltrue([for cidr in var.private_db_subnet_cidrs : can(cidrnetmask(cidr))])
+    error_message = "private_db_subnet_cidrs must contain exactly two valid IPv4 CIDRs."
+  }
+}
+
+variable "ssh_ingress_cidr" {
+  description = "CIDR allowed to connect to EC2 SSH port 22. Prefer a single operator IP /32."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.ssh_ingress_cidr))
+    error_message = "ssh_ingress_cidr must be a valid IPv4 CIDR."
+  }
+}
+
+variable "ec2_key_name" {
+  description = "Existing AWS EC2 key pair name for SSH."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(trimspace(var.ec2_key_name)) > 0
+    error_message = "ec2_key_name must not be empty."
+  }
+}
+
+variable "ec2_ami_id" {
+  description = "Optional EC2 AMI ID override. Leave null to use the latest Amazon Linux 2023 x86_64 AMI."
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.ec2_ami_id == null || can(regex("^ami-[0-9a-f]+$", var.ec2_ami_id))
+    error_message = "ec2_ami_id must be null or start with ami-."
+  }
+}
+
+variable "ec2_instance_type" {
+  description = "EC2 instance type. Baseline target is t3.micro."
+  type        = string
+  default     = "t3.micro"
+  nullable    = false
+
+  validation {
+    condition     = var.ec2_instance_type == "t3.micro"
+    error_message = "This baseline intentionally allows only t3.micro."
+  }
+}
+
+variable "ec2_root_volume_size" {
+  description = "EC2 root EBS volume size in GiB."
+  type        = number
+  default     = 30
+  nullable    = false
+
+  validation {
+    condition     = var.ec2_root_volume_size >= 8 && var.ec2_root_volume_size <= 100
+    error_message = "ec2_root_volume_size must be between 8 and 100 GiB."
+  }
+}
+
+variable "db_identifier" {
+  description = "RDS DB instance identifier."
+  type        = string
+  default     = "aquila-bank-baseline-postgres"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,61}[a-z0-9]$", var.db_identifier))
+    error_message = "db_identifier must be lowercase kebab-case, 3-63 characters."
+  }
+}
+
+variable "db_name" {
+  description = "Initial PostgreSQL database name."
+  type        = string
+  default     = "aquilabank"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[A-Za-z][A-Za-z0-9_]{0,62}$", var.db_name))
+    error_message = "db_name must be a PostgreSQL-compatible identifier."
+  }
+}
+
+variable "db_username" {
+  description = "RDS master username."
+  type        = string
+  default     = "aquila_admin"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[A-Za-z][A-Za-z0-9_]{0,62}$", var.db_username))
+    error_message = "db_username must be a PostgreSQL-compatible identifier."
+  }
+}
+
+variable "db_password" {
+  description = "RDS master password. Pass through terraform.tfvars or TF_VAR_db_password; do not commit it."
+  type        = string
+  nullable    = false
+  sensitive   = true
+
+  validation {
+    condition     = length(var.db_password) >= 16
+    error_message = "db_password must be at least 16 characters."
+  }
+}
+
+variable "db_engine_version" {
+  description = "Optional PostgreSQL engine major or minor version. Null lets AWS select the regional default supported version."
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.db_engine_version == null || can(regex("^[0-9]+(\\.[0-9]+)?$", var.db_engine_version))
+    error_message = "db_engine_version must be null or a major/minor PostgreSQL version such as 17 or 17.5."
+  }
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class. Baseline target is db.t4g.small."
+  type        = string
+  default     = "db.t4g.small"
+  nullable    = false
+
+  validation {
+    condition     = var.db_instance_class == "db.t4g.small"
+    error_message = "This baseline intentionally allows only db.t4g.small."
+  }
+}
+
+variable "db_allocated_storage" {
+  description = "Initial RDS storage in GiB."
+  type        = number
+  default     = 100
+  nullable    = false
+
+  validation {
+    condition     = var.db_allocated_storage >= 20 && var.db_allocated_storage <= 1024
+    error_message = "db_allocated_storage must be between 20 and 1024 GiB."
+  }
+}
+
+variable "db_max_allocated_storage" {
+  description = "Optional RDS storage autoscaling ceiling in GiB. Null disables autoscaling."
+  type        = number
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.db_max_allocated_storage == null || var.db_max_allocated_storage >= var.db_allocated_storage
+    error_message = "db_max_allocated_storage must be null or greater than/equal to db_allocated_storage."
+  }
+}
+
+variable "db_backup_retention_period" {
+  description = "RDS backup retention period in days."
+  type        = number
+  default     = 1
+  nullable    = false
+
+  validation {
+    condition     = var.db_backup_retention_period >= 0 && var.db_backup_retention_period <= 7
+    error_message = "db_backup_retention_period must be between 0 and 7 for this cost-controlled baseline."
+  }
+}
+
+variable "freeform_tags" {
+  description = "Additional tags applied to all resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/infra/terraform/aws/ec2-rds-baseline/versions.tf
+++ b/infra/terraform/aws/ec2-rds-baseline/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #511

## 🌿 Base Branch
- `main`

## 📝 Summary
- AWS 기준 EC2 `t3.micro` + RDS PostgreSQL `db.t4g.small` + gp3 baseline Terraform 스택을 추가합니다.
- 1억 건 규모 테스트를 위한 EC2/RDS 분리 구조를 만들되, NAT Gateway/Load Balancer/Multi-AZ처럼 고정 비용이 큰 리소스는 제외했습니다.

## 🛠 Changes
- `infra/terraform/aws/ec2-rds-baseline` root module 추가
- VPC, public EC2 subnet, private DB subnet 2개, Internet Gateway, DB subnet group 구성
- EC2 SSH는 지정 CIDR만 허용하고 RDS 5432는 EC2 security group에서만 허용
- Amazon Linux 2023 AMI 자동 조회, optional AMI override 지원
- RDS engine version은 기본 `null`로 두어 AWS 리전 기본 지원 버전을 사용하고, 필요 시 변수로 고정 가능
- `terraform.tfvars.example`과 실행/삭제/비용 주의 README 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `terraform -chdir=infra/terraform/aws/ec2-rds-baseline fmt -check`
- `terraform -chdir=infra/terraform/aws/ec2-rds-baseline init -backend=false`
- `terraform -chdir=infra/terraform/aws/ec2-rds-baseline validate`
- `git rev-list --count main..HEAD` = `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: RDS `db.t4g.small`과 gp3 storage는 계정 Free Tier/credit 상태에 따라 비용이 발생할 수 있습니다. Terraform state에는 RDS password가 포함될 수 있으므로 state 보관 위치를 별도로 관리해야 합니다.
- 롤백 방법: PR revert 또는 해당 모듈 미사용. 실제 생성 후에는 `terraform -chdir=infra/terraform/aws/ec2-rds-baseline destroy`로 리소스를 삭제합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
