### PR TITLE
[CI] EC2 blue-green 무중단 CD 구성

### DIFF
--- a/.github/workflows/ec2-bluegreen-deploy.yml
+++ b/.github/workflows/ec2-bluegreen-deploy.yml
@@ -1,0 +1,321 @@
+name: EC2 Blue/Green Deploy
+
+on:
+  workflow_run:
+    workflows:
+      - Main CI
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy"
+        required: false
+        default: "main"
+
+permissions:
+  contents: read
+  packages: write
+  deployments: write
+
+concurrency:
+  group: ec2-bluegreen-deploy
+  cancel-in-progress: false
+
+env:
+  BACKEND_IMAGE_NAME: aquila-bank-backend
+  FRONTEND_IMAGE_NAME: aquila-bank-frontend
+  DEFAULT_EC2_INSTANCE_TAG_NAME: aquila-bank-baseline-ec2
+
+jobs:
+  prepare:
+    name: Resolve Deploy Ref
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.event == 'push'
+      )
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_sha: ${{ steps.ref.outputs.deploy_sha }}
+      image_tag: ${{ steps.ref.outputs.image_tag }}
+    steps:
+      - name: Checkout deploy ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || inputs.ref }}
+          fetch-depth: 0
+
+      - name: Validate deploy ref
+        id: ref
+        shell: bash
+        run: |
+          set -euo pipefail
+          deploy_sha="$(git rev-parse HEAD)"
+          image_tag="${deploy_sha:0:12}"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
+            git fetch --no-tags --depth=1 origin main
+            current_main_sha="$(git rev-parse origin/main)"
+            if [[ "${current_main_sha}" != "${deploy_sha}" ]]; then
+              echo "::notice::Skipping stale deploy SHA ${deploy_sha}; current origin/main is ${current_main_sha}."
+              exit 0
+            fi
+          fi
+
+          echo "deploy_sha=${deploy_sha}" >> "${GITHUB_OUTPUT}"
+          echo "image_tag=${image_tag}" >> "${GITHUB_OUTPUT}"
+
+  build-and-push:
+    name: Build And Push Images
+    needs: prepare
+    if: needs.prepare.outputs.deploy_sha != ''
+    runs-on: ubuntu-latest
+    outputs:
+      backend_image: ${{ steps.images.outputs.backend_image }}
+      frontend_image: ${{ steps.images.outputs.frontend_image }}
+    steps:
+      - name: Checkout deploy SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.deploy_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image names
+        id: images
+        shell: bash
+        run: |
+          set -euo pipefail
+          owner_lc="${GITHUB_REPOSITORY_OWNER,,}"
+          backend_image="ghcr.io/${owner_lc}/${BACKEND_IMAGE_NAME}"
+          frontend_image="ghcr.io/${owner_lc}/${FRONTEND_IMAGE_NAME}"
+          echo "backend_image=${backend_image}" >> "${GITHUB_OUTPUT}"
+          echo "frontend_image=${frontend_image}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./back
+          push: true
+          tags: |
+            ${{ steps.images.outputs.backend_image }}:${{ needs.prepare.outputs.image_tag }}
+            ${{ steps.images.outputs.backend_image }}:main-latest
+          cache-from: type=gha,scope=aquila-bank-backend
+          cache-to: type=gha,mode=max,scope=aquila-bank-backend
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./front
+          push: true
+          build-args: |
+            NEXT_PUBLIC_API_BASE_URL=${{ secrets.EC2_PUBLIC_API_BASE_URL }}
+          tags: |
+            ${{ steps.images.outputs.frontend_image }}:${{ needs.prepare.outputs.image_tag }}
+            ${{ steps.images.outputs.frontend_image }}:main-latest
+          cache-from: type=gha,scope=aquila-bank-frontend
+          cache-to: type=gha,mode=max,scope=aquila-bank-frontend
+
+  deploy:
+    name: Deploy To EC2
+    needs: [prepare, build-and-push]
+    if: needs.prepare.outputs.deploy_sha != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: staging
+    permissions:
+      contents: read
+      packages: read
+      deployments: write
+    env:
+      AWS_REGION: ${{ secrets.AWS_REGION || 'ap-northeast-2' }}
+      EC2_INSTANCE_TAG_NAME: ${{ secrets.EC2_INSTANCE_TAG_NAME || 'aquila-bank-baseline-ec2' }}
+      EC2_PUBLIC_BASE_URL: ${{ secrets.EC2_PUBLIC_BASE_URL }}
+      DEPLOY_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Checkout deploy SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.deploy_sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Resolve running EC2 instance
+        id: ec2
+        shell: bash
+        run: |
+          set -euo pipefail
+          instance_id="$(
+            aws ec2 describe-instances \
+              --filters "Name=tag:Name,Values=${EC2_INSTANCE_TAG_NAME}" "Name=instance-state-name,Values=running" \
+              --query "Reservations[].Instances[].InstanceId" \
+              --output text
+          )"
+          if [[ -z "${instance_id}" || "${instance_id}" == "None" ]]; then
+            echo "::error::No running EC2 instance found for Name=${EC2_INSTANCE_TAG_NAME}."
+            exit 1
+          fi
+          echo "instance_id=${instance_id}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate deploy secrets
+        shell: bash
+        env:
+          EC2_BACKEND_ENV: ${{ secrets.EC2_BACKEND_ENV }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${EC2_BACKEND_ENV}" ]]; then
+            echo "::error::EC2_BACKEND_ENV secret is required."
+            exit 1
+          fi
+
+      - name: Create GitHub deployment
+        id: deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(
+            jq -n \
+              --arg ref "${{ needs.prepare.outputs.deploy_sha }}" \
+              --arg description "Blue/green deploy ${EC2_INSTANCE_TAG_NAME}" \
+              '{
+                ref: $ref,
+                environment: "staging",
+                description: $description,
+                auto_merge: false,
+                required_contexts: [],
+                production_environment: false,
+                transient_environment: false
+              }'
+          )"
+          deployment_id="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments" --input - --jq ".id" <<< "${payload}")"
+          echo "deployment_id=${deployment_id}" >> "${GITHUB_OUTPUT}"
+
+      - name: Mark deployment in progress
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg log_url "${DEPLOY_LOG_URL}" \
+            '{state:"in_progress", environment:"staging", log_url:$log_url, auto_inactive:false}' \
+            | gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input -
+
+      - name: Run SSM blue-green deploy
+        env:
+          INSTANCE_ID: ${{ steps.ec2.outputs.instance_id }}
+          BACKEND_IMAGE: ${{ needs.build-and-push.outputs.backend_image }}
+          FRONTEND_IMAGE: ${{ needs.build-and-push.outputs.frontend_image }}
+          IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
+          GITHUB_ACTOR_VALUE: ${{ github.actor }}
+          GITHUB_TOKEN_VALUE: ${{ github.token }}
+          EC2_BACKEND_ENV: ${{ secrets.EC2_BACKEND_ENV }}
+          EC2_FRONTEND_ENV: ${{ secrets.EC2_FRONTEND_ENV }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          script_b64="$(base64 -w0 ops/deploy/ec2/bluegreen-deploy.sh)"
+          github_token_b64="$(printf '%s' "${GITHUB_TOKEN_VALUE}" | base64 -w0)"
+          backend_env_b64="$(printf '%s' "${EC2_BACKEND_ENV}" | base64 -w0)"
+          frontend_env_b64="$(printf '%s' "${EC2_FRONTEND_ENV}" | base64 -w0)"
+
+          printf -v command_prefix '%s\n' \
+            "export BACKEND_IMAGE=$(printf '%q' "${BACKEND_IMAGE}")" \
+            "export FRONTEND_IMAGE=$(printf '%q' "${FRONTEND_IMAGE}")" \
+            "export IMAGE_TAG=$(printf '%q' "${IMAGE_TAG}")" \
+            "export GITHUB_ACTOR=$(printf '%q' "${GITHUB_ACTOR_VALUE}")" \
+            "export GITHUB_TOKEN_B64=$(printf '%q' "${github_token_b64}")" \
+            "export BACKEND_ENV_B64=$(printf '%q' "${backend_env_b64}")" \
+            "export FRONTEND_ENV_B64=$(printf '%q' "${frontend_env_b64}")" \
+            "mkdir -p /tmp/aquila-bank-deploy" \
+            "printf %s $(printf '%q' "${script_b64}") | base64 -d > /tmp/aquila-bank-deploy/bluegreen-deploy.sh" \
+            "chmod 755 /tmp/aquila-bank-deploy/bluegreen-deploy.sh" \
+            "/tmp/aquila-bank-deploy/bluegreen-deploy.sh"
+          params="$(jq -nc --arg command "${command_prefix}" '{commands:[$command]}' )"
+          command_id="$(
+            aws ssm send-command \
+              --region "${AWS_REGION}" \
+              --instance-ids "${INSTANCE_ID}" \
+              --document-name "AWS-RunShellScript" \
+              --parameters "${params}" \
+              --query "Command.CommandId" \
+              --output text
+          )"
+          echo "SSM Command ID: ${command_id}"
+
+          wait_max=900
+          wait_interval=10
+          waited=0
+          while (( waited < wait_max )); do
+            status="$(aws ssm get-command-invocation \
+              --command-id "${command_id}" \
+              --instance-id "${INSTANCE_ID}" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")"
+            [[ "${status}" == "Pending" || "${status}" == "InProgress" || "${status}" == "Delayed" ]] || break
+            sleep "${wait_interval}"
+            waited=$((waited + wait_interval))
+          done
+
+          invocation="$(aws ssm get-command-invocation --command-id "${command_id}" --instance-id "${INSTANCE_ID}")"
+          status="$(jq -r ".Status" <<< "${invocation}")"
+          echo "===== stdout ====="
+          jq -r ".StandardOutputContent" <<< "${invocation}"
+          echo "===== stderr ====="
+          jq -r ".StandardErrorContent" <<< "${invocation}"
+          echo "=================="
+          echo "Status: ${status}"
+          [[ "${status}" == "Success" ]]
+
+      - name: Run external smoke
+        if: success() && env.EC2_PUBLIC_BASE_URL != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail-with-body --show-error --silent --max-time 10 "${EC2_PUBLIC_BASE_URL%/}/actuator/health" >/dev/null
+
+      - name: Mark deployment success
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg log_url "${DEPLOY_LOG_URL}" \
+            '{state:"success", environment:"staging", log_url:$log_url, auto_inactive:false}' \
+            | gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input -
+
+      - name: Mark deployment failure
+        if: failure() && steps.deployment.outputs.deployment_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg log_url "${DEPLOY_LOG_URL}" \
+            '{state:"failure", environment:"staging", log_url:$log_url, auto_inactive:false}' \
+            | gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input -

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - feature 작업은 `main`에서 짧게 분기한 `feat/*`, `fix/*`, `perf/*`, `chore/*`, `build/*`, `docs/*` 브랜치에서 진행합니다.
 - PR 리뷰와 backend/frontend CI 통과 후 `main`에 병합합니다.
 - `main`에 병합되면 `Main CI` workflow가 backend/frontend check를 다시 실행하고, 같은 SHA를 `Staging Deploy` workflow로 전달합니다.
+- EC2 app smoke는 `EC2 Blue/Green Deploy` workflow가 GHCR image를 만들고 SSM으로 단일 EC2 Docker/Nginx blue-green slot을 전환합니다.
 - staging 배포는 현재 `origin/main` SHA와 일치하는 `Main CI` 성공 SHA만 진행하며, deploy hook secret이 없으면 no-op으로 종료합니다.
 - production 승격은 staging deployment status가 `success`인 같은 SHA만 대상으로 하고, GitHub Environment 수동 승인 또는 `prod-*` tag로만 진행합니다.
 - 미완성 기능은 장기 `develop` 브랜치 대신 feature flag로 기본 비노출 처리합니다.

--- a/back/.dockerignore
+++ b/back/.dockerignore
@@ -1,0 +1,10 @@
+.gradle/
+.gradle-user/
+build/
+out/
+bin/
+.env
+.env.*
+!/.env.example
+logs/
+*.log

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,0 +1,27 @@
+FROM eclipse-temurin:21-jdk AS builder
+WORKDIR /workspace
+
+COPY gradlew gradlew
+COPY gradle gradle
+COPY build.gradle.kts settings.gradle.kts ./
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
+
+COPY config config
+COPY src src
+RUN ./gradlew bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+ENV TZ=Asia/Seoul \
+    LANG=C.UTF-8 \
+    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8"
+
+RUN groupadd --system aquila && useradd --system --gid aquila aquila
+
+COPY --from=builder /workspace/build/libs/*.jar /app/app.jar
+
+USER aquila
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/front/.dockerignore
+++ b/front/.dockerignore
@@ -1,0 +1,15 @@
+node_modules/
+.next/
+out/
+build/
+coverage/
+test-results/
+playwright-report/
+storybook-static/
+.storybook-home/
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+*.log

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --non-interactive
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN yarn build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: 'standalone',
 };
 
 module.exports = nextConfig;

--- a/infra/terraform/aws/ec2-app-baseline/README.md
+++ b/infra/terraform/aws/ec2-app-baseline/README.md
@@ -9,6 +9,9 @@ AWS에 App EC2 1대만 만든다. 1억 건 PostgreSQL 데이터는 AWS에 올리
 - Network: 새 VPC, public subnet 1개, Internet Gateway
 - Security:
   - SSH `22/tcp`: `ssh_ingress_cidr`에서만 허용
+  - HTTP `80/tcp`: `http_ingress_cidr`에서 허용
+- IAM:
+  - EC2 instance profile에 `AmazonSSMManagedInstanceCore`를 연결해 GitHub Actions가 SSM으로 배포 스크립트를 실행할 수 있게 한다.
 - 제외: RDS, private DB subnet, NAT Gateway, ALB/NLB, Elastic IP
 
 이 module은 로컬 Mac Docker PostgreSQL에 있는 1억 건 fixture를 생성하거나 이동하지 않는다. EC2에서 로컬 Mac DB에 접속해야 하는 별도 실험은 SSH tunnel, VPN, allowlist 같은 별도 보안 설계가 필요하며 이번 Terraform 범위에서 제외한다.
@@ -25,6 +28,7 @@ AWS에 App EC2 1대만 만든다. 1억 건 PostgreSQL 데이터는 AWS에 올리
 - AWS credentials: environment, shared config, SSO 중 하나
 - 기존 EC2 key pair name
 - 운영자 공인 IP `/32`
+- HTTP 공개 CIDR. 개인 검증이면 좁게, 임시 공개 smoke면 `0.0.0.0/0`
 
 ## 실행
 

--- a/infra/terraform/aws/ec2-app-baseline/compute.tf
+++ b/infra/terraform/aws/ec2-app-baseline/compute.tf
@@ -1,6 +1,7 @@
 resource "aws_instance" "app" {
   ami                         = local.ec2_ami_id
   associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.app.name
   instance_type               = var.ec2_instance_type
   key_name                    = var.ec2_key_name
   subnet_id                   = aws_subnet.public.id

--- a/infra/terraform/aws/ec2-app-baseline/iam.tf
+++ b/infra/terraform/aws/ec2-app-baseline/iam.tf
@@ -1,0 +1,33 @@
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["ec2.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "app" {
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+  name               = "${var.name_prefix}-app-ec2-role"
+
+  tags = {
+    Name = "${var.name_prefix}-app-ec2-role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.app.name
+}
+
+resource "aws_iam_instance_profile" "app" {
+  name = "${var.name_prefix}-app-ec2-profile"
+  role = aws_iam_role.app.name
+
+  tags = {
+    Name = "${var.name_prefix}-app-ec2-profile"
+  }
+}

--- a/infra/terraform/aws/ec2-app-baseline/security.tf
+++ b/infra/terraform/aws/ec2-app-baseline/security.tf
@@ -4,6 +4,14 @@ resource "aws_security_group" "ec2" {
   vpc_id      = aws_vpc.this.id
 
   ingress {
+    cidr_blocks = [var.http_ingress_cidr]
+    description = "HTTP access for blue-green Nginx entrypoint"
+    from_port   = 80
+    protocol    = "tcp"
+    to_port     = 80
+  }
+
+  ingress {
     cidr_blocks = [var.ssh_ingress_cidr]
     description = "SSH from operator CIDR"
     from_port   = 22

--- a/infra/terraform/aws/ec2-app-baseline/terraform.tfvars.example
+++ b/infra/terraform/aws/ec2-app-baseline/terraform.tfvars.example
@@ -5,6 +5,7 @@ vpc_cidr                = "10.50.0.0/16"
 public_subnet_cidr      = "10.50.1.0/24"
 
 ssh_ingress_cidr = "203.0.113.10/32"
+http_ingress_cidr = "0.0.0.0/0"
 ec2_key_name     = "replace-with-existing-key-pair"
 ec2_ami_id       = null
 

--- a/infra/terraform/aws/ec2-app-baseline/variables.tf
+++ b/infra/terraform/aws/ec2-app-baseline/variables.tf
@@ -57,6 +57,18 @@ variable "ssh_ingress_cidr" {
   }
 }
 
+variable "http_ingress_cidr" {
+  description = "CIDR allowed to connect to the EC2 HTTP port 80."
+  type        = string
+  default     = "0.0.0.0/0"
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.http_ingress_cidr))
+    error_message = "http_ingress_cidr must be a valid IPv4 CIDR."
+  }
+}
+
 variable "ec2_key_name" {
   description = "Existing AWS EC2 key pair name for SSH."
   type        = string

--- a/ops/deploy/ec2/README.md
+++ b/ops/deploy/ec2/README.md
@@ -1,0 +1,35 @@
+# EC2 Blue/Green Deploy
+
+이 경로는 AWS App EC2 한 대에서 Docker + Nginx blue/green 배포를 수행한다.
+
+## Runtime
+
+- entrypoint: `aquila-bank-nginx` on host port `80`
+- backend slots: `aquila-bank-backend-a`, `aquila-bank-backend-b`
+- frontend slots: `aquila-bank-front-a`, `aquila-bank-front-b`
+- Docker network: `aquila-bank-prod`
+- deploy root: `/opt/aquila-bank`
+
+## Database Boundary
+
+1억 건 PostgreSQL fixture는 EC2로 옮기지 않는다. Backend container는 `EC2_BACKEND_ENV` secret으로 주입되는 DB 접속 설정을 사용한다. 로컬 Mac Docker PostgreSQL을 EC2에서 사용하려면 reverse SSH tunnel 또는 VPN을 별도 보안 작업으로 구성한다.
+
+Backend/frontend container에는 `host.docker.internal`이 EC2 Docker host gateway로 잡힌다. 로컬 Mac DB를 tunnel로 붙일 때는 EC2 host가 접근할 수 있는 포트로 먼저 고정한 뒤, `EC2_BACKEND_ENV`의 JDBC URL에서 해당 host/port를 사용한다.
+
+## Required GitHub Secrets
+
+- `AWS_REGION`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `EC2_INSTANCE_TAG_NAME`: 기본 Terraform 값은 `aquila-bank-baseline-ec2`
+- `EC2_BACKEND_ENV`: backend container에 넣을 `.env` 본문
+
+Optional:
+
+- `EC2_FRONTEND_ENV`: frontend runtime `.env` 본문
+- `EC2_PUBLIC_API_BASE_URL`: frontend build arg `NEXT_PUBLIC_API_BASE_URL`
+- `EC2_PUBLIC_BASE_URL`: deploy 후 smoke URL
+
+## Failure Behavior
+
+Green 슬롯 헬스체크나 Nginx reload가 실패하면 green container를 제거하고 기존 blue 슬롯과 기존 Nginx 설정을 유지한다.

--- a/ops/deploy/ec2/bluegreen-deploy.sh
+++ b/ops/deploy/ec2/bluegreen-deploy.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-/opt/aquila-bank}"
+NETWORK="${DOCKER_NETWORK:-aquila-bank-prod}"
+NGINX_CONTAINER="${NGINX_CONTAINER:-aquila-bank-nginx}"
+BACKEND_SLOT_A="${BACKEND_SLOT_A:-aquila-bank-backend-a}"
+BACKEND_SLOT_B="${BACKEND_SLOT_B:-aquila-bank-backend-b}"
+FRONTEND_SLOT_A="${FRONTEND_SLOT_A:-aquila-bank-front-a}"
+FRONTEND_SLOT_B="${FRONTEND_SLOT_B:-aquila-bank-front-b}"
+BACKEND_PORT="${BACKEND_PORT:-8080}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+BACKEND_HOST_PORT_A="${BACKEND_HOST_PORT_A:-18080}"
+BACKEND_HOST_PORT_B="${BACKEND_HOST_PORT_B:-18081}"
+FRONTEND_HOST_PORT_A="${FRONTEND_HOST_PORT_A:-13000}"
+FRONTEND_HOST_PORT_B="${FRONTEND_HOST_PORT_B:-13001}"
+HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-120}"
+HEALTH_INTERVAL_SECONDS="${HEALTH_INTERVAL_SECONDS:-3}"
+BLUE_DRAIN_SECONDS="${BLUE_DRAIN_SECONDS:-10}"
+SERVER_NAME="${NGINX_SERVER_NAME:-_}"
+BACKEND_IMAGE="${BACKEND_IMAGE:?BACKEND_IMAGE is required}"
+FRONTEND_IMAGE="${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}"
+IMAGE_TAG="${IMAGE_TAG:?IMAGE_TAG is required}"
+GITHUB_ACTOR="${GITHUB_ACTOR:?GITHUB_ACTOR is required}"
+GITHUB_TOKEN_B64="${GITHUB_TOKEN_B64:?GITHUB_TOKEN_B64 is required}"
+BACKEND_ENV_B64="${BACKEND_ENV_B64:?BACKEND_ENV_B64 is required}"
+FRONTEND_ENV_B64="${FRONTEND_ENV_B64:-}"
+
+log() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+install_runtime() {
+  if ! command -v docker >/dev/null 2>&1; then
+    log "install docker"
+    sudo dnf install -y docker
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    log "install jq"
+    sudo dnf install -y jq
+  fi
+
+  if ! command -v curl >/dev/null 2>&1; then
+    log "install curl"
+    sudo dnf install -y curl
+  fi
+
+  sudo systemctl enable --now docker
+}
+
+prepare_layout() {
+  sudo mkdir -p "${APP_DIR}/env" "${APP_DIR}/nginx" "${APP_DIR}/state" "${APP_DIR}/logs"
+  sudo chown -R "$(id -u):$(id -g)" "${APP_DIR}"
+  docker network create "${NETWORK}" >/dev/null 2>&1 || true
+}
+
+write_env_files() {
+  printf '%s' "${BACKEND_ENV_B64}" | base64 -d >"${APP_DIR}/env/backend.env"
+  chmod 600 "${APP_DIR}/env/backend.env"
+
+  if [[ -n "${FRONTEND_ENV_B64}" ]]; then
+    printf '%s' "${FRONTEND_ENV_B64}" | base64 -d >"${APP_DIR}/env/frontend.env"
+  else
+    : >"${APP_DIR}/env/frontend.env"
+  fi
+  chmod 600 "${APP_DIR}/env/frontend.env"
+}
+
+docker_login() {
+  local token
+  token="$(printf '%s' "${GITHUB_TOKEN_B64}" | base64 -d)"
+  printf '%s' "${token}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin >/dev/null
+}
+
+active_slot() {
+  if [[ -s "${APP_DIR}/state/active-slot" ]]; then
+    tr -d '[:space:]' <"${APP_DIR}/state/active-slot"
+    return
+  fi
+
+  if docker ps --format '{{.Names}}' | grep -qx "${BACKEND_SLOT_A}"; then
+    printf 'a'
+    return
+  fi
+
+  if docker ps --format '{{.Names}}' | grep -qx "${BACKEND_SLOT_B}"; then
+    printf 'b'
+    return
+  fi
+
+  printf 'none'
+}
+
+slot_name() {
+  local kind="$1"
+  local slot="$2"
+  case "${kind}:${slot}" in
+    backend:a) printf '%s' "${BACKEND_SLOT_A}" ;;
+    backend:b) printf '%s' "${BACKEND_SLOT_B}" ;;
+    frontend:a) printf '%s' "${FRONTEND_SLOT_A}" ;;
+    frontend:b) printf '%s' "${FRONTEND_SLOT_B}" ;;
+    *) log "invalid slot: ${kind}:${slot}"; exit 1 ;;
+  esac
+}
+
+slot_host_port() {
+  local kind="$1"
+  local slot="$2"
+  case "${kind}:${slot}" in
+    backend:a) printf '%s' "${BACKEND_HOST_PORT_A}" ;;
+    backend:b) printf '%s' "${BACKEND_HOST_PORT_B}" ;;
+    frontend:a) printf '%s' "${FRONTEND_HOST_PORT_A}" ;;
+    frontend:b) printf '%s' "${FRONTEND_HOST_PORT_B}" ;;
+    *) log "invalid slot host port: ${kind}:${slot}"; exit 1 ;;
+  esac
+}
+
+wait_http_ok() {
+  local label="$1"
+  local url="$2"
+  local elapsed=0
+  local code
+
+  log "health check ${label}: ${url}"
+  while ((elapsed < HEALTH_TIMEOUT_SECONDS)); do
+    code="$(curl -sS -o /dev/null -w '%{http_code}' "${url}" || true)"
+    if [[ "${code}" == "200" ]]; then
+      log "${label} healthy"
+      return 0
+    fi
+    sleep "${HEALTH_INTERVAL_SECONDS}"
+    elapsed=$((elapsed + HEALTH_INTERVAL_SECONDS))
+  done
+
+  log "${label} health failed: last_status=${code:-none}"
+  return 1
+}
+
+run_green_slot() {
+  local green="$1"
+  local backend_name frontend_name backend_host_port frontend_host_port
+  backend_name="$(slot_name backend "${green}")"
+  frontend_name="$(slot_name frontend "${green}")"
+  backend_host_port="$(slot_host_port backend "${green}")"
+  frontend_host_port="$(slot_host_port frontend "${green}")"
+
+  docker pull "${BACKEND_IMAGE}:${IMAGE_TAG}"
+  docker pull "${FRONTEND_IMAGE}:${IMAGE_TAG}"
+
+  docker rm -f "${backend_name}" "${frontend_name}" >/dev/null 2>&1 || true
+
+  log "start green backend: ${backend_name}"
+  docker run -d \
+    --name "${backend_name}" \
+    --restart unless-stopped \
+    --network "${NETWORK}" \
+    --add-host host.docker.internal:host-gateway \
+    --env-file "${APP_DIR}/env/backend.env" \
+    -e TZ=Asia/Seoul \
+    -p "127.0.0.1:${backend_host_port}:${BACKEND_PORT}" \
+    "${BACKEND_IMAGE}:${IMAGE_TAG}" >/dev/null
+
+  log "start green frontend: ${frontend_name}"
+  docker run -d \
+    --name "${frontend_name}" \
+    --restart unless-stopped \
+    --network "${NETWORK}" \
+    --add-host host.docker.internal:host-gateway \
+    --env-file "${APP_DIR}/env/frontend.env" \
+    -e TZ=Asia/Seoul \
+    -p "127.0.0.1:${frontend_host_port}:${FRONTEND_PORT}" \
+    "${FRONTEND_IMAGE}:${IMAGE_TAG}" >/dev/null
+
+  if ! wait_http_ok "${backend_name}" "http://127.0.0.1:${backend_host_port}/actuator/health"; then
+    docker logs --tail=200 "${backend_name}" || true
+    docker rm -f "${backend_name}" "${frontend_name}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  if ! wait_http_ok "${frontend_name}" "http://127.0.0.1:${frontend_host_port}/"; then
+    docker logs --tail=200 "${frontend_name}" || true
+    docker rm -f "${backend_name}" "${frontend_name}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+}
+
+render_nginx_config() {
+  local slot="$1"
+  local backend_name frontend_name
+  backend_name="$(slot_name backend "${slot}")"
+  frontend_name="$(slot_name frontend "${slot}")"
+
+  cat <<NGINX
+worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  upstream aquila_bank_backend {
+    server ${backend_name}:${BACKEND_PORT};
+    keepalive 16;
+  }
+
+  upstream aquila_bank_frontend {
+    server ${frontend_name}:${FRONTEND_PORT};
+    keepalive 8;
+  }
+
+  server {
+    listen 80 default_server;
+    server_name ${SERVER_NAME};
+
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_connect_timeout 3s;
+
+    location = /api/v1/notifications/stream {
+      # SSE 장기 연결은 proxy buffering을 끄고 blue 슬롯 drain 시간만 짧게 유지한다.
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Connection "";
+      proxy_buffering off;
+      proxy_request_buffering off;
+      proxy_cache off;
+      gzip off;
+      proxy_next_upstream off;
+      proxy_read_timeout 1900s;
+      proxy_send_timeout 1900s;
+      add_header X-Accel-Buffering no always;
+    }
+
+    location ^~ /actuator/health {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Connection "";
+      proxy_read_timeout 5s;
+      proxy_send_timeout 5s;
+      access_log off;
+    }
+
+    location /api/ {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Connection "";
+      proxy_read_timeout 30s;
+      proxy_send_timeout 30s;
+    }
+
+    location / {
+      proxy_pass http://aquila_bank_frontend;
+      proxy_set_header Connection "";
+      proxy_read_timeout 60s;
+      proxy_send_timeout 60s;
+    }
+  }
+}
+NGINX
+}
+
+ensure_nginx_container() {
+  if docker ps --format '{{.Names}}' | grep -qx "${NGINX_CONTAINER}"; then
+    return 0
+  fi
+
+  docker rm -f "${NGINX_CONTAINER}" >/dev/null 2>&1 || true
+  log "start nginx entrypoint"
+  docker run -d \
+    --name "${NGINX_CONTAINER}" \
+    --restart unless-stopped \
+    --network "${NETWORK}" \
+    -p 80:80 \
+    -v "${APP_DIR}/nginx/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    nginx:1.27-alpine >/dev/null
+}
+
+switch_nginx() {
+  local green="$1"
+  local next_config="${APP_DIR}/nginx/nginx.conf.next"
+  local active_config="${APP_DIR}/nginx/nginx.conf"
+  local backup_config="${APP_DIR}/nginx/nginx.conf.previous"
+
+  render_nginx_config "${green}" >"${next_config}"
+  # Nginx reload 전에 동일 Docker network에서 설정을 검증해 기존 blue 슬롯을 보존한다.
+  docker run --rm --network "${NETWORK}" \
+    -v "${next_config}:/etc/nginx/nginx.conf:ro" \
+    nginx:1.27-alpine nginx -t
+
+  if [[ -s "${active_config}" ]]; then
+    cp "${active_config}" "${backup_config}"
+  fi
+
+  mv "${next_config}" "${active_config}"
+  ensure_nginx_container
+
+  if ! docker exec "${NGINX_CONTAINER}" nginx -s reload; then
+    log "nginx reload failed; restore previous config"
+    if [[ -s "${backup_config}" ]]; then
+      cp "${backup_config}" "${active_config}"
+      docker exec "${NGINX_CONTAINER}" nginx -s reload || true
+    fi
+    return 1
+  fi
+
+  printf '%s\n' "${green}" >"${APP_DIR}/state/active-slot"
+}
+
+cleanup_blue() {
+  local blue="$1"
+  if [[ "${blue}" == "none" ]]; then
+    return 0
+  fi
+
+  log "drain old blue slot=${blue} seconds=${BLUE_DRAIN_SECONDS}"
+  sleep "${BLUE_DRAIN_SECONDS}"
+  docker rm -f "$(slot_name backend "${blue}")" "$(slot_name frontend "${blue}")" >/dev/null 2>&1 || true
+}
+
+main() {
+  local blue green
+  install_runtime
+  prepare_layout
+  write_env_files
+  docker_login
+
+  blue="$(active_slot)"
+  case "${blue}" in
+    a) green="b" ;;
+    b) green="a" ;;
+    none) green="a" ;;
+    *) log "unknown active slot=${blue}"; exit 1 ;;
+  esac
+  log "blue=${blue} green=${green}"
+
+  run_green_slot "${green}"
+  if ! switch_nginx "${green}"; then
+    docker rm -f "$(slot_name backend "${green}")" "$(slot_name frontend "${green}")" >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  cleanup_blue "${blue}"
+  docker image prune -f >/dev/null || true
+  log "blue-green deploy complete active=${green}"
+}
+
+main "$@"

--- a/tools/test/check-ec2-bluegreen-cd-contract.sh
+++ b/tools/test/check-ec2-bluegreen-cd-contract.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/ec2-bluegreen-deploy.yml"
+deploy_script="ops/deploy/ec2/bluegreen-deploy.sh"
+deploy_readme="ops/deploy/ec2/README.md"
+terraform_dir="infra/terraform/aws/ec2-app-baseline"
+
+contains() {
+  local pattern="$1"
+  local file="$2"
+  if command -v rg >/dev/null 2>&1; then
+    rg -F --quiet -- "$pattern" "$file"
+    return
+  fi
+  grep -Fq -- "$pattern" "$file"
+}
+
+require_file() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "[ec2-bluegreen-cd] missing file: $file" >&2
+    exit 1
+  fi
+}
+
+require_pattern() {
+  local pattern="$1"
+  local file="$2"
+  if ! contains "$pattern" "$file"; then
+    echo "[ec2-bluegreen-cd] missing pattern in $file: $pattern" >&2
+    exit 1
+  fi
+}
+
+echo "[ec2-bluegreen-cd] required files"
+require_file "$workflow"
+require_file "$deploy_script"
+require_file "$deploy_readme"
+require_file "back/Dockerfile"
+require_file "front/Dockerfile"
+require_file "${terraform_dir}/iam.tf"
+
+echo "[ec2-bluegreen-cd] shell syntax"
+bash -n "$deploy_script"
+bash -n "$0"
+
+if command -v ruby >/dev/null 2>&1; then
+  ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "$workflow"
+fi
+
+echo "[ec2-bluegreen-cd] workflow contract"
+workflow_patterns=(
+  "workflow_run:"
+  "workflow_dispatch:"
+  "workflows:"
+  "- Main CI"
+  "docker/build-push-action@v6"
+  "registry: ghcr.io"
+  "AWS-RunShellScript"
+  "aws ssm send-command"
+  "EC2_BACKEND_ENV"
+  "Mark deployment success"
+  "Mark deployment failure"
+  "env.EC2_PUBLIC_BASE_URL"
+)
+for pattern in "${workflow_patterns[@]}"; do
+  require_pattern "$pattern" "$workflow"
+done
+
+echo "[ec2-bluegreen-cd] deploy script contract"
+script_patterns=(
+  "aquila-bank-backend-a"
+  "aquila-bank-backend-b"
+  "aquila-bank-front-a"
+  "aquila-bank-front-b"
+  "host.docker.internal:host-gateway"
+  "/actuator/health"
+  "location = /api/v1/notifications/stream"
+  "proxy_buffering off;"
+  "nginx -s reload"
+  'docker rm -f "$(slot_name backend "${green}")"'
+)
+for pattern in "${script_patterns[@]}"; do
+  require_pattern "$pattern" "$deploy_script"
+done
+
+echo "[ec2-bluegreen-cd] runtime image contract"
+require_pattern "ENTRYPOINT [\"java\", \"-jar\", \"/app/app.jar\"]" "back/Dockerfile"
+require_pattern "COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./" "front/Dockerfile"
+require_pattern "output: 'standalone'" "front/next.config.js"
+
+echo "[ec2-bluegreen-cd] terraform contract"
+require_pattern "AmazonSSMManagedInstanceCore" "${terraform_dir}/iam.tf"
+require_pattern "iam_instance_profile" "${terraform_dir}/compute.tf"
+require_pattern "http_ingress_cidr" "${terraform_dir}/security.tf"
+require_pattern "from_port   = 80" "${terraform_dir}/security.tf"
+
+echo "[ec2-bluegreen-cd] docs contract"
+require_pattern "로컬 Mac Docker PostgreSQL" "$deploy_readme"
+require_pattern "reverse SSH tunnel" "$deploy_readme"
+require_pattern "EC2_BACKEND_ENV" "$deploy_readme"
+
+echo "[ec2-bluegreen-cd] contract check passed"


### PR DESCRIPTION
## 🔗 Related Issue
- close #521

## 🌿 Base Branch
- `main`

## 📝 Summary
- EC2 `t3.small` app smoke 배포를 GHCR image + SSM RunShellScript + Docker/Nginx blue-green slot 구조로 구성합니다.
- RDS 없이 로컬 Mac Docker PostgreSQL 1억 건 fixture는 유지하고, EC2 backend는 `EC2_BACKEND_ENV`와 별도 tunnel/VPN 계약으로만 DB를 바라보게 합니다.

## 🛠 Changes
- backend/frontend Docker image build를 위한 Dockerfile과 Next standalone output을 추가했습니다.
- Terraform EC2 baseline에 SSM instance profile과 HTTP 80 ingress를 추가하고 실제 AWS에 반영했습니다.
- `EC2 Blue/Green Deploy` GitHub Actions workflow와 EC2 배포 스크립트를 추가했습니다.
- CD 계약 검증 스크립트와 README 연결 문구를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-ec2-bluegreen-cd-contract.sh`
- `terraform -chdir=infra/terraform/aws/ec2-app-baseline fmt -check`
- `terraform -chdir=infra/terraform/aws/ec2-app-baseline validate`
- `terraform -chdir=infra/terraform/aws/ec2-app-baseline plan -detailed-exitcode` before apply: `3 to add, 2 to change, 0 to destroy`
- `terraform -chdir=infra/terraform/aws/ec2-app-baseline apply -auto-approve`: `3 added, 2 changed, 0 destroyed`
- `terraform -chdir=infra/terraform/aws/ec2-app-baseline plan -detailed-exitcode` after apply: `No changes`
- `aws ssm describe-instance-information`: `i-0ca0f721465acc9ac` Online
- `aws ssm send-command` echo smoke: `Success`, stdout `aquila-ssm-ready`
- `yarn --cwd front lint`
- `tools/test/with-resource-lock.sh back-gradlew ./back/gradlew -p back check`
- `git diff --check`
- `git rev-list --count origin/main..HEAD`: `3`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: GitHub Actions environment/repository secrets가 없으면 deploy job이 실패합니다. 필수값은 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `EC2_BACKEND_ENV`입니다.
- 예상 리스크: EC2에서 로컬 Mac PostgreSQL을 실제로 쓰려면 별도 reverse SSH tunnel 또는 VPN이 필요합니다.
- 롤백 방법: PR revert 후 Terraform apply로 SSM/HTTP 변경을 되돌리거나, 이전 GHCR image tag를 workflow_dispatch로 재배포합니다. 배포 스크립트는 green 실패 시 기존 blue slot을 유지합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
