### PR TITLE
[Fix] Frontend Docker public 디렉터리 없는 빌드 실패 수정

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -14,7 +14,7 @@ ARG NEXT_PUBLIC_API_BASE_URL
 ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN yarn build
+RUN mkdir -p public && yarn build
 
 FROM node:20-alpine AS runner
 WORKDIR /app

--- a/tools/test/check-ec2-bluegreen-cd-contract.sh
+++ b/tools/test/check-ec2-bluegreen-cd-contract.sh
@@ -87,6 +87,7 @@ done
 
 echo "[ec2-bluegreen-cd] runtime image contract"
 require_pattern "ENTRYPOINT [\"java\", \"-jar\", \"/app/app.jar\"]" "back/Dockerfile"
+require_pattern "mkdir -p public" "front/Dockerfile"
 require_pattern "COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./" "front/Dockerfile"
 require_pattern "output: 'standalone'" "front/next.config.js"
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #523

## 🌿 Base Branch
- `main`

## 📝 Summary
- EC2 blue-green CD의 frontend Docker build가 `front/public` 부재로 실패하던 문제를 수정합니다.
- builder stage에서 `public` 디렉터리를 보장해 runner stage의 `COPY --from=builder /app/public ./public`가 안정적으로 동작하게 했습니다.

## 🛠 Changes
- `front/Dockerfile`에서 `yarn build` 전에 `mkdir -p public` 실행
- CD 계약 테스트에 frontend Dockerfile의 `public` 디렉터리 보장 조건 추가

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- RED: `tools/test/check-ec2-bluegreen-cd-contract.sh` failed with `missing pattern in front/Dockerfile: mkdir -p public`
- GREEN: `tools/test/check-ec2-bluegreen-cd-contract.sh`
- `docker build ./front`
- `yarn --cwd front lint`
- `git diff --check`
- `git rev-list --count origin/main..HEAD`: `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 없음. 빈 `public` 디렉터리 생성은 Next standalone build artifact 복사 안정성만 보강합니다.
- 롤백 방법: 이 PR revert 후 기존 Dockerfile로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A
