### PR TITLE
[Docs] OCI A1 운영 기준 문서 동기화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aquila Bank
 
-대용량 트래픽을 작은 인프라에서 무제한 처리하는 대신, 로컬 Docker PostgreSQL 18 + 로컬 디스크/volume 기준으로 1억 건 거래 데이터를 적재하고 bounded query로 조회하는 것을 목표로 하는 웹뱅킹 프로젝트입니다. AWS는 App EC2 배포 smoke 기준으로만 두고, 비용형 remote 1억 건 DB 후보는 OCI A1 Flex + self-managed PostgreSQL로 분리합니다. 1억 건 DB primary evidence는 로컬 Mac Docker fixture로 유지합니다.
+대용량 트래픽을 작은 인프라에서 무제한 처리하는 대신, 로컬 Docker PostgreSQL 18 + 로컬 디스크/volume 기준으로 1억 건 거래 데이터를 적재하고 bounded query로 조회하는 것을 목표로 하는 웹뱅킹 프로젝트입니다. 비용형 remote DB/capacity 기준은 OCI A1 Flex 4 OCPU / 24GB + data 300GB self-managed PostgreSQL로 둡니다. AWS EC2는 legacy/optional app smoke 기준으로만 유지하고, 1억 건 DB primary evidence는 로컬 Mac Docker fixture로 유지합니다.
 
 ## Overview
 
@@ -10,7 +10,8 @@
   - 로컬 Docker PostgreSQL 18 + 로컬 디스크/volume 기반 1억 건 fixture 적재와 계좌/기간/keyset page 조회 지원
   - 제한된 local Docker budget에서도 운영 가능한 구조 지향
   - 로컬/배포 환경 모두 `PostgreSQL 18` 표준화
-  - AWS App EC2는 선택적 배포 smoke로만 사용하고, 비용형 remote DB baseline은 OCI A1 Flex self-managed PostgreSQL로 분리
+  - 비용형 remote DB/capacity baseline은 OCI A1 Flex 4 OCPU / 24GB + data 300GB self-managed PostgreSQL로 분리
+  - AWS App EC2는 legacy/optional 배포 smoke로만 사용
 - 제외 목표:
   - 전체 1억 건 검색/집계/정렬
   - Kafka, Prometheus, Grafana의 같은 host 상시 필수 운영
@@ -36,11 +37,11 @@
 
 - `front`: 고객/운영 웹 애플리케이션
 - `back`: API, 도메인, 배치, 어댑터
-- `infra`: 선택형 cloud baseline Terraform. 1억 건 비용형 remote DB 후보는 OCI A1 Flex self-managed PostgreSQL 기준
+- `infra`: 선택형 cloud baseline Terraform. 1억 건 비용형 remote DB/capacity 후보는 OCI A1 Flex 4 OCPU / 24GB + data 300GB self-managed PostgreSQL 기준
 - `ops`: reverse proxy 같은 운영 baseline 파일
 - `.github`: 이슈/PR 템플릿과 협업 메타 설정
 - `compose.yml`: 로컬 개발용 Docker Compose 인프라 실행 기준
-- `compose.t3micro.yml`: 로컬 인프라를 작은 CPU/메모리 budget으로 띄우는 t3.micro 근사 override
+- `compose.t3micro.yml`: 로컬 인프라를 작은 CPU/메모리 budget으로 띄우는 legacy small-budget override
 - `compose.loadtest.yml`: k6, Prometheus, Grafana 기반 HTTP 부하 테스트 runtime overlay
 
 ## Runtime Baseline
@@ -48,21 +49,21 @@
 - database: `PostgreSQL 18`
 - primary 100m evidence: `Docker Compose + PostgreSQL 18 + local disk/volume`
 - query/admission budget: local Docker cgroup 기반 작은 CPU/메모리 budget
-- optional deployed smoke: `EC2 t3.small + gp3 40GiB`
-- optional paid remote DB baseline: `OCI A1 Flex + self-managed PostgreSQL 18 + 300GB Block Volume`
+- paid remote DB/capacity baseline: `OCI A1 Flex 4 OCPU / 24GB + self-managed PostgreSQL 18 + 300GB Block Volume`
+- optional legacy app smoke: `EC2 t3.small + gp3 40GiB`
 
 ## Environment Split
 
 - 로컬 개발: `Docker Compose + PostgreSQL 18`
 - Kafka 로컬 검증: `docker compose --profile kafka up`로 명시적으로 opt-in 합니다.
-- 로컬 t3.micro 근사 검증: `compose.t3micro.yml`과 `tools/test/run-docker-t3micro-capacity-smoke.sh`로 CPU/메모리 cgroup 제한을 적용합니다.
-- 로컬 HTTP 부하 테스트: `compose.loadtest.yml`로 backend, k6, Prometheus, Grafana, Alertmanager, Postgres exporter를 함께 띄웁니다. Prometheus/Grafana는 부하테스트/선택 운영 자산이며 같은 t3.micro host 상시 필수 구성에서 제외합니다.
+- 로컬 small-budget 근사 검증: legacy 이름의 `compose.t3micro.yml`과 `tools/test/run-docker-t3micro-capacity-smoke.sh`로 CPU/메모리 cgroup 제한을 적용합니다.
+- 로컬 HTTP 부하 테스트: `compose.loadtest.yml`로 backend, k6, Prometheus, Grafana, Alertmanager, Postgres exporter를 함께 띄웁니다. Prometheus/Grafana는 부하테스트/선택 운영 자산이며 앱/DB host 상시 필수 구성에서 제외합니다.
 - 로컬 1억 건 synthetic 조회 테스트: dataset 생성은 `tools/test/prepare-transaction-read-model-100m-fixture.sh`, 로컬 k6 조회는 `tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only`로 분리합니다. 생성 phase는 로컬 디스크/volume과 별도 PostgreSQL budget을 사용하고, 조회 phase만 작은 Docker budget으로 제한합니다.
-- 배포 환경: `EC2 t3.small + gp3 40GiB`는 선택적 app smoke 기준입니다.
-- 비용형 remote 1억 건 DB 후보: [infra/terraform/oci/paid-a1-postgres](/Users/aquila/Custom/GitProjects/aquila-bank/infra/terraform/oci/paid-a1-postgres/README.md)는 `VM.Standard.A1.Flex` 4 OCPU / 24GB + data 300GB self-managed PostgreSQL 18 기준입니다. PostgreSQL 5432 public ingress는 열지 않고 SSH tunnel/private 경로로만 접근합니다.
-- EC2 reverse proxy baseline template은 [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)에 두고, runtime 값은 `ops/nginx/runtime.env.example` 기반으로 렌더링합니다.
+- 비용형 remote 1억 건 DB/capacity 후보: [infra/terraform/oci/paid-a1-postgres](/Users/aquila/Custom/GitProjects/aquila-bank/infra/terraform/oci/paid-a1-postgres/README.md)는 `VM.Standard.A1.Flex` 4 OCPU / 24GB + data 300GB self-managed PostgreSQL 18 기준입니다. PostgreSQL 5432 public ingress는 열지 않고 SSH tunnel/private 경로로만 접근합니다.
+- legacy app smoke: `EC2 t3.small + gp3 40GiB`는 AWS 배포 경로 확인용으로만 남기며, remote DB/capacity 기준으로 사용하지 않습니다.
+- reverse proxy baseline template은 [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)에 두고, runtime 값은 `ops/nginx/runtime.env.example` 기반으로 렌더링합니다.
 - `compose.yml`은 로컬 개발 전용이며, 배포용 인프라 정의는 포함하지 않습니다.
-- 최종 1억 건 primary evidence는 로컬 Docker PostgreSQL + 로컬 디스크/volume fixture와 로컬 k6 summary로 닫습니다. OCI A1 paid remote DB는 비용형 비교 baseline이며, AWS staging smoke는 EC2 app 배포 확인 범위로 제한합니다.
+- 최종 1억 건 primary evidence는 로컬 Docker PostgreSQL + 로컬 디스크/volume fixture와 로컬 k6 summary로 닫습니다. OCI A1 paid remote DB/capacity baseline은 4 OCPU / 24GB + data 300GB 기준 비교/확장 경로이며, AWS staging smoke는 EC2 app 배포 확인 범위로 제한합니다.
 - 성능 테스트 결과는 [docs/performance-results](/Users/aquila/Custom/GitProjects/aquila-bank/docs/performance-results/README.md)에 Markdown으로 남깁니다.
 
 ## Delivery Flow
@@ -70,7 +71,7 @@
 - feature 작업은 `main`에서 짧게 분기한 `feat/*`, `fix/*`, `perf/*`, `chore/*`, `build/*`, `docs/*` 브랜치에서 진행합니다.
 - PR 리뷰와 backend/frontend CI 통과 후 `main`에 병합합니다.
 - `main`에 병합되면 `Main CI` workflow가 backend/frontend check를 다시 실행하고, 같은 SHA를 `Staging Deploy` workflow로 전달합니다.
-- EC2 app smoke는 `EC2 Blue/Green Deploy` workflow가 GHCR image를 만들고 SSM으로 단일 EC2 Docker/Nginx blue-green slot을 전환합니다. Backend smoke는 public Host를 backend Host로 그대로 전달하지 않고, health/API 경로를 배포 직후 확인합니다.
+- legacy EC2 app smoke는 `EC2 Blue/Green Deploy` workflow가 GHCR image를 만들고 SSM으로 단일 EC2 Docker/Nginx blue-green slot을 전환합니다. Backend smoke는 public Host를 backend Host로 그대로 전달하지 않고, health/API 경로를 배포 직후 확인합니다.
 - staging 배포는 현재 `origin/main` SHA와 일치하는 `Main CI` 성공 SHA만 진행하며, deploy hook secret이 없으면 no-op으로 종료합니다.
 - production 승격은 staging deployment status가 `success`인 같은 SHA만 대상으로 하고, GitHub Environment 수동 승인 또는 `prod-*` tag로만 진행합니다.
 - 미완성 기능은 장기 `develop` 브랜치 대신 feature flag로 기본 비노출 처리합니다.

--- a/back/README.md
+++ b/back/README.md
@@ -4,7 +4,7 @@ Spring Boot 4 기반 백엔드 애플리케이션입니다.
 
 ## Goal
 
-- EC2 `t3.micro` + RDS `db.t4g.small` + gp3 기준에서 대용량 트래픽을 무제한 처리하지 않고, API admission/SSE cap/작은 worker batch로 과부하를 방어합니다.
+- OCI A1 Flex 4 OCPU / 24GB + data 300GB self-managed PostgreSQL 18 기준에서 대용량 트래픽을 무제한 처리하지 않고, API admission/SSE cap/작은 worker batch로 과부하를 방어합니다.
 - 거래 조회는 1억 건 저장 규모에서도 `accountId + 기간 + keyset pagination`으로 범위를 제한한 bounded query만 온라인 목표로 둡니다.
 - 전체 1억 건 검색/집계/정렬, Kafka 상시 필수 운영, Prometheus/Grafana 같은 host 상시 운영은 기본 목표에서 제외합니다.
 - 로컬/배포 환경 모두 `PostgreSQL 18`을 표준 DB 버전으로 사용합니다.
@@ -263,7 +263,7 @@ docker compose up -d postgres
 - topic partition을 늘릴 때는 `KAFKA_TOPIC_PROVISIONING_PARTITIONS`와 `NOTIFICATION_INBOX_CONSUMER_CONCURRENCY`를 같이 조정합니다.
 - Kafka notification E2E가 필요하면 `docker compose --profile kafka up -d kafka`로 별도 실행합니다. 이 경로는 로컬 개발 전용입니다.
 
-t3.micro에 가까운 작은 로컬 인프라 budget으로 띄울 때는 override 파일을 함께 지정합니다.
+작은 로컬 인프라 budget으로 띄울 때는 legacy 이름의 override 파일을 함께 지정합니다.
 
 ```bash
 docker compose -f compose.yml -f compose.t3micro.yml up -d postgres
@@ -276,7 +276,7 @@ docker compose -f compose.yml -f compose.t3micro.yml --profile kafka up -d postg
 ```
 
 - [compose.t3micro.yml](/Users/aquila/Custom/GitProjects/aquila-bank/compose.t3micro.yml)은 Postgres/Kafka/Redis에 CPU, memory, swap, pids 상한을 겁니다. Kafka와 Redis 상한은 해당 profile을 켰을 때만 적용됩니다.
-- 이 override는 로컬 병목 신호를 빨리 보기 위한 근사값이며, AWS `t3.micro`의 CPU credit, EBS 지연, 실제 네트워크를 재현하지 않습니다.
+- 이 override는 로컬 병목 신호를 빨리 보기 위한 근사값이며, OCI A1의 Ampere CPU, Block Volume 지연, 실제 네트워크를 재현하지 않습니다.
 - Redis까지 같은 budget으로 올릴 때는 `docker compose -f compose.yml -f compose.t3micro.yml --profile redis up -d redis`를 사용합니다.
 
 Redis login throttling runtime smoke가 필요할 때만 profile을 켭니다.
@@ -287,11 +287,11 @@ docker compose --profile redis up -d redis
 
 ## Deployment Baseline
 
-- 백엔드 런타임: `EC2`
-- 데이터베이스: `RDS PostgreSQL 18`
-- EC2 reverse proxy baseline: [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)
-- prod profile은 `DB_URL`, `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` 환경변수를 받아 EC2에서 외부 PostgreSQL에 연결합니다.
-- `compose.yml`은 배포 인프라를 대체하지 않으며, 운영 DB는 local Docker volume이 아니라 관리형 PostgreSQL 기준으로 봅니다.
+- 백엔드 런타임 기준: OCI A1 Flex 4 OCPU / 24GB app/DB baseline 또는 legacy EC2 app smoke
+- 데이터베이스 기준: OCI A1 data 300GB self-managed PostgreSQL 18
+- reverse proxy baseline: [ops/nginx/nginx.conf](/Users/aquila/Custom/GitProjects/aquila-bank/ops/nginx/nginx.conf)
+- prod profile은 `DB_URL`, `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` 환경변수를 받아 외부 PostgreSQL에 연결합니다.
+- `compose.yml`은 배포 인프라를 대체하지 않으며, 운영 DB는 local Docker volume이 아니라 OCI A1 PostgreSQL baseline 기준으로 봅니다.
 
 백엔드는 [back/.env.example](/Users/aquila/Custom/GitProjects/aquila-bank/back/.env.example)를 복사한 뒤 실행합니다.
 
@@ -304,7 +304,7 @@ set +a
 ```
 
 - 애플리케이션 시작 시 `back/src/main/resources/db/migration`의 Flyway 마이그레이션이 자동 적용됩니다.
-- 기본값은 `t3.micro`를 전제로 작은 커넥션 풀과 짧은 DB 타임아웃을 사용합니다.
+- 기본값은 작은 단일 노드 운영을 전제로 작은 커넥션 풀과 짧은 DB 타임아웃을 사용합니다. remote baseline은 OCI A1 4 OCPU / 24GB + data 300GB입니다.
 - 운영 기본 인증 방식은 bearer JWT 입니다.
 - `dev`/`test` 프로필에서는 필요 시 `X-Account-Id` 헤더 fallback을 사용할 수 있습니다.
 - Kafka notification E2E가 필요할 때만 `docker compose --profile kafka up -d kafka`를 먼저 실행하고 `OUTBOX_KAFKA_ENABLED=true`, `NOTIFICATION_INBOX_CONSUMER_ENABLED=true`를 지정합니다.
@@ -332,7 +332,7 @@ set +a
 - export endpoint:
   - `GET /actuator/prometheus`
 - 운영 기준:
-  - metric export endpoint는 유지하지만, EC2 `t3.micro` 애플리케이션 host에서 Prometheus/Grafana를 상시 동거시키는 구성은 기본 목표에서 제외합니다.
+  - metric export endpoint는 유지하지만, OCI A1 app/DB host에서 Prometheus/Grafana를 상시 동거시키는 구성은 기본 목표에서 제외합니다.
   - 부하테스트 overlay, 별도 관측 host, 또는 장애 분석용 단기 실행으로 수집합니다.
 - 보안 기준:
   - application security는 `/actuator/prometheus`를 permitAll 로 열어 Prometheus scrape를 단순화합니다.
@@ -383,7 +383,7 @@ set +a
   - command idempotency conflict counter는 transfer/reversal conflict를 `reason_code` 축으로만 누적합니다.
   - command idempotency recovery/cleanup counter는 stale recovery row 수, retention cleanup delete row 수를 누적합니다.
   - provider delivery gauge는 notification/password recovery delivery table의 sent/skipped/failed/quarantined/retry backlog row 수와 skip reason을 5초 cache로 export 합니다.
-  - t3.micro query timeout counter는 backend query timeout exception이 발생하면 증가합니다.
+  - legacy `t3micro` 이름의 query timeout counter는 backend query timeout exception이 발생하면 증가합니다.
   - Hikari pool metric은 Spring Boot/Micrometer 기본 binder와 `aquila-bank-pool` pool tag 기준으로 export 됩니다.
   - Postgres exporter `pg_stat_statements_*`는 `pg_stat_statements` extension과 collector 활성화가 필요합니다.
   - `pg_stat_activity_lock_waiting_count`는 `wait_event_type = 'Lock'` custom query metric으로 둡니다.
@@ -423,7 +423,7 @@ set +a
   - command idempotency summary gauge는 `ledger.command-idempotency.ops.enabled=true`일 때 live count를 export 하고, 비활성 상태에서는 zero baseline만 남깁니다.
   - p95 alert는 `query_shape`별 5분 rate가 충분할 때만 평가해 low traffic 노이즈를 줄입니다.
   - `AquilaDbPoolPendingWaitDetected`는 Hikari pending connection이 남은 상태라 lock wait, slow query, DB CPU, transaction p95를 같은 시간대에서 같이 확인합니다.
-  - `AquilaDbPoolActivePressureHigh`는 active/max pool ratio 90% 이상을 queueing 전조로 봅니다. t3.micro 기본 `DB_POOL_MAX_SIZE=4`에서는 순간 spike보다 10분 지속 여부가 중요합니다.
+  - `AquilaDbPoolActivePressureHigh`는 active/max pool ratio 90% 이상을 queueing 전조로 봅니다. 작은 단일 노드 기본 `DB_POOL_MAX_SIZE=4`에서는 순간 spike보다 10분 지속 여부가 중요합니다.
   - `AquilaDbQueryTimeoutDetected`는 `statement_timeout` 또는 `lock_timeout` 전파 신호로 보고 blocking query와 pool pending을 먼저 좁힙니다.
   - `AquilaPostgresLockWaitDetected`는 Postgres exporter custom metric이 있을 때만 동작합니다. alert label에는 query text/pid/user/requestId를 올리지 않고 DB drill-down에서 확인합니다.
   - `AquilaPostgresSlowQueryDetected`는 `pg_stat_statements` database-level 평균이 750ms를 넘는지 보는 coarse guard입니다. query별 확인은 `queryid` 기준으로 별도 조회합니다.
@@ -443,7 +443,7 @@ set +a
 
 - outbox retention cleanup은 `publish_status = 'PUBLISHED'` 이고 `published_at` 이 retention cutoff 밖인 row만 정리합니다.
 - `PENDING`, `FAILED`, `SENDING` row는 dispatch 복구와 ops 확인 대상이라 cleanup에서 제외합니다.
-- cleanup batch는 `published_at ASC, id ASC` 순서의 작은 batch delete만 수행해 `t3.micro`에서 lock/vacuum 충격을 낮춥니다.
+- cleanup batch는 `published_at ASC, id ASC` 순서의 작은 batch delete만 수행해 단일 노드 PostgreSQL에서 lock/vacuum 충격을 낮춥니다.
 - 기본 설정은 `OUTBOX_CLEANUP_ENABLED=true`, `OUTBOX_CLEANUP_RETENTION_DAYS=30`, `OUTBOX_CLEANUP_BATCH_SIZE=500`, `OUTBOX_CLEANUP_FIXED_DELAY_MS=300000` 입니다.
 
 ### Local Notification E2E
@@ -469,7 +469,7 @@ tools/test/run-kafka-consumer-partition-concurrency.sh
 - fixture: 4 partitions, 48 records, listener당 고정 30ms work
 - 목표: 최종 consumer lag `0`, concurrency `4` throughput 이 concurrency `1`보다 `1.5x` 초과
 - 운영 적용: `KAFKA_TOPIC_PROVISIONING_PARTITIONS=<n>`으로 topic 최소 partition을 올리고 `NOTIFICATION_INBOX_CONSUMER_CONCURRENCY=<n>`은 partition 수 이하로 둡니다.
-- t3.micro 기준: DB write path가 같이 느려질 수 있으므로 consumer lag, Hikari pool pending, `AquilaDbPoolActivePressureHigh`를 함께 확인합니다.
+- OCI A1 단일 노드 기준: DB write path가 같이 느려질 수 있으므로 consumer lag, Hikari pool pending, `AquilaDbPoolActivePressureHigh`를 함께 확인합니다.
 - rollback: lag가 줄지 않거나 DB pool wait가 늘면 `NOTIFICATION_INBOX_CONSUMER_CONCURRENCY=1`로 되돌리고 partition 증설 효과를 재측정합니다.
 
 ### Kafka Production Replication Baseline
@@ -485,18 +485,18 @@ tools/test/run-kafka-production-replication-baseline.sh
 - startup validation 은 required broker 수, topic 최소 partition 수, topic replication factor, topic `min.insync.replicas`를 같이 확인합니다.
 - rollback: broker 수를 줄이거나 quorum 정책을 완화해야 하면 topic baseline env 와 실제 topic config 를 같이 낮춘 뒤 재시작합니다.
 
-### Production t3.micro Capacity Smoke
+### Production OCI A1 Capacity Smoke
 
-production budget 회귀는 아래 smoke entrypoint와 scheduled workflow로 주기 확인합니다.
+production budget 회귀는 legacy `t3micro` 이름을 유지한 smoke entrypoint와 scheduled workflow로 주기 확인합니다. 현재 remote baseline은 OCI A1 4 OCPU / 24GB + data 300GB입니다.
 
 ```bash
 tools/test/run-production-t3micro-capacity-smoke.sh
 ```
 
-- 위 script는 기존 `tools/test/run-t3micro-mixed-workload-soak.sh`를 production budget env와 함께 실행합니다.
+- 위 script는 기존 `tools/test/run-t3micro-mixed-workload-soak.sh`를 production budget env와 함께 실행합니다. 스크립트 이름은 호환성 때문에 유지합니다.
 - 기본 budget은 `DB_POOL_MAX_SIZE=4`, `SERVER_THREADS_MAX=16`, `NOTIFICATION_SSE_MAX_TOTAL_SESSIONS=64`, `OPS_API_ADMISSION_CONTROL_NOTIFICATION_STREAM_MAX=4` 입니다.
 - 기본 repeat는 `1`이고, 장시간 rehearsal이 필요하면 `SOAK_REPEAT=<n>`으로 늘립니다.
-- scheduled workflow `Production t3.micro Capacity Smoke`는 매주 월요일 03:15 KST(`15 18 * * 0` UTC)와 manual `workflow_dispatch`를 지원합니다.
+- scheduled production capacity smoke workflow는 OCI A1 production budget 회귀 확인 용도로 사용합니다. 매주 월요일 03:15 KST(`15 18 * * 0` UTC)와 manual `workflow_dispatch`를 지원합니다.
 - repository variable로 아래 값을 override 할 수 있습니다.
   - `PRODUCTION_T3MICRO_SOAK_REPEAT`
   - `PRODUCTION_T3MICRO_DB_POOL_MAX_SIZE`
@@ -517,7 +517,7 @@ tools/test/run-docker-t3micro-capacity-smoke.sh
 - 기본값은 실행 전 host에서 `testClasses`를 준비해 Gradle compile 비용을 Docker 1GiB 판정에서 분리합니다. 이 동작을 끄려면 `DOCKER_T3MICRO_PREPARE_TEST_CLASSES=false`를 사용합니다.
 - 기본 image는 `eclipse-temurin:21-jdk`이고, 로컬에 다른 Java 21 image가 있으면 `DOCKER_T3MICRO_IMAGE=<image>`로 바꿀 수 있습니다.
 - Docker smoke는 host 자원이 큰 개발 머신에서 놓칠 수 있는 JVM/thread/pool 압력 회귀를 빨리 잡는 용도입니다.
-- 최종 120% headroom 판정은 실제 EC2 `t3.micro` staging에서 transaction replay, read replica smoke, production capacity smoke를 실행한 결과로 닫습니다.
+- 최종 120% headroom 판정은 OCI A1 4 OCPU / 24GB + data 300GB staging에서 transaction replay, read replica smoke, production capacity smoke를 실행한 결과로 닫습니다.
 
 ### k6 Transaction 100m Load Test
 
@@ -552,8 +552,8 @@ tools/test/run-transaction-read-model-100m-k6-local.sh
 - 기본 hot account는 `910000001`, cold account는 `910000002`입니다.
 - 기본 조회 기간은 hot `2026-04-01T00:00:00Z..2026-04-30T00:00:00Z`, cold `2026-01-01T00:00:00Z..2026-01-31T00:00:00Z`입니다.
 - seed는 read path 성능 검증 전용입니다. 원장 1억 건을 생성하지 않고, seed 중에만 read model FK trigger를 비활성화합니다.
-- 기본 `SEED_INDEX_STRATEGY=required`는 k6에 필요한 account cursor index만 빈 테이블 상태에서 먼저 유지합니다. t3.micro에서는 5천만 row btree를 seed 후 한 번에 build하면 OOM이 발생할 수 있으므로 기본값으로 사용하지 않습니다.
-- 전체 filter index 재생성 검증이 필요하면 `SEED_INDEX_STRATEGY=rebuild-all`을 명시합니다. 이 모드는 t3.micro보다 큰 메모리 budget 또는 partition/chunk 전환 검증에서만 사용합니다.
+- 기본 `SEED_INDEX_STRATEGY=required`는 k6에 필요한 account cursor index만 빈 테이블 상태에서 먼저 유지합니다. 작은 memory budget에서는 5천만 row btree를 seed 후 한 번에 build하면 OOM이 발생할 수 있으므로 기본값으로 사용하지 않습니다.
+- 전체 filter index 재생성 검증이 필요하면 `SEED_INDEX_STRATEGY=rebuild-all`을 명시합니다. 이 모드는 OCI A1 24GB 이상 memory budget 또는 partition/chunk 전환 검증에서만 사용합니다.
 - k6 runner는 실행 전 PostgreSQL `OOMKilled` 상태와 필수 account cursor index 존재 여부를 preflight로 확인합니다.
 - local disk와 Docker volume을 크게 사용합니다. 실행 전 `df -h .`로 여유 공간을 확인합니다.
 - 실패 후 재시도할 때는 `SEED_TRUNCATE=true`를 유지해 중간 적재 데이터를 정리하고 다시 시작합니다.

--- a/docs/transaction-read-model-chunk-lifecycle.md
+++ b/docs/transaction-read-model-chunk-lifecycle.md
@@ -10,7 +10,7 @@
 - archive partition detach/drop은 월 경계가 지난 cold data에만 적용합니다.
 - 모든 destructive 작업은 먼저 `--print-sql`로 review합니다.
 - `drop-detached` 실행은 `CONFIRM_DROP=drop-detached-transaction-read-model`이 없으면 실패합니다.
-- `lock_timeout` 기본값은 `1000ms`, `statement_timeout` 기본값은 `30000ms`로 두어 t3.micro에서 장기 lock을 만들지 않습니다.
+- `lock_timeout` 기본값은 `1000ms`, `statement_timeout` 기본값은 `30000ms`로 두어 OCI A1 단일 노드 PostgreSQL에서 장기 lock을 만들지 않습니다.
 
 ## Monthly Precreate
 
@@ -131,7 +131,7 @@ tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
 
 ## SLO Verification
 
-로컬 t3.micro loadtest:
+로컬 small-budget loadtest:
 
 ```bash
 SEED_TOTAL_ROWS=100000000 \
@@ -140,7 +140,7 @@ SEED_TRUNCATE=true \
 tools/test/run-transaction-read-model-100m-k6-local.sh
 ```
 
-local t3.micro wrapper는 backend를 force-recreate해 최신 Flyway runtime을 보장하고, `flyway_schema_history` 최신 version을 로컬 migration 최신 version과 비교한 뒤 seed를 시작합니다. 기본 conflict mode는 `fail`이라 truncate 신규 seed에서 `ON CONFLICT` 비용을 내지 않습니다.
+legacy 이름의 local small-budget wrapper는 backend를 force-recreate해 최신 Flyway runtime을 보장하고, `flyway_schema_history` 최신 version을 로컬 migration 최신 version과 비교한 뒤 seed를 시작합니다. 기본 conflict mode는 `fail`이라 truncate 신규 seed에서 `ON CONFLICT` 비용을 내지 않습니다.
 
 이미 dataset이 준비되어 있으면 k6만 실행합니다.
 
@@ -162,6 +162,8 @@ tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only
 - archived summary: `docs/performance-results/*`
 
 운영/staging replay:
+
+권장 remote baseline은 OCI A1 Flex 4 OCPU / 24GB + data 300GB self-managed PostgreSQL 18입니다. AWS EC2 staging smoke는 app 배포 확인 범위로만 사용합니다.
 
 ```bash
 STAGING_BASE_URL="$STAGING_BASE_URL" \

--- a/infra/terraform/aws/ec2-app-baseline/README.md
+++ b/infra/terraform/aws/ec2-app-baseline/README.md
@@ -1,10 +1,10 @@
-# AWS EC2 App Baseline Terraform
+# AWS EC2 Legacy App Smoke Terraform
 
-AWS에 App EC2 1대만 만든다. 1억 건 PostgreSQL 데이터는 AWS에 올리지 않고, 로컬 Mac Docker PostgreSQL + 로컬 디스크/volume에 적재된 fixture를 그대로 primary evidence로 사용한다.
+AWS에 App EC2 1대만 만드는 legacy/optional smoke stack이다. 현재 비용형 remote DB/capacity 기준은 OCI A1 Flex 4 OCPU / 24GB + data 300GB self-managed PostgreSQL이며, 이 AWS stack은 1억 건 DB baseline으로 사용하지 않는다.
 
 ## 구성
 
-- EC2: `t3.small`
+- EC2: `t3.small` legacy app smoke only
 - EC2 root EBS: gp3, 40GiB
 - Network: 새 VPC, public subnet 1개, Internet Gateway
 - Security:
@@ -14,11 +14,12 @@ AWS에 App EC2 1대만 만든다. 1억 건 PostgreSQL 데이터는 AWS에 올리
   - EC2 instance profile에 `AmazonSSMManagedInstanceCore`를 연결해 GitHub Actions가 SSM으로 배포 스크립트를 실행할 수 있게 한다.
 - 제외: RDS, private DB subnet, NAT Gateway, ALB/NLB, Elastic IP
 
-이 module은 로컬 Mac Docker PostgreSQL에 있는 1억 건 fixture를 생성하거나 이동하지 않는다. EC2에서 로컬 Mac DB에 접속해야 하는 별도 실험은 SSH tunnel, VPN, allowlist 같은 별도 보안 설계가 필요하며 이번 Terraform 범위에서 제외한다.
+이 module은 로컬 Mac Docker PostgreSQL 또는 OCI A1 PostgreSQL에 있는 1억 건 fixture를 생성하거나 이동하지 않는다. EC2에서 외부 DB에 접속해야 하는 별도 실험은 SSH tunnel, VPN, allowlist 같은 별도 보안 설계가 필요하며 이번 Terraform 범위에서 제외한다.
 
 ## 비용 주의
 
 - EC2 `t3.small`과 gp3 40GiB EBS는 free tier가 아닐 수 있다.
+- 이 stack은 legacy app smoke 전용이다. remote 1억 건 DB/capacity 비교는 OCI A1 4 OCPU / 24GB + data 300GB stack을 사용한다.
 - RDS를 만들지 않으므로 DB instance, RDS storage, snapshot 비용은 발생하지 않는다.
 - 1억 건 검증 비용은 로컬 Mac Docker PostgreSQL + 로컬 디스크 사용량으로 제한한다.
 - NAT Gateway와 Load Balancer는 고정 비용이 생기므로 기본 구성에서 제외한다.
@@ -55,7 +56,7 @@ EC2 접속:
 ssh -i ~/.ssh/<private-key> ec2-user@<ec2_public_ip>
 ```
 
-로컬 1억 건 DB는 Mac Docker PostgreSQL에 남아 있다. 기본 loadtest fixture 기준 접속 정보는 로컬에서 `localhost:15432`와 `aquila_bank`를 사용한다.
+1억 건 DB primary evidence는 Mac Docker PostgreSQL에 남아 있고, 비용형 remote 비교는 OCI A1 PostgreSQL stack을 사용한다. 기본 local loadtest fixture 기준 접속 정보는 로컬에서 `localhost:15432`와 `aquila_bank`를 사용한다.
 
 ## 삭제
 

--- a/ops/deploy/ec2/README.md
+++ b/ops/deploy/ec2/README.md
@@ -1,6 +1,6 @@
 # EC2 Blue/Green Deploy
 
-이 경로는 AWS App EC2 한 대에서 Docker + Nginx blue/green 배포를 수행한다.
+이 경로는 AWS App EC2 한 대에서 Docker + Nginx blue/green 배포 smoke를 수행한다. 현재 remote DB/capacity baseline은 OCI A1 Flex 4 OCPU / 24GB + data 300GB self-managed PostgreSQL이며, EC2 경로는 legacy/optional app smoke로만 유지한다.
 
 ## Runtime
 
@@ -12,7 +12,7 @@
 
 ## Database Boundary
 
-1억 건 PostgreSQL fixture는 EC2로 옮기지 않는다. Backend container는 `EC2_BACKEND_ENV` secret으로 주입되는 DB 접속 설정을 사용한다. 로컬 Mac Docker PostgreSQL을 EC2에서 사용하려면 reverse SSH tunnel 또는 VPN을 별도 보안 작업으로 구성한다.
+1억 건 PostgreSQL fixture는 EC2로 옮기지 않는다. Backend container는 `EC2_BACKEND_ENV` secret으로 주입되는 DB 접속 설정을 사용한다. 로컬 Mac Docker PostgreSQL 또는 OCI A1 PostgreSQL을 EC2에서 사용하려면 reverse SSH tunnel 또는 VPN을 별도 보안 작업으로 구성한다.
 
 Backend/frontend container에는 `host.docker.internal`이 EC2 Docker host gateway로 잡힌다. 로컬 Mac DB를 tunnel로 붙일 때는 EC2 host가 접근할 수 있는 포트로 먼저 고정한 뒤, `EC2_BACKEND_ENV`의 JDBC URL에서 해당 host/port를 사용한다.
 
@@ -30,7 +30,7 @@ Nginx는 public Host를 backend에 그대로 넘기지 않는다. backend locati
 
 ## Local DB Capacity Smoke
 
-EC2 App + 로컬 Mac DB 1억 건 부하 테스트는 저장소에 secret을 남기지 않고 local-only env 파일로 실행한다.
+EC2 App + 외부 DB 1억 건 부하 테스트는 legacy 진단 경로다. 저장소에 secret을 남기지 않고 local-only env 파일로 실행한다. 현재 권장 remote DB/capacity 경로는 OCI A1 4 OCPU / 24GB + data 300GB이다.
 
 ```bash
 tools/test/run-ec2-local-db-capacity-env-doctor.sh --print-env-template > .env/ec2-local-db-capacity.env
@@ -76,7 +76,7 @@ EC2_NGINX_K6_SUMMARY_MD=build/reports/k6/<run>-nginx-summary.md \
   tools/test/compare-ec2-direct-vs-nginx-latency.sh
 ```
 
-`EC2_RESOURCE_CLOUDWATCH_ENABLED=true`를 켜면 `EC2_CAPACITY_AWS_REGION`, `EC2_CAPACITY_EC2_INSTANCE_ID`, `EC2_CAPACITY_EBS_VOLUME_ID`, `EC2_CAPACITY_CLOUDWATCH_START_TIME`, `EC2_CAPACITY_CLOUDWATCH_END_TIME`를 함께 지정한다. CloudWatch는 EC2 CPU credit, CPU utilization, EBS queue/ops만 수집하며 RDS 지표는 이 app-only 경로에서 사용하지 않는다.
+`EC2_RESOURCE_CLOUDWATCH_ENABLED=true`를 켜면 `EC2_CAPACITY_AWS_REGION`, `EC2_CAPACITY_EC2_INSTANCE_ID`, `EC2_CAPACITY_EBS_VOLUME_ID`, `EC2_CAPACITY_CLOUDWATCH_START_TIME`, `EC2_CAPACITY_CLOUDWATCH_END_TIME`를 함께 지정한다. CloudWatch는 EC2 CPU credit, CPU utilization, EBS queue/ops만 수집하며 RDS 지표는 이 app-only 경로에서 사용하지 않는다. OCI A1 baseline 리소스는 이 EC2 CloudWatch 수집 대상이 아니다.
 
 ## Required GitHub Secrets
 

--- a/ops/prometheus/README.md
+++ b/ops/prometheus/README.md
@@ -2,7 +2,7 @@
 
 `ops/prometheus`는 Aquila Bank backend가 이미 export 중인 metric을 기준으로 Grafana dashboard와 Prometheus alert rule baseline을 보관하는 디렉터리입니다. 실제 Prometheus server, Grafana provisioning, Alertmanager routing은 환경별로 다르므로 이번 baseline은 import/apply 가능한 자산만 저장소에 고정합니다.
 
-EC2 `t3.micro` + RDS `db.t4g.small` + gp3 방어형 runtime에서는 Prometheus/Grafana/Alertmanager를 같은 t3.micro host에 상시 필수 운영하지 않습니다. 이 디렉터리의 자산은 부하테스트 overlay, 별도 관측 host, 또는 장애 분석을 위한 단기 실행 기준으로 사용합니다.
+OCI A1 Flex 4 OCPU / 24GB + data 300GB self-managed PostgreSQL 18 runtime에서는 Prometheus/Grafana/Alertmanager를 같은 app/DB host에 상시 필수 운영하지 않습니다. 이 디렉터리의 자산은 부하테스트 overlay, 별도 관측 host, 또는 장애 분석을 위한 단기 실행 기준으로 사용합니다.
 
 ## 포함 파일
 
@@ -29,7 +29,7 @@ EC2 `t3.micro` + RDS `db.t4g.small` + gp3 방어형 runtime에서는 Prometheus/
   - SSE total session, account/user/total trend, reject/drop trend
   - auth throttling reject rate by `entry_point`, `scope`, `store`
   - admission control decision rate / inflight by `group`
-  - t3 saturation guard request, saturated, query timeout trend
+  - legacy `t3micro` metric name의 saturation guard request, saturated, query timeout trend
   - DB pool pending/active pressure, query timeout, Postgres lock/slow query signal
   - transaction query rate by `query_shape`
   - transaction p95 latency by `query_shape`
@@ -40,7 +40,7 @@ EC2 `t3.micro` + RDS `db.t4g.small` + gp3 방어형 runtime에서는 Prometheus/
   - transaction stat latency는 `sum(rate(..._sum)) / sum(rate(..._count))` 평균값을 유지합니다.
   - transaction shape별 latency는 `aquila_transaction_query_latency_seconds_bucket`의 `histogram_quantile(0.95, ...)`를 사용합니다.
   - admission control panel은 `aquila_api_admission_requests_total`, `aquila_api_admission_inflight`를 `group` 기준으로 나눠 봅니다.
-  - t3 saturation guard panel은 reject rate, saturated gauge, query timeout rate를 같은 시간축에 두고 fail-fast와 DB 전조를 같이 봅니다.
+  - saturation guard panel은 reject rate, saturated gauge, query timeout rate를 같은 시간축에 두고 fail-fast와 DB 전조를 같이 봅니다.
   - DB saturation panel은 Hikari pool metric과 Postgres exporter metric을 한 panel에 모아 p95 악화 전 전조를 먼저 봅니다.
   - notification lag panel은 topic label이 있을 때 topic별로 분리해 보여줍니다.
   - SSE reject/drop metric은 앱 재시작 전까지 누적되는 gauge 성격이므로 절대값 trend로만 봅니다.
@@ -81,11 +81,11 @@ EC2 `t3.micro` + RDS `db.t4g.small` + gp3 방어형 runtime에서는 Prometheus/
   - auth throttling reject increase `>= 5` for `10m`
 - runtime guard baseline:
   - endpoint `group`별 admission reject increase `>= 5` for `10m`
-  - t3 saturation guard reject + saturated signal 동시 발생 for `5m`
+  - saturation guard reject + saturated signal 동시 발생 for `5m`
 - Postgres/DB saturation baseline:
   - Hikari pending connection `> 0` for `5m`
   - Hikari active/max pool ratio `> 90%` for `10m`
-  - t3.micro query timeout rate `> 0` for `5m`
+  - query timeout rate `> 0` for `5m`
   - `pg_stat_activity` lock wait custom metric `> 0` for `5m`
   - `pg_stat_statements` average query seconds `> 750ms` for `10m`
 - transaction baseline:
@@ -125,7 +125,7 @@ cp ops/prometheus/rules/aquila-bank-alerts.yml /etc/prometheus/rules/
 
 ## Provisioning Apply
 
-저장소 baseline은 runtime을 강제하지 않고, compose/Kubernetes/systemd 어디서든 같은 mount path로 적용할 수 있게 둡니다. t3.micro 애플리케이션 host에 상시 동거시키는 방식은 기본 운영 목표에서 제외합니다.
+저장소 baseline은 runtime을 강제하지 않고, compose/Kubernetes/systemd 어디서든 같은 mount path로 적용할 수 있게 둡니다. OCI A1 app/DB host에 상시 동거시키는 방식은 기본 운영 목표에서 제외합니다.
 
 - Prometheus:
   - `ops/prometheus/prometheus.yml` -> `/etc/prometheus/prometheus.yml`
@@ -199,7 +199,7 @@ tools/test/run-alertmanager-receiver-secret-workflow-gate.sh
 ## Threshold Tuning
 
 - outbox/notification threshold는 현재 README와 actuator health 기본값을 기준으로 둔 값입니다.
-- Hikari pool alert는 `DB_POOL_MAX_SIZE=4`, `DB_CONNECTION_TIMEOUT_MS=3000`, `DB_LOCK_TIMEOUT_MS=1000`의 t3.micro 기본값을 기준으로 둡니다.
+- Hikari pool alert는 `DB_POOL_MAX_SIZE=4`, `DB_CONNECTION_TIMEOUT_MS=3000`, `DB_LOCK_TIMEOUT_MS=1000`의 작은 단일 노드 기본값을 기준으로 둡니다. remote baseline은 OCI A1 4 OCPU / 24GB + data 300GB입니다.
 - `AquilaDbPoolPendingWaitDetected`는 root cause가 아니라 queueing 전조입니다. 같은 시간대 lock wait, slow query, DB CPU, transaction p95를 같이 확인합니다.
 - `AquilaPostgresSlowQueryDetected`는 `pg_stat_statements`의 database-level 평균을 사용합니다. query별 drill-down은 별도 dashboard 또는 psql에서 `queryid` 기준으로 수행합니다.
 - `AquilaPostgresLockWaitDetected`는 custom exporter metric이 없으면 평가 series가 없으므로, 환경별 exporter 설정 적용 후 Prometheus rule을 활성화합니다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #531

## 🌿 Base Branch
- `main`

## 📝 Summary
- 현재 운영/용량 기준 문서를 OCI A1 Flex 4 OCPU / 24GB + data 300GB self-managed PostgreSQL 기준으로 동기화합니다.
- AWS EC2 문서는 remote DB/capacity 기준이 아니라 legacy/optional app smoke 경로로 명시합니다.

## 🛠 Changes
- `README.md`, `back/README.md`의 운영 baseline을 OCI A1 기준으로 정리했습니다.
- EC2 배포/Terraform 문서는 legacy app smoke 목적과 제외 범위를 명시했습니다.
- Prometheus 및 transaction read model 운영 문서에서 OCI A1 기준과 기존 `t3micro` script/metric 이름의 legacy 의미를 분리했습니다.
- historical performance result 문서는 증거 보존을 위해 변경하지 않았습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [ ] 자동화 테스트: N/A, 문서 변경만 포함
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인: N/A, 런타임 변경 없음

### 실행한 검증
- `git diff --check origin/main..HEAD`
- `rg -n "t3\.micro" README.md back/README.md docs ops infra/terraform --glob "*.md" --glob "!docs/performance-results/**" --glob "!docs/agent/**" --glob "!docs/superpowers/specs/**" --glob "!docs/superpowers/plans/**"`
- `git rev-list --count origin/main..HEAD` → `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 문서상 OCI A1 기준과 아직 남아 있는 legacy script/metric 이름을 혼동할 수 있습니다. 본문에 legacy 이름 유지 사유를 명시했습니다.
- 롤백 방법: 이 PR commit revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A, 문서 변경
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?