### PR TITLE
[CI] OCI A1 blue-green 무중단 CD 구성

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   deployments: write
+  packages: write
 
 concurrency:
   group: staging-deploy
@@ -23,12 +24,16 @@ jobs:
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 35
     environment:
       name: staging
     env:
       DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
       DEPLOY_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      DEPLOY_TARGET_RUNTIME: oci-a1
+      DEPLOY_DATABASE_BASELINE: oci-a1-postgres-100m
+      BACKEND_IMAGE_NAME: aquila-bank-backend
+      FRONTEND_IMAGE_NAME: aquila-bank-frontend
     steps:
       - name: Checkout deploy SHA
         uses: actions/checkout@v4
@@ -60,46 +65,191 @@ jobs:
 
           echo "should_deploy=true" >> "${GITHUB_OUTPUT}"
 
-      - name: Resolve staging deploy hook configuration
-        id: hook_config
+      - name: Load OCI A1 staging env
         if: steps.validate.outputs.should_deploy == 'true'
         env:
-          STAGING_DEPLOY_WEBHOOK_URL: ${{ secrets.STAGING_DEPLOY_WEBHOOK_URL }}
-          STAGING_DEPLOY_TOKEN: ${{ secrets.STAGING_DEPLOY_TOKEN }}
+          OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}
         shell: bash
         run: |
           set -euo pipefail
-          missing_secret=false
-
-          if [ -z "${STAGING_DEPLOY_WEBHOOK_URL}" ]; then
-            echo "::notice::STAGING_DEPLOY_WEBHOOK_URL environment secret is not configured."
-            missing_secret=true
+          if [[ -z "${OCI_A1_STAGING_ENV}" ]]; then
+            echo "::error::Missing OCI_A1_STAGING_ENV environment secret."
+            exit 1
           fi
 
-          if [ -z "${STAGING_DEPLOY_TOKEN}" ]; then
-            echo "::notice::STAGING_DEPLOY_TOKEN environment secret is not configured."
-            missing_secret=true
+          staging_env_path="${RUNNER_TEMP}/oci-a1-staging.env"
+          printf '%s\n' "${OCI_A1_STAGING_ENV}" >"${staging_env_path}"
+          chmod 600 "${staging_env_path}"
+
+          set -a
+          # staging 설정은 GitHub Environment secret 하나에 shell env 파일 형식으로 보관한다.
+          source "${staging_env_path}"
+          set +a
+
+          OCI_A1_SSH_USER="${OCI_A1_SSH_USER:-ubuntu}"
+          OCI_A1_SSH_PORT="${OCI_A1_SSH_PORT:-22}"
+          STAGING_PUBLIC_API_BASE_URL="${STAGING_PUBLIC_API_BASE_URL:-${STAGING_BASE_URL:-}}"
+          STAGING_SMOKE_HEALTH_PATH="${STAGING_SMOKE_HEALTH_PATH:-/actuator/health}"
+          STAGING_SMOKE_WRITE_METHOD="${STAGING_SMOKE_WRITE_METHOD:-POST}"
+          STAGING_SMOKE_WRITE_BODY="${STAGING_SMOKE_WRITE_BODY:-{}}"
+          ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT=staging
+
+          HOT_ACCOUNT_ID="${STAGING_REPLAY_HOT_ACCOUNT_ID:-${HOT_ACCOUNT_ID:-}}"
+          HOT_FROM="${STAGING_REPLAY_HOT_FROM:-${HOT_FROM:-}}"
+          HOT_TO="${STAGING_REPLAY_HOT_TO:-${HOT_TO:-}}"
+          COLD_ACCOUNT_ID="${STAGING_REPLAY_COLD_ACCOUNT_ID:-${COLD_ACCOUNT_ID:-}}"
+          COLD_FROM="${STAGING_REPLAY_COLD_FROM:-${COLD_FROM:-}}"
+          COLD_TO="${STAGING_REPLAY_COLD_TO:-${COLD_TO:-}}"
+          ITERATIONS="${STAGING_REPLAY_ITERATIONS:-${ITERATIONS:-}}"
+          PAGE_LIMIT="${STAGING_REPLAY_PAGE_LIMIT:-${PAGE_LIMIT:-}}"
+          REQUEST_TIMEOUT_SECONDS="${STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS:-${REQUEST_TIMEOUT_SECONDS:-}}"
+          EXPECTED_TOTAL_ROWS="${STAGING_REPLAY_EXPECTED_TOTAL_ROWS:-${EXPECTED_TOTAL_ROWS:-}}"
+          HOT_P95_THRESHOLD_MS="${STAGING_REPLAY_HOT_P95_THRESHOLD_MS:-${HOT_P95_THRESHOLD_MS:-}}"
+          COLD_P95_THRESHOLD_MS="${STAGING_REPLAY_COLD_P95_THRESHOLD_MS:-${COLD_P95_THRESHOLD_MS:-}}"
+          PLANNER_STATS_MAX_AGE_HOURS="${STAGING_REPLAY_STATS_MAX_AGE_HOURS:-${PLANNER_STATS_MAX_AGE_HOURS:-}}"
+          PLANNER_STATS_MAX_MODIFIED_RATIO="${STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO:-${PLANNER_STATS_MAX_MODIFIED_RATIO:-}}"
+
+          missing=()
+          [[ -z "${OCI_A1_SSH_HOST:-}" ]] && missing+=("OCI_A1_SSH_HOST")
+          [[ -z "${OCI_A1_SSH_PRIVATE_KEY_B64:-}" ]] && missing+=("OCI_A1_SSH_PRIVATE_KEY_B64")
+          [[ -z "${OCI_A1_BACKEND_ENV_B64:-}" ]] && missing+=("OCI_A1_BACKEND_ENV_B64")
+          [[ -z "${STAGING_BASE_URL:-}" ]] && missing+=("STAGING_BASE_URL")
+          [[ -z "${STAGING_SMOKE_READ_PATH:-}" ]] && missing+=("STAGING_SMOKE_READ_PATH")
+          [[ -z "${STAGING_SMOKE_WRITE_PATH:-}" ]] && missing+=("STAGING_SMOKE_WRITE_PATH")
+          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
+          [[ -z "${STAGING_OCI_A1_DATABASE_URL:-}" ]] && missing+=("STAGING_OCI_A1_DATABASE_URL")
+          [[ -z "${HOT_ACCOUNT_ID}" ]] && missing+=("STAGING_REPLAY_HOT_ACCOUNT_ID")
+          [[ -z "${HOT_FROM}" ]] && missing+=("STAGING_REPLAY_HOT_FROM")
+          [[ -z "${HOT_TO}" ]] && missing+=("STAGING_REPLAY_HOT_TO")
+          [[ -z "${COLD_ACCOUNT_ID}" ]] && missing+=("STAGING_REPLAY_COLD_ACCOUNT_ID")
+          [[ -z "${COLD_FROM}" ]] && missing+=("STAGING_REPLAY_COLD_FROM")
+          [[ -z "${COLD_TO}" ]] && missing+=("STAGING_REPLAY_COLD_TO")
+
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing OCI A1 staging env keys: %s\n' "${missing[*]}"
+            exit 1
           fi
 
-          # hook 미구성 환경에서는 실제 deploy가 없으므로 staging success status도 만들지 않는다.
-          if [ "${missing_secret}" = "true" ]; then
-            echo "::notice::Skipping staging deploy hook. Configure both staging Environment secrets to enable deployment."
-            echo "hook_configured=false" >> "${GITHUB_OUTPUT}"
-            exit 0
+          if ! [[ "${OCI_A1_SSH_PORT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::OCI_A1_SSH_PORT must be numeric."
+            exit 1
           fi
 
-          echo "hook_configured=true" >> "${GITHUB_OUTPUT}"
+          env_names=(
+            OCI_A1_SSH_HOST
+            OCI_A1_SSH_USER
+            OCI_A1_SSH_PORT
+            OCI_A1_SSH_PRIVATE_KEY_B64
+            OCI_A1_SSH_KNOWN_HOSTS_B64
+            OCI_A1_BACKEND_ENV_B64
+            OCI_A1_FRONTEND_ENV_B64
+            STAGING_PUBLIC_API_BASE_URL
+            STAGING_BASE_URL
+            STAGING_SMOKE_HEALTH_PATH
+            STAGING_SMOKE_READ_PATH
+            STAGING_SMOKE_WRITE_PATH
+            STAGING_SMOKE_WRITE_METHOD
+            STAGING_SMOKE_WRITE_BODY
+            STAGING_SMOKE_AUTH_HEADER_NAME
+            STAGING_SMOKE_AUTH_HEADER_VALUE
+            STAGING_REPLAY_TOKEN
+            STAGING_OCI_A1_DATABASE_URL
+            STAGING_RDS_DATABASE_URL
+            HOT_ACCOUNT_ID
+            HOT_FROM
+            HOT_TO
+            COLD_ACCOUNT_ID
+            COLD_FROM
+            COLD_TO
+            ITERATIONS
+            PAGE_LIMIT
+            REQUEST_TIMEOUT_SECONDS
+            EXPECTED_TOTAL_ROWS
+            HOT_P95_THRESHOLD_MS
+            COLD_P95_THRESHOLD_MS
+            PLANNER_STATS_MAX_AGE_HOURS
+            PLANNER_STATS_MAX_MODIFIED_RATIO
+            ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT
+            ALERTMANAGER_RECEIVER_SLACK_ENABLED
+            ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL
+            ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED
+            ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY
+            ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED
+            ALERTMANAGER_RECEIVER_WEBHOOK_URL
+            STAGING_ROLLBACK_WEBHOOK_URL
+            STAGING_ROLLBACK_TOKEN
+          )
+
+          for name in "${env_names[@]}"; do
+            value="${!name:-}"
+            if [[ -n "${value}" ]]; then
+              echo "::add-mask::${value}"
+            fi
+            if [[ "${value}" == *$'\n'* ]]; then
+              delimiter="AQUILA_${name}_EOF_$(date +%s%N)"
+              {
+                printf '%s<<%s\n' "${name}" "${delimiter}"
+                printf '%s\n' "${value}"
+                printf '%s\n' "${delimiter}"
+              } >>"${GITHUB_ENV}"
+            else
+              printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
+            fi
+          done
+
+      - name: Set up Docker Buildx
+        if: steps.validate.outputs.should_deploy == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        if: steps.validate.outputs.should_deploy == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image names
+        if: steps.validate.outputs.should_deploy == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          owner_lc="${GITHUB_REPOSITORY_OWNER,,}"
+          image_tag="${DEPLOY_SHA:0:12}"
+          backend_image="ghcr.io/${owner_lc}/${BACKEND_IMAGE_NAME}"
+          frontend_image="ghcr.io/${owner_lc}/${FRONTEND_IMAGE_NAME}"
+
+          echo "IMAGE_TAG=${image_tag}" >> "${GITHUB_ENV}"
+          echo "BACKEND_IMAGE=${backend_image}" >> "${GITHUB_ENV}"
+          echo "FRONTEND_IMAGE=${frontend_image}" >> "${GITHUB_ENV}"
+
+      - name: Build and push backend image
+        if: steps.validate.outputs.should_deploy == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker buildx build ./back \
+            --push \
+            --tag "${BACKEND_IMAGE}:${IMAGE_TAG}" \
+            --tag "${BACKEND_IMAGE}:main-latest" \
+            --cache-from type=gha,scope=aquila-bank-backend \
+            --cache-to type=gha,mode=max,scope=aquila-bank-backend
+
+      - name: Build and push frontend image
+        if: steps.validate.outputs.should_deploy == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker buildx build ./front \
+            --push \
+            --build-arg "NEXT_PUBLIC_API_BASE_URL=${STAGING_PUBLIC_API_BASE_URL}" \
+            --tag "${FRONTEND_IMAGE}:${IMAGE_TAG}" \
+            --tag "${FRONTEND_IMAGE}:main-latest" \
+            --cache-from type=gha,scope=aquila-bank-frontend \
+            --cache-to type=gha,mode=max,scope=aquila-bank-frontend
 
       - name: Run Alertmanager receiver secret smoke
-        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
-        env:
-          ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT: staging
-          ALERTMANAGER_RECEIVER_SLACK_ENABLED: ${{ secrets.ALERTMANAGER_RECEIVER_SLACK_ENABLED }}
-          ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL: ${{ secrets.ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL }}
-          ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED: ${{ secrets.ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED }}
-          ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY: ${{ secrets.ALERTMANAGER_RECEIVER_PAGERDUTY_ROUTING_KEY }}
-          ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED: ${{ secrets.ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED }}
-          ALERTMANAGER_RECEIVER_WEBHOOK_URL: ${{ secrets.ALERTMANAGER_RECEIVER_WEBHOOK_URL }}
+        if: steps.validate.outputs.should_deploy == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -107,7 +257,7 @@ jobs:
 
       - name: Create staging deployment
         id: deployment
-        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
+        if: steps.validate.outputs.should_deploy == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -137,7 +287,7 @@ jobs:
           echo "deployment_id=${deployment_id}" >> "${GITHUB_OUTPUT}"
 
       - name: Mark staging deployment in progress
-        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
+        if: steps.validate.outputs.should_deploy == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
@@ -156,91 +306,77 @@ jobs:
           )"
           gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
 
-      - name: Dispatch staging deploy hook
-        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
+      - name: Deploy OCI A1 blue-green over SSH
+        if: steps.validate.outputs.should_deploy == 'true'
         env:
-          STAGING_DEPLOY_WEBHOOK_URL: ${{ secrets.STAGING_DEPLOY_WEBHOOK_URL }}
-          STAGING_DEPLOY_TOKEN: ${{ secrets.STAGING_DEPLOY_TOKEN }}
+          GITHUB_ACTOR_VALUE: ${{ github.actor }}
+          GITHUB_TOKEN_VALUE: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/ssh"
 
-          if [ -z "${STAGING_DEPLOY_WEBHOOK_URL}" ]; then
-            echo "::error::Missing STAGING_DEPLOY_WEBHOOK_URL environment secret."
-            exit 1
+          key_path="${RUNNER_TEMP}/ssh/oci-a1-deploy-key"
+          known_hosts_path="${RUNNER_TEMP}/ssh/oci-a1-known-hosts"
+          printf '%s' "${OCI_A1_SSH_PRIVATE_KEY_B64}" | base64 -d >"${key_path}"
+          chmod 600 "${key_path}"
+
+          if [[ -n "${OCI_A1_SSH_KNOWN_HOSTS_B64:-}" ]]; then
+            printf '%s' "${OCI_A1_SSH_KNOWN_HOSTS_B64}" | base64 -d >"${known_hosts_path}"
+          else
+            echo "::notice::OCI_A1_SSH_KNOWN_HOSTS is not configured. Falling back to ssh-keyscan for this run."
+            ssh-keyscan -p "${OCI_A1_SSH_PORT}" -H "${OCI_A1_SSH_HOST}" >"${known_hosts_path}"
           fi
+          chmod 600 "${known_hosts_path}"
 
-          if [ -z "${STAGING_DEPLOY_TOKEN}" ]; then
-            echo "::error::Missing STAGING_DEPLOY_TOKEN environment secret."
-            exit 1
-          fi
+          script_b64="$(base64 -w0 ops/deploy/oci/bluegreen-deploy.sh)"
+          github_token_b64="$(printf '%s' "${GITHUB_TOKEN_VALUE}" | base64 -w0)"
+          backend_env_b64="${OCI_A1_BACKEND_ENV_B64}"
+          frontend_env_b64="${OCI_A1_FRONTEND_ENV_B64:-}"
 
-          payload="$(
-            jq -n \
-              --arg sha "${DEPLOY_SHA}" \
-              --arg repository "${GITHUB_REPOSITORY}" \
-              --arg run_url "${DEPLOY_LOG_URL}" \
-              '{
-                sha: $sha,
-                repository: $repository,
-                environment: "staging",
-                runUrl: $run_url
-              }'
-          )"
+          printf -v remote_command '%s\n' \
+            "set -euo pipefail" \
+            "export BACKEND_IMAGE=$(printf '%q' "${BACKEND_IMAGE}")" \
+            "export FRONTEND_IMAGE=$(printf '%q' "${FRONTEND_IMAGE}")" \
+            "export IMAGE_TAG=$(printf '%q' "${IMAGE_TAG}")" \
+            "export GITHUB_ACTOR=$(printf '%q' "${GITHUB_ACTOR_VALUE}")" \
+            "export GITHUB_TOKEN_B64=$(printf '%q' "${github_token_b64}")" \
+            "export BACKEND_ENV_B64=$(printf '%q' "${backend_env_b64}")" \
+            "export FRONTEND_ENV_B64=$(printf '%q' "${frontend_env_b64}")" \
+            "mkdir -p /tmp/aquila-bank-deploy" \
+            "printf %s $(printf '%q' "${script_b64}") | base64 -d > /tmp/aquila-bank-deploy/bluegreen-deploy.sh" \
+            "chmod 755 /tmp/aquila-bank-deploy/bluegreen-deploy.sh" \
+            "/tmp/aquila-bank-deploy/bluegreen-deploy.sh"
 
-          curl --fail-with-body --show-error --silent \
-            --request POST \
-            --header "Authorization: Bearer ${STAGING_DEPLOY_TOKEN}" \
-            --header "Content-Type: application/json" \
-            --data "${payload}" \
-            "${STAGING_DEPLOY_WEBHOOK_URL}"
+          ssh_args=(
+            -i "${key_path}"
+            -p "${OCI_A1_SSH_PORT}"
+            -o BatchMode=yes
+            -o ConnectTimeout=15
+            -o ServerAliveInterval=30
+            -o ServerAliveCountMax=10
+            -o StrictHostKeyChecking=yes
+            -o UserKnownHostsFile="${known_hosts_path}"
+          )
+          ssh "${ssh_args[@]}" "${OCI_A1_SSH_USER}@${OCI_A1_SSH_HOST}" "bash -se" <<<"${remote_command}"
 
       - name: Run staging post-deploy smoke
-        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
-        env:
-          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
-          STAGING_SMOKE_HEALTH_PATH: ${{ secrets.STAGING_SMOKE_HEALTH_PATH }}
-          STAGING_SMOKE_READ_PATH: ${{ secrets.STAGING_SMOKE_READ_PATH }}
-          STAGING_SMOKE_WRITE_PATH: ${{ secrets.STAGING_SMOKE_WRITE_PATH }}
-          STAGING_SMOKE_WRITE_METHOD: ${{ secrets.STAGING_SMOKE_WRITE_METHOD }}
-          STAGING_SMOKE_WRITE_BODY: ${{ secrets.STAGING_SMOKE_WRITE_BODY }}
-          STAGING_SMOKE_AUTH_HEADER_NAME: ${{ secrets.STAGING_SMOKE_AUTH_HEADER_NAME }}
-          STAGING_SMOKE_AUTH_HEADER_VALUE: ${{ secrets.STAGING_SMOKE_AUTH_HEADER_VALUE }}
+        if: steps.validate.outputs.should_deploy == 'true'
         shell: bash
         run: |
           set -euo pipefail
           tools/ops/staging-postdeploy-smoke.sh
 
       - name: Run transaction replay regression gate
-        if: steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
-        env:
-          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
-          STAGING_REPLAY_TOKEN: ${{ secrets.STAGING_REPLAY_TOKEN }}
-          STAGING_RDS_DATABASE_URL: ${{ secrets.STAGING_RDS_DATABASE_URL }}
-          HOT_ACCOUNT_ID: ${{ secrets.STAGING_REPLAY_HOT_ACCOUNT_ID }}
-          HOT_FROM: ${{ secrets.STAGING_REPLAY_HOT_FROM }}
-          HOT_TO: ${{ secrets.STAGING_REPLAY_HOT_TO }}
-          COLD_ACCOUNT_ID: ${{ secrets.STAGING_REPLAY_COLD_ACCOUNT_ID }}
-          COLD_FROM: ${{ secrets.STAGING_REPLAY_COLD_FROM }}
-          COLD_TO: ${{ secrets.STAGING_REPLAY_COLD_TO }}
-          ITERATIONS: ${{ secrets.STAGING_REPLAY_ITERATIONS }}
-          PAGE_LIMIT: ${{ secrets.STAGING_REPLAY_PAGE_LIMIT }}
-          REQUEST_TIMEOUT_SECONDS: ${{ secrets.STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS }}
-          EXPECTED_TOTAL_ROWS: ${{ secrets.STAGING_REPLAY_EXPECTED_TOTAL_ROWS }}
-          HOT_P95_THRESHOLD_MS: ${{ secrets.STAGING_REPLAY_HOT_P95_THRESHOLD_MS }}
-          COLD_P95_THRESHOLD_MS: ${{ secrets.STAGING_REPLAY_COLD_P95_THRESHOLD_MS }}
-          PLANNER_STATS_MAX_AGE_HOURS: ${{ secrets.STAGING_REPLAY_STATS_MAX_AGE_HOURS }}
-          PLANNER_STATS_MAX_MODIFIED_RATIO: ${{ secrets.STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO }}
+        if: steps.validate.outputs.should_deploy == 'true'
         shell: bash
         run: |
           set -euo pipefail
           tools/ops/transaction-read-model-staging-replay.sh
 
       - name: Dispatch staging rollback guard
-        if: failure() && steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true' && steps.deployment.outputs.deployment_id != ''
+        if: failure() && steps.validate.outputs.should_deploy == 'true' && steps.deployment.outputs.deployment_id != ''
         env:
-          STAGING_ROLLBACK_WEBHOOK_URL: ${{ secrets.STAGING_ROLLBACK_WEBHOOK_URL }}
-          STAGING_ROLLBACK_TOKEN: ${{ secrets.STAGING_ROLLBACK_TOKEN }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
         shell: bash
         run: |
@@ -248,7 +384,7 @@ jobs:
           tools/ops/staging-rollback-guard.sh
 
       - name: Mark staging deployment success
-        if: success() && steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true'
+        if: success() && steps.validate.outputs.should_deploy == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
@@ -268,7 +404,7 @@ jobs:
           gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
 
       - name: Mark staging deployment failure
-        if: failure() && steps.validate.outputs.should_deploy == 'true' && steps.hook_config.outputs.hook_configured == 'true' && steps.deployment.outputs.deployment_id != ''
+        if: failure() && steps.validate.outputs.should_deploy == 'true' && steps.deployment.outputs.deployment_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -29,53 +29,94 @@
 
 - GitHub Environment: `staging`
 - concurrency group: `staging-deploy`
-- actual deploy required environment secrets:
-  - `STAGING_DEPLOY_WEBHOOK_URL`
-  - `STAGING_DEPLOY_TOKEN`
-- post-deploy smoke required environment secrets:
-  - `STAGING_BASE_URL`
-  - `STAGING_SMOKE_READ_PATH`
-  - `STAGING_SMOKE_WRITE_PATH`
-- post-deploy smoke optional environment secrets:
-  - `STAGING_SMOKE_HEALTH_PATH` (default: `/actuator/health`)
-  - `STAGING_SMOKE_WRITE_METHOD` (default: `POST`)
-  - `STAGING_SMOKE_WRITE_BODY` (default: `{}`)
-  - `STAGING_SMOKE_AUTH_HEADER_NAME`
-  - `STAGING_SMOKE_AUTH_HEADER_VALUE`
-- transaction replay gate required environment secrets:
-  - `STAGING_REPLAY_TOKEN`
-  - `STAGING_RDS_DATABASE_URL`
-  - `STAGING_REPLAY_HOT_ACCOUNT_ID`
-  - `STAGING_REPLAY_HOT_FROM`
-  - `STAGING_REPLAY_HOT_TO`
-  - `STAGING_REPLAY_COLD_ACCOUNT_ID`
-  - `STAGING_REPLAY_COLD_FROM`
-  - `STAGING_REPLAY_COLD_TO`
-- transaction replay gate optional environment secrets:
-  - `STAGING_REPLAY_ITERATIONS` (default: `40`)
-  - `STAGING_REPLAY_PAGE_LIMIT` (default: `50`)
-  - `STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS` (default: `5`)
-  - `STAGING_REPLAY_EXPECTED_TOTAL_ROWS` (default: `100000000`)
-  - `STAGING_REPLAY_HOT_P95_THRESHOLD_MS` (default: `350`)
-  - `STAGING_REPLAY_COLD_P95_THRESHOLD_MS` (default: `750`)
-  - `STAGING_REPLAY_STATS_MAX_AGE_HOURS` (default: `24`)
-  - `STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO` (default: `0.05`)
-- rollback hook optional environment secrets:
-  - `STAGING_ROLLBACK_WEBHOOK_URL`
-  - `STAGING_ROLLBACK_TOKEN`
-- deploy hook payload:
-  - `sha`: staging에 배포할 main SHA
-  - `repository`: `owner/repo`
-  - `environment`: `staging`
-  - `runUrl`: GitHub Actions run URL
-- deploy hook secret이 없으면 workflow는 no-op skip으로 끝내고 staging GitHub deployment status를 만들지 않습니다.
-- workflow는 실제 hook 호출 후 post-deploy smoke를 통과한 경우에만 staging GitHub deployment status를 `success`로 갱신합니다.
+- deploy target runtime: `oci-a1`
+- database baseline: `oci-a1-postgres-100m`
+- image registry: GHCR `aquila-bank-backend`, `aquila-bank-frontend`
+- required environment secret:
+  - `OCI_A1_STAGING_ENV`
+- deploy flow:
+  - `OCI_A1_STAGING_ENV`를 shell env 파일로 로드한다.
+  - `Main CI`가 성공한 main SHA를 checkout한다.
+  - backend/frontend image를 `${DEPLOY_SHA:0:12}`와 `main-latest` tag로 GHCR에 push한다.
+  - workflow가 OCI A1 VM에 SSH로 접속해 `ops/deploy/oci/bluegreen-deploy.sh`를 실행한다.
+  - deploy script는 green backend/frontend container health가 모두 200일 때만 Nginx config를 교체하고 reload한다.
+  - Nginx config 검증 또는 reload가 실패하면 이전 config와 blue slot을 유지한다.
+- required OCI deploy secret이 없으면 workflow는 fail-fast하며 staging GitHub deployment status를 성공으로 만들지 않습니다.
+- workflow는 OCI A1 SSH deploy와 post-deploy smoke를 통과한 경우에만 staging GitHub deployment status를 `success`로 갱신합니다.
 - transaction replay gate는 post-deploy smoke 뒤에 실행되며, `pg_class.reltuples` 검증 전에 planner stats freshness guard로 stale stats를 차단합니다.
 - replay gate가 실패하면 staging deployment status는 `success`로 올라가지 않으므로 production promotion guard가 같은 SHA를 자동으로 거부합니다.
 - post-deploy smoke는 health/read/write endpoint를 호출하며, read/write path는 환경별 smoke 전용 endpoint를 secret으로 주입합니다.
-- smoke 또는 deploy hook 실패 시 deployment status는 `failure`가 되고, rollback hook이 설정된 경우 `sha`, `repository`, `runUrl`, `deploymentId`와 함께 호출합니다.
+- smoke 또는 OCI deploy 실패 시 deployment status는 `failure`가 되고, rollback hook이 설정된 경우 `sha`, `repository`, `runUrl`, `deploymentId`와 함께 호출합니다.
 - production 승격은 staging deployment status가 `success`인 같은 SHA만 대상으로 삼습니다.
 - rollback은 `main` 기준 revert PR을 merge해 새 staging SHA를 배포하거나, 운영자가 직전 staging 성공 SHA를 확인해 별도 재배포 절차로 진행합니다.
+
+### OCI A1 Staging Env 예시
+
+`OCI_A1_STAGING_ENV` 하나에 staging CD, smoke, replay, alertmanager 값을 모두 넣습니다. 저장소에 커밋하지 않습니다. 값에 공백, `#`, `&`가 있으면 shell env 문법에 맞게 quote합니다. multi-line 값은 base64로 넣습니다.
+
+```env
+OCI_A1_SSH_HOST=146.56.149.120
+OCI_A1_SSH_USER=ubuntu
+OCI_A1_SSH_PORT=22
+OCI_A1_SSH_PRIVATE_KEY_B64=REPLACE_BASE64_PRIVATE_KEY
+OCI_A1_SSH_KNOWN_HOSTS_B64=REPLACE_BASE64_SSH_KEYSCAN_OUTPUT
+OCI_A1_BACKEND_ENV_B64=REPLACE_BASE64_BACKEND_ENV
+OCI_A1_FRONTEND_ENV_B64=
+
+STAGING_BASE_URL=http://146.56.149.120
+STAGING_PUBLIC_API_BASE_URL=http://146.56.149.120
+STAGING_SMOKE_HEALTH_PATH=/actuator/health
+STAGING_SMOKE_READ_PATH='/api/v1/transactions?accountId=910000001&from=2026-04-01T00%3A00%3A00Z&to=2026-04-30T00%3A00%3A00Z&limit=1'
+STAGING_SMOKE_WRITE_PATH=/actuator/health
+STAGING_SMOKE_WRITE_METHOD=GET
+STAGING_SMOKE_WRITE_BODY={}
+STAGING_SMOKE_AUTH_HEADER_NAME=Authorization
+STAGING_SMOKE_AUTH_HEADER_VALUE='Bearer REPLACE_FIXTURE_TOKEN'
+
+STAGING_REPLAY_TOKEN=REPLACE_FIXTURE_TOKEN
+STAGING_OCI_A1_DATABASE_URL='postgresql://aquila:<password>@127.0.0.1:5432/aquila'
+STAGING_REPLAY_HOT_ACCOUNT_ID=910000001
+STAGING_REPLAY_HOT_FROM=2026-04-01T00:00:00Z
+STAGING_REPLAY_HOT_TO=2026-04-30T00:00:00Z
+STAGING_REPLAY_COLD_ACCOUNT_ID=910000002
+STAGING_REPLAY_COLD_FROM=2025-04-01T00:00:00Z
+STAGING_REPLAY_COLD_TO=2025-04-30T00:00:00Z
+STAGING_REPLAY_ITERATIONS=40
+STAGING_REPLAY_PAGE_LIMIT=50
+STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS=5
+STAGING_REPLAY_EXPECTED_TOTAL_ROWS=100000000
+STAGING_REPLAY_HOT_P95_THRESHOLD_MS=350
+STAGING_REPLAY_COLD_P95_THRESHOLD_MS=750
+STAGING_REPLAY_STATS_MAX_AGE_HOURS=24
+STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO=0.05
+
+ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED=true
+ALERTMANAGER_RECEIVER_WEBHOOK_URL='https://example.invalid/alertmanager'
+ALERTMANAGER_RECEIVER_SLACK_ENABLED=false
+ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED=false
+```
+
+`OCI_A1_BACKEND_ENV_B64`는 backend container `.env` 본문을 base64 인코딩한 값입니다.
+
+```env
+SPRING_PROFILES_ACTIVE=prod
+SERVER_PORT=8080
+SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:5432/aquila
+SPRING_DATASOURCE_USERNAME=aquila
+SPRING_DATASOURCE_PASSWORD=<secret>
+DB_POOL_MAX_SIZE=4
+SERVER_THREADS_MAX=16
+OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=3
+NOTIFICATION_SSE_MAX_TOTAL_SESSIONS=64
+```
+
+예시 생성:
+
+```bash
+base64 -w0 ~/.ssh/oci_a1_deploy
+ssh-keyscan -p 22 -H 146.56.149.120 | base64 -w0
+base64 -w0 .env.backend-staging
+```
 
 ## Feature Flag
 

--- a/docs/production-promotion.md
+++ b/docs/production-promotion.md
@@ -12,6 +12,7 @@
 - target SHA는 `origin/main`에서 도달 가능해야 합니다.
 - target SHA와 같은 staging GitHub deployment가 있어야 합니다.
 - 해당 staging deployment의 최신 status가 `success`여야 합니다.
+- staging success는 OCI A1 blue/green deploy, post-deploy smoke, 1억 건 replay gate를 통과한 same SHA만 기록합니다.
 - guard가 실패하면 `production` Environment approval 전 단계에서 workflow가 중단됩니다.
 
 ## Approval

--- a/docs/transaction-read-model-staging-replay.md
+++ b/docs/transaction-read-model-staging-replay.md
@@ -14,7 +14,8 @@
 - staging GitHub Environment secrets:
   - `STAGING_BASE_URL`
   - `STAGING_REPLAY_TOKEN`
-  - `STAGING_RDS_DATABASE_URL` 또는 같은 값으로 연결되는 OCI A1 PostgreSQL URL
+  - `STAGING_OCI_A1_DATABASE_URL`
+  - `STAGING_RDS_DATABASE_URL`는 legacy fallback으로만 사용
 - OCI A1 100m primary evidence:
   - `tools/test/prepare-transaction-read-model-100m-fixture.sh`
   - `tools/test/run-transaction-read-model-100m-k6-local.sh --k6-only`
@@ -35,7 +36,7 @@
 
 ## Staging Deploy Release Gate
 
-- `Staging Deploy` workflow는 staging hook과 OCI A1 PostgreSQL replay secret이 준비된 환경에서 post-deploy smoke 뒤에 같은 replay script를 실행합니다.
+- `Staging Deploy` workflow는 OCI A1 SSH deploy와 OCI A1 PostgreSQL replay secret이 준비된 환경에서 post-deploy smoke 뒤에 같은 replay script를 실행합니다.
 - release gate는 아래 `staging` Environment secret을 읽어 수동 입력 없이 same SHA를 검증합니다.
   - required:
     - `STAGING_REPLAY_HOT_ACCOUNT_ID`

--- a/infra/terraform/oci/always-free-a1-flex/README.md
+++ b/infra/terraform/oci/always-free-a1-flex/README.md
@@ -9,7 +9,7 @@ OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만�
 - Memory: `24GB`
 - Boot Volume: `150GB`
 - Network: 새 VCN, public subnet, Internet Gateway, Route Table
-- Ingress: SSH `22/tcp`만 허용
+- Ingress: SSH `22/tcp`, staging HTTP `80/tcp`
 - 제외: NAT Gateway, Load Balancer, Database, 추가 Block Volume
 
 ## 무료 한도 조건
@@ -32,6 +32,7 @@ OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만�
 - `availability_domain`
 - `ssh_public_key`
 - `ssh_ingress_cidr`
+- `http_ingress_cidr`
 
 선택 값:
 
@@ -40,6 +41,7 @@ OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만�
 - `source_image_ocid_override`: 기본값 `null`
 
 `ssh_ingress_cidr`는 운영자 현재 공인 IP의 `/32`를 우선 사용한다. `0.0.0.0/0`은 임시 테스트가 아니면 사용하지 않는다.
+`http_ingress_cidr`는 GitHub Actions smoke와 브라우저 접근을 받는 staging HTTP 포트다. public staging이면 `0.0.0.0/0`, 사설 접근만 허용할 수 있으면 제한 CIDR을 사용한다.
 
 ## 실행
 

--- a/infra/terraform/oci/always-free-a1-flex/network.tf
+++ b/infra/terraform/oci/always-free-a1-flex/network.tf
@@ -52,6 +52,18 @@ resource "oci_core_security_list" "public_ssh" {
       min = 22
     }
   }
+
+  ingress_security_rules {
+    description = "HTTP ingress for OCI A1 staging"
+    protocol    = "6"
+    source      = var.http_ingress_cidr
+    source_type = "CIDR_BLOCK"
+
+    tcp_options {
+      max = 80
+      min = 80
+    }
+  }
 }
 
 resource "oci_core_subnet" "public" {

--- a/infra/terraform/oci/always-free-a1-flex/terraform.tfvars.example
+++ b/infra/terraform/oci/always-free-a1-flex/terraform.tfvars.example
@@ -13,6 +13,7 @@ source_image_ocid_override     = null
 
 ssh_public_key   = "ssh-ed25519 example-public-key"
 ssh_ingress_cidr = "203.0.113.10/32"
+http_ingress_cidr = "0.0.0.0/0"
 
 name_prefix    = "aquila-free-a1"
 hostname_label = "aquilafreea1"

--- a/infra/terraform/oci/always-free-a1-flex/variables.tf
+++ b/infra/terraform/oci/always-free-a1-flex/variables.tf
@@ -136,6 +136,18 @@ variable "ssh_ingress_cidr" {
   }
 }
 
+variable "http_ingress_cidr" {
+  description = "CIDR allowed to connect to the staging Nginx HTTP port 80. Public staging uses 0.0.0.0/0."
+  type        = string
+  default     = "0.0.0.0/0"
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.http_ingress_cidr))
+    error_message = "http_ingress_cidr must be a valid IPv4 CIDR."
+  }
+}
+
 variable "name_prefix" {
   description = "Name prefix for OCI resources."
   type        = string

--- a/ops/deploy/oci/README.md
+++ b/ops/deploy/oci/README.md
@@ -1,0 +1,67 @@
+# OCI A1 Blue/Green Deploy
+
+이 경로는 OCI A1 Ubuntu VM 한 대에서 Docker + Nginx blue/green staging 배포를 수행한다.
+
+## Runtime
+
+- host: OCI A1 Flex 4 OCPU / 24GB
+- app dir: `/opt/aquila-bank`
+- Docker network: `aquila-bank-prod`
+- public entrypoint: `aquila-bank-nginx` on host port `80`
+- backend slots: `aquila-bank-backend-a`, `aquila-bank-backend-b`
+- frontend slots: `aquila-bank-front-a`, `aquila-bank-front-b`
+
+`bluegreen-deploy.sh`는 green backend/frontend container를 먼저 시작하고, `/actuator/health`와 `/`가 200을 반환해야 Nginx config를 교체한다. Nginx config test 또는 reload가 실패하면 이전 config를 복원하고 기존 blue slot을 유지한다.
+
+## GitHub Actions Input
+
+`staging` Environment에는 `OCI_A1_STAGING_ENV` secret 하나만 둔다. 이 값은 shell env 파일 형식이며, multi-line 값은 base64로 넣는다.
+
+필수 key:
+
+- `OCI_A1_SSH_HOST`
+- `OCI_A1_SSH_PRIVATE_KEY_B64`
+- `OCI_A1_BACKEND_ENV_B64`
+- `STAGING_BASE_URL`
+- `STAGING_SMOKE_READ_PATH`
+- `STAGING_SMOKE_WRITE_PATH`
+- `STAGING_REPLAY_TOKEN`
+- `STAGING_OCI_A1_DATABASE_URL`
+- `STAGING_REPLAY_HOT_ACCOUNT_ID`
+- `STAGING_REPLAY_HOT_FROM`
+- `STAGING_REPLAY_HOT_TO`
+- `STAGING_REPLAY_COLD_ACCOUNT_ID`
+- `STAGING_REPLAY_COLD_FROM`
+- `STAGING_REPLAY_COLD_TO`
+
+선택 key:
+
+- `OCI_A1_SSH_USER`: 기본 `ubuntu`
+- `OCI_A1_SSH_PORT`: 기본 `22`
+- `OCI_A1_SSH_KNOWN_HOSTS_B64`: 없으면 workflow가 `ssh-keyscan`으로 수집
+- `OCI_A1_FRONTEND_ENV_B64`
+- `STAGING_PUBLIC_API_BASE_URL`: 없으면 `STAGING_BASE_URL`
+- `STAGING_SMOKE_HEALTH_PATH`: 기본 `/actuator/health`
+- `STAGING_SMOKE_WRITE_METHOD`: 기본 `POST`
+- `STAGING_SMOKE_WRITE_BODY`: 기본 `{}`
+- `STAGING_SMOKE_AUTH_HEADER_NAME`, `STAGING_SMOKE_AUTH_HEADER_VALUE`
+- `STAGING_REPLAY_ITERATIONS`, `STAGING_REPLAY_PAGE_LIMIT`, replay threshold 계열
+- `ALERTMANAGER_RECEIVER_*`
+- `STAGING_ROLLBACK_WEBHOOK_URL`, `STAGING_ROLLBACK_TOKEN`
+
+## Local Manual Run
+
+수동 실행은 같은 변수명을 export한 뒤 root 권한으로 실행한다.
+
+```bash
+export BACKEND_IMAGE=ghcr.io/aquilaxk/aquila-bank-backend
+export FRONTEND_IMAGE=ghcr.io/aquilaxk/aquila-bank-frontend
+export IMAGE_TAG=<12-char-sha>
+export GITHUB_ACTOR=<github-user>
+export GITHUB_TOKEN_B64=<base64-token>
+export BACKEND_ENV_B64=<base64-backend-env>
+export FRONTEND_ENV_B64=<base64-frontend-env>
+sudo -E ops/deploy/oci/bluegreen-deploy.sh
+```
+
+비밀값은 파일이나 shell history에 남기지 않는다. GitHub Actions 경로를 기본 운영 경로로 사용한다.

--- a/ops/deploy/oci/bluegreen-deploy.sh
+++ b/ops/deploy/oci/bluegreen-deploy.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  exec sudo -E bash "$0" "$@"
+fi
+
+APP_DIR="${APP_DIR:-/opt/aquila-bank}"
+NETWORK="${DOCKER_NETWORK:-aquila-bank-prod}"
+NGINX_CONTAINER="${NGINX_CONTAINER:-aquila-bank-nginx}"
+BACKEND_SLOT_A="${BACKEND_SLOT_A:-aquila-bank-backend-a}"
+BACKEND_SLOT_B="${BACKEND_SLOT_B:-aquila-bank-backend-b}"
+FRONTEND_SLOT_A="${FRONTEND_SLOT_A:-aquila-bank-front-a}"
+FRONTEND_SLOT_B="${FRONTEND_SLOT_B:-aquila-bank-front-b}"
+BACKEND_PORT="${BACKEND_PORT:-8080}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+BACKEND_HOST_PORT_A="${BACKEND_HOST_PORT_A:-18080}"
+BACKEND_HOST_PORT_B="${BACKEND_HOST_PORT_B:-18081}"
+FRONTEND_HOST_PORT_A="${FRONTEND_HOST_PORT_A:-13000}"
+FRONTEND_HOST_PORT_B="${FRONTEND_HOST_PORT_B:-13001}"
+HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-180}"
+HEALTH_INTERVAL_SECONDS="${HEALTH_INTERVAL_SECONDS:-3}"
+BLUE_DRAIN_SECONDS="${BLUE_DRAIN_SECONDS:-15}"
+SERVER_NAME="${NGINX_SERVER_NAME:-_}"
+BACKEND_PROXY_HOST="${NGINX_BACKEND_PROXY_HOST:-}"
+BACKEND_IMAGE="${BACKEND_IMAGE:?BACKEND_IMAGE is required}"
+FRONTEND_IMAGE="${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}"
+IMAGE_TAG="${IMAGE_TAG:?IMAGE_TAG is required}"
+GITHUB_ACTOR="${GITHUB_ACTOR:?GITHUB_ACTOR is required}"
+GITHUB_TOKEN_B64="${GITHUB_TOKEN_B64:?GITHUB_TOKEN_B64 is required}"
+BACKEND_ENV_B64="${BACKEND_ENV_B64:?BACKEND_ENV_B64 is required}"
+FRONTEND_ENV_B64="${FRONTEND_ENV_B64:-}"
+
+log() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+install_runtime() {
+  export DEBIAN_FRONTEND=noninteractive
+
+  if ! command -v docker >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
+    log "install OCI Ubuntu runtime packages"
+    apt-get update
+    apt-get install -y ca-certificates curl jq docker.io
+  fi
+
+  systemctl enable --now docker
+}
+
+prepare_layout() {
+  mkdir -p "${APP_DIR}/env" "${APP_DIR}/nginx" "${APP_DIR}/state" "${APP_DIR}/logs"
+  chmod 750 "${APP_DIR}" "${APP_DIR}/env" "${APP_DIR}/nginx" "${APP_DIR}/state" "${APP_DIR}/logs"
+  docker network create "${NETWORK}" >/dev/null 2>&1 || true
+}
+
+write_env_files() {
+  printf '%s' "${BACKEND_ENV_B64}" | base64 -d >"${APP_DIR}/env/backend.env"
+  chmod 600 "${APP_DIR}/env/backend.env"
+
+  if [[ -n "${FRONTEND_ENV_B64}" ]]; then
+    printf '%s' "${FRONTEND_ENV_B64}" | base64 -d >"${APP_DIR}/env/frontend.env"
+  else
+    : >"${APP_DIR}/env/frontend.env"
+  fi
+  chmod 600 "${APP_DIR}/env/frontend.env"
+}
+
+docker_login() {
+  local token
+  token="$(printf '%s' "${GITHUB_TOKEN_B64}" | base64 -d)"
+  printf '%s' "${token}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin >/dev/null
+}
+
+active_slot() {
+  if [[ -s "${APP_DIR}/state/active-slot" ]]; then
+    tr -d '[:space:]' <"${APP_DIR}/state/active-slot"
+    return
+  fi
+
+  if docker ps --format '{{.Names}}' | grep -qx "${BACKEND_SLOT_A}"; then
+    printf 'a'
+    return
+  fi
+
+  if docker ps --format '{{.Names}}' | grep -qx "${BACKEND_SLOT_B}"; then
+    printf 'b'
+    return
+  fi
+
+  printf 'none'
+}
+
+slot_name() {
+  local kind="$1"
+  local slot="$2"
+  case "${kind}:${slot}" in
+    backend:a) printf '%s' "${BACKEND_SLOT_A}" ;;
+    backend:b) printf '%s' "${BACKEND_SLOT_B}" ;;
+    frontend:a) printf '%s' "${FRONTEND_SLOT_A}" ;;
+    frontend:b) printf '%s' "${FRONTEND_SLOT_B}" ;;
+    *) log "invalid slot: ${kind}:${slot}"; exit 1 ;;
+  esac
+}
+
+slot_host_port() {
+  local kind="$1"
+  local slot="$2"
+  case "${kind}:${slot}" in
+    backend:a) printf '%s' "${BACKEND_HOST_PORT_A}" ;;
+    backend:b) printf '%s' "${BACKEND_HOST_PORT_B}" ;;
+    frontend:a) printf '%s' "${FRONTEND_HOST_PORT_A}" ;;
+    frontend:b) printf '%s' "${FRONTEND_HOST_PORT_B}" ;;
+    *) log "invalid slot host port: ${kind}:${slot}"; exit 1 ;;
+  esac
+}
+
+wait_http_ok() {
+  local label="$1"
+  local url="$2"
+  local elapsed=0
+  local code
+
+  log "health check ${label}: ${url}"
+  while ((elapsed < HEALTH_TIMEOUT_SECONDS)); do
+    code="$(curl -sS -o /dev/null -w '%{http_code}' "${url}" || true)"
+    if [[ "${code}" == "200" ]]; then
+      log "${label} healthy"
+      return 0
+    fi
+    sleep "${HEALTH_INTERVAL_SECONDS}"
+    elapsed=$((elapsed + HEALTH_INTERVAL_SECONDS))
+  done
+
+  log "${label} health failed: last_status=${code:-none}"
+  return 1
+}
+
+run_green_slot() {
+  local green="$1"
+  local backend_name frontend_name backend_host_port frontend_host_port
+  backend_name="$(slot_name backend "${green}")"
+  frontend_name="$(slot_name frontend "${green}")"
+  backend_host_port="$(slot_host_port backend "${green}")"
+  frontend_host_port="$(slot_host_port frontend "${green}")"
+
+  docker pull "${BACKEND_IMAGE}:${IMAGE_TAG}"
+  docker pull "${FRONTEND_IMAGE}:${IMAGE_TAG}"
+
+  docker rm -f "${backend_name}" "${frontend_name}" >/dev/null 2>&1 || true
+
+  log "start green backend: ${backend_name}"
+  docker run -d \
+    --name "${backend_name}" \
+    --restart unless-stopped \
+    --network "${NETWORK}" \
+    --add-host host.docker.internal:host-gateway \
+    --env-file "${APP_DIR}/env/backend.env" \
+    -e TZ=Asia/Seoul \
+    -p "127.0.0.1:${backend_host_port}:${BACKEND_PORT}" \
+    "${BACKEND_IMAGE}:${IMAGE_TAG}" >/dev/null
+
+  log "start green frontend: ${frontend_name}"
+  docker run -d \
+    --name "${frontend_name}" \
+    --restart unless-stopped \
+    --network "${NETWORK}" \
+    --add-host host.docker.internal:host-gateway \
+    --env-file "${APP_DIR}/env/frontend.env" \
+    -e TZ=Asia/Seoul \
+    -p "127.0.0.1:${frontend_host_port}:${FRONTEND_PORT}" \
+    "${FRONTEND_IMAGE}:${IMAGE_TAG}" >/dev/null
+
+  if ! wait_http_ok "${backend_name}" "http://127.0.0.1:${backend_host_port}/actuator/health"; then
+    docker logs --tail=200 "${backend_name}" || true
+    docker rm -f "${backend_name}" "${frontend_name}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  if ! wait_http_ok "${frontend_name}" "http://127.0.0.1:${frontend_host_port}/"; then
+    docker logs --tail=200 "${frontend_name}" || true
+    docker rm -f "${backend_name}" "${frontend_name}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+}
+
+render_nginx_config() {
+  local slot="$1"
+  local backend_name frontend_name backend_proxy_host
+  backend_name="$(slot_name backend "${slot}")"
+  frontend_name="$(slot_name frontend "${slot}")"
+  backend_proxy_host="${BACKEND_PROXY_HOST:-${backend_name}}"
+
+  cat <<NGINX
+worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  upstream aquila_bank_backend {
+    server ${backend_name}:${BACKEND_PORT};
+    keepalive 16;
+  }
+
+  upstream aquila_bank_frontend {
+    server ${frontend_name}:${FRONTEND_PORT};
+    keepalive 8;
+  }
+
+  server {
+    listen 80 default_server;
+    server_name ${SERVER_NAME};
+
+    proxy_http_version 1.1;
+    proxy_connect_timeout 3s;
+
+    location = /api/v1/notifications/stream {
+      # SSE 장기 연결은 proxy buffering을 끄고 기존 blue 슬롯을 짧게 drain한다.
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Host ${backend_proxy_host};
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_set_header X-Forwarded-Host \$host;
+      proxy_set_header X-Forwarded-Port \$server_port;
+      proxy_set_header Connection "";
+      proxy_buffering off;
+      proxy_request_buffering off;
+      proxy_cache off;
+      gzip off;
+      proxy_next_upstream off;
+      proxy_read_timeout 1900s;
+      proxy_send_timeout 1900s;
+      add_header X-Accel-Buffering no always;
+    }
+
+    location ^~ /actuator/health {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Host ${backend_proxy_host};
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_set_header X-Forwarded-Host \$host;
+      proxy_set_header X-Forwarded-Port \$server_port;
+      proxy_set_header Connection "";
+      proxy_read_timeout 5s;
+      proxy_send_timeout 5s;
+      access_log off;
+    }
+
+    location /api/ {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Host ${backend_proxy_host};
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_set_header X-Forwarded-Host \$host;
+      proxy_set_header X-Forwarded-Port \$server_port;
+      proxy_set_header Connection "";
+      proxy_read_timeout 30s;
+      proxy_send_timeout 30s;
+    }
+
+    location / {
+      proxy_pass http://aquila_bank_frontend;
+      proxy_set_header Host \$host;
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_set_header X-Forwarded-Host \$host;
+      proxy_set_header X-Forwarded-Port \$server_port;
+      proxy_set_header Connection "";
+      proxy_read_timeout 60s;
+      proxy_send_timeout 60s;
+    }
+  }
+}
+NGINX
+}
+
+ensure_nginx_container() {
+  if docker ps --format '{{.Names}}' | grep -qx "${NGINX_CONTAINER}"; then
+    return 0
+  fi
+
+  docker rm -f "${NGINX_CONTAINER}" >/dev/null 2>&1 || true
+  log "start nginx entrypoint"
+  docker run -d \
+    --name "${NGINX_CONTAINER}" \
+    --restart unless-stopped \
+    --network "${NETWORK}" \
+    -p 80:80 \
+    -v "${APP_DIR}/nginx/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    nginx:1.27-alpine >/dev/null
+}
+
+switch_nginx() {
+  local green="$1"
+  local next_config="${APP_DIR}/nginx/nginx.conf.next"
+  local active_config="${APP_DIR}/nginx/nginx.conf"
+  local backup_config="${APP_DIR}/nginx/nginx.conf.previous"
+
+  render_nginx_config "${green}" >"${next_config}"
+  # Nginx reload 전 동일 Docker network에서 config를 검증해 기존 blue 슬롯을 보존한다.
+  docker run --rm --network "${NETWORK}" \
+    -v "${next_config}:/etc/nginx/nginx.conf:ro" \
+    nginx:1.27-alpine nginx -t
+
+  if [[ -s "${active_config}" ]]; then
+    cp "${active_config}" "${backup_config}"
+  fi
+
+  mv "${next_config}" "${active_config}"
+  ensure_nginx_container
+
+  if ! docker exec "${NGINX_CONTAINER}" nginx -s reload; then
+    log "nginx reload failed; restore previous config"
+    if [[ -s "${backup_config}" ]]; then
+      cp "${backup_config}" "${active_config}"
+      docker exec "${NGINX_CONTAINER}" nginx -s reload || true
+    fi
+    return 1
+  fi
+
+  printf '%s\n' "${green}" >"${APP_DIR}/state/active-slot"
+}
+
+cleanup_blue() {
+  local blue="$1"
+  if [[ "${blue}" == "none" ]]; then
+    return 0
+  fi
+
+  log "drain old blue slot=${blue} seconds=${BLUE_DRAIN_SECONDS}"
+  sleep "${BLUE_DRAIN_SECONDS}"
+  docker rm -f "$(slot_name backend "${blue}")" "$(slot_name frontend "${blue}")" >/dev/null 2>&1 || true
+}
+
+main() {
+  local blue green
+  install_runtime
+  prepare_layout
+  write_env_files
+  docker_login
+
+  blue="$(active_slot)"
+  case "${blue}" in
+    a) green="b" ;;
+    b) green="a" ;;
+    none) green="a" ;;
+    *) log "unknown active slot=${blue}"; exit 1 ;;
+  esac
+  log "blue=${blue} green=${green}"
+
+  run_green_slot "${green}"
+  if ! switch_nginx "${green}"; then
+    docker rm -f "$(slot_name backend "${green}")" "$(slot_name frontend "${green}")" >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  cleanup_blue "${blue}"
+  docker image prune -f >/dev/null || true
+  log "blue-green deploy complete active=${green}"
+}
+
+main "$@"

--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -7,7 +7,9 @@ SUMMARY_MD="${REPORT_DIR}/summary.md"
 
 STAGING_BASE_URL="${STAGING_BASE_URL:-}"
 STAGING_REPLAY_TOKEN="${STAGING_REPLAY_TOKEN:-}"
+STAGING_OCI_A1_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-}"
 STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-}"
+STAGING_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-${STAGING_RDS_DATABASE_URL}}"
 EXPECTED_TOTAL_ROWS="${EXPECTED_TOTAL_ROWS:-100000000}"
 ITERATIONS="${ITERATIONS:-40}"
 PAGE_LIMIT="${PAGE_LIMIT:-50}"
@@ -60,7 +62,7 @@ require_ratio_between_zero_and_one() {
 
 psql_scalar() {
   local sql="$1"
-  psql "$STAGING_RDS_DATABASE_URL" -v ON_ERROR_STOP=1 --no-align --tuples-only --command "$sql"
+  psql "$STAGING_DATABASE_URL" -v ON_ERROR_STOP=1 --no-align --tuples-only --command "$sql"
 }
 
 validate_inputs() {
@@ -72,7 +74,7 @@ validate_inputs() {
 
   require_env STAGING_BASE_URL
   require_env STAGING_REPLAY_TOKEN
-  require_env STAGING_RDS_DATABASE_URL
+  require_env STAGING_DATABASE_URL
   require_env HOT_ACCOUNT_ID
   require_env HOT_FROM
   require_env HOT_TO
@@ -102,7 +104,7 @@ validate_inputs() {
 
 run_planner_stats_guard() {
   # `reltuples` estimate는 stale stats에 취약해서 replay 전에 ANALYZE 필요 여부를 먼저 차단합니다.
-  if ! DATABASE_URL="$STAGING_RDS_DATABASE_URL" \
+  if ! DATABASE_URL="$STAGING_DATABASE_URL" \
     STATS_MAX_AGE_HOURS="$PLANNER_STATS_MAX_AGE_HOURS" \
     STATS_MAX_MODIFIED_RATIO="$PLANNER_STATS_MAX_MODIFIED_RATIO" \
     "$PLANNER_STATS_GUARD_SCRIPT"; then
@@ -111,7 +113,7 @@ run_planner_stats_guard() {
 }
 
 verify_staging_distribution() {
-  # 1억 건 검증에서 full count는 RDS에 부담이 커서 planner 통계 estimate로 gate를 둡니다.
+  # 1억 건 검증에서 full count는 OCI A1 PostgreSQL에 부담이 커서 planner 통계 estimate로 gate를 둡니다.
   local estimated_total
   estimated_total="$(
     psql_scalar \
@@ -123,9 +125,9 @@ verify_staging_distribution() {
        );"
   )"
 
-  [[ "$estimated_total" =~ ^[0-9]+$ ]] || fail "RDS row estimate is not numeric: ${estimated_total}"
+  [[ "$estimated_total" =~ ^[0-9]+$ ]] || fail "OCI A1 row estimate is not numeric: ${estimated_total}"
   if [ "$estimated_total" -lt "$EXPECTED_TOTAL_ROWS" ]; then
-    fail "RDS read model estimate ${estimated_total} is below expected ${EXPECTED_TOTAL_ROWS}"
+    fail "OCI A1 read model estimate ${estimated_total} is below expected ${EXPECTED_TOTAL_ROWS}"
   fi
 
   local hot_exists
@@ -152,7 +154,7 @@ verify_staging_distribution() {
   )"
   [ "$cold_exists" = "t" ] || fail "COLD_ACCOUNT_ID ${COLD_ACCOUNT_ID} has no archive rows"
 
-  notice "RDS read model estimate ${estimated_total} rows"
+  notice "OCI A1 read model estimate ${estimated_total} rows"
   echo "$estimated_total" >"${REPORT_DIR}/estimated-total-rows.txt"
 }
 

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/staging-deploy.yml"
+deploy_script="ops/deploy/oci/bluegreen-deploy.sh"
+delivery_doc="docs/delivery-flow.md"
+production_doc="docs/production-promotion.md"
+terraform_dir="infra/terraform/oci/always-free-a1-flex"
+
+contains() {
+  local pattern="$1"
+  local file="$2"
+  if command -v rg >/dev/null 2>&1; then
+    rg -F --quiet -- "$pattern" "$file"
+    return
+  fi
+  grep -Fq -- "$pattern" "$file"
+}
+
+require_file() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "[oci-a1-bluegreen-cd] missing file: $file" >&2
+    exit 1
+  fi
+}
+
+require_pattern() {
+  local pattern="$1"
+  local file="$2"
+  if ! contains "$pattern" "$file"; then
+    echo "[oci-a1-bluegreen-cd] missing pattern in $file: $pattern" >&2
+    exit 1
+  fi
+}
+
+reject_pattern() {
+  local pattern="$1"
+  local file="$2"
+  if contains "$pattern" "$file"; then
+    echo "[oci-a1-bluegreen-cd] forbidden scattered env pattern in $file: $pattern" >&2
+    exit 1
+  fi
+}
+
+echo "[oci-a1-bluegreen-cd] required files"
+require_file "$workflow"
+require_file "$deploy_script"
+require_file "$delivery_doc"
+require_file "$production_doc"
+require_file "back/Dockerfile"
+require_file "front/Dockerfile"
+
+echo "[oci-a1-bluegreen-cd] shell syntax"
+bash -n "$deploy_script"
+bash -n "$0"
+
+if command -v ruby >/dev/null 2>&1; then
+  ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "$workflow"
+fi
+
+echo "[oci-a1-bluegreen-cd] workflow contract"
+workflow_patterns=(
+  "workflow_run:"
+  "- Main CI"
+  "DEPLOY_TARGET_RUNTIME: oci-a1"
+  "OCI_A1_STAGING_ENV"
+  "Load OCI A1 staging env"
+  'source "${staging_env_path}"'
+  "docker buildx build"
+  "registry: ghcr.io"
+  "OCI_A1_SSH_PRIVATE_KEY_B64"
+  "OCI_A1_BACKEND_ENV_B64"
+  "ops/deploy/oci/bluegreen-deploy.sh"
+  'ssh "${ssh_args[@]}"'
+  "Mark staging deployment success"
+  "Run staging post-deploy smoke"
+  "Run transaction replay regression gate"
+)
+for pattern in "${workflow_patterns[@]}"; do
+  require_pattern "$pattern" "$workflow"
+done
+
+scattered_patterns=(
+  "vars.OCI_A1_"
+  "vars.STAGING_"
+  "secrets.OCI_A1_SSH_"
+  "secrets.OCI_A1_BACKEND_ENV"
+  "secrets.OCI_A1_FRONTEND_ENV"
+  "secrets.STAGING_"
+  "secrets.ALERTMANAGER_"
+)
+for pattern in "${scattered_patterns[@]}"; do
+  reject_pattern "$pattern" "$workflow"
+done
+
+echo "[oci-a1-bluegreen-cd] deploy script contract"
+script_patterns=(
+  "apt-get update"
+  "docker.io"
+  "aquila-bank-backend-a"
+  "aquila-bank-backend-b"
+  "aquila-bank-front-a"
+  "aquila-bank-front-b"
+  "host.docker.internal:host-gateway"
+  "/actuator/health"
+  'proxy_set_header Host ${backend_proxy_host};'
+  'proxy_set_header X-Forwarded-Host \$host;'
+  "location = /api/v1/notifications/stream"
+  "proxy_buffering off;"
+  "nginx -s reload"
+  'docker rm -f "$(slot_name backend "${green}")"'
+)
+for pattern in "${script_patterns[@]}"; do
+  require_pattern "$pattern" "$deploy_script"
+done
+
+echo "[oci-a1-bluegreen-cd] terraform contract"
+require_pattern "http_ingress_cidr" "${terraform_dir}/variables.tf"
+require_pattern "HTTP ingress for OCI A1 staging" "${terraform_dir}/network.tf"
+require_pattern "min = 80" "${terraform_dir}/network.tf"
+
+echo "[oci-a1-bluegreen-cd] docs contract"
+doc_patterns=(
+  "OCI_A1_STAGING_ENV"
+  "OCI_A1_SSH_HOST"
+  "OCI_A1_SSH_PRIVATE_KEY_B64"
+  "OCI_A1_BACKEND_ENV_B64"
+  "STAGING_OCI_A1_DATABASE_URL"
+  "STAGING_BASE_URL"
+)
+for pattern in "${doc_patterns[@]}"; do
+  require_pattern "$pattern" "$delivery_doc"
+done
+require_pattern "same SHA" "$production_doc"
+
+echo "[oci-a1-bluegreen-cd] contract check passed"

--- a/tools/test/run-staging-deploy-transaction-replay-gate.sh
+++ b/tools/test/run-staging-deploy-transaction-replay-gate.sh
@@ -17,21 +17,27 @@ step_names = steps.map { |step| step['name'] }
 replay_name = 'Run transaction replay regression gate'
 smoke_name = 'Run staging post-deploy smoke'
 success_name = 'Mark staging deployment success'
+load_env_name = 'Load OCI A1 staging env'
 
 replay_index = step_names.index(replay_name) or abort("missing step: #{replay_name}")
 smoke_index = step_names.index(smoke_name) or abort("missing step: #{smoke_name}")
 success_index = step_names.index(success_name) or abort("missing step: #{success_name}")
+load_env_index = step_names.index(load_env_name) or abort("missing step: #{load_env_name}")
 
+abort('staging env must load before smoke') unless load_env_index < smoke_index
 abort('replay gate must run after staging smoke') unless smoke_index < replay_index
 abort('replay gate must run before success status') unless replay_index < success_index
 
+load_env_step = steps.fetch(load_env_index)
+load_env = load_env_step.fetch('env')
+load_run = load_env_step.fetch('run')
 replay_step = steps.fetch(replay_index)
-env = replay_step.fetch('env')
 run = replay_step.fetch('run')
 
 required_keys = %w[
   STAGING_BASE_URL
   STAGING_REPLAY_TOKEN
+  STAGING_OCI_A1_DATABASE_URL
   STAGING_RDS_DATABASE_URL
   HOT_ACCOUNT_ID
   HOT_FROM
@@ -41,10 +47,14 @@ required_keys = %w[
   COLD_TO
 ]
 required_keys.each do |key|
-  abort("missing env: #{key}") unless env.key?(key)
+  abort("load step must persist env: #{key}") unless load_run.include?(key)
 end
 
+abort('load step must read only the unified staging env secret') unless load_env.fetch('OCI_A1_STAGING_ENV').include?('secrets.OCI_A1_STAGING_ENV')
+abort('load step must source the staging env file') unless load_run.include?('source "${staging_env_path}"')
+abort('replay step should not scatter staging env mappings') if replay_step.key?('env')
 abort('replay step must call transaction replay script') unless run.include?('tools/ops/transaction-read-model-staging-replay.sh')
-abort('hot account must come from staging replay secret') unless env.fetch('HOT_ACCOUNT_ID').include?('STAGING_REPLAY_HOT_ACCOUNT_ID')
-abort('cold account must come from staging replay secret') unless env.fetch('COLD_ACCOUNT_ID').include?('STAGING_REPLAY_COLD_ACCOUNT_ID')
+abort('OCI A1 database URL must come from unified staging env') unless load_run.include?('STAGING_OCI_A1_DATABASE_URL')
+abort('hot account must map from staging replay key') unless load_run.include?('HOT_ACCOUNT_ID="${STAGING_REPLAY_HOT_ACCOUNT_ID')
+abort('cold account must map from staging replay key') unless load_run.include?('COLD_ACCOUNT_ID="${STAGING_REPLAY_COLD_ACCOUNT_ID')
 RUBY


### PR DESCRIPTION
## 🔗 Related Issue
- close #536

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI A1 staging을 generic deploy hook이 아니라 SSH 기반 Docker + Nginx blue/green 배포로 전환합니다.
- main SHA backend/frontend image를 GHCR에 push한 뒤 green slot health 확인과 Nginx reload를 통과해야 staging success를 기록합니다.
- 필요한 GitHub Actions secrets/variables와 OCI HTTP ingress 계약을 문서화했습니다.

## 🛠 Changes
- `ops/deploy/oci/bluegreen-deploy.sh` 추가
- `Staging Deploy` workflow에 GHCR build/push와 OCI SSH deploy 추가
- OCI Always Free Terraform에 `http_ingress_cidr` 80/tcp ingress 추가
- staging replay gate를 `STAGING_OCI_A1_DATABASE_URL` 우선으로 변경
- OCI CD 계약 테스트와 운영 문서 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex fmt -check`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: staging Environment secret/variable이 누락되면 deploy가 fail-fast합니다. OCI security list에 80/tcp ingress를 적용해야 public smoke가 통과합니다.
- 롤백 방법: PR revert. 이미 배포된 VM은 직전 successful staging SHA를 재배포하거나 Nginx active slot state를 이전 slot으로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?