### PR TITLE
[CI] staging fixture principal bootstrap gate 추가

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -161,6 +161,12 @@ jobs:
             COLD_ACCOUNT_ID
             COLD_FROM
             COLD_TO
+            STAGING_REPLAY_USER_ID
+            STAGING_REPLAY_LOGIN_ID
+            STAGING_REPLAY_USER_PASSWORD_HASH
+            STAGING_REPLAY_USER_DISPLAY_NAME
+            STAGING_REPLAY_HOT_ACCOUNT_NUMBER
+            STAGING_REPLAY_COLD_ACCOUNT_NUMBER
             ITERATIONS
             PAGE_LIMIT
             REQUEST_TIMEOUT_SECONDS
@@ -359,6 +365,13 @@ jobs:
             -o UserKnownHostsFile="${known_hosts_path}"
           )
           ssh "${ssh_args[@]}" "${OCI_A1_SSH_USER}@${OCI_A1_SSH_HOST}" "bash -se" <<<"${remote_command}"
+
+      - name: Ensure staging fixture principal
+        if: steps.validate.outputs.should_deploy == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools/ops/staging-fixture-principal-bootstrap.sh
 
       - name: Run staging post-deploy smoke
         if: steps.validate.outputs.should_deploy == 'true'

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -44,6 +44,7 @@
 - required OCI deploy secret이 없으면 workflow는 fail-fast하며 staging GitHub deployment status를 성공으로 만들지 않습니다.
 - workflow는 OCI A1 SSH deploy와 post-deploy smoke를 통과한 경우에만 staging GitHub deployment status를 `success`로 갱신합니다.
 - transaction replay gate는 post-deploy smoke 뒤에 실행되며, `pg_class.reltuples` 검증 전에 planner stats freshness guard로 stale stats를 차단합니다.
+- fixture principal bootstrap은 smoke/replay 전에 `STAGING_REPLAY_USER_ID`와 hot/cold 계좌 membership을 idempotent하게 보장해 fixture JWT 403을 차단합니다.
 - replay gate가 실패하면 staging deployment status는 `success`로 올라가지 않으므로 production promotion guard가 같은 SHA를 자동으로 거부합니다.
 - post-deploy smoke는 health/read/write endpoint를 호출하며, read/write path는 환경별 smoke 전용 endpoint를 secret으로 주입합니다.
 - smoke 또는 OCI deploy 실패 시 deployment status는 `failure`가 되고, rollback hook이 설정된 경우 `sha`, `repository`, `runUrl`, `deploymentId`와 함께 호출합니다.
@@ -75,12 +76,18 @@ STAGING_SMOKE_AUTH_HEADER_VALUE='Bearer REPLACE_FIXTURE_TOKEN'
 
 STAGING_REPLAY_TOKEN=REPLACE_FIXTURE_TOKEN
 STAGING_OCI_A1_DATABASE_URL='postgresql://aquila:<password>@127.0.0.1:5432/aquila'
+STAGING_REPLAY_USER_ID=55
+STAGING_REPLAY_LOGIN_ID=staging-fixture-user
+STAGING_REPLAY_USER_PASSWORD_HASH=staging-fixture-password-hash-not-for-login
+STAGING_REPLAY_USER_DISPLAY_NAME='Staging Fixture User'
 STAGING_REPLAY_HOT_ACCOUNT_ID=910000001
+STAGING_REPLAY_HOT_ACCOUNT_NUMBER=STG-HOT-910000001
 STAGING_REPLAY_HOT_FROM=2026-04-01T00:00:00Z
 STAGING_REPLAY_HOT_TO=2026-04-30T00:00:00Z
 STAGING_REPLAY_COLD_ACCOUNT_ID=910000002
-STAGING_REPLAY_COLD_FROM=2025-04-01T00:00:00Z
-STAGING_REPLAY_COLD_TO=2025-04-30T00:00:00Z
+STAGING_REPLAY_COLD_ACCOUNT_NUMBER=STG-COLD-910000002
+STAGING_REPLAY_COLD_FROM=2026-01-01T00:00:00Z
+STAGING_REPLAY_COLD_TO=2026-01-31T00:00:00Z
 STAGING_REPLAY_ITERATIONS=40
 STAGING_REPLAY_PAGE_LIMIT=50
 STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS=5
@@ -104,6 +111,7 @@ SERVER_PORT=8080
 SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:5432/aquila
 SPRING_DATASOURCE_USERNAME=aquila
 SPRING_DATASOURCE_PASSWORD=<secret>
+SECURITY_JWT_SECRET=<secret>
 DB_POOL_MAX_SIZE=4
 SERVER_THREADS_MAX=16
 OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX=3

--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STAGING_OCI_A1_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-}"
+STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-}"
+STAGING_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-${STAGING_RDS_DATABASE_URL}}"
+STAGING_REPLAY_USER_ID="${STAGING_REPLAY_USER_ID:-55}"
+STAGING_REPLAY_LOGIN_ID="${STAGING_REPLAY_LOGIN_ID:-staging-fixture-user}"
+STAGING_REPLAY_USER_PASSWORD_HASH="${STAGING_REPLAY_USER_PASSWORD_HASH:-staging-fixture-password-hash-not-for-login}"
+STAGING_REPLAY_USER_DISPLAY_NAME="${STAGING_REPLAY_USER_DISPLAY_NAME:-Staging Fixture User}"
+HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID:-${STAGING_REPLAY_HOT_ACCOUNT_ID:-}}"
+COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID:-${STAGING_REPLAY_COLD_ACCOUNT_ID:-}}"
+STAGING_REPLAY_HOT_ACCOUNT_NUMBER="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER:-STG-HOT-${HOT_ACCOUNT_ID}}"
+STAGING_REPLAY_COLD_ACCOUNT_NUMBER="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER:-STG-COLD-${COLD_ACCOUNT_ID}}"
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+require_env() {
+  local name="$1"
+  local value="${!name:-}"
+  [ -n "$value" ] || fail "Missing required environment variable: ${name}"
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="${!name:-}"
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "${name} must be a positive integer"
+}
+
+require_max_length() {
+  local name="$1"
+  local value="${!name:-}"
+  local max="$2"
+  if ((${#value} > max)); then
+    fail "${name} must be ${max} characters or less"
+  fi
+}
+
+validate_inputs() {
+  require_command psql
+  require_env STAGING_DATABASE_URL
+  require_env STAGING_REPLAY_LOGIN_ID
+  require_env STAGING_REPLAY_USER_PASSWORD_HASH
+  require_env STAGING_REPLAY_USER_DISPLAY_NAME
+  require_env HOT_ACCOUNT_ID
+  require_env COLD_ACCOUNT_ID
+  require_positive_integer STAGING_REPLAY_USER_ID
+  require_positive_integer HOT_ACCOUNT_ID
+  require_positive_integer COLD_ACCOUNT_ID
+  require_max_length STAGING_REPLAY_LOGIN_ID "${STAGING_REPLAY_LOGIN_ID}" 80
+  require_max_length STAGING_REPLAY_USER_PASSWORD_HASH "${STAGING_REPLAY_USER_PASSWORD_HASH}" 120
+  require_max_length STAGING_REPLAY_USER_DISPLAY_NAME "${STAGING_REPLAY_USER_DISPLAY_NAME}" 80
+  require_max_length STAGING_REPLAY_HOT_ACCOUNT_NUMBER "${STAGING_REPLAY_HOT_ACCOUNT_NUMBER}" 20
+  require_max_length STAGING_REPLAY_COLD_ACCOUNT_NUMBER "${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" 20
+}
+
+ensure_fixture_principal() {
+  # replay JWT는 user_id claim을 고정하므로, smoke/replay 전에 권한 row도 같은 id로 고정합니다.
+  psql "${STAGING_DATABASE_URL}" \
+    -v ON_ERROR_STOP=1 \
+    -v fixture_user_id="${STAGING_REPLAY_USER_ID}" \
+    -v fixture_login_id="${STAGING_REPLAY_LOGIN_ID}" \
+    -v fixture_password_hash="${STAGING_REPLAY_USER_PASSWORD_HASH}" \
+    -v fixture_display_name="${STAGING_REPLAY_USER_DISPLAY_NAME}" \
+    -v hot_account_id="${HOT_ACCOUNT_ID}" \
+    -v cold_account_id="${COLD_ACCOUNT_ID}" \
+    -v hot_account_number="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER}" \
+    -v cold_account_number="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" \
+    --command "
+      BEGIN;
+
+      INSERT INTO bank_account (
+          id,
+          account_number,
+          display_name,
+          account_status,
+          currency_code,
+          created_at,
+          updated_at
+      )
+      OVERRIDING SYSTEM VALUE
+      VALUES
+          (:hot_account_id, :'hot_account_number', 'Staging hot fixture account', 'ACTIVE', 'KRW', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+          (:cold_account_id, :'cold_account_number', 'Staging cold fixture account', 'ACTIVE', 'KRW', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      ON CONFLICT (id)
+      DO UPDATE
+      SET account_status = 'ACTIVE',
+          updated_at = CURRENT_TIMESTAMP;
+
+      INSERT INTO account_balance_snapshot (
+          account_id,
+          last_applied_ledger_entry_id,
+          available_balance_minor,
+          pending_balance_minor,
+          currency_code,
+          updated_at
+      )
+      VALUES
+          (:hot_account_id, 0, 0, 0, 'KRW', CURRENT_TIMESTAMP),
+          (:cold_account_id, 0, 0, 0, 'KRW', CURRENT_TIMESTAMP)
+      ON CONFLICT (account_id)
+      DO UPDATE
+      SET currency_code = EXCLUDED.currency_code,
+          updated_at = CURRENT_TIMESTAMP;
+
+      INSERT INTO bank_user (
+          id,
+          login_id,
+          password_hash,
+          display_name,
+          user_status,
+          created_at,
+          updated_at
+      )
+      OVERRIDING SYSTEM VALUE
+      VALUES (
+          :fixture_user_id,
+          :'fixture_login_id',
+          :'fixture_password_hash',
+          :'fixture_display_name',
+          'ACTIVE',
+          CURRENT_TIMESTAMP,
+          CURRENT_TIMESTAMP
+      )
+      ON CONFLICT (id)
+      DO UPDATE
+      SET login_id = EXCLUDED.login_id,
+          display_name = EXCLUDED.display_name,
+          user_status = 'ACTIVE',
+          updated_at = CURRENT_TIMESTAMP;
+
+      INSERT INTO user_account_membership (
+          user_id,
+          account_id,
+          membership_role,
+          membership_status,
+          created_at,
+          updated_at
+      )
+      VALUES
+          (:fixture_user_id, :hot_account_id, 'OWNER', 'ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+          (:fixture_user_id, :cold_account_id, 'OWNER', 'ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      ON CONFLICT (user_id, account_id)
+      DO UPDATE
+      SET membership_role = EXCLUDED.membership_role,
+          membership_status = 'ACTIVE',
+          updated_at = CURRENT_TIMESTAMP;
+
+      SELECT setval(
+          pg_get_serial_sequence('bank_user', 'id'),
+          GREATEST((SELECT COALESCE(MAX(id), 1) FROM bank_user), 1),
+          true
+      );
+
+      COMMIT;
+    "
+}
+
+validate_inputs
+ensure_fixture_principal
+
+echo "[staging-fixture-principal] ensured user_id=${STAGING_REPLAY_USER_ID} hot_account_id=${HOT_ACCOUNT_ID} cold_account_id=${COLD_ACCOUNT_ID}"

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 workflow=".github/workflows/staging-deploy.yml"
 deploy_script="ops/deploy/oci/bluegreen-deploy.sh"
+fixture_principal_script="tools/ops/staging-fixture-principal-bootstrap.sh"
 delivery_doc="docs/delivery-flow.md"
 production_doc="docs/production-promotion.md"
 terraform_dir="infra/terraform/oci/always-free-a1-flex"
@@ -46,6 +47,7 @@ reject_pattern() {
 echo "[oci-a1-bluegreen-cd] required files"
 require_file "$workflow"
 require_file "$deploy_script"
+require_file "$fixture_principal_script"
 require_file "$delivery_doc"
 require_file "$production_doc"
 require_file "back/Dockerfile"
@@ -53,6 +55,7 @@ require_file "front/Dockerfile"
 
 echo "[oci-a1-bluegreen-cd] shell syntax"
 bash -n "$deploy_script"
+bash -n "$fixture_principal_script"
 bash -n "$0"
 
 if command -v ruby >/dev/null 2>&1; then
@@ -72,6 +75,8 @@ workflow_patterns=(
   "OCI_A1_SSH_PRIVATE_KEY_B64"
   "OCI_A1_BACKEND_ENV_B64"
   "ops/deploy/oci/bluegreen-deploy.sh"
+  "Ensure staging fixture principal"
+  "tools/ops/staging-fixture-principal-bootstrap.sh"
   'ssh "${ssh_args[@]}"'
   "Mark staging deployment success"
   "Run staging post-deploy smoke"
@@ -115,6 +120,20 @@ for pattern in "${script_patterns[@]}"; do
   require_pattern "$pattern" "$deploy_script"
 done
 
+echo "[oci-a1-bluegreen-cd] fixture principal contract"
+fixture_principal_patterns=(
+  "STAGING_REPLAY_USER_ID"
+  "OVERRIDING SYSTEM VALUE"
+  "INSERT INTO bank_account"
+  "INSERT INTO bank_user"
+  "INSERT INTO user_account_membership"
+  "ON CONFLICT (user_id, account_id)"
+  "pg_get_serial_sequence('bank_user', 'id')"
+)
+for pattern in "${fixture_principal_patterns[@]}"; do
+  require_pattern "$pattern" "$fixture_principal_script"
+done
+
 echo "[oci-a1-bluegreen-cd] terraform contract"
 require_pattern "http_ingress_cidr" "${terraform_dir}/variables.tf"
 require_pattern "HTTP ingress for OCI A1 staging" "${terraform_dir}/network.tf"
@@ -127,6 +146,7 @@ doc_patterns=(
   "OCI_A1_SSH_PRIVATE_KEY_B64"
   "OCI_A1_BACKEND_ENV_B64"
   "STAGING_OCI_A1_DATABASE_URL"
+  "STAGING_REPLAY_USER_ID"
   "STAGING_BASE_URL"
 )
 for pattern in "${doc_patterns[@]}"; do

--- a/tools/test/run-staging-deploy-transaction-replay-gate.sh
+++ b/tools/test/run-staging-deploy-transaction-replay-gate.sh
@@ -16,15 +16,21 @@ step_names = steps.map { |step| step['name'] }
 
 replay_name = 'Run transaction replay regression gate'
 smoke_name = 'Run staging post-deploy smoke'
+fixture_principal_name = 'Ensure staging fixture principal'
+deploy_name = 'Deploy OCI A1 blue-green over SSH'
 success_name = 'Mark staging deployment success'
 load_env_name = 'Load OCI A1 staging env'
 
 replay_index = step_names.index(replay_name) or abort("missing step: #{replay_name}")
 smoke_index = step_names.index(smoke_name) or abort("missing step: #{smoke_name}")
+fixture_principal_index = step_names.index(fixture_principal_name) or abort("missing step: #{fixture_principal_name}")
+deploy_index = step_names.index(deploy_name) or abort("missing step: #{deploy_name}")
 success_index = step_names.index(success_name) or abort("missing step: #{success_name}")
 load_env_index = step_names.index(load_env_name) or abort("missing step: #{load_env_name}")
 
 abort('staging env must load before smoke') unless load_env_index < smoke_index
+abort('fixture principal must run after OCI deploy') unless deploy_index < fixture_principal_index
+abort('fixture principal must run before smoke') unless fixture_principal_index < smoke_index
 abort('replay gate must run after staging smoke') unless smoke_index < replay_index
 abort('replay gate must run before success status') unless replay_index < success_index
 
@@ -45,6 +51,10 @@ required_keys = %w[
   COLD_ACCOUNT_ID
   COLD_FROM
   COLD_TO
+  STAGING_REPLAY_USER_ID
+  STAGING_REPLAY_LOGIN_ID
+  STAGING_REPLAY_USER_PASSWORD_HASH
+  STAGING_REPLAY_USER_DISPLAY_NAME
 ]
 required_keys.each do |key|
   abort("load step must persist env: #{key}") unless load_run.include?(key)
@@ -54,6 +64,7 @@ abort('load step must read only the unified staging env secret') unless load_env
 abort('load step must source the staging env file') unless load_run.include?('source "${staging_env_path}"')
 abort('replay step should not scatter staging env mappings') if replay_step.key?('env')
 abort('replay step must call transaction replay script') unless run.include?('tools/ops/transaction-read-model-staging-replay.sh')
+abort('fixture principal step must call fixture principal script') unless steps.fetch(fixture_principal_index).fetch('run').include?('tools/ops/staging-fixture-principal-bootstrap.sh')
 abort('OCI A1 database URL must come from unified staging env') unless load_run.include?('STAGING_OCI_A1_DATABASE_URL')
 abort('hot account must map from staging replay key') unless load_run.include?('HOT_ACCOUNT_ID="${STAGING_REPLAY_HOT_ACCOUNT_ID')
 abort('cold account must map from staging replay key') unless load_run.include?('COLD_ACCOUNT_ID="${STAGING_REPLAY_COLD_ACCOUNT_ID')


### PR DESCRIPTION
## 🔗 Related Issue
- close #538

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging smoke/replay JWT가 참조하는 fixture user/account membership을 배포 직후 보장합니다.
- OCI A1 deploy 후 smoke 전에 DB에 fixture principal row를 idempotent upsert해 403 false-negative를 막습니다.

## 🛠 Changes
- `tools/ops/staging-fixture-principal-bootstrap.sh` 추가
- `.github/workflows/staging-deploy.yml`에 fixture principal step 추가
- unified `OCI_A1_STAGING_ENV` 문서와 workflow contract test 보강

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex fmt -check`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: staging DB URL이 GitHub runner에서 접근 불가하면 fixture principal step이 fail-fast합니다. 이는 뒤의 replay gate도 동일하게 실패하는 환경 오류입니다.
- 롤백 방법: 이 PR을 revert하면 fixture principal step 추가 전 상태로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
