### PR TITLE
[Test] notification provider delivery smoke flaky 수정

### DIFF
--- a/back/src/test/java/com/aquilabank/global/notification/NotificationChannelProviderDeliverySmokeTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/NotificationChannelProviderDeliverySmokeTest.java
@@ -45,7 +45,7 @@ class NotificationChannelProviderDeliverySmokeTest {
   }
 
   @Test
-  void dispatchesImmediateEmailAndMarksSlowSmsForRetryBackoff() throws Exception {
+  void dispatchesImmediateEmailAndMarksProviderRejectedSmsForRetryBackoff() throws Exception {
     AtomicInteger emailRequests = new AtomicInteger();
     AtomicInteger smsRequests = new AtomicInteger();
     server = HttpServer.create(new InetSocketAddress(0), 0);
@@ -60,16 +60,8 @@ class NotificationChannelProviderDeliverySmokeTest {
         "/sms",
         exchange -> {
           smsRequests.incrementAndGet();
-          try {
-            Thread.sleep(200L);
-          } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-          }
-          try {
-            writeAccepted(exchange);
-          } catch (IOException ignored) {
-            // read timeout 이후 client가 먼저 연결을 닫을 수 있어 서버 응답 write 실패는 무시합니다.
-          }
+          // CI runner 부하에 민감한 read timeout 대신 provider reject를 고정해 retry 경로만 검증합니다.
+          writeProviderRejected(exchange);
         });
     server.start();
 
@@ -130,6 +122,11 @@ class NotificationChannelProviderDeliverySmokeTest {
 
   private void writeAccepted(HttpExchange exchange) throws IOException {
     exchange.sendResponseHeaders(202, -1);
+    exchange.close();
+  }
+
+  private void writeProviderRejected(HttpExchange exchange) throws IOException {
+    exchange.sendResponseHeaders(503, -1);
     exchange.close();
   }
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #540

## 🌿 Base Branch
- `main`

## 📝 Summary
- Main CI에서 간헐 실패한 `NotificationChannelProviderDeliverySmokeTest`의 시간 의존 fixture를 제거했습니다.
- SMS 실패 경로를 50ms read timeout 대신 deterministic HTTP 503 응답으로 고정해 retry/backoff assertion이 CI 부하에 흔들리지 않게 했습니다.

## 🛠 Changes
- SMS smoke endpoint가 요청 수신 후 즉시 provider reject 응답을 반환하도록 변경
- 테스트 이름을 실제 검증 의미에 맞게 갱신

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `./gradlew test --tests com.aquilabank.global.notification.NotificationChannelProviderDeliverySmokeTest --no-daemon --stacktrace`
- `./gradlew check --no-daemon --stacktrace`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: production code 변경 없음. 테스트가 timeout failure 대신 provider 5xx failure를 검증하므로 timeout 자체 smoke는 별도 coverage가 아닙니다.
- 롤백 방법: 이 PR을 revert하면 기존 timeout 기반 smoke test로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
