### PR TITLE
[CI] OCI A1 self-hosted runner bootstrap 자동화

### DIFF
--- a/.github/workflows/oci-a1-runner-doctor.yml
+++ b/.github/workflows/oci-a1-runner-doctor.yml
@@ -1,0 +1,22 @@
+name: OCI A1 Runner Doctor
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  doctor:
+    name: Check OCI A1 Self-Hosted Runner
+    runs-on: [self-hosted, oci-a1-staging]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check OCI self-hosted runner prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          ops/deploy/oci/check-self-hosted-runner.sh

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -375,22 +375,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          missing=()
-          for command_name in base64 curl jq psql; do
-            if ! command -v "${command_name}" >/dev/null 2>&1; then
-              missing+=("${command_name}")
-            fi
-          done
-
-          if (( ${#missing[@]} > 0 )); then
-            printf '::error::OCI A1 self-hosted runner is missing commands: %s\n' "${missing[*]}"
-            exit 1
-          fi
-
-          if (( EUID != 0 )) && ! sudo -n true; then
-            echo "::error::OCI A1 self-hosted runner user must have passwordless sudo for bluegreen-deploy.sh."
-            exit 1
-          fi
+          ops/deploy/oci/check-self-hosted-runner.sh
 
       - name: Run Alertmanager receiver secret smoke
         shell: bash

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -36,6 +36,10 @@
 - deploy runner: OCI VM에 등록한 GitHub Actions OCI self-hosted runner `self-hosted`, `oci-a1-staging`
 - required environment secret:
   - `OCI_A1_STAGING_ENV`
+- runner bootstrap:
+  - OCI VM에서 `ops/deploy/oci/bootstrap-self-hosted-runner.sh`를 1회 실행한다.
+  - `GITHUB_RUNNER_TOKEN`은 GitHub runner registration token이며 저장소에 기록하지 않는다.
+  - 설치 후 `ops/deploy/oci/check-self-hosted-runner.sh` 또는 `OCI A1 Runner Doctor` workflow로 runner 상태를 확인한다.
 - deploy flow:
   - `OCI_A1_STAGING_ENV`를 shell env 파일로 로드한다.
   - `Main CI`가 성공한 main SHA를 checkout한다.
@@ -122,6 +126,15 @@ base64 -w0 .env.backend-staging
 ```
 
 GitHub Actions runner 등록값은 `OCI_A1_STAGING_ENV`에 넣지 않습니다. OCI VM에서 runner를 등록할 때 label에 `self-hosted`, `oci-a1-staging`을 붙이고, runner 사용자에는 `bluegreen-deploy.sh` 실행을 위한 passwordless sudo를 부여합니다.
+
+```bash
+GITHUB_RUNNER_TOKEN=<registration-token> \
+GITHUB_REPOSITORY_SLUG=AquilaXk/aquila-bank \
+RUNNER_LABELS=self-hosted,oci-a1-staging \
+  ops/deploy/oci/bootstrap-self-hosted-runner.sh
+
+ops/deploy/oci/check-self-hosted-runner.sh
+```
 
 ## Feature Flag
 

--- a/ops/deploy/oci/README.md
+++ b/ops/deploy/oci/README.md
@@ -27,6 +27,23 @@ runner 선행 조건:
 - privilege: passwordless sudo
 - database: `STAGING_OCI_A1_DATABASE_URL`로 PostgreSQL fixture DB 접근 가능
 
+## Runner Bootstrap
+
+OCI VM에서 GitHub self-hosted runner를 처음 등록할 때는 `bootstrap-self-hosted-runner.sh`를 1회 실행한다. `GITHUB_RUNNER_TOKEN`은 GitHub의 repository runner 등록 화면에서 발급한 단기 registration token이며 저장소나 shell history에 남기지 않는다.
+
+```bash
+GITHUB_RUNNER_TOKEN=<registration-token> \
+GITHUB_REPOSITORY_SLUG=AquilaXk/aquila-bank \
+RUNNER_LABELS=self-hosted,oci-a1-staging \
+  ops/deploy/oci/bootstrap-self-hosted-runner.sh
+```
+
+설치 후에는 로컬 doctor나 GitHub Actions의 `OCI A1 Runner Doctor` workflow로 확인한다.
+
+```bash
+ops/deploy/oci/check-self-hosted-runner.sh
+```
+
 필수 key:
 
 - `OCI_A1_BACKEND_ENV_B64`

--- a/ops/deploy/oci/bootstrap-self-hosted-runner.sh
+++ b/ops/deploy/oci/bootstrap-self-hosted-runner.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: export GITHUB_RUNNER_TOKEN; ops/deploy/oci/bootstrap-self-hosted-runner.sh
+
+Environment:
+  GITHUB_RUNNER_TOKEN required GitHub self-hosted runner registration token
+  GITHUB_REPOSITORY_SLUG default AquilaXk/aquila-bank
+  RUNNER_LABELS default self-hosted,oci-a1-staging
+  RUNNER_NAME default <hostname>-oci-a1-staging
+  RUNNER_USER default github-runner
+  RUNNER_HOME default /opt/actions-runner/aquila-bank-staging
+  RUNNER_WORK_DIR default _work
+  GITHUB_RUNNER_VERSION default latest
+  AQUILA_CONFIGURE_PASSWORDLESS_SUDO default true
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if (( EUID != 0 )); then
+  exec sudo -E bash "$0" "$@"
+fi
+
+token="${GITHUB_RUNNER_TOKEN:-}"
+repository_slug="${GITHUB_REPOSITORY_SLUG:-AquilaXk/aquila-bank}"
+runner_labels="${RUNNER_LABELS:-self-hosted,oci-a1-staging}"
+runner_name="${RUNNER_NAME:-$(hostname)-oci-a1-staging}"
+runner_user="${RUNNER_USER:-github-runner}"
+runner_home="${RUNNER_HOME:-/opt/actions-runner/aquila-bank-staging}"
+runner_work_dir="${RUNNER_WORK_DIR:-_work}"
+runner_version="${GITHUB_RUNNER_VERSION:-latest}"
+configure_passwordless_sudo="${AQUILA_CONFIGURE_PASSWORDLESS_SUDO:-true}"
+
+fail() {
+  echo "[oci-runner-bootstrap] $1" >&2
+  exit 1
+}
+
+require_non_empty() {
+  local name="$1"
+  local value="$2"
+  [[ -n "${value}" ]] || fail "${name} is required"
+}
+
+require_bool() {
+  local name="$1"
+  local value="$2"
+  case "${value}" in
+    true|false) ;;
+    *) fail "${name} must be true or false: ${value}" ;;
+  esac
+}
+
+require_non_empty "GITHUB_RUNNER_TOKEN" "${token}"
+require_non_empty "GITHUB_REPOSITORY_SLUG" "${repository_slug}"
+require_non_empty "RUNNER_LABELS" "${runner_labels}"
+require_bool "AQUILA_CONFIGURE_PASSWORDLESS_SUDO" "${configure_passwordless_sudo}"
+
+case "$(uname -m)" in
+  aarch64|arm64)
+    runner_arch="arm64"
+    ;;
+  x86_64|amd64)
+    runner_arch="x64"
+    ;;
+  *)
+    fail "unsupported runner architecture: $(uname -m)"
+    ;;
+esac
+
+echo "[oci-runner-bootstrap] installing host packages"
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  ca-certificates \
+  curl \
+  docker.io \
+  gzip \
+  jq \
+  postgresql-client \
+  tar
+
+systemctl enable --now docker.service
+
+if ! id -u "${runner_user}" >/dev/null 2>&1; then
+  useradd --create-home --shell /bin/bash "${runner_user}"
+fi
+usermod -aG docker "${runner_user}"
+
+if [[ "${configure_passwordless_sudo}" == "true" ]]; then
+  # staging deploy script는 Docker/Nginx/패키지 설치를 수행하므로 runner 사용자에 root sudo를 고정한다.
+  sudoers_file="/etc/sudoers.d/aquila-github-runner"
+  printf '%s ALL=(root) NOPASSWD:ALL\n' "${runner_user}" >"${sudoers_file}"
+  chmod 0440 "${sudoers_file}"
+  visudo -cf "${sudoers_file}" >/dev/null
+fi
+
+if [[ "${runner_version}" == "latest" ]]; then
+  runner_version="$(
+    curl -fsSL "https://api.github.com/repos/actions/runner/releases/latest" |
+      jq -r '.tag_name | sub("^v"; "")'
+  )"
+fi
+require_non_empty "GITHUB_RUNNER_VERSION" "${runner_version}"
+
+runner_package="actions-runner-linux-${runner_arch}-${runner_version}.tar.gz"
+runner_url="https://github.com/actions/runner/releases/download/v${runner_version}/${runner_package}"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+install -d -o "${runner_user}" -g "${runner_user}" "${runner_home}"
+
+if [[ ! -x "${runner_home}/bin/Runner.Listener" ]]; then
+  echo "[oci-runner-bootstrap] downloading ${runner_package}"
+  curl -fsSL "${runner_url}" -o "${temp_dir}/${runner_package}"
+  tar -xzf "${temp_dir}/${runner_package}" -C "${runner_home}"
+  chown -R "${runner_user}:${runner_user}" "${runner_home}"
+fi
+
+repo_url="https://github.com/${repository_slug}"
+if [[ ! -f "${runner_home}/.runner" ]]; then
+  echo "[oci-runner-bootstrap] configuring runner ${runner_name} for ${repository_slug}"
+  sudo -u "${runner_user}" bash -c '
+    set -euo pipefail
+    cd "$1"
+    ./config.sh \
+      --unattended \
+      --replace \
+      --url "$2" \
+      --token "$3" \
+      --name "$4" \
+      --labels "$5" \
+      --work "$6"
+  ' bash "${runner_home}" "${repo_url}" "${token}" "${runner_name}" "${runner_labels}" "${runner_work_dir}"
+else
+  echo "[oci-runner-bootstrap] runner already configured at ${runner_home}"
+fi
+
+echo "[oci-runner-bootstrap] installing runner service"
+cd "${runner_home}"
+./svc.sh install "${runner_user}"
+./svc.sh start
+
+echo "[oci-runner-bootstrap] installed runner=${runner_name} labels=${runner_labels} home=${runner_home}"

--- a/ops/deploy/oci/check-self-hosted-runner.sh
+++ b/ops/deploy/oci/check-self-hosted-runner.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: ops/deploy/oci/check-self-hosted-runner.sh [--dry-run|--print-plan]
+
+Environment:
+  OCI_A1_RUNNER_CHECK_NETWORK default true
+  OCI_A1_RUNNER_CHECK_GHCR default true
+  OCI_A1_RUNNER_REQUIRED_COMMANDS default "base64 curl jq psql"
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      mode="dry-run"
+      ;;
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+check_network="${OCI_A1_RUNNER_CHECK_NETWORK:-true}"
+check_ghcr="${OCI_A1_RUNNER_CHECK_GHCR:-true}"
+required_commands="${OCI_A1_RUNNER_REQUIRED_COMMANDS:-base64 curl jq psql}"
+
+fail() {
+  echo "[oci-runner-doctor] $1" >&2
+  exit 1
+}
+
+require_bool() {
+  local name="$1"
+  local value="$2"
+  case "${value}" in
+    true|false) ;;
+    *) fail "${name} must be true or false: ${value}" ;;
+  esac
+}
+
+print_plan() {
+  echo "[oci-runner-doctor] mode=${mode}"
+  echo "[oci-runner-doctor] required_commands=${required_commands}"
+  echo "[oci-runner-doctor] check_network=${check_network}"
+  echo "[oci-runner-doctor] check_ghcr=${check_ghcr}"
+}
+
+require_bool "OCI_A1_RUNNER_CHECK_NETWORK" "${check_network}"
+require_bool "OCI_A1_RUNNER_CHECK_GHCR" "${check_ghcr}"
+print_plan
+
+if [[ "${mode}" == "print-plan" || "${mode}" == "dry-run" ]]; then
+  echo "[oci-runner-doctor] ${mode} passed"
+  exit 0
+fi
+
+missing=()
+for command_name in ${required_commands}; do
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    missing+=("${command_name}")
+  fi
+done
+if (( ${#missing[@]} > 0 )); then
+  printf '[oci-runner-doctor] missing commands: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+if (( EUID != 0 )) && ! sudo -n true; then
+  fail "runner user must have passwordless sudo for bluegreen-deploy.sh"
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  fail "docker info failed; check docker service and runner user docker group"
+fi
+
+if [[ "${check_network}" == "true" ]]; then
+  curl -fsS --max-time 10 https://github.com >/dev/null ||
+    fail "github.com outbound check failed"
+fi
+
+if [[ "${check_ghcr}" == "true" ]]; then
+  status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 https://ghcr.io/v2/ || echo 000)"
+  case "${status}" in
+    2*|3*|401)
+      ;;
+    *)
+      fail "GHCR outbound check failed: status=${status}"
+      ;;
+  esac
+fi
+
+echo "[oci-runner-doctor] passed"

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -94,7 +94,7 @@ workflow_patterns=(
   "registry: ghcr.io"
   "OCI_A1_BACKEND_ENV_B64"
   "Check OCI self-hosted runner prerequisites"
-  "sudo -n true"
+  "ops/deploy/oci/check-self-hosted-runner.sh"
   "Run OCI A1 blue-green deploy locally"
   "ops/deploy/oci/bluegreen-deploy.sh"
   "Ensure staging fixture principal"

--- a/tools/test/check-oci-self-hosted-runner-automation.sh
+++ b/tools/test/check-oci-self-hosted-runner-automation.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bootstrap_script="ops/deploy/oci/bootstrap-self-hosted-runner.sh"
+doctor_script="ops/deploy/oci/check-self-hosted-runner.sh"
+doctor_workflow=".github/workflows/oci-a1-runner-doctor.yml"
+staging_workflow=".github/workflows/staging-deploy.yml"
+delivery_doc="docs/delivery-flow.md"
+deploy_doc="ops/deploy/oci/README.md"
+
+contains() {
+  local pattern="$1"
+  local file="$2"
+  if command -v rg >/dev/null 2>&1; then
+    rg -F --quiet -- "$pattern" "$file"
+    return
+  fi
+  grep -Fq -- "$pattern" "$file"
+}
+
+require_file() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "[oci-runner-automation] missing file: $file" >&2
+    exit 1
+  fi
+}
+
+require_pattern() {
+  local pattern="$1"
+  local file="$2"
+  if ! contains "$pattern" "$file"; then
+    echo "[oci-runner-automation] missing pattern in $file: $pattern" >&2
+    exit 1
+  fi
+}
+
+reject_pattern() {
+  local pattern="$1"
+  local file="$2"
+  if contains "$pattern" "$file"; then
+    echo "[oci-runner-automation] forbidden pattern in $file: $pattern" >&2
+    exit 1
+  fi
+}
+
+echo "[oci-runner-automation] required files"
+require_file "$bootstrap_script"
+require_file "$doctor_script"
+require_file "$doctor_workflow"
+require_file "$staging_workflow"
+require_file "$delivery_doc"
+require_file "$deploy_doc"
+
+echo "[oci-runner-automation] shell syntax"
+bash -n "$bootstrap_script"
+bash -n "$doctor_script"
+bash -n "$0"
+
+echo "[oci-runner-automation] yaml syntax"
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); YAML.load_file(ARGV.fetch(1)); puts "ok"' \
+  "$doctor_workflow" "$staging_workflow" >/dev/null
+
+echo "[oci-runner-automation] bootstrap contract"
+bootstrap_patterns=(
+  "GITHUB_RUNNER_TOKEN"
+  "GITHUB_REPOSITORY_SLUG"
+  "RUNNER_LABELS"
+  "oci-a1-staging"
+  'runner_arch="arm64"'
+  'actions-runner-linux-${runner_arch}'
+  "svc.sh install"
+  "svc.sh start"
+  "AQUILA_CONFIGURE_PASSWORDLESS_SUDO"
+  "/etc/sudoers.d/aquila-github-runner"
+  "apt-get install"
+  "postgresql-client"
+)
+for pattern in "${bootstrap_patterns[@]}"; do
+  require_pattern "$pattern" "$bootstrap_script"
+done
+reject_pattern "RUNNER_TOKEN=" "$bootstrap_script"
+reject_pattern "GITHUB_RUNNER_TOKEN=" "$bootstrap_script"
+
+echo "[oci-runner-automation] doctor contract"
+doctor_patterns=(
+  "OCI_A1_RUNNER_CHECK_NETWORK"
+  "OCI_A1_RUNNER_CHECK_GHCR"
+  "base64 curl jq psql"
+  "sudo -n true"
+  "docker info"
+  "https://github.com"
+  "https://ghcr.io/v2/"
+)
+for pattern in "${doctor_patterns[@]}"; do
+  require_pattern "$pattern" "$doctor_script"
+done
+
+OCI_A1_RUNNER_CHECK_NETWORK=false \
+OCI_A1_RUNNER_CHECK_GHCR=false \
+  "$doctor_script" --dry-run >/dev/null
+
+echo "[oci-runner-automation] workflow contract"
+workflow_patterns=(
+  "name: OCI A1 Runner Doctor"
+  "workflow_dispatch:"
+  "runs-on: [self-hosted, oci-a1-staging]"
+  "ops/deploy/oci/check-self-hosted-runner.sh"
+)
+for pattern in "${workflow_patterns[@]}"; do
+  require_pattern "$pattern" "$doctor_workflow"
+done
+require_pattern "ops/deploy/oci/check-self-hosted-runner.sh" "$staging_workflow"
+reject_pattern "for command_name in base64 curl jq psql" "$staging_workflow"
+
+echo "[oci-runner-automation] docs contract"
+doc_patterns=(
+  "bootstrap-self-hosted-runner.sh"
+  "check-self-hosted-runner.sh"
+  "GITHUB_RUNNER_TOKEN"
+  "oci-a1-staging"
+)
+for pattern in "${doc_patterns[@]}"; do
+  require_pattern "$pattern" "$delivery_doc"
+  require_pattern "$pattern" "$deploy_doc"
+done
+
+echo "[oci-runner-automation] contract check passed"


### PR DESCRIPTION
## 🔗 Related Issue
close #546

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI A1 self-hosted runner 준비를 수동 절차에서 bootstrap/doctor 스크립트로 자동화했습니다.
- staging deploy는 inline prerequisite 대신 `check-self-hosted-runner.sh`를 호출하고, 수동 `OCI A1 Runner Doctor` workflow로 runner 상태를 확인할 수 있습니다.

## 🛠 Changes
- `ops/deploy/oci/bootstrap-self-hosted-runner.sh` 추가: runner token 기반 설치, label 지정, systemd service 등록, Docker/PostgreSQL client 패키지 준비, passwordless sudo 설정.
- `ops/deploy/oci/check-self-hosted-runner.sh` 추가: 필수 command, passwordless sudo, Docker, GitHub/GHCR outbound 검증.
- `.github/workflows/oci-a1-runner-doctor.yml` 추가: `[self-hosted, oci-a1-staging]` runner에서 doctor 수동 실행.
- staging deploy workflow와 OCI CD contract gate를 doctor 스크립트 기준으로 정리.
- delivery flow와 OCI deploy README에 bootstrap/doctor 절차 문서화.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-oci-self-hosted-runner-automation.sh`
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `tools/test/run-alertmanager-receiver-secret-workflow-gate.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/oci-a1-runner-doctor.yml'); YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"`
- `git diff --check`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: bootstrap은 OCI VM에서 root/sudo 권한으로 실행되며 `/etc/sudoers.d/aquila-github-runner`를 생성합니다. runner token은 실행 시점에만 환경변수로 주입해야 합니다.
- 롤백 방법: 이 PR을 revert하면 staging deploy는 이전 inline prerequisite 방식으로 돌아가고, 추가된 bootstrap/doctor 파일과 manual workflow가 제거됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
