### PR TITLE
[Fix] OCI A1 staging image ARM64 manifest 누락 수정

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -171,6 +171,11 @@ jobs:
           echo "::add-mask::${STAGING_PUBLIC_API_BASE_URL}"
           printf 'STAGING_PUBLIC_API_BASE_URL=%s\n' "${STAGING_PUBLIC_API_BASE_URL}" >>"${GITHUB_ENV}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -204,6 +209,7 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx build ./back \
+            --platform linux/amd64,linux/arm64 \
             --push \
             --tag "${BACKEND_IMAGE}:${IMAGE_TAG}" \
             --tag "${BACKEND_IMAGE}:main-latest" \
@@ -217,6 +223,7 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx build ./front \
+            --platform linux/amd64,linux/arm64 \
             --push \
             --build-arg "NEXT_PUBLIC_API_BASE_URL=${STAGING_PUBLIC_API_BASE_URL}" \
             --tag "${FRONTEND_IMAGE}:${IMAGE_TAG}" \

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -44,6 +44,7 @@
   - `OCI_A1_STAGING_ENV`를 shell env 파일로 로드한다.
   - `Main CI`가 성공한 main SHA를 checkout한다.
   - backend/frontend image를 `${DEPLOY_SHA:0:12}`와 `main-latest` tag로 GHCR에 push한다.
+  - OCI A1은 ARM64이므로 staging image는 `linux/amd64,linux/arm64` multi-platform manifest로 push한다.
   - OCI self-hosted runner가 VM 안에서 `ops/deploy/oci/bluegreen-deploy.sh`를 직접 실행한다.
   - deploy script는 green backend/frontend container health가 모두 200일 때만 Nginx config를 교체하고 reload한다.
   - Nginx config 검증 또는 reload가 실패하면 이전 config와 blue slot을 유지한다.

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -90,7 +90,10 @@ workflow_patterns=(
   "runs-on: [self-hosted, oci-a1-staging]"
   "Load OCI A1 staging env"
   'source "${staging_env_path}"'
+  "docker/setup-qemu-action@v3"
+  "platforms: arm64"
   "docker buildx build"
+  "--platform linux/amd64,linux/arm64"
   "registry: ghcr.io"
   "OCI_A1_BACKEND_ENV_B64"
   "Check OCI self-hosted runner prerequisites"


### PR DESCRIPTION
## 🔗 Related Issue
close #548

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI A1 ARM64 runner가 GHCR image를 pull하지 못하던 staging deploy 실패를 수정합니다.
- staging backend/frontend image를 `linux/amd64,linux/arm64` multi-platform manifest로 push하도록 build job을 갱신했습니다.

## 🛠 Changes
- staging build job에 `docker/setup-qemu-action@v3`를 추가했습니다.
- backend/frontend `docker buildx build`에 `--platform linux/amd64,linux/arm64`를 추가했습니다.
- OCI CD contract gate가 QEMU와 multi-platform push 계약을 검증하도록 갱신했습니다.
- delivery flow에 OCI A1 ARM64 image manifest 계약을 문서화했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"`
- `git diff --check`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: multi-platform image build는 기존 amd64 단일 build보다 시간이 더 걸릴 수 있습니다.
- 롤백 방법: 이 PR을 revert하면 기존 단일 platform build로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
