### PR TITLE
[Fix] OCI A1 staging ARM64-only build 및 DB network preflight

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx build ./back \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/arm64 \
             --push \
             --tag "${BACKEND_IMAGE}:${IMAGE_TAG}" \
             --tag "${BACKEND_IMAGE}:main-latest" \
@@ -223,7 +223,7 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx build ./front \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/arm64 \
             --push \
             --build-arg "NEXT_PUBLIC_API_BASE_URL=${STAGING_PUBLIC_API_BASE_URL}" \
             --tag "${FRONTEND_IMAGE}:${IMAGE_TAG}" \

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -44,7 +44,7 @@
   - `OCI_A1_STAGING_ENV`를 shell env 파일로 로드한다.
   - `Main CI`가 성공한 main SHA를 checkout한다.
   - backend/frontend image를 `${DEPLOY_SHA:0:12}`와 `main-latest` tag로 GHCR에 push한다.
-  - OCI A1은 ARM64이므로 staging image는 `linux/amd64,linux/arm64` multi-platform manifest로 push한다.
+  - OCI A1은 ARM64 전용 staging이므로 image는 `linux/arm64` manifest만 push한다.
   - OCI self-hosted runner가 VM 안에서 `ops/deploy/oci/bluegreen-deploy.sh`를 직접 실행한다.
   - deploy script는 green backend/frontend container health가 모두 200일 때만 Nginx config를 교체하고 reload한다.
   - Nginx config 검증 또는 reload가 실패하면 이전 config와 blue slot을 유지한다.
@@ -110,7 +110,7 @@ ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED=false
 ```env
 SPRING_PROFILES_ACTIVE=prod
 SERVER_PORT=8080
-SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:5432/aquila
+SPRING_DATASOURCE_URL=jdbc:postgresql://aquila-postgres:5432/aquila
 SPRING_DATASOURCE_USERNAME=aquila
 SPRING_DATASOURCE_PASSWORD=<secret>
 SECURITY_JWT_SECRET=<secret>

--- a/infra/terraform/oci/paid-a1-postgres/README.md
+++ b/infra/terraform/oci/paid-a1-postgres/README.md
@@ -10,7 +10,7 @@ OCI 유료 계정에서 `VM.Standard.A1.Flex` 단일 VM과 self-managed PostgreS
 - PostgreSQL data volume: `300GB`, Balanced `10` VPUs
 - Network: 새 VCN, public subnet, Internet Gateway, Route Table
 - Ingress: SSH `22/tcp`, 선택 HTTP `80/tcp`, 선택 HTTPS `443/tcp`
-- PostgreSQL: Docker `PostgreSQL 18`, host `127.0.0.1:5432` 바인딩
+- PostgreSQL: Docker `PostgreSQL 18`, host `127.0.0.1:5432` 바인딩, app network `aquila-bank-prod`
 - 100m fixture: `/var/lib/aquila-postgres/data`가 1억 건 transaction read model primary evidence 저장소
 - 제외: Managed Database, NAT Gateway, Load Balancer, PostgreSQL public ingress
 
@@ -61,6 +61,7 @@ sudo systemctl status aquila-postgres.service
 - mount: `/var/lib/aquila-postgres`
 - PostgreSQL data: `/var/lib/aquila-postgres/data`
 - container port: `127.0.0.1:5432:5432`
+- app container DNS: `aquila-postgres:5432`
 
 1억 건 fixture도 같은 data volume에 적재합니다. fixture 생성/restore/k6 실행 전에는 `df -h /var/lib/aquila-postgres`로 여유 공간을 확인하고, DB 접속은 public ingress 대신 SSH tunnel 또는 private 경로만 사용합니다.
 

--- a/infra/terraform/oci/paid-a1-postgres/cloud-init.yaml
+++ b/infra/terraform/oci/paid-a1-postgres/cloud-init.yaml
@@ -65,9 +65,11 @@ write_files:
       set -euo pipefail
 
       source /etc/aquila-postgres.env
+      docker network create aquila-bank-prod >/dev/null 2>&1 || true
       exec docker run --rm \
         --name aquila-postgres \
         --pull missing \
+        --network aquila-bank-prod \
         -p 127.0.0.1:5432:5432 \
         -e POSTGRES_DB="$${AQUILA_POSTGRES_DB}" \
         -e POSTGRES_USER="$${AQUILA_POSTGRES_USER}" \

--- a/ops/deploy/oci/README.md
+++ b/ops/deploy/oci/README.md
@@ -26,6 +26,7 @@ runner 선행 조건:
 - commands: `base64`, `curl`, `jq`, `psql`
 - privilege: passwordless sudo
 - database: `STAGING_OCI_A1_DATABASE_URL`로 PostgreSQL fixture DB 접근 가능
+- app database host: backend container는 Docker network의 `aquila-postgres:5432`로 PostgreSQL에 접근
 
 ## Runner Bootstrap
 

--- a/ops/deploy/oci/bluegreen-deploy.sh
+++ b/ops/deploy/oci/bluegreen-deploy.sh
@@ -23,6 +23,11 @@ HEALTH_INTERVAL_SECONDS="${HEALTH_INTERVAL_SECONDS:-3}"
 BLUE_DRAIN_SECONDS="${BLUE_DRAIN_SECONDS:-15}"
 SERVER_NAME="${NGINX_SERVER_NAME:-_}"
 BACKEND_PROXY_HOST="${NGINX_BACKEND_PROXY_HOST:-}"
+POSTGRES_CONTAINER_NAME="${POSTGRES_CONTAINER_NAME:-aquila-postgres}"
+POSTGRES_NETWORK_ALIAS="${POSTGRES_NETWORK_ALIAS:-aquila-postgres}"
+DB_PREFLIGHT_ENABLED="${DB_PREFLIGHT_ENABLED:-true}"
+DB_PREFLIGHT_IMAGE="${DB_PREFLIGHT_IMAGE:-postgres:18-alpine}"
+DB_PREFLIGHT_TIMEOUT_SECONDS="${DB_PREFLIGHT_TIMEOUT_SECONDS:-10}"
 BACKEND_IMAGE="${BACKEND_IMAGE:?BACKEND_IMAGE is required}"
 FRONTEND_IMAGE="${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}"
 IMAGE_TAG="${IMAGE_TAG:?IMAGE_TAG is required}"
@@ -30,6 +35,14 @@ GITHUB_ACTOR="${GITHUB_ACTOR:?GITHUB_ACTOR is required}"
 GITHUB_TOKEN_B64="${GITHUB_TOKEN_B64:?GITHUB_TOKEN_B64 is required}"
 BACKEND_ENV_B64="${BACKEND_ENV_B64:?BACKEND_ENV_B64 is required}"
 FRONTEND_ENV_B64="${FRONTEND_ENV_B64:-}"
+DOCKER_CONFIG_DIR=""
+
+cleanup_temp() {
+  if [[ -n "${DOCKER_CONFIG_DIR}" && -d "${DOCKER_CONFIG_DIR}" ]]; then
+    rm -rf "${DOCKER_CONFIG_DIR}"
+  fi
+}
+trap cleanup_temp EXIT
 
 log() {
   printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
@@ -53,6 +66,12 @@ prepare_layout() {
   docker network create "${NETWORK}" >/dev/null 2>&1 || true
 }
 
+prepare_docker_config() {
+  DOCKER_CONFIG_DIR="$(mktemp -d)"
+  chmod 700 "${DOCKER_CONFIG_DIR}"
+  export DOCKER_CONFIG="${DOCKER_CONFIG_DIR}"
+}
+
 write_env_files() {
   printf '%s' "${BACKEND_ENV_B64}" | base64 -d >"${APP_DIR}/env/backend.env"
   chmod 600 "${APP_DIR}/env/backend.env"
@@ -66,9 +85,92 @@ write_env_files() {
 }
 
 docker_login() {
-  local token
+  local token login_log
   token="$(printf '%s' "${GITHUB_TOKEN_B64}" | base64 -d)"
-  printf '%s' "${token}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin >/dev/null
+  login_log="$(mktemp)"
+
+  # Docker credential helper 없는 OCI VM에서도 token은 임시 DOCKER_CONFIG에만 저장하고 종료 시 삭제한다.
+  if ! printf '%s' "${token}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin >/dev/null 2>"${login_log}"; then
+    cat "${login_log}" >&2
+    rm -f "${login_log}"
+    exit 1
+  fi
+
+  grep -Fv "WARNING! Your credentials are stored unencrypted" "${login_log}" \
+    | grep -Fv "Configure a credential helper" \
+    | grep -Fv "https://docs.docker.com/go/credential-store/" >&2 || true
+  rm -f "${login_log}"
+}
+
+env_value() {
+  local name="$1"
+  sed -n "s/^${name}=//p" "${APP_DIR}/env/backend.env" | tail -1
+}
+
+connect_postgres_container() {
+  if ! docker ps --format '{{.Names}}' | grep -qx "${POSTGRES_CONTAINER_NAME}"; then
+    return 0
+  fi
+
+  if docker inspect -f '{{json .NetworkSettings.Networks}}' "${POSTGRES_CONTAINER_NAME}" | grep -Fq "\"${NETWORK}\""; then
+    return 0
+  fi
+
+  log "connect postgres container ${POSTGRES_CONTAINER_NAME} to network ${NETWORK}"
+  docker network connect --alias "${POSTGRES_NETWORK_ALIAS}" "${NETWORK}" "${POSTGRES_CONTAINER_NAME}"
+}
+
+preflight_backend_database() {
+  if [[ "${DB_PREFLIGHT_ENABLED}" != "true" ]]; then
+    log "backend database preflight skipped"
+    return 0
+  fi
+
+  local jdbc_url db_host db_port db_name db_user db_password host_port
+  jdbc_url="$(env_value SPRING_DATASOURCE_URL)"
+  if [[ -z "${jdbc_url}" ]]; then
+    jdbc_url="$(env_value DB_URL)"
+  fi
+
+  db_host="$(env_value DB_HOST)"
+  db_port="$(env_value DB_PORT)"
+  db_name="$(env_value DB_NAME)"
+
+  if [[ -n "${jdbc_url}" && "${jdbc_url}" == jdbc:postgresql://* ]]; then
+    host_port="${jdbc_url#jdbc:postgresql://}"
+    host_port="${host_port%%/*}"
+    db_name="${jdbc_url#jdbc:postgresql://}"
+    db_name="${db_name#*/}"
+    db_name="${db_name%%\?*}"
+    db_host="${host_port%%:*}"
+    if [[ "${host_port}" == *:* ]]; then
+      db_port="${host_port##*:}"
+    fi
+  fi
+
+  db_port="${db_port:-5432}"
+  db_user="$(env_value SPRING_DATASOURCE_USERNAME)"
+  db_user="${db_user:-$(env_value DB_USERNAME)}"
+  db_password="$(env_value SPRING_DATASOURCE_PASSWORD)"
+  db_password="${db_password:-$(env_value DB_PASSWORD)}"
+
+  if [[ -z "${db_host}" || -z "${db_name}" || -z "${db_user}" ]]; then
+    log "backend database preflight skipped: DB host/name/user not found in backend env"
+    return 0
+  fi
+
+  if [[ "${db_host}" == "host.docker.internal" && "$(docker ps --format '{{.Names}}' | grep -x "${POSTGRES_CONTAINER_NAME}" || true)" == "${POSTGRES_CONTAINER_NAME}" ]]; then
+    log "backend DB host=host.docker.internal detected while ${POSTGRES_CONTAINER_NAME} is a Docker container; use jdbc:postgresql://${POSTGRES_NETWORK_ALIAS}:5432/${db_name}"
+  fi
+
+  log "backend database preflight: ${db_user}@${db_host}:${db_port}/${db_name}"
+  if ! docker run --rm --network "${NETWORK}" \
+    -e PGPASSWORD="${db_password}" \
+    "${DB_PREFLIGHT_IMAGE}" \
+    pg_isready -h "${db_host}" -p "${db_port}" -U "${db_user}" -d "${db_name}" -t "${DB_PREFLIGHT_TIMEOUT_SECONDS}" >/dev/null; then
+    log "backend database preflight failed: ${db_user}@${db_host}:${db_port}/${db_name}"
+    exit 1
+  fi
 }
 
 active_slot() {
@@ -342,7 +444,10 @@ main() {
   install_runtime
   prepare_layout
   write_env_files
+  prepare_docker_config
   docker_login
+  connect_postgres_container
+  preflight_backend_database
 
   blue="$(active_slot)"
   case "${blue}" in

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -93,7 +93,7 @@ workflow_patterns=(
   "docker/setup-qemu-action@v3"
   "platforms: arm64"
   "docker buildx build"
-  "--platform linux/amd64,linux/arm64"
+  "--platform linux/arm64"
   "registry: ghcr.io"
   "OCI_A1_BACKEND_ENV_B64"
   "Check OCI self-hosted runner prerequisites"
@@ -139,6 +139,12 @@ echo "[oci-a1-bluegreen-cd] deploy script contract"
 script_patterns=(
   "apt-get update"
   "docker.io"
+  "DOCKER_CONFIG"
+  "mktemp -d"
+  "connect_postgres_container"
+  "preflight_backend_database"
+  "POSTGRES_CONTAINER_NAME"
+  "aquila-postgres"
   "aquila-bank-backend-a"
   "aquila-bank-backend-b"
   "aquila-bank-front-a"
@@ -155,6 +161,7 @@ script_patterns=(
 for pattern in "${script_patterns[@]}"; do
   require_pattern "$pattern" "$deploy_script"
 done
+reject_pattern "--platform linux/amd64,linux/arm64" "$workflow"
 
 echo "[oci-a1-bluegreen-cd] fixture principal contract"
 fixture_principal_patterns=(
@@ -180,6 +187,7 @@ doc_patterns=(
   "OCI_A1_STAGING_ENV"
   "OCI self-hosted runner"
   "oci-a1-staging"
+  "linux/arm64"
   "OCI_A1_BACKEND_ENV_B64"
   "STAGING_OCI_A1_DATABASE_URL"
   "STAGING_REPLAY_USER_ID"

--- a/tools/test/check-oci-paid-a1-postgres-baseline.sh
+++ b/tools/test/check-oci-paid-a1-postgres-baseline.sh
@@ -14,7 +14,7 @@ require_file() {
 require_pattern() {
   local pattern="$1"
   local path="$2"
-  if ! grep -F "${pattern}" "${path}" >/dev/null; then
+  if ! grep -F -- "${pattern}" "${path}" >/dev/null; then
     echo "required pattern missing in ${path}: ${pattern}" >&2
     exit 1
   fi
@@ -23,7 +23,7 @@ require_pattern() {
 reject_pattern() {
   local pattern="$1"
   local path="$2"
-  if grep -F "${pattern}" "${path}" >/dev/null; then
+  if grep -F -- "${pattern}" "${path}" >/dev/null; then
     echo "forbidden pattern found in ${path}: ${pattern}" >&2
     exit 1
   fi
@@ -71,6 +71,8 @@ echo "[oci-paid-a1-postgres] bootstrap contract"
 require_pattern 'postgres:18' "${module_dir}/cloud-init.yaml"
 require_pattern '/var/lib/aquila-postgres' "${module_dir}/cloud-init.yaml"
 require_pattern '127.0.0.1:5432:5432' "${module_dir}/cloud-init.yaml"
+require_pattern 'docker network create aquila-bank-prod' "${module_dir}/cloud-init.yaml"
+require_pattern '--network aquila-bank-prod' "${module_dir}/cloud-init.yaml"
 require_pattern 'AQUILA_POSTGRES_PASSWORD' "${module_dir}/cloud-init.yaml"
 require_pattern 'mkfs.ext4' "${module_dir}/cloud-init.yaml"
 require_pattern '/etc/fstab' "${module_dir}/cloud-init.yaml"
@@ -91,6 +93,8 @@ require_pattern 'VM.Standard.A1.Flex' "${module_dir}/README.md"
 require_pattern '4 OCPU / 24GB' "${module_dir}/README.md"
 require_pattern '300GB' "${module_dir}/README.md"
 require_pattern 'PostgreSQL 18' "${module_dir}/README.md"
+require_pattern 'aquila-bank-prod' "${module_dir}/README.md"
+require_pattern 'aquila-postgres:5432' "${module_dir}/README.md"
 require_pattern '5432' "${module_dir}/README.md"
 require_pattern 'public ingress' "${module_dir}/README.md"
 require_pattern 'terraform init' "${module_dir}/README.md"


### PR DESCRIPTION
## 🔗 Related Issue
close #550

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI A1 전용 staging build를 `linux/arm64` only로 줄여 build 시간을 낮춥니다.
- backend 시작 전 PostgreSQL 접근성을 app Docker network에서 preflight하고, GHCR login token은 임시 Docker config에만 저장하도록 정리했습니다.

## 🛠 Changes
- staging backend/frontend image build platform을 `linux/arm64`로 변경했습니다.
- `bluegreen-deploy.sh`가 `DOCKER_CONFIG` 임시 디렉토리를 사용하고 종료 시 삭제하도록 수정했습니다.
- `aquila-postgres` container를 `aquila-bank-prod` Docker network에 연결하고 backend DB preflight를 수행합니다.
- paid A1 PostgreSQL cloud-init이 PostgreSQL container를 `aquila-bank-prod` network에서 시작하도록 갱신했습니다.
- backend env 문서의 DB URL을 `jdbc:postgresql://aquila-postgres:5432/aquila` 기준으로 수정했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `tools/test/check-oci-paid-a1-postgres-baseline.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"`
- `bash -n ops/deploy/oci/bluegreen-deploy.sh`
- `git diff --check`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: x64 배포 대상에서는 이 staging image를 그대로 사용할 수 없습니다. 현재 staging deploy target은 OCI A1 ARM64 전용입니다.
- 운영 반영 필요: `OCI_A1_BACKEND_ENV_B64` 안의 backend DB URL이 `host.docker.internal`이면 `jdbc:postgresql://aquila-postgres:5432/aquila`로 바꿔 다시 base64 인코딩해야 합니다.
- 롤백 방법: 이 PR을 revert하면 multi-platform build와 기존 DB 접근 방식으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
