### PR TITLE
[Fix] staging fixture principal 길이 검증 오류 수정

### DIFF
--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -54,11 +54,11 @@ validate_inputs() {
   require_positive_integer STAGING_REPLAY_USER_ID
   require_positive_integer HOT_ACCOUNT_ID
   require_positive_integer COLD_ACCOUNT_ID
-  require_max_length STAGING_REPLAY_LOGIN_ID "${STAGING_REPLAY_LOGIN_ID}" 80
-  require_max_length STAGING_REPLAY_USER_PASSWORD_HASH "${STAGING_REPLAY_USER_PASSWORD_HASH}" 120
-  require_max_length STAGING_REPLAY_USER_DISPLAY_NAME "${STAGING_REPLAY_USER_DISPLAY_NAME}" 80
-  require_max_length STAGING_REPLAY_HOT_ACCOUNT_NUMBER "${STAGING_REPLAY_HOT_ACCOUNT_NUMBER}" 20
-  require_max_length STAGING_REPLAY_COLD_ACCOUNT_NUMBER "${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" 20
+  require_max_length STAGING_REPLAY_LOGIN_ID 80
+  require_max_length STAGING_REPLAY_USER_PASSWORD_HASH 120
+  require_max_length STAGING_REPLAY_USER_DISPLAY_NAME 80
+  require_max_length STAGING_REPLAY_HOT_ACCOUNT_NUMBER 20
+  require_max_length STAGING_REPLAY_COLD_ACCOUNT_NUMBER 20
 }
 
 ensure_fixture_principal() {

--- a/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+++ b/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/ops/staging-fixture-principal-bootstrap.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+psql_log="${tmp_dir}/psql.log"
+cat >"${tmp_dir}/psql" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${PSQL_STUB_LOG}"
+SH
+chmod +x "${tmp_dir}/psql"
+
+run_bootstrap() {
+  env \
+    PATH="${tmp_dir}:${PATH}" \
+    PSQL_STUB_LOG="${psql_log}" \
+    STAGING_OCI_A1_DATABASE_URL="postgresql://fixture-db/aquila" \
+    STAGING_REPLAY_USER_ID="55" \
+    STAGING_REPLAY_LOGIN_ID="staging-fixture-user" \
+    STAGING_REPLAY_USER_PASSWORD_HASH="fixturePasswordHashWithLetters" \
+    STAGING_REPLAY_USER_DISPLAY_NAME="Staging Fixture User" \
+    HOT_ACCOUNT_ID="1001" \
+    COLD_ACCOUNT_ID="1002" \
+    "${script}"
+}
+
+assert_valid_secret_like_values_do_not_enter_arithmetic() {
+  run_bootstrap >/dev/null
+  grep -q -- "fixture_password_hash=fixturePasswordHashWithLetters" "${psql_log}"
+}
+
+assert_too_long_password_hash_fails_before_psql() {
+  local log="${tmp_dir}/too-long.log"
+  local long_hash
+  long_hash="$(printf '%0121d' 0)"
+  : >"${psql_log}"
+
+  if env \
+    PATH="${tmp_dir}:${PATH}" \
+    PSQL_STUB_LOG="${psql_log}" \
+    STAGING_OCI_A1_DATABASE_URL="postgresql://fixture-db/aquila" \
+    STAGING_REPLAY_USER_ID="55" \
+    STAGING_REPLAY_LOGIN_ID="staging-fixture-user" \
+    STAGING_REPLAY_USER_PASSWORD_HASH="${long_hash}" \
+    STAGING_REPLAY_USER_DISPLAY_NAME="Staging Fixture User" \
+    HOT_ACCOUNT_ID="1001" \
+    COLD_ACCOUNT_ID="1002" \
+    "${script}" >"${log}" 2>&1; then
+    echo "expected too long password hash to fail" >&2
+    exit 1
+  fi
+
+  grep -q -- "STAGING_REPLAY_USER_PASSWORD_HASH must be 120 characters or less" "${log}"
+  if [ -s "${psql_log}" ]; then
+    echo "expected validation failure before psql execution" >&2
+    exit 1
+  fi
+}
+
+assert_valid_secret_like_values_do_not_enter_arithmetic
+assert_too_long_password_hash_fails_before_psql
+
+echo "[staging-fixture-principal-contract] ok"


### PR DESCRIPTION
## 🔗 Related Issue
- close #558

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging deploy의 `Ensure staging fixture principal` 단계에서 `require_max_length` 호출 인자가 helper 계약과 맞지 않아 `set -u` 산술 평가 오류가 발생하던 문제를 수정합니다.
- secret 값 자체가 max 길이 인자로 재평가되지 않도록 호출부를 `name, max` 계약으로 정리하고, psql stub 기반 contract test를 추가했습니다.

## 🛠 Changes
- `tools/ops/staging-fixture-principal-bootstrap.sh`의 `require_max_length` 호출에서 불필요한 value 인자를 제거했습니다.
- `tools/test/run-staging-fixture-principal-bootstrap-contract.sh`를 추가해 정상 secret-like 값과 길이 초과 실패 경로를 검증합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `bash -n tools/test/run-staging-fixture-principal-bootstrap-contract.sh tools/ops/staging-fixture-principal-bootstrap.sh`
- `git diff --check HEAD~1..HEAD`
- `git rev-list --count main..HEAD` -> `1` (`commit_plan` 1개와 일치)

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: staging fixture principal bootstrap 검증 경로만 수정하며 거래/잔액/원장 로직 영향은 없습니다. 실제 staging DB 접속은 로컬 contract test에서 stub 처리했습니다.
- 롤백 방법: 이 PR merge commit 또는 `a2d9cbd8` revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A