### PR TITLE
[Fix] staging DB URL local resolver 추가

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -356,6 +356,9 @@ jobs:
           STAGING_SMOKE_WRITE_METHOD="${STAGING_SMOKE_WRITE_METHOD:-POST}"
           STAGING_SMOKE_WRITE_BODY="${STAGING_SMOKE_WRITE_BODY:-{}}"
           ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT=staging
+          POSTGRES_CONTAINER_NAME="${POSTGRES_CONTAINER_NAME:-aquila-postgres}"
+          POSTGRES_NETWORK_ALIAS="${POSTGRES_NETWORK_ALIAS:-aquila-postgres}"
+          POSTGRES_HOST_BIND="${POSTGRES_HOST_BIND:-127.0.0.1:5432}"
 
           HOT_ACCOUNT_ID="${STAGING_REPLAY_HOT_ACCOUNT_ID:-${HOT_ACCOUNT_ID:-}}"
           HOT_FROM="${STAGING_REPLAY_HOT_FROM:-${HOT_FROM:-}}"
@@ -418,6 +421,9 @@ jobs:
             STAGING_REPLAY_USER_DISPLAY_NAME
             STAGING_REPLAY_HOT_ACCOUNT_NUMBER
             STAGING_REPLAY_COLD_ACCOUNT_NUMBER
+            POSTGRES_CONTAINER_NAME
+            POSTGRES_NETWORK_ALIAS
+            POSTGRES_HOST_BIND
             ITERATIONS
             PAGE_LIMIT
             REQUEST_TIMEOUT_SECONDS
@@ -459,6 +465,15 @@ jobs:
         run: |
           set -euo pipefail
           ops/deploy/oci/check-self-hosted-runner.sh
+
+      - name: Resolve OCI A1 staging database URL
+        shell: bash
+        run: |
+          set -euo pipefail
+          # backend env가 Docker alias DB를 쓰면 host psql용 URL은 배포 시점에 재산출한다.
+          resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"
+          echo "::add-mask::${resolved_database_url}"
+          printf 'STAGING_OCI_A1_DATABASE_URL=%s\n' "${resolved_database_url}" >>"${GITHUB_ENV}"
 
       - name: Run Alertmanager receiver secret smoke
         shell: bash

--- a/tools/ops/resolve-oci-a1-staging-database-url.sh
+++ b/tools/ops/resolve-oci-a1-staging-database-url.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND_ENV_B64="${OCI_A1_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-}}"
+STAGING_OCI_A1_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-}"
+POSTGRES_CONTAINER_NAME="${POSTGRES_CONTAINER_NAME:-aquila-postgres}"
+POSTGRES_NETWORK_ALIAS="${POSTGRES_NETWORK_ALIAS:-aquila-postgres}"
+POSTGRES_HOST_BIND="${POSTGRES_HOST_BIND:-127.0.0.1:5432}"
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+decode_base64() {
+  local encoded="$1"
+  local output="$2"
+
+  if printf '%s' "$encoded" | base64 -d >"$output" 2>/dev/null; then
+    return 0
+  fi
+
+  if printf '%s' "$encoded" | base64 -D >"$output" 2>/dev/null; then
+    return 0
+  fi
+
+  fail "Failed to decode OCI_A1_BACKEND_ENV_B64"
+}
+
+env_value() {
+  local name="$1"
+  local file="$2"
+  sed -n "s/^${name}=//p" "$file" | tail -1
+}
+
+url_encode() {
+  jq -nr --arg value "$1" '$value | @uri'
+}
+
+postgres_host_requires_container() {
+  local db_host="$1"
+  [[ "$db_host" == "$POSTGRES_CONTAINER_NAME" || "$db_host" == "$POSTGRES_NETWORK_ALIAS" ]]
+}
+
+resolve_host_bind() {
+  local bind="$1"
+  local host port
+
+  if [[ "$bind" == *:* ]]; then
+    host="${bind%:*}"
+    port="${bind##*:}"
+  else
+    host="127.0.0.1"
+    port="$bind"
+  fi
+
+  if [[ -z "$host" || "$host" == "0.0.0.0" || "$host" == "::" ]]; then
+    host="127.0.0.1"
+  fi
+
+  [[ "$port" =~ ^[1-9][0-9]*$ ]] || fail "POSTGRES_HOST_BIND must include a positive port"
+  printf '%s %s\n' "$host" "$port"
+}
+
+build_postgres_url() {
+  local db_host="$1"
+  local db_port="$2"
+  local db_name="$3"
+  local db_user="$4"
+  local db_password="$5"
+
+  printf 'postgresql://%s:%s@%s:%s/%s\n' \
+    "$(url_encode "$db_user")" \
+    "$(url_encode "$db_password")" \
+    "$db_host" \
+    "$db_port" \
+    "$(url_encode "$db_name")"
+}
+
+fallback_explicit_url() {
+  if [[ -n "$STAGING_OCI_A1_DATABASE_URL" ]]; then
+    printf '%s\n' "$STAGING_OCI_A1_DATABASE_URL"
+    return 0
+  fi
+
+  fail "STAGING_OCI_A1_DATABASE_URL is required when backend DB host is not the OCI PostgreSQL container alias"
+}
+
+require_command base64
+require_command jq
+
+if [[ -z "$BACKEND_ENV_B64" ]]; then
+  fallback_explicit_url
+  exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+backend_env="${tmp_dir}/backend.env"
+decode_base64 "$BACKEND_ENV_B64" "$backend_env"
+
+# backend env는 secret 본문이라 실행하지 않고 key lookup만 수행한다.
+jdbc_url="$(env_value SPRING_DATASOURCE_URL "$backend_env")"
+if [[ -z "$jdbc_url" ]]; then
+  jdbc_url="$(env_value DB_URL "$backend_env")"
+fi
+
+if [[ "$jdbc_url" != jdbc:postgresql://* ]]; then
+  fallback_explicit_url
+  exit 0
+fi
+
+host_port="${jdbc_url#jdbc:postgresql://}"
+host_port="${host_port%%/*}"
+db_name="${jdbc_url#jdbc:postgresql://}"
+db_name="${db_name#*/}"
+db_name="${db_name%%\?*}"
+db_host="${host_port%%:*}"
+db_port="5432"
+if [[ "$host_port" == *:* ]]; then
+  db_port="${host_port##*:}"
+fi
+
+if ! postgres_host_requires_container "$db_host"; then
+  fallback_explicit_url
+  exit 0
+fi
+
+# backend는 Docker alias로 접근하지만 host psql은 published bind 주소로 접근한다.
+db_user="$(env_value SPRING_DATASOURCE_USERNAME "$backend_env")"
+if [[ -z "$db_user" ]]; then
+  db_user="$(env_value DB_USERNAME "$backend_env")"
+fi
+db_password="$(env_value SPRING_DATASOURCE_PASSWORD "$backend_env")"
+if [[ -z "$db_password" ]]; then
+  db_password="$(env_value DB_PASSWORD "$backend_env")"
+fi
+
+[[ -n "$db_name" ]] || fail "Backend JDBC database name is required"
+[[ -n "$db_user" ]] || fail "Backend database username is required"
+[[ -n "$db_password" ]] || fail "Backend database password is required"
+
+read -r host_db_host host_db_port < <(resolve_host_bind "$POSTGRES_HOST_BIND")
+build_postgres_url "$host_db_host" "$host_db_port" "$db_name" "$db_user" "$db_password"

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 workflow=".github/workflows/staging-deploy.yml"
 deploy_script="ops/deploy/oci/bluegreen-deploy.sh"
+database_url_resolver_script="tools/ops/resolve-oci-a1-staging-database-url.sh"
 fixture_principal_script="tools/ops/staging-fixture-principal-bootstrap.sh"
 delivery_doc="docs/delivery-flow.md"
 production_doc="docs/production-promotion.md"
@@ -62,6 +63,7 @@ reject_workflow_pattern() {
 echo "[oci-a1-bluegreen-cd] required files"
 require_file "$workflow"
 require_file "$deploy_script"
+require_file "$database_url_resolver_script"
 require_file "$fixture_principal_script"
 require_file "$delivery_doc"
 require_file "$production_doc"
@@ -70,6 +72,7 @@ require_file "front/Dockerfile"
 
 echo "[oci-a1-bluegreen-cd] shell syntax"
 bash -n "$deploy_script"
+bash -n "$database_url_resolver_script"
 bash -n "$fixture_principal_script"
 bash -n "$0"
 
@@ -99,6 +102,8 @@ workflow_patterns=(
   "OCI_A1_BACKEND_ENV_B64"
   "Check OCI self-hosted runner prerequisites"
   "ops/deploy/oci/check-self-hosted-runner.sh"
+  "Resolve OCI A1 staging database URL"
+  "tools/ops/resolve-oci-a1-staging-database-url.sh"
   "Run OCI A1 blue-green deploy locally"
   "ops/deploy/oci/bluegreen-deploy.sh"
   "Ensure staging fixture principal"
@@ -179,6 +184,19 @@ for pattern in "${script_patterns[@]}"; do
   require_pattern "$pattern" "$deploy_script"
 done
 reject_pattern "--platform linux/amd64,linux/arm64" "$workflow"
+
+echo "[oci-a1-bluegreen-cd] database URL resolver contract"
+database_url_resolver_patterns=(
+  "OCI_A1_BACKEND_ENV_B64"
+  "SPRING_DATASOURCE_URL"
+  "SPRING_DATASOURCE_USERNAME"
+  "SPRING_DATASOURCE_PASSWORD"
+  "POSTGRES_HOST_BIND"
+  "postgresql://%s:%s@%s:%s/%s"
+)
+for pattern in "${database_url_resolver_patterns[@]}"; do
+  require_pattern "$pattern" "$database_url_resolver_script"
+done
 
 echo "[oci-a1-bluegreen-cd] fixture principal contract"
 fixture_principal_patterns=(

--- a/tools/test/run-oci-a1-staging-database-url-resolver.sh
+++ b/tools/test/run-oci-a1-staging-database-url-resolver.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="tools/ops/resolve-oci-a1-staging-database-url.sh"
+
+base64_one_line() {
+  printf '%s' "$1" | base64 | tr -d '\n'
+}
+
+assert_container_alias_resolves_to_host_local_url() {
+  local backend_env result expected
+  backend_env=$'SPRING_DATASOURCE_URL=jdbc:postgresql://aquila-postgres:5432/aquila\nSPRING_DATASOURCE_USERNAME=aquila\nSPRING_DATASOURCE_PASSWORD=p@ss word/!?'
+  expected="postgresql://aquila:p%40ss%20word%2F%21%3F@127.0.0.1:5432/aquila"
+
+  result="$(
+    OCI_A1_BACKEND_ENV_B64="$(base64_one_line "$backend_env")" \
+    STAGING_OCI_A1_DATABASE_URL="postgresql://aquila:old@146.56.149.120:15432/aquila" \
+    "$script"
+  )"
+
+  if [[ "$result" != "$expected" ]]; then
+    echo "expected host-local URL, got: ${result}" >&2
+    exit 1
+  fi
+}
+
+assert_container_alias_uses_custom_host_bind_port() {
+  local backend_env result expected
+  backend_env=$'SPRING_DATASOURCE_URL=jdbc:postgresql://aquila-postgres:5432/aquila\nSPRING_DATASOURCE_USERNAME=aquila\nSPRING_DATASOURCE_PASSWORD=secret'
+  expected="postgresql://aquila:secret@127.0.0.1:15432/aquila"
+
+  result="$(
+    OCI_A1_BACKEND_ENV_B64="$(base64_one_line "$backend_env")" \
+    POSTGRES_HOST_BIND="127.0.0.1:15432" \
+    STAGING_OCI_A1_DATABASE_URL="postgresql://aquila:old@146.56.149.120:15432/aquila" \
+    "$script"
+  )"
+
+  if [[ "$result" != "$expected" ]]; then
+    echo "expected custom host bind URL, got: ${result}" >&2
+    exit 1
+  fi
+}
+
+assert_external_backend_keeps_explicit_staging_url() {
+  local backend_env result expected
+  backend_env=$'SPRING_DATASOURCE_URL=jdbc:postgresql://db.example.internal:5432/aquila\nSPRING_DATASOURCE_USERNAME=aquila\nSPRING_DATASOURCE_PASSWORD=secret'
+  expected="postgresql://aquila:secret@db.example.internal:5432/aquila"
+
+  result="$(
+    OCI_A1_BACKEND_ENV_B64="$(base64_one_line "$backend_env")" \
+    STAGING_OCI_A1_DATABASE_URL="$expected" \
+    "$script"
+  )"
+
+  if [[ "$result" != "$expected" ]]; then
+    echo "expected explicit staging URL fallback, got: ${result}" >&2
+    exit 1
+  fi
+}
+
+assert_container_alias_resolves_to_host_local_url
+assert_container_alias_uses_custom_host_bind_port
+assert_external_backend_keeps_explicit_staging_url
+
+echo "[oci-a1-staging-db-url-resolver] ok"

--- a/tools/test/run-staging-deploy-transaction-replay-gate.sh
+++ b/tools/test/run-staging-deploy-transaction-replay-gate.sh
@@ -21,6 +21,7 @@ replay_name = 'Run transaction replay regression gate'
 smoke_name = 'Run staging post-deploy smoke'
 fixture_principal_name = 'Ensure staging fixture principal'
 deploy_name = 'Run OCI A1 blue-green deploy locally'
+resolver_name = 'Resolve OCI A1 staging database URL'
 load_env_name = 'Load OCI A1 staging env'
 prerequisite_name = 'Check OCI self-hosted runner prerequisites'
 
@@ -28,6 +29,7 @@ replay_index = step_names.index(replay_name) or abort("missing step: #{replay_na
 smoke_index = step_names.index(smoke_name) or abort("missing step: #{smoke_name}")
 fixture_principal_index = step_names.index(fixture_principal_name) or abort("missing step: #{fixture_principal_name}")
 deploy_index = step_names.index(deploy_name) or abort("missing step: #{deploy_name}")
+resolver_index = step_names.index(resolver_name) or abort("missing step: #{resolver_name}")
 load_env_index = step_names.index(load_env_name) or abort("missing step: #{load_env_name}")
 prerequisite_index = step_names.index(prerequisite_name) or abort("missing step: #{prerequisite_name}")
 
@@ -35,6 +37,8 @@ runner_labels = Array(deploy_job.fetch('runs-on'))
 abort('deploy job must run on OCI self-hosted runner') unless runner_labels.include?('self-hosted') && runner_labels.include?('oci-a1-staging')
 abort('staging env must load before smoke') unless load_env_index < smoke_index
 abort('runner prerequisites must run after env load') unless load_env_index < prerequisite_index
+abort('DB URL resolver must run after runner prerequisites') unless prerequisite_index < resolver_index
+abort('DB URL resolver must run before OCI deploy') unless resolver_index < deploy_index
 abort('runner prerequisites must run before OCI deploy') unless prerequisite_index < deploy_index
 abort('fixture principal must run after OCI deploy') unless deploy_index < fixture_principal_index
 abort('fixture principal must run before smoke') unless fixture_principal_index < smoke_index
@@ -67,6 +71,9 @@ required_keys = %w[
   STAGING_REPLAY_LOGIN_ID
   STAGING_REPLAY_USER_PASSWORD_HASH
   STAGING_REPLAY_USER_DISPLAY_NAME
+  POSTGRES_CONTAINER_NAME
+  POSTGRES_NETWORK_ALIAS
+  POSTGRES_HOST_BIND
 ]
 required_keys.each do |key|
   abort("load step must persist env: #{key}") unless load_run.include?(key)
@@ -78,7 +85,12 @@ abort('replay step should not scatter staging env mappings') if replay_step.key?
 abort('replay step must call transaction replay script') unless run.include?('tools/ops/transaction-read-model-staging-replay.sh')
 abort('fixture principal step must call fixture principal script') unless steps.fetch(fixture_principal_index).fetch('run').include?('tools/ops/staging-fixture-principal-bootstrap.sh')
 abort('OCI deploy step must call local bluegreen script') unless steps.fetch(deploy_index).fetch('run').include?('ops/deploy/oci/bluegreen-deploy.sh')
+resolver_run = steps.fetch(resolver_index).fetch('run')
+abort('DB URL resolver step must call resolver script') unless resolver_run.include?('tools/ops/resolve-oci-a1-staging-database-url.sh')
+abort('DB URL resolver must mask resolved URL') unless resolver_run.include?('::add-mask::${resolved_database_url}')
+abort('DB URL resolver must rewrite staging DB URL in GITHUB_ENV') unless resolver_run.include?('STAGING_OCI_A1_DATABASE_URL=%s')
 abort('OCI A1 database URL must come from unified staging env') unless load_run.include?('STAGING_OCI_A1_DATABASE_URL')
+abort('Postgres host bind must default to host-local port') unless load_run.include?('POSTGRES_HOST_BIND="${POSTGRES_HOST_BIND:-127.0.0.1:5432}"')
 abort('hot account must map from staging replay key') unless load_run.include?('HOT_ACCOUNT_ID="${STAGING_REPLAY_HOT_ACCOUNT_ID')
 abort('cold account must map from staging replay key') unless load_run.include?('COLD_ACCOUNT_ID="${STAGING_REPLAY_COLD_ACCOUNT_ID')
 RUBY


### PR DESCRIPTION
## 🔗 Related Issue
- close #560

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI A1 staging deploy에서 backend DB가 `aquila-postgres` Docker alias로 전환된 뒤에도 `STAGING_OCI_A1_DATABASE_URL`이 stale public endpoint를 가리켜 fixture principal psql 접속이 timeout 되던 문제를 방지합니다.
- backend env의 JDBC 설정에서 host-local psql URL을 산출해 fixture principal/smoke/replay 전에 `STAGING_OCI_A1_DATABASE_URL`을 다시 기록합니다.

## 🛠 Changes
- `tools/ops/resolve-oci-a1-staging-database-url.sh` 추가: `OCI_A1_BACKEND_ENV_B64`를 decode해 `SPRING_DATASOURCE_URL`, username, password를 읽고, container alias DB이면 `POSTGRES_HOST_BIND` 기반 host-local PostgreSQL URL을 생성합니다.
- `staging-deploy.yml`에 `Resolve OCI A1 staging database URL` step 추가 및 `POSTGRES_CONTAINER_NAME`/`POSTGRES_NETWORK_ALIAS`/`POSTGRES_HOST_BIND` env 보존.
- resolver 단위 test와 staging deploy contract gate를 추가/보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-oci-a1-staging-database-url-resolver.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `bash -n tools/ops/resolve-oci-a1-staging-database-url.sh tools/test/run-oci-a1-staging-database-url-resolver.sh`
- `git diff --check HEAD~1..HEAD`
- `git rev-list --count main..HEAD` -> `1` (`commit_plan` 1개와 일치)

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: backend env와 `POSTGRES_HOST_BIND`가 실제 PostgreSQL bind와 불일치하면 fixture/replay psql 접속은 계속 실패할 수 있습니다. resolver는 backend DB host가 `aquila-postgres` alias일 때만 stale public endpoint보다 host-local URL을 우선합니다.
- 롤백 방법: 이 PR merge commit 또는 `f10dfa01` revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? resolved DB URL은 workflow에서 `::add-mask::` 처리
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A