### PR TITLE
[Fix] staging fixture psql 변수 치환 오류 수정

### DIFF
--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -72,8 +72,8 @@ ensure_fixture_principal() {
     -v hot_account_id="${HOT_ACCOUNT_ID}" \
     -v cold_account_id="${COLD_ACCOUNT_ID}" \
     -v hot_account_number="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER}" \
-    -v cold_account_number="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" \
-    --command "
+    -v cold_account_number="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" <<'SQL'
+      -- psql 변수(:name)는 -c 경로에서 치환되지 않아 stdin으로 전달한다.
       BEGIN;
 
       INSERT INTO bank_account (
@@ -160,7 +160,7 @@ ensure_fixture_principal() {
       );
 
       COMMIT;
-    "
+SQL
 }
 
 validate_inputs

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -201,6 +201,7 @@ done
 echo "[oci-a1-bluegreen-cd] fixture principal contract"
 fixture_principal_patterns=(
   "STAGING_REPLAY_USER_ID"
+  "<<'SQL'"
   "OVERRIDING SYSTEM VALUE"
   "INSERT INTO bank_account"
   "INSERT INTO bank_user"
@@ -211,6 +212,7 @@ fixture_principal_patterns=(
 for pattern in "${fixture_principal_patterns[@]}"; do
   require_pattern "$pattern" "$fixture_principal_script"
 done
+reject_pattern "--command" "$fixture_principal_script"
 
 echo "[oci-a1-bluegreen-cd] terraform contract"
 require_pattern "http_ingress_cidr" "${terraform_dir}/variables.tf"

--- a/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+++ b/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
@@ -6,10 +6,18 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
 
 psql_log="${tmp_dir}/psql.log"
+psql_stdin_log="${tmp_dir}/psql.stdin.sql"
 cat >"${tmp_dir}/psql" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${PSQL_STUB_LOG}"
+for arg in "$@"; do
+  if [[ "$arg" == "--command" || "$arg" == "-c" ]]; then
+    echo "fixture SQL must be passed through stdin so psql variables are substituted" >&2
+    exit 64
+  fi
+done
+cat >"${PSQL_STDIN_LOG}"
 SH
 chmod +x "${tmp_dir}/psql"
 
@@ -17,6 +25,7 @@ run_bootstrap() {
   env \
     PATH="${tmp_dir}:${PATH}" \
     PSQL_STUB_LOG="${psql_log}" \
+    PSQL_STDIN_LOG="${psql_stdin_log}" \
     STAGING_OCI_A1_DATABASE_URL="postgresql://fixture-db/aquila" \
     STAGING_REPLAY_USER_ID="55" \
     STAGING_REPLAY_LOGIN_ID="staging-fixture-user" \
@@ -41,6 +50,7 @@ assert_too_long_password_hash_fails_before_psql() {
   if env \
     PATH="${tmp_dir}:${PATH}" \
     PSQL_STUB_LOG="${psql_log}" \
+    PSQL_STDIN_LOG="${psql_stdin_log}" \
     STAGING_OCI_A1_DATABASE_URL="postgresql://fixture-db/aquila" \
     STAGING_REPLAY_USER_ID="55" \
     STAGING_REPLAY_LOGIN_ID="staging-fixture-user" \


### PR DESCRIPTION
## 🔗 Related Issue
- close #562

## 🌿 Base Branch
- `main`

## 📝 Summary
- `Ensure staging fixture principal` 단계에서 `psql --command`로 전달한 SQL의 `:hot_account_id` 같은 psql 변수가 치환되지 않아 PostgreSQL syntax error가 발생하던 문제를 수정합니다.
- fixture SQL을 stdin heredoc으로 전달해 psql 변수 치환 대상이 되도록 변경하고, 같은 회귀를 contract test에서 잡게 했습니다.

## 🛠 Changes
- `tools/ops/staging-fixture-principal-bootstrap.sh`에서 fixture SQL 전달 방식을 `--command`에서 stdin heredoc으로 변경했습니다.
- `tools/test/run-staging-fixture-principal-bootstrap-contract.sh`의 psql stub이 `--command/-c` 사용을 실패로 처리하도록 보강했습니다.
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`에서 fixture bootstrap script의 stdin SQL 전달과 `--command` 금지를 확인합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `bash -n tools/ops/staging-fixture-principal-bootstrap.sh tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `git diff --check HEAD~1..HEAD`
- `git rev-list --count origin/main..HEAD` -> `1` (`commit_plan` 1개와 일치)

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: SQL 의미는 유지하고 전달 경로만 변경합니다. contract test는 psql stub 기반이라 실제 DB schema 검증은 staging deploy가 담당합니다.
- 롤백 방법: 이 PR merge commit 또는 `77548975` revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A