### PR TITLE
[Fix] staging frontend ARM64 image build cancellation 수정

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -187,8 +187,8 @@ jobs:
     needs:
       - prepare
     if: needs.prepare.outputs.should_deploy == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    runs-on: [self-hosted, oci-a1-staging]
+    timeout-minutes: 25
     environment:
       name: staging
     outputs:
@@ -228,10 +228,11 @@ jobs:
           echo "::add-mask::${STAGING_PUBLIC_API_BASE_URL}"
           printf 'STAGING_PUBLIC_API_BASE_URL=%s\n' "${STAGING_PUBLIC_API_BASE_URL}" >>"${GITHUB_ENV}"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
+      - name: Check OCI self-hosted runner prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          ops/deploy/oci/check-self-hosted-runner.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -117,6 +117,35 @@ for pattern in "${workflow_patterns[@]}"; do
   require_pattern "$pattern" "$workflow"
 done
 
+if command -v ruby >/dev/null 2>&1; then
+  ruby <<'RUBY'
+require "yaml"
+
+workflow = YAML.load_file(".github/workflows/staging-deploy.yml")
+jobs = workflow.fetch("jobs")
+frontend_job = jobs.fetch("frontend-image")
+frontend_runner_labels = Array(frontend_job.fetch("runs-on"))
+unless frontend_runner_labels.include?("self-hosted") && frontend_runner_labels.include?("oci-a1-staging")
+  abort("frontend image job must run on OCI A1 self-hosted ARM64 runner")
+end
+
+frontend_steps = frontend_job.fetch("steps")
+frontend_step_names = frontend_steps.map { |step| step["name"] }
+if frontend_steps.any? { |step| step["uses"] == "docker/setup-qemu-action@v3" }
+  abort("frontend image job must not use QEMU for ARM64 image build")
+end
+
+prerequisite_index = frontend_step_names.index("Check OCI self-hosted runner prerequisites") ||
+  abort("frontend image job must check OCI self-hosted runner prerequisites")
+build_index = frontend_step_names.index("Build and push frontend image") ||
+  abort("frontend image job must build and push frontend image")
+abort("frontend runner prerequisites must run before frontend image build") unless prerequisite_index < build_index
+
+build_run = frontend_steps.fetch(build_index).fetch("run")
+abort("frontend image must remain linux/arm64") unless build_run.include?("--platform linux/arm64")
+RUBY
+fi
+
 scattered_patterns=(
   "vars.OCI_A1_"
   "vars.STAGING_"


### PR DESCRIPTION
## 🔗 Related Issue
- close #566

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging CD의 frontend image build가 hosted x64 runner의 QEMU ARM64 emulation에서 `qemu: uncaught target signal 4 (Illegal instruction)` 후 cancel되는 문제를 수정합니다.
- frontend image job을 OCI A1 self-hosted ARM64 runner에서 native build하도록 전환해 QEMU 의존을 제거했습니다.

## 🛠 Changes
- `frontend-image` job의 `runs-on`을 `[self-hosted, oci-a1-staging]`으로 변경했습니다.
- frontend job의 `docker/setup-qemu-action@v3` 단계를 제거했습니다.
- frontend image build 전에 `ops/deploy/oci/check-self-hosted-runner.sh`를 실행하도록 추가했습니다.
- frontend image는 기존처럼 `--platform linux/arm64` 단일 platform으로 push합니다.
- OCI A1 blue/green CD 계약 테스트가 frontend job의 native ARM64 runner/QEMU 금지/prerequisite 순서를 검증하도록 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `tools/test/check-ci-runtime-optimization-contract.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `git diff --check HEAD~1..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: frontend image build가 self-hosted OCI runner 점유 시간을 사용합니다. 대신 QEMU illegal instruction/hang 경로를 제거합니다.
- 롤백 방법: 이 PR의 단일 커밋 `fca8bfe3`를 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? 계약 테스트로 반영