### PR TITLE
[Fix] staging self-hosted Docker config 권한 오류 수정

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -234,6 +234,16 @@ jobs:
           set -euo pipefail
           ops/deploy/oci/check-self-hosted-runner.sh
 
+      - name: Prepare frontend Docker config
+        shell: bash
+        run: |
+          set -euo pipefail
+          # self-hosted runner home의 .docker 권한 드리프트와 분리된 job-local Docker config.
+          docker_config="${RUNNER_TEMP}/docker-config"
+          mkdir -p "${docker_config}"
+          chmod 700 "${docker_config}"
+          printf 'DOCKER_CONFIG=%s\n' "${docker_config}" >>"${GITHUB_ENV}"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -137,9 +137,18 @@ end
 
 prerequisite_index = frontend_step_names.index("Check OCI self-hosted runner prerequisites") ||
   abort("frontend image job must check OCI self-hosted runner prerequisites")
+docker_config_index = frontend_step_names.index("Prepare frontend Docker config") ||
+  abort("frontend image job must prepare isolated Docker config")
+buildx_index = frontend_step_names.index("Set up Docker Buildx") ||
+  abort("frontend image job must set up Docker Buildx")
 build_index = frontend_step_names.index("Build and push frontend image") ||
   abort("frontend image job must build and push frontend image")
 abort("frontend runner prerequisites must run before frontend image build") unless prerequisite_index < build_index
+abort("frontend Docker config must be prepared before buildx setup") unless docker_config_index < buildx_index
+
+docker_config_run = frontend_steps.fetch(docker_config_index).fetch("run")
+abort("frontend Docker config must use RUNNER_TEMP") unless docker_config_run.include?("RUNNER_TEMP") && docker_config_run.include?("DOCKER_CONFIG")
+abort("frontend Docker config must be persisted through GITHUB_ENV") unless docker_config_run.include?("GITHUB_ENV")
 
 build_run = frontend_steps.fetch(build_index).fetch("run")
 abort("frontend image must remain linux/arm64") unless build_run.include?("--platform linux/arm64")


### PR DESCRIPTION
## 🔗 Related Issue
- close #568

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging CD의 self-hosted frontend image job에서 `docker/setup-buildx-action@v3`가 `/home/github-runner/.docker` 권한 문제로 실패하는 경로를 수정합니다.
- buildx/login/build 단계가 runner home이 아니라 job-local `${RUNNER_TEMP}/docker-config`를 `DOCKER_CONFIG`로 사용하도록 격리했습니다.

## 🛠 Changes
- `Set up Docker Buildx` 전에 `Prepare frontend Docker config` 단계를 추가했습니다.
- `RUNNER_TEMP/docker-config`를 생성하고 `DOCKER_CONFIG`로 `GITHUB_ENV`에 저장합니다.
- OCI A1 blue/green CD 계약 테스트가 frontend Docker config 준비 단계와 buildx 전 순서를 검증하도록 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `tools/test/check-ci-runtime-optimization-contract.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `git diff --check HEAD~1..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Docker login/buildx cache가 job-local Docker config를 사용하므로 self-hosted runner home의 기존 Docker client config를 참조하지 않습니다. staging image build에는 필요한 GHCR login을 workflow에서 다시 수행하므로 영향 범위는 제한적입니다.
- 롤백 방법: 이 PR의 단일 커밋 `f0aceca4`를 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? 계약 테스트로 반영