### PR TITLE
[Fix] transaction planner stats guard reltuples 조회 수정

### DIFF
--- a/tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
+++ b/tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
@@ -72,7 +72,8 @@ relation_data AS (
     FROM target_table t
     LEFT JOIN (
         SELECT c.oid,
-               c.relname
+               c.relname,
+               c.reltuples AS reltuples
         FROM pg_class c
         JOIN pg_namespace n
           ON n.oid = c.relnamespace

--- a/tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh
+++ b/tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh
@@ -13,6 +13,10 @@ grep -F "last_autoanalyze" <<<"${sql}" >/dev/null
 grep -F "stale_analyze_age" <<<"${sql}" >/dev/null
 grep -F "stale_modified_ratio" <<<"${sql}" >/dev/null
 grep -F "format('ANALYZE VERBOSE public.%I;', table_name)" <<<"${sql}" >/dev/null
+grep -F "c.reltuples AS reltuples" <<<"${sql}" >/dev/null || {
+  echo "pg_class reltuples must be projected from the derived relation query" >&2
+  exit 1
+}
 
 echo "[transaction-planner-stats-guard] guard: invalid threshold fails before querying"
 if STATS_MAX_AGE_HOURS=0 "${script}" --print-sql >/dev/null 2>&1; then


### PR DESCRIPTION
## 🔗 Related Issue
- close #572

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging transaction replay 전 planner stats freshness guard가 derived table에 없는 `c.reltuples`를 참조해 실패하는 문제를 수정합니다.
- `pg_class.reltuples`를 relation subquery에서 projection하도록 복구하고, 같은 누락을 잡는 계약 테스트를 추가했습니다.

## 🛠 Changes
- `tools/ops/transaction-read-model-planner-stats-freshness-guard.sh`의 `pg_class` derived relation에 `c.reltuples AS reltuples` 추가
- `tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh`에 reltuples projection 계약 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `git diff --check HEAD~1..HEAD`
- `git rev-list --count main..HEAD` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `pg_class.reltuples` 조회 projection만 복구하는 변경이라 runtime 정책 변화는 없습니다.
- 롤백 방법: 이 PR 커밋을 revert하면 이전 planner stats guard SQL로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A