### PR TITLE
[Fix] staging nginx bind mount config reload 수정

### DIFF
--- a/ops/deploy/oci/bluegreen-deploy.sh
+++ b/ops/deploy/oci/bluegreen-deploy.sh
@@ -613,11 +613,16 @@ switch_nginx() {
     -v "${next_config}:/etc/nginx/nginx.conf:ro" \
     nginx:1.27-alpine nginx -t
 
-  if [[ -s "${active_config}" ]]; then
-    cp "${active_config}" "${backup_config}"
+  if [[ -e "${active_config}" ]]; then
+    if [[ -s "${active_config}" ]]; then
+      cp "${active_config}" "${backup_config}"
+    fi
+    # Docker file bind mount는 inode를 따라가므로 기존 active 파일은 제자리에서 갱신한다.
+    cat "${next_config}" >"${active_config}"
+    rm -f "${next_config}"
+  else
+    mv "${next_config}" "${active_config}"
   fi
-
-  mv "${next_config}" "${active_config}"
   ensure_nginx_container
 
   if ! docker exec "${NGINX_CONTAINER}" nginx -s reload; then

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -216,6 +216,8 @@ script_patterns=(
   "location = /api/v1/notifications/stream"
   "proxy_buffering off;"
   "nginx -s reload"
+  'if [[ -e "${active_config}" ]]; then'
+  'cat "${next_config}" >"${active_config}"'
   'docker rm -f "$(slot_name backend "${green}")"'
 )
 for pattern in "${script_patterns[@]}"; do


### PR DESCRIPTION
## 🔗 Related Issue
- close #574

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging blue-green deploy에서 nginx config를 Docker file bind mount로 붙인 뒤 `mv`로 active config inode를 교체해 reload가 이전 upstream을 계속 볼 수 있는 문제를 수정합니다.
- 기존 active config가 있으면 같은 파일에 내용을 덮어써 nginx 컨테이너가 새 upstream config를 읽도록 했습니다.

## 🛠 Changes
- `ops/deploy/oci/bluegreen-deploy.sh`에서 기존 active nginx config가 있으면 `cat next > active`로 inode 보존 갱신
- 최초 active config 생성 경로는 기존 `mv` 유지
- OCI blue-green CD 계약 테스트에 bind mount reload 회귀 조건 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `tools/test/run-nginx-runtime-template-gate.sh`
- `bash tools/test/check-nginx-sse-proxy.sh`
- `tools/test/run-staging-postdeploy-smoke-contract.sh`
- `git diff --check HEAD~1..HEAD`
- `git rev-list --count main..HEAD` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: active config를 제자리에서 덮어쓰는 동안 아주 짧은 쓰기 창이 있지만, 렌더된 next config는 `nginx -t`를 먼저 통과한 뒤 적용됩니다.
- 롤백 방법: 이 PR 커밋을 revert하면 기존 `mv` 기반 active config 교체 방식으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A