### PR TITLE
[Fix] staging replay planner stats leaf partition 기준 적용

### DIFF
--- a/docs/transaction-read-model-staging-replay.md
+++ b/docs/transaction-read-model-staging-replay.md
@@ -6,7 +6,7 @@
 
 - hot: `GET /api/v1/transactions`
 - cold: `GET /api/v1/transactions/archive`
-- DB 분포 확인: `transaction_read_model` + `transaction_read_model_archive`의 `pg_class.reltuples` estimate
+- DB 분포 확인: `transaction_read_model` + `transaction_read_model_archive`의 leaf partition `pg_class.reltuples` estimate 합계
 - p95 산출: hot first, hot cursor, cold first, cold cursor
 
 ## Prerequisites
@@ -71,8 +71,8 @@
 
 ## Gate Behavior
 
-- planner stats freshness guard가 `transaction_read_model`, `transaction_read_model_archive`의 analyze 시각과 `n_mod_since_analyze / reltuples` 비율을 먼저 확인합니다.
-- freshness guard가 stale stats를 감지하면 table별 `ANALYZE VERBOSE public.<table>;` guidance와 함께 즉시 실패합니다.
+- planner stats freshness guard가 `transaction_read_model`, `transaction_read_model_archive`의 leaf partition analyze 시각과 `n_mod_since_analyze / reltuples` 비율을 먼저 확인합니다.
+- freshness guard가 stale stats를 감지하면 table별 `tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target <hot|archive>` guidance와 함께 즉시 실패합니다.
 - PostgreSQL estimate가 `expected_total_rows`보다 작으면 실패합니다.
 - hot/cold account에 row가 없으면 실패합니다.
 - 각 first page가 `nextCursor`를 반환하지 않으면 cursor replay가 불가능하므로 실패합니다.

--- a/tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
+++ b/tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
@@ -58,35 +58,55 @@ WITH target_table(table_name) AS (
         ('transaction_read_model'),
         ('transaction_read_model_archive')
 ),
-relation_data AS (
+parent_data AS (
     SELECT
         t.table_name,
-        c.oid AS relid,
-        GREATEST(c.reltuples, 0)::bigint AS row_estimate,
-        s.n_live_tup,
-        s.n_mod_since_analyze,
-        s.last_analyze,
-        s.last_autoanalyze,
-        s.analyze_count,
-        s.autoanalyze_count
+        parent.oid AS relid
     FROM target_table t
     LEFT JOIN (
-        SELECT c.oid,
-               c.relname,
-               c.reltuples AS reltuples
-        FROM pg_class c
-        JOIN pg_namespace n
-          ON n.oid = c.relnamespace
-        WHERE n.nspname = 'public'
-    ) c
-      ON c.relname = t.table_name
-    LEFT JOIN pg_stat_user_tables s
-      ON s.relid = c.oid
+        SELECT item.oid,
+               item.relname
+        FROM pg_class item
+        JOIN pg_namespace item_ns
+          ON item_ns.oid = item.relnamespace
+        WHERE item_ns.nspname = 'public'
+    ) parent
+      ON parent.relname = t.table_name
+),
+relation_data AS (
+    SELECT
+        parent.table_name,
+        parent.relid,
+        COUNT(tree.relid) FILTER (WHERE tree.relid IS NOT NULL) AS partition_count,
+        COALESCE(SUM(GREATEST(partition.reltuples, 0))::bigint, 0) AS row_estimate,
+        COALESCE(SUM(stats.n_live_tup), 0)::bigint AS n_live_tup,
+        COALESCE(SUM(stats.n_mod_since_analyze), 0)::bigint AS n_mod_since_analyze,
+        MAX(
+            CASE
+                WHEN stats.last_analyze IS NULL AND stats.last_autoanalyze IS NULL THEN NULL
+                ELSE GREATEST(
+                    COALESCE(stats.last_analyze, '-infinity'::timestamp with time zone),
+                    COALESCE(stats.last_autoanalyze, '-infinity'::timestamp with time zone)
+                )
+            END
+        ) AS last_analyze_at,
+        COALESCE(SUM(stats.analyze_count), 0)::bigint AS analyze_count,
+        COALESCE(SUM(stats.autoanalyze_count), 0)::bigint AS autoanalyze_count
+    FROM parent_data parent
+    LEFT JOIN LATERAL pg_partition_tree(parent.relid::regclass) tree
+      ON parent.relid IS NOT NULL
+     AND tree.isleaf
+    LEFT JOIN pg_class partition
+      ON partition.oid = tree.relid
+    LEFT JOIN pg_stat_user_tables stats
+      ON stats.relid = partition.oid
+    GROUP BY parent.table_name, parent.relid
 ),
 calculated AS (
     SELECT
         table_name,
         relid,
+        partition_count,
         COALESCE(row_estimate, 0) AS row_estimate,
         COALESCE(n_live_tup, 0) AS live_tuple_count,
         COALESCE(n_mod_since_analyze, 0) AS modified_tuple_count,
@@ -101,23 +121,27 @@ calculated AS (
                 4
             )
         END AS modified_ratio,
-        CASE
-            WHEN last_analyze IS NULL AND last_autoanalyze IS NULL THEN NULL
-            ELSE GREATEST(
-                COALESCE(last_analyze, '-infinity'::timestamp with time zone),
-                COALESCE(last_autoanalyze, '-infinity'::timestamp with time zone)
-            )
-        END AS last_analyze_at,
+        last_analyze_at,
         COALESCE(analyze_count, 0) AS analyze_count,
         COALESCE(autoanalyze_count, 0) AS autoanalyze_count,
-        format('ANALYZE VERBOSE public.%I;', table_name) AS analyze_command
+        format(
+            'tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target %s',
+            CASE
+                WHEN table_name = 'transaction_read_model' THEN 'hot'
+                WHEN table_name = 'transaction_read_model_archive' THEN 'archive'
+                ELSE 'both'
+            END
+        ) AS analyze_command
     FROM relation_data
 )
 SELECT
     table_name,
     CASE
         WHEN relid IS NULL THEN 'missing_table'
-        WHEN last_analyze_at IS NULL THEN 'missing_analyze'
+        WHEN partition_count = 0 THEN 'missing_partition'
+        WHEN last_analyze_at IS NULL
+             AND (row_estimate > 0 OR live_tuple_count > 0 OR modified_tuple_count > 0)
+            THEN 'missing_analyze'
         WHEN ROUND(EXTRACT(EPOCH FROM (now() - last_analyze_at)) / 3600, 1) >= :'stats_max_age_hours'::numeric
             THEN 'stale_analyze_age'
         WHEN modified_ratio >= :'stats_max_modified_ratio'::numeric

--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -117,12 +117,21 @@ verify_staging_distribution() {
   local estimated_total
   estimated_total="$(
     psql_scalar \
-      "SELECT COALESCE(SUM(c.reltuples), 0)::bigint
-       FROM pg_class c
-       WHERE c.oid IN (
-         'transaction_read_model'::regclass,
-         'transaction_read_model_archive'::regclass
-       );"
+      "WITH target_parent(table_name) AS (
+         VALUES
+           ('transaction_read_model'),
+           ('transaction_read_model_archive')
+       ),
+       leaf AS (
+         SELECT tree.relid
+         FROM target_parent target
+         CROSS JOIN LATERAL pg_partition_tree(('public.' || target.table_name)::regclass) tree
+         WHERE tree.isleaf
+       )
+       SELECT COALESCE(SUM(GREATEST(c.reltuples, 0))::bigint, 0)
+       FROM leaf
+       JOIN pg_class c
+         ON c.oid = leaf.relid;"
   )"
 
   [[ "$estimated_total" =~ ^[0-9]+$ ]] || fail "OCI A1 row estimate is not numeric: ${estimated_total}"

--- a/tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh
+++ b/tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh
@@ -12,9 +12,11 @@ grep -F "n_mod_since_analyze" <<<"${sql}" >/dev/null
 grep -F "last_autoanalyze" <<<"${sql}" >/dev/null
 grep -F "stale_analyze_age" <<<"${sql}" >/dev/null
 grep -F "stale_modified_ratio" <<<"${sql}" >/dev/null
-grep -F "format('ANALYZE VERBOSE public.%I;', table_name)" <<<"${sql}" >/dev/null
-grep -F "c.reltuples AS reltuples" <<<"${sql}" >/dev/null || {
-  echo "pg_class reltuples must be projected from the derived relation query" >&2
+grep -F "tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target" <<<"${sql}" >/dev/null
+grep -F "pg_partition_tree(parent.relid::regclass)" <<<"${sql}" >/dev/null
+grep -F "tree.isleaf" <<<"${sql}" >/dev/null
+grep -F "SUM(GREATEST(partition.reltuples, 0))" <<<"${sql}" >/dev/null || {
+  echo "planner stats guard must aggregate leaf partition reltuples" >&2
   exit 1
 }
 

--- a/tools/test/run-transaction-read-model-staging-replay-guard.sh
+++ b/tools/test/run-transaction-read-model-staging-replay-guard.sh
@@ -6,6 +6,11 @@ script="tools/ops/transaction-read-model-staging-replay.sh"
 echo "[transaction-staging-replay-guard] syntax: ${script}"
 bash -n "${script}"
 
+echo "[transaction-staging-replay-guard] distribution estimate uses leaf partitions"
+grep -F "pg_partition_tree(('public.' || target.table_name)::regclass)" "${script}" >/dev/null
+grep -F "tree.isleaf" "${script}" >/dev/null
+grep -F "SUM(GREATEST(c.reltuples, 0))" "${script}" >/dev/null
+
 temp_dir="$(mktemp -d)"
 trap 'rm -rf "${temp_dir}"' EXIT
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #576

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging transaction replay gate가 partition parent 통계만 보고 `missing_analyze`로 중단되는 문제를 수정합니다.
- planner stats freshness guard와 replay total row estimate를 leaf partition `reltuples`/stats 합산 기준으로 맞췄습니다.

## 🛠 Changes
- planner stats guard가 `pg_partition_tree(...).isleaf` 기준으로 row estimate, analyze freshness, modified ratio를 parent별 집계
- staging replay의 `EXPECTED_TOTAL_ROWS` 검증도 leaf partition `reltuples` 합계 사용
- stale stats guidance를 partition lifecycle analyze 명령 기준으로 정리
- 관련 계약 테스트와 staging replay 문서 갱신

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh`
- `tools/test/run-transaction-read-model-staging-replay-guard.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `git diff --check HEAD~1..HEAD`
- `git rev-list --count main..HEAD` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: leaf partition 통계가 실제로 없으면 guard 또는 row estimate gate가 계속 실패합니다. 이 경우 guidance는 partition lifecycle analyze 실행 경로를 가리킵니다.
- 롤백 방법: 이 PR 커밋을 revert하면 기존 parent table stats 기준으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?