### PR TITLE
[Fix] staging nginx stale bind mount 감지 및 재생성

### DIFF
--- a/ops/deploy/oci/bluegreen-deploy.sh
+++ b/ops/deploy/oci/bluegreen-deploy.sh
@@ -585,8 +585,16 @@ http {
 NGINX
 }
 
-ensure_nginx_container() {
+nginx_container_running() {
   if docker ps --format '{{.Names}}' | grep -qx "${NGINX_CONTAINER}"; then
+    return 0
+  fi
+
+  return 1
+}
+
+ensure_nginx_container() {
+  if nginx_container_running; then
     return 0
   fi
 
@@ -599,6 +607,26 @@ ensure_nginx_container() {
     -p 80:80 \
     -v "${APP_DIR}/nginx/nginx.conf:/etc/nginx/nginx.conf:ro" \
     nginx:1.27-alpine >/dev/null
+}
+
+ensure_nginx_config_visible() {
+  local slot="$1"
+  local backend_name frontend_name
+  backend_name="$(slot_name backend "${slot}")"
+  frontend_name="$(slot_name frontend "${slot}")"
+
+  if ! nginx_container_running; then
+    return 0
+  fi
+
+  # 과거 mv 기반 교체로 남은 stale file bind mount는 컨테이너 내부 config 직접 확인으로만 식별된다.
+  if docker exec "${NGINX_CONTAINER}" grep -Fq "server ${backend_name}:${BACKEND_PORT};" /etc/nginx/nginx.conf \
+    && docker exec "${NGINX_CONTAINER}" grep -Fq "server ${frontend_name}:${FRONTEND_PORT};" /etc/nginx/nginx.conf; then
+    return 0
+  fi
+
+  log "stale nginx config bind mount detected; recreate nginx container for active config"
+  docker rm -f "${NGINX_CONTAINER}" >/dev/null
 }
 
 switch_nginx() {
@@ -623,6 +651,7 @@ switch_nginx() {
   else
     mv "${next_config}" "${active_config}"
   fi
+  ensure_nginx_config_visible "${green}"
   ensure_nginx_container
 
   if ! docker exec "${NGINX_CONTAINER}" nginx -s reload; then

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -216,6 +216,10 @@ script_patterns=(
   "location = /api/v1/notifications/stream"
   "proxy_buffering off;"
   "nginx -s reload"
+  "ensure_nginx_config_visible"
+  'docker exec "${NGINX_CONTAINER}" grep -Fq'
+  "stale nginx config bind mount detected"
+  'docker rm -f "${NGINX_CONTAINER}"'
   'if [[ -e "${active_config}" ]]; then'
   'cat "${next_config}" >"${active_config}"'
   'docker rm -f "$(slot_name backend "${green}")"'


### PR DESCRIPTION
## 🔗 Related Issue
- close #578

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging blue-green deploy 후 nginx 컨테이너가 stale file bind mount로 이전 upstream config를 계속 보는 경우를 감지합니다.
- active config 갱신 후 컨테이너 내부 config가 green backend/frontend upstream을 포함하지 않으면 nginx 컨테이너만 재생성해 post-deploy smoke 504 계열 실패를 줄입니다.

## 🛠 Changes
- `bluegreen-deploy.sh`에 running nginx 컨테이너의 내부 `/etc/nginx/nginx.conf` 확인 로직 추가
- stale bind mount 감지 시 old slot drain 전에 `aquila-bank-nginx` 컨테이너 재생성
- OCI A1 blue-green CD 계약 테스트에 stale bind mount 재발 방지 패턴 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `tools/test/run-nginx-runtime-template-gate.sh`
- `bash tools/test/check-nginx-sse-proxy.sh`
- `tools/test/run-staging-postdeploy-smoke-contract.sh`
- `git diff --check HEAD~1..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: stale 감지 시 nginx 컨테이너 재생성으로 아주 짧은 HTTP 경로 재연결이 발생할 수 있음. 정상 config가 보이는 경우 기존 reload 경로 유지.
- 롤백 방법: 이 PR revert 후 이전 blue-green deploy 동작으로 복귀.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A
