### PR TITLE
[Fix] staging replay 빈 fixture 실패 보고 보강

### DIFF
--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -35,6 +35,51 @@ notice() {
   echo "::notice::$*" >&2
 }
 
+fixture_restore_guidance() {
+  printf '%s' "Restore OCI A1 100m fixture before replay: tools/test/run-transaction-100m-fresh-volume-restore-k6.sh --dry-run, then tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target both."
+}
+
+write_distribution_failure_report() {
+  local status="$1"
+  local estimated_total="$2"
+  local detail="$3"
+  local guidance="$4"
+
+  echo "$estimated_total" >"${REPORT_DIR}/estimated-total-rows.txt"
+  jq -n \
+    --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg baseUrl "$STAGING_BASE_URL" \
+    --arg phase "distribution" \
+    --arg status "$status" \
+    --arg detail "$detail" \
+    --arg guidance "$guidance" \
+    --argjson expectedTotalRows "$EXPECTED_TOTAL_ROWS" \
+    --argjson estimatedTotalRows "$estimated_total" \
+    '{
+      generatedAt: $generatedAt,
+      baseUrl: $baseUrl,
+      phase: $phase,
+      status: $status,
+      detail: $detail,
+      guidance: $guidance,
+      expectedTotalRows: $expectedTotalRows,
+      estimatedTotalRows: $estimatedTotalRows,
+      failed: true
+    }' >"$SUMMARY_JSON"
+
+  {
+    echo "# Transaction Read Model Staging Replay"
+    echo
+    echo "- status: failed"
+    echo "- phase: distribution"
+    echo "- failure: ${status}"
+    echo "- estimated total rows: ${estimated_total}"
+    echo "- expected total rows: ${EXPECTED_TOTAL_ROWS}"
+    echo "- detail: ${detail}"
+    echo "- guidance: ${guidance}"
+  } >"$SUMMARY_MD"
+}
+
 require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
 }
@@ -136,7 +181,15 @@ verify_staging_distribution() {
 
   [[ "$estimated_total" =~ ^[0-9]+$ ]] || fail "OCI A1 row estimate is not numeric: ${estimated_total}"
   if [ "$estimated_total" -lt "$EXPECTED_TOTAL_ROWS" ]; then
-    fail "OCI A1 read model estimate ${estimated_total} is below expected ${EXPECTED_TOTAL_ROWS}"
+    local status detail guidance
+    status="estimate_below_expected"
+    if [ "$estimated_total" -eq 0 ]; then
+      status="fixture_missing"
+    fi
+    detail="OCI A1 read model estimate ${estimated_total} is below expected ${EXPECTED_TOTAL_ROWS}"
+    guidance="$(fixture_restore_guidance)"
+    write_distribution_failure_report "$status" "$estimated_total" "$detail" "$guidance"
+    fail "${status}: ${detail}. ${guidance}"
   fi
 
   local hot_exists
@@ -149,7 +202,13 @@ verify_staging_distribution() {
          LIMIT 1
        );"
   )"
-  [ "$hot_exists" = "t" ] || fail "HOT_ACCOUNT_ID ${HOT_ACCOUNT_ID} has no hot rows"
+  if [ "$hot_exists" != "t" ]; then
+    local detail guidance
+    detail="HOT_ACCOUNT_ID ${HOT_ACCOUNT_ID} has no hot rows"
+    guidance="$(fixture_restore_guidance)"
+    write_distribution_failure_report "hot_account_missing" "$estimated_total" "$detail" "$guidance"
+    fail "hot_account_missing: ${detail}. ${guidance}"
+  fi
 
   local cold_exists
   cold_exists="$(
@@ -161,7 +220,13 @@ verify_staging_distribution() {
          LIMIT 1
        );"
   )"
-  [ "$cold_exists" = "t" ] || fail "COLD_ACCOUNT_ID ${COLD_ACCOUNT_ID} has no archive rows"
+  if [ "$cold_exists" != "t" ]; then
+    local detail guidance
+    detail="COLD_ACCOUNT_ID ${COLD_ACCOUNT_ID} has no archive rows"
+    guidance="$(fixture_restore_guidance)"
+    write_distribution_failure_report "cold_account_missing" "$estimated_total" "$detail" "$guidance"
+    fail "cold_account_missing: ${detail}. ${guidance}"
+  fi
 
   notice "OCI A1 read model estimate ${estimated_total} rows"
   echo "$estimated_total" >"${REPORT_DIR}/estimated-total-rows.txt"

--- a/tools/test/run-transaction-read-model-staging-replay-guard.sh
+++ b/tools/test/run-transaction-read-model-staging-replay-guard.sh
@@ -78,3 +78,51 @@ if [ -f "${psql_marker}" ]; then
   echo "psql must not run before planner stats guard passes" >&2
   exit 1
 fi
+
+echo "[transaction-staging-replay-guard] empty fixture failure writes report"
+guard_success_script="${temp_dir}/planner-guard-success.sh"
+cat >"${guard_success_script}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "${guard_success_script}"
+
+cat >"${bin_dir}/psql" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '0\n'
+EOF
+chmod +x "${bin_dir}/psql"
+
+empty_report_dir="${temp_dir}/empty-report"
+set +e
+empty_output="$(
+  PATH="${bin_dir}:${PATH}" \
+  REPORT_DIR="${empty_report_dir}" \
+  PLANNER_STATS_GUARD_SCRIPT="${guard_success_script}" \
+  STAGING_BASE_URL="https://staging.example.com" \
+  STAGING_REPLAY_TOKEN="token" \
+  STAGING_RDS_DATABASE_URL="postgres://user:pass@localhost:5432/db" \
+  EXPECTED_TOTAL_ROWS="100" \
+  HOT_ACCOUNT_ID="101" \
+  HOT_FROM="2026-04-01T00:00:00Z" \
+  HOT_TO="2026-04-15T00:00:00Z" \
+  COLD_ACCOUNT_ID="202" \
+  COLD_FROM="2026-03-01T00:00:00Z" \
+  COLD_TO="2026-03-31T00:00:00Z" \
+  "${script}" 2>&1
+)"
+empty_status=$?
+set -e
+
+if [ "${empty_status}" -eq 0 ]; then
+  echo "empty fixture replay unexpectedly succeeded" >&2
+  exit 1
+fi
+
+grep -F "fixture_missing" <<<"${empty_output}" >/dev/null
+grep -F "OCI A1 read model estimate 0 is below expected 100" <<<"${empty_output}" >/dev/null
+grep -F "fixture_missing" "${empty_report_dir}/summary.md" >/dev/null
+grep -F "tools/test/run-transaction-100m-fresh-volume-restore-k6.sh --dry-run" "${empty_report_dir}/summary.md" >/dev/null
+grep -Fx "0" "${empty_report_dir}/estimated-total-rows.txt" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #580

## 🌿 Base Branch
- `main`

## 📝 Summary
- Staging replay gate가 빈 read model fixture를 만났을 때 기존처럼 실패는 유지하되, 실패 원인을 `fixture_missing`으로 분류합니다.
- 실패 전에 summary/report 파일을 남겨 Actions summary와 artifact에서 expected/estimated rows 및 복구 guidance를 확인할 수 있게 합니다.

## 🛠 Changes
- `transaction-read-model-staging-replay.sh`에 distribution 단계 실패 report 작성 로직 추가
- estimate 0을 `fixture_missing`으로 분류하고 fixture restore/analyze guidance 출력
- 빈 fixture 실패 시 report가 생성되는 계약 테스트 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-transaction-read-model-staging-replay-guard.sh`
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `bash -n tools/ops/transaction-read-model-staging-replay.sh`
- `git diff --check HEAD~1..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: replay gate는 계속 실패하므로 100m fixture가 없는 staging SHA는 production promotion 대상이 되지 않음. 이 동작은 기존 정책 유지.
- 롤백 방법: 이 PR revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A
