### PR TITLE
[CI] staging CD와 100m replay evidence 분리

### DIFF
--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -109,6 +109,47 @@ jobs:
             exit 1
           fi
 
+      - name: Verify staging 100m replay evidence success
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          deployment_ids="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments" \
+              -f environment=staging-100m-replay \
+              -f sha="${TARGET_SHA}" \
+              --paginate \
+              --jq ".[].id"
+          )"
+
+          if [ -z "${deployment_ids}" ]; then
+            echo "::error::No staging 100m replay evidence found for ${TARGET_SHA}."
+            exit 1
+          fi
+
+          found_success=false
+          while IFS= read -r deployment_id; do
+            if [ -z "${deployment_id}" ]; then
+              continue
+            fi
+
+            state="$(
+              gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+                --jq ".[0].state // \"\""
+            )"
+            if [ "${state}" = "success" ]; then
+              found_success=true
+              break
+            fi
+          done <<< "${deployment_ids}"
+
+          if [ "${found_success}" != "true" ]; then
+            echo "::error::No successful staging 100m replay evidence found for ${TARGET_SHA}."
+            exit 1
+          fi
+
   promote:
     name: Promote SHA To Production
     needs:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -335,6 +335,8 @@ jobs:
       DEPLOY_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       BACKEND_IMAGE: ${{ needs.backend-image.outputs.backend_image }}
       FRONTEND_IMAGE: ${{ needs.frontend-image.outputs.frontend_image }}
+    outputs:
+      transaction_replay_result: ${{ steps.resolve-transaction-replay-result.outputs.result }}
     steps:
       - name: Checkout deploy SHA
         uses: actions/checkout@v4
@@ -367,6 +369,7 @@ jobs:
           STAGING_SMOKE_HEALTH_PATH="${STAGING_SMOKE_HEALTH_PATH:-/actuator/health}"
           STAGING_SMOKE_WRITE_METHOD="${STAGING_SMOKE_WRITE_METHOD:-POST}"
           STAGING_SMOKE_WRITE_BODY="${STAGING_SMOKE_WRITE_BODY:-{}}"
+          STAGING_REPLAY_REQUIRED="${STAGING_REPLAY_REQUIRED:-false}"
           ALERTMANAGER_RECEIVER_SECRET_SMOKE_ENVIRONMENT=staging
           POSTGRES_CONTAINER_NAME="${POSTGRES_CONTAINER_NAME:-aquila-postgres}"
           POSTGRES_NETWORK_ALIAS="${POSTGRES_NETWORK_ALIAS:-aquila-postgres}"
@@ -387,19 +390,46 @@ jobs:
           PLANNER_STATS_MAX_AGE_HOURS="${STAGING_REPLAY_STATS_MAX_AGE_HOURS:-${PLANNER_STATS_MAX_AGE_HOURS:-}}"
           PLANNER_STATS_MAX_MODIFIED_RATIO="${STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO:-${PLANNER_STATS_MAX_MODIFIED_RATIO:-}}"
 
+          case "${STAGING_REPLAY_REQUIRED}" in
+            true|false) ;;
+            *) echo "::error::STAGING_REPLAY_REQUIRED must be true or false."; exit 1 ;;
+          esac
+
+          replay_missing=()
+          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && replay_missing+=("STAGING_REPLAY_TOKEN")
+          [[ -z "${STAGING_OCI_A1_DATABASE_URL:-}" && -z "${OCI_A1_BACKEND_ENV_B64:-}" ]] && replay_missing+=("STAGING_OCI_A1_DATABASE_URL")
+          [[ -z "${HOT_ACCOUNT_ID}" ]] && replay_missing+=("STAGING_REPLAY_HOT_ACCOUNT_ID")
+          [[ -z "${HOT_FROM}" ]] && replay_missing+=("STAGING_REPLAY_HOT_FROM")
+          [[ -z "${HOT_TO}" ]] && replay_missing+=("STAGING_REPLAY_HOT_TO")
+          [[ -z "${COLD_ACCOUNT_ID}" ]] && replay_missing+=("STAGING_REPLAY_COLD_ACCOUNT_ID")
+          [[ -z "${COLD_FROM}" ]] && replay_missing+=("STAGING_REPLAY_COLD_FROM")
+          [[ -z "${COLD_TO}" ]] && replay_missing+=("STAGING_REPLAY_COLD_TO")
+
+          STAGING_REPLAY_ENABLED="${STAGING_REPLAY_ENABLED:-}"
+          if [[ -z "${STAGING_REPLAY_ENABLED}" ]]; then
+            if (( ${#replay_missing[@]} == 0 )); then
+              STAGING_REPLAY_ENABLED=true
+            else
+              STAGING_REPLAY_ENABLED=false
+            fi
+          fi
+          case "${STAGING_REPLAY_ENABLED}" in
+            true|false) ;;
+            *) echo "::error::STAGING_REPLAY_ENABLED must be true or false."; exit 1 ;;
+          esac
+          if [[ "${STAGING_REPLAY_REQUIRED}" == "true" && "${STAGING_REPLAY_ENABLED}" != "true" ]]; then
+            printf '::error::Missing required staging replay keys: %s\n' "${replay_missing[*]}"
+            exit 1
+          fi
+          if [[ "${STAGING_REPLAY_ENABLED}" != "true" && ${#replay_missing[@]} -gt 0 ]]; then
+            printf '::notice::Staging replay disabled; missing keys: %s\n' "${replay_missing[*]}"
+          fi
+
           missing=()
           [[ -z "${OCI_A1_BACKEND_ENV_B64:-}" ]] && missing+=("OCI_A1_BACKEND_ENV_B64")
           [[ -z "${STAGING_BASE_URL:-}" ]] && missing+=("STAGING_BASE_URL")
           [[ -z "${STAGING_SMOKE_READ_PATH:-}" ]] && missing+=("STAGING_SMOKE_READ_PATH")
           [[ -z "${STAGING_SMOKE_WRITE_PATH:-}" ]] && missing+=("STAGING_SMOKE_WRITE_PATH")
-          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
-          [[ -z "${STAGING_OCI_A1_DATABASE_URL:-}" ]] && missing+=("STAGING_OCI_A1_DATABASE_URL")
-          [[ -z "${HOT_ACCOUNT_ID}" ]] && missing+=("STAGING_REPLAY_HOT_ACCOUNT_ID")
-          [[ -z "${HOT_FROM}" ]] && missing+=("STAGING_REPLAY_HOT_FROM")
-          [[ -z "${HOT_TO}" ]] && missing+=("STAGING_REPLAY_HOT_TO")
-          [[ -z "${COLD_ACCOUNT_ID}" ]] && missing+=("STAGING_REPLAY_COLD_ACCOUNT_ID")
-          [[ -z "${COLD_FROM}" ]] && missing+=("STAGING_REPLAY_COLD_FROM")
-          [[ -z "${COLD_TO}" ]] && missing+=("STAGING_REPLAY_COLD_TO")
 
           if (( ${#missing[@]} > 0 )); then
             printf '::error::Missing OCI A1 staging env keys: %s\n' "${missing[*]}"
@@ -419,6 +449,8 @@ jobs:
             STAGING_SMOKE_WRITE_BODY
             STAGING_SMOKE_AUTH_HEADER_NAME
             STAGING_SMOKE_AUTH_HEADER_VALUE
+            STAGING_REPLAY_ENABLED
+            STAGING_REPLAY_REQUIRED
             STAGING_REPLAY_TOKEN
             STAGING_OCI_A1_DATABASE_URL
             STAGING_RDS_DATABASE_URL
@@ -484,7 +516,19 @@ jobs:
         run: |
           set -euo pipefail
           # backend env가 Docker alias DB를 쓰면 host psql용 URL은 배포 시점에 재산출한다.
-          resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"
+          if [[ "${STAGING_REPLAY_ENABLED}" != "true" ]]; then
+            echo "::notice::Staging replay disabled; skip staging database URL resolution."
+            exit 0
+          fi
+          if ! resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"; then
+            if [[ "${STAGING_REPLAY_REQUIRED}" == "true" ]]; then
+              echo "::error::Failed to resolve required staging replay database URL."
+              exit 1
+            fi
+            echo "::notice::Failed to resolve staging replay database URL; optional replay will be skipped."
+            printf 'STAGING_REPLAY_ENABLED=false\n' >>"${GITHUB_ENV}"
+            exit 0
+          fi
           echo "::add-mask::${resolved_database_url}"
           printf 'STAGING_OCI_A1_DATABASE_URL=%s\n' "${resolved_database_url}" >>"${GITHUB_ENV}"
 
@@ -511,6 +555,7 @@ jobs:
           ops/deploy/oci/bluegreen-deploy.sh
 
       - name: Ensure staging fixture principal
+        if: env.STAGING_REPLAY_ENABLED == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -523,10 +568,29 @@ jobs:
           tools/ops/staging-postdeploy-smoke.sh
 
       - name: Run transaction replay regression gate
+        id: transaction_replay
+        if: env.STAGING_REPLAY_ENABLED == 'true'
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
           tools/ops/transaction-read-model-staging-replay.sh
+
+      - name: Resolve transaction replay result
+        id: resolve-transaction-replay-result
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${STAGING_REPLAY_ENABLED}" != "true" ]]; then
+            result=skipped
+          elif [[ "${{ steps.transaction_replay.outcome }}" == "success" ]]; then
+            result=success
+          else
+            result=failure
+          fi
+          echo "::notice::Transaction replay result=${result}"
+          printf 'result=%s\n' "${result}" >>"${GITHUB_OUTPUT}"
 
       - name: Append transaction replay summary
         if: always()
@@ -568,6 +632,7 @@ jobs:
       DEPLOY_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       DEPLOYMENT_ID: ${{ needs.create-deployment.outputs.deployment_id }}
       DEPLOY_RESULT: ${{ needs.deploy-and-verify.result }}
+      TRANSACTION_REPLAY_RESULT: ${{ needs.deploy-and-verify.outputs.transaction_replay_result }}
       BACKEND_IMAGE_RESULT: ${{ needs.backend-image.result }}
       FRONTEND_IMAGE_RESULT: ${{ needs.frontend-image.result }}
       LATEST_MAIN_RESULT: ${{ needs.validate-latest-before-deploy.result }}
@@ -614,6 +679,53 @@ jobs:
         run: |
           set -euo pipefail
           tools/ops/staging-rollback-guard.sh
+
+      - name: Record staging 100m replay evidence
+        if: always() && needs.validate-latest-before-deploy.outputs.should_deploy == 'true' && needs.deploy-and-verify.result == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          replay_result="${TRANSACTION_REPLAY_RESULT:-skipped}"
+          replay_state=failure
+          if [[ "${replay_result}" == "success" ]]; then
+            replay_state=success
+          fi
+
+          payload="$(
+            jq -n \
+              --arg ref "${DEPLOY_SHA}" \
+              --arg description "Record staging 100m replay evidence for ${DEPLOY_SHA}" \
+              '{
+                ref: $ref,
+                environment: "staging-100m-replay",
+                description: $description,
+                auto_merge: false,
+                required_contexts: [],
+                production_environment: false,
+                transient_environment: false
+              }'
+          )"
+          if ! replay_deployment_id="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments" --input - --jq ".id" <<< "${payload}")"; then
+            echo "::warning::Failed to create staging 100m replay evidence deployment."
+            exit 0
+          fi
+
+          status_payload="$(
+            jq -n \
+              --arg state "${replay_state}" \
+              --arg log_url "${DEPLOY_LOG_URL}" \
+              --arg description "transaction replay ${replay_result}" \
+              '{
+                state: $state,
+                environment: "staging-100m-replay",
+                log_url: $log_url,
+                description: $description,
+                auto_inactive: false
+              }'
+          )"
+          if ! gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${replay_deployment_id}/statuses" --input - <<< "${status_payload}"; then
+            echo "::warning::Failed to record staging 100m replay evidence status."
+          fi
 
       - name: Mark staging deployment success
         if: always() && needs.validate-latest-before-deploy.outputs.should_deploy == 'true' && needs.deploy-and-verify.result == 'success'

--- a/docs/delivery-flow.md
+++ b/docs/delivery-flow.md
@@ -59,13 +59,14 @@
   - deploy script는 green backend/frontend container health가 모두 200일 때만 Nginx config를 교체하고 reload한다.
   - Nginx config 검증 또는 reload가 실패하면 이전 config와 blue slot을 유지한다.
 - required OCI deploy secret이 없으면 workflow는 fail-fast하며 staging GitHub deployment status를 성공으로 만들지 않습니다.
-- workflow는 OCI A1 local deploy와 post-deploy smoke를 통과한 경우에만 staging GitHub deployment status를 `success`로 갱신합니다.
+- workflow는 OCI A1 local deploy와 post-deploy smoke를 통과한 경우 staging GitHub deployment status를 `success`로 갱신합니다.
 - transaction replay gate는 post-deploy smoke 뒤에 실행되며, `pg_class.reltuples` 검증 전에 planner stats freshness guard로 stale stats를 차단합니다.
+- replay gate 결과는 별도 GitHub deployment environment `staging-100m-replay`에 기록합니다. fixture가 비어 있어 replay가 실패해도 앱 staging CD는 실패시키지 않고 report/artifact를 남깁니다.
 - fixture principal bootstrap은 smoke/replay 전에 `STAGING_REPLAY_USER_ID`와 hot/cold 계좌 membership을 idempotent하게 보장해 fixture JWT 403을 차단합니다.
-- replay gate가 실패하면 staging deployment status는 `success`로 올라가지 않으므로 production promotion guard가 같은 SHA를 자동으로 거부합니다.
+- replay evidence가 `success`가 아니면 production promotion guard가 같은 SHA를 자동으로 거부합니다.
 - post-deploy smoke는 health/read/write endpoint를 호출하며, read/write path는 환경별 smoke 전용 endpoint를 secret으로 주입합니다.
 - smoke 또는 OCI deploy 실패 시 deployment status는 `failure`가 되고, rollback hook이 설정된 경우 `sha`, `repository`, `runUrl`, `deploymentId`와 함께 호출합니다.
-- production 승격은 staging deployment status가 `success`인 같은 SHA만 대상으로 삼습니다.
+- production 승격은 staging deployment status와 `staging-100m-replay` evidence가 모두 `success`인 같은 SHA만 대상으로 삼습니다.
 - rollback은 `main` 기준 revert PR을 merge해 새 staging SHA를 배포하거나, 운영자가 직전 staging 성공 SHA를 확인해 별도 재배포 절차로 진행합니다.
 
 ### OCI A1 Staging Env 예시
@@ -105,6 +106,7 @@ STAGING_REPLAY_ITERATIONS=40
 STAGING_REPLAY_PAGE_LIMIT=50
 STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS=5
 STAGING_REPLAY_EXPECTED_TOTAL_ROWS=100000000
+STAGING_REPLAY_REQUIRED=false
 STAGING_REPLAY_HOT_P95_THRESHOLD_MS=350
 STAGING_REPLAY_COLD_P95_THRESHOLD_MS=750
 STAGING_REPLAY_STATS_MAX_AGE_HOURS=24

--- a/docs/production-promotion.md
+++ b/docs/production-promotion.md
@@ -3,7 +3,7 @@
 ## Trigger
 
 - Manual: GitHub Actions `Production Promotion` workflow dispatch
-  - input `sha`: staging deployment status가 `success`인 40자 main commit SHA
+- input `sha`: staging deployment status와 `staging-100m-replay` evidence가 모두 `success`인 40자 main commit SHA
 - Tag: `prod-*` tag push
   - tag가 가리키는 commit을 promotion target SHA로 사용
 
@@ -12,7 +12,10 @@
 - target SHA는 `origin/main`에서 도달 가능해야 합니다.
 - target SHA와 같은 staging GitHub deployment가 있어야 합니다.
 - 해당 staging deployment의 최신 status가 `success`여야 합니다.
-- staging success는 OCI A1 blue/green deploy, post-deploy smoke, 1억 건 replay gate를 통과한 same SHA만 기록합니다.
+- target SHA와 같은 `staging-100m-replay` GitHub deployment가 있어야 합니다.
+- 해당 `staging-100m-replay` deployment의 최신 status가 `success`여야 합니다.
+- staging success는 OCI A1 blue/green deploy와 post-deploy smoke 통과를 뜻하고, 1억 건 replay gate 통과 여부는 별도 evidence status로 기록합니다.
+- production promotion은 두 status가 same SHA에 대해 모두 성공일 때만 진행합니다.
 - guard가 실패하면 `production` Environment approval 전 단계에서 workflow가 중단됩니다.
 
 ## Approval
@@ -73,7 +76,7 @@ rollback secret 3개는 모두 없으면 rollback hook을 호출하지 않고 wo
 ## Rollback
 
 - 기본 rollback은 `main` 기준 revert PR을 merge한 뒤 새 staging 성공 SHA를 production으로 승격합니다.
-- 긴급 재승격이 필요하면 직전 production 성공 SHA가 staging success guard를 통과하는지 먼저 확인합니다.
+- 긴급 재승격이 필요하면 직전 production 성공 SHA가 staging success와 `staging-100m-replay` evidence guard를 모두 통과하는지 먼저 확인합니다.
 - main 밖 commit, staging 성공 기록이 없는 commit, 짧은 SHA 입력은 production promotion 대상이 아닙니다.
 - rollback guard는 `PRODUCTION_ROLLBACK_TARGET_SHA`가 staging deployment `success` 상태일 때만 hook을 호출합니다.
 - rollback target은 실패한 `TARGET_SHA`와 같을 수 없습니다.

--- a/docs/transaction-read-model-staging-replay.md
+++ b/docs/transaction-read-model-staging-replay.md
@@ -46,6 +46,7 @@
     - `STAGING_REPLAY_COLD_FROM`
     - `STAGING_REPLAY_COLD_TO`
   - optional:
+    - `STAGING_REPLAY_REQUIRED`
     - `STAGING_REPLAY_ITERATIONS`
     - `STAGING_REPLAY_PAGE_LIMIT`
     - `STAGING_REPLAY_REQUEST_TIMEOUT_SECONDS`
@@ -54,7 +55,8 @@
     - `STAGING_REPLAY_COLD_P95_THRESHOLD_MS`
     - `STAGING_REPLAY_STATS_MAX_AGE_HOURS`
     - `STAGING_REPLAY_STATS_MAX_MODIFIED_RATIO`
-- replay gate가 실행되고 실패하면 staging deployment status가 `success`로 기록되지 않아 production promotion이 같은 SHA를 통과시키지 않습니다.
+- replay gate가 실행되고 실패하면 `staging-100m-replay` evidence status가 `failure`로 기록되어 production promotion이 같은 SHA를 통과시키지 않습니다.
+- 앱 staging CD는 OCI A1 blue/green deploy와 post-deploy smoke가 성공하면 성공으로 기록합니다. 100m fixture가 비어 있는 경우 replay report/artifact를 남기고 production promotion만 차단합니다.
 - OCI A1 secret 조건이 맞지 않는 환경에서는 이 gate를 성공으로 간주하지 않고, 1억 건 primary evidence가 blocked 상태로 남습니다.
 
 ## Workflow Inputs
@@ -74,6 +76,7 @@
 - planner stats freshness guard가 `transaction_read_model`, `transaction_read_model_archive`의 leaf partition analyze 시각과 `n_mod_since_analyze / reltuples` 비율을 먼저 확인합니다.
 - freshness guard가 stale stats를 감지하면 table별 `tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target <hot|archive>` guidance와 함께 즉시 실패합니다.
 - PostgreSQL estimate가 `expected_total_rows`보다 작으면 실패합니다.
+- estimate가 0이면 `fixture_missing`으로 분류하고 fixture restore/analyze guidance와 함께 report를 남깁니다.
 - hot/cold account에 row가 없으면 실패합니다.
 - 각 first page가 `nextCursor`를 반환하지 않으면 cursor replay가 불가능하므로 실패합니다.
 - HTTP non-2xx, timeout, empty `items` 응답은 실패합니다.

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -112,6 +112,9 @@ workflow_patterns=(
   "Mark staging deployment failure"
   "Run staging post-deploy smoke"
   "Run transaction replay regression gate"
+  "STAGING_REPLAY_ENABLED"
+  "Record staging 100m replay evidence"
+  "staging-100m-replay"
 )
 for pattern in "${workflow_patterns[@]}"; do
   require_pattern "$pattern" "$workflow"
@@ -278,6 +281,8 @@ for pattern in "${doc_patterns[@]}"; do
   require_pattern "$pattern" "$delivery_doc"
 done
 require_pattern "self-hosted runner" "ops/deploy/oci/README.md"
+require_pattern "Verify staging 100m replay evidence success" ".github/workflows/production-promotion.yml"
+require_pattern "staging-100m-replay" ".github/workflows/production-promotion.yml"
 reject_pattern "OCI_A1_SSH_" "$delivery_doc"
 reject_pattern "ssh-keyscan" "$delivery_doc"
 reject_pattern "OCI_A1_SSH_" "ops/deploy/oci/README.md"

--- a/tools/test/run-production-high-traffic-config-gate.sh
+++ b/tools/test/run-production-high-traffic-config-gate.sh
@@ -13,6 +13,15 @@ ruby <<'RUBY'
 require 'yaml'
 
 workflow = YAML.load_file('.github/workflows/production-promotion.yml')
+guard_steps = workflow.fetch('jobs').fetch('guard').fetch('steps')
+guard_step_names = guard_steps.map { |step| step['name'] }
+staging_success_index = guard_step_names.index('Verify staging deployment success') or abort('staging deployment success guard missing')
+replay_evidence_index = guard_step_names.index('Verify staging 100m replay evidence success') or abort('staging 100m replay evidence guard missing')
+abort('staging replay evidence guard must run after staging deployment guard') unless staging_success_index < replay_evidence_index
+replay_evidence_run = guard_steps.fetch(replay_evidence_index).fetch('run')
+abort('staging replay evidence guard must query separate environment') unless replay_evidence_run.include?('staging-100m-replay')
+abort('staging replay evidence guard must require success') unless replay_evidence_run.include?('No successful staging 100m replay evidence')
+
 steps = workflow.fetch('jobs').fetch('promote').fetch('steps')
 step_names = steps.map { |step| step['name'] }
 target_name = 'Run production high-traffic config gate'

--- a/tools/test/run-staging-deploy-transaction-replay-gate.sh
+++ b/tools/test/run-staging-deploy-transaction-replay-gate.sh
@@ -18,8 +18,10 @@ steps = deploy_job.fetch('steps')
 step_names = steps.map { |step| step['name'] }
 
 replay_name = 'Run transaction replay regression gate'
+replay_result_name = 'Resolve transaction replay result'
 append_replay_summary_name = 'Append transaction replay summary'
 upload_replay_report_name = 'Upload transaction replay report'
+record_replay_evidence_name = 'Record staging 100m replay evidence'
 smoke_name = 'Run staging post-deploy smoke'
 fixture_principal_name = 'Ensure staging fixture principal'
 deploy_name = 'Run OCI A1 blue-green deploy locally'
@@ -28,6 +30,7 @@ load_env_name = 'Load OCI A1 staging env'
 prerequisite_name = 'Check OCI self-hosted runner prerequisites'
 
 replay_index = step_names.index(replay_name) or abort("missing step: #{replay_name}")
+replay_result_index = step_names.index(replay_result_name) or abort("missing step: #{replay_result_name}")
 append_replay_summary_index = step_names.index(append_replay_summary_name) or abort("missing step: #{append_replay_summary_name}")
 upload_replay_report_index = step_names.index(upload_replay_report_name) or abort("missing step: #{upload_replay_report_name}")
 smoke_index = step_names.index(smoke_name) or abort("missing step: #{smoke_name}")
@@ -47,19 +50,30 @@ abort('runner prerequisites must run before OCI deploy') unless prerequisite_ind
 abort('fixture principal must run after OCI deploy') unless deploy_index < fixture_principal_index
 abort('fixture principal must run before smoke') unless fixture_principal_index < smoke_index
 abort('replay gate must run after staging smoke') unless smoke_index < replay_index
+abort('replay result must run after replay gate') unless replay_index < replay_result_index
 abort('replay summary must run after replay gate') unless replay_index < append_replay_summary_index
 abort('replay report upload must run after replay gate') unless replay_index < upload_replay_report_index
+
+deploy_outputs = deploy_job.fetch('outputs')
+abort('deploy job must expose transaction replay result') unless deploy_outputs.fetch('transaction_replay_result').include?('resolve-transaction-replay-result')
 
 finalize_needs = Array(finalize_job.fetch('needs'))
 abort('finalize job must depend on deploy-and-verify') unless finalize_needs.include?('deploy-and-verify')
 finalize_steps = finalize_job.fetch('steps')
+finalize_step_names = finalize_steps.map { |step| step['name'] }
+record_replay_evidence_index = finalize_step_names.index(record_replay_evidence_name) or abort("missing step: #{record_replay_evidence_name}")
 success_step = finalize_steps.find { |step| step['name'] == 'Mark staging deployment success' } or abort('missing finalize success step')
 abort('success status must require deploy-and-verify success') unless success_step.fetch('if').include?("needs.deploy-and-verify.result == 'success'")
+record_replay_evidence_step = finalize_steps.fetch(record_replay_evidence_index)
+record_replay_evidence_run = record_replay_evidence_step.fetch('run')
+abort('replay evidence must use separate deployment environment') unless record_replay_evidence_run.include?('staging-100m-replay')
+abort('replay evidence must not fail staging CD on replay failure') if record_replay_evidence_run.include?('exit 1')
 
 load_env_step = steps.fetch(load_env_index)
 load_env = load_env_step.fetch('env')
 load_run = load_env_step.fetch('run')
 replay_step = steps.fetch(replay_index)
+replay_result_step = steps.fetch(replay_result_index)
 run = replay_step.fetch('run')
 append_replay_summary_step = steps.fetch(append_replay_summary_index)
 upload_replay_report_step = steps.fetch(upload_replay_report_index)
@@ -68,6 +82,8 @@ required_keys = %w[
   STAGING_BASE_URL
   STAGING_SMOKE_BASE_URL
   STAGING_REPLAY_TOKEN
+  STAGING_REPLAY_ENABLED
+  STAGING_REPLAY_REQUIRED
   STAGING_OCI_A1_DATABASE_URL
   STAGING_RDS_DATABASE_URL
   HOT_ACCOUNT_ID
@@ -90,8 +106,14 @@ end
 
 abort('load step must read only the unified staging env secret') unless load_env.fetch('OCI_A1_STAGING_ENV').include?('secrets.OCI_A1_STAGING_ENV')
 abort('load step must source the staging env file') unless load_run.include?('source "${staging_env_path}"')
+abort('load step must default replay required to false') unless load_run.include?('STAGING_REPLAY_REQUIRED="${STAGING_REPLAY_REQUIRED:-false}"')
+abort('load step must derive replay enabled from replay keys') unless load_run.include?('STAGING_REPLAY_ENABLED')
 abort('replay step should not scatter staging env mappings') if replay_step.key?('env')
+abort('replay step must be soft-fail for staging CD') unless replay_step['continue-on-error'] == true
+abort('replay step must run only when replay is enabled') unless replay_step.fetch('if').include?("env.STAGING_REPLAY_ENABLED == 'true'")
 abort('replay step must call transaction replay script') unless run.include?('tools/ops/transaction-read-model-staging-replay.sh')
+abort('replay result step must run always') unless replay_result_step.fetch('if').include?('always()')
+abort('replay result step must report skipped when replay is disabled') unless replay_result_step.fetch('run').include?('result=skipped')
 abort('replay summary must run even after replay failure') unless append_replay_summary_step.fetch('if').include?('always()')
 append_replay_summary_run = append_replay_summary_step.fetch('run')
 abort('replay summary must append summary.md to GITHUB_STEP_SUMMARY') unless append_replay_summary_run.include?('build/reports/transaction-staging-replay/summary.md') && append_replay_summary_run.include?('GITHUB_STEP_SUMMARY')
@@ -107,6 +129,7 @@ resolver_run = steps.fetch(resolver_index).fetch('run')
 abort('DB URL resolver step must call resolver script') unless resolver_run.include?('tools/ops/resolve-oci-a1-staging-database-url.sh')
 abort('DB URL resolver must mask resolved URL') unless resolver_run.include?('::add-mask::${resolved_database_url}')
 abort('DB URL resolver must rewrite staging DB URL in GITHUB_ENV') unless resolver_run.include?('STAGING_OCI_A1_DATABASE_URL=%s')
+abort('DB URL resolver failure must disable optional replay') unless resolver_run.include?('STAGING_REPLAY_ENABLED=false')
 abort('OCI A1 database URL must come from unified staging env') unless load_run.include?('STAGING_OCI_A1_DATABASE_URL')
 abort('Postgres host bind must default to host-local port') unless load_run.include?('POSTGRES_HOST_BIND="${POSTGRES_HOST_BIND:-127.0.0.1:5432}"')
 abort('smoke base URL must default to loopback for self-hosted runner') unless load_run.include?('STAGING_SMOKE_BASE_URL="${STAGING_SMOKE_BASE_URL:-${STAGING_LOCAL_BASE_URL:-http://127.0.0.1}}"')


### PR DESCRIPTION
## 🔗 Related Issue
- close #582

## 🌿 Base Branch
- `main`

## 📝 Summary
- Staging CD에서 앱 배포/smoke 성공과 100m replay evidence를 분리했습니다.
- read model fixture가 비어 있어 replay가 실패해도 staging deploy 자체는 성공으로 기록하고, production promotion은 별도 `staging-100m-replay` evidence success가 없으면 차단합니다.

## 🛠 Changes
- `Staging Deploy`에서 transaction replay를 soft-fail로 실행하고 결과를 job output으로 분리
- `staging-100m-replay` GitHub deployment status에 replay success/failure/skipped 기록
- `Production Promotion` guard가 staging success와 `staging-100m-replay` success를 모두 확인
- 관련 CD 계약 테스트와 운영 문서 갱신

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `tools/test/run-production-high-traffic-config-gate.sh`
- `tools/test/run-transaction-read-model-staging-replay-guard.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); YAML.load_file('.github/workflows/production-promotion.yml'); puts 'ok'"`
- `git diff --check HEAD~1..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: staging deploy status가 이제 앱 배포/smoke 성공을 뜻하고, 100m evidence는 `staging-100m-replay`로 분리됨. production promotion guard에 evidence 확인을 추가해 무검증 승격은 차단함.
- 롤백 방법: 이 PR revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
