### PR TITLE
[Perf] transaction burst generator headroom 분리

### DIFF
--- a/tools/test/check-transaction-read-burst-429-budget-gate.sh
+++ b/tools/test/check-transaction-read-burst-429-budget-gate.sh
@@ -57,6 +57,10 @@ grep -F "burst_rate=256" <<<"${plan}" >/dev/null
 grep -F "expected_rate=0" <<<"${plan}" >/dev/null
 grep -F "warn_rate=0.001" <<<"${plan}" >/dev/null
 grep -F "fail_rate=0.005" <<<"${plan}" >/dev/null
+grep -F "pre_allocated_vus=256" <<<"${plan}" >/dev/null
+grep -F "max_vus=512" <<<"${plan}" >/dev/null
+grep -F "max_retry_after_sleep_seconds=1" <<<"${plan}" >/dev/null
+grep -F "K6_PRE_ALLOCATED_VUS=256 K6_MAX_VUS=512" <<<"${plan}" >/dev/null
 grep -F "result_tsv=${output_dir}/burst-429-check-burst-429-budget.tsv" <<<"${plan}" >/dev/null
 grep -F "report_md=${output_dir}/burst-429-check-burst-429-budget.md" <<<"${plan}" >/dev/null
 
@@ -76,8 +80,14 @@ test "${report_md}" = "${output_dir}/burst-429-check-burst-429-budget.md"
 grep -F $'metric\tvalue\twarn_threshold\tfail_threshold\tstatus' "${result_tsv}" >/dev/null
 grep -F $'transaction_429_rate\t0.00275\t0.001\t0.005\twarn' "${result_tsv}" >/dev/null
 grep -F $'dropped_iterations\t0\t0\t0\tpass' "${result_tsv}" >/dev/null
+grep -F $'interrupted_iterations\t0\t0\t0\tpass' "${result_tsv}" >/dev/null
+grep -F $'generator_headroom_status\tpass\tn/a\tn/a\tpass' "${result_tsv}" >/dev/null
 grep -F "gate_status=warn" "${report_md}" >/dev/null
 grep -F "burst rate: 256/s" "${report_md}" >/dev/null
+grep -F "preAllocated VUs: 256" "${report_md}" >/dev/null
+grep -F "max VUs: 512" "${report_md}" >/dev/null
+grep -F "max Retry-After sleep seconds: 1" "${report_md}" >/dev/null
+grep -F "generator headroom status: pass" "${report_md}" >/dev/null
 grep -F "transaction 429 rate: 0.00275" "${report_md}" >/dev/null
 
 echo "[transaction-read-burst-429] fail threshold"
@@ -99,6 +109,10 @@ grep -F "BURST_429_WARN_RATE" "${runner}" >/dev/null
 grep -F "BURST_429_FAIL_RATE" "${runner}" >/dev/null
 grep -F "K6_SCENARIO_MODE=burst" "${runner}" >/dev/null
 grep -F "K6_BURST_RATE" "${runner}" >/dev/null
+grep -F "K6_PRE_ALLOCATED_VUS" "${runner}" >/dev/null
+grep -F "K6_MAX_VUS" "${runner}" >/dev/null
+grep -F "K6_MAX_RETRY_AFTER_SLEEP_SECONDS" "${runner}" >/dev/null
+grep -F "generator_headroom_status" "${runner}" >/dev/null
 
 echo "[transaction-read-burst-429] invalid input fails"
 if BURST_429_GATE_NAME=bad-threshold \
@@ -111,5 +125,9 @@ if BURST_429_GATE_NAME=bad-threshold \
 fi
 if BURST_429_GATE_NAME=missing-json "${runner}" >/dev/null 2>&1; then
   echo "missing burst summary unexpectedly succeeded" >&2
+  exit 1
+fi
+if BURST_429_PRE_ALLOCATED_VUS=0 "${runner}" --print-plan >/dev/null 2>&1; then
+  echo "invalid preAllocated VUs unexpectedly succeeded" >&2
   exit 1
 fi

--- a/tools/test/check-transaction-read-stepped-burst-gate.sh
+++ b/tools/test/check-transaction-read-stepped-burst-gate.sh
@@ -18,13 +18,15 @@ write_summary() {
   local transaction_429_rate="$2"
   local transaction_503_rate="${3:-0}"
   local transaction_503_count="${4:-0}"
+  local dropped_iterations="${5:-0}"
+  local interrupted_iterations="${6:-0}"
   cat >"${summary_dir}/rate-${rate}-summary.json" <<JSON
 {
   "metrics": {
     "http_req_failed": {"values": {"rate": 0}},
     "http_reqs": {"values": {"count": 4096}},
-    "dropped_iterations": {"values": {"count": 0}},
-    "interrupted_iterations": {"values": {"count": 0}},
+    "dropped_iterations": {"values": {"count": ${dropped_iterations}}},
+    "interrupted_iterations": {"values": {"count": ${interrupted_iterations}}},
     "aquila_transaction_429_rate": {"values": {"rate": ${transaction_429_rate}}},
     "aquila_transaction_503_rate": {"values": {"rate": ${transaction_503_rate}}},
     "aquila_transaction_503_count": {"values": {"count": ${transaction_503_count}}}
@@ -33,11 +35,11 @@ write_summary() {
 JSON
 }
 
-write_summary 64 0
-write_summary 80 0.042
-write_summary 96 0.0836
-write_summary 112 0.095
-write_summary 128 0.099
+write_summary 32 0
+write_summary 48 0.02
+write_summary 64 0.042
+write_summary 80 0.0836
+write_summary 96 0.095
 
 echo "[transaction-read-stepped-burst] print plan"
 plan="$(
@@ -49,7 +51,7 @@ plan="$(
     "${runner}" --print-plan
 )"
 grep -F "gate=stepped-check" <<<"${plan}" >/dev/null
-grep -F "rates=64,80,96,112,128" <<<"${plan}" >/dev/null
+grep -F "rates=32,48,64,80,96" <<<"${plan}" >/dev/null
 grep -F "summary_dir=${summary_dir}" <<<"${plan}" >/dev/null
 grep -F "output_dir=${output_dir}" <<<"${plan}" >/dev/null
 grep -F "run_k6=false" <<<"${plan}" >/dev/null
@@ -68,20 +70,20 @@ output="$(
 report_md="$(tail -1 <<<"${output}")"
 summary_tsv="${output_dir}/stepped-check-stepped-burst.tsv"
 test "${report_md}" = "${output_dir}/stepped-check-stepped-burst.md"
-grep -F $'rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\treport_md\tsummary_json' "${summary_tsv}" >/dev/null
-grep -F $'64\tpass\t0\t0\t0' "${summary_tsv}" >/dev/null
-grep -F $'80\tpass\t0.042\t0\t0' "${summary_tsv}" >/dev/null
-grep -F $'96\twarn\t0.0836\t0\t0' "${summary_tsv}" >/dev/null
-grep -F $'112\twarn\t0.095\t0\t0' "${summary_tsv}" >/dev/null
-grep -F $'128\twarn\t0.099\t0\t0' "${summary_tsv}" >/dev/null
+grep -F $'rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\tdropped_iterations\tinterrupted_iterations\tgenerator_headroom_status\treport_md\tsummary_json' "${summary_tsv}" >/dev/null
+grep -F $'32\tpass\t0\t0\t0\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'48\tpass\t0.02\t0\t0\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'64\tpass\t0.042\t0\t0\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'80\twarn\t0.0836\t0\t0\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'96\twarn\t0.095\t0\t0\t0\t0\tpass' "${summary_tsv}" >/dev/null
 grep -F "gate_status=warn" "${report_md}" >/dev/null
 grep -F "first_fail_rate=none" "${report_md}" >/dev/null
-grep -F "max_non_fail_rate=128" "${report_md}" >/dev/null
-grep -F "| 64 | pass | 0 | 0 | 0 |" "${report_md}" >/dev/null
-grep -F "64/80/96/112/128" "${report_md}" >/dev/null
+grep -F "max_non_fail_rate=96" "${report_md}" >/dev/null
+grep -F "| 32 | pass | 0 | 0 | 0 | 0 | 0 | pass |" "${report_md}" >/dev/null
+grep -F "32/48/64/80/96" "${report_md}" >/dev/null
 
 echo "[transaction-read-stepped-burst] aggregate fail"
-write_summary 128 0.125
+write_summary 80 0.0836 0 0 1 0
 set +e
 fail_output="$(
   STEPPED_BURST_GATE_NAME=stepped-fail-check \
@@ -99,16 +101,18 @@ if [[ "${fail_status}" -eq 0 ]]; then
 fi
 fail_report_md="$(tail -1 <<<"${fail_output}")"
 test "${fail_report_md}" = "${output_dir}/stepped-fail-check-stepped-burst.md"
-grep -F "first_fail_rate=128" "${fail_report_md}" >/dev/null
-grep -F "max_non_fail_rate=112" "${fail_report_md}" >/dev/null
-grep -F "| 128 | fail | 0.125 | 0 | 0 |" "${fail_report_md}" >/dev/null
+grep -F "first_fail_rate=80" "${fail_report_md}" >/dev/null
+grep -F "max_non_fail_rate=64" "${fail_report_md}" >/dev/null
+grep -F "| 80 | fail | 0.0836 | 0 | 0 | 1 | 0 | fail |" "${fail_report_md}" >/dev/null
 
 echo "[transaction-read-stepped-burst] runner contract"
 grep -F "run-transaction-read-burst-429-budget-gate.sh" "${runner}" >/dev/null
 grep -F "STEPPED_BURST_RATES" "${runner}" >/dev/null
-grep -F "64,80,96,112,128" "${runner}" >/dev/null
+grep -F "32,48,64,80,96" "${runner}" >/dev/null
 grep -F "rate-96-summary.json" "${runner}" >/dev/null
 grep -F "K6_SCENARIO_MODE=burst" "${runner}" >/dev/null
+grep -F "dropped_iterations" "${runner}" >/dev/null
+grep -F "generator_headroom_status" "${runner}" >/dev/null
 
 echo "[transaction-read-stepped-burst] invalid input fails"
 if STEPPED_BURST_RATES=bad "${runner}" --print-plan >/dev/null 2>&1; then

--- a/tools/test/run-transaction-read-burst-429-budget-gate.sh
+++ b/tools/test/run-transaction-read-burst-429-budget-gate.sh
@@ -11,6 +11,9 @@ Environment:
   BURST_429_OUTPUT_DIR      default build/reports/k6/<gate>
   BURST_429_BURST_RATE      default 256
   BURST_429_BURST_DURATION  default 20s
+  BURST_429_PRE_ALLOCATED_VUS default BURST_429_BURST_RATE
+  BURST_429_MAX_VUS         default BURST_429_BURST_RATE*2
+  BURST_429_MAX_RETRY_AFTER_SLEEP_SECONDS default 1
   BURST_429_WARN_RATE       default 0.001
   BURST_429_FAIL_RATE       default 0.005
   BURST_429_EXPECTED_RATE   default 0
@@ -45,6 +48,9 @@ summary_json="${BURST_429_SUMMARY_JSON:-}"
 output_dir="${BURST_429_OUTPUT_DIR:-build/reports/k6/${gate_name}}"
 burst_rate="${BURST_429_BURST_RATE:-256}"
 burst_duration="${BURST_429_BURST_DURATION:-20s}"
+pre_allocated_vus="${BURST_429_PRE_ALLOCATED_VUS:-}"
+max_vus="${BURST_429_MAX_VUS:-}"
+max_retry_after_sleep_seconds="${BURST_429_MAX_RETRY_AFTER_SLEEP_SECONDS:-1}"
 warn_rate="${BURST_429_WARN_RATE:-0.001}"
 fail_rate="${BURST_429_FAIL_RATE:-0.005}"
 expected_rate="${BURST_429_EXPECTED_RATE:-0}"
@@ -78,6 +84,19 @@ require_rate_value() {
   }
 }
 
+require_non_negative_number_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${name} must be zero or greater: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0) }' || {
+    echo "${name} must be zero or greater: ${value}" >&2
+    exit 1
+  }
+}
+
 require_positive_integer_value() {
   local name="$1"
   local value="$2"
@@ -102,6 +121,11 @@ number_greater_than() {
 
 require_bool_value "BURST_429_RUN_K6" "${run_k6}"
 require_positive_integer_value "BURST_429_BURST_RATE" "${burst_rate}"
+pre_allocated_vus="${pre_allocated_vus:-${burst_rate}}"
+max_vus="${max_vus:-$((burst_rate * 2))}"
+require_positive_integer_value "BURST_429_PRE_ALLOCATED_VUS" "${pre_allocated_vus}"
+require_positive_integer_value "BURST_429_MAX_VUS" "${max_vus}"
+require_non_negative_number_value "BURST_429_MAX_RETRY_AFTER_SLEEP_SECONDS" "${max_retry_after_sleep_seconds}"
 require_duration_value "BURST_429_BURST_DURATION" "${burst_duration}"
 require_duration_value "BURST_429_K6_DURATION" "${k6_duration}"
 require_rate_value "BURST_429_WARN_RATE" "${warn_rate}"
@@ -121,8 +145,11 @@ print_plan() {
   echo "[transaction-read-burst-429] expected_rate=${expected_rate}"
   echo "[transaction-read-burst-429] warn_rate=${warn_rate}"
   echo "[transaction-read-burst-429] fail_rate=${fail_rate}"
+  echo "[transaction-read-burst-429] pre_allocated_vus=${pre_allocated_vus}"
+  echo "[transaction-read-burst-429] max_vus=${max_vus}"
+  echo "[transaction-read-burst-429] max_retry_after_sleep_seconds=${max_retry_after_sleep_seconds}"
   echo "[transaction-read-burst-429] run_k6=${run_k6}"
-  echo "[transaction-read-burst-429] k6_command=K6_SCENARIO_MODE=burst K6_BURST_RATE=${burst_rate} ${k6_runner}"
+  echo "[transaction-read-burst-429] k6_command=K6_SCENARIO_MODE=burst K6_BURST_RATE=${burst_rate} K6_PRE_ALLOCATED_VUS=${pre_allocated_vus} K6_MAX_VUS=${max_vus} K6_MAX_RETRY_AFTER_SLEEP_SECONDS=${max_retry_after_sleep_seconds} ${k6_runner}"
   echo "[transaction-read-burst-429] result_tsv=${result_tsv}"
   echo "[transaction-read-burst-429] report_md=${report_md}"
 }
@@ -137,9 +164,12 @@ if [[ "${run_k6}" == "true" ]]; then
   K6_SCENARIO_MODE=burst \
   K6_BURST_RATE="${burst_rate}" \
   K6_BURST_DURATION="${burst_duration}" \
+  K6_PRE_ALLOCATED_VUS="${pre_allocated_vus}" \
+  K6_MAX_VUS="${max_vus}" \
   K6_DURATION="${k6_duration}" \
   K6_OVERLOAD_MODE=true \
   K6_BURST_429_RATE_THRESHOLD="${fail_rate}" \
+  K6_MAX_RETRY_AFTER_SLEEP_SECONDS="${max_retry_after_sleep_seconds}" \
   K6_ARCHIVE_RESULTS=false \
     "${k6_runner}"
   summary_json="${generated_summary_json}"
@@ -193,6 +223,10 @@ http_reqs="$(metric_value http_reqs count)"
 transaction_429_status="$(status_for_rate "${transaction_429_rate}")"
 dropped_status="$(status_for_zero "${dropped_iterations}")"
 interrupted_status="$(status_for_zero "${interrupted_iterations}")"
+generator_headroom_status="pass"
+if [[ "${dropped_status}" == "fail" || "${interrupted_status}" == "fail" ]]; then
+  generator_headroom_status="fail"
+fi
 status="pass"
 case "${transaction_429_status}:${dropped_status}:${interrupted_status}" in
   *fail*) status="fail" ;;
@@ -209,6 +243,7 @@ fi
   printf "transaction_503_count\t%s\t0\t0\t%s\n" "${transaction_503_count}" "$(status_for_zero "${transaction_503_count}")"
   printf "dropped_iterations\t%s\t0\t0\t%s\n" "${dropped_iterations}" "${dropped_status}"
   printf "interrupted_iterations\t%s\t0\t0\t%s\n" "${interrupted_iterations}" "${interrupted_status}"
+  printf "generator_headroom_status\t%s\tn/a\tn/a\t%s\n" "${generator_headroom_status}" "${generator_headroom_status}"
   printf "http_failed_rate\t%s\tn/a\tn/a\tobserve\n" "${http_failed_rate}"
   printf "http_reqs\t%s\tn/a\tn/a\tobserve\n" "${http_reqs}"
 } >"${result_tsv}"
@@ -222,6 +257,10 @@ cat >"${report_md}" <<REPORT
 - gate_status=${status}
 - burst rate: ${burst_rate}/s
 - burst duration: ${burst_duration}
+- preAllocated VUs: ${pre_allocated_vus}
+- max VUs: ${max_vus}
+- max Retry-After sleep seconds: ${max_retry_after_sleep_seconds}
+- generator headroom status: ${generator_headroom_status}
 - expected 429 rate: ${expected_rate}
 - warning threshold: ${warn_rate}
 - fail threshold: ${fail_rate}

--- a/tools/test/run-transaction-read-stepped-burst-gate.sh
+++ b/tools/test/run-transaction-read-stepped-burst-gate.sh
@@ -7,7 +7,7 @@ usage: tools/test/run-transaction-read-stepped-burst-gate.sh [--print-plan]
 
 Environment:
   STEPPED_BURST_GATE_NAME     default transaction-read-stepped-burst-<timestamp>
-  STEPPED_BURST_RATES         default 64,80,96,112,128
+  STEPPED_BURST_RATES         default 32,48,64,80,96
   STEPPED_BURST_DURATION      default 20s
   STEPPED_BURST_WARN_RATE     default 0.08
   STEPPED_BURST_FAIL_RATE     default 0.10
@@ -16,11 +16,11 @@ Environment:
   STEPPED_BURST_OUTPUT_DIR    default build/reports/k6/<gate>
 
 Summary input when STEPPED_BURST_RUN_K6=false:
+  ${STEPPED_BURST_SUMMARY_DIR}/rate-32-summary.json
+  ${STEPPED_BURST_SUMMARY_DIR}/rate-48-summary.json
   ${STEPPED_BURST_SUMMARY_DIR}/rate-64-summary.json
   ${STEPPED_BURST_SUMMARY_DIR}/rate-80-summary.json
   ${STEPPED_BURST_SUMMARY_DIR}/rate-96-summary.json
-  ${STEPPED_BURST_SUMMARY_DIR}/rate-112-summary.json
-  ${STEPPED_BURST_SUMMARY_DIR}/rate-128-summary.json
 USAGE
 }
 
@@ -43,7 +43,7 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 gate_name="${STEPPED_BURST_GATE_NAME:-transaction-read-stepped-burst-$(date +%Y-%m-%d-%H%M%S)}"
-rates="${STEPPED_BURST_RATES:-64,80,96,112,128}"
+rates="${STEPPED_BURST_RATES:-32,48,64,80,96}"
 burst_duration="${STEPPED_BURST_DURATION:-20s}"
 warn_rate="${STEPPED_BURST_WARN_RATE:-0.08}"
 fail_rate="${STEPPED_BURST_FAIL_RATE:-0.10}"
@@ -128,6 +128,7 @@ print_plan() {
   echo "[transaction-read-stepped-burst] summary_dir=${summary_dir:-missing}"
   echo "[transaction-read-stepped-burst] output_dir=${output_dir}"
   echo "[transaction-read-stepped-burst] k6_command=K6_SCENARIO_MODE=burst K6_BURST_RATE=<rate> ${single_gate}"
+  echo "[transaction-read-stepped-burst] k6_headroom=K6_PRE_ALLOCATED_VUS=<rate> K6_MAX_VUS=<rate*2> K6_MAX_RETRY_AFTER_SLEEP_SECONDS=1"
   echo "[transaction-read-stepped-burst] summary_tsv=${summary_tsv}"
   echo "[transaction-read-stepped-burst] report_md=${report_md}"
 }
@@ -153,12 +154,12 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 mkdir -p "${output_dir}"
-printf "rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\treport_md\tsummary_json\n" >"${summary_tsv}"
+printf "rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\tdropped_iterations\tinterrupted_iterations\tgenerator_headroom_status\treport_md\tsummary_json\n" >"${summary_tsv}"
 
 gate_status="pass"
 first_fail_rate="none"
 max_non_fail_rate="none"
-summary_table=$'| rate | status | transaction 429 rate | transaction 503 rate | transaction 503 count | report |\n| --- | --- | --- | --- | --- | --- |'
+summary_table=$'| rate | status | transaction 429 rate | transaction 503 rate | transaction 503 count | dropped iterations | interrupted iterations | generator headroom | report |\n| --- | --- | --- | --- | --- | --- | --- | --- | --- |'
 IFS=',' read -r -a rate_items <<<"${rates}"
 for rate in "${rate_items[@]}"; do
   single_name="${gate_name}-rate-${rate}"
@@ -188,10 +189,17 @@ for rate in "${rate_items[@]}"; do
   transaction_429_rate="$(metric_value "${summary_json}" aquila_transaction_429_rate rate)"
   transaction_503_rate="$(metric_value "${summary_json}" aquila_transaction_503_rate rate)"
   transaction_503_count="$(metric_value "${summary_json}" aquila_transaction_503_count count)"
+  dropped_iterations="$(metric_value "${summary_json}" dropped_iterations count)"
+  interrupted_iterations="$(metric_value "${summary_json}" interrupted_iterations count)"
+  generator_headroom_status="pass"
+  if number_greater_than "${dropped_iterations}" "0" || number_greater_than "${interrupted_iterations}" "0"; then
+    generator_headroom_status="fail"
+  fi
   rate_status="pass"
   if [[ "${single_status}" -ne 0 ]] || number_greater_than "${transaction_429_rate}" "${fail_rate}" \
       || number_greater_than "${transaction_503_rate}" "0" \
-      || number_greater_than "${transaction_503_count}" "0"; then
+      || number_greater_than "${transaction_503_count}" "0" \
+      || [[ "${generator_headroom_status}" == "fail" ]]; then
     rate_status="fail"
     gate_status="fail"
     if [[ "${first_fail_rate}" == "none" ]]; then
@@ -202,15 +210,20 @@ for rate in "${rate_items[@]}"; do
     if [[ "${gate_status}" == "pass" ]]; then
       gate_status="warn"
     fi
-    max_non_fail_rate="${rate}"
+    if [[ "${first_fail_rate}" == "none" ]]; then
+      max_non_fail_rate="${rate}"
+    fi
   else
-    max_non_fail_rate="${rate}"
+    if [[ "${first_fail_rate}" == "none" ]]; then
+      max_non_fail_rate="${rate}"
+    fi
   fi
 
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
     "${rate}" "${rate_status}" "${transaction_429_rate}" "${transaction_503_rate}" \
-    "${transaction_503_count}" "${single_report}" "${summary_json}" >>"${summary_tsv}"
-  summary_table="${summary_table}"$'\n'"| ${rate} | ${rate_status} | ${transaction_429_rate} | ${transaction_503_rate} | ${transaction_503_count} | ${single_report} |"
+    "${transaction_503_count}" "${dropped_iterations}" "${interrupted_iterations}" \
+    "${generator_headroom_status}" "${single_report}" "${summary_json}" >>"${summary_tsv}"
+  summary_table="${summary_table}"$'\n'"| ${rate} | ${rate_status} | ${transaction_429_rate} | ${transaction_503_rate} | ${transaction_503_count} | ${dropped_iterations} | ${interrupted_iterations} | ${generator_headroom_status} | ${single_report} |"
 done
 
 cat >"${report_md}" <<REPORT
@@ -221,7 +234,7 @@ cat >"${report_md}" <<REPORT
 - gate: ${gate_name}
 - gate_status=${gate_status}
 - rates: ${rates}
-- focus: 64/80/96/112/128 it/s boundary
+- focus: 32/48/64/80/96 it/s boundary
 - burst duration: ${burst_duration}
 - warning threshold: ${warn_rate}
 - fail threshold: ${fail_rate}
@@ -239,8 +252,9 @@ ${summary_table}
 
 ## Notes
 
-- 64/80/96/112/128 단계는 2026-04-29 OCI A1 burst 경계인 96~128 it/s의 전후 구간까지 고정합니다.
+- 32/48/64/80/96 단계는 2026-04-30 OCI A1 burst 재현 기준의 fail point를 낮은 구간부터 고정합니다.
 - 429는 admission 보호 신호로 따로 budget 관리하고, 503은 hard fail로 처리합니다.
+- dropped/interrupted iterations는 generator headroom 실패로 분리합니다.
 REPORT
 
 echo "${report_md}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #598

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction read burst gate에서 k6 generator headroom을 서버 admission 실패와 분리했습니다.
- stepped burst 기본 구간을 `32/48/64/80/96`으로 낮추고, rate별 generator dropped/interrupted 상태를 summary artifact에 남기도록 조정했습니다.

## 🛠 Changes
- single burst 429 budget gate에 `preAllocated VUs`, `max VUs`, `max Retry-After sleep seconds`, `generator_headroom_status`를 추가
- `BURST_429_PRE_ALLOCATED_VUS`, `BURST_429_MAX_VUS`, `BURST_429_MAX_RETRY_AFTER_SLEEP_SECONDS`를 k6 runner에 명시 전달
- stepped burst gate 기본 rates를 `32,48,64,80,96`으로 변경
- stepped summary TSV/Markdown table에 `dropped_iterations`, `interrupted_iterations`, `generator_headroom_status`를 추가
- generator loss 발생 시 first fail point와 max non-fail point가 서버 429/503과 같은 표에 남도록 변경

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-burst-429-budget-gate.sh`
- `bash tools/test/check-transaction-read-stepped-burst-gate.sh`
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `tools/test/with-resource-lock.sh back-gradle-check ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: stepped burst artifact column이 늘어나 downstream parser가 strict TSV column 수를 가정하면 수정이 필요할 수 있습니다.
- 롤백 방법: 이 PR의 2개 커밋을 revert하면 #597의 `64/80/96/112/128` stepped gate와 기존 artifact 형식으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
