### PR TITLE
[Perf] transaction-read admission burst policy 안정화

### DIFF
--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControl.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControl.java
@@ -5,8 +5,11 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
 
 public class ApiAdmissionControl {
+
+  private static final long NANOS_PER_SECOND = 1_000_000_000L;
 
   private final ApiAdmissionControlProperties properties;
   private final MeterRegistry meterRegistry;
@@ -14,13 +17,19 @@ public class ApiAdmissionControl {
 
   public ApiAdmissionControl(
       ApiAdmissionControlProperties properties, MeterRegistry meterRegistry) {
+    this(properties, meterRegistry, System::nanoTime);
+  }
+
+  ApiAdmissionControl(
+      ApiAdmissionControlProperties properties, MeterRegistry meterRegistry, LongSupplier ticker) {
     this.properties = properties;
     this.meterRegistry = meterRegistry;
     this.endpoints =
         properties.endpoints().stream()
             .map(
                 endpoint ->
-                    new EndpointState(endpoint, properties.retryAfterSeconds(), meterRegistry))
+                    new EndpointState(
+                        endpoint, properties.retryAfterSeconds(), meterRegistry, ticker))
             .toList();
   }
 
@@ -37,6 +46,7 @@ public class ApiAdmissionControl {
       increment(endpoint.group(), "rejected");
       return ApiAdmissionPermit.rejected(endpoint.group(), endpoint.retryAfterSeconds());
     }
+    endpoint.recordAccepted();
     increment(endpoint.group(), "accepted");
     return ApiAdmissionPermit.acquired(endpoint.group(), endpoint::release);
   }
@@ -64,29 +74,38 @@ public class ApiAdmissionControl {
     return queryIndex < 0 ? rawPath : rawPath.substring(0, queryIndex);
   }
 
-  private record EndpointState(
-      String group,
-      int retryAfterSeconds,
-      List<String> pathPrefixes,
-      ApiAdmissionControlProperties.AdaptiveLimit adaptive,
-      AtomicInteger currentLimit,
-      AtomicInteger inFlight,
-      AtomicInteger healthyCompletions) {
+  private static final class EndpointState {
+
+    private final String group;
+    private final int retryAfterSeconds;
+    private final List<String> pathPrefixes;
+    private final ApiAdmissionControlProperties.AdaptiveLimit adaptive;
+    private final AtomicInteger currentLimit;
+    private final AtomicInteger inFlight = new AtomicInteger();
+    private final AtomicInteger healthyCompletions = new AtomicInteger();
+    private final LongSupplier ticker;
+    private final boolean[] rejectionWindow;
+
+    private int rejectionWindowIndex;
+    private int rejectionWindowSamples;
+    private int rejectionWindowRejected;
+    private long decreaseCooldownUntilNanos;
 
     private EndpointState(
         ApiAdmissionControlProperties.EndpointLimit endpoint,
         int defaultRetryAfterSeconds,
-        MeterRegistry meterRegistry) {
-      this(
-          endpoint.group(),
+        MeterRegistry meterRegistry,
+        LongSupplier ticker) {
+      this.group = endpoint.group();
+      this.retryAfterSeconds =
           endpoint.retryAfterSeconds() > 0
               ? endpoint.retryAfterSeconds()
-              : defaultRetryAfterSeconds,
-          endpoint.pathPrefixes(),
-          endpoint.adaptive(),
-          new AtomicInteger(endpoint.maxConcurrency()),
-          new AtomicInteger(),
-          new AtomicInteger());
+              : defaultRetryAfterSeconds;
+      this.pathPrefixes = endpoint.pathPrefixes();
+      this.adaptive = endpoint.adaptive();
+      this.currentLimit = new AtomicInteger(endpoint.maxConcurrency());
+      this.ticker = ticker;
+      this.rejectionWindow = new boolean[endpoint.adaptive().rejectionWindowSize()];
       Gauge.builder("aquila.api.admission.inflight", inFlight, AtomicInteger::get)
           .tag("group", group)
           .description("endpoint admission control in-flight requests")
@@ -95,6 +114,14 @@ public class ApiAdmissionControl {
           .tag("group", group)
           .description("endpoint admission control current concurrency limit")
           .register(meterRegistry);
+    }
+
+    private String group() {
+      return group;
+    }
+
+    private int retryAfterSeconds() {
+      return retryAfterSeconds;
     }
 
     private boolean matches(String path) {
@@ -113,14 +140,56 @@ public class ApiAdmissionControl {
       }
     }
 
+    private void recordAccepted() {
+      if (adaptive.enabled()) {
+        recordAdmissionDecision(false);
+      }
+    }
+
     private void recordRejection() {
       if (!adaptive.enabled()) {
         return;
       }
       healthyCompletions.set(0);
-      // 429는 이미 포화 신호이므로 다음 요청부터 즉시 낮은 한도로 되돌립니다.
+      recordAdmissionDecision(true);
+      if (!canDecrease()) {
+        return;
+      }
+      decreaseCooldownUntilNanos =
+          ticker.getAsLong() + adaptive.decreaseCooldownSeconds() * NANOS_PER_SECOND;
+      // 429가 짧게 튄 경우는 window ratio로 거르고, 실제 포화가 이어질 때만 단계적으로 낮춥니다.
       currentLimit.updateAndGet(
           value -> Math.max(adaptive.minConcurrency(), value - adaptive.decreaseOnRejections()));
+    }
+
+    private synchronized void recordAdmissionDecision(boolean rejected) {
+      if (rejectionWindowSamples < rejectionWindow.length) {
+        rejectionWindow[rejectionWindowSamples] = rejected;
+        rejectionWindowSamples++;
+      } else {
+        if (rejectionWindow[rejectionWindowIndex]) {
+          rejectionWindowRejected--;
+        }
+        rejectionWindow[rejectionWindowIndex] = rejected;
+        rejectionWindowIndex = (rejectionWindowIndex + 1) % rejectionWindow.length;
+      }
+      if (rejected) {
+        rejectionWindowRejected++;
+      }
+    }
+
+    private synchronized boolean canDecrease() {
+      if (currentLimit.get() <= adaptive.minConcurrency()) {
+        return false;
+      }
+      if (rejectionWindowSamples < rejectionWindow.length) {
+        return false;
+      }
+      if (ticker.getAsLong() < decreaseCooldownUntilNanos) {
+        return false;
+      }
+      double ratio = (double) rejectionWindowRejected / rejectionWindowSamples;
+      return ratio >= adaptive.decreaseRejectionRatio();
     }
 
     private void release() {
@@ -137,7 +206,8 @@ public class ApiAdmissionControl {
         return;
       }
       if (healthyCompletions.compareAndSet(completions, 0)) {
-        currentLimit.updateAndGet(value -> Math.min(adaptive.maxConcurrency(), value + 1));
+        currentLimit.updateAndGet(
+            value -> Math.min(adaptive.maxConcurrency(), value + adaptive.recoveryStep()));
       }
     }
   }

--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControl.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControl.java
@@ -98,7 +98,7 @@ public class ApiAdmissionControl {
         LongSupplier ticker) {
       this.group = endpoint.group();
       this.retryAfterSeconds =
-          endpoint.retryAfterSeconds() > 0
+          endpoint.retryAfterSeconds() >= 0
               ? endpoint.retryAfterSeconds()
               : defaultRetryAfterSeconds;
       this.pathPrefixes = endpoint.pathPrefixes();

--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
@@ -21,7 +21,7 @@ public record ApiAdmissionControlProperties(
             6,
             1,
             List.of("/api/v1/transactions"),
-            new AdaptiveLimit(true, 6, 12, 64, 1)),
+            new AdaptiveLimit(true, 6, 12, 64, 1, 20, 0.5, 1, 1)),
         new EndpointLimit("account-read", 4, 0, List.of("/api/v1/accounts"), null),
         new EndpointLimit("transfer-write", 2, 0, List.of("/api/v1/transfers"), null),
         new EndpointLimit(
@@ -80,7 +80,11 @@ public record ApiAdmissionControlProperties(
       int minConcurrency,
       int maxConcurrency,
       int increaseEverySuccesses,
-      int decreaseOnRejections) {
+      int decreaseOnRejections,
+      int rejectionWindowSize,
+      double decreaseRejectionRatio,
+      int decreaseCooldownSeconds,
+      int recoveryStep) {
 
     public AdaptiveLimit {
       enabled = enabled == null ? Boolean.FALSE : enabled;
@@ -89,20 +93,34 @@ public record ApiAdmissionControlProperties(
         maxConcurrency = maxConcurrency >= minConcurrency ? maxConcurrency : minConcurrency;
         increaseEverySuccesses = increaseEverySuccesses > 0 ? increaseEverySuccesses : 100;
         decreaseOnRejections = decreaseOnRejections > 0 ? decreaseOnRejections : 1;
+        rejectionWindowSize = rejectionWindowSize > 0 ? rejectionWindowSize : 1;
+        decreaseRejectionRatio =
+            decreaseRejectionRatio > 0.0 && decreaseRejectionRatio <= 1.0
+                ? decreaseRejectionRatio
+                : 1.0;
+        decreaseCooldownSeconds = Math.max(decreaseCooldownSeconds, 0);
+        recoveryStep = recoveryStep > 0 ? recoveryStep : 1;
       } else if (minConcurrency <= 0) {
         throw new IllegalArgumentException(
             "ops.api-admission-control adaptive min-concurrency must be positive");
       } else if (maxConcurrency < minConcurrency) {
         throw new IllegalArgumentException(
             "ops.api-admission-control adaptive max-concurrency must be greater than or equal to min-concurrency");
+      } else if (decreaseRejectionRatio > 1.0) {
+        throw new IllegalArgumentException(
+            "ops.api-admission-control adaptive decrease-rejection-ratio must be within (0, 1]");
       } else {
         increaseEverySuccesses = increaseEverySuccesses > 0 ? increaseEverySuccesses : 100;
         decreaseOnRejections = decreaseOnRejections > 0 ? decreaseOnRejections : 1;
+        rejectionWindowSize = rejectionWindowSize > 0 ? rejectionWindowSize : 20;
+        decreaseRejectionRatio = decreaseRejectionRatio > 0.0 ? decreaseRejectionRatio : 0.5;
+        decreaseCooldownSeconds = Math.max(decreaseCooldownSeconds, 0);
+        recoveryStep = recoveryStep > 0 ? recoveryStep : 1;
       }
     }
 
     static AdaptiveLimit disabled(int maxConcurrency) {
-      return new AdaptiveLimit(false, maxConcurrency, maxConcurrency, 100, 1);
+      return new AdaptiveLimit(false, maxConcurrency, maxConcurrency, 100, 1, 1, 1.0, 0, 1);
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
+++ b/back/src/main/java/com/aquilabank/global/ops/ApiAdmissionControlProperties.java
@@ -5,11 +5,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "ops.api-admission-control")
 public record ApiAdmissionControlProperties(
-    Boolean enabled, int retryAfterSeconds, List<EndpointLimit> endpoints) {
+    Boolean enabled, Integer retryAfterSeconds, List<EndpointLimit> endpoints) {
 
   public ApiAdmissionControlProperties {
     enabled = enabled == null ? Boolean.TRUE : enabled;
-    retryAfterSeconds = retryAfterSeconds > 0 ? retryAfterSeconds : 1;
+    retryAfterSeconds = retryAfterSeconds == null ? 1 : retryAfterSeconds;
+    if (retryAfterSeconds < 0) {
+      throw new IllegalArgumentException(
+          "ops.api-admission-control retry-after-seconds must not be negative");
+    }
     endpoints =
         endpoints == null || endpoints.isEmpty() ? defaultEndpoints() : List.copyOf(endpoints);
   }
@@ -44,7 +48,7 @@ public record ApiAdmissionControlProperties(
   public record EndpointLimit(
       String group,
       int maxConcurrency,
-      int retryAfterSeconds,
+      Integer retryAfterSeconds,
       List<String> pathPrefixes,
       AdaptiveLimit adaptive) {
 
@@ -60,9 +64,10 @@ public record ApiAdmissionControlProperties(
         throw new IllegalArgumentException(
             "ops.api-admission-control path-prefixes must not be empty");
       }
-      if (retryAfterSeconds < 0) {
+      retryAfterSeconds = retryAfterSeconds == null ? -1 : retryAfterSeconds;
+      if (retryAfterSeconds < -1) {
         throw new IllegalArgumentException(
-            "ops.api-admission-control retry-after-seconds must not be negative");
+            "ops.api-admission-control endpoint retry-after-seconds must be -1 or greater");
       }
       pathPrefixes = List.copyOf(pathPrefixes);
       adaptive = adaptive == null ? AdaptiveLimit.disabled(maxConcurrency) : adaptive;

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -57,6 +57,9 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 public class ApiExceptionHandler {
 
   private static final Logger log = LoggerFactory.getLogger(ApiExceptionHandler.class);
+  private static final String REJECT_REASON_HEADER = "X-Aquila-Reject-Reason";
+  private static final String RATE_LIMIT_SCOPE_HEADER = "X-RateLimit-Scope";
+  private static final String RATE_LIMIT_RETRY_AFTER_HEADER = "X-RateLimit-Retry-After-Seconds";
   private static final Pattern USER_STATUS_PATH_PATTERN =
       Pattern.compile("^/internal/api/v1/auth/users/(\\d+)/status$");
   private static final Pattern MEMBERSHIP_STATUS_PATH_PATTERN =
@@ -131,6 +134,9 @@ public class ApiExceptionHandler {
     logInternalAuthStatusFailure(HttpStatus.TOO_MANY_REQUESTS, request, ex.getMessage());
     return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
         .header("Retry-After", Integer.toString(ex.retryAfterSeconds()))
+        .header(REJECT_REASON_HEADER, "backend-admission")
+        .header(RATE_LIMIT_SCOPE_HEADER, ex.group())
+        .header(RATE_LIMIT_RETRY_AFTER_HEADER, Integer.toString(ex.retryAfterSeconds()))
         .body(
             new ApiErrorResponse(
                 Instant.now(),
@@ -162,6 +168,9 @@ public class ApiExceptionHandler {
     // 정상 방어 거절은 429로 분리해 query timeout 503 hard fail과 섞이지 않게 합니다.
     return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
         .header("Retry-After", Integer.toString(ex.retryAfterSeconds()))
+        .header(REJECT_REASON_HEADER, "saturation-guard")
+        .header(RATE_LIMIT_SCOPE_HEADER, "saturation-guard")
+        .header(RATE_LIMIT_RETRY_AFTER_HEADER, Integer.toString(ex.retryAfterSeconds()))
         .body(
             new ApiErrorResponse(
                 Instant.now(),

--- a/back/src/main/resources/application-oci-a1.yml
+++ b/back/src/main/resources/application-oci-a1.yml
@@ -24,3 +24,17 @@ server:
 transaction:
   read-replica:
     maximum-pool-size: ${OCI_A1_TRANSACTION_READ_REPLICA_POOL_MAX_SIZE:4}
+
+oci-a1:
+  transaction-read:
+    admission:
+      # 64 it/s 경계에서 limit 3까지 하락한 증거를 반영해 floor를 DB pool보다 조금 낮게 고정한다.
+      max: ${OCI_A1_TRANSACTION_READ_ADMISSION_MAX:6}
+      min: ${OCI_A1_TRANSACTION_READ_ADMISSION_MIN:5}
+      adaptive-max: ${OCI_A1_TRANSACTION_READ_ADMISSION_ADAPTIVE_MAX:8}
+      increase-every-successes: ${OCI_A1_TRANSACTION_READ_ADMISSION_INCREASE_EVERY_SUCCESSES:48}
+      decrease-on-rejections: ${OCI_A1_TRANSACTION_READ_ADMISSION_DECREASE_ON_REJECTIONS:1}
+      rejection-window-size: ${OCI_A1_TRANSACTION_READ_ADMISSION_REJECTION_WINDOW_SIZE:24}
+      decrease-rejection-ratio: ${OCI_A1_TRANSACTION_READ_ADMISSION_DECREASE_REJECTION_RATIO:0.35}
+      decrease-cooldown-seconds: ${OCI_A1_TRANSACTION_READ_ADMISSION_DECREASE_COOLDOWN_SECONDS:2}
+      recovery-step: ${OCI_A1_TRANSACTION_READ_ADMISSION_RECOVERY_STEP:1}

--- a/back/src/main/resources/application-oci-a1.yml
+++ b/back/src/main/resources/application-oci-a1.yml
@@ -30,6 +30,7 @@ oci-a1:
     admission:
       # 64 it/s 경계에서 limit 3까지 하락한 증거를 반영해 floor를 DB pool보다 조금 낮게 고정한다.
       max: ${OCI_A1_TRANSACTION_READ_ADMISSION_MAX:6}
+      retry-after-seconds: ${OCI_A1_TRANSACTION_READ_ADMISSION_RETRY_AFTER_SECONDS:0}
       min: ${OCI_A1_TRANSACTION_READ_ADMISSION_MIN:5}
       adaptive-max: ${OCI_A1_TRANSACTION_READ_ADMISSION_ADAPTIVE_MAX:8}
       increase-every-successes: ${OCI_A1_TRANSACTION_READ_ADMISSION_INCREASE_EVERY_SUCCESSES:48}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -81,14 +81,18 @@ ops:
     endpoints:
       - group: transaction-read
         # OCI A1 96 it/s 429 budget 기준. 작은 host는 env로 더 낮춰서 사용합니다.
-        max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX:6}
-        retry-after-seconds: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_RETRY_AFTER_SECONDS:1}
+        max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX:${oci-a1.transaction-read.admission.max:6}}
+        retry-after-seconds: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_RETRY_AFTER_SECONDS:${oci-a1.transaction-read.admission.retry-after-seconds:1}}
         adaptive:
           enabled: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_ENABLED:true}
-          min-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_MIN:${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX:6}}
-          max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_MAX:${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX:12}}
-          increase-every-successes: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_INCREASE_EVERY_SUCCESSES:64}
-          decrease-on-rejections: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_DECREASE_ON_REJECTIONS:1}
+          min-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_MIN:${oci-a1.transaction-read.admission.min:${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX:6}}}
+          max-concurrency: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_MAX:${oci-a1.transaction-read.admission.adaptive-max:${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX:12}}}
+          increase-every-successes: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_INCREASE_EVERY_SUCCESSES:${oci-a1.transaction-read.admission.increase-every-successes:64}}
+          decrease-on-rejections: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_DECREASE_ON_REJECTIONS:${oci-a1.transaction-read.admission.decrease-on-rejections:1}}
+          rejection-window-size: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_REJECTION_WINDOW_SIZE:${oci-a1.transaction-read.admission.rejection-window-size:20}}
+          decrease-rejection-ratio: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_DECREASE_REJECTION_RATIO:${oci-a1.transaction-read.admission.decrease-rejection-ratio:0.5}}
+          decrease-cooldown-seconds: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_DECREASE_COOLDOWN_SECONDS:${oci-a1.transaction-read.admission.decrease-cooldown-seconds:1}}
+          recovery-step: ${OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_RECOVERY_STEP:${oci-a1.transaction-read.admission.recovery-step:1}}
         path-prefixes:
           - /api/v1/transactions
       - group: account-read

--- a/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
@@ -58,6 +58,10 @@ class OciA1CapacityProfileTest {
               .isEqualTo(6);
           assertThat(
                   environment.getProperty(
+                      "ops.api-admission-control.endpoints[0].retry-after-seconds", Integer.class))
+              .isZero();
+          assertThat(
+                  environment.getProperty(
                       "ops.api-admission-control.endpoints[0].adaptive.min-concurrency",
                       Integer.class))
               .isEqualTo(5);
@@ -106,6 +110,7 @@ class OciA1CapacityProfileTest {
                                 entry("OCI_A1_TASK_EXECUTION_MAX_SIZE", "7"),
                                 entry("OCI_A1_TASK_EXECUTION_QUEUE_CAPACITY", "160"),
                                 entry("OCI_A1_TRANSACTION_READ_ADMISSION_MAX", "7"),
+                                entry("OCI_A1_TRANSACTION_READ_ADMISSION_RETRY_AFTER_SECONDS", "1"),
                                 entry("OCI_A1_TRANSACTION_READ_ADMISSION_MIN", "6"),
                                 entry("OCI_A1_TRANSACTION_READ_ADMISSION_ADAPTIVE_MAX", "9"),
                                 entry(
@@ -154,6 +159,11 @@ class OciA1CapacityProfileTest {
                       environment.getProperty(
                           "ops.api-admission-control.endpoints[0].max-concurrency", Integer.class))
                   .isEqualTo(7);
+              assertThat(
+                      environment.getProperty(
+                          "ops.api-admission-control.endpoints[0].retry-after-seconds",
+                          Integer.class))
+                  .isEqualTo(1);
               assertThat(
                       environment.getProperty(
                           "ops.api-admission-control.endpoints[0].adaptive.min-concurrency",

--- a/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
@@ -1,5 +1,6 @@
 package com.aquilabank.global.config;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -51,6 +52,35 @@ class OciA1CapacityProfileTest {
                   environment.getProperty(
                       "spring.task.execution.pool.queue-capacity", Integer.class))
               .isEqualTo(200);
+          assertThat(
+                  environment.getProperty(
+                      "ops.api-admission-control.endpoints[0].max-concurrency", Integer.class))
+              .isEqualTo(6);
+          assertThat(
+                  environment.getProperty(
+                      "ops.api-admission-control.endpoints[0].adaptive.min-concurrency",
+                      Integer.class))
+              .isEqualTo(5);
+          assertThat(
+                  environment.getProperty(
+                      "ops.api-admission-control.endpoints[0].adaptive.max-concurrency",
+                      Integer.class))
+              .isEqualTo(8);
+          assertThat(
+                  environment.getProperty(
+                      "ops.api-admission-control.endpoints[0].adaptive.rejection-window-size",
+                      Integer.class))
+              .isEqualTo(24);
+          assertThat(
+                  environment.getProperty(
+                      "ops.api-admission-control.endpoints[0].adaptive.decrease-rejection-ratio",
+                      Double.class))
+              .isEqualTo(0.35);
+          assertThat(
+                  environment.getProperty(
+                      "ops.api-admission-control.endpoints[0].adaptive.decrease-cooldown-seconds",
+                      Integer.class))
+              .isEqualTo(2);
         });
   }
 
@@ -65,25 +95,28 @@ class OciA1CapacityProfileTest {
                     .addFirst(
                         new MapPropertySource(
                             "ociA1Override",
-                            Map.of(
-                                "OCI_A1_DB_POOL_MAX_SIZE",
-                                "7",
-                                "OCI_A1_DB_POOL_MIN_IDLE",
-                                "2",
-                                "OCI_A1_TRANSACTION_READ_REPLICA_POOL_MAX_SIZE",
-                                "5",
-                                "OCI_A1_SERVER_THREADS_MAX",
-                                "28",
-                                "OCI_A1_SERVER_THREADS_MIN_SPARE",
-                                "3",
-                                "OCI_A1_SERVER_ACCEPT_COUNT",
-                                "48",
-                                "OCI_A1_TASK_EXECUTION_CORE_SIZE",
-                                "3",
-                                "OCI_A1_TASK_EXECUTION_MAX_SIZE",
-                                "7",
-                                "OCI_A1_TASK_EXECUTION_QUEUE_CAPACITY",
-                                "160"))))
+                            Map.ofEntries(
+                                entry("OCI_A1_DB_POOL_MAX_SIZE", "7"),
+                                entry("OCI_A1_DB_POOL_MIN_IDLE", "2"),
+                                entry("OCI_A1_TRANSACTION_READ_REPLICA_POOL_MAX_SIZE", "5"),
+                                entry("OCI_A1_SERVER_THREADS_MAX", "28"),
+                                entry("OCI_A1_SERVER_THREADS_MIN_SPARE", "3"),
+                                entry("OCI_A1_SERVER_ACCEPT_COUNT", "48"),
+                                entry("OCI_A1_TASK_EXECUTION_CORE_SIZE", "3"),
+                                entry("OCI_A1_TASK_EXECUTION_MAX_SIZE", "7"),
+                                entry("OCI_A1_TASK_EXECUTION_QUEUE_CAPACITY", "160"),
+                                entry("OCI_A1_TRANSACTION_READ_ADMISSION_MAX", "7"),
+                                entry("OCI_A1_TRANSACTION_READ_ADMISSION_MIN", "6"),
+                                entry("OCI_A1_TRANSACTION_READ_ADMISSION_ADAPTIVE_MAX", "9"),
+                                entry(
+                                    "OCI_A1_TRANSACTION_READ_ADMISSION_REJECTION_WINDOW_SIZE",
+                                    "30"),
+                                entry(
+                                    "OCI_A1_TRANSACTION_READ_ADMISSION_DECREASE_REJECTION_RATIO",
+                                    "0.4"),
+                                entry(
+                                    "OCI_A1_TRANSACTION_READ_ADMISSION_DECREASE_COOLDOWN_SECONDS",
+                                    "3")))))
         .run(
             context -> {
               Environment environment = context.getEnvironment();
@@ -117,6 +150,35 @@ class OciA1CapacityProfileTest {
                       environment.getProperty(
                           "spring.task.execution.pool.queue-capacity", Integer.class))
                   .isEqualTo(160);
+              assertThat(
+                      environment.getProperty(
+                          "ops.api-admission-control.endpoints[0].max-concurrency", Integer.class))
+                  .isEqualTo(7);
+              assertThat(
+                      environment.getProperty(
+                          "ops.api-admission-control.endpoints[0].adaptive.min-concurrency",
+                          Integer.class))
+                  .isEqualTo(6);
+              assertThat(
+                      environment.getProperty(
+                          "ops.api-admission-control.endpoints[0].adaptive.max-concurrency",
+                          Integer.class))
+                  .isEqualTo(9);
+              assertThat(
+                      environment.getProperty(
+                          "ops.api-admission-control.endpoints[0].adaptive.rejection-window-size",
+                          Integer.class))
+                  .isEqualTo(30);
+              assertThat(
+                      environment.getProperty(
+                          "ops.api-admission-control.endpoints[0].adaptive.decrease-rejection-ratio",
+                          Double.class))
+                  .isEqualTo(0.4);
+              assertThat(
+                      environment.getProperty(
+                          "ops.api-admission-control.endpoints[0].adaptive.decrease-cooldown-seconds",
+                          Integer.class))
+                  .isEqualTo(3);
             });
   }
 

--- a/back/src/test/java/com/aquilabank/global/ops/ApiAdmissionControlTest.java
+++ b/back/src/test/java/com/aquilabank/global/ops/ApiAdmissionControlTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
 class ApiAdmissionControlTest {
@@ -150,6 +151,77 @@ class ApiAdmissionControlTest {
   }
 
   @Test
+  void keepsAdaptiveLimitAfterSingleRejectedAdmission() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiAdmissionControl admissionControl =
+        new ApiAdmissionControl(adaptiveProperties(4, 2, 4, 100, 1, 4, 0.5, 1, 1), meterRegistry);
+
+    ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit second = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit third = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit fourth = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit rejected = admissionControl.tryAcquire("/api/v1/transactions");
+
+    assertThat(first.allowed()).isTrue();
+    assertThat(second.allowed()).isTrue();
+    assertThat(third.allowed()).isTrue();
+    assertThat(fourth.allowed()).isTrue();
+    assertThat(rejected.allowed()).isFalse();
+    assertCurrentLimit(meterRegistry, 4.0);
+
+    first.release();
+    second.release();
+    third.release();
+    fourth.release();
+  }
+
+  @Test
+  void lowersAdaptiveLimitByRollingRejectionRatioAndCooldown() {
+    AtomicLong now = new AtomicLong();
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiAdmissionControl admissionControl =
+        new ApiAdmissionControl(
+            adaptiveProperties(4, 2, 4, 100, 1, 4, 0.5, 5, 1), meterRegistry, now::get);
+
+    ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit second = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit third = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit fourth = admissionControl.tryAcquire("/api/v1/transactions");
+
+    assertThat(admissionControl.tryAcquire("/api/v1/transactions").allowed()).isFalse();
+    assertCurrentLimit(meterRegistry, 4.0);
+
+    assertThat(admissionControl.tryAcquire("/api/v1/transactions").allowed()).isFalse();
+    assertCurrentLimit(meterRegistry, 3.0);
+
+    assertThat(admissionControl.tryAcquire("/api/v1/transactions").allowed()).isFalse();
+    assertCurrentLimit(meterRegistry, 3.0);
+
+    now.addAndGet(5_000_000_000L);
+    assertThat(admissionControl.tryAcquire("/api/v1/transactions").allowed()).isFalse();
+    assertCurrentLimit(meterRegistry, 2.0);
+
+    first.release();
+    second.release();
+    third.release();
+    fourth.release();
+  }
+
+  @Test
+  void raisesAdaptiveLimitByRecoveryStepAfterHealthyCompletions() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiAdmissionControl admissionControl =
+        new ApiAdmissionControl(adaptiveProperties(2, 1, 5, 2, 1, 4, 0.5, 1, 2), meterRegistry);
+
+    ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
+    first.release();
+    ApiAdmissionPermit second = admissionControl.tryAcquire("/api/v1/transactions");
+    second.release();
+
+    assertCurrentLimit(meterRegistry, 4.0);
+  }
+
+  @Test
   void usesEndpointRetryAfterAndOciA1TransactionReadAdaptiveBounds() {
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     ApiAdmissionControl admissionControl =
@@ -163,7 +235,8 @@ class ApiAdmissionControlTest {
                         6,
                         1,
                         List.of("/api/v1/transactions"),
-                        new ApiAdmissionControlProperties.AdaptiveLimit(true, 6, 12, 64, 1)))),
+                        new ApiAdmissionControlProperties.AdaptiveLimit(
+                            true, 6, 12, 64, 1, 20, 0.5, 1, 1)))),
             meterRegistry);
 
     ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
@@ -206,7 +279,8 @@ class ApiAdmissionControlTest {
                         1,
                         0,
                         List.of("/api/v1/transactions"),
-                        new ApiAdmissionControlProperties.AdaptiveLimit(false, 0, 0, 0, 0)))),
+                        new ApiAdmissionControlProperties.AdaptiveLimit(
+                            false, 0, 0, 0, 0, 0, 0, 0, 0)))),
             meterRegistry);
 
     ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
@@ -248,7 +322,42 @@ class ApiAdmissionControlTest {
                     minConcurrency,
                     adaptiveMaxConcurrency,
                     increaseEverySuccesses,
-                    decreaseOnRejections))));
+                    decreaseOnRejections,
+                    1,
+                    1.0,
+                    0,
+                    1))));
+  }
+
+  private ApiAdmissionControlProperties adaptiveProperties(
+      int maxConcurrency,
+      int minConcurrency,
+      int adaptiveMaxConcurrency,
+      int increaseEverySuccesses,
+      int decreaseOnRejections,
+      int rejectionWindowSize,
+      double decreaseRejectionRatio,
+      int decreaseCooldownSeconds,
+      int recoveryStep) {
+    return new ApiAdmissionControlProperties(
+        true,
+        1,
+        List.of(
+            new ApiAdmissionControlProperties.EndpointLimit(
+                "transaction-read",
+                maxConcurrency,
+                0,
+                List.of("/api/v1/transactions"),
+                new ApiAdmissionControlProperties.AdaptiveLimit(
+                    true,
+                    minConcurrency,
+                    adaptiveMaxConcurrency,
+                    increaseEverySuccesses,
+                    decreaseOnRejections,
+                    rejectionWindowSize,
+                    decreaseRejectionRatio,
+                    decreaseCooldownSeconds,
+                    recoveryStep))));
   }
 
   private void assertCurrentLimit(SimpleMeterRegistry meterRegistry, double expected) {

--- a/back/src/test/java/com/aquilabank/global/ops/ApiAdmissionControlTest.java
+++ b/back/src/test/java/com/aquilabank/global/ops/ApiAdmissionControlTest.java
@@ -222,6 +222,29 @@ class ApiAdmissionControlTest {
   }
 
   @Test
+  void usesExplicitZeroRetryAfterWithoutDefaultFallback() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ApiAdmissionControl admissionControl =
+        new ApiAdmissionControl(
+            new ApiAdmissionControlProperties(
+                true,
+                1,
+                List.of(
+                    new ApiAdmissionControlProperties.EndpointLimit(
+                        "transaction-read", 1, 0, List.of("/api/v1/transactions"), null))),
+            meterRegistry);
+
+    ApiAdmissionPermit first = admissionControl.tryAcquire("/api/v1/transactions");
+    ApiAdmissionPermit rejected = admissionControl.tryAcquire("/api/v1/transactions");
+
+    assertThat(first.allowed()).isTrue();
+    assertThat(rejected.allowed()).isFalse();
+    assertThat(rejected.retryAfterSeconds()).isZero();
+
+    first.release();
+  }
+
+  @Test
   void usesEndpointRetryAfterAndOciA1TransactionReadAdaptiveBounds() {
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     ApiAdmissionControl admissionControl =
@@ -299,7 +322,7 @@ class ApiAdmissionControlTest {
         1,
         List.of(
             new ApiAdmissionControlProperties.EndpointLimit(
-                "transaction-read", 1, 0, List.of("/api/v1/transactions"), null)));
+                "transaction-read", 1, -1, List.of("/api/v1/transactions"), null)));
   }
 
   private ApiAdmissionControlProperties adaptiveProperties(
@@ -315,7 +338,7 @@ class ApiAdmissionControlTest {
             new ApiAdmissionControlProperties.EndpointLimit(
                 "transaction-read",
                 maxConcurrency,
-                0,
+                -1,
                 List.of("/api/v1/transactions"),
                 new ApiAdmissionControlProperties.AdaptiveLimit(
                     true,
@@ -346,7 +369,7 @@ class ApiAdmissionControlTest {
             new ApiAdmissionControlProperties.EndpointLimit(
                 "transaction-read",
                 maxConcurrency,
-                0,
+                -1,
                 List.of("/api/v1/transactions"),
                 new ApiAdmissionControlProperties.AdaptiveLimit(
                     true,

--- a/back/src/test/java/com/aquilabank/global/web/ApiExceptionHandlerApiOverloadTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ApiExceptionHandlerApiOverloadTest.java
@@ -17,10 +17,14 @@ class ApiExceptionHandlerApiOverloadTest {
 
     ResponseEntity<ApiExceptionHandler.ApiErrorResponse> response =
         handler.handleApiOverloadRejected(
-            new ApiOverloadRejectedException("transaction-read", 1), request);
+            new ApiOverloadRejectedException("transaction-read", 0), request);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
-    assertThat(response.getHeaders().getFirst("Retry-After")).isEqualTo("1");
+    assertThat(response.getHeaders().getFirst("Retry-After")).isEqualTo("0");
+    assertThat(response.getHeaders().getFirst("X-Aquila-Reject-Reason"))
+        .isEqualTo("backend-admission");
+    assertThat(response.getHeaders().getFirst("X-RateLimit-Scope")).isEqualTo("transaction-read");
+    assertThat(response.getHeaders().getFirst("X-RateLimit-Retry-After-Seconds")).isEqualTo("0");
     assertThat(response.getBody().message()).isEqualTo("api overloaded; retry later");
     assertThat(response.getBody().path()).isEqualTo("/api/v1/transactions");
   }

--- a/back/src/test/java/com/aquilabank/global/web/ApiExceptionHandlerT3MicroSaturationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ApiExceptionHandlerT3MicroSaturationTest.java
@@ -24,6 +24,10 @@ class ApiExceptionHandlerT3MicroSaturationTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
     assertThat(response.getHeaders().getFirst("Retry-After")).isEqualTo("2");
+    assertThat(response.getHeaders().getFirst("X-Aquila-Reject-Reason"))
+        .isEqualTo("saturation-guard");
+    assertThat(response.getHeaders().getFirst("X-RateLimit-Scope")).isEqualTo("saturation-guard");
+    assertThat(response.getHeaders().getFirst("X-RateLimit-Retry-After-Seconds")).isEqualTo("2");
     assertThat(response.getBody().message()).isEqualTo("server is saturated; retry later");
     assertThat(response.getBody().path()).isEqualTo("/api/v1/transactions");
   }


### PR DESCRIPTION
## 🔗 Related Issue
- close #602

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction-read adaptive admission이 단일/소수 429에 즉시 limit을 낮추지 않도록 rolling rejection ratio, cooldown, recovery step을 추가했습니다.
- OCI A1 profile에 DB pool/thread와 transaction-read admission floor/max를 명시하고, 429 response header로 backend admission과 saturation guard를 분리합니다.

## 🛠 Changes
- `ApiAdmissionControl`에 rolling rejection window, decrease cooldown, recovery step 기반 adaptive policy 추가
- `application-oci-a1.yml`에 transaction-read admission max/min/adaptive max/retry-after/hysteresis profile 고정
- backend admission 429: `X-Aquila-Reject-Reason=backend-admission`, `X-RateLimit-Scope=<group>`, `X-RateLimit-Retry-After-Seconds`
- saturation guard 429: `X-Aquila-Reject-Reason=saturation-guard` 계열 header 추가
- transaction-read OCI A1 profile의 fixed Retry-After 기본값을 `0`으로 낮춰 burst client sleep 동기화를 줄이는 계약 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle-final-focused ./back/gradlew -p back test --tests com.aquilabank.global.ops.ApiAdmissionControlTest --tests com.aquilabank.global.config.ApiAdmissionControlConfigurationTest --tests com.aquilabank.global.config.OciA1CapacityProfileTest --tests com.aquilabank.global.web.ApiExceptionHandlerApiOverloadTest --tests com.aquilabank.global.web.ApiExceptionHandlerT3MicroSaturationTest`
- `tools/test/with-resource-lock.sh back-gradle-final-check ./back/gradlew -p back check`
- `git rev-list --count main..HEAD` = `3`, brief `commit_plan` = `3`
- 참고: commit hook 중 장기 integration test 3건이 각각 다른 테스트에서 일시 실패했으나, 실패 테스트 단독 재실행은 통과했고 최종 `back check`는 통과했습니다.

## 📸 Screenshot / API Example
- API 예시: backend admission 429 응답에 `Retry-After`, `X-Aquila-Reject-Reason`, `X-RateLimit-Scope`, `X-RateLimit-Retry-After-Seconds`가 포함됩니다.

## ⚠️ Risk & Rollback
- 예상 리스크: transaction-read burst에서 429 비율은 낮아질 수 있지만 floor가 올라가므로 OCI A1 실측에서 DB pending/CPU를 함께 확인해야 합니다.
- 롤백 방법: 이 PR revert 또는 `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_ENABLED=false`, `OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ADAPTIVE_MIN/MAX` env로 이전 admission profile 복구.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?