### PR TITLE
[Build] OCI bluegreen Nginx API limit_req parity 적용

### DIFF
--- a/ops/deploy/oci/bluegreen-deploy.sh
+++ b/ops/deploy/oci/bluegreen-deploy.sh
@@ -535,6 +535,8 @@ events {
 }
 
 http {
+  limit_req_status 429;
+  # upstream latency와 edge limit 결과를 같은 JSON line에 남겨 429 원인을 분리합니다.
   log_format aquila_bank_upstream escape=json
     '{'
       '"time":"\$time_iso8601",'
@@ -545,10 +547,16 @@ http {
       '"upstream_response_time":"\$upstream_response_time",'
       '"upstream_connect_time":"\$upstream_connect_time",'
       '"upstream_header_time":"\$upstream_header_time",'
+      '"limit_req_status":"\$limit_req_status",'
       '"request_id":"\$request_id",'
       '"k6_run_id":"\$http_x_k6_run_id"'
     '}';
   access_log /var/log/nginx/access.log aquila_bank_upstream;
+
+  # 짧은 API 요청만 1차 보호하고, SSE는 exact location과 전용 timeout으로 분리합니다.
+  limit_req_zone \$binary_remote_addr zone=aquila_bank_api_per_ip:10m rate=30r/s;
+  # 공개 auth 진입점은 token/bcrypt 비용 전에 더 보수적으로 edge 차단합니다.
+  limit_req_zone \$binary_remote_addr zone=aquila_bank_auth_per_ip:10m rate=5r/s;
 
   upstream aquila_bank_backend {
     server ${backend_name}:${BACKEND_PORT};
@@ -605,6 +613,55 @@ http {
       access_log off;
     }
 
+    # 공개 auth는 generic /api/ limit에 섞지 않고 별도 zone으로 먼저 자릅니다.
+    location = /api/v1/auth/login {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Host ${backend_proxy_host};
+      proxy_set_header X-Request-Id \$request_id;
+      proxy_set_header X-K6-Run-Id \$http_x_k6_run_id;
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_set_header X-Forwarded-Host \$host;
+      proxy_set_header X-Forwarded-Port \$server_port;
+      proxy_set_header Connection "";
+      limit_req zone=aquila_bank_auth_per_ip burst=10 nodelay;
+      proxy_read_timeout 30s;
+      proxy_send_timeout 30s;
+    }
+
+    location = /api/v1/auth/refresh {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Host ${backend_proxy_host};
+      proxy_set_header X-Request-Id \$request_id;
+      proxy_set_header X-K6-Run-Id \$http_x_k6_run_id;
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_set_header X-Forwarded-Host \$host;
+      proxy_set_header X-Forwarded-Port \$server_port;
+      proxy_set_header Connection "";
+      limit_req zone=aquila_bank_auth_per_ip burst=10 nodelay;
+      proxy_read_timeout 30s;
+      proxy_send_timeout 30s;
+    }
+
+    location = /api/v1/auth/password-recovery/request {
+      proxy_pass http://aquila_bank_backend;
+      proxy_set_header Host ${backend_proxy_host};
+      proxy_set_header X-Request-Id \$request_id;
+      proxy_set_header X-K6-Run-Id \$http_x_k6_run_id;
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_set_header X-Forwarded-Host \$host;
+      proxy_set_header X-Forwarded-Port \$server_port;
+      proxy_set_header Connection "";
+      limit_req zone=aquila_bank_auth_per_ip burst=10 nodelay;
+      proxy_read_timeout 30s;
+      proxy_send_timeout 30s;
+    }
+
     location /api/ {
       proxy_pass http://aquila_bank_backend;
       proxy_set_header Host ${backend_proxy_host};
@@ -616,6 +673,8 @@ http {
       proxy_set_header X-Forwarded-Host \$host;
       proxy_set_header X-Forwarded-Port \$server_port;
       proxy_set_header Connection "";
+      proxy_next_upstream off;
+      limit_req zone=aquila_bank_api_per_ip burst=60 nodelay;
       proxy_read_timeout 30s;
       proxy_send_timeout 30s;
     }

--- a/tools/test/check-oci-a1-bluegreen-cd-contract.sh
+++ b/tools/test/check-oci-a1-bluegreen-cd-contract.sh
@@ -65,8 +65,6 @@ require_file "$workflow"
 require_file "$deploy_script"
 require_file "$database_url_resolver_script"
 require_file "$fixture_principal_script"
-require_file "$delivery_doc"
-require_file "$production_doc"
 require_file "back/Dockerfile"
 require_file "front/Dockerfile"
 require_file "back/src/main/resources/application-oci-a1.yml"
@@ -229,10 +227,19 @@ script_patterns=(
   'proxy_set_header X-Request-Id \$request_id;'
   'proxy_set_header X-K6-Run-Id \$http_x_k6_run_id;'
   '"upstream_status":"\$upstream_status"'
+  '"limit_req_status":"\$limit_req_status"'
   '"k6_run_id":"\$http_x_k6_run_id"'
+  "limit_req_status 429;"
+  'limit_req_zone \$binary_remote_addr zone=aquila_bank_api_per_ip:10m rate=30r/s;'
+  'limit_req_zone \$binary_remote_addr zone=aquila_bank_auth_per_ip:10m rate=5r/s;'
   'proxy_set_header X-Forwarded-Host \$host;'
   "location = /api/v1/notifications/stream"
   "proxy_buffering off;"
+  "location = /api/v1/auth/login"
+  "location = /api/v1/auth/refresh"
+  "location = /api/v1/auth/password-recovery/request"
+  "limit_req zone=aquila_bank_auth_per_ip burst=10 nodelay;"
+  "limit_req zone=aquila_bank_api_per_ip burst=60 nodelay;"
   "nginx -s reload"
   "ensure_nginx_config_visible"
   'docker exec "${NGINX_CONTAINER}" grep -Fq'
@@ -282,26 +289,34 @@ require_pattern "HTTP ingress for OCI A1 staging" "${terraform_dir}/network.tf"
 require_pattern "min = 80" "${terraform_dir}/network.tf"
 
 echo "[oci-a1-bluegreen-cd] docs contract"
-doc_patterns=(
-  "OCI_A1_STAGING_ENV"
-  "OCI self-hosted runner"
-  "oci-a1-staging"
-  "linux/arm64"
-  "OCI_A1_BACKEND_ENV_B64"
-  "STAGING_OCI_A1_DATABASE_URL"
-  "STAGING_REPLAY_USER_ID"
-  "STAGING_BASE_URL"
-)
-for pattern in "${doc_patterns[@]}"; do
-  require_pattern "$pattern" "$delivery_doc"
-done
+if [[ -f "$delivery_doc" ]]; then
+  doc_patterns=(
+    "OCI_A1_STAGING_ENV"
+    "OCI self-hosted runner"
+    "oci-a1-staging"
+    "linux/arm64"
+    "OCI_A1_BACKEND_ENV_B64"
+    "STAGING_OCI_A1_DATABASE_URL"
+    "STAGING_REPLAY_USER_ID"
+    "STAGING_BASE_URL"
+  )
+  for pattern in "${doc_patterns[@]}"; do
+    require_pattern "$pattern" "$delivery_doc"
+  done
+  reject_pattern "OCI_A1_SSH_" "$delivery_doc"
+  reject_pattern "ssh-keyscan" "$delivery_doc"
+else
+  echo "[oci-a1-bluegreen-cd] skip local delivery doc contract: $delivery_doc"
+fi
 require_pattern "self-hosted runner" "ops/deploy/oci/README.md"
 require_pattern "Verify staging 100m replay evidence success" ".github/workflows/production-promotion.yml"
 require_pattern "staging-100m-replay" ".github/workflows/production-promotion.yml"
-reject_pattern "OCI_A1_SSH_" "$delivery_doc"
-reject_pattern "ssh-keyscan" "$delivery_doc"
 reject_pattern "OCI_A1_SSH_" "ops/deploy/oci/README.md"
 reject_pattern "ssh-keyscan" "ops/deploy/oci/README.md"
-require_pattern "same SHA" "$production_doc"
+if [[ -f "$production_doc" ]]; then
+  require_pattern "same SHA" "$production_doc"
+else
+  echo "[oci-a1-bluegreen-cd] skip local production doc contract: $production_doc"
+fi
 
 echo "[oci-a1-bluegreen-cd] contract check passed"


### PR DESCRIPTION
## 🔗 Related Issue
- close #604

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI bluegreen generated Nginx config에 static `ops/nginx/nginx.conf`와 같은 API/auth `limit_req` 정책을 반영합니다.
- edge 429를 backend admission 429와 분리할 수 있도록 generated access log에 `limit_req_status`를 추가합니다.
- docs 추적 해제 이후에도 bluegreen CD contract gate가 로컬 전용 docs 부재로 실패하지 않게 보정합니다.

## 🛠 Changes
- `render_nginx_config` generated config에 `limit_req_status 429`, API/auth per-IP `limit_req_zone`, auth exact location limit, generic `/api/` limit을 추가했습니다.
- bluegreen CD contract test에 generated `limit_req` parity 필수 패턴을 추가했습니다.
- 로컬 전용 `docs/delivery-flow.md`, `docs/production-promotion.md`가 없을 때 문서 계약 검증을 skip하도록 했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `bash tools/test/check-nginx-sse-proxy.sh`
- `bash tools/test/run-nginx-runtime-template-gate.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` → `1`
- 참고: 로컬에 `nginx` binary가 없어 runtime template gate의 `nginx -t` 단계는 skip되었습니다.

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: edge 429 비율이 추가로 관측될 수 있으며, `limit_req` 적용 이후 API/auth burst의 client-visible 429 source가 분리됩니다.
- 롤백 방법: 이 PR 커밋을 revert하면 bluegreen generated config가 이전 API edge limit 미적용 상태로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A - 배포 config parity 보정
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? access log 필드 contract 반영
