### PR TITLE
[Perf] transaction-read HTTP overhead profile 및 serialization 경량화

### DIFF
--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryController.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.web.transaction;
 import com.aquilabank.domain.transaction.model.TransactionCursor;
 import com.aquilabank.domain.transaction.model.TransactionDirection;
 import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
 import com.aquilabank.domain.transaction.model.TransactionStatus;
 import com.aquilabank.domain.transaction.usecase.TransactionArchiveQueryUseCase;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
@@ -27,12 +28,15 @@ public class TransactionArchiveQueryController {
 
   private final TransactionArchiveQueryUseCase transactionArchiveQueryUseCase;
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
+  private final TransactionReadHotPathMetrics hotPathMetrics;
 
   public TransactionArchiveQueryController(
       TransactionArchiveQueryUseCase transactionArchiveQueryUseCase,
-      RequestAccountAuthorizationService requestAccountAuthorizationService) {
+      RequestAccountAuthorizationService requestAccountAuthorizationService,
+      TransactionReadHotPathMetrics hotPathMetrics) {
     this.transactionArchiveQueryUseCase = transactionArchiveQueryUseCase;
     this.requestAccountAuthorizationService = requestAccountAuthorizationService;
+    this.hotPathMetrics = hotPathMetrics;
   }
 
   @GetMapping
@@ -48,11 +52,46 @@ public class TransactionArchiveQueryController {
       @RequestParam(required = false) Long minAmountMinor,
       @RequestParam(required = false) Long maxAmountMinor,
       @RequestParam(required = false) String transactionReference) {
+    return hotPathMetrics.record(
+        TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
+        TransactionReadHotPathMetrics.STAGE_TOTAL,
+        () ->
+            getArchivedTransactionsMeasured(
+                principal,
+                accountId,
+                from,
+                to,
+                limit,
+                cursor,
+                status,
+                direction,
+                minAmountMinor,
+                maxAmountMinor,
+                transactionReference));
+  }
+
+  private TransactionQueryResponse getArchivedTransactionsMeasured(
+      AuthenticatedRequestPrincipal principal,
+      long accountId,
+      OffsetDateTime from,
+      OffsetDateTime to,
+      int limit,
+      String cursor,
+      TransactionStatus status,
+      TransactionDirection direction,
+      Long minAmountMinor,
+      Long maxAmountMinor,
+      String transactionReference) {
     try {
       TransactionCursor decodedCursor =
           cursor == null || cursor.isBlank() ? null : TransactionCursorCodec.decode(cursor);
       long resolvedAccountId =
-          requestAccountAuthorizationService.resolveReadableAccountId(principal, accountId);
+          hotPathMetrics.record(
+              TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
+              TransactionReadHotPathMetrics.STAGE_AUTHORIZATION,
+              () ->
+                  requestAccountAuthorizationService.resolveReadableAccountId(
+                      principal, accountId));
       TransactionQuery query =
           new TransactionQuery(
               resolvedAccountId,
@@ -65,8 +104,15 @@ public class TransactionArchiveQueryController {
               minAmountMinor,
               maxAmountMinor,
               transactionReference);
-      return TransactionQueryResponse.from(
-          transactionArchiveQueryUseCase.getArchivedTransactions(query));
+      TransactionSlice slice =
+          hotPathMetrics.record(
+              TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
+              TransactionReadHotPathMetrics.STAGE_USECASE,
+              () -> transactionArchiveQueryUseCase.getArchivedTransactions(query));
+      return hotPathMetrics.record(
+          TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
+          TransactionReadHotPathMetrics.STAGE_RESPONSE_MAPPING,
+          () -> TransactionQueryResponse.from(slice));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.web.transaction;
 import com.aquilabank.domain.transaction.model.TransactionCursor;
 import com.aquilabank.domain.transaction.model.TransactionDirection;
 import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
 import com.aquilabank.domain.transaction.model.TransactionStatus;
 import com.aquilabank.domain.transaction.usecase.TransactionQueryUseCase;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
@@ -27,12 +28,15 @@ public class TransactionQueryController {
 
   private final TransactionQueryUseCase transactionQueryUseCase;
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
+  private final TransactionReadHotPathMetrics hotPathMetrics;
 
   public TransactionQueryController(
       TransactionQueryUseCase transactionQueryUseCase,
-      RequestAccountAuthorizationService requestAccountAuthorizationService) {
+      RequestAccountAuthorizationService requestAccountAuthorizationService,
+      TransactionReadHotPathMetrics hotPathMetrics) {
     this.transactionQueryUseCase = transactionQueryUseCase;
     this.requestAccountAuthorizationService = requestAccountAuthorizationService;
+    this.hotPathMetrics = hotPathMetrics;
   }
 
   @GetMapping
@@ -48,12 +52,47 @@ public class TransactionQueryController {
       @RequestParam(required = false) Long minAmountMinor,
       @RequestParam(required = false) Long maxAmountMinor,
       @RequestParam(required = false) String transactionReference) {
+    return hotPathMetrics.record(
+        TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
+        TransactionReadHotPathMetrics.STAGE_TOTAL,
+        () ->
+            getTransactionsMeasured(
+                principal,
+                accountId,
+                from,
+                to,
+                limit,
+                cursor,
+                status,
+                direction,
+                minAmountMinor,
+                maxAmountMinor,
+                transactionReference));
+  }
+
+  private TransactionQueryResponse getTransactionsMeasured(
+      AuthenticatedRequestPrincipal principal,
+      long accountId,
+      OffsetDateTime from,
+      OffsetDateTime to,
+      int limit,
+      String cursor,
+      TransactionStatus status,
+      TransactionDirection direction,
+      Long minAmountMinor,
+      Long maxAmountMinor,
+      String transactionReference) {
     try {
       // 첫 page와 후속 page를 같은 endpoint로 통일
       TransactionCursor decodedCursor =
           cursor == null || cursor.isBlank() ? null : TransactionCursorCodec.decode(cursor);
       long resolvedAccountId =
-          requestAccountAuthorizationService.resolveReadableAccountId(principal, accountId);
+          hotPathMetrics.record(
+              TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
+              TransactionReadHotPathMetrics.STAGE_AUTHORIZATION,
+              () ->
+                  requestAccountAuthorizationService.resolveReadableAccountId(
+                      principal, accountId));
       TransactionQuery query =
           new TransactionQuery(
               resolvedAccountId,
@@ -66,7 +105,15 @@ public class TransactionQueryController {
               minAmountMinor,
               maxAmountMinor,
               transactionReference);
-      return TransactionQueryResponse.from(transactionQueryUseCase.getTransactions(query));
+      TransactionSlice slice =
+          hotPathMetrics.record(
+              TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
+              TransactionReadHotPathMetrics.STAGE_USECASE,
+              () -> transactionQueryUseCase.getTransactions(query));
+      return hotPathMetrics.record(
+          TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
+          TransactionReadHotPathMetrics.STAGE_RESPONSE_MAPPING,
+          () -> TransactionQueryResponse.from(slice));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionReadHotPathMetrics.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionReadHotPathMetrics.java
@@ -1,0 +1,41 @@
+package com.aquilabank.global.web.transaction;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+
+/** transaction-read HTTP overhead를 DB query timer와 분리해 보는 low-cardinality timer */
+@Component
+public final class TransactionReadHotPathMetrics {
+
+  static final String ENDPOINT_ACTIVE = "active";
+  static final String ENDPOINT_ARCHIVE = "archive";
+  static final String STAGE_AUTHORIZATION = "authorization";
+  static final String STAGE_USECASE = "usecase";
+  static final String STAGE_RESPONSE_MAPPING = "response_mapping";
+  static final String STAGE_TOTAL = "total";
+
+  private static final String TIMER_NAME = "aquila.transaction.read.http.stage";
+
+  private final MeterRegistry meterRegistry;
+
+  public TransactionReadHotPathMetrics(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  public <T> T record(String endpoint, String stage, Supplier<T> action) {
+    Timer.Sample sample = Timer.start(meterRegistry);
+    String outcome = "success";
+    try {
+      return action.get();
+    } catch (RuntimeException ex) {
+      outcome = "error";
+      throw ex;
+    } finally {
+      sample.stop(
+          meterRegistry.timer(
+              TIMER_NAME, "endpoint", endpoint, "stage", stage, "outcome", outcome));
+    }
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryControllerTest.java
@@ -18,6 +18,7 @@ import com.aquilabank.domain.transaction.usecase.TransactionArchiveQueryUseCase;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
 import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,16 +30,20 @@ class TransactionArchiveQueryControllerTest {
 
   private TransactionArchiveQueryUseCase transactionArchiveQueryUseCase;
   private RequestAccountAuthorizationService requestAccountAuthorizationService;
+  private SimpleMeterRegistry meterRegistry;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
     transactionArchiveQueryUseCase = mock(TransactionArchiveQueryUseCase.class);
     requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
+    meterRegistry = new SimpleMeterRegistry();
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new TransactionArchiveQueryController(
-                    transactionArchiveQueryUseCase, requestAccountAuthorizationService))
+                    transactionArchiveQueryUseCase,
+                    requestAccountAuthorizationService,
+                    new TransactionReadHotPathMetrics(meterRegistry)))
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .build();
@@ -84,6 +89,11 @@ class TransactionArchiveQueryControllerTest {
         .andExpect(jsonPath("$.items[0].transactionReference").value("ARCHIVE-TX-777"))
         .andExpect(jsonPath("$.hasNext").value(true))
         .andExpect(jsonPath("$.nextCursor").isString());
+
+    assertTimerCount("archive", "authorization", "success", 1);
+    assertTimerCount("archive", "usecase", "success", 1);
+    assertTimerCount("archive", "response_mapping", "success", 1);
+    assertTimerCount("archive", "total", "success", 1);
   }
 
   @Test
@@ -137,5 +147,18 @@ class TransactionArchiveQueryControllerTest {
         && Long.valueOf(1000L).equals(query.minAmountMinor())
         && Long.valueOf(2000L).equals(query.maxAmountMinor())
         && "ARCHIVE-TX-777".equals(query.transactionReference());
+  }
+
+  private void assertTimerCount(String endpoint, String stage, String outcome, long expected) {
+    org.assertj.core.api.Assertions.assertThat(
+            meterRegistry
+                .find("aquila.transaction.read.http.stage")
+                .tag("endpoint", endpoint)
+                .tag("stage", stage)
+                .tag("outcome", outcome)
+                .timer())
+        .isNotNull()
+        .extracting(timer -> timer.count())
+        .isEqualTo(expected);
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
@@ -18,6 +18,7 @@ import com.aquilabank.domain.transaction.usecase.TransactionQueryUseCase;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
 import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,16 +30,20 @@ class TransactionQueryControllerTest {
 
   private TransactionQueryUseCase transactionQueryUseCase;
   private RequestAccountAuthorizationService requestAccountAuthorizationService;
+  private SimpleMeterRegistry meterRegistry;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
     transactionQueryUseCase = mock(TransactionQueryUseCase.class);
     requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
+    meterRegistry = new SimpleMeterRegistry();
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new TransactionQueryController(
-                    transactionQueryUseCase, requestAccountAuthorizationService))
+                    transactionQueryUseCase,
+                    requestAccountAuthorizationService,
+                    new TransactionReadHotPathMetrics(meterRegistry)))
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .build();
@@ -84,6 +89,11 @@ class TransactionQueryControllerTest {
         .andExpect(jsonPath("$.items[0].status").value("BOOKED"))
         .andExpect(jsonPath("$.hasNext").value(true))
         .andExpect(jsonPath("$.nextCursor").isString());
+
+    assertTimerCount("active", "authorization", "success", 1);
+    assertTimerCount("active", "usecase", "success", 1);
+    assertTimerCount("active", "response_mapping", "success", 1);
+    assertTimerCount("active", "total", "success", 1);
   }
 
   @Test
@@ -190,5 +200,18 @@ class TransactionQueryControllerTest {
         && Long.valueOf(1000L).equals(query.minAmountMinor())
         && Long.valueOf(2000L).equals(query.maxAmountMinor())
         && "TX-777".equals(query.transactionReference());
+  }
+
+  private void assertTimerCount(String endpoint, String stage, String outcome, long expected) {
+    org.assertj.core.api.Assertions.assertThat(
+            meterRegistry
+                .find("aquila.transaction.read.http.stage")
+                .tag("endpoint", endpoint)
+                .tag("stage", stage)
+                .tag("outcome", outcome)
+                .timer())
+        .isNotNull()
+        .extracting(timer -> timer.count())
+        .isEqualTo(expected);
   }
 }

--- a/tools/test/check-ec2-local-db-resource-and-comparison.sh
+++ b/tools/test/check-ec2-local-db-resource-and-comparison.sh
@@ -94,8 +94,10 @@ fi
 echo "[ec2-resource-comparison] comparison report"
 direct_md="${temp_dir}/direct.md"
 nginx_md="${temp_dir}/nginx.md"
+local_loopback_md="${temp_dir}/local-loopback.md"
 cat >"${direct_md}" <<'MD'
 # direct
+- run id: overhead-run-001
 - transaction 429 rate: 0
 - transaction 503 rate: 0
 - transaction 503 count: 0
@@ -110,6 +112,7 @@ cat >"${direct_md}" <<'MD'
 MD
 cat >"${nginx_md}" <<'MD'
 # nginx
+- run id: overhead-run-001
 - transaction 429 rate: 0.01
 - transaction 503 rate: 0
 - transaction 503 count: 0
@@ -122,13 +125,30 @@ cat >"${nginx_md}" <<'MD'
 - cold cursor p95 ms: 190
 - cold cursor p99 ms: 225
 MD
+cat >"${local_loopback_md}" <<'MD'
+# local loopback
+- run id: overhead-run-001
+- transaction 429 rate: 0
+- transaction 503 rate: 0
+- transaction 503 count: 0
+- hot first p95 ms: 104
+- hot first p99 ms: 126
+- hot cursor p95 ms: 82
+- hot cursor p99 ms: 93
+- cold first p95 ms: 205
+- cold first p99 ms: 246
+- cold cursor p95 ms: 184
+- cold cursor p99 ms: 215
+MD
 output_md="${temp_dir}/comparison.md"
 EC2_DIRECT_K6_SUMMARY_MD="${direct_md}" \
 EC2_NGINX_K6_SUMMARY_MD="${nginx_md}" \
+EC2_LOCAL_LOOPBACK_K6_SUMMARY_MD="${local_loopback_md}" \
 EC2_COMPARISON_OUTPUT_MD="${output_md}" \
   "${compare_script}" >/dev/null
-grep -F "| hot first p95 ms | 100 | 110 | 10.000 |" "${output_md}" >/dev/null
-grep -F "| transaction 429 rate | 0 | 0.01 | 0.010 |" "${output_md}" >/dev/null
+grep -F "run id: overhead-run-001" "${output_md}" >/dev/null
+grep -F "| hot first p95 ms | 100 | 110 | 104 | 10.000 | 4.000 |" "${output_md}" >/dev/null
+grep -F "| transaction 429 rate | 0 | 0.01 | 0 | 0.010 | 0.000 |" "${output_md}" >/dev/null
 
 echo "[ec2-resource-comparison] invalid comparison fails"
 if EC2_DIRECT_K6_SUMMARY_MD="${temp_dir}/missing.md" EC2_NGINX_K6_SUMMARY_MD="${nginx_md}" "${compare_script}" >/dev/null 2>&1; then

--- a/tools/test/check-transaction-read-hotpath-profile.sh
+++ b/tools/test/check-transaction-read-hotpath-profile.sh
@@ -24,6 +24,10 @@ grep -F "k6 vus=8 duration=15s" <<<"${plan}" >/dev/null
 grep -F "jfr duration=20s" <<<"${plan}" >/dev/null
 grep -F "k6_generator_mode=docker-context" <<<"${plan}" >/dev/null
 grep -F "k6_docker_context=profile-k6-remote" <<<"${plan}" >/dev/null
+grep -F "k6_run_id=transaction-read-hotpath-check-k6" <<<"${plan}" >/dev/null
+grep -F "backend_timer=aquila_transaction_read_http_stage_seconds" <<<"${plan}" >/dev/null
+grep -F "backend_timer_labels=endpoint,stage,outcome" <<<"${plan}" >/dev/null
+grep -F "method_timer_stage=authorization,usecase,response_mapping,total" <<<"${plan}" >/dev/null
 grep -F "jfr_dump_timeout_seconds=60" <<<"${plan}" >/dev/null
 grep -F "backend_health_url=http://localhost:8080/actuator/health" <<<"${plan}" >/dev/null
 grep -F "artifact=build/reports/profiling/transaction-read-hotpath-check/transaction-read-hotpath-check.jfr" <<<"${plan}" >/dev/null
@@ -75,6 +79,8 @@ grep -F "view --width 160 hot-methods" "${script}" >/dev/null
 grep -F "view --width 160 allocation-by-class" "${script}" >/dev/null
 grep -F "hot_first_spike_metrics" "${script}" >/dev/null
 grep -F "aquila_transaction_hot_first_ms" "${script}" >/dev/null
+grep -F "aquila.transaction.read.http.stage" "${script}" >/dev/null
+grep -F "backend method timer" "${script}" >/dev/null
 grep -F '\`build/reports/profiling\`' "${script}" >/dev/null
 grep -F "artifact missing or empty" "${script}" >/dev/null
 

--- a/tools/test/compare-ec2-direct-vs-nginx-latency.sh
+++ b/tools/test/compare-ec2-direct-vs-nginx-latency.sh
@@ -8,6 +8,7 @@ usage: tools/test/compare-ec2-direct-vs-nginx-latency.sh [--print-plan]
 Environment:
   EC2_DIRECT_K6_SUMMARY_MD required
   EC2_NGINX_K6_SUMMARY_MD required
+  EC2_LOCAL_LOOPBACK_K6_SUMMARY_MD optional
   EC2_COMPARISON_NAME default ec2-direct-vs-nginx-<timestamp>
   EC2_COMPARISON_OUTPUT_MD default build/reports/ec2-local-db/<name>/<name>.md
 USAGE
@@ -25,6 +26,7 @@ done
 
 direct_md="${EC2_DIRECT_K6_SUMMARY_MD:-}"
 nginx_md="${EC2_NGINX_K6_SUMMARY_MD:-}"
+local_loopback_md="${EC2_LOCAL_LOOPBACK_K6_SUMMARY_MD:-}"
 name="${EC2_COMPARISON_NAME:-ec2-direct-vs-nginx-$(date +%Y-%m-%d-%H%M%S)}"
 output_md="${EC2_COMPARISON_OUTPUT_MD:-build/reports/ec2-local-db/${name}/${name}.md}"
 
@@ -43,22 +45,52 @@ metric_value() {
   awk -F': ' -v label="- ${label}: " '$0 ~ "^" label {print $2; found=1; exit} END {exit !found}' "${path}"
 }
 
+metric_value_or_na() {
+  local path="$1"
+  local label="$2"
+  awk -F': ' -v label="- ${label}: " '$0 ~ "^" label {print $2; found=1; exit} END {if (!found) print "n/a"}' "${path}"
+}
+
 delta_value() {
   local direct="$1"
-  local nginx="$2"
-  awk -v direct="${direct}" -v nginx="${nginx}" 'BEGIN {
-    if (direct == "n/a" || nginx == "n/a") {
+  local target="$2"
+  awk -v direct="${direct}" -v target="${target}" 'BEGIN {
+    if (direct == "n/a" || target == "n/a") {
       print "n/a";
       exit;
     }
-    printf "%.3f", nginx - direct;
+    printf "%.3f", target - direct;
   }'
+}
+
+same_or_mixed_run_id() {
+  local direct="$1"
+  local nginx="$2"
+  local local_loopback="$3"
+  if [[ "${direct}" == "n/a" && "${nginx}" == "n/a" && "${local_loopback}" == "n/a" ]]; then
+    echo "n/a"
+    return
+  fi
+  if [[ "${local_loopback}" == "n/a" ]]; then
+    if [[ "${direct}" == "${nginx}" ]]; then
+      echo "${direct}"
+    else
+      echo "mixed direct=${direct} nginx=${nginx}"
+    fi
+    return
+  fi
+  if [[ "${direct}" == "${nginx}" && "${direct}" == "${local_loopback}" ]]; then
+    echo "${direct}"
+  else
+    echo "mixed direct=${direct} nginx=${nginx} local_loopback=${local_loopback}"
+  fi
 }
 
 print_plan() {
   echo "[ec2-direct-vs-nginx] mode=${mode}"
   echo "[ec2-direct-vs-nginx] direct_md=${direct_md:-missing}"
   echo "[ec2-direct-vs-nginx] nginx_md=${nginx_md:-missing}"
+  echo "[ec2-direct-vs-nginx] local_loopback_md=${local_loopback_md:-optional-missing}"
   echo "[ec2-direct-vs-nginx] output_md=${output_md}"
 }
 
@@ -69,6 +101,9 @@ fi
 
 require_file "EC2_DIRECT_K6_SUMMARY_MD" "${direct_md}"
 require_file "EC2_NGINX_K6_SUMMARY_MD" "${nginx_md}"
+if [[ -n "${local_loopback_md}" ]]; then
+  require_file "EC2_LOCAL_LOOPBACK_K6_SUMMARY_MD" "${local_loopback_md}"
+fi
 mkdir -p "$(dirname "${output_md}")"
 
 labels=(
@@ -85,19 +120,57 @@ labels=(
   "transaction 503 count"
 )
 
+direct_run_id="$(metric_value_or_na "${direct_md}" "run id")"
+nginx_run_id="$(metric_value_or_na "${nginx_md}" "run id")"
+if [[ -n "${local_loopback_md}" ]]; then
+  local_loopback_run_id="$(metric_value_or_na "${local_loopback_md}" "run id")"
+else
+  local_loopback_run_id="n/a"
+fi
+run_id="$(same_or_mixed_run_id "${direct_run_id}" "${nginx_run_id}" "${local_loopback_run_id}")"
+
 {
-  echo "# EC2 Direct vs Nginx 100m Latency Comparison"
+  if [[ -n "${local_loopback_md}" ]]; then
+    echo "# EC2 Direct vs Nginx vs Local Loopback 100m Latency Comparison"
+  else
+    echo "# EC2 Direct vs Nginx 100m Latency Comparison"
+  fi
   echo
+  echo "- run id: ${run_id}"
   echo "- direct summary: ${direct_md}"
   echo "- nginx summary: ${nginx_md}"
+  if [[ -n "${local_loopback_md}" ]]; then
+    echo "- local loopback summary: ${local_loopback_md}"
+  fi
   echo
-  echo "| metric | direct | nginx | nginx-direct |"
-  echo "|---|---:|---:|---:|"
+  if [[ -n "${local_loopback_md}" ]]; then
+    echo "| metric | direct | nginx | local_loopback | nginx-direct | local-direct |"
+    echo "|---|---:|---:|---:|---:|---:|"
+  else
+    echo "| metric | direct | nginx | nginx-direct |"
+    echo "|---|---:|---:|---:|"
+  fi
   for label in "${labels[@]}"; do
     direct_value="$(metric_value "${direct_md}" "${label}")"
     nginx_value="$(metric_value "${nginx_md}" "${label}")"
-    delta="$(delta_value "${direct_value}" "${nginx_value}")"
-    printf "| %s | %s | %s | %s |\n" "${label}" "${direct_value}" "${nginx_value}" "${delta}"
+    nginx_delta="$(delta_value "${direct_value}" "${nginx_value}")"
+    if [[ -n "${local_loopback_md}" ]]; then
+      local_loopback_value="$(metric_value "${local_loopback_md}" "${label}")"
+      local_delta="$(delta_value "${direct_value}" "${local_loopback_value}")"
+      printf "| %s | %s | %s | %s | %s | %s |\n" \
+        "${label}" \
+        "${direct_value}" \
+        "${nginx_value}" \
+        "${local_loopback_value}" \
+        "${nginx_delta}" \
+        "${local_delta}"
+    else
+      printf "| %s | %s | %s | %s |\n" \
+        "${label}" \
+        "${direct_value}" \
+        "${nginx_value}" \
+        "${nginx_delta}"
+    fi
   done
 } >"${output_md}"
 

--- a/tools/test/run-transaction-read-hotpath-profile.sh
+++ b/tools/test/run-transaction-read-hotpath-profile.sh
@@ -36,6 +36,7 @@ Optional environment:
   K6_DURATION               default 1m
   K6_LIMIT                  default 50
   K6_REPORT_NAME            default <profile-name>-k6
+  K6_RUN_ID                 default K6_REPORT_NAME; Prometheus/k6 summary correlation id
 
 Examples:
   tools/test/run-transaction-read-hotpath-profile.sh --print-plan
@@ -99,6 +100,7 @@ k6_overload_mode="${K6_OVERLOAD_MODE:-${default_k6_overload_mode}}"
 k6_burst_429_rate_threshold="${K6_BURST_429_RATE_THRESHOLD:-0.10}"
 k6_limit="${K6_LIMIT:-50}"
 k6_report_name="${K6_REPORT_NAME:-${profile_name}-k6}"
+k6_run_id="${K6_RUN_ID:-${k6_report_name}}"
 report_dir="build/reports/profiling/${profile_name}"
 jfr_container_path="/tmp/${profile_name}.jfr"
 jfr_artifact="${report_dir}/${profile_name}.jfr"
@@ -278,6 +280,7 @@ print_plan() {
   echo "[transaction-read-hotpath-profile] spike_profile=${profile_spike_profile}"
   echo "[transaction-read-hotpath-profile] admission=${profile_admission} db_pool=${profile_db_pool_max_size}"
   echo "[transaction-read-hotpath-profile] k6 vus=${k6_vus} duration=${k6_duration} limit=${k6_limit} report=${k6_report_name}"
+  echo "[transaction-read-hotpath-profile] k6_run_id=${k6_run_id}"
   echo "[transaction-read-hotpath-profile] k6 scenario=${profile_k6_scenario_mode}"
   echo "[transaction-read-hotpath-profile] k6 burst rate=${k6_burst_rate} duration=${k6_burst_duration}"
   echo "[transaction-read-hotpath-profile] k6_overload_mode=${k6_overload_mode}"
@@ -290,6 +293,9 @@ print_plan() {
   echo "[transaction-read-hotpath-profile] jfr_dump_timeout_seconds=${profile_jfr_dump_timeout_seconds}"
   echo "[transaction-read-hotpath-profile] backend_health_url=${backend_health_url}"
   echo "[transaction-read-hotpath-profile] readiness_timeout_seconds=${profile_readiness_timeout_seconds}"
+  echo "[transaction-read-hotpath-profile] backend_timer=aquila_transaction_read_http_stage_seconds"
+  echo "[transaction-read-hotpath-profile] backend_timer_labels=endpoint,stage,outcome"
+  echo "[transaction-read-hotpath-profile] method_timer_stage=authorization,usecase,response_mapping,total"
   echo "[transaction-read-hotpath-profile] artifact=${jfr_artifact}"
   echo "[transaction-read-hotpath-profile] jfr_summary=${jfr_summary_txt}"
   echo "[transaction-read-hotpath-profile] hot_first_spike_metric=aquila_transaction_hot_first_ms"
@@ -343,6 +349,7 @@ K6_REMOTE_BASE_URL="${profile_k6_remote_base_url}" \
 K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${profile_k6_remote_prometheus_rw_server_url}" \
 K6_REMOTE_WORKDIR="${profile_k6_remote_workdir}" \
 K6_REPORT_NAME="${k6_report_name}" \
+K6_RUN_ID="${k6_run_id}" \
 K6_OVERLOAD_MODE="${k6_overload_mode}" \
 K6_BURST_429_RATE_THRESHOLD="${k6_burst_429_rate_threshold}" \
 K6_HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
@@ -431,6 +438,7 @@ cat >"${summary_md}" <<SUMMARY
 - spike profile: ${profile_spike_profile}
 - admission: ${profile_admission}
 - db pool max size: ${profile_db_pool_max_size}
+- k6 run id: ${k6_run_id}
 - k6 scenario: ${profile_k6_scenario_mode}
 - k6 vus: ${k6_vus}
 - k6 duration: ${k6_duration}
@@ -452,6 +460,14 @@ cat >"${summary_md}" <<SUMMARY
 - k6 summary json: ${k6_summary_json}
 - k6 summary markdown: ${k6_summary_md}
 - run log: ${run_log}
+
+## Backend Method Timers
+
+- backend method timer: \`aquila.transaction.read.http.stage\`
+- prometheus metric: \`aquila_transaction_read_http_stage_seconds\`
+- labels: \`endpoint\`, \`stage\`, \`outcome\`
+- stages: \`authorization\`, \`usecase\`, \`response_mapping\`, \`total\`
+- correlation: compare this timer with k6 \`run_id=${k6_run_id}\` and Nginx \`X-K6-Run-Id\` logs for the same window.
 
 ## Result
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #606

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction-read HTTP adapter에 active/archive stage timer를 추가해 DB query timer와 HTTP overhead를 분리합니다.
- profile runner가 k6 run id와 backend method timer 확인 지점을 summary에 남기도록 확장했습니다.
- direct backend / Nginx / local loopback summary를 같은 run id로 비교할 수 있게 comparison report를 확장했습니다.

## 🛠 Changes
- `aquila.transaction.read.http.stage` timer 추가: `endpoint`, `stage`, `outcome` label.
- active/archive controller에 `authorization`, `usecase`, `response_mapping`, `total` stage 계측 추가.
- hotpath profile contract에 backend timer와 k6 run id correlation 정보를 추가.
- direct vs Nginx comparison script에 optional local loopback summary 열과 run id 비교를 추가.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back test --tests '*TransactionQueryResponseTest' --tests '*TransactionQueryControllerTest' --tests '*TransactionArchiveQueryControllerTest'`
- `bash tools/test/check-transaction-read-hotpath-profile.sh`
- `bash tools/test/check-ec2-local-db-resource-and-comparison.sh`
- `git diff --check`
- pre-commit: `./back/gradlew -p back check`
- `git rev-list --count main..HEAD` → `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Prometheus metric series가 endpoint/stage/outcome 조합만큼 증가합니다. label은 고정 enum 값만 사용해 cardinality를 제한했습니다.
- 롤백 방법: 이 PR 커밋을 revert하면 controller stage timer와 profile comparison 확장이 제거됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A - metrics/profile contract
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? profile runner summary와 metric contract 반영
