### PR TITLE
[Perf] transaction-read cache-state SLO 및 48-64 capacity gate 분리

### DIFF
--- a/tools/test/check-transaction-100m-cold-start-cache-warm-gate.sh
+++ b/tools/test/check-transaction-100m-cold-start-cache-warm-gate.sh
@@ -26,8 +26,10 @@ grep -F "cold_start_p95_threshold_ms=1000" <<<"${plan}" >/dev/null
 grep -F "warm_hot_p95_threshold_ms=350" <<<"${plan}" >/dev/null
 grep -F "warm_cold_p95_threshold_ms=750" <<<"${plan}" >/dev/null
 grep -F "transaction_429_rate_threshold=0" <<<"${plan}" >/dev/null
+grep -F "transaction_503_rate_threshold=0" <<<"${plan}" >/dev/null
 grep -F "runner=tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" <<<"${plan}" >/dev/null
 grep -F "summary=build/reports/k6/transaction-cold-warm-check/cold-warm-summary.tsv" <<<"${plan}" >/dev/null
+grep -F "report=build/reports/k6/transaction-cold-warm-check/cold-warm-cache-state-slo.md" <<<"${plan}" >/dev/null
 
 echo "[transaction-100m-cold-warm] runner contract"
 grep -F "COLD_WARM_FORCE_RECREATE" "${script}" >/dev/null
@@ -46,6 +48,13 @@ grep -F "run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${script}" >/de
 grep -F "cold-start" "${script}" >/dev/null
 grep -F "warm-read" "${script}" >/dev/null
 grep -F "cold-warm-summary.tsv" "${script}" >/dev/null
+grep -F "cold-warm-cache-state-slo.md" "${script}" >/dev/null
+grep -F "cache_state" "${script}" >/dev/null
+grep -F "first_p95_ms" "${script}" >/dev/null
+grep -F "deep_p95_ms" "${script}" >/dev/null
+grep -F "aquila_transaction_503_rate" "${script}" >/dev/null
+grep -F "aquila_transaction_503_count" "${script}" >/dev/null
+grep -F "write_report" "${script}" >/dev/null
 grep -F "check_phase_thresholds" "${script}" >/dev/null
 
 echo "[transaction-100m-cold-warm] invalid input fails"

--- a/tools/test/check-transaction-read-48-64-capacity-gate.sh
+++ b/tools/test/check-transaction-read-48-64-capacity-gate.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-48-64-capacity-gate.sh"
+
+echo "[transaction-read-48-64-capacity] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+summary_dir="${temp_dir}/summaries"
+output_dir="${temp_dir}/output"
+mkdir -p "${summary_dir}"
+
+write_summary() {
+  local rate="$1"
+  local transaction_429_rate="$2"
+  local hot_first_p95="$3"
+  local hot_cursor_p95="$4"
+  local cold_first_p95="$5"
+  local cold_cursor_p95="$6"
+  local transaction_503_rate="${7:-0}"
+  local transaction_503_count="${8:-0}"
+  local dropped_iterations="${9:-0}"
+  local interrupted_iterations="${10:-0}"
+  cat >"${summary_dir}/rate-${rate}-summary.json" <<JSON
+{
+  "metrics": {
+    "http_req_failed": {"values": {"rate": 0}},
+    "http_req_duration": {"values": {"p(95)": ${hot_cursor_p95}}},
+    "http_reqs": {"values": {"count": 4096}},
+    "dropped_iterations": {"values": {"count": ${dropped_iterations}}},
+    "interrupted_iterations": {"values": {"count": ${interrupted_iterations}}},
+    "aquila_transaction_429_rate": {"values": {"rate": ${transaction_429_rate}}},
+    "aquila_transaction_503_rate": {"values": {"rate": ${transaction_503_rate}}},
+    "aquila_transaction_503_count": {"values": {"count": ${transaction_503_count}}},
+    "aquila_transaction_hot_first_ms": {"values": {"p(95)": ${hot_first_p95}}},
+    "aquila_transaction_hot_cursor_ms": {"values": {"p(95)": ${hot_cursor_p95}}},
+    "aquila_transaction_cold_first_ms": {"values": {"p(95)": ${cold_first_p95}}},
+    "aquila_transaction_cold_cursor_ms": {"values": {"p(95)": ${cold_cursor_p95}}}
+  }
+}
+JSON
+}
+
+write_summary 52 0.020 72 88 95 120
+write_summary 56 0.060 81 102 110 145
+write_summary 60 0.091 91 130 138 180
+write_summary 64 0.120 110 190 210 260
+
+echo "[transaction-read-48-64-capacity] print plan"
+plan="$(
+  CAPACITY_48_64_GATE_NAME=capacity-check \
+  CAPACITY_48_64_SUMMARY_DIR="${summary_dir}" \
+  CAPACITY_48_64_OUTPUT_DIR="${output_dir}" \
+  CAPACITY_48_64_WARN_RATE=0.08 \
+  CAPACITY_48_64_FAIL_RATE=0.10 \
+    "${runner}" --print-plan
+)"
+grep -F "gate=capacity-check" <<<"${plan}" >/dev/null
+grep -F "lower_anchor_rate=48" <<<"${plan}" >/dev/null
+grep -F "rates=52,56,60,64" <<<"${plan}" >/dev/null
+grep -F "summary_dir=${summary_dir}" <<<"${plan}" >/dev/null
+grep -F "output_dir=${output_dir}" <<<"${plan}" >/dev/null
+grep -F "run_k6=false" <<<"${plan}" >/dev/null
+grep -F "warn_rate=0.08" <<<"${plan}" >/dev/null
+grep -F "fail_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "report_md=${output_dir}/capacity-check-48-64-capacity.md" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-48-64-capacity] aggregate boundary"
+set +e
+output="$(
+  CAPACITY_48_64_GATE_NAME=capacity-check \
+  CAPACITY_48_64_SUMMARY_DIR="${summary_dir}" \
+  CAPACITY_48_64_OUTPUT_DIR="${output_dir}" \
+  CAPACITY_48_64_WARN_RATE=0.08 \
+  CAPACITY_48_64_FAIL_RATE=0.10 \
+    "${runner}"
+)"
+status=$?
+set -e
+if [[ "${status}" -eq 0 ]]; then
+  echo "48-64 boundary unexpectedly passed despite 64 it/s fail sample" >&2
+  exit 1
+fi
+report_md="$(tail -1 <<<"${output}")"
+summary_tsv="${output_dir}/capacity-check-48-64-capacity.tsv"
+test "${report_md}" = "${output_dir}/capacity-check-48-64-capacity.md"
+grep -F $'rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\thttp_req_duration_p95_ms\tfirst_p95_ms\tdeep_p95_ms\tdropped_iterations\tinterrupted_iterations\tgenerator_headroom_status\treport_md\tsummary_json' "${summary_tsv}" >/dev/null
+grep -F $'52\tpass\t0.020\t0\t0\t88\t95\t120\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'56\tpass\t0.060\t0\t0\t102\t110\t145\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'60\twarn\t0.091\t0\t0\t130\t138\t180\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'64\tfail\t0.120\t0\t0\t190\t210\t260\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F "gate_status=fail" "${report_md}" >/dev/null
+grep -F "lower_anchor_rate=48" "${report_md}" >/dev/null
+grep -F "stable_pass_rate=56" "${report_md}" >/dev/null
+grep -F "max_non_fail_rate=60" "${report_md}" >/dev/null
+grep -F "first_fail_rate=64" "${report_md}" >/dev/null
+grep -F "| 64 | fail | 0.120 | 0 | 0 | 190 | 210 | 260 | pass |" "${report_md}" >/dev/null
+
+echo "[transaction-read-48-64-capacity] generator headroom fail"
+write_summary 64 0.020 80 90 100 120 0 0 1 0
+if CAPACITY_48_64_GATE_NAME=capacity-headroom-fail \
+  CAPACITY_48_64_SUMMARY_DIR="${summary_dir}" \
+  CAPACITY_48_64_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "generator headroom failure unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "[transaction-read-48-64-capacity] runner contract"
+grep -F "run-transaction-read-burst-429-budget-gate.sh" "${runner}" >/dev/null
+grep -F "CAPACITY_48_64_RATES" "${runner}" >/dev/null
+grep -F "52,56,60,64" "${runner}" >/dev/null
+grep -F "lower_anchor_rate" "${runner}" >/dev/null
+grep -F "stable_pass_rate" "${runner}" >/dev/null
+grep -F "max_non_fail_rate" "${runner}" >/dev/null
+grep -F "first_fail_rate" "${runner}" >/dev/null
+grep -F "http_req_duration" "${runner}" >/dev/null
+grep -F "first_p95_ms" "${runner}" >/dev/null
+grep -F "deep_p95_ms" "${runner}" >/dev/null
+grep -F "generator_headroom_status" "${runner}" >/dev/null
+
+echo "[transaction-read-48-64-capacity] invalid input fails"
+if CAPACITY_48_64_RATES=bad "${runner}" --print-plan >/dev/null 2>&1; then
+  echo "invalid capacity rate unexpectedly succeeded" >&2
+  exit 1
+fi
+if CAPACITY_48_64_WARN_RATE=0.12 CAPACITY_48_64_FAIL_RATE=0.10 "${runner}" --print-plan >/dev/null 2>&1; then
+  echo "warn greater than fail unexpectedly succeeded" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh
+++ b/tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh
@@ -28,6 +28,7 @@ Optional environment:
   COLD_WARM_WARM_HOT_P95_THRESHOLD_MS    default 350
   COLD_WARM_WARM_COLD_P95_THRESHOLD_MS   default 750
   COLD_WARM_429_RATE_THRESHOLD           default 0
+  COLD_WARM_503_RATE_THRESHOLD           default 0
 
 Examples:
   tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh --print-plan
@@ -67,12 +68,14 @@ cold_start_p95_threshold_ms="${COLD_WARM_COLD_START_P95_THRESHOLD_MS:-1000}"
 warm_hot_p95_threshold_ms="${COLD_WARM_WARM_HOT_P95_THRESHOLD_MS:-350}"
 warm_cold_p95_threshold_ms="${COLD_WARM_WARM_COLD_P95_THRESHOLD_MS:-750}"
 transaction_429_rate_threshold="${COLD_WARM_429_RATE_THRESHOLD:-0}"
+transaction_503_rate_threshold="${COLD_WARM_503_RATE_THRESHOLD:-0}"
 backend_health_url="${COLD_WARM_BACKEND_HEALTH_URL:-http://localhost:${BACKEND_PORT:-8080}/actuator/health}"
 prometheus_url="${PROMETHEUS_URL:-http://localhost:9090}"
 prometheus_base_url="${prometheus_url%/}"
 compose_files=(-f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml)
 report_dir="build/reports/k6/${name}"
 summary_tsv="${report_dir}/cold-warm-summary.tsv"
+report_md="${report_dir}/cold-warm-cache-state-slo.md"
 threshold_failed=false
 
 require_bool_value() {
@@ -152,6 +155,7 @@ require_positive_number_value "COLD_WARM_COLD_START_P95_THRESHOLD_MS" "${cold_st
 require_positive_number_value "COLD_WARM_WARM_HOT_P95_THRESHOLD_MS" "${warm_hot_p95_threshold_ms}"
 require_positive_number_value "COLD_WARM_WARM_COLD_P95_THRESHOLD_MS" "${warm_cold_p95_threshold_ms}"
 require_rate_value "COLD_WARM_429_RATE_THRESHOLD" "${transaction_429_rate_threshold}"
+require_rate_value "COLD_WARM_503_RATE_THRESHOLD" "${transaction_503_rate_threshold}"
 
 print_plan() {
   echo "[transaction-100m-cold-warm] name=${name}"
@@ -170,8 +174,10 @@ print_plan() {
   echo "[transaction-100m-cold-warm] warm_hot_p95_threshold_ms=${warm_hot_p95_threshold_ms}"
   echo "[transaction-100m-cold-warm] warm_cold_p95_threshold_ms=${warm_cold_p95_threshold_ms}"
   echo "[transaction-100m-cold-warm] transaction_429_rate_threshold=${transaction_429_rate_threshold}"
+  echo "[transaction-100m-cold-warm] transaction_503_rate_threshold=${transaction_503_rate_threshold}"
   echo "[transaction-100m-cold-warm] runner=tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps"
   echo "[transaction-100m-cold-warm] summary=${summary_tsv}"
+  echo "[transaction-100m-cold-warm] report=${report_md}"
 }
 
 print_plan
@@ -231,7 +237,7 @@ wait_for_prometheus_readiness() {
 }
 
 write_header() {
-  printf "phase\tstatus\tvus\tduration\tlimit\thttp_failed_rate\thttp_reqs\ttransaction_429_rate\thot_first_p95_ms\thot_cursor_p95_ms\tcold_first_p95_ms\tcold_cursor_p95_ms\tlog_path\tsummary_json\n" >"${summary_tsv}"
+  printf "phase\tcache_state\tstatus\tvus\tduration\tlimit\thttp_failed_rate\thttp_reqs\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\tfirst_p95_ms\tdeep_p95_ms\thot_first_p95_ms\thot_cursor_p95_ms\tcold_first_p95_ms\tcold_cursor_p95_ms\tlog_path\tsummary_json\n" >"${summary_tsv}"
 }
 
 append_summary() {
@@ -246,6 +252,17 @@ number_greater_than() {
   local value="$1"
   local threshold="$2"
   awk -v value="${value}" -v threshold="${threshold}" 'BEGIN { exit !(value > threshold) }'
+}
+
+max_numeric_value() {
+  local result="n/a"
+  local value
+  for value in "$@"; do
+    if is_numeric_value "${value}" && { [[ "${result}" == "n/a" ]] || number_greater_than "${value}" "${result}"; }; then
+      result="${value}"
+    fi
+  done
+  echo "${result}"
 }
 
 record_threshold_violation() {
@@ -276,10 +293,12 @@ check_phase_thresholds() {
   local phase="$1"
   local status="$2"
   local transaction_429_rate="$3"
-  local hot_first_p95="$4"
-  local hot_cursor_p95="$5"
-  local cold_first_p95="$6"
-  local cold_cursor_p95="$7"
+  local transaction_503_rate="$4"
+  local transaction_503_count="$5"
+  local hot_first_p95="$6"
+  local hot_cursor_p95="$7"
+  local cold_first_p95="$8"
+  local cold_cursor_p95="$9"
 
   if [[ "${hard_threshold_enabled}" != "true" ]]; then
     return 0
@@ -290,6 +309,8 @@ check_phase_thresholds() {
   fi
 
   check_metric_lte "${phase}" "transaction_429_rate" "${transaction_429_rate}" "${transaction_429_rate_threshold}"
+  check_metric_lte "${phase}" "transaction_503_rate" "${transaction_503_rate}" "${transaction_503_rate_threshold}"
+  check_metric_lte "${phase}" "transaction_503_count" "${transaction_503_count}" "0"
   if [[ "${phase}" == "cold-start" ]]; then
     check_metric_lte "${phase}" "hot_first_p95_ms" "${hot_first_p95}" "${cold_start_p95_threshold_ms}"
     check_metric_lte "${phase}" "hot_cursor_p95_ms" "${hot_cursor_p95}" "${cold_start_p95_threshold_ms}"
@@ -316,11 +337,12 @@ start_loadtest_services() {
 run_k6_phase() {
   local phase="$1"
   local duration="$2"
+  local cache_state="$3"
   local report_name="${name}-${phase}"
   local log_path="${report_dir}/${report_name}.log"
   local summary_json="build/reports/k6/${report_name}-summary.json"
-  local status http_failed_rate http_reqs transaction_429_rate
-  local hot_first_p95 hot_cursor_p95 cold_first_p95 cold_cursor_p95
+  local status http_failed_rate http_reqs transaction_429_rate transaction_503_rate transaction_503_count
+  local hot_first_p95 hot_cursor_p95 cold_first_p95 cold_cursor_p95 first_p95 deep_p95
 
   echo "[transaction-100m-cold-warm] running phase=${phase} duration=${duration}"
   set +e
@@ -337,20 +359,70 @@ run_k6_phase() {
   http_failed_rate="$(metric_from_json "${summary_json}" "http_req_failed" "rate")"
   http_reqs="$(metric_from_json "${summary_json}" "http_reqs" "count")"
   transaction_429_rate="$(metric_from_json "${summary_json}" "aquila_transaction_429_rate" "rate")"
+  transaction_503_rate="$(metric_from_json "${summary_json}" "aquila_transaction_503_rate" "rate")"
+  transaction_503_count="$(metric_from_json "${summary_json}" "aquila_transaction_503_count" "count")"
   hot_first_p95="$(metric_from_json "${summary_json}" "aquila_transaction_hot_first_ms" "p(95)")"
   hot_cursor_p95="$(metric_from_json "${summary_json}" "aquila_transaction_hot_cursor_ms" "p(95)")"
   cold_first_p95="$(metric_from_json "${summary_json}" "aquila_transaction_cold_first_ms" "p(95)")"
   cold_cursor_p95="$(metric_from_json "${summary_json}" "aquila_transaction_cold_cursor_ms" "p(95)")"
+  first_p95="$(max_numeric_value "${hot_first_p95}" "${cold_first_p95}")"
+  deep_p95="$(max_numeric_value "${hot_cursor_p95}" "${cold_cursor_p95}")"
 
   append_summary \
-    "${phase}" "${status}" "${vus}" "${duration}" "${limit}" \
+    "${phase}" "${cache_state}" "${status}" "${vus}" "${duration}" "${limit}" \
     "${http_failed_rate}" "${http_reqs}" "${transaction_429_rate}" \
+    "${transaction_503_rate}" "${transaction_503_count}" "${first_p95}" "${deep_p95}" \
     "${hot_first_p95}" "${hot_cursor_p95}" "${cold_first_p95}" "${cold_cursor_p95}" \
     "${log_path}" "${summary_json}"
 
   check_phase_thresholds \
-    "${phase}" "${status}" "${transaction_429_rate}" \
+    "${phase}" "${status}" "${transaction_429_rate}" "${transaction_503_rate}" "${transaction_503_count}" \
     "${hot_first_p95}" "${hot_cursor_p95}" "${cold_first_p95}" "${cold_cursor_p95}"
+}
+
+write_report() {
+  local rows=""
+  local phase cache_state status phase_vus duration phase_limit http_failed_rate http_reqs
+  local transaction_429_rate transaction_503_rate transaction_503_count first_p95 deep_p95
+  local hot_first_p95 hot_cursor_p95 cold_first_p95 cold_cursor_p95 log_path summary_json
+
+  while IFS=$'\t' read -r phase cache_state status phase_vus duration phase_limit http_failed_rate http_reqs \
+    transaction_429_rate transaction_503_rate transaction_503_count first_p95 deep_p95 \
+    hot_first_p95 hot_cursor_p95 cold_first_p95 cold_cursor_p95 log_path summary_json; do
+    if [[ "${phase}" == "phase" ]]; then
+      continue
+    fi
+    rows="${rows}"$'\n'"| ${phase} | ${cache_state} | ${status} | ${first_p95} | ${deep_p95} | ${transaction_429_rate} | ${transaction_503_rate} | ${transaction_503_count} | ${summary_json} |"
+  done <"${summary_tsv}"
+
+  cat >"${report_md}" <<REPORT
+# Transaction 100m Cache-State SLO
+
+## Summary
+
+- gate: ${name}
+- cold-start duration: ${cold_start_duration}
+- warmup duration: ${warmup_duration}
+- warm-cache read duration: ${warm_read_duration}
+- first/deep p95 source: max(hot,cold) first page and deep cursor p95
+- 429 rate threshold: ${transaction_429_rate_threshold}
+- 503 rate threshold: ${transaction_503_rate_threshold}
+
+## Cache-State Result
+
+| phase | cache state | status | first p95 ms | deep p95 ms | 429 rate | 503 rate | 503 count | summary JSON |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |${rows}
+
+## Artifacts
+
+- summary TSV: ${summary_tsv}
+- report: ${report_md}
+
+## Notes
+
+- cold-start와 warm-cache를 분리해 cache 상태가 섞인 p95/429 해석을 피합니다.
+- 503은 admission 실패가 아니라 service failure로 보아 0 budget으로 판정합니다.
+REPORT
 }
 
 run_warmup() {
@@ -385,11 +457,13 @@ wait_for_backend_readiness
 wait_for_prometheus_readiness
 
 write_header
-run_k6_phase "cold-start" "${cold_start_duration}"
+run_k6_phase "cold-start" "${cold_start_duration}" "cold-start"
 run_warmup
-run_k6_phase "warm-read" "${warm_read_duration}"
+run_k6_phase "warm-read" "${warm_read_duration}" "warm-cache"
+write_report
 
 echo "[transaction-100m-cold-warm] summary=${summary_tsv}"
+echo "[transaction-100m-cold-warm] report=${report_md}"
 if [[ "${threshold_failed}" == "true" ]]; then
   exit 1
 fi

--- a/tools/test/run-transaction-read-48-64-capacity-gate.sh
+++ b/tools/test/run-transaction-read-48-64-capacity-gate.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-48-64-capacity-gate.sh [--print-plan]
+
+Environment:
+  CAPACITY_48_64_GATE_NAME                  default transaction-read-48-64-capacity-<timestamp>
+  CAPACITY_48_64_LOWER_ANCHOR_RATE         default 48
+  CAPACITY_48_64_RATES                     default 52,56,60,64
+  CAPACITY_48_64_DURATION                  default 20s
+  CAPACITY_48_64_WARN_RATE                 default 0.08
+  CAPACITY_48_64_FAIL_RATE                 default 0.10
+  CAPACITY_48_64_RUN_K6                    true|false, default false
+  CAPACITY_48_64_SUMMARY_DIR               required when CAPACITY_48_64_RUN_K6=false
+  CAPACITY_48_64_OUTPUT_DIR                default build/reports/k6/<gate>
+  CAPACITY_48_64_MAX_RETRY_AFTER_SLEEP_SECONDS default 1
+
+Summary input when CAPACITY_48_64_RUN_K6=false:
+  ${CAPACITY_48_64_SUMMARY_DIR}/rate-52-summary.json
+  ${CAPACITY_48_64_SUMMARY_DIR}/rate-56-summary.json
+  ${CAPACITY_48_64_SUMMARY_DIR}/rate-60-summary.json
+  ${CAPACITY_48_64_SUMMARY_DIR}/rate-64-summary.json
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+gate_name="${CAPACITY_48_64_GATE_NAME:-transaction-read-48-64-capacity-$(date +%Y-%m-%d-%H%M%S)}"
+lower_anchor_rate="${CAPACITY_48_64_LOWER_ANCHOR_RATE:-48}"
+rates="${CAPACITY_48_64_RATES:-52,56,60,64}"
+duration="${CAPACITY_48_64_DURATION:-20s}"
+warn_rate="${CAPACITY_48_64_WARN_RATE:-0.08}"
+fail_rate="${CAPACITY_48_64_FAIL_RATE:-0.10}"
+run_k6="${CAPACITY_48_64_RUN_K6:-false}"
+summary_dir="${CAPACITY_48_64_SUMMARY_DIR:-}"
+output_dir="${CAPACITY_48_64_OUTPUT_DIR:-build/reports/k6/${gate_name}}"
+max_retry_after_sleep_seconds="${CAPACITY_48_64_MAX_RETRY_AFTER_SLEEP_SECONDS:-1}"
+summary_tsv="${output_dir}/${gate_name}-48-64-capacity.tsv"
+report_md="${output_dir}/${gate_name}-48-64-capacity.md"
+single_gate="tools/test/run-transaction-read-burst-429-budget-gate.sh"
+
+require_positive_integer_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_csv_positive_integers() {
+  local name="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "${name} must not be empty" >&2
+    exit 1
+  fi
+  IFS=',' read -r -a items <<<"${value}"
+  local item
+  for item in "${items[@]}"; do
+    require_positive_integer_value "${name}" "${item}"
+  done
+}
+
+require_rate_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${name} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0 && value <= 1) }' || {
+    echo "${name} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  }
+}
+
+require_non_negative_number_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${name} must be zero or greater: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0) }' || {
+    echo "${name} must be zero or greater: ${value}" >&2
+    exit 1
+  }
+}
+
+require_bool_value() {
+  local name="$1"
+  local value="$2"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "${name} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_duration_value() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*(s|m|h)$ ]]; then
+    echo "${name} must use a positive duration such as 20s, 1m, or 1h: ${value}" >&2
+    exit 1
+  fi
+}
+
+number_greater_than() {
+  awk -v value="$1" -v threshold="$2" 'BEGIN { exit !(value > threshold) }'
+}
+
+is_numeric_value() {
+  [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+}
+
+max_numeric_value() {
+  local result="0"
+  local value
+  for value in "$@"; do
+    if is_numeric_value "${value}" && number_greater_than "${value}" "${result}"; then
+      result="${value}"
+    fi
+  done
+  echo "${result}"
+}
+
+metric_value() {
+  local summary_json="$1"
+  local metric="$2"
+  local field="$3"
+  jq -r --arg metric "${metric}" --arg field "${field}" \
+    '.metrics[$metric].values[$field] // "0"' "${summary_json}"
+}
+
+status_for_rate() {
+  local value="$1"
+  if number_greater_than "${value}" "${fail_rate}"; then
+    echo "fail"
+  elif number_greater_than "${value}" "${warn_rate}"; then
+    echo "warn"
+  else
+    echo "pass"
+  fi
+}
+
+status_for_zero() {
+  local value="$1"
+  if number_greater_than "${value}" "0"; then
+    echo "fail"
+  else
+    echo "pass"
+  fi
+}
+
+require_positive_integer_value "CAPACITY_48_64_LOWER_ANCHOR_RATE" "${lower_anchor_rate}"
+require_csv_positive_integers "CAPACITY_48_64_RATES" "${rates}"
+require_duration_value "CAPACITY_48_64_DURATION" "${duration}"
+require_rate_value "CAPACITY_48_64_WARN_RATE" "${warn_rate}"
+require_rate_value "CAPACITY_48_64_FAIL_RATE" "${fail_rate}"
+require_bool_value "CAPACITY_48_64_RUN_K6" "${run_k6}"
+require_non_negative_number_value "CAPACITY_48_64_MAX_RETRY_AFTER_SLEEP_SECONDS" "${max_retry_after_sleep_seconds}"
+if number_greater_than "${warn_rate}" "${fail_rate}"; then
+  echo "CAPACITY_48_64_WARN_RATE must be less than or equal to CAPACITY_48_64_FAIL_RATE" >&2
+  exit 1
+fi
+
+print_plan() {
+  echo "[transaction-read-48-64-capacity] gate=${gate_name}"
+  echo "[transaction-read-48-64-capacity] lower_anchor_rate=${lower_anchor_rate}"
+  echo "[transaction-read-48-64-capacity] rates=${rates}"
+  echo "[transaction-read-48-64-capacity] duration=${duration}"
+  echo "[transaction-read-48-64-capacity] warn_rate=${warn_rate}"
+  echo "[transaction-read-48-64-capacity] fail_rate=${fail_rate}"
+  echo "[transaction-read-48-64-capacity] run_k6=${run_k6}"
+  echo "[transaction-read-48-64-capacity] summary_dir=${summary_dir:-missing}"
+  echo "[transaction-read-48-64-capacity] output_dir=${output_dir}"
+  echo "[transaction-read-48-64-capacity] k6_command=K6_SCENARIO_MODE=burst K6_BURST_RATE=<rate> ${single_gate}"
+  echo "[transaction-read-48-64-capacity] k6_headroom=K6_PRE_ALLOCATED_VUS=<rate> K6_MAX_VUS=<rate*2> K6_MAX_RETRY_AFTER_SLEEP_SECONDS=${max_retry_after_sleep_seconds}"
+  echo "[transaction-read-48-64-capacity] summary_tsv=${summary_tsv}"
+  echo "[transaction-read-48-64-capacity] report_md=${report_md}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+if [[ ! -x "${single_gate}" ]]; then
+  echo "single burst gate missing or not executable: ${single_gate}" >&2
+  exit 1
+fi
+if [[ "${run_k6}" != "true" ]]; then
+  if [[ -z "${summary_dir}" || ! -d "${summary_dir}" ]]; then
+    echo "CAPACITY_48_64_SUMMARY_DIR is required when CAPACITY_48_64_RUN_K6=false" >&2
+    exit 1
+  fi
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+printf "rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\thttp_req_duration_p95_ms\tfirst_p95_ms\tdeep_p95_ms\tdropped_iterations\tinterrupted_iterations\tgenerator_headroom_status\treport_md\tsummary_json\n" >"${summary_tsv}"
+
+gate_status="pass"
+stable_pass_rate="${lower_anchor_rate}"
+max_non_fail_rate="${lower_anchor_rate}"
+first_fail_rate="none"
+summary_table=$'| rate | status | 429 rate | 503 rate | 503 count | http p95 ms | first p95 ms | deep p95 ms | generator headroom |\n| --- | --- | --- | --- | --- | --- | --- | --- | --- |'
+IFS=',' read -r -a rate_items <<<"${rates}"
+for rate in "${rate_items[@]}"; do
+  single_name="${gate_name}-rate-${rate}"
+  single_output_dir="${output_dir}/rate-${rate}"
+  summary_json="${summary_dir%/}/rate-${rate}-summary.json"
+  if [[ "${run_k6}" == "true" ]]; then
+    summary_json="build/reports/k6/${single_name}-k6-summary.json"
+  elif [[ ! -s "${summary_json}" ]]; then
+    echo "capacity summary missing for rate ${rate}: ${summary_json}" >&2
+    exit 1
+  fi
+
+  set +e
+  BURST_429_GATE_NAME="${single_name}" \
+  BURST_429_SUMMARY_JSON="${summary_json}" \
+  BURST_429_OUTPUT_DIR="${single_output_dir}" \
+  BURST_429_BURST_RATE="${rate}" \
+  BURST_429_BURST_DURATION="${duration}" \
+  BURST_429_WARN_RATE="${warn_rate}" \
+  BURST_429_FAIL_RATE="${fail_rate}" \
+  BURST_429_RUN_K6="${run_k6}" \
+  BURST_429_MAX_RETRY_AFTER_SLEEP_SECONDS="${max_retry_after_sleep_seconds}" \
+    "${single_gate}" >/dev/null
+  single_status=$?
+  set -e
+
+  if [[ "${run_k6}" == "true" ]]; then
+    summary_json="build/reports/k6/${single_name}-k6-summary.json"
+  fi
+
+  transaction_429_rate="$(metric_value "${summary_json}" aquila_transaction_429_rate rate)"
+  transaction_503_rate="$(metric_value "${summary_json}" aquila_transaction_503_rate rate)"
+  transaction_503_count="$(metric_value "${summary_json}" aquila_transaction_503_count count)"
+  http_req_duration_p95="$(metric_value "${summary_json}" http_req_duration "p(95)")"
+  hot_first_p95="$(metric_value "${summary_json}" aquila_transaction_hot_first_ms "p(95)")"
+  hot_cursor_p95="$(metric_value "${summary_json}" aquila_transaction_hot_cursor_ms "p(95)")"
+  cold_first_p95="$(metric_value "${summary_json}" aquila_transaction_cold_first_ms "p(95)")"
+  cold_cursor_p95="$(metric_value "${summary_json}" aquila_transaction_cold_cursor_ms "p(95)")"
+  first_p95="$(max_numeric_value "${hot_first_p95}" "${cold_first_p95}")"
+  deep_p95="$(max_numeric_value "${hot_cursor_p95}" "${cold_cursor_p95}")"
+  dropped_iterations="$(metric_value "${summary_json}" dropped_iterations count)"
+  interrupted_iterations="$(metric_value "${summary_json}" interrupted_iterations count)"
+  generator_headroom_status="pass"
+  if [[ "$(status_for_zero "${dropped_iterations}")" == "fail" || "$(status_for_zero "${interrupted_iterations}")" == "fail" ]]; then
+    generator_headroom_status="fail"
+  fi
+
+  rate_status="$(status_for_rate "${transaction_429_rate}")"
+  if [[ "${single_status}" -ne 0 ]] || [[ "${generator_headroom_status}" == "fail" ]] \
+      || number_greater_than "${transaction_503_rate}" "0" \
+      || number_greater_than "${transaction_503_count}" "0"; then
+    rate_status="fail"
+  fi
+
+  case "${rate_status}" in
+    fail)
+      gate_status="fail"
+      if [[ "${first_fail_rate}" == "none" ]]; then
+        first_fail_rate="${rate}"
+      fi
+      ;;
+    warn)
+      if [[ "${gate_status}" == "pass" ]]; then
+        gate_status="warn"
+      fi
+      if [[ "${first_fail_rate}" == "none" ]]; then
+        max_non_fail_rate="${rate}"
+      fi
+      ;;
+    pass)
+      if [[ "${first_fail_rate}" == "none" ]]; then
+        stable_pass_rate="${rate}"
+        max_non_fail_rate="${rate}"
+      fi
+      ;;
+  esac
+
+  single_report="${single_output_dir}/${single_name}-burst-429-budget.md"
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "${rate}" "${rate_status}" "${transaction_429_rate}" "${transaction_503_rate}" \
+    "${transaction_503_count}" "${http_req_duration_p95}" "${first_p95}" "${deep_p95}" \
+    "${dropped_iterations}" "${interrupted_iterations}" "${generator_headroom_status}" \
+    "${single_report}" "${summary_json}" >>"${summary_tsv}"
+  summary_table="${summary_table}"$'\n'"| ${rate} | ${rate_status} | ${transaction_429_rate} | ${transaction_503_rate} | ${transaction_503_count} | ${http_req_duration_p95} | ${first_p95} | ${deep_p95} | ${generator_headroom_status} |"
+done
+
+cat >"${report_md}" <<REPORT
+# Transaction Read 48-64 Capacity Boundary Gate
+
+## Summary
+
+- gate: ${gate_name}
+- gate_status=${gate_status}
+- lower_anchor_rate=${lower_anchor_rate}
+- rates: ${rates}
+- duration: ${duration}
+- warning threshold: ${warn_rate}
+- fail threshold: ${fail_rate}
+- stable_pass_rate=${stable_pass_rate}
+- max_non_fail_rate=${max_non_fail_rate}
+- first_fail_rate=${first_fail_rate}
+
+## Result Table
+
+${summary_table}
+
+## Artifacts
+
+- summary TSV: ${summary_tsv}
+- output dir: ${output_dir}
+
+## Notes
+
+- 48 it/s는 최근 통과 anchor로 두고 52/56/60/64 it/s 경계만 자동 측정합니다.
+- 429는 admission 보호 신호로 budget 관리하고, 503과 generator headroom 실패는 hard fail로 처리합니다.
+- p95는 HTTP overhead와 first/deep cursor 비용을 함께 해석할 수 있도록 report에 포함합니다.
+REPORT
+
+echo "${report_md}"
+
+if [[ "${gate_status}" == "fail" ]]; then
+  echo "48-64 capacity gate failed: ${summary_tsv}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #610

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction-read 1억 row gate에서 cold-start와 warm-cache SLO를 분리해 first/deep p95, 429, 503을 별도 report로 남기도록 보강했습니다.
- 48 pass / 64 fail 경계 구간을 52/56/60/64 it/s로 자동 산출하는 capacity boundary gate를 추가했습니다.

## 🛠 Changes
- cold-start/cache-warm runner TSV에 cache state, first/deep p95, 503 rate/count를 추가하고 markdown SLO report 생성
- 52/56/60/64 boundary runner/checker 추가
- boundary report에 generator headroom, 429, 503, HTTP p95, first/deep p95, stable pass/max non-fail/first fail rate 기록

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-100m-cold-start-cache-warm-gate.sh`
- `bash tools/test/check-transaction-read-48-64-capacity-gate.sh`
- `bash -n tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh`
- `bash -n tools/test/run-transaction-read-48-64-capacity-gate.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` -> `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 실제 OCI 1억 row 실행 시간이 늘어날 수 있습니다. 새 gate는 shell tooling/report 추가라 runtime API 동작에는 영향 없습니다.
- 롤백 방법: PR revert 후 기존 cold/warm 및 stepped burst gate만 사용합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?