### PR TITLE
[Fix] Kafka topic provisioning startup validation CI flake 보정

### DIFF
--- a/back/src/main/java/com/aquilabank/global/config/KafkaTopicAdministrationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/KafkaTopicAdministrationConfiguration.java
@@ -17,6 +17,7 @@ import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Condition;
@@ -81,8 +82,12 @@ public class KafkaTopicAdministrationConfiguration {
   @Bean
   @Conditional(KafkaTopicStartupValidationCondition.class)
   InitializingBean kafkaTopicStartupValidationInitializer(
-      KafkaAdmin kafkaTopicAdmin, KafkaTopicTopology kafkaTopicTopology) {
+      KafkaAdmin kafkaTopicAdmin,
+      KafkaTopicTopology kafkaTopicTopology,
+      ObjectProvider<KafkaAdmin.NewTopics> kafkaProvisioningTopics) {
     return () -> {
+      // KafkaAdmin.initialize() 는 이미 생성된 NewTopics bean만 조회하므로 검증 전 먼저 materialize합니다.
+      kafkaProvisioningTopics.ifAvailable(ignored -> {});
       kafkaTopicAdmin.initialize();
       validateTopics(kafkaTopicTopology);
     };


### PR DESCRIPTION
## 🔗 Related Issue
- close #612

## 🌿 Base Branch
- `main`

## 📝 Summary
- Main CI Backend Check에서 Kafka topic provisioning test가 `ApplicationContextRunner` startup 실패로 간헐 실패하던 문제를 보정했습니다.
- startup validation이 `KafkaAdmin.initialize()`를 호출하기 전에 `KafkaAdmin.NewTopics` bean을 먼저 materialize하도록 해, topic 생성 대상이 bean 생성 순서에 따라 누락되지 않게 했습니다.

## 🛠 Changes
- `KafkaTopicAdministrationConfiguration`의 startup validation initializer에 `ObjectProvider<KafkaAdmin.NewTopics>`를 주입
- validation 전에 provisioning topic bean을 먼저 생성한 뒤 `KafkaAdmin.initialize()`와 runtime validation 수행

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*KafkaTopicAdministrationConfigurationTest'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back check jacocoFullTestReport --no-daemon --stacktrace`
- pre-commit: `./back/gradlew -p back check`
- `git diff --check`
- `git rev-list --count main..HEAD` -> `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: startup validation enabled + provisioning enabled 경로에서 topic bean 생성 순서만 고정합니다. Kafka runtime contract와 topic spec은 변경하지 않습니다.
- 롤백 방법: PR revert 후 Main CI 재실행으로 기존 상태를 복원합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?