### PR TITLE
[Perf] transaction-read public capacity v2 운영화

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionQuery.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionQuery.java
@@ -17,6 +17,7 @@ public record TransactionQuery(
     String transactionReference) {
 
   private static final Duration MAX_RANGE = Duration.ofDays(31);
+  public static final int MAX_LIMIT = 50;
 
   public TransactionQuery {
     if (accountId <= 0) {
@@ -28,8 +29,8 @@ public record TransactionQuery(
     if (!from.isBefore(to)) {
       throw new IllegalArgumentException("from must be before to");
     }
-    if (limit < 1 || limit > 100) {
-      throw new IllegalArgumentException("limit must be between 1 and 100");
+    if (limit < 1 || limit > MAX_LIMIT) {
+      throw new IllegalArgumentException("limit must be between 1 and 50");
     }
     if (minAmountMinor != null && minAmountMinor < 0) {
       throw new IllegalArgumentException("minAmountMinor must be zero or positive");

--- a/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionSlice.java
+++ b/back/src/main/java/com/aquilabank/domain/transaction/model/TransactionSlice.java
@@ -9,8 +9,8 @@ public record TransactionSlice(
   public TransactionSlice {
     // 반환 후 외부 수정 차단용 방어 복사
     items = List.copyOf(items);
-    if (limit < 1 || limit > 100) {
-      throw new IllegalArgumentException("limit must be between 1 and 100");
+    if (limit < 1 || limit > TransactionQuery.MAX_LIMIT) {
+      throw new IllegalArgumentException("limit must be between 1 and 50");
     }
     if (!hasNext && nextCursor != null) {
       throw new IllegalArgumentException("nextCursor must be null when hasNext is false");

--- a/back/src/main/java/com/aquilabank/global/web/account/InternalAccountAdminController.java
+++ b/back/src/main/java/com/aquilabank/global/web/account/InternalAccountAdminController.java
@@ -8,6 +8,7 @@ import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceScope;
 import com.aquilabank.global.security.InternalServiceTokenClaims;
 import com.aquilabank.global.web.RequestTraceContext;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -29,12 +30,15 @@ public class InternalAccountAdminController {
 
   private final AccountStatusUpdateUseCase accountStatusUpdateUseCase;
   private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
+  private final RequestAccountAuthorizationService requestAccountAuthorizationService;
 
   public InternalAccountAdminController(
       AccountStatusUpdateUseCase accountStatusUpdateUseCase,
-      InternalServiceRequestAuthorizer internalServiceRequestAuthorizer) {
+      InternalServiceRequestAuthorizer internalServiceRequestAuthorizer,
+      RequestAccountAuthorizationService requestAccountAuthorizationService) {
     this.accountStatusUpdateUseCase = accountStatusUpdateUseCase;
     this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
+    this.requestAccountAuthorizationService = requestAccountAuthorizationService;
   }
 
   @PutMapping("/{accountId}/status")
@@ -45,13 +49,15 @@ public class InternalAccountAdminController {
     InternalServiceTokenClaims claims =
         internalServiceRequestAuthorizer.requireScope(
             httpServletRequest, InternalServiceScope.ACCOUNT_ADMIN);
-    return AccountResponse.from(
+    AccountSummary summary =
         accountStatusUpdateUseCase.update(
             new AccountStatusUpdateCommand(
                 accountId,
                 request.accountStatus(),
                 claims.subject(),
-                resolveRequestId(httpServletRequest))));
+                resolveRequestId(httpServletRequest)));
+    requestAccountAuthorizationService.evictAccount(accountId);
+    return AccountResponse.from(summary);
   }
 
   /** 내부 계좌 상태 변경 요청 body */

--- a/back/src/main/java/com/aquilabank/global/web/security/RequestAccountAuthorizationService.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/RequestAccountAuthorizationService.java
@@ -7,8 +7,13 @@ import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.web.RequestTraceContext;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** 요청에 담긴 accountId를 principal 기준으로 검증해 controller 중복을 줄입니다. */
@@ -17,11 +22,27 @@ public class RequestAccountAuthorizationService {
 
   private static final Logger log =
       LoggerFactory.getLogger(RequestAccountAuthorizationService.class);
+  private static final Duration AUTHORIZATION_CACHE_TTL = Duration.ofMillis(500);
 
   private final AccountAccessUseCase accountAccessUseCase;
+  // 성공한 account access만 짧게 재사용해 hot read의 반복 DB 왕복을 줄입니다.
+  private final ConcurrentHashMap<AuthorizationCacheKey, AuthorizationCacheEntry>
+      authorizationCache = new ConcurrentHashMap<>();
+  private final long authorizationCacheTtlNanos;
+  private final LongSupplier nanoTime;
 
+  @Autowired
   public RequestAccountAuthorizationService(AccountAccessUseCase accountAccessUseCase) {
-    this.accountAccessUseCase = accountAccessUseCase;
+    this(accountAccessUseCase, AUTHORIZATION_CACHE_TTL, System::nanoTime);
+  }
+
+  RequestAccountAuthorizationService(
+      AccountAccessUseCase accountAccessUseCase,
+      Duration authorizationCacheTtl,
+      LongSupplier nanoTime) {
+    this.accountAccessUseCase = Objects.requireNonNull(accountAccessUseCase);
+    this.authorizationCacheTtlNanos = Objects.requireNonNull(authorizationCacheTtl).toNanos();
+    this.nanoTime = Objects.requireNonNull(nanoTime);
   }
 
   public long resolveReadableAccountId(
@@ -41,7 +62,9 @@ public class RequestAccountAuthorizationService {
     }
 
     if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
-      return accountAccessUseCase.verify(userPrincipal.userId(), requestedAccountId, scope);
+      return resolveCached(
+          new AuthorizationCacheKey(userPrincipal.userId(), requestedAccountId, scope),
+          () -> accountAccessUseCase.verify(userPrincipal.userId(), requestedAccountId, scope));
     }
 
     if (principal instanceof AuthenticatedAccountPrincipal accountPrincipal) {
@@ -54,9 +77,42 @@ public class RequestAccountAuthorizationService {
             requestedAccountId);
         throw new AccountAccessDeniedException("account access is denied");
       }
+      // bootstrap principal은 account status exact 확인이 목적이라 cache하지 않습니다.
       return accountAccessUseCase.verifyBootstrapAccount(requestedAccountId, scope);
     }
 
     throw new IllegalArgumentException("unsupported principal type");
+  }
+
+  public void evictAccount(long accountId) {
+    if (accountId <= 0) {
+      return;
+    }
+    // 상태 변경 직후 오래된 권한 cache가 남지 않도록 account 단위로 비웁니다.
+    authorizationCache.keySet().removeIf(key -> key.accountId() == accountId);
+  }
+
+  private long resolveCached(AuthorizationCacheKey key, LongSupplier accountIdResolver) {
+    long nowNanos = nanoTime.getAsLong();
+    AuthorizationCacheEntry cached = authorizationCache.get(key);
+    if (cached != null && cached.isFresh(nowNanos)) {
+      return cached.resolvedAccountId();
+    }
+    if (cached != null) {
+      authorizationCache.remove(key, cached);
+    }
+    long resolvedAccountId = accountIdResolver.getAsLong();
+    authorizationCache.put(
+        key, new AuthorizationCacheEntry(resolvedAccountId, nowNanos + authorizationCacheTtlNanos));
+    return resolvedAccountId;
+  }
+
+  private record AuthorizationCacheKey(long userId, long accountId, AccountAccessScope scope) {}
+
+  private record AuthorizationCacheEntry(long resolvedAccountId, long expiresAtNanos) {
+
+    boolean isFresh(long nowNanos) {
+      return nowNanos < expiresAtNanos;
+    }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryController.java
@@ -45,13 +45,14 @@ public class TransactionArchiveQueryController {
       @RequestParam @Positive(message = "accountId must be positive") long accountId,
       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
-      @RequestParam(defaultValue = "20") int limit,
+      @RequestParam(defaultValue = "50") int limit,
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false) TransactionStatus status,
       @RequestParam(required = false) TransactionDirection direction,
       @RequestParam(required = false) Long minAmountMinor,
       @RequestParam(required = false) Long maxAmountMinor,
-      @RequestParam(required = false) String transactionReference) {
+      @RequestParam(required = false) String transactionReference,
+      @RequestParam(defaultValue = "full") String responseShape) {
     return hotPathMetrics.record(
         TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
         TransactionReadHotPathMetrics.STAGE_TOTAL,
@@ -67,7 +68,8 @@ public class TransactionArchiveQueryController {
                 direction,
                 minAmountMinor,
                 maxAmountMinor,
-                transactionReference));
+                transactionReference,
+                responseShape));
   }
 
   private TransactionQueryResponse getArchivedTransactionsMeasured(
@@ -81,7 +83,8 @@ public class TransactionArchiveQueryController {
       TransactionDirection direction,
       Long minAmountMinor,
       Long maxAmountMinor,
-      String transactionReference) {
+      String transactionReference,
+      String responseShape) {
     try {
       TransactionCursor decodedCursor =
           cursor == null || cursor.isBlank() ? null : TransactionCursorCodec.decode(cursor);
@@ -104,6 +107,7 @@ public class TransactionArchiveQueryController {
               minAmountMinor,
               maxAmountMinor,
               transactionReference);
+      TransactionResponseShape resolvedResponseShape = TransactionResponseShape.from(responseShape);
       TransactionSlice slice =
           hotPathMetrics.record(
               TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
@@ -112,7 +116,7 @@ public class TransactionArchiveQueryController {
       return hotPathMetrics.record(
           TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
           TransactionReadHotPathMetrics.STAGE_RESPONSE_MAPPING,
-          () -> TransactionQueryResponse.from(slice));
+          () -> TransactionQueryResponse.from(slice, resolvedResponseShape));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryController.java
@@ -29,14 +29,20 @@ public class TransactionArchiveQueryController {
   private final TransactionArchiveQueryUseCase transactionArchiveQueryUseCase;
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
   private final TransactionReadHotPathMetrics hotPathMetrics;
+  private final TransactionReadSingleFlight singleFlight;
+  private final TransactionReadAccountFairnessLimiter accountFairnessLimiter;
 
   public TransactionArchiveQueryController(
       TransactionArchiveQueryUseCase transactionArchiveQueryUseCase,
       RequestAccountAuthorizationService requestAccountAuthorizationService,
-      TransactionReadHotPathMetrics hotPathMetrics) {
+      TransactionReadHotPathMetrics hotPathMetrics,
+      TransactionReadSingleFlight singleFlight,
+      TransactionReadAccountFairnessLimiter accountFairnessLimiter) {
     this.transactionArchiveQueryUseCase = transactionArchiveQueryUseCase;
     this.requestAccountAuthorizationService = requestAccountAuthorizationService;
     this.hotPathMetrics = hotPathMetrics;
+    this.singleFlight = singleFlight;
+    this.accountFairnessLimiter = accountFairnessLimiter;
   }
 
   @GetMapping
@@ -112,7 +118,15 @@ public class TransactionArchiveQueryController {
           hotPathMetrics.record(
               TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
               TransactionReadHotPathMetrics.STAGE_USECASE,
-              () -> transactionArchiveQueryUseCase.getArchivedTransactions(query));
+              () ->
+                  singleFlight.get(
+                      TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
+                      query,
+                      () ->
+                          accountFairnessLimiter.execute(
+                              resolvedAccountId,
+                              () ->
+                                  transactionArchiveQueryUseCase.getArchivedTransactions(query))));
       return hotPathMetrics.record(
           TransactionReadHotPathMetrics.ENDPOINT_ARCHIVE,
           TransactionReadHotPathMetrics.STAGE_RESPONSE_MAPPING,

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
@@ -45,13 +45,14 @@ public class TransactionQueryController {
       @RequestParam @Positive(message = "accountId must be positive") long accountId,
       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
-      @RequestParam(defaultValue = "20") int limit,
+      @RequestParam(defaultValue = "50") int limit,
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false) TransactionStatus status,
       @RequestParam(required = false) TransactionDirection direction,
       @RequestParam(required = false) Long minAmountMinor,
       @RequestParam(required = false) Long maxAmountMinor,
-      @RequestParam(required = false) String transactionReference) {
+      @RequestParam(required = false) String transactionReference,
+      @RequestParam(defaultValue = "full") String responseShape) {
     return hotPathMetrics.record(
         TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
         TransactionReadHotPathMetrics.STAGE_TOTAL,
@@ -67,7 +68,8 @@ public class TransactionQueryController {
                 direction,
                 minAmountMinor,
                 maxAmountMinor,
-                transactionReference));
+                transactionReference,
+                responseShape));
   }
 
   private TransactionQueryResponse getTransactionsMeasured(
@@ -81,7 +83,8 @@ public class TransactionQueryController {
       TransactionDirection direction,
       Long minAmountMinor,
       Long maxAmountMinor,
-      String transactionReference) {
+      String transactionReference,
+      String responseShape) {
     try {
       // 첫 page와 후속 page를 같은 endpoint로 통일
       TransactionCursor decodedCursor =
@@ -105,6 +108,7 @@ public class TransactionQueryController {
               minAmountMinor,
               maxAmountMinor,
               transactionReference);
+      TransactionResponseShape resolvedResponseShape = TransactionResponseShape.from(responseShape);
       TransactionSlice slice =
           hotPathMetrics.record(
               TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
@@ -113,7 +117,7 @@ public class TransactionQueryController {
       return hotPathMetrics.record(
           TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
           TransactionReadHotPathMetrics.STAGE_RESPONSE_MAPPING,
-          () -> TransactionQueryResponse.from(slice));
+          () -> TransactionQueryResponse.from(slice, resolvedResponseShape));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryController.java
@@ -29,14 +29,20 @@ public class TransactionQueryController {
   private final TransactionQueryUseCase transactionQueryUseCase;
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
   private final TransactionReadHotPathMetrics hotPathMetrics;
+  private final TransactionReadSingleFlight singleFlight;
+  private final TransactionReadAccountFairnessLimiter accountFairnessLimiter;
 
   public TransactionQueryController(
       TransactionQueryUseCase transactionQueryUseCase,
       RequestAccountAuthorizationService requestAccountAuthorizationService,
-      TransactionReadHotPathMetrics hotPathMetrics) {
+      TransactionReadHotPathMetrics hotPathMetrics,
+      TransactionReadSingleFlight singleFlight,
+      TransactionReadAccountFairnessLimiter accountFairnessLimiter) {
     this.transactionQueryUseCase = transactionQueryUseCase;
     this.requestAccountAuthorizationService = requestAccountAuthorizationService;
     this.hotPathMetrics = hotPathMetrics;
+    this.singleFlight = singleFlight;
+    this.accountFairnessLimiter = accountFairnessLimiter;
   }
 
   @GetMapping
@@ -113,7 +119,14 @@ public class TransactionQueryController {
           hotPathMetrics.record(
               TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
               TransactionReadHotPathMetrics.STAGE_USECASE,
-              () -> transactionQueryUseCase.getTransactions(query));
+              () ->
+                  singleFlight.get(
+                      TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
+                      query,
+                      () ->
+                          accountFairnessLimiter.execute(
+                              resolvedAccountId,
+                              () -> transactionQueryUseCase.getTransactions(query))));
       return hotPathMetrics.record(
           TransactionReadHotPathMetrics.ENDPOINT_ACTIVE,
           TransactionReadHotPathMetrics.STAGE_RESPONSE_MAPPING,

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryResponse.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionQueryResponse.java
@@ -2,6 +2,7 @@ package com.aquilabank.global.web.transaction;
 
 import com.aquilabank.domain.transaction.model.TransactionSlice;
 import com.aquilabank.domain.transaction.model.TransactionSummary;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,14 +12,20 @@ public record TransactionQueryResponse(
     List<TransactionItemResponse> items, String nextCursor, boolean hasNext, int limit) {
 
   public static TransactionQueryResponse from(TransactionSlice slice) {
+    return from(slice, TransactionResponseShape.FULL);
+  }
+
+  public static TransactionQueryResponse from(
+      TransactionSlice slice, TransactionResponseShape responseShape) {
     return new TransactionQueryResponse(
-        toItemResponses(slice.items()),
+        toItemResponses(slice.items(), responseShape),
         slice.nextCursor() == null ? null : TransactionCursorCodec.encode(slice.nextCursor()),
         slice.hasNext(),
         slice.limit());
   }
 
-  private static List<TransactionItemResponse> toItemResponses(List<TransactionSummary> items) {
+  private static List<TransactionItemResponse> toItemResponses(
+      List<TransactionSummary> items, TransactionResponseShape responseShape) {
     int size = items.size();
     if (size == 0) {
       return List.of();
@@ -26,12 +33,13 @@ public record TransactionQueryResponse(
     // JFR에서 DTO mapping allocation site로 확인된 경로라 Stream/Iterator를 피한다.
     List<TransactionItemResponse> responses = new ArrayList<>(size);
     for (int i = 0; i < size; i++) {
-      responses.add(TransactionItemResponse.from(items.get(i)));
+      responses.add(TransactionItemResponse.from(items.get(i), responseShape));
     }
     return List.copyOf(responses);
   }
 
   /** 웹/모바일 클라이언트용 flat item shape */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public record TransactionItemResponse(
       long id,
       long accountId,
@@ -39,13 +47,14 @@ public record TransactionQueryResponse(
       String direction,
       String status,
       long amountMinor,
-      long balanceAfterMinor,
+      Long balanceAfterMinor,
       String currencyCode,
       String summary,
       String counterpartyMaskedName,
       Instant bookedAt) {
 
-    static TransactionItemResponse from(TransactionSummary item) {
+    static TransactionItemResponse from(
+        TransactionSummary item, TransactionResponseShape responseShape) {
       return new TransactionItemResponse(
           item.id(),
           item.accountId(),
@@ -53,10 +62,10 @@ public record TransactionQueryResponse(
           item.direction().name(),
           item.status().name(),
           item.amountMinor(),
-          item.balanceAfterMinor(),
+          responseShape == TransactionResponseShape.SLIM ? null : item.balanceAfterMinor(),
           item.currencyCode(),
-          item.summary(),
-          item.counterpartyMaskedName(),
+          responseShape == TransactionResponseShape.SLIM ? null : item.summary(),
+          responseShape == TransactionResponseShape.SLIM ? null : item.counterpartyMaskedName(),
           item.bookedAt());
     }
   }

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionReadAccountFairnessLimiter.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionReadAccountFairnessLimiter.java
@@ -1,0 +1,50 @@
+package com.aquilabank.global.web.transaction;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+/** 단일 hot account가 transaction read worker를 독점하지 않게 계좌별 동시 실행을 제한합니다. */
+@Component
+public class TransactionReadAccountFairnessLimiter {
+
+  private static final String REJECTION_REASON =
+      "transaction read account concurrency limit exceeded";
+
+  private final ConcurrentHashMap<Long, AtomicInteger> activeRequests = new ConcurrentHashMap<>();
+  private final int maxConcurrentRequests;
+
+  public TransactionReadAccountFairnessLimiter(
+      @Value("${transaction.read.per-account.max-concurrency:2}") int maxConcurrentRequests) {
+    if (maxConcurrentRequests < 1) {
+      throw new IllegalArgumentException("maxConcurrentRequests must be positive");
+    }
+    this.maxConcurrentRequests = maxConcurrentRequests;
+  }
+
+  public <T> T execute(long accountId, Supplier<T> supplier) {
+    AtomicInteger counter =
+        activeRequests.computeIfAbsent(accountId, ignored -> new AtomicInteger());
+    int active = counter.incrementAndGet();
+    if (active > maxConcurrentRequests) {
+      release(accountId, counter);
+      throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, REJECTION_REASON);
+    }
+
+    try {
+      return supplier.get();
+    } finally {
+      release(accountId, counter);
+    }
+  }
+
+  private void release(long accountId, AtomicInteger counter) {
+    if (counter.decrementAndGet() == 0) {
+      activeRequests.remove(accountId, counter);
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionReadSingleFlight.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionReadSingleFlight.java
@@ -1,0 +1,48 @@
+package com.aquilabank.global.web.transaction;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+
+/** 동일 transaction read in-flight 요청을 하나의 upstream 실행으로 합칩니다. */
+@Component
+public class TransactionReadSingleFlight {
+
+  private final ConcurrentHashMap<RequestKey, CompletableFuture<TransactionSlice>> inFlight =
+      new ConcurrentHashMap<>();
+
+  public TransactionSlice get(
+      String endpoint, TransactionQuery query, Supplier<TransactionSlice> supplier) {
+    RequestKey key = new RequestKey(endpoint, query);
+    CompletableFuture<TransactionSlice> ownerFuture = new CompletableFuture<>();
+    CompletableFuture<TransactionSlice> existingFuture = inFlight.putIfAbsent(key, ownerFuture);
+    if (existingFuture != null) {
+      return await(existingFuture);
+    }
+
+    try {
+      TransactionSlice slice = supplier.get();
+      ownerFuture.complete(slice);
+      return slice;
+    } catch (RuntimeException ex) {
+      ownerFuture.completeExceptionally(ex);
+      throw ex;
+    } finally {
+      inFlight.remove(key, ownerFuture);
+    }
+  }
+
+  private TransactionSlice await(CompletableFuture<TransactionSlice> future) {
+    try {
+      return future.join();
+    } catch (CompletionException ex) {
+      throw (RuntimeException) ex.getCause();
+    }
+  }
+
+  private record RequestKey(String endpoint, TransactionQuery query) {}
+}

--- a/back/src/main/java/com/aquilabank/global/web/transaction/TransactionResponseShape.java
+++ b/back/src/main/java/com/aquilabank/global/web/transaction/TransactionResponseShape.java
@@ -1,0 +1,17 @@
+package com.aquilabank.global.web.transaction;
+
+/** transaction list response payload 크기 선택 */
+enum TransactionResponseShape {
+  FULL,
+  SLIM;
+
+  static TransactionResponseShape from(String value) {
+    if (value == null || value.isBlank() || "full".equalsIgnoreCase(value)) {
+      return FULL;
+    }
+    if ("slim".equalsIgnoreCase(value)) {
+      return SLIM;
+    }
+    throw new IllegalArgumentException("responseShape must be full or slim");
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/DomainModelCoverageTest.java
+++ b/back/src/test/java/com/aquilabank/domain/DomainModelCoverageTest.java
@@ -526,11 +526,20 @@ class DomainModelCoverageTest {
                     null,
                     null))
         .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () ->
+                new TransactionQuery(
+                    1L, base, base.plusSeconds(1), 51, null, null, null, null, null, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("limit must be between 1 and 50");
 
     TransactionCursor transactionCursor = new TransactionCursor(base, 1L);
     assertThat(new TransactionSlice(List.of(), null, false, 10).hasNext()).isFalse();
     assertThat(new TransactionSlice(List.of(), transactionCursor, true, 10).nextCursor())
         .isEqualTo(transactionCursor);
+    assertThatThrownBy(() -> new TransactionSlice(List.of(), null, false, 51))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("limit must be between 1 and 50");
     NotificationCursor notificationCursor = new NotificationCursor(base, 1L);
     assertThat(new NotificationSlice(List.of(), null, false, 10).hasNext()).isFalse();
     assertThat(new NotificationSlice(List.of(), notificationCursor, true, 10).nextCursor())

--- a/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/account/InternalAccountAdminControllerTest.java
@@ -13,6 +13,7 @@ import com.aquilabank.domain.account.usecase.AccountStatusUpdateUseCase;
 import com.aquilabank.global.security.InternalServiceScope;
 import com.aquilabank.global.security.InternalServiceTokenTestSupport;
 import com.aquilabank.global.web.ApiExceptionHandler;
+import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,15 +26,19 @@ class InternalAccountAdminControllerTest {
   private static final String REQUEST_ID_HEADER = "X-Request-Id";
 
   private AccountStatusUpdateUseCase accountStatusUpdateUseCase;
+  private RequestAccountAuthorizationService requestAccountAuthorizationService;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
     accountStatusUpdateUseCase = mock(AccountStatusUpdateUseCase.class);
+    requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new InternalAccountAdminController(
-                    accountStatusUpdateUseCase, InternalServiceTokenTestSupport.authorizer()))
+                    accountStatusUpdateUseCase,
+                    InternalServiceTokenTestSupport.authorizer(),
+                    requestAccountAuthorizationService))
             .setControllerAdvice(new ApiExceptionHandler())
             .build();
   }
@@ -87,6 +92,7 @@ class InternalAccountAdminControllerTest {
                         && command.status().name().equals("LOCKED")
                         && command.actorSubject().equals(SUBJECT)
                         && command.requestId().equals("account-lock-request")));
+    verify(requestAccountAuthorizationService).evictAccount(101L);
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/security/RequestAccountAuthorizationServiceTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/security/RequestAccountAuthorizationServiceTest.java
@@ -1,0 +1,94 @@
+package com.aquilabank.global.web.security;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
+import com.aquilabank.domain.auth.model.AccountAccessScope;
+import com.aquilabank.domain.auth.usecase.AccountAccessUseCase;
+import com.aquilabank.global.security.AuthenticatedAccountPrincipal;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class RequestAccountAuthorizationServiceTest {
+
+  private final AccountAccessUseCase accountAccessUseCase = mock(AccountAccessUseCase.class);
+  private final AtomicLong nowNanos = new AtomicLong(Duration.ofSeconds(10).toNanos());
+  private final RequestAccountAuthorizationService service =
+      new RequestAccountAuthorizationService(
+          accountAccessUseCase, Duration.ofMillis(500), nowNanos::get);
+
+  @Test
+  void cachesSuccessfulUserAuthorizationWithinShortTtl() {
+    AuthenticatedUserPrincipal principal = new AuthenticatedUserPrincipal(10L, "user-10");
+    when(accountAccessUseCase.verify(10L, 101L, AccountAccessScope.READ)).thenReturn(101L);
+
+    service.resolveReadableAccountId(principal, 101L);
+    service.resolveReadableAccountId(principal, 101L);
+
+    verify(accountAccessUseCase, times(1)).verify(10L, 101L, AccountAccessScope.READ);
+  }
+
+  @Test
+  void expiresSuccessfulAuthorizationAfterTtl() {
+    AuthenticatedUserPrincipal principal = new AuthenticatedUserPrincipal(10L, "user-10");
+    when(accountAccessUseCase.verify(10L, 101L, AccountAccessScope.READ)).thenReturn(101L);
+
+    service.resolveReadableAccountId(principal, 101L);
+    nowNanos.addAndGet(Duration.ofMillis(501).toNanos());
+    service.resolveReadableAccountId(principal, 101L);
+
+    verify(accountAccessUseCase, times(2)).verify(10L, 101L, AccountAccessScope.READ);
+  }
+
+  @Test
+  void evictsAccountAuthorizationCacheByAccountId() {
+    AuthenticatedUserPrincipal principal = new AuthenticatedUserPrincipal(10L, "user-10");
+    when(accountAccessUseCase.verify(10L, 101L, AccountAccessScope.READ)).thenReturn(101L);
+
+    service.resolveReadableAccountId(principal, 101L);
+    service.evictAccount(101L);
+    service.resolveReadableAccountId(principal, 101L);
+
+    verify(accountAccessUseCase, times(2)).verify(10L, 101L, AccountAccessScope.READ);
+  }
+
+  @Test
+  void ignoresInvalidEvictionKey() {
+    service.evictAccount(0L);
+
+    verifyNoInteractions(accountAccessUseCase);
+  }
+
+  @Test
+  void doesNotCacheDeniedAuthorization() {
+    AuthenticatedUserPrincipal principal = new AuthenticatedUserPrincipal(10L, "user-10");
+    when(accountAccessUseCase.verify(10L, 101L, AccountAccessScope.READ))
+        .thenThrow(new AccountAccessDeniedException("account access is denied"));
+
+    assertThatThrownBy(() -> service.resolveReadableAccountId(principal, 101L))
+        .isInstanceOf(AccountAccessDeniedException.class);
+    assertThatThrownBy(() -> service.resolveReadableAccountId(principal, 101L))
+        .isInstanceOf(AccountAccessDeniedException.class);
+
+    verify(accountAccessUseCase, times(2)).verify(10L, 101L, AccountAccessScope.READ);
+  }
+
+  @Test
+  void doesNotCacheBootstrapAuthorizationBecauseStatusMustStayExact() {
+    AuthenticatedAccountPrincipal principal = new AuthenticatedAccountPrincipal(101L, "bootstrap");
+    when(accountAccessUseCase.verifyBootstrapAccount(101L, AccountAccessScope.READ))
+        .thenReturn(101L);
+
+    service.resolveReadableAccountId(principal, 101L);
+    service.resolveReadableAccountId(principal, 101L);
+
+    verify(accountAccessUseCase, times(2)).verifyBootstrapAccount(101L, AccountAccessScope.READ);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryControllerTest.java
@@ -125,6 +125,32 @@ class TransactionArchiveQueryControllerTest {
   }
 
   @Test
+  void decodesIncomingArchiveCursor() throws Exception {
+    TransactionCursor cursor = new TransactionCursor(Instant.parse("2025-01-16T09:00:00Z"), 777L);
+    String encoded = TransactionCursorCodec.encode(cursor);
+    when(transactionArchiveQueryUseCase.getArchivedTransactions(
+            argThat(query -> cursor.equals(query.cursor()))))
+        .thenReturn(new TransactionSlice(List.of(), null, false, 20));
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/archive")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2025-01-01T00:00:00Z")
+                .param("to", "2025-01-31T00:00:00Z")
+                .param("limit", "20")
+                .param("cursor", encoded))
+        .andExpect(status().isOk());
+
+    verify(transactionArchiveQueryUseCase)
+        .getArchivedTransactions(argThat(query -> cursor.equals(query.cursor())));
+  }
+
+  @Test
   void rejectsArchiveDateRangeLargerThanThirtyOneDays() throws Exception {
     when(requestAccountAuthorizationService.resolveReadableAccountId(
             org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
@@ -137,6 +163,36 @@ class TransactionArchiveQueryControllerTest {
                 .param("accountId", "101")
                 .param("from", "2025-01-01T00:00:00Z")
                 .param("to", "2025-03-01T00:00:00Z"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void usesLimit50AsDefaultAndHardCapForArchive() throws Exception {
+    when(transactionArchiveQueryUseCase.getArchivedTransactions(
+            argThat(query -> query.limit() == 50)))
+        .thenReturn(new TransactionSlice(List.of(), null, false, 50));
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/archive")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2025-01-01T00:00:00Z")
+                .param("to", "2025-01-31T00:00:00Z"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.limit").value(50));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions/archive")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2025-01-01T00:00:00Z")
+                .param("to", "2025-01-31T00:00:00Z")
+                .param("limit", "51"))
         .andExpect(status().isBadRequest());
   }
 

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionArchiveQueryControllerTest.java
@@ -43,7 +43,9 @@ class TransactionArchiveQueryControllerTest {
                 new TransactionArchiveQueryController(
                     transactionArchiveQueryUseCase,
                     requestAccountAuthorizationService,
-                    new TransactionReadHotPathMetrics(meterRegistry)))
+                    new TransactionReadHotPathMetrics(meterRegistry),
+                    new TransactionReadSingleFlight(),
+                    new TransactionReadAccountFairnessLimiter(2)))
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .build();

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
@@ -43,7 +43,9 @@ class TransactionQueryControllerTest {
                 new TransactionQueryController(
                     transactionQueryUseCase,
                     requestAccountAuthorizationService,
-                    new TransactionReadHotPathMetrics(meterRegistry)))
+                    new TransactionReadHotPathMetrics(meterRegistry),
+                    new TransactionReadSingleFlight(),
+                    new TransactionReadAccountFairnessLimiter(2)))
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .build();

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionQueryControllerTest.java
@@ -113,6 +113,35 @@ class TransactionQueryControllerTest {
   }
 
   @Test
+  void usesLimit50AsDefaultAndHardCap() throws Exception {
+    when(transactionQueryUseCase.getTransactions(argThat(query -> query.limit() == 50)))
+        .thenReturn(new TransactionSlice(List.of(), null, false, 50));
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.limit").value(50));
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z")
+                .param("limit", "51"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   void decodesIncomingCursor() throws Exception {
     TransactionCursor cursor = new TransactionCursor(Instant.parse("2026-04-16T09:00:00Z"), 777L);
     String encoded = TransactionCursorCodec.encode(cursor);
@@ -161,6 +190,64 @@ class TransactionQueryControllerTest {
         .andExpect(status().isOk());
 
     verify(transactionQueryUseCase).getTransactions(argThat(this::matchesExpandedFilters));
+  }
+
+  @Test
+  void returnsSlimResponseShapeWithoutHeavyDisplayFields() throws Exception {
+    when(transactionQueryUseCase.getTransactions(argThat(query -> query.accountId() == 101L)))
+        .thenReturn(
+            new TransactionSlice(
+                List.of(
+                    new TransactionSummary(
+                        778L,
+                        101L,
+                        "TX-778",
+                        TransactionDirection.CREDIT,
+                        TransactionStatus.BOOKED,
+                        3400L,
+                        123400L,
+                        "KRW",
+                        "payroll settlement",
+                        "EMPLOYER",
+                        Instant.parse("2026-04-16T10:00:00Z"))),
+                null,
+                false,
+                50));
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z")
+                .param("responseShape", "slim"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].transactionReference").value("TX-778"))
+        .andExpect(jsonPath("$.items[0].amountMinor").value(3400))
+        .andExpect(jsonPath("$.items[0].balanceAfterMinor").doesNotExist())
+        .andExpect(jsonPath("$.items[0].summary").doesNotExist())
+        .andExpect(jsonPath("$.items[0].counterpartyMaskedName").doesNotExist());
+  }
+
+  @Test
+  void rejectsInvalidResponseShape() throws Exception {
+    when(requestAccountAuthorizationService.resolveReadableAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transactions")
+                .header("X-Account-Id", "101")
+                .param("accountId", "101")
+                .param("from", "2026-04-01T00:00:00Z")
+                .param("to", "2026-04-17T00:00:00Z")
+                .param("responseShape", "compact"))
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionReadAccountFairnessLimiterTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionReadAccountFairnessLimiterTest.java
@@ -1,0 +1,81 @@
+package com.aquilabank.global.web.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+class TransactionReadAccountFairnessLimiterTest {
+
+  @Test
+  void rejectsConcurrentRequestAbovePerAccountLimit() throws Exception {
+    TransactionReadAccountFairnessLimiter limiter = new TransactionReadAccountFairnessLimiter(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    CountDownLatch ownerStarted = new CountDownLatch(1);
+    CountDownLatch releaseOwner = new CountDownLatch(1);
+    try {
+      Future<String> owner =
+          executor.submit(
+              () ->
+                  limiter.execute(
+                      101L,
+                      () -> {
+                        ownerStarted.countDown();
+                        await(releaseOwner);
+                        return "owner";
+                      }));
+      assertThat(ownerStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+      assertThatThrownBy(() -> limiter.execute(101L, () -> "rejected"))
+          .isInstanceOf(ResponseStatusException.class)
+          .hasMessageContaining("429 TOO_MANY_REQUESTS");
+
+      releaseOwner.countDown();
+      assertThat(owner.get(1, TimeUnit.SECONDS)).isEqualTo("owner");
+    } finally {
+      releaseOwner.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void separatesDifferentAccountsAndReleasesAfterFailure() {
+    TransactionReadAccountFairnessLimiter limiter = new TransactionReadAccountFairnessLimiter(1);
+
+    assertThat(limiter.execute(101L, () -> "first")).isEqualTo("first");
+    assertThat(limiter.execute(202L, () -> "second")).isEqualTo("second");
+    assertThatThrownBy(
+            () ->
+                limiter.execute(
+                    101L,
+                    () -> {
+                      throw new IllegalStateException("failed");
+                    }))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(limiter.execute(101L, () -> "recovered")).isEqualTo("recovered");
+  }
+
+  @Test
+  void rejectsInvalidLimitConfiguration() {
+    assertThatThrownBy(() -> new TransactionReadAccountFairnessLimiter(0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("maxConcurrentRequests must be positive");
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(1, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("latch timeout");
+      }
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(ex);
+    }
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionReadSingleFlightTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionReadSingleFlightTest.java
@@ -1,0 +1,164 @@
+package com.aquilabank.global.web.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.domain.transaction.model.TransactionSlice;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class TransactionReadSingleFlightTest {
+
+  private final TransactionReadSingleFlight singleFlight = new TransactionReadSingleFlight();
+  private final TransactionQuery query =
+      new TransactionQuery(
+          101L,
+          Instant.parse("2026-04-01T00:00:00Z"),
+          Instant.parse("2026-04-17T00:00:00Z"),
+          50,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null);
+
+  @Test
+  void coalescesIdenticalInFlightRequest() throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch ownerStarted = new CountDownLatch(1);
+    CountDownLatch releaseOwner = new CountDownLatch(1);
+    AtomicInteger supplierCalls = new AtomicInteger();
+    AtomicReference<Thread> waiterThread = new AtomicReference<>();
+    TransactionSlice expected = new TransactionSlice(List.of(), null, false, 50);
+    try {
+      Future<TransactionSlice> first =
+          executor.submit(
+              () ->
+                  singleFlight.get(
+                      "active",
+                      query,
+                      () -> {
+                        supplierCalls.incrementAndGet();
+                        ownerStarted.countDown();
+                        await(releaseOwner);
+                        return expected;
+                      }));
+      assertThat(ownerStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+      Future<TransactionSlice> second =
+          executor.submit(
+              () -> {
+                waiterThread.set(Thread.currentThread());
+                return singleFlight.get(
+                    "active",
+                    query,
+                    () -> {
+                      supplierCalls.incrementAndGet();
+                      return new TransactionSlice(List.of(), null, false, 50);
+                    });
+              });
+      assertThat(awaitWaiting(waiterThread)).isTrue();
+
+      releaseOwner.countDown();
+
+      assertThat(first.get(1, TimeUnit.SECONDS)).isSameAs(expected);
+      assertThat(second.get(1, TimeUnit.SECONDS)).isSameAs(expected);
+      assertThat(supplierCalls).hasValue(1);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void propagatesOwnerFailureToWaiterAndAllowsRetry() throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch ownerStarted = new CountDownLatch(1);
+    CountDownLatch releaseOwner = new CountDownLatch(1);
+    AtomicInteger supplierCalls = new AtomicInteger();
+    AtomicReference<Thread> waiterThread = new AtomicReference<>();
+    try {
+      Future<TransactionSlice> first =
+          executor.submit(
+              () ->
+                  singleFlight.get(
+                      "active",
+                      query,
+                      () -> {
+                        supplierCalls.incrementAndGet();
+                        ownerStarted.countDown();
+                        await(releaseOwner);
+                        throw new IllegalStateException("query failed");
+                      }));
+      assertThat(ownerStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+      Future<TransactionSlice> second =
+          executor.submit(
+              () -> {
+                waiterThread.set(Thread.currentThread());
+                return singleFlight.get(
+                    "active",
+                    query,
+                    () -> {
+                      supplierCalls.incrementAndGet();
+                      return new TransactionSlice(List.of(), null, false, 50);
+                    });
+              });
+      assertThat(awaitWaiting(waiterThread)).isTrue();
+
+      releaseOwner.countDown();
+
+      assertThatThrownBy(() -> first.get(1, TimeUnit.SECONDS))
+          .hasRootCauseInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> second.get(1, TimeUnit.SECONDS))
+          .hasRootCauseInstanceOf(IllegalStateException.class);
+      TransactionSlice recovered =
+          singleFlight.get(
+              "active",
+              query,
+              () -> {
+                supplierCalls.incrementAndGet();
+                return new TransactionSlice(List.of(), null, false, 50);
+              });
+
+      assertThat(recovered.limit()).isEqualTo(50);
+      assertThat(supplierCalls).hasValue(2);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(1, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("latch timeout");
+      }
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(ex);
+    }
+  }
+
+  private static boolean awaitWaiting(AtomicReference<Thread> threadRef) {
+    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+    while (System.nanoTime() < deadlineNanos) {
+      Thread thread = threadRef.get();
+      if (thread != null
+          && (thread.getState() == Thread.State.WAITING
+              || thread.getState() == Thread.State.TIMED_WAITING)) {
+        return true;
+      }
+      Thread.yield();
+    }
+    return false;
+  }
+}

--- a/ops/nginx/README.md
+++ b/ops/nginx/README.md
@@ -71,6 +71,7 @@ bash tools/ops/render-nginx-runtime-config.sh /tmp/aquila-bank-nginx.conf ops/ng
 - `/api/`에는 `limit_req zone=aquila_bank_api_per_ip burst=20 delay=5;`를 유지합니다.
 - `/api/v1/notifications/stream`은 장기 연결이라 일반 API와 성격이 달라 exact location으로 분리하고 rate limit 대상에서 제외합니다.
 - `429`는 Nginx에서 JSON body와 `X-Aquila-Reject-Source: nginx-edge`, `Retry-After`, `X-RateLimit-Retry-After-Millis`, `X-RateLimit-Retry-Jitter-Millis`를 내려 k6/client backoff가 edge rejection을 구분하게 합니다. OCI A1 기본값은 `150ms + jitter 100ms`로 retry 동기화를 짧게 분산합니다.
+- 정상 client/SDK는 `X-RateLimit-Retry-After-Millis`와 jitter를 반영하고, sustained read에서는 k6 `preemptive pacing`과 같은 요청 전 token pacing으로 edge reject 동기화를 피합니다.
 - backend에는 login/password recovery throttling이 이미 있으므로, Nginx auth zone은 edge 1차 차단으로 보고 backend는 계정/IP 단위 2차 가드로 둡니다.
 - transaction-read `burst64` profile은 delay queue 의존을 줄이기 위해 `128r/s`, `burst=16`, `nodelay`를 기본값으로 둡니다. 이전 queue 기반 기준은 `balanced` profile로 되돌릴 수 있습니다.
 - `fail-fast` profile은 `96r/s`, `burst=12`, `nodelay`로 delayed ratio ceiling 검증이나 latency 우선 rollback에 사용합니다.

--- a/tools/test/check-transaction-read-client-pacing-contract.sh
+++ b/tools/test/check-transaction-read-client-pacing-contract.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[transaction-read-client-pacing] nginx retry headers"
+grep -F 'add_header Retry-After ${NGINX_EDGE_RETRY_AFTER_SECONDS} always;' ops/nginx/nginx.conf >/dev/null
+grep -F 'add_header X-RateLimit-Scope nginx-edge always;' ops/nginx/nginx.conf >/dev/null
+grep -F 'add_header X-RateLimit-Retry-After-Millis ${NGINX_EDGE_RETRY_AFTER_MILLIS} always;' ops/nginx/nginx.conf >/dev/null
+grep -F 'add_header X-RateLimit-Retry-Jitter-Millis ${NGINX_EDGE_RETRY_JITTER_MILLIS} always;' ops/nginx/nginx.conf >/dev/null
+grep -F '"retryAfterMillis":${NGINX_EDGE_RETRY_AFTER_MILLIS}' ops/nginx/nginx.conf >/dev/null
+
+echo "[transaction-read-client-pacing] k6 client pacing"
+grep -F 'K6_PREEMPTIVE_PACING enable request-before token pacing' tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F 'K6_PREEMPTIVE_PACING_RPS global target request rate split by K6_VUS' tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F 'K6_PREEMPTIVE_PACING_MAX_SLEEP_MS default 250' tools/test/run-k6-transaction-100m-loadtest.sh >/dev/null
+grep -F 'const preemptivePacingEnabled = preemptivePacing && preemptivePacingIntervalMs > 0;' ops/k6/transaction-read-100m.js >/dev/null
+grep -F 'aquila_transaction_preemptive_pacing_count' ops/k6/transaction-read-100m.js >/dev/null
+grep -F 'aquila_transaction_preemptive_pacing_sleep_ms' ops/k6/transaction-read-100m.js >/dev/null
+
+echo "[transaction-read-client-pacing] docs contract"
+grep -F 'Retry-After' ops/nginx/README.md >/dev/null
+grep -F 'X-RateLimit-Retry-After-Millis' ops/nginx/README.md >/dev/null
+grep -F 'preemptive pacing' ops/nginx/README.md >/dev/null

--- a/tools/test/check-transaction-read-operational-evidence-gate.sh
+++ b/tools/test/check-transaction-read-operational-evidence-gate.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-operational-evidence-gate.sh"
+
+echo "[transaction-read-operational-evidence] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+evidence_tsv="${temp_dir}/operational-evidence.tsv"
+output_dir="${temp_dir}/output"
+
+cat >"${evidence_tsv}" <<'TSV'
+scenario	duration_min	source_ips	cold_p95_ms	warm_p95_ms	p999_ms	edge_429_rate	backend_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	sse_reject_count	deploy_drain_5xx_count	pg_wait_p95_ms	timeline_artifact
+hikari-soak	10	1	420	210	390	0.01	0	0	0	0	0	0	0	3	oci/hikari-soak.json
+cold-warm	3	1	760	240	410	0.02	0	0	0	0	0	0	0	4	oci/cold-warm.json
+mixed-workload	30	1	650	260	450	0.08	0	0	0	0	0	0	0	6	oci/mixed-workload.json
+real-ip-multisource	2	3	560	230	430	0.07	0	0	0	0	0	0	0	5	oci/real-ip.json
+deploy-drain	5	1	590	250	470	0.04	0	0	0	0	0	0	0	5	oci/deploy-drain.json
+p999-long	30	1	700	280	490	0.06	0	0	0	0	0	0	0	8	oci/p999-long.json
+TSV
+
+echo "[transaction-read-operational-evidence] print plan"
+plan="$(
+  OP_EVIDENCE_NAME=operational-check \
+  OP_EVIDENCE_INPUT_TSV="${evidence_tsv}" \
+  OP_EVIDENCE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" --print-plan
+)"
+grep -F "name=operational-check" <<<"${plan}" >/dev/null
+grep -F "input_tsv=${evidence_tsv}" <<<"${plan}" >/dev/null
+grep -F "required_scenarios=hikari-soak,cold-warm,mixed-workload,real-ip-multisource,deploy-drain,p999-long" <<<"${plan}" >/dev/null
+grep -F "max_edge_429_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "max_p999_ms=500" <<<"${plan}" >/dev/null
+grep -F "mixed_min_duration_min=30" <<<"${plan}" >/dev/null
+grep -F "min_real_source_ips=2" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-operational-evidence] pass report"
+output="$(
+  OP_EVIDENCE_NAME=operational-check \
+  OP_EVIDENCE_INPUT_TSV="${evidence_tsv}" \
+  OP_EVIDENCE_OUTPUT_DIR="${output_dir}" \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+summary_tsv="${output_dir}/operational-check-operational-evidence.tsv"
+test "${report_md}" = "${output_dir}/operational-check-operational-evidence.md"
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "Hikari validation warning: 0" "${report_md}" >/dev/null
+grep -F "499/5xx/backend429 hard target: 0" "${report_md}" >/dev/null
+grep -F "mixed workload min duration: 30m" "${report_md}" >/dev/null
+grep -F "p99.9 long observation max: 500ms" "${report_md}" >/dev/null
+grep -F $'mixed-workload\tpass\tok\t30\t1\t650\t260\t450\t0.08\t0\t0\t0\t0\t0\t0\t0\t6\toci/mixed-workload.json' "${summary_tsv}" >/dev/null
+grep -F $'real-ip-multisource\tpass\tok\t2\t3' "${summary_tsv}" >/dev/null
+
+echo "[transaction-read-operational-evidence] fail report"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload" { $6 = 560; $7 = 0.12; $9 = 1; $10 = 1; $11 = 1 } { print }' \
+  "${evidence_tsv}" >"${evidence_tsv}.fail"
+if OP_EVIDENCE_NAME=operational-fail \
+  OP_EVIDENCE_INPUT_TSV="${evidence_tsv}.fail" \
+  OP_EVIDENCE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "operational evidence gate unexpectedly passed Hikari/499/p999/429 failure" >&2
+  exit 1
+fi
+
+OP_EVIDENCE_NAME=operational-fail \
+OP_EVIDENCE_INPUT_TSV="${evidence_tsv}.fail" \
+OP_EVIDENCE_OUTPUT_DIR="${output_dir}" \
+  "${runner}" >/dev/null 2>&1 || true
+grep -F $'mixed-workload\tfail\t' "${output_dir}/operational-fail-operational-evidence.tsv" >/dev/null
+grep -F "edge429>0.10" "${output_dir}/operational-fail-operational-evidence.tsv" >/dev/null
+grep -F "5xx>0" "${output_dir}/operational-fail-operational-evidence.tsv" >/dev/null
+grep -F "499>0" "${output_dir}/operational-fail-operational-evidence.tsv" >/dev/null
+grep -F "hikari-warning>0" "${output_dir}/operational-fail-operational-evidence.tsv" >/dev/null
+
+echo "[transaction-read-operational-evidence] missing scenario fails"
+awk -F '\t' '$1 != "deploy-drain"' "${evidence_tsv}" >"${evidence_tsv}.missing"
+if OP_EVIDENCE_NAME=operational-missing \
+  OP_EVIDENCE_INPUT_TSV="${evidence_tsv}.missing" \
+  OP_EVIDENCE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "operational evidence gate unexpectedly passed missing deploy-drain scenario" >&2
+  exit 1
+fi
+
+echo "[transaction-read-operational-evidence] real IP source fail"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "real-ip-multisource" { $3 = 1 } { print }' \
+  "${evidence_tsv}" >"${evidence_tsv}.source-fail"
+if OP_EVIDENCE_NAME=operational-source-fail \
+  OP_EVIDENCE_INPUT_TSV="${evidence_tsv}.source-fail" \
+  OP_EVIDENCE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "operational evidence gate unexpectedly passed single source real-IP evidence" >&2
+  exit 1
+fi

--- a/tools/test/check-transaction-read-short-burst-smoothing-matrix.sh
+++ b/tools/test/check-transaction-read-short-burst-smoothing-matrix.sh
@@ -13,10 +13,10 @@ input_tsv="${temp_dir}/short-burst.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${input_tsv}" <<'TSV'
-policy	hot_limit_mode	archive_limit_mode	hot_burst	archive_burst	burst48_429_rate	burst64_429_rate	accepted_p95_ms	accepted_p99_ms	retry_after_p95_ms	edge_delayed_rate	five_xx_count	backend_429_rate	backend_pending	hikari_warning_count
-nodelay	nodelay	nodelay	10	10	0.1833	0.2088	95	145	180	0	0	0.0002	0	0
-delay1	delay=1	delay=1	12	12	0.0959	0.2088	188	295	190	0.85	0	0.0002	0	0
-burst64	nodelay	nodelay	16	16	0.0400	0.0900	160	250	170	0.05	0	0.0002	0	0
+policy	hot_limit_mode	archive_limit_mode	hot_burst	archive_burst	burst48_429_rate	burst64_429_rate	burst80_429_rate	burst96_429_rate	accepted_p95_ms	accepted_p99_ms	retry_after_p95_ms	edge_delayed_rate	five_xx_count	backend_429_rate	backend_pending	hikari_warning_count
+nodelay	nodelay	nodelay	10	10	0.1833	0.2088	0.4200	0.5600	95	145	180	0	0	0.0002	0	0
+delay1	delay=1	delay=1	12	12	0.0959	0.2088	0.3900	0.5100	188	295	190	0.85	0	0.0002	0	0
+burst64	nodelay	nodelay	16	16	0.0400	0.0900	0.1800	0.2600	160	250	170	0.05	0	0.0002	0	0
 TSV
 
 echo "[transaction-read-short-burst-smoothing] print plan"
@@ -30,6 +30,8 @@ grep -F "name=short-burst-check" <<<"${plan}" >/dev/null
 grep -F "required_policies=nodelay,delay1,burst64" <<<"${plan}" >/dev/null
 grep -F "max_burst48_429_rate=0.10" <<<"${plan}" >/dev/null
 grep -F "max_burst64_429_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "min_burst80_429_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "min_burst96_429_rate=0.10" <<<"${plan}" >/dev/null
 grep -F "max_accepted_p95_ms=200" <<<"${plan}" >/dev/null
 grep -F "max_accepted_p99_ms=300" <<<"${plan}" >/dev/null
 grep -F "max_retry_after_p95_ms=250" <<<"${plan}" >/dev/null
@@ -48,10 +50,12 @@ test "${report_md}" = "${output_dir}/short-burst-check-short-burst-smoothing.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "recommended policy: burst64" "${report_md}" >/dev/null
 grep -F "Retry-After contract: fixed 150ms + jitter 100ms" "${report_md}" >/dev/null
-grep -F $'policy\tstatus\thot_limit_mode\tarchive_limit_mode\thot_burst\tarchive_burst\tburst48_429_rate\tburst64_429_rate\taccepted_p95_ms\taccepted_p99_ms\tretry_after_p95_ms\tedge_delayed_rate\tfive_xx_count\tbackend_429_rate\tbackend_pending\thikari_warning_count' "${summary_tsv}" >/dev/null
-grep -F $'nodelay\tfail\tnodelay\tnodelay\t10\t10\t0.1833\t0.2088\t95\t145\t180\t0\t0\t0.0002\t0\t0' "${summary_tsv}" >/dev/null
-grep -F $'delay1\tfail\tdelay=1\tdelay=1\t12\t12\t0.0959\t0.2088\t188\t295\t190\t0.85\t0\t0.0002\t0\t0' "${summary_tsv}" >/dev/null
-grep -F $'burst64\tpass\tnodelay\tnodelay\t16\t16\t0.0400\t0.0900\t160\t250\t170\t0.05\t0\t0.0002\t0\t0' "${summary_tsv}" >/dev/null
+grep -F $'policy\tstatus\thot_limit_mode\tarchive_limit_mode\thot_burst\tarchive_burst\tburst48_429_rate\tburst64_429_rate\tburst80_429_rate\tburst96_429_rate\taccepted_p95_ms\taccepted_p99_ms\tretry_after_p95_ms\tedge_delayed_rate\tfive_xx_count\tbackend_429_rate\tbackend_pending\thikari_warning_count' "${summary_tsv}" >/dev/null
+grep -F $'nodelay\tfail\tnodelay\tnodelay\t10\t10\t0.1833\t0.2088\t0.4200\t0.5600\t95\t145\t180\t0\t0\t0.0002\t0\t0' "${summary_tsv}" >/dev/null
+grep -F $'delay1\tfail\tdelay=1\tdelay=1\t12\t12\t0.0959\t0.2088\t0.3900\t0.5100\t188\t295\t190\t0.85\t0\t0.0002\t0\t0' "${summary_tsv}" >/dev/null
+grep -F $'burst64\tpass\tnodelay\tnodelay\t16\t16\t0.0400\t0.0900\t0.1800\t0.2600\t160\t250\t170\t0.05\t0\t0.0002\t0\t0' "${summary_tsv}" >/dev/null
+grep -F "burst-80 fail-fast lower bound: >= 0.10" "${report_md}" >/dev/null
+grep -F "burst-96 fail-fast lower bound: >= 0.10" "${report_md}" >/dev/null
 
 echo "[transaction-read-short-burst-smoothing] fail report"
 awk -F '\t' 'BEGIN { OFS = "\t" } NR == 1 { print; next } { $7 = "0.1800"; print }' \
@@ -65,7 +69,7 @@ if SHORT_BURST_SMOOTHING_NAME=short-burst-fail \
 fi
 
 echo "[transaction-read-short-burst-smoothing] latency fail report"
-awk -F '\t' 'BEGIN { OFS = "\t" } NR == 1 { print; next } { $9 = "360"; print }' \
+awk -F '\t' 'BEGIN { OFS = "\t" } NR == 1 { print; next } { $11 = "360"; print }' \
   "${input_tsv}" >"${input_tsv}.p99-fail"
 if SHORT_BURST_SMOOTHING_NAME=short-burst-p99-fail \
   SHORT_BURST_SMOOTHING_INPUT_TSV="${input_tsv}.p99-fail" \
@@ -76,13 +80,24 @@ if SHORT_BURST_SMOOTHING_NAME=short-burst-p99-fail \
 fi
 
 echo "[transaction-read-short-burst-smoothing] delayed ratio fail report"
-awk -F '\t' 'BEGIN { OFS = "\t" } NR == 1 { print; next } { $11 = "0.30"; print }' \
+awk -F '\t' 'BEGIN { OFS = "\t" } NR == 1 { print; next } { $13 = "0.30"; print }' \
   "${input_tsv}" >"${input_tsv}.delayed-fail"
 if SHORT_BURST_SMOOTHING_NAME=short-burst-delayed-fail \
   SHORT_BURST_SMOOTHING_INPUT_TSV="${input_tsv}.delayed-fail" \
   SHORT_BURST_SMOOTHING_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "short burst smoothing matrix unexpectedly passed without a delayed-ratio-safe candidate" >&2
+  exit 1
+fi
+
+echo "[transaction-read-short-burst-smoothing] overload fail-fast fail report"
+awk -F '\t' 'BEGIN { OFS = "\t" } NR == 1 { print; next } { $8 = "0.0400"; $9 = "0.0500"; print }' \
+  "${input_tsv}" >"${input_tsv}.overload-fail"
+if SHORT_BURST_SMOOTHING_NAME=short-burst-overload-fail \
+  SHORT_BURST_SMOOTHING_INPUT_TSV="${input_tsv}.overload-fail" \
+  SHORT_BURST_SMOOTHING_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "short burst smoothing matrix unexpectedly passed without 80/96 fail-fast reject" >&2
   exit 1
 fi
 

--- a/tools/test/check-transaction-read-single-source-edge-budget-gate.sh
+++ b/tools/test/check-transaction-read-single-source-edge-budget-gate.sh
@@ -14,8 +14,8 @@ output_dir="${temp_dir}/output"
 
 cat >"${budget_tsv}" <<'TSV'
 run	source_mode	workload_shape	edge_429_rate	backend_429_rate	backend_rejected_count	upstream_502_count	client_499_count	hikari_warning_count	accepted_p95_ms
-vu16-soak-2m	single-source	fixed	0.2995	0	0	0	0	0	93.3
-weighted-vu16-soak-2m	single-source	weighted-random	0.2763	0.0014	29	0	0	0	93.5
+vu16-soak-2m	single-source	fixed	0.0956	0	0	0	0	0	93.3
+weighted-vu16-soak-2m	single-source	weighted-random	0.0873	0	0	0	0	0	93.5
 weighted-vu16-multisource-10m	multi-source	weighted-random	0.0800	0.0002	0	0	0	0	145.0
 TSV
 
@@ -28,10 +28,11 @@ plan="$(
 )"
 grep -F "name=single-source-budget-check" <<<"${plan}" >/dev/null
 grep -F "input_tsv=${budget_tsv}" <<<"${plan}" >/dev/null
-grep -F "defensive_single_source_edge_429_rate=0.30" <<<"${plan}" >/dev/null
+grep -F "single_source_edge_429_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "single_source_backend_429_rate=0" <<<"${plan}" >/dev/null
 grep -F "operating_edge_429_rate=0.10" <<<"${plan}" >/dev/null
 grep -F "operating_backend_429_rate=0.0005" <<<"${plan}" >/dev/null
-grep -F "decision=single-source-defensive-lab-only" <<<"${plan}" >/dev/null
+grep -F "decision=single-source-operating-budget" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-single-source-budget] report"
 output="$(
@@ -44,24 +45,24 @@ report_md="$(tail -1 <<<"${output}")"
 summary_tsv="${output_dir}/single-source-budget-check-single-source-edge-budget.tsv"
 test "${report_md}" = "${output_dir}/single-source-budget-check-single-source-edge-budget.md"
 grep -F $'run\tstatus\tbudget_class\tsource_mode\tworkload_shape\tedge_429_rate\tedge_429_budget\tbackend_429_rate\tbackend_429_budget\tbackend_rejected_count\toperating_candidate\treason' "${summary_tsv}" >/dev/null
-grep -F $'vu16-soak-2m\tpass\tdefensive-lab\tsingle-source\tfixed\t0.2995\t0.30\t0\t0.005\t0\tno\twithin-defensive-single-source-budget' "${summary_tsv}" >/dev/null
-grep -F $'weighted-vu16-soak-2m\tpass\tdefensive-lab\tsingle-source\tweighted-random\t0.2763\t0.30\t0.0014\t0.005\t29\tno\twithin-defensive-single-source-budget' "${summary_tsv}" >/dev/null
+grep -F $'vu16-soak-2m\tpass\toperating-candidate\tsingle-source\tfixed\t0.0956\t0.10\t0\t0\t0\tyes\twithin-single-source-operating-budget' "${summary_tsv}" >/dev/null
+grep -F $'weighted-vu16-soak-2m\tpass\toperating-candidate\tsingle-source\tweighted-random\t0.0873\t0.10\t0\t0\t0\tyes\twithin-single-source-operating-budget' "${summary_tsv}" >/dev/null
 grep -F $'weighted-vu16-multisource-10m\tpass\toperating-candidate\tmulti-source\tweighted-random\t0.0800\t0.10\t0.0002\t0.0005\t0\tyes\twithin-operating-budget' "${summary_tsv}" >/dev/null
 grep -F "gate_status=pass" "${report_md}" >/dev/null
-grep -F "single-source decision: defensive-lab-only" "${report_md}" >/dev/null
+grep -F "single-source decision: operating-budget" "${report_md}" >/dev/null
 grep -F "operating edge 429 target: < 0.10" "${report_md}" >/dev/null
-grep -F "operating candidates: 1" "${report_md}" >/dev/null
+grep -F "operating candidates: 3" "${report_md}" >/dev/null
 
 echo "[transaction-read-single-source-budget] fail report"
 cat >"${budget_tsv}.fail" <<'TSV'
 run	source_mode	workload_shape	edge_429_rate	backend_429_rate	backend_rejected_count	upstream_502_count	client_499_count	hikari_warning_count	accepted_p95_ms
-vu16-soak-2m	single-source	fixed	0.3100	0	0	0	0	0	93.3
+vu16-soak-2m	single-source	fixed	0.1050	0	0	0	0	0	93.3
 TSV
 if SINGLE_SOURCE_EDGE_BUDGET_NAME=single-source-budget-fail \
   SINGLE_SOURCE_EDGE_BUDGET_INPUT_TSV="${budget_tsv}.fail" \
   SINGLE_SOURCE_EDGE_BUDGET_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
-  echo "single-source edge budget unexpectedly passed edge 429 over defensive budget" >&2
+  echo "single-source edge budget unexpectedly passed edge 429 over operating budget" >&2
   exit 1
 fi
 

--- a/tools/test/run-transaction-read-operational-evidence-gate.sh
+++ b/tools/test/run-transaction-read-operational-evidence-gate.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-operational-evidence-gate.sh [--print-plan]
+
+Environment:
+  OP_EVIDENCE_NAME                default transaction-read-operational-evidence-<timestamp>
+  OP_EVIDENCE_INPUT_TSV           required TSV with OCI scenario evidence
+  OP_EVIDENCE_OUTPUT_DIR          default build/reports/k6/<gate>
+  OP_EVIDENCE_REQUIRED_SCENARIOS  default hikari-soak,cold-warm,mixed-workload,real-ip-multisource,deploy-drain,p999-long
+  OP_EVIDENCE_MAX_EDGE_429_RATE   default 0.10
+  OP_EVIDENCE_MAX_COLD_P95_MS     default 1000
+  OP_EVIDENCE_MAX_WARM_P95_MS     default 350
+  OP_EVIDENCE_MAX_P999_MS         default 500
+  OP_EVIDENCE_MAX_POOL_PENDING    default 0
+  OP_EVIDENCE_MIXED_MIN_DURATION_MIN  default 30
+  OP_EVIDENCE_P999_MIN_DURATION_MIN   default 30
+  OP_EVIDENCE_HIKARI_MIN_DURATION_MIN default 10
+  OP_EVIDENCE_DEPLOY_MIN_DURATION_MIN default 5
+  OP_EVIDENCE_MIN_REAL_SOURCE_IPS     default 2
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${OP_EVIDENCE_NAME:-transaction-read-operational-evidence-$(date +%Y-%m-%d-%H%M%S)}"
+input_tsv="${OP_EVIDENCE_INPUT_TSV:-}"
+output_dir="${OP_EVIDENCE_OUTPUT_DIR:-build/reports/k6/${name}}"
+required_scenarios="${OP_EVIDENCE_REQUIRED_SCENARIOS:-hikari-soak,cold-warm,mixed-workload,real-ip-multisource,deploy-drain,p999-long}"
+max_edge_429_rate="${OP_EVIDENCE_MAX_EDGE_429_RATE:-0.10}"
+max_cold_p95_ms="${OP_EVIDENCE_MAX_COLD_P95_MS:-1000}"
+max_warm_p95_ms="${OP_EVIDENCE_MAX_WARM_P95_MS:-350}"
+max_p999_ms="${OP_EVIDENCE_MAX_P999_MS:-500}"
+max_pool_pending="${OP_EVIDENCE_MAX_POOL_PENDING:-0}"
+mixed_min_duration_min="${OP_EVIDENCE_MIXED_MIN_DURATION_MIN:-30}"
+p999_min_duration_min="${OP_EVIDENCE_P999_MIN_DURATION_MIN:-30}"
+hikari_min_duration_min="${OP_EVIDENCE_HIKARI_MIN_DURATION_MIN:-10}"
+deploy_min_duration_min="${OP_EVIDENCE_DEPLOY_MIN_DURATION_MIN:-5}"
+min_real_source_ips="${OP_EVIDENCE_MIN_REAL_SOURCE_IPS:-2}"
+summary_tsv="${output_dir}/${name}-operational-evidence.tsv"
+report_md="${output_dir}/${name}-operational-evidence.md"
+meta_file="${output_dir}/${name}-operational-evidence.meta"
+
+require_non_negative_number() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${key} must be a non-negative number: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_non_negative_integer() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${key} must be a non-negative integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_rate() {
+  local key="$1"
+  local value="$2"
+  require_non_negative_number "${key}" "${value}"
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0 && value <= 1) }' || {
+    echo "${key} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  }
+}
+
+require_rate "OP_EVIDENCE_MAX_EDGE_429_RATE" "${max_edge_429_rate}"
+require_non_negative_number "OP_EVIDENCE_MAX_COLD_P95_MS" "${max_cold_p95_ms}"
+require_non_negative_number "OP_EVIDENCE_MAX_WARM_P95_MS" "${max_warm_p95_ms}"
+require_non_negative_number "OP_EVIDENCE_MAX_P999_MS" "${max_p999_ms}"
+require_non_negative_integer "OP_EVIDENCE_MAX_POOL_PENDING" "${max_pool_pending}"
+require_non_negative_integer "OP_EVIDENCE_MIXED_MIN_DURATION_MIN" "${mixed_min_duration_min}"
+require_non_negative_integer "OP_EVIDENCE_P999_MIN_DURATION_MIN" "${p999_min_duration_min}"
+require_non_negative_integer "OP_EVIDENCE_HIKARI_MIN_DURATION_MIN" "${hikari_min_duration_min}"
+require_non_negative_integer "OP_EVIDENCE_DEPLOY_MIN_DURATION_MIN" "${deploy_min_duration_min}"
+require_non_negative_integer "OP_EVIDENCE_MIN_REAL_SOURCE_IPS" "${min_real_source_ips}"
+
+print_plan() {
+  echo "[transaction-read-operational-evidence] name=${name}"
+  echo "[transaction-read-operational-evidence] input_tsv=${input_tsv:-missing}"
+  echo "[transaction-read-operational-evidence] output_dir=${output_dir}"
+  echo "[transaction-read-operational-evidence] required_scenarios=${required_scenarios}"
+  echo "[transaction-read-operational-evidence] max_edge_429_rate=${max_edge_429_rate}"
+  echo "[transaction-read-operational-evidence] max_cold_p95_ms=${max_cold_p95_ms}"
+  echo "[transaction-read-operational-evidence] max_warm_p95_ms=${max_warm_p95_ms}"
+  echo "[transaction-read-operational-evidence] max_p999_ms=${max_p999_ms}"
+  echo "[transaction-read-operational-evidence] max_pool_pending=${max_pool_pending}"
+  echo "[transaction-read-operational-evidence] mixed_min_duration_min=${mixed_min_duration_min}"
+  echo "[transaction-read-operational-evidence] p999_min_duration_min=${p999_min_duration_min}"
+  echo "[transaction-read-operational-evidence] hikari_min_duration_min=${hikari_min_duration_min}"
+  echo "[transaction-read-operational-evidence] deploy_min_duration_min=${deploy_min_duration_min}"
+  echo "[transaction-read-operational-evidence] min_real_source_ips=${min_real_source_ips}"
+  echo "[transaction-read-operational-evidence] summary_tsv=${summary_tsv}"
+  echo "[transaction-read-operational-evidence] report_md=${report_md}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  if [[ -z "${input_tsv}" || ! -s "${input_tsv}" ]]; then
+    echo "OP_EVIDENCE_INPUT_TSV is required" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+if [[ -z "${input_tsv}" || ! -s "${input_tsv}" ]]; then
+  echo "OP_EVIDENCE_INPUT_TSV is required" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+
+awk -F '\t' \
+  -v required_scenarios="${required_scenarios}" \
+  -v max_edge_429_rate="${max_edge_429_rate}" \
+  -v max_cold_p95_ms="${max_cold_p95_ms}" \
+  -v max_warm_p95_ms="${max_warm_p95_ms}" \
+  -v max_p999_ms="${max_p999_ms}" \
+  -v max_pool_pending="${max_pool_pending}" \
+  -v mixed_min_duration_min="${mixed_min_duration_min}" \
+  -v p999_min_duration_min="${p999_min_duration_min}" \
+  -v hikari_min_duration_min="${hikari_min_duration_min}" \
+  -v deploy_min_duration_min="${deploy_min_duration_min}" \
+  -v min_real_source_ips="${min_real_source_ips}" '
+function add_reason(value) {
+  if (reason == "ok") {
+    reason = value
+  } else {
+    reason = reason "," value
+  }
+  status = "fail"
+}
+BEGIN {
+  split(required_scenarios, required_items, ",")
+  for (i in required_items) {
+    required[required_items[i]] = 1
+  }
+  print "scenario\tstatus\treason\tduration_min\tsource_ips\tcold_p95_ms\twarm_p95_ms\tp999_ms\tedge_429_rate\tbackend_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tsse_reject_count\tdeploy_drain_5xx_count\tpg_wait_p95_ms\ttimeline_artifact"
+}
+NR == 1 {
+  for (i = 1; i <= NF; i++) {
+    col[$i] = i
+  }
+  next
+}
+{
+  scenario = $col["scenario"]
+  duration_min = $col["duration_min"] + 0
+  source_ips = $col["source_ips"] + 0
+  cold_p95_ms = $col["cold_p95_ms"] + 0
+  warm_p95_ms = $col["warm_p95_ms"] + 0
+  p999_ms = $col["p999_ms"] + 0
+  edge_429_rate = $col["edge_429_rate"] + 0
+  backend_429_count = $col["backend_429_count"] + 0
+  five_xx_count = $col["five_xx_count"] + 0
+  nginx_499_count = $col["nginx_499_count"] + 0
+  hikari_validation_warnings = $col["hikari_validation_warnings"] + 0
+  db_pool_pending_max = $col["db_pool_pending_max"] + 0
+  sse_reject_count = $col["sse_reject_count"] + 0
+  deploy_drain_5xx_count = $col["deploy_drain_5xx_count"] + 0
+  pg_wait_p95_ms = $col["pg_wait_p95_ms"] + 0
+  timeline_artifact = $col["timeline_artifact"]
+  status = "pass"
+  reason = "ok"
+  seen[scenario] = 1
+
+  if (cold_p95_ms > max_cold_p95_ms) add_reason("cold-p95>" max_cold_p95_ms)
+  if (warm_p95_ms > max_warm_p95_ms) add_reason("warm-p95>" max_warm_p95_ms)
+  if (p999_ms > max_p999_ms) add_reason("p999>" max_p999_ms)
+  if (edge_429_rate > max_edge_429_rate) add_reason("edge429>" max_edge_429_rate)
+  if (backend_429_count > 0) add_reason("backend429>0")
+  if (five_xx_count > 0) add_reason("5xx>0")
+  if (nginx_499_count > 0) add_reason("499>0")
+  if (hikari_validation_warnings > 0) add_reason("hikari-warning>0")
+  if (db_pool_pending_max > max_pool_pending) add_reason("pool-pending>" max_pool_pending)
+  if (sse_reject_count > 0) add_reason("sse-reject>0")
+  if (deploy_drain_5xx_count > 0) add_reason("deploy-drain-5xx>0")
+  if (timeline_artifact == "" || timeline_artifact == "n/a") add_reason("timeline-missing")
+  if (scenario == "mixed-workload" && duration_min < mixed_min_duration_min) {
+    add_reason("mixed-duration<" mixed_min_duration_min)
+  }
+  if (scenario == "p999-long" && duration_min < p999_min_duration_min) {
+    add_reason("p999-duration<" p999_min_duration_min)
+  }
+  if (scenario == "hikari-soak" && duration_min < hikari_min_duration_min) {
+    add_reason("hikari-duration<" hikari_min_duration_min)
+  }
+  if (scenario == "deploy-drain" && duration_min < deploy_min_duration_min) {
+    add_reason("deploy-duration<" deploy_min_duration_min)
+  }
+  if (scenario == "real-ip-multisource" && source_ips < min_real_source_ips) {
+    add_reason("source-ips<" min_real_source_ips)
+  }
+
+  if (status == "fail") fail_count++
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    scenario, status, reason, duration_min, source_ips, cold_p95_ms, warm_p95_ms, p999_ms,
+    edge_429_rate, backend_429_count, five_xx_count, nginx_499_count,
+    hikari_validation_warnings, db_pool_pending_max, sse_reject_count,
+    deploy_drain_5xx_count, pg_wait_p95_ms, timeline_artifact
+}
+END {
+  missing = ""
+  for (scenario in required) {
+    if (!(scenario in seen)) {
+      if (missing == "") {
+        missing = scenario
+      } else {
+        missing = missing "," scenario
+      }
+      fail_count++
+    }
+  }
+  print "fail_count=" (fail_count + 0) > "/dev/stderr"
+  print "missing_scenarios=" missing > "/dev/stderr"
+}
+' "${input_tsv}" >"${summary_tsv}" 2>"${meta_file}"
+
+fail_count="$(awk -F '=' '/^fail_count=/ { print $2 }' "${meta_file}")"
+missing_scenarios="$(awk -F '=' '/^missing_scenarios=/ { print $2 }' "${meta_file}")"
+gate_status="pass"
+if [[ "${fail_count}" != "0" ]]; then
+  gate_status="fail"
+fi
+
+status_table="$(awk -F '\t' '
+  BEGIN {
+    print "| Scenario | Status | Reason | Duration min | Source IPs | Edge 429 | 499 | 5xx | Hikari warnings | p99.9 ms | Timeline |"
+    print "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
+  }
+  NR > 1 {
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+      $1, $2, $3, $4, $5, $9, $12, $11, $13, $8, $18
+  }
+' "${summary_tsv}")"
+
+cat >"${report_md}" <<REPORT
+# Transaction Read Operational Evidence Gate
+
+## Summary
+
+- gate_status=${gate_status}
+- missing_scenarios=${missing_scenarios:-none}
+- required scenarios: ${required_scenarios}
+- Hikari validation warning: 0
+- 499/5xx/backend429 hard target: 0
+- edge 429 max rate: ${max_edge_429_rate}
+- cold first-read p95 max: ${max_cold_p95_ms}ms
+- warm steady-read p95 max: ${max_warm_p95_ms}ms
+- p99.9 long observation max: ${max_p999_ms}ms
+- mixed workload min duration: ${mixed_min_duration_min}m
+- real-IP multi-source minimum sources: ${min_real_source_ips}
+
+## Result Table
+
+${status_table}
+
+## Evidence Contract
+
+- Hikari idle validation warning, 499, 5xx, backend 429은 hard-zero로 묶는다.
+- cold/warm cache, mixed workload, real-IP multi-source, deploy drain, p99.9 long observation은 같은 TSV timeline artifact로 추적한다.
+- 이 gate는 OCI 실측 산출물을 닫는 검증기이며, 실제 부하 실행은 각 run-* script와 OCI runner에서 수행한다.
+
+## Artifacts
+
+- summary TSV: ${summary_tsv}
+- input TSV: ${input_tsv}
+REPORT
+
+echo "${report_md}"
+
+if [[ "${gate_status}" == "fail" ]]; then
+  echo "transaction read operational evidence gate failed: ${summary_tsv}" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-read-short-burst-smoothing-matrix.sh
+++ b/tools/test/run-transaction-read-short-burst-smoothing-matrix.sh
@@ -12,6 +12,8 @@ Environment:
   SHORT_BURST_SMOOTHING_REQUIRED_POLICIES     default nodelay,delay1,burst64
   SHORT_BURST_SMOOTHING_MAX_BURST48_429_RATE  default 0.10
   SHORT_BURST_SMOOTHING_MAX_BURST64_429_RATE  default 0.10
+  SHORT_BURST_SMOOTHING_MIN_BURST80_429_RATE  default 0.10
+  SHORT_BURST_SMOOTHING_MIN_BURST96_429_RATE  default 0.10
   SHORT_BURST_SMOOTHING_MAX_ACCEPTED_P95_MS   default 200
   SHORT_BURST_SMOOTHING_MAX_ACCEPTED_P99_MS   default 300
   SHORT_BURST_SMOOTHING_MAX_RETRY_AFTER_P95_MS default 250
@@ -44,6 +46,8 @@ output_dir="${SHORT_BURST_SMOOTHING_OUTPUT_DIR:-build/reports/k6/${name}}"
 required_policies="${SHORT_BURST_SMOOTHING_REQUIRED_POLICIES:-nodelay,delay1,burst64}"
 max_burst48_429_rate="${SHORT_BURST_SMOOTHING_MAX_BURST48_429_RATE:-0.10}"
 max_burst64_429_rate="${SHORT_BURST_SMOOTHING_MAX_BURST64_429_RATE:-0.10}"
+min_burst80_429_rate="${SHORT_BURST_SMOOTHING_MIN_BURST80_429_RATE:-0.10}"
+min_burst96_429_rate="${SHORT_BURST_SMOOTHING_MIN_BURST96_429_RATE:-0.10}"
 max_accepted_p95_ms="${SHORT_BURST_SMOOTHING_MAX_ACCEPTED_P95_MS:-200}"
 max_accepted_p99_ms="${SHORT_BURST_SMOOTHING_MAX_ACCEPTED_P99_MS:-300}"
 max_retry_after_p95_ms="${SHORT_BURST_SMOOTHING_MAX_RETRY_AFTER_P95_MS:-250}"
@@ -130,6 +134,8 @@ print_plan() {
   echo "[transaction-read-short-burst-smoothing] missing_required_policies=$(missing_required_policies "${policies}")"
   echo "[transaction-read-short-burst-smoothing] max_burst48_429_rate=${max_burst48_429_rate}"
   echo "[transaction-read-short-burst-smoothing] max_burst64_429_rate=${max_burst64_429_rate}"
+  echo "[transaction-read-short-burst-smoothing] min_burst80_429_rate=${min_burst80_429_rate}"
+  echo "[transaction-read-short-burst-smoothing] min_burst96_429_rate=${min_burst96_429_rate}"
   echo "[transaction-read-short-burst-smoothing] max_accepted_p95_ms=${max_accepted_p95_ms}"
   echo "[transaction-read-short-burst-smoothing] max_accepted_p99_ms=${max_accepted_p99_ms}"
   echo "[transaction-read-short-burst-smoothing] max_retry_after_p95_ms=${max_retry_after_p95_ms}"
@@ -142,6 +148,8 @@ print_plan() {
 
 require_rate "SHORT_BURST_SMOOTHING_MAX_BURST48_429_RATE" "${max_burst48_429_rate}"
 require_rate "SHORT_BURST_SMOOTHING_MAX_BURST64_429_RATE" "${max_burst64_429_rate}"
+require_rate "SHORT_BURST_SMOOTHING_MIN_BURST80_429_RATE" "${min_burst80_429_rate}"
+require_rate "SHORT_BURST_SMOOTHING_MIN_BURST96_429_RATE" "${min_burst96_429_rate}"
 require_rate "SHORT_BURST_SMOOTHING_MAX_DELAYED_RATE" "${max_delayed_rate}"
 require_rate "SHORT_BURST_SMOOTHING_MAX_BACKEND_429_RATE" "${max_backend_429_rate}"
 require_non_negative_number "SHORT_BURST_SMOOTHING_MAX_ACCEPTED_P95_MS" "${max_accepted_p95_ms}"
@@ -172,6 +180,8 @@ mkdir -p "${output_dir}"
 awk -F '\t' \
   -v max_burst48="${max_burst48_429_rate}" \
   -v max_burst64="${max_burst64_429_rate}" \
+  -v min_burst80="${min_burst80_429_rate}" \
+  -v min_burst96="${min_burst96_429_rate}" \
   -v max_p95="${max_accepted_p95_ms}" \
   -v max_p99="${max_accepted_p99_ms}" \
   -v max_retry_p95="${max_retry_after_p95_ms}" \
@@ -186,13 +196,15 @@ awk -F '\t' \
     for (i = 1; i <= NF; i++) {
       col[$i] = i
     }
-    print "policy\tstatus\thot_limit_mode\tarchive_limit_mode\thot_burst\tarchive_burst\tburst48_429_rate\tburst64_429_rate\taccepted_p95_ms\taccepted_p99_ms\tretry_after_p95_ms\tedge_delayed_rate\tfive_xx_count\tbackend_429_rate\tbackend_pending\thikari_warning_count"
+    print "policy\tstatus\thot_limit_mode\tarchive_limit_mode\thot_burst\tarchive_burst\tburst48_429_rate\tburst64_429_rate\tburst80_429_rate\tburst96_429_rate\taccepted_p95_ms\taccepted_p99_ms\tretry_after_p95_ms\tedge_delayed_rate\tfive_xx_count\tbackend_429_rate\tbackend_pending\thikari_warning_count"
     next
   }
   {
     policy = value("policy", "unknown")
     burst48 = value("burst48_429_rate", "1") + 0
     burst64 = value("burst64_429_rate", "1") + 0
+    burst80 = value("burst80_429_rate", "0") + 0
+    burst96 = value("burst96_429_rate", "0") + 0
     accepted_p95 = value("accepted_p95_ms", "999999") + 0
     accepted_p99 = value("accepted_p99_ms", "999999") + 0
     retry_after_p95 = value("retry_after_p95_ms", "999999") + 0
@@ -202,7 +214,7 @@ awk -F '\t' \
     backend_pending = value("backend_pending", "1") + 0
     hikari_warnings = value("hikari_warning_count", "1") + 0
     status = "pass"
-    if (burst48 > max_burst48 || burst64 > max_burst64 || accepted_p95 > max_p95 || accepted_p99 > max_p99 || retry_after_p95 > max_retry_p95 || delayed > max_delayed || five_xx > 0 || backend_429 > max_backend_429 || backend_pending > 0 || hikari_warnings > 0) {
+    if (burst48 > max_burst48 || burst64 > max_burst64 || burst80 < min_burst80 || burst96 < min_burst96 || accepted_p95 > max_p95 || accepted_p99 > max_p99 || retry_after_p95 > max_retry_p95 || delayed > max_delayed || five_xx > 0 || backend_429 > max_backend_429 || backend_pending > 0 || hikari_warnings > 0) {
       status = "fail"
     }
     if (status == "pass" && recommended == "") {
@@ -211,10 +223,11 @@ awk -F '\t' \
     if (status == "pass") {
       pass_count++
     }
-    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
       policy, status, value("hot_limit_mode", "n/a"), value("archive_limit_mode", "n/a"),
       value("hot_burst", "0"), value("archive_burst", "0"), value("burst48_429_rate", "0"),
-      value("burst64_429_rate", "0"), value("accepted_p95_ms", "0"), value("accepted_p99_ms", "0"), value("retry_after_p95_ms", "0"), value("edge_delayed_rate", "0"),
+      value("burst64_429_rate", "0"), value("burst80_429_rate", "0"), value("burst96_429_rate", "0"),
+      value("accepted_p95_ms", "0"), value("accepted_p99_ms", "0"), value("retry_after_p95_ms", "0"), value("edge_delayed_rate", "0"),
       value("five_xx_count", "0"), value("backend_429_rate", "0"), value("backend_pending", "0"),
       value("hikari_warning_count", "0")
   }
@@ -235,11 +248,11 @@ fi
 
 matrix_table="$(awk -F '\t' '
   BEGIN {
-    print "| Policy | Status | Hot mode | Archive mode | burst48 429 | burst64 429 | p95 ms | p99 ms | Retry-After p95 ms | delayed rate | 5xx | backend 429 | backend pending | Hikari warnings |"
-    print "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    print "| Policy | Status | Hot mode | Archive mode | burst48 429 | burst64 429 | burst80 429 | burst96 429 | p95 ms | p99 ms | Retry-After p95 ms | delayed rate | 5xx | backend 429 | backend pending | Hikari warnings |"
+    print "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
   }
   NR > 1 {
-    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
   }
 ' "${summary_tsv}")"
 
@@ -254,6 +267,8 @@ cat >"${report_md}" <<REPORT
 - required policies: ${required_policies}
 - burst-48 429 budget: <= ${max_burst48_429_rate}
 - burst-64 429 budget: <= ${max_burst64_429_rate}
+- burst-80 fail-fast lower bound: >= ${min_burst80_429_rate}
+- burst-96 fail-fast lower bound: >= ${min_burst96_429_rate}
 - accepted p95 budget: <= ${max_accepted_p95_ms}ms
 - accepted p99 budget: <= ${max_accepted_p99_ms}ms
 - Retry-After contract: fixed 150ms + jitter 100ms

--- a/tools/test/run-transaction-read-single-source-edge-budget-gate.sh
+++ b/tools/test/run-transaction-read-single-source-edge-budget-gate.sh
@@ -9,8 +9,8 @@ Environment:
   SINGLE_SOURCE_EDGE_BUDGET_NAME                           default transaction-read-single-source-edge-budget-<timestamp>
   SINGLE_SOURCE_EDGE_BUDGET_INPUT_TSV                      required TSV with run/source_mode/429/failure columns
   SINGLE_SOURCE_EDGE_BUDGET_OUTPUT_DIR                     default build/reports/k6/<gate>
-  SINGLE_SOURCE_EDGE_BUDGET_DEFENSIVE_MAX_EDGE_429_RATE    default 0.30
-  SINGLE_SOURCE_EDGE_BUDGET_DEFENSIVE_MAX_BACKEND_429_RATE default 0.005
+  SINGLE_SOURCE_EDGE_BUDGET_MAX_EDGE_429_RATE              default 0.10
+  SINGLE_SOURCE_EDGE_BUDGET_MAX_BACKEND_429_RATE           default 0
   SINGLE_SOURCE_EDGE_BUDGET_OPERATING_MAX_EDGE_429_RATE    default 0.10
   SINGLE_SOURCE_EDGE_BUDGET_OPERATING_MAX_BACKEND_429_RATE default 0.0005
 USAGE
@@ -37,8 +37,8 @@ done
 name="${SINGLE_SOURCE_EDGE_BUDGET_NAME:-transaction-read-single-source-edge-budget-$(date +%Y-%m-%d-%H%M%S)}"
 input_tsv="${SINGLE_SOURCE_EDGE_BUDGET_INPUT_TSV:-}"
 output_dir="${SINGLE_SOURCE_EDGE_BUDGET_OUTPUT_DIR:-build/reports/k6/${name}}"
-defensive_edge_429_rate="${SINGLE_SOURCE_EDGE_BUDGET_DEFENSIVE_MAX_EDGE_429_RATE:-0.30}"
-defensive_backend_429_rate="${SINGLE_SOURCE_EDGE_BUDGET_DEFENSIVE_MAX_BACKEND_429_RATE:-0.005}"
+single_source_edge_429_rate="${SINGLE_SOURCE_EDGE_BUDGET_MAX_EDGE_429_RATE:-0.10}"
+single_source_backend_429_rate="${SINGLE_SOURCE_EDGE_BUDGET_MAX_BACKEND_429_RATE:-0}"
 operating_edge_429_rate="${SINGLE_SOURCE_EDGE_BUDGET_OPERATING_MAX_EDGE_429_RATE:-0.10}"
 operating_backend_429_rate="${SINGLE_SOURCE_EDGE_BUDGET_OPERATING_MAX_BACKEND_429_RATE:-0.0005}"
 summary_tsv="${output_dir}/${name}-single-source-edge-budget.tsv"
@@ -95,17 +95,17 @@ print_plan() {
   echo "[transaction-read-single-source-budget] input_tsv=${input_tsv:-missing}"
   echo "[transaction-read-single-source-budget] output_dir=${output_dir}"
   echo "[transaction-read-single-source-budget] source_modes=$(source_modes)"
-  echo "[transaction-read-single-source-budget] defensive_single_source_edge_429_rate=${defensive_edge_429_rate}"
-  echo "[transaction-read-single-source-budget] defensive_single_source_backend_429_rate=${defensive_backend_429_rate}"
+  echo "[transaction-read-single-source-budget] single_source_edge_429_rate=${single_source_edge_429_rate}"
+  echo "[transaction-read-single-source-budget] single_source_backend_429_rate=${single_source_backend_429_rate}"
   echo "[transaction-read-single-source-budget] operating_edge_429_rate=${operating_edge_429_rate}"
   echo "[transaction-read-single-source-budget] operating_backend_429_rate=${operating_backend_429_rate}"
-  echo "[transaction-read-single-source-budget] decision=single-source-defensive-lab-only"
+  echo "[transaction-read-single-source-budget] decision=single-source-operating-budget"
   echo "[transaction-read-single-source-budget] summary_tsv=${summary_tsv}"
   echo "[transaction-read-single-source-budget] report_md=${report_md}"
 }
 
-require_rate "SINGLE_SOURCE_EDGE_BUDGET_DEFENSIVE_MAX_EDGE_429_RATE" "${defensive_edge_429_rate}"
-require_rate "SINGLE_SOURCE_EDGE_BUDGET_DEFENSIVE_MAX_BACKEND_429_RATE" "${defensive_backend_429_rate}"
+require_rate "SINGLE_SOURCE_EDGE_BUDGET_MAX_EDGE_429_RATE" "${single_source_edge_429_rate}"
+require_rate "SINGLE_SOURCE_EDGE_BUDGET_MAX_BACKEND_429_RATE" "${single_source_backend_429_rate}"
 require_rate "SINGLE_SOURCE_EDGE_BUDGET_OPERATING_MAX_EDGE_429_RATE" "${operating_edge_429_rate}"
 require_rate "SINGLE_SOURCE_EDGE_BUDGET_OPERATING_MAX_BACKEND_429_RATE" "${operating_backend_429_rate}"
 
@@ -119,8 +119,8 @@ require_file "SINGLE_SOURCE_EDGE_BUDGET_INPUT_TSV" "${input_tsv}"
 mkdir -p "${output_dir}"
 
 awk -F '\t' \
-  -v defensive_edge="${defensive_edge_429_rate}" \
-  -v defensive_backend="${defensive_backend_429_rate}" \
+  -v single_source_edge="${single_source_edge_429_rate}" \
+  -v single_source_backend="${single_source_backend_429_rate}" \
   -v operating_edge="${operating_edge_429_rate}" \
   -v operating_backend="${operating_backend_429_rate}" \
   '
@@ -156,11 +156,11 @@ awk -F '\t' \
     reason = ""
 
     if (source == "single-source") {
-      budget_class = "defensive-lab"
-      edge_budget = defensive_edge
-      backend_budget = defensive_backend
-      operating_candidate = "no"
-      reason = "within-defensive-single-source-budget"
+      budget_class = "operating-candidate"
+      edge_budget = single_source_edge
+      backend_budget = single_source_backend
+      operating_candidate = "yes"
+      reason = "within-single-source-operating-budget"
     } else if (source == "multi-source" || source == "preemptive-pacing") {
       budget_class = "operating-candidate"
       edge_budget = operating_edge
@@ -218,8 +218,9 @@ cat >"${report_md}" <<REPORT
 ## Summary
 
 - gate_status=${gate_status}
-- single-source decision: defensive-lab-only
-- defensive single-source edge 429 target: <= ${defensive_edge_429_rate}
+- single-source decision: operating-budget
+- single-source edge 429 target: <= ${single_source_edge_429_rate}
+- single-source backend 429 target: <= ${single_source_backend_429_rate}
 - operating edge 429 target: < ${operating_edge_429_rate}
 - operating backend 429 target: <= ${operating_backend_429_rate}
 - 499/502/Hikari target: 0
@@ -231,7 +232,7 @@ ${budget_table}
 
 ## Contract Notes
 
-- single-source VU16은 \`\$binary_remote_addr\` 병목 확인용 defensive lab budget으로만 해석한다.
+- single-source VU16은 NAT/shared-client 방어 상한이라 운영 budget과 같은 10% 이하로 유지한다.
 - 운영 후보는 multi-source 또는 preemptive pacing evidence에서 edge 429와 backend reject를 동시에 낮춰야 한다.
 - 499/502/Hikari warning은 overload 방어 budget이 아니라 hard-zero gate로 유지한다.
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #632

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction-read public capacity v2 작업을 한 PR로 묶어 VU16/burst64 edge 429 budget, client pacing, limit 50 hard cap, hot path 중복 실행 방어, 운영 evidence gate를 정리합니다.
- backend 429/5xx hard-zero를 유지하면서 edge reject를 fail-fast/계약 기반으로 다루도록 shell gate와 controller hot path를 함께 보강했습니다.

## 🛠 Changes
- VU16 single-source와 burst64 edge 429 budget gate를 10% 기준으로 조정하고 burst80/96 fail-fast curve를 고정했습니다.
- Nginx Retry-After/X-RateLimit/client pacing 계약 check를 추가했습니다.
- public transaction/archive 기본/최대 limit를 50으로 고정하고 `responseShape=slim` 응답 옵션을 추가했습니다.
- user-account authorization micro-cache를 추가하고 account status update 성공 시 계좌 cache를 무효화합니다.
- 동일 in-flight transaction read singleflight와 per-account fairness limiter를 추가했습니다.
- Hikari/499/cold-warm/mixed/real-IP/deploy-drain/p99.9 운영 evidence TSV gate를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-single-source-edge-budget-gate.sh`
- `bash tools/test/check-transaction-read-short-burst-smoothing-matrix.sh`
- `bash tools/test/check-transaction-read-client-pacing-contract.sh`
- `./back/gradlew -p back test --tests '*TransactionQueryControllerTest' --tests '*TransactionArchiveQueryControllerTest' --tests '*DomainModelCoverageTest' --tests '*TransactionQueryResponseTest'`
- `./back/gradlew -p back test --tests '*RequestAccountAuthorizationServiceTest' --tests '*InternalAccountAdminControllerTest'`
- `./back/gradlew -p back test --tests '*TransactionReadSingleFlightTest' --tests '*TransactionReadAccountFairnessLimiterTest' --tests '*TransactionQueryControllerTest' --tests '*TransactionArchiveQueryControllerTest'`
- `./back/gradlew -p back queryPlanTest --tests '*TransactionJdbcQueryTimeoutIntegrationTest.jdbcQueryTimeoutCancelsSlowQueryBeforeDatasourceStatementTimeout'`
- `bash tools/test/check-transaction-read-operational-evidence-gate.sh`
- `bash tools/test/check-transaction-read-client-close-499-gate.sh`
- `bash tools/test/check-transaction-read-p999-spike-attribution.sh`
- `bash tools/test/check-transaction-read-weighted-10m-soak-gate.sh`
- `git diff --check`
- pre-commit hook `./back/gradlew -p back check` 통과: commits `5fc54d3a`, `02ef63dc`, `7965ad01`

## 📸 Screenshot / API Example
- API 예시: `GET /api/v1/transactions?accountId=101&from=...&to=...&responseShape=slim`
- UI 변경: 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `responseShape=slim`, authorization micro-cache, singleflight/fairness가 transaction read hot path의 latency/429 분포에 영향을 줄 수 있습니다. OCI live gate로 실제 budget을 닫아야 합니다.
- 롤백 방법: 이 PR revert. 운영 설정으로는 `transaction.read.per-account.max-concurrency` 값을 높여 per-account fairness를 완화할 수 있습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
