### PR TITLE
[Perf] transaction read rejection runtime budget 재보정

### DIFF
--- a/tools/test/check-transaction-read-rejection-runtime-retune.sh
+++ b/tools/test/check-transaction-read-rejection-runtime-retune.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-rejection-runtime-retune.sh"
+
+echo "[transaction-read-rejection-runtime-retune] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+input_tsv="${temp_dir}/rejection-retune.tsv"
+output_dir="${temp_dir}/output"
+
+cat >"${input_tsv}" <<'TSV'
+scenario	policy	total_429_rate	edge_429_rate	accepted_hot_p95_ms	accepted_cold_p95_ms	retry_after_p95_ms	reject_streak_max	five_xx_count	backend_429_count	unknown_429_count	degradation_curve_ref	gate_threshold_ref	operation_policy_ref
+burst64	smoothing	0.090	0.088	142	130	420	3	0	0	0	n/a	oci/policy/burst64-gate.md	oci/policy/runtime-budget.md
+burst80	fail-fast	0.140	0.140	138	128	430	3	0	0	0	oci/curve/burst80.tsv	oci/policy/burst80-gate.md	oci/policy/runtime-budget.md
+burst96	fail-fast	0.190	0.190	135	124	440	3	0	0	0	oci/curve/burst96.tsv	oci/policy/burst96-gate.md	oci/policy/runtime-budget.md
+vu16-unpaced	fail-fast	0.160	0.160	145	135	430	3	0	0	0	oci/curve/vu16.tsv	oci/policy/vu16-gate.md	oci/policy/runtime-budget.md
+retry-after	smoothing	0.090	0.090	140	130	430	3	0	0	0	n/a	oci/policy/retry-after-gate.md	oci/policy/runtime-budget.md
+TSV
+
+echo "[transaction-read-rejection-runtime-retune] print plan"
+plan="$(
+  REJECTION_RETUNE_NAME=retune-check \
+  REJECTION_RETUNE_INPUT_TSV="${input_tsv}" \
+  REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" --print-plan
+)"
+grep -F "name=retune-check" <<<"${plan}" >/dev/null
+grep -F "required_scenarios=burst64,burst80,burst96,vu16-unpaced,retry-after" <<<"${plan}" >/dev/null
+grep -F "max_burst64_429_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "max_accepted_p95_ms=150" <<<"${plan}" >/dev/null
+grep -F "max_retry_p95_ms=450" <<<"${plan}" >/dev/null
+grep -F "max_reject_streak=3" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-rejection-runtime-retune] pass report"
+output="$(
+  REJECTION_RETUNE_NAME=retune-check \
+  REJECTION_RETUNE_INPUT_TSV="${input_tsv}" \
+  REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+summary_tsv="${output_dir}/retune-check-rejection-runtime-retune.tsv"
+test "${report_md}" = "${output_dir}/retune-check-rejection-runtime-retune.md"
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "burst64 total/edge 429 budget: <= 0.10" "${report_md}" >/dev/null
+grep -F "Retry-After p95 budget: <= 450ms" "${report_md}" >/dev/null
+grep -F $'burst64\tpass\tok\tsmoothing\t0.090\t0.088\t142\t130\t420\t3' "${summary_tsv}" >/dev/null
+grep -F "oci/curve/burst80.tsv" "${summary_tsv}" >/dev/null
+grep -F "oci/policy/runtime-budget.md" "${summary_tsv}" >/dev/null
+
+echo "[transaction-read-rejection-runtime-retune] burst64 budget fail"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "burst64" { $3 = 0.13553; $4 = 0.12798; $5 = 151 } { print }' \
+  "${input_tsv}" >"${input_tsv}.burst64-fail"
+if REJECTION_RETUNE_NAME=retune-burst64-fail \
+  REJECTION_RETUNE_INPUT_TSV="${input_tsv}.burst64-fail" \
+  REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "rejection retune unexpectedly passed burst64 budget violation" >&2
+  exit 1
+fi
+REJECTION_RETUNE_NAME=retune-burst64-fail \
+REJECTION_RETUNE_INPUT_TSV="${input_tsv}.burst64-fail" \
+REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+  "${runner}" >/dev/null 2>&1 || true
+grep -F "burst64-total429>0.10" "${output_dir}/retune-burst64-fail-rejection-runtime-retune.tsv" >/dev/null
+grep -F "burst64-edge429>0.10" "${output_dir}/retune-burst64-fail-rejection-runtime-retune.tsv" >/dev/null
+grep -F "hot-p95>150" "${output_dir}/retune-burst64-fail-rejection-runtime-retune.tsv" >/dev/null
+
+echo "[transaction-read-rejection-runtime-retune] retry-after fail"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "retry-after" { $7 = 517; $8 = 6 } { print }' \
+  "${input_tsv}" >"${input_tsv}.retry-fail"
+if REJECTION_RETUNE_NAME=retune-retry-fail \
+  REJECTION_RETUNE_INPUT_TSV="${input_tsv}.retry-fail" \
+  REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "rejection retune unexpectedly passed Retry-After violation" >&2
+  exit 1
+fi
+REJECTION_RETUNE_NAME=retune-retry-fail \
+REJECTION_RETUNE_INPUT_TSV="${input_tsv}.retry-fail" \
+REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+  "${runner}" >/dev/null 2>&1 || true
+grep -F "retry-p95>450" "${output_dir}/retune-retry-fail-rejection-runtime-retune.tsv" >/dev/null
+grep -F "streak-max>3" "${output_dir}/retune-retry-fail-rejection-runtime-retune.tsv" >/dev/null
+
+echo "[transaction-read-rejection-runtime-retune] hard-zero fail"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "vu16-unpaced" { $9 = 1; $10 = 1; $11 = 1 } { print }' \
+  "${input_tsv}" >"${input_tsv}.hard-zero-fail"
+if REJECTION_RETUNE_NAME=retune-hard-zero-fail \
+  REJECTION_RETUNE_INPUT_TSV="${input_tsv}.hard-zero-fail" \
+  REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "rejection retune unexpectedly passed hard-zero violation" >&2
+  exit 1
+fi
+REJECTION_RETUNE_NAME=retune-hard-zero-fail \
+REJECTION_RETUNE_INPUT_TSV="${input_tsv}.hard-zero-fail" \
+REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+  "${runner}" >/dev/null 2>&1 || true
+grep -F "5xx>0" "${output_dir}/retune-hard-zero-fail-rejection-runtime-retune.tsv" >/dev/null
+grep -F "backend429>0" "${output_dir}/retune-hard-zero-fail-rejection-runtime-retune.tsv" >/dev/null
+grep -F "unknown429>0" "${output_dir}/retune-hard-zero-fail-rejection-runtime-retune.tsv" >/dev/null
+
+echo "[transaction-read-rejection-runtime-retune] missing policy refs fail"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "burst96" { $12 = "n/a"; $13 = "n/a"; $14 = "https://internal.example/policy?token=secret" } { print }' \
+  "${input_tsv}" >"${input_tsv}.ref-fail"
+if REJECTION_RETUNE_NAME=retune-ref-fail \
+  REJECTION_RETUNE_INPUT_TSV="${input_tsv}.ref-fail" \
+  REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "rejection retune unexpectedly passed missing/unsafe policy refs" >&2
+  exit 1
+fi
+REJECTION_RETUNE_NAME=retune-ref-fail \
+REJECTION_RETUNE_INPUT_TSV="${input_tsv}.ref-fail" \
+REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+  "${runner}" >/dev/null 2>&1 || true
+grep -F "degradation_curve_ref-missing" "${output_dir}/retune-ref-fail-rejection-runtime-retune.tsv" >/dev/null
+grep -F "gate_threshold_ref-missing" "${output_dir}/retune-ref-fail-rejection-runtime-retune.tsv" >/dev/null
+grep -F "operation_policy_ref-unsafe" "${output_dir}/retune-ref-fail-rejection-runtime-retune.tsv" >/dev/null
+
+echo "[transaction-read-rejection-runtime-retune] missing scenario fail"
+awk -F '\t' '$1 != "vu16-unpaced"' "${input_tsv}" >"${input_tsv}.missing"
+if REJECTION_RETUNE_NAME=retune-missing \
+  REJECTION_RETUNE_INPUT_TSV="${input_tsv}.missing" \
+  REJECTION_RETUNE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "rejection retune unexpectedly passed missing vu16-unpaced scenario" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-read-rejection-runtime-retune.sh
+++ b/tools/test/run-transaction-read-rejection-runtime-retune.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-rejection-runtime-retune.sh [--print-plan]
+
+Environment:
+  REJECTION_RETUNE_NAME                 default transaction-read-rejection-runtime-retune-<timestamp>
+  REJECTION_RETUNE_INPUT_TSV            required TSV with rejection runtime evidence
+  REJECTION_RETUNE_OUTPUT_DIR           default build/reports/k6/<name>
+  REJECTION_RETUNE_REQUIRED_SCENARIOS   default burst64,burst80,burst96,vu16-unpaced,retry-after
+  REJECTION_RETUNE_MAX_BURST64_429_RATE default 0.10
+  REJECTION_RETUNE_MAX_ACCEPTED_P95_MS  default 150
+  REJECTION_RETUNE_MAX_RETRY_P95_MS     default 450
+  REJECTION_RETUNE_MAX_REJECT_STREAK    default 3
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${REJECTION_RETUNE_NAME:-transaction-read-rejection-runtime-retune-$(date +%Y-%m-%d-%H%M%S)}"
+input_tsv="${REJECTION_RETUNE_INPUT_TSV:-}"
+output_dir="${REJECTION_RETUNE_OUTPUT_DIR:-build/reports/k6/${name}}"
+required_scenarios="${REJECTION_RETUNE_REQUIRED_SCENARIOS:-burst64,burst80,burst96,vu16-unpaced,retry-after}"
+max_burst64_429_rate="${REJECTION_RETUNE_MAX_BURST64_429_RATE:-0.10}"
+max_accepted_p95_ms="${REJECTION_RETUNE_MAX_ACCEPTED_P95_MS:-150}"
+max_retry_p95_ms="${REJECTION_RETUNE_MAX_RETRY_P95_MS:-450}"
+max_reject_streak="${REJECTION_RETUNE_MAX_REJECT_STREAK:-3}"
+summary_tsv="${output_dir}/${name}-rejection-runtime-retune.tsv"
+report_md="${output_dir}/${name}-rejection-runtime-retune.md"
+meta_file="${output_dir}/${name}-rejection-runtime-retune.meta"
+
+require_non_negative_number() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${key} must be zero or greater: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_rate() {
+  local key="$1"
+  local value="$2"
+  require_non_negative_number "${key}" "${value}"
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0 && value <= 1) }' || {
+    echo "${key} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  }
+}
+
+require_file() {
+  local key="$1"
+  local file="$2"
+  if [[ -z "${file}" || ! -s "${file}" ]]; then
+    echo "${key} is required and must be a non-empty file: ${file:-missing}" >&2
+    exit 1
+  fi
+}
+
+scenarios() {
+  if [[ -z "${input_tsv}" || ! -s "${input_tsv}" ]]; then
+    echo "missing"
+    return
+  fi
+  awk -F '\t' '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) if ($i == "scenario") scenario_col = i
+      next
+    }
+    scenario_col {
+      if (result != "") result = result ","
+      result = result $scenario_col
+    }
+    END { if (result == "") print "missing"; else print result }
+  ' "${input_tsv}"
+}
+
+require_rate "REJECTION_RETUNE_MAX_BURST64_429_RATE" "${max_burst64_429_rate}"
+require_non_negative_number "REJECTION_RETUNE_MAX_ACCEPTED_P95_MS" "${max_accepted_p95_ms}"
+require_non_negative_number "REJECTION_RETUNE_MAX_RETRY_P95_MS" "${max_retry_p95_ms}"
+require_non_negative_number "REJECTION_RETUNE_MAX_REJECT_STREAK" "${max_reject_streak}"
+
+print_plan() {
+  echo "[transaction-read-rejection-runtime-retune] name=${name}"
+  echo "[transaction-read-rejection-runtime-retune] input_tsv=${input_tsv:-missing}"
+  echo "[transaction-read-rejection-runtime-retune] output_dir=${output_dir}"
+  echo "[transaction-read-rejection-runtime-retune] scenarios=$(scenarios)"
+  echo "[transaction-read-rejection-runtime-retune] required_scenarios=${required_scenarios}"
+  echo "[transaction-read-rejection-runtime-retune] max_burst64_429_rate=${max_burst64_429_rate}"
+  echo "[transaction-read-rejection-runtime-retune] max_accepted_p95_ms=${max_accepted_p95_ms}"
+  echo "[transaction-read-rejection-runtime-retune] max_retry_p95_ms=${max_retry_p95_ms}"
+  echo "[transaction-read-rejection-runtime-retune] max_reject_streak=${max_reject_streak}"
+  echo "[transaction-read-rejection-runtime-retune] required_policy=fail-fast|smoothing"
+  echo "[transaction-read-rejection-runtime-retune] hard_zero=five_xx_count,backend_429_count,unknown_429_count"
+  echo "[transaction-read-rejection-runtime-retune] summary_tsv=${summary_tsv}"
+  echo "[transaction-read-rejection-runtime-retune] report_md=${report_md}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  require_file "REJECTION_RETUNE_INPUT_TSV" "${input_tsv}"
+  exit 0
+fi
+
+require_file "REJECTION_RETUNE_INPUT_TSV" "${input_tsv}"
+mkdir -p "${output_dir}"
+
+awk -F '\t' \
+  -v required_scenarios="${required_scenarios}" \
+  -v max_burst64_429_rate="${max_burst64_429_rate}" \
+  -v max_accepted_p95_ms="${max_accepted_p95_ms}" \
+  -v max_retry_p95_ms="${max_retry_p95_ms}" \
+  -v max_reject_streak="${max_reject_streak}" '
+function value(name, fallback) {
+  if (!(name in col) || col[name] == "") return fallback
+  return $(col[name])
+}
+function add_reason(value) {
+  if (reason == "ok") reason = value
+  else reason = reason "," value
+  status = "fail"
+}
+function unsafe_ref(value) {
+  return value ~ /:\/\// || value ~ /(^|[?&])(token|password|secret|access_key|signature)=/ || value ~ /(Bearer|Authorization|PRIVATE KEY)/
+}
+function require_ref(name) {
+  ref = value(name, "")
+  if (ref == "" || ref == "n/a") add_reason(name "-missing")
+  else if (unsafe_ref(ref)) add_reason(name "-unsafe")
+}
+function valid_policy(policy) {
+  return policy == "fail-fast" || policy == "smoothing"
+}
+BEGIN {
+  split(required_scenarios, required_items, ",")
+  for (i in required_items) required[required_items[i]] = 1
+  split("scenario policy total_429_rate edge_429_rate accepted_hot_p95_ms accepted_cold_p95_ms retry_after_p95_ms reject_streak_max five_xx_count backend_429_count unknown_429_count degradation_curve_ref gate_threshold_ref operation_policy_ref", header_items, " ")
+  print "scenario\tstatus\treason\tpolicy\ttotal_429_rate\tedge_429_rate\taccepted_hot_p95_ms\taccepted_cold_p95_ms\tretry_after_p95_ms\treject_streak_max\tfive_xx_count\tbackend_429_count\tunknown_429_count\tdegradation_curve_ref\tgate_threshold_ref\toperation_policy_ref"
+}
+NR == 1 {
+  for (i = 1; i <= NF; i++) col[$i] = i
+  for (i in header_items) {
+    if (!(header_items[i] in col)) {
+      printf "missing required column: %s\n", header_items[i] > "/dev/stderr"
+      exit 2
+    }
+  }
+  next
+}
+{
+  scenario = value("scenario", "unknown")
+  policy = value("policy", "unknown")
+  status = "pass"
+  reason = "ok"
+  seen[scenario] = 1
+
+  if (!valid_policy(policy)) add_reason("policy-invalid")
+  require_ref("gate_threshold_ref")
+  require_ref("operation_policy_ref")
+
+  if (value("five_xx_count", "1") + 0 > 0) add_reason("5xx>0")
+  if (value("backend_429_count", "1") + 0 > 0) add_reason("backend429>0")
+  if (value("unknown_429_count", "1") + 0 > 0) add_reason("unknown429>0")
+
+  if (scenario == "burst64") {
+    if (value("total_429_rate", "1") + 0 > max_burst64_429_rate) add_reason("burst64-total429>" max_burst64_429_rate)
+    if (value("edge_429_rate", "1") + 0 > max_burst64_429_rate) add_reason("burst64-edge429>" max_burst64_429_rate)
+    if (value("accepted_hot_p95_ms", "999999") + 0 > max_accepted_p95_ms) add_reason("hot-p95>" max_accepted_p95_ms)
+    if (value("accepted_cold_p95_ms", "999999") + 0 > max_accepted_p95_ms) add_reason("cold-p95>" max_accepted_p95_ms)
+  }
+  if (scenario == "burst80" || scenario == "burst96") {
+    require_ref("degradation_curve_ref")
+  }
+  if (scenario == "vu16-unpaced") {
+    if (!valid_policy(policy)) add_reason("vu16-policy-missing")
+  }
+  if (scenario == "retry-after") {
+    if (value("retry_after_p95_ms", "999999") + 0 > max_retry_p95_ms) add_reason("retry-p95>" max_retry_p95_ms)
+    if (value("reject_streak_max", "999999") + 0 > max_reject_streak) add_reason("streak-max>" max_reject_streak)
+  }
+
+  if (status == "fail") fail_count++
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    scenario, status, reason, policy, value("total_429_rate", "0"), value("edge_429_rate", "0"),
+    value("accepted_hot_p95_ms", "0"), value("accepted_cold_p95_ms", "0"),
+    value("retry_after_p95_ms", "0"), value("reject_streak_max", "0"),
+    value("five_xx_count", "0"), value("backend_429_count", "0"),
+    value("unknown_429_count", "0"), value("degradation_curve_ref", "n/a"),
+    value("gate_threshold_ref", ""), value("operation_policy_ref", "")
+}
+END {
+  missing = ""
+  for (scenario in required) {
+    if (!(scenario in seen)) {
+      if (missing != "") missing = missing ","
+      missing = missing scenario
+      fail_count++
+    }
+  }
+  print "fail_count=" (fail_count + 0) > "/dev/stderr"
+  print "missing_scenarios=" missing > "/dev/stderr"
+}
+' "${input_tsv}" >"${summary_tsv}" 2>"${meta_file}"
+
+fail_count="$(awk -F '=' '/^fail_count=/ { print $2 }' "${meta_file}")"
+missing_scenarios="$(awk -F '=' '/^missing_scenarios=/ { print $2 }' "${meta_file}")"
+gate_status="pass"
+if [[ "${fail_count}" != "0" ]]; then
+  gate_status="fail"
+fi
+
+retune_table="$(awk -F '\t' '
+  BEGIN {
+    print "| Scenario | Status | Reason | Policy | Total 429 | Edge 429 | Hot p95 | Cold p95 | Retry p95 | Streak max |"
+    print "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |"
+  }
+  NR > 1 {
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+  }
+' "${summary_tsv}")"
+
+cat >"${report_md}" <<REPORT
+# Transaction Read Rejection Runtime Retune
+
+## Summary
+
+- gate_status=${gate_status}
+- required scenarios: ${required_scenarios}
+- missing scenarios: ${missing_scenarios:-none}
+- burst64 total/edge 429 budget: <= ${max_burst64_429_rate}
+- accepted hot/cold p95 budget: <= ${max_accepted_p95_ms}ms
+- Retry-After p95 budget: <= ${max_retry_p95_ms}ms
+- reject streak max: <= ${max_reject_streak}
+- hard-zero: 5xx, backend 429, unknown 429
+
+## Retune Matrix
+
+${retune_table}
+
+## Contract Notes
+
+- burst64는 residual rejection과 accepted latency를 같이 통과해야 한다.
+- burst80/96은 degradation curve ref를 필수로 남겨 운영자가 smoothing과 fail-fast 경계를 비교할 수 있어야 한다.
+- unpaced VU16은 smoothing 또는 fail-fast 중 하나로 닫고, gate threshold와 운영 policy ref를 같은 row에 남긴다.
+
+## Artifacts
+
+- input TSV: ${input_tsv}
+- summary TSV: ${summary_tsv}
+- report: ${report_md}
+REPORT
+
+echo "${report_md}"
+
+if [[ "${gate_status}" == "fail" ]]; then
+  echo "transaction read rejection runtime retune failed: ${summary_tsv}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #643

## 🌿 Base Branch
- `main`

## 📝 Summary
- burst64, burst80/96, unpaced VU16, Retry-After runtime retune evidence를 하나의 shell gate로 묶습니다.
- burst64 429/accepted p95, Retry-After p95/streak, hard-zero, 운영 policy ref 누락을 manifest 단계에서 차단합니다.

## 🛠 Changes
- `tools/test/run-transaction-read-rejection-runtime-retune.sh` 추가
- `tools/test/check-transaction-read-rejection-runtime-retune.sh` 추가
- burst64 <= 10%, accepted hot/cold p95 <= 150ms, Retry-After p95 <= 450ms, streak max <= 3 계약 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-rejection-runtime-retune.sh`
- `bash -n tools/test/run-transaction-read-rejection-runtime-retune.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 실제 OCI runtime tuning 값 변경은 포함하지 않고 evidence manifest gate만 추가하므로, 운영값 보정은 후속 실제 run 결과에 의존합니다.
- 롤백 방법: 이 PR의 단일 커밋 revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?