### PR TITLE
[Fix] OCI A1 Hikari idle-in-transaction root cause 제거

### DIFF
--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionArchiveReadQueryStatement.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionArchiveReadQueryStatement.java
@@ -25,8 +25,9 @@ final class TransactionArchiveReadQueryStatement {
             .addValue("fetchLimit", query.limit() + 1);
 
     StringBuilder sql =
-        new StringBuilder(
-            """
+        new StringBuilder(TransactionReadSqlTraceComment.current("archive-timeline"))
+            .append(
+                """
             SELECT id,
                    account_id,
                    transaction_reference,

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionDetailQueryStatement.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionDetailQueryStatement.java
@@ -23,7 +23,8 @@ final class TransactionDetailQueryStatement {
             .addValue("rowLimit", 2);
 
     return new TransactionDetailQueryStatement(
-        """
+        TransactionReadSqlTraceComment.current("detail-exact")
+            + """
         SELECT trm.account_id,
                trm.transaction_reference,
                trm.direction,

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionReadQueryStatement.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionReadQueryStatement.java
@@ -25,8 +25,9 @@ final class TransactionReadQueryStatement {
             .addValue("fetchLimit", query.limit() + 1);
 
     StringBuilder sql =
-        new StringBuilder(
-            """
+        new StringBuilder(TransactionReadSqlTraceComment.current("hot-timeline"))
+            .append(
+                """
             SELECT id,
                    account_id,
                    transaction_reference,

--- a/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionReadSqlTraceComment.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/transaction/TransactionReadSqlTraceComment.java
@@ -1,0 +1,20 @@
+package com.aquilabank.global.persistence.transaction;
+
+import com.aquilabank.global.web.RequestTraceContext;
+
+/** pg_stat_activity에서 transaction read 요청을 requestId로 역추적하기 위한 SQL comment */
+final class TransactionReadSqlTraceComment {
+
+  static String current(String shape) {
+    String requestId = RequestTraceContext.currentRequestId().orElse("unknown");
+    return "/* requestId=%s queryShape=%s */%n".formatted(sanitize(requestId), sanitize(shape));
+  }
+
+  private static String sanitize(String value) {
+    if (value.isBlank()) {
+      return "unknown";
+    }
+    String sanitized = value.replaceAll("[^A-Za-z0-9_.:-]", "_");
+    return sanitized.length() > 96 ? sanitized.substring(0, 96) : sanitized;
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/transaction/TransactionReadQueryStatementTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/transaction/TransactionReadQueryStatementTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.aquilabank.domain.transaction.model.TransactionCursor;
 import com.aquilabank.domain.transaction.model.TransactionQuery;
+import com.aquilabank.global.web.RequestTraceContext;
 import java.sql.Timestamp;
 import java.time.Instant;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class TransactionReadQueryStatementTest {
@@ -13,6 +15,11 @@ class TransactionReadQueryStatementTest {
   private static final Instant FROM = Instant.parse("2026-04-01T00:00:00Z");
   private static final Instant TO = Instant.parse("2026-05-01T00:00:00Z");
   private static final Instant CURSOR_AT = Instant.parse("2026-04-15T00:00:00Z");
+
+  @AfterEach
+  void clearRequestTrace() {
+    RequestTraceContext.clear();
+  }
 
   @Test
   void hotCursorQueryUsesCursorTimeAsEffectiveUpperBound() {
@@ -41,6 +48,39 @@ class TransactionReadQueryStatementTest {
 
     assertThat(statement.sql()).contains("AND booked_at < :effectiveTo");
     assertThat(statement.params().getValue("effectiveTo")).isEqualTo(Timestamp.from(TO));
+  }
+
+  @Test
+  void queryStatementsIncludeSanitizedRequestIdTraceComment() {
+    RequestTraceContext.set("tx read/req 001");
+
+    TransactionReadQueryStatement hot = TransactionReadQueryStatement.from(query(null));
+    TransactionArchiveReadQueryStatement archive =
+        TransactionArchiveReadQueryStatement.from(query(null));
+    TransactionDetailQueryStatement detail =
+        TransactionDetailQueryStatement.from(
+            new com.aquilabank.domain.transaction.model.TransactionDetailQuery(11L, "tr-ref-001"));
+
+    assertThat(hot.sql()).startsWith("/* requestId=tx_read_req_001 queryShape=hot-timeline */");
+    assertThat(archive.sql())
+        .startsWith("/* requestId=tx_read_req_001 queryShape=archive-timeline */");
+    assertThat(detail.sql()).startsWith("/* requestId=tx_read_req_001 queryShape=detail-exact */");
+  }
+
+  @Test
+  void queryTraceCommentFallsBackAndBoundsRequestId() {
+    RequestTraceContext.set("   ");
+    assertThat(TransactionReadQueryStatement.from(query(null)).sql())
+        .startsWith("/* requestId=unknown queryShape=hot-timeline */");
+
+    RequestTraceContext.set("x".repeat(120));
+    assertThat(TransactionReadQueryStatement.from(query(null)).sql())
+        .startsWith("/* requestId=%s queryShape=hot-timeline */".formatted("x".repeat(96)));
+  }
+
+  @Test
+  void queryTraceCommentHelperIsPackageScoped() {
+    assertThat(new TransactionReadSqlTraceComment()).isNotNull();
   }
 
   private static TransactionQuery query(TransactionCursor cursor) {

--- a/tools/test/check-hikari-idle-in-transaction-attribution.sh
+++ b/tools/test/check-hikari-idle-in-transaction-attribution.sh
@@ -18,11 +18,14 @@ output_dir="${temp_dir}/output"
 cat >"${pg_tsv}" <<'TSV'
 sample_time_utc	pid	usename	application_name	request_id	state	wait_event_type	wait_event	xact_age_seconds	query
 2026-05-02T03:00:05Z	123	aquila	aquila-bank	tx-read-req-001	idle in transaction	Client	ClientRead	182	select pg_sleep(30) /* requestId=tx-read-req-001 */
-2026-05-02T03:00:10Z	124	aquila	aquila-bank	tx-read-req-002	active	IO	DataFileRead	1	select 1
+2026-05-02T03:00:10Z	124	aquila	aquila-bank	n/a	idle in transaction	Client	ClientRead	188	select 1 /* requestId=tx-read-req-002 */
+2026-05-02T03:00:20Z	125	aquila	aquila-bank	tx-read-req-003	active	IO	DataFileRead	1	select 1
 TSV
 
 cat >"${hikari_log}" <<'LOG'
 2026-05-02T03:00:05Z WARN com.zaxxer.hikari.pool.PoolBase - aquila-bank-pool - Failed to validate connection org.postgresql.jdbc.PgConnection@1 (This connection has been closed.)
+2026-05-02T03:00:12Z WARN com.zaxxer.hikari.pool.PoolBase - aquila-bank-pool - Failed to validate connection org.postgresql.jdbc.PgConnection@2 (This connection has been closed.)
+2026-05-02T03:00:18Z WARN com.zaxxer.hikari.pool.PoolBase - aquila-bank-pool - Failed to validate connection org.postgresql.jdbc.PgConnection@3 (This connection has been closed.)
 LOG
 
 cat >"${hikari_log_zero}" <<'LOG'
@@ -74,10 +77,13 @@ summary_tsv="${output_dir}/hikari-check-hikari-idle-attribution.tsv"
 test "${report_md}" = "${output_dir}/hikari-check-hikari-idle-attribution.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "config_status=pass" "${report_md}" >/dev/null
+grep -F "warning_count=3" "${report_md}" >/dev/null
 grep -F "OCI A1 lifetime alignment" "${report_md}" >/dev/null
 grep -F "PostgreSQL PID/query/requestId correlation" "${report_md}" >/dev/null
 grep -F $'warning_time_utc\tstatus\tpid\trequest_id\tstate\twait_event_type\twait_event\txact_age_seconds\tquery\tcause' "${summary_tsv}" >/dev/null
 grep -F $'2026-05-02T03:00:05Z\tpass\t123\ttx-read-req-001\tidle in transaction\tClient\tClientRead\t182\tselect pg_sleep(30) /* requestId=tx-read-req-001 */\tidle-in-transaction-candidate' "${summary_tsv}" >/dev/null
+grep -F $'2026-05-02T03:00:12Z\tpass\t124\ttx-read-req-002\tidle in transaction\tClient\tClientRead\t188\tselect 1 /* requestId=tx-read-req-002 */\tidle-in-transaction-candidate' "${summary_tsv}" >/dev/null
+grep -F $'2026-05-02T03:00:18Z\tpass\t125\ttx-read-req-003\tactive\tIO\tDataFileRead\t1\tselect 1\tpostgres-timeout-candidate' "${summary_tsv}" >/dev/null
 
 echo "[hikari-idle-attribution] 30m zero warning soak passes"
 zero_output="$(

--- a/tools/test/check-transaction-read-production-evidence-pack.sh
+++ b/tools/test/check-transaction-read-production-evidence-pack.sh
@@ -13,13 +13,13 @@ input_tsv="${temp_dir}/production-evidence.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${input_tsv}" <<'TSV'
-scenario	run_id	duration_min	source_ips	k6_summary_ref	nginx_aggregate_ref	nginx_499_aggregate_ref	spring_429_ref	hikari_log_ref	postgres_explain_ref	prometheus_timeline_ref	source_fairness_ref	cache_state_ref	deploy_event_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max
-hikari-soak	oci-001	30	1	oci/k6/hikari.json	oci/nginx/hikari.tsv	oci/nginx/hikari-499.tsv	oci/spring/hikari-429.tsv	oci/hikari/hikari.log	oci/pg/hikari-explain.txt	oci/prom/hikari.json	n/a	n/a	n/a	0.01	0	0	0	0	0	0
-cold-warm	oci-002	10	1	oci/k6/cold-warm.json	oci/nginx/cold-warm.tsv	oci/nginx/cold-warm-499.tsv	oci/spring/cold-warm-429.tsv	oci/hikari/cold-warm.log	oci/pg/cold-warm-explain.txt	oci/prom/cold-warm.json	n/a	oci/cache/cold-warm.tsv	n/a	0.02	0	0	0	0	0	0
-mixed-workload	oci-003	30	1	oci/k6/mixed.json	oci/nginx/mixed.tsv	oci/nginx/mixed-499.tsv	oci/spring/mixed-429.tsv	oci/hikari/mixed.log	oci/pg/mixed-explain.txt	oci/prom/mixed.json	n/a	n/a	n/a	0.08	0	0	0	0	0	0
-real-ip-multisource	oci-004	10	2	oci/k6/real-ip.json	oci/nginx/real-ip.tsv	oci/nginx/real-ip-499.tsv	oci/spring/real-ip-429.tsv	oci/hikari/real-ip.log	oci/pg/real-ip-explain.txt	oci/prom/real-ip.json	oci/source/real-ip-fairness.tsv	n/a	n/a	0.07	0	0	0	0	0	0
-deploy-drain	oci-005	5	1	oci/k6/deploy-drain.json	oci/nginx/deploy-drain.tsv	oci/nginx/deploy-drain-499.tsv	oci/spring/deploy-drain-429.tsv	oci/hikari/deploy-drain.log	oci/pg/deploy-drain-explain.txt	oci/prom/deploy-drain.json	n/a	n/a	oci/deploy/drain-events.tsv	0.04	0	0	0	0	0	0
-p999-long	oci-006	30	1	oci/k6/p999.json	oci/nginx/p999.tsv	oci/nginx/p999-499.tsv	oci/spring/p999-429.tsv	oci/hikari/p999.log	oci/pg/p999-explain.txt	oci/prom/p999.json	n/a	n/a	n/a	0.06	0	0	0	0	0	0
+scenario	run_id	duration_min	source_ips	k6_summary_ref	nginx_aggregate_ref	nginx_499_aggregate_ref	spring_429_ref	hikari_log_ref	postgres_explain_ref	postgres_activity_ref	postgres_wait_ref	prometheus_timeline_ref	source_fairness_ref	cache_state_ref	deploy_event_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max
+hikari-soak	oci-001	30	1	oci/k6/hikari.json	oci/nginx/hikari.tsv	oci/nginx/hikari-499.tsv	oci/spring/hikari-429.tsv	oci/hikari/hikari.log	oci/pg/hikari-explain.txt	oci/pg/hikari-activity.tsv	oci/pg/hikari-wait.tsv	oci/prom/hikari.json	n/a	n/a	n/a	0.01	0	0	0	0	0	0
+cold-warm	oci-002	10	1	oci/k6/cold-warm.json	oci/nginx/cold-warm.tsv	oci/nginx/cold-warm-499.tsv	oci/spring/cold-warm-429.tsv	oci/hikari/cold-warm.log	oci/pg/cold-warm-explain.txt	oci/pg/cold-warm-activity.tsv	oci/pg/cold-warm-wait.tsv	oci/prom/cold-warm.json	n/a	oci/cache/cold-warm.tsv	n/a	0.02	0	0	0	0	0	0
+mixed-workload	oci-003	30	1	oci/k6/mixed.json	oci/nginx/mixed.tsv	oci/nginx/mixed-499.tsv	oci/spring/mixed-429.tsv	oci/hikari/mixed.log	oci/pg/mixed-explain.txt	oci/pg/mixed-activity.tsv	oci/pg/mixed-wait.tsv	oci/prom/mixed.json	n/a	n/a	n/a	0.08	0	0	0	0	0	0
+real-ip-multisource	oci-004	10	2	oci/k6/real-ip.json	oci/nginx/real-ip.tsv	oci/nginx/real-ip-499.tsv	oci/spring/real-ip-429.tsv	oci/hikari/real-ip.log	oci/pg/real-ip-explain.txt	oci/pg/real-ip-activity.tsv	oci/pg/real-ip-wait.tsv	oci/prom/real-ip.json	oci/source/real-ip-fairness.tsv	n/a	n/a	0.07	0	0	0	0	0	0
+deploy-drain	oci-005	5	1	oci/k6/deploy-drain.json	oci/nginx/deploy-drain.tsv	oci/nginx/deploy-drain-499.tsv	oci/spring/deploy-drain-429.tsv	oci/hikari/deploy-drain.log	oci/pg/deploy-drain-explain.txt	oci/pg/deploy-drain-activity.tsv	oci/pg/deploy-drain-wait.tsv	oci/prom/deploy-drain.json	n/a	n/a	oci/deploy/drain-events.tsv	0.04	0	0	0	0	0	0
+p999-long	oci-006	30	1	oci/k6/p999.json	oci/nginx/p999.tsv	oci/nginx/p999-499.tsv	oci/spring/p999-429.tsv	oci/hikari/p999.log	oci/pg/p999-explain.txt	oci/pg/p999-activity.tsv	oci/pg/p999-wait.tsv	oci/prom/p999.json	n/a	n/a	n/a	0.06	0	0	0	0	0	0
 TSV
 
 echo "[transaction-read-production-evidence-pack] print plan"
@@ -32,7 +32,7 @@ plan="$(
 grep -F "name=production-check" <<<"${plan}" >/dev/null
 grep -F "required_scenarios=hikari-soak,cold-warm,mixed-workload,real-ip-multisource,deploy-drain,p999-long" <<<"${plan}" >/dev/null
 grep -F "min_real_source_ips=2" <<<"${plan}" >/dev/null
-grep -F "required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,prometheus_timeline_ref" <<<"${plan}" >/dev/null
+grep -F "required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] pass report"
 output="$(
@@ -46,14 +46,18 @@ summary_tsv="${output_dir}/production-check-production-evidence-pack.tsv"
 test "${report_md}" = "${output_dir}/production-check-production-evidence-pack.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "Nginx 499 aggregate" "${report_md}" >/dev/null
+grep -F "PostgreSQL activity sampler" "${report_md}" >/dev/null
+grep -F "PostgreSQL wait timeline" "${report_md}" >/dev/null
 grep -F "hard-zero: backend 429, unknown 429, 499, 5xx, Hikari warning, Hikari pending" "${report_md}" >/dev/null
 grep -F $'real-ip-multisource\tpass\tok\toci-004\t10\t2' "${summary_tsv}" >/dev/null
+grep -F "oci/pg/real-ip-activity.tsv" "${summary_tsv}" >/dev/null
+grep -F "oci/pg/real-ip-wait.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/source/real-ip-fairness.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/deploy/drain-events.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/cache/cold-warm.tsv" "${summary_tsv}" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] hard-zero fail"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload" { $17 = 1; $18 = 1; $19 = 1; $20 = 1; $21 = 1 } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload" { $19 = 1; $20 = 1; $21 = 1; $22 = 1; $23 = 1 } { print }' \
   "${input_tsv}" >"${input_tsv}.hard-zero-fail"
 if PROD_EVIDENCE_PACK_NAME=production-hard-zero-fail \
   PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.hard-zero-fail" \
@@ -74,7 +78,7 @@ grep -F "hikari-warning>0" "${output_dir}/production-hard-zero-fail-production-e
 grep -F "pool-pending>0" "${output_dir}/production-hard-zero-fail-production-evidence-pack.tsv" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] missing ref fail"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long" { $11 = "n/a" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long" { $11 = "n/a"; $12 = "n/a"; $13 = "n/a" } { print }' \
   "${input_tsv}" >"${input_tsv}.missing-ref"
 if PROD_EVIDENCE_PACK_NAME=production-missing-ref \
   PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.missing-ref" \
@@ -87,10 +91,12 @@ PROD_EVIDENCE_PACK_NAME=production-missing-ref \
 PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.missing-ref" \
 PROD_EVIDENCE_PACK_OUTPUT_DIR="${output_dir}" \
   "${runner}" >/dev/null 2>&1 || true
+grep -F "postgres_activity_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
+grep -F "postgres_wait_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
 grep -F "prometheus_timeline_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] source fail"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "real-ip-multisource" { $4 = 1; $12 = "n/a" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "real-ip-multisource" { $4 = 1; $14 = "n/a" } { print }' \
   "${input_tsv}" >"${input_tsv}.source-fail"
 if PROD_EVIDENCE_PACK_NAME=production-source-fail \
   PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.source-fail" \

--- a/tools/test/run-hikari-idle-in-transaction-attribution.sh
+++ b/tools/test/run-hikari-idle-in-transaction-attribution.sh
@@ -168,10 +168,21 @@ awk '
 }
 ' "${hikari_log}" >"${warning_tsv}"
 
-awk -F '\t' -v warnings="${warning_tsv}" '
+awk -F '\t' -v warnings="${warning_tsv}" -v correlation_window_seconds="${correlation_window_seconds}" '
 function value(name, fallback) {
   if (!(name in col) || col[name] == "") return fallback
   return $(col[name])
+}
+function day_part(ts) {
+  return substr(ts, 1, 10)
+}
+function second_of_day(ts) {
+  return (substr(ts, 12, 2) * 3600) + (substr(ts, 15, 2) * 60) + substr(ts, 18, 2)
+}
+function within_window(left, right) {
+  delta = second_of_day(left) - second_of_day(right)
+  if (delta < 0) delta = -delta
+  return day_part(left) == day_part(right) && delta <= correlation_window_seconds
 }
 function request_id_from_query(text) {
   if (match(text, /requestId=[A-Za-z0-9_.:-]+/)) {
@@ -182,7 +193,6 @@ function request_id_from_query(text) {
 BEGIN {
   while ((getline line < warnings) > 0) {
     split(line, parts, "\t")
-    warning_seen[parts[1]] = 1
     warning_order[++warning_count] = parts[1]
   }
   close(warnings)
@@ -195,17 +205,21 @@ NR == 1 {
 }
 {
   ts = value("sample_time_utc", "")
-  if (warning_seen[ts] && !(ts in matched)) {
-    matched[ts] = 1
-    pid[ts] = value("pid", "n/a")
-    request_id[ts] = value("request_id", "")
-    state[ts] = value("state", "n/a")
-    wait_type[ts] = value("wait_event_type", "n/a")
-    wait_event[ts] = value("wait_event", "n/a")
-    age[ts] = value("xact_age_seconds", "0")
-    query[ts] = value("query", "n/a")
-    if (request_id[ts] == "" || request_id[ts] == "n/a") {
-      request_id[ts] = request_id_from_query(query[ts])
+  for (i = 1; i <= warning_count; i++) {
+    warning_ts = warning_order[i]
+    if (!(warning_ts in matched) && within_window(ts, warning_ts)) {
+      matched[warning_ts] = 1
+      sample_time[warning_ts] = ts
+      pid[warning_ts] = value("pid", "n/a")
+      request_id[warning_ts] = value("request_id", "")
+      state[warning_ts] = value("state", "n/a")
+      wait_type[warning_ts] = value("wait_event_type", "n/a")
+      wait_event[warning_ts] = value("wait_event", "n/a")
+      age[warning_ts] = value("xact_age_seconds", "0")
+      query[warning_ts] = value("query", "n/a")
+      if (request_id[warning_ts] == "" || request_id[warning_ts] == "n/a") {
+        request_id[warning_ts] = request_id_from_query(query[warning_ts])
+      }
     }
   }
 }
@@ -214,8 +228,12 @@ END {
   for (i = 1; i <= warning_count; i++) {
     ts = warning_order[i]
     if (matched[ts]) {
-      cause = (state[ts] == "idle in transaction") ? "idle-in-transaction-candidate" : "postgres-timeout-candidate"
-      printf "%s\tpass\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", ts, pid[ts], request_id[ts], state[ts], wait_type[ts], wait_event[ts], age[ts], query[ts], cause
+      if (request_id[ts] == "" || request_id[ts] == "n/a") {
+        printf "%s\tfail\t%s\tn/a\t%s\t%s\t%s\t%s\t%s\trequest-id-missing\n", ts, pid[ts], state[ts], wait_type[ts], wait_event[ts], age[ts], query[ts]
+      } else {
+        cause = (state[ts] == "idle in transaction") ? "idle-in-transaction-candidate" : "postgres-timeout-candidate"
+        printf "%s\tpass\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", ts, pid[ts], request_id[ts], state[ts], wait_type[ts], wait_event[ts], age[ts], query[ts], cause
+      }
     } else {
       printf "%s\tfail\tn/a\tn/a\tn/a\tn/a\tn/a\t0\tn/a\tunattributed-warning\n", ts
     }

--- a/tools/test/run-transaction-read-production-evidence-pack.sh
+++ b/tools/test/run-transaction-read-production-evidence-pack.sh
@@ -103,7 +103,7 @@ print_plan() {
   echo "[transaction-read-production-evidence-pack] required_scenarios=${required_scenarios}"
   echo "[transaction-read-production-evidence-pack] min_real_source_ips=${min_real_source_ips}"
   echo "[transaction-read-production-evidence-pack] max_edge_429_rate=${max_edge_429_rate}"
-  echo "[transaction-read-production-evidence-pack] required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,prometheus_timeline_ref"
+  echo "[transaction-read-production-evidence-pack] required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref"
   echo "[transaction-read-production-evidence-pack] hard_zero=backend_429_count,unknown_429_count,five_xx_count,nginx_499_count,hikari_validation_warnings,db_pool_pending_max"
   echo "[transaction-read-production-evidence-pack] summary_tsv=${summary_tsv}"
   echo "[transaction-read-production-evidence-pack] report_md=${report_md}"
@@ -142,8 +142,8 @@ function require_ref(name) {
 BEGIN {
   split(required_scenarios, required_items, ",")
   for (i in required_items) required[required_items[i]] = 1
-  split("scenario run_id duration_min source_ips k6_summary_ref nginx_aggregate_ref nginx_499_aggregate_ref spring_429_ref hikari_log_ref postgres_explain_ref prometheus_timeline_ref edge_429_rate backend_429_count unknown_429_count five_xx_count nginx_499_count hikari_validation_warnings db_pool_pending_max", header_items, " ")
-  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tk6_summary_ref\tnginx_aggregate_ref\tnginx_499_aggregate_ref\tspring_429_ref\thikari_log_ref\tpostgres_explain_ref\tprometheus_timeline_ref\tsource_fairness_ref\tcache_state_ref\tdeploy_event_ref"
+  split("scenario run_id duration_min source_ips k6_summary_ref nginx_aggregate_ref nginx_499_aggregate_ref spring_429_ref hikari_log_ref postgres_explain_ref postgres_activity_ref postgres_wait_ref prometheus_timeline_ref edge_429_rate backend_429_count unknown_429_count five_xx_count nginx_499_count hikari_validation_warnings db_pool_pending_max", header_items, " ")
+  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tk6_summary_ref\tnginx_aggregate_ref\tnginx_499_aggregate_ref\tspring_429_ref\thikari_log_ref\tpostgres_explain_ref\tpostgres_activity_ref\tpostgres_wait_ref\tprometheus_timeline_ref\tsource_fairness_ref\tcache_state_ref\tdeploy_event_ref"
 }
 NR == 1 {
   for (i = 1; i <= NF; i++) col[$i] = i
@@ -167,6 +167,8 @@ NR == 1 {
   require_ref("spring_429_ref")
   require_ref("hikari_log_ref")
   require_ref("postgres_explain_ref")
+  require_ref("postgres_activity_ref")
+  require_ref("postgres_wait_ref")
   require_ref("prometheus_timeline_ref")
 
   if (value("edge_429_rate", "1") + 0 > max_edge_429_rate) add_reason("edge429>" max_edge_429_rate)
@@ -196,7 +198,7 @@ NR == 1 {
   }
 
   if (status == "fail") fail_count++
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
     scenario, status, reason, value("run_id", ""),
     value("duration_min", "0"), value("source_ips", "0"), value("edge_429_rate", "0"),
     value("backend_429_count", "0"), value("unknown_429_count", "0"),
@@ -205,6 +207,7 @@ NR == 1 {
     value("k6_summary_ref", ""), value("nginx_aggregate_ref", ""),
     value("nginx_499_aggregate_ref", ""), value("spring_429_ref", ""),
     value("hikari_log_ref", ""), value("postgres_explain_ref", ""),
+    value("postgres_activity_ref", ""), value("postgres_wait_ref", ""),
     value("prometheus_timeline_ref", ""), source_fairness_ref, cache_state_ref, deploy_event_ref
 }
 END {
@@ -234,7 +237,7 @@ scenario_table="$(awk -F '\t' '
     print "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
   }
   NR > 1 {
-    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $6, $7, $11, $10, $12, $13, $20
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $6, $7, $11, $10, $12, $13, $22
   }
 ' "${summary_tsv}")"
 
@@ -258,6 +261,8 @@ cat >"${report_md}" <<REPORT
 - Spring 429 attribution
 - Hikari log
 - PostgreSQL EXPLAIN
+- PostgreSQL activity sampler
+- PostgreSQL wait timeline
 - Prometheus timeline
 - source fairness artifact for real multi-source runs
 - cache state artifact for cold/warm runs
@@ -271,7 +276,7 @@ ${scenario_table}
 
 - 운영 secret, token, URL은 artifact ref에 넣지 않고 상대 경로만 기록한다.
 - 이 runner는 부하를 실행하지 않고 OCI에서 만든 증거 manifest를 review 가능한 pack으로 정규화한다.
-- 429 source, 499, Hikari, p99.9, cache state, deploy drain 증거는 같은 run id로 묶어야 한다.
+- 429 source, 499, Hikari, PostgreSQL activity/wait, p99.9, cache state, deploy drain 증거는 같은 run id로 묶어야 한다.
 
 ## Artifacts
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #648

## 🌿 Base Branch
- `main`

## 📝 Summary
- Hikari closed connection warning과 PostgreSQL idle-in-transaction timeout을 같은 시간대 증거로 묶을 수 있도록 transaction read SQL에 requestId/queryShape trace comment를 추가했습니다.
- attribution runner가 warning timestamp와 pg_stat_activity sampler를 correlation window로 매칭하고, production evidence pack이 PostgreSQL activity/wait ref 없이는 통과하지 않도록 강화했습니다.

## 🛠 Changes
- transaction read hot/archive/detail SQL 앞에 `requestId`, `queryShape` SQL comment 추가
- Hikari idle attribution runner의 warning-to-pg_stat_activity 매칭을 exact timestamp에서 window 기반으로 보강
- checker fixture를 Hikari warning 3건 / idle-in-transaction 3건 재현 구조로 확장
- production evidence pack 필수 컬럼에 `postgres_activity_ref`, `postgres_wait_ref` 추가
- evidence pack report에 PostgreSQL activity sampler, wait timeline 필수 증거 명시

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-hikari-idle-in-transaction-attribution.sh`
- `bash tools/test/check-transaction-read-production-evidence-pack.sh`
- `tools/test/with-resource-lock.sh back-gradle-transaction-read-query-statement ./back/gradlew -p back test --tests com.aquilabank.global.persistence.transaction.TransactionReadQueryStatementTest`
- `git diff --check`
- `git rev-list --count main..HEAD` = `2`
- pre-commit: `./back/gradlew -p back check` 통과 (commit `55aadcf1`)

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: SQL comment가 pg_stat_activity query text에 노출되는 운영 trace 계약이 추가됩니다. requestId/queryShape는 sanitizer로 허용 문자만 남기고 96자로 제한했습니다.
- 롤백 방법: 이 PR revert. 기존 SQL shape와 evidence pack 계약으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? SQL comment sanitizer 적용
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? DB schema/API 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? evidence pack contract 반영