### PR TITLE
[Fix] OCI A1 Hikari validation warning zero-budget closure

### DIFF
--- a/tools/test/check-hikari-idle-in-transaction-attribution.sh
+++ b/tools/test/check-hikari-idle-in-transaction-attribution.sh
@@ -10,9 +10,12 @@ temp_dir="$(mktemp -d)"
 trap 'rm -rf "${temp_dir}"' EXIT
 
 pg_tsv="${temp_dir}/pg-activity.tsv"
+pg_zero_tsv="${temp_dir}/pg-activity-zero.tsv"
 hikari_log="${temp_dir}/hikari.log"
 hikari_log_zero="${temp_dir}/hikari-zero.log"
 config_tsv="${temp_dir}/config.tsv"
+http_status_tsv="${temp_dir}/http-status.tsv"
+http_status_5xx_tsv="${temp_dir}/http-status-5xx.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${pg_tsv}" <<'TSV'
@@ -20,6 +23,11 @@ sample_time_utc	pid	usename	application_name	request_id	state	wait_event_type	wa
 2026-05-02T03:00:05Z	123	aquila	aquila-bank	tx-read-req-001	idle in transaction	Client	ClientRead	182	select pg_sleep(30) /* requestId=tx-read-req-001 */
 2026-05-02T03:00:10Z	124	aquila	aquila-bank	n/a	idle in transaction	Client	ClientRead	188	select 1 /* requestId=tx-read-req-002 */
 2026-05-02T03:00:20Z	125	aquila	aquila-bank	tx-read-req-003	active	IO	DataFileRead	1	select 1
+TSV
+
+cat >"${pg_zero_tsv}" <<'TSV'
+sample_time_utc	pid	usename	application_name	request_id	state	wait_event_type	wait_event	xact_age_seconds	query
+2026-05-02T03:30:05Z	223	aquila	aquila-bank	tx-read-req-101	active	IO	DataFileRead	1	select 1 /* requestId=tx-read-req-101 */
 TSV
 
 cat >"${hikari_log}" <<'LOG'
@@ -41,12 +49,23 @@ hikari_keepalive_time_ms	60000
 scheduled_worker_max_interval_ms	120000
 TSV
 
+cat >"${http_status_tsv}" <<'TSV'
+key	value
+five_xx_count	0
+TSV
+
+cat >"${http_status_5xx_tsv}" <<'TSV'
+key	value
+five_xx_count	1
+TSV
+
 echo "[hikari-idle-attribution] print plan"
 plan="$(
   HIKARI_IDLE_ATTRIBUTION_NAME=hikari-check \
   HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV="${pg_tsv}" \
   HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG="${hikari_log}" \
   HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV="${config_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV="${http_status_tsv}" \
   HIKARI_IDLE_ATTRIBUTION_OUTPUT_DIR="${output_dir}" \
     "${runner}" --print-plan
 )"
@@ -78,6 +97,8 @@ test "${report_md}" = "${output_dir}/hikari-check-hikari-idle-attribution.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "config_status=pass" "${report_md}" >/dev/null
 grep -F "warning_count=3" "${report_md}" >/dev/null
+grep -F "idle_in_transaction_samples=2" "${report_md}" >/dev/null
+grep -F "five_xx_count=0" "${report_md}" >/dev/null
 grep -F "OCI A1 lifetime alignment" "${report_md}" >/dev/null
 grep -F "PostgreSQL PID/query/requestId correlation" "${report_md}" >/dev/null
 grep -F $'warning_time_utc\tstatus\tpid\trequest_id\tstate\twait_event_type\twait_event\txact_age_seconds\tquery\tcause' "${summary_tsv}" >/dev/null
@@ -88,9 +109,10 @@ grep -F $'2026-05-02T03:00:18Z\tpass\t125\ttx-read-req-003\tactive\tIO\tDataFile
 echo "[hikari-idle-attribution] 30m zero warning soak passes"
 zero_output="$(
   HIKARI_IDLE_ATTRIBUTION_NAME=hikari-zero \
-  HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV="${pg_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV="${pg_zero_tsv}" \
   HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG="${hikari_log_zero}" \
   HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV="${config_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV="${http_status_tsv}" \
   HIKARI_IDLE_ATTRIBUTION_OUTPUT_DIR="${output_dir}" \
   HIKARI_IDLE_ATTRIBUTION_EXPECT_WARNING_COUNT=0 \
   HIKARI_IDLE_ATTRIBUTION_SOAK_DURATION_MIN=30 \
@@ -100,13 +122,45 @@ zero_report_md="$(tail -1 <<<"${zero_output}")"
 grep -F "gate_status=pass" "${zero_report_md}" >/dev/null
 grep -F "warning_count=0" "${zero_report_md}" >/dev/null
 grep -F "expected_warning_count=0" "${zero_report_md}" >/dev/null
+grep -F "idle_in_transaction_samples=0" "${zero_report_md}" >/dev/null
+grep -F "five_xx_count=0" "${zero_report_md}" >/dev/null
+grep -F "zero-budget hard target: Hikari warning 0, idle in transaction 0, 5xx 0" "${zero_report_md}" >/dev/null
 grep -F "30m soak Hikari warning budget: 0" "${zero_report_md}" >/dev/null
+
+echo "[hikari-idle-attribution] 30m zero warning with idle transaction fails"
+if HIKARI_IDLE_ATTRIBUTION_NAME=hikari-zero-idle-fail \
+  HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV="${pg_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG="${hikari_log_zero}" \
+  HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV="${config_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV="${http_status_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_OUTPUT_DIR="${output_dir}" \
+  HIKARI_IDLE_ATTRIBUTION_EXPECT_WARNING_COUNT=0 \
+  HIKARI_IDLE_ATTRIBUTION_SOAK_DURATION_MIN=30 \
+    "${runner}" >/dev/null 2>&1; then
+  echo "hikari attribution unexpectedly passed zero-warning run with idle in transaction samples" >&2
+  exit 1
+fi
+
+echo "[hikari-idle-attribution] 30m zero warning with 5xx fails"
+if HIKARI_IDLE_ATTRIBUTION_NAME=hikari-zero-5xx-fail \
+  HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV="${pg_zero_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG="${hikari_log_zero}" \
+  HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV="${config_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV="${http_status_5xx_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_OUTPUT_DIR="${output_dir}" \
+  HIKARI_IDLE_ATTRIBUTION_EXPECT_WARNING_COUNT=0 \
+  HIKARI_IDLE_ATTRIBUTION_SOAK_DURATION_MIN=30 \
+    "${runner}" >/dev/null 2>&1; then
+  echo "hikari attribution unexpectedly passed zero-warning run with 5xx" >&2
+  exit 1
+fi
 
 echo "[hikari-idle-attribution] 30m zero warning violation fails"
 if HIKARI_IDLE_ATTRIBUTION_NAME=hikari-zero-fail \
   HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV="${pg_tsv}" \
   HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG="${hikari_log}" \
   HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV="${config_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV="${http_status_tsv}" \
   HIKARI_IDLE_ATTRIBUTION_OUTPUT_DIR="${output_dir}" \
   HIKARI_IDLE_ATTRIBUTION_EXPECT_WARNING_COUNT=0 \
   HIKARI_IDLE_ATTRIBUTION_SOAK_DURATION_MIN=30 \

--- a/tools/test/check-transaction-read-production-evidence-pack.sh
+++ b/tools/test/check-transaction-read-production-evidence-pack.sh
@@ -13,13 +13,13 @@ input_tsv="${temp_dir}/production-evidence.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${input_tsv}" <<'TSV'
-scenario	run_id	duration_min	source_ips	k6_summary_ref	nginx_aggregate_ref	nginx_499_aggregate_ref	spring_429_ref	hikari_log_ref	postgres_explain_ref	postgres_activity_ref	postgres_wait_ref	prometheus_timeline_ref	source_fairness_ref	cache_state_ref	deploy_event_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max
-hikari-soak	oci-001	30	1	oci/k6/hikari.json	oci/nginx/hikari.tsv	oci/nginx/hikari-499.tsv	oci/spring/hikari-429.tsv	oci/hikari/hikari.log	oci/pg/hikari-explain.txt	oci/pg/hikari-activity.tsv	oci/pg/hikari-wait.tsv	oci/prom/hikari.json	n/a	n/a	n/a	0.01	0	0	0	0	0	0
-cold-warm	oci-002	10	1	oci/k6/cold-warm.json	oci/nginx/cold-warm.tsv	oci/nginx/cold-warm-499.tsv	oci/spring/cold-warm-429.tsv	oci/hikari/cold-warm.log	oci/pg/cold-warm-explain.txt	oci/pg/cold-warm-activity.tsv	oci/pg/cold-warm-wait.tsv	oci/prom/cold-warm.json	n/a	oci/cache/cold-warm.tsv	n/a	0.02	0	0	0	0	0	0
-mixed-workload	oci-003	30	1	oci/k6/mixed.json	oci/nginx/mixed.tsv	oci/nginx/mixed-499.tsv	oci/spring/mixed-429.tsv	oci/hikari/mixed.log	oci/pg/mixed-explain.txt	oci/pg/mixed-activity.tsv	oci/pg/mixed-wait.tsv	oci/prom/mixed.json	n/a	n/a	n/a	0.08	0	0	0	0	0	0
-real-ip-multisource	oci-004	10	2	oci/k6/real-ip.json	oci/nginx/real-ip.tsv	oci/nginx/real-ip-499.tsv	oci/spring/real-ip-429.tsv	oci/hikari/real-ip.log	oci/pg/real-ip-explain.txt	oci/pg/real-ip-activity.tsv	oci/pg/real-ip-wait.tsv	oci/prom/real-ip.json	oci/source/real-ip-fairness.tsv	n/a	n/a	0.07	0	0	0	0	0	0
-deploy-drain	oci-005	5	1	oci/k6/deploy-drain.json	oci/nginx/deploy-drain.tsv	oci/nginx/deploy-drain-499.tsv	oci/spring/deploy-drain-429.tsv	oci/hikari/deploy-drain.log	oci/pg/deploy-drain-explain.txt	oci/pg/deploy-drain-activity.tsv	oci/pg/deploy-drain-wait.tsv	oci/prom/deploy-drain.json	n/a	n/a	oci/deploy/drain-events.tsv	0.04	0	0	0	0	0	0
-p999-long	oci-006	30	1	oci/k6/p999.json	oci/nginx/p999.tsv	oci/nginx/p999-499.tsv	oci/spring/p999-429.tsv	oci/hikari/p999.log	oci/pg/p999-explain.txt	oci/pg/p999-activity.tsv	oci/pg/p999-wait.tsv	oci/prom/p999.json	n/a	n/a	n/a	0.06	0	0	0	0	0	0
+scenario	run_id	duration_min	source_ips	k6_summary_ref	nginx_aggregate_ref	nginx_499_aggregate_ref	spring_429_ref	hikari_log_ref	hikari_closure_ref	postgres_explain_ref	postgres_activity_ref	postgres_wait_ref	prometheus_timeline_ref	source_fairness_ref	cache_state_ref	deploy_event_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max
+hikari-soak	oci-001	30	1	oci/k6/hikari.json	oci/nginx/hikari.tsv	oci/nginx/hikari-499.tsv	oci/spring/hikari-429.tsv	oci/hikari/hikari.log	oci/hikari/hikari-closure.md	oci/pg/hikari-explain.txt	oci/pg/hikari-activity.tsv	oci/pg/hikari-wait.tsv	oci/prom/hikari.json	n/a	n/a	n/a	0.01	0	0	0	0	0	0
+cold-warm	oci-002	10	1	oci/k6/cold-warm.json	oci/nginx/cold-warm.tsv	oci/nginx/cold-warm-499.tsv	oci/spring/cold-warm-429.tsv	oci/hikari/cold-warm.log	n/a	oci/pg/cold-warm-explain.txt	oci/pg/cold-warm-activity.tsv	oci/pg/cold-warm-wait.tsv	oci/prom/cold-warm.json	n/a	oci/cache/cold-warm.tsv	n/a	0.02	0	0	0	0	0	0
+mixed-workload	oci-003	30	1	oci/k6/mixed.json	oci/nginx/mixed.tsv	oci/nginx/mixed-499.tsv	oci/spring/mixed-429.tsv	oci/hikari/mixed.log	n/a	oci/pg/mixed-explain.txt	oci/pg/mixed-activity.tsv	oci/pg/mixed-wait.tsv	oci/prom/mixed.json	n/a	n/a	n/a	0.08	0	0	0	0	0	0
+real-ip-multisource	oci-004	10	2	oci/k6/real-ip.json	oci/nginx/real-ip.tsv	oci/nginx/real-ip-499.tsv	oci/spring/real-ip-429.tsv	oci/hikari/real-ip.log	n/a	oci/pg/real-ip-explain.txt	oci/pg/real-ip-activity.tsv	oci/pg/real-ip-wait.tsv	oci/prom/real-ip.json	oci/source/real-ip-fairness.tsv	n/a	n/a	0.07	0	0	0	0	0	0
+deploy-drain	oci-005	5	1	oci/k6/deploy-drain.json	oci/nginx/deploy-drain.tsv	oci/nginx/deploy-drain-499.tsv	oci/spring/deploy-drain-429.tsv	oci/hikari/deploy-drain.log	n/a	oci/pg/deploy-drain-explain.txt	oci/pg/deploy-drain-activity.tsv	oci/pg/deploy-drain-wait.tsv	oci/prom/deploy-drain.json	n/a	n/a	oci/deploy/drain-events.tsv	0.04	0	0	0	0	0	0
+p999-long	oci-006	30	1	oci/k6/p999.json	oci/nginx/p999.tsv	oci/nginx/p999-499.tsv	oci/spring/p999-429.tsv	oci/hikari/p999.log	n/a	oci/pg/p999-explain.txt	oci/pg/p999-activity.tsv	oci/pg/p999-wait.tsv	oci/prom/p999.json	n/a	n/a	n/a	0.06	0	0	0	0	0	0
 TSV
 
 echo "[transaction-read-production-evidence-pack] print plan"
@@ -32,7 +32,7 @@ plan="$(
 grep -F "name=production-check" <<<"${plan}" >/dev/null
 grep -F "required_scenarios=hikari-soak,cold-warm,mixed-workload,real-ip-multisource,deploy-drain,p999-long" <<<"${plan}" >/dev/null
 grep -F "min_real_source_ips=2" <<<"${plan}" >/dev/null
-grep -F "required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref" <<<"${plan}" >/dev/null
+grep -F "required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref,hikari_closure_ref(hikari-soak)" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] pass report"
 output="$(
@@ -48,16 +48,18 @@ grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "Nginx 499 aggregate" "${report_md}" >/dev/null
 grep -F "PostgreSQL activity sampler" "${report_md}" >/dev/null
 grep -F "PostgreSQL wait timeline" "${report_md}" >/dev/null
+grep -F "Hikari zero-budget closure report" "${report_md}" >/dev/null
 grep -F "hard-zero: backend 429, unknown 429, 499, 5xx, Hikari warning, Hikari pending" "${report_md}" >/dev/null
 grep -F $'real-ip-multisource\tpass\tok\toci-004\t10\t2' "${summary_tsv}" >/dev/null
 grep -F "oci/pg/real-ip-activity.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/pg/real-ip-wait.tsv" "${summary_tsv}" >/dev/null
+grep -F "oci/hikari/hikari-closure.md" "${summary_tsv}" >/dev/null
 grep -F "oci/source/real-ip-fairness.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/deploy/drain-events.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/cache/cold-warm.tsv" "${summary_tsv}" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] hard-zero fail"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload" { $19 = 1; $20 = 1; $21 = 1; $22 = 1; $23 = 1 } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload" { $20 = 1; $21 = 1; $22 = 1; $23 = 1; $24 = 1 } { print }' \
   "${input_tsv}" >"${input_tsv}.hard-zero-fail"
 if PROD_EVIDENCE_PACK_NAME=production-hard-zero-fail \
   PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.hard-zero-fail" \
@@ -78,7 +80,7 @@ grep -F "hikari-warning>0" "${output_dir}/production-hard-zero-fail-production-e
 grep -F "pool-pending>0" "${output_dir}/production-hard-zero-fail-production-evidence-pack.tsv" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] missing ref fail"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long" { $11 = "n/a"; $12 = "n/a"; $13 = "n/a" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long" { $12 = "n/a"; $13 = "n/a"; $14 = "n/a" } { print }' \
   "${input_tsv}" >"${input_tsv}.missing-ref"
 if PROD_EVIDENCE_PACK_NAME=production-missing-ref \
   PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.missing-ref" \
@@ -95,8 +97,24 @@ grep -F "postgres_activity_ref-missing" "${output_dir}/production-missing-ref-pr
 grep -F "postgres_wait_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
 grep -F "prometheus_timeline_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
 
+echo "[transaction-read-production-evidence-pack] missing Hikari closure ref fail"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "hikari-soak" { $10 = "n/a" } { print }' \
+  "${input_tsv}" >"${input_tsv}.missing-hikari-closure"
+if PROD_EVIDENCE_PACK_NAME=production-missing-hikari-closure \
+  PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.missing-hikari-closure" \
+  PROD_EVIDENCE_PACK_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "production evidence pack unexpectedly passed missing Hikari closure ref" >&2
+  exit 1
+fi
+PROD_EVIDENCE_PACK_NAME=production-missing-hikari-closure \
+PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.missing-hikari-closure" \
+PROD_EVIDENCE_PACK_OUTPUT_DIR="${output_dir}" \
+  "${runner}" >/dev/null 2>&1 || true
+grep -F "hikari_closure_ref-missing" "${output_dir}/production-missing-hikari-closure-production-evidence-pack.tsv" >/dev/null
+
 echo "[transaction-read-production-evidence-pack] source fail"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "real-ip-multisource" { $4 = 1; $14 = "n/a" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "real-ip-multisource" { $4 = 1; $15 = "n/a" } { print }' \
   "${input_tsv}" >"${input_tsv}.source-fail"
 if PROD_EVIDENCE_PACK_NAME=production-source-fail \
   PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.source-fail" \

--- a/tools/test/run-hikari-idle-in-transaction-attribution.sh
+++ b/tools/test/run-hikari-idle-in-transaction-attribution.sh
@@ -10,6 +10,7 @@ Environment:
   HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV            required pg_stat_activity sampler TSV
   HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG                 required Hikari warning log
   HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV                 required key/value timeout config TSV
+  HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV            optional key/value HTTP status TSV; required when EXPECT_WARNING_COUNT=0
   HIKARI_IDLE_ATTRIBUTION_OUTPUT_DIR                 default build/reports/k6/<name>
   HIKARI_IDLE_ATTRIBUTION_CORRELATION_WINDOW_SECONDS default 5
   HIKARI_IDLE_ATTRIBUTION_EXPECT_WARNING_COUNT       optional exact warning count, use 0 for 30m soak removal gate
@@ -71,6 +72,7 @@ name="${HIKARI_IDLE_ATTRIBUTION_NAME:-hikari-idle-attribution-$(date +%Y-%m-%d-%
 pg_activity_tsv="${HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV:-}"
 hikari_log="${HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG:-}"
 config_tsv="${HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV:-}"
+http_status_tsv="${HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV:-}"
 output_dir="${HIKARI_IDLE_ATTRIBUTION_OUTPUT_DIR:-build/reports/k6/${name}}"
 correlation_window_seconds="${HIKARI_IDLE_ATTRIBUTION_CORRELATION_WINDOW_SECONDS:-5}"
 expected_warning_count="${HIKARI_IDLE_ATTRIBUTION_EXPECT_WARNING_COUNT:-}"
@@ -102,6 +104,7 @@ print_plan() {
   echo "[hikari-idle-attribution] pg_activity_tsv=${pg_activity_tsv:-missing}"
   echo "[hikari-idle-attribution] hikari_log=${hikari_log:-missing}"
   echo "[hikari-idle-attribution] config_tsv=${config_tsv:-missing}"
+  echo "[hikari-idle-attribution] http_status_tsv=${http_status_tsv:-missing}"
   echo "[hikari-idle-attribution] output_dir=${output_dir}"
   echo "[hikari-idle-attribution] sampler=pg_stat_activity"
   echo "[hikari-idle-attribution] correlation_window_seconds=${correlation_window_seconds}"
@@ -123,13 +126,42 @@ if [[ "${mode}" == "print-plan" ]]; then
   require_file "HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV" "${pg_activity_tsv}"
   require_file "HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG" "${hikari_log}"
   require_file "HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV" "${config_tsv}"
+  if [[ -n "${http_status_tsv}" || "${expected_warning_count}" == "0" ]]; then
+    require_file "HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV" "${http_status_tsv}"
+  fi
   exit 0
 fi
 
 require_file "HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV" "${pg_activity_tsv}"
 require_file "HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG" "${hikari_log}"
 require_file "HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV" "${config_tsv}"
+if [[ -n "${http_status_tsv}" || "${expected_warning_count}" == "0" ]]; then
+  require_file "HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV" "${http_status_tsv}"
+fi
 mkdir -p "${output_dir}"
+
+idle_in_transaction_samples="$(
+  awk -F '\t' '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) if ($i == "state") state_col = i
+      next
+    }
+    state_col && $state_col == "idle in transaction" { count++ }
+    END { print count + 0 }
+  ' "${pg_activity_tsv}"
+)"
+
+five_xx_count="0"
+if [[ -n "${http_status_tsv}" ]]; then
+  five_xx_count="$(
+    awk -F '\t' '
+      NR == 1 { next }
+      $1 == "five_xx_count" { print $2; found = 1 }
+      END { if (!found) print "missing" }
+    ' "${http_status_tsv}"
+  )"
+  require_non_negative_integer "HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV five_xx_count" "${five_xx_count}"
+fi
 
 awk -F '\t' '
 NR == 1 { next }
@@ -250,6 +282,11 @@ fi
 if [[ -n "${expected_warning_count}" && "${warning_count}" != "${expected_warning_count}" ]]; then
   gate_status="fail"
 fi
+if [[ "${expected_warning_count}" == "0" ]]; then
+  if [[ "${idle_in_transaction_samples}" != "0" || "${five_xx_count}" != "0" ]]; then
+    gate_status="fail"
+  fi
+fi
 if [[ -z "${expected_warning_count}" && "${warning_count}" == "0" ]]; then
   gate_status="fail"
 fi
@@ -275,11 +312,14 @@ cat >"${report_md}" <<REPORT
 - warning_count=${warning_count}
 - expected_warning_count=${expected_warning_count:-not-set}
 - unattributed_warning_count=${unattributed_count}
+- idle_in_transaction_samples=${idle_in_transaction_samples}
+- five_xx_count=${five_xx_count}
 - sampler: pg_stat_activity
 - correlation window seconds: ${correlation_window_seconds}
 - soak_duration_min=${soak_duration_min}
 - OCI A1 lifetime alignment: maxLifetime < NAT idle, keepalive < maxLifetime, scheduled worker <= PostgreSQL idle timeout
 - ${soak_duration_min}m soak Hikari warning budget: ${expected_warning_count:-attribution-required}
+- zero-budget hard target: Hikari warning 0, idle in transaction 0, 5xx 0
 
 ## Correlation
 

--- a/tools/test/run-transaction-read-production-evidence-pack.sh
+++ b/tools/test/run-transaction-read-production-evidence-pack.sh
@@ -103,7 +103,7 @@ print_plan() {
   echo "[transaction-read-production-evidence-pack] required_scenarios=${required_scenarios}"
   echo "[transaction-read-production-evidence-pack] min_real_source_ips=${min_real_source_ips}"
   echo "[transaction-read-production-evidence-pack] max_edge_429_rate=${max_edge_429_rate}"
-  echo "[transaction-read-production-evidence-pack] required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref"
+  echo "[transaction-read-production-evidence-pack] required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref,hikari_closure_ref(hikari-soak)"
   echo "[transaction-read-production-evidence-pack] hard_zero=backend_429_count,unknown_429_count,five_xx_count,nginx_499_count,hikari_validation_warnings,db_pool_pending_max"
   echo "[transaction-read-production-evidence-pack] summary_tsv=${summary_tsv}"
   echo "[transaction-read-production-evidence-pack] report_md=${report_md}"
@@ -142,8 +142,8 @@ function require_ref(name) {
 BEGIN {
   split(required_scenarios, required_items, ",")
   for (i in required_items) required[required_items[i]] = 1
-  split("scenario run_id duration_min source_ips k6_summary_ref nginx_aggregate_ref nginx_499_aggregate_ref spring_429_ref hikari_log_ref postgres_explain_ref postgres_activity_ref postgres_wait_ref prometheus_timeline_ref edge_429_rate backend_429_count unknown_429_count five_xx_count nginx_499_count hikari_validation_warnings db_pool_pending_max", header_items, " ")
-  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tk6_summary_ref\tnginx_aggregate_ref\tnginx_499_aggregate_ref\tspring_429_ref\thikari_log_ref\tpostgres_explain_ref\tpostgres_activity_ref\tpostgres_wait_ref\tprometheus_timeline_ref\tsource_fairness_ref\tcache_state_ref\tdeploy_event_ref"
+  split("scenario run_id duration_min source_ips k6_summary_ref nginx_aggregate_ref nginx_499_aggregate_ref spring_429_ref hikari_log_ref hikari_closure_ref postgres_explain_ref postgres_activity_ref postgres_wait_ref prometheus_timeline_ref edge_429_rate backend_429_count unknown_429_count five_xx_count nginx_499_count hikari_validation_warnings db_pool_pending_max", header_items, " ")
+  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tk6_summary_ref\tnginx_aggregate_ref\tnginx_499_aggregate_ref\tspring_429_ref\thikari_log_ref\thikari_closure_ref\tpostgres_explain_ref\tpostgres_activity_ref\tpostgres_wait_ref\tprometheus_timeline_ref\tsource_fairness_ref\tcache_state_ref\tdeploy_event_ref"
 }
 NR == 1 {
   for (i = 1; i <= NF; i++) col[$i] = i
@@ -170,6 +170,14 @@ NR == 1 {
   require_ref("postgres_activity_ref")
   require_ref("postgres_wait_ref")
   require_ref("prometheus_timeline_ref")
+
+  hikari_closure_ref = value("hikari_closure_ref", "n/a")
+  if (scenario == "hikari-soak") {
+    if (hikari_closure_ref == "" || hikari_closure_ref == "n/a") add_reason("hikari_closure_ref-missing")
+    else if (unsafe_ref(hikari_closure_ref)) add_reason("hikari_closure_ref-unsafe")
+  } else if (hikari_closure_ref != "" && hikari_closure_ref != "n/a" && unsafe_ref(hikari_closure_ref)) {
+    add_reason("hikari_closure_ref-unsafe")
+  }
 
   if (value("edge_429_rate", "1") + 0 > max_edge_429_rate) add_reason("edge429>" max_edge_429_rate)
   if (value("backend_429_count", "1") + 0 > 0) add_reason("backend429>0")
@@ -198,7 +206,7 @@ NR == 1 {
   }
 
   if (status == "fail") fail_count++
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
     scenario, status, reason, value("run_id", ""),
     value("duration_min", "0"), value("source_ips", "0"), value("edge_429_rate", "0"),
     value("backend_429_count", "0"), value("unknown_429_count", "0"),
@@ -206,7 +214,7 @@ NR == 1 {
     value("hikari_validation_warnings", "0"), value("db_pool_pending_max", "0"),
     value("k6_summary_ref", ""), value("nginx_aggregate_ref", ""),
     value("nginx_499_aggregate_ref", ""), value("spring_429_ref", ""),
-    value("hikari_log_ref", ""), value("postgres_explain_ref", ""),
+    value("hikari_log_ref", ""), hikari_closure_ref, value("postgres_explain_ref", ""),
     value("postgres_activity_ref", ""), value("postgres_wait_ref", ""),
     value("prometheus_timeline_ref", ""), source_fairness_ref, cache_state_ref, deploy_event_ref
 }
@@ -237,7 +245,7 @@ scenario_table="$(awk -F '\t' '
     print "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
   }
   NR > 1 {
-    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $6, $7, $11, $10, $12, $13, $22
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $6, $7, $11, $10, $12, $13, $23
   }
 ' "${summary_tsv}")"
 
@@ -260,6 +268,7 @@ cat >"${report_md}" <<REPORT
 - Nginx 499 aggregate
 - Spring 429 attribution
 - Hikari log
+- Hikari zero-budget closure report
 - PostgreSQL EXPLAIN
 - PostgreSQL activity sampler
 - PostgreSQL wait timeline


### PR DESCRIPTION
## 🔗 Related Issue
- close #650

## 🌿 Base Branch
- `main`

## 📝 Summary
- Hikari warning attribution runner의 zero-budget 모드가 Hikari warning 0뿐 아니라 `idle in transaction` sample 0, 5xx 0까지 같은 evidence로 검증하게 했습니다.
- production evidence pack에서 `hikari-soak` scenario가 별도 `hikari_closure_ref` artifact를 반드시 남기도록 계약을 고정했습니다.

## 🛠 Changes
- `run-hikari-idle-in-transaction-attribution.sh`에 HTTP status TSV 입력과 zero-budget hard target 검증을 추가했습니다.
- `run-transaction-read-production-evidence-pack.sh`에 `hikari_closure_ref` 컬럼과 `hikari-soak` 필수 ref 검증을 추가했습니다.
- 관련 contract check에 RED/GREEN 케이스를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-hikari-idle-in-transaction-attribution.sh`
- `bash tools/test/check-transaction-read-production-evidence-pack.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` => `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: production evidence manifest에 `hikari_closure_ref` 컬럼이 없으면 pack gate가 실패합니다. 의도된 fail-fast입니다.
- 롤백 방법: 이 PR revert 후 기존 evidence pack 계약으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?