### PR TITLE
[Perf] transaction read edge/fairness overload policy retune

### DIFF
--- a/tools/test/check-transaction-read-burst64-residual-smoothing.sh
+++ b/tools/test/check-transaction-read-burst64-residual-smoothing.sh
@@ -13,8 +13,8 @@ input_tsv="${temp_dir}/burst64.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${input_tsv}" <<'TSV'
-policy	burst48_429_rate	burst64_429_rate	burst80_429_rate	burst96_429_rate	accepted_p95_ms	retry_after_p95_ms	reject_streak_max	delayed_rate	five_xx_count	backend_429_count
-residual-v2	0.080	0.095	0.220	0.330	145	220	4	0.04	0	0
+policy	burst48_429_rate	burst64_429_rate	burst80_429_rate	burst96_429_rate	accepted_p95_ms	retry_after_p95_ms	reject_streak_max	delayed_rate	five_xx_count	backend_429_rate	backend_429_count
+residual-v2	0.080	0.095	0.220	0.330	118	220	4	0.04	0	0.004	25
 TSV
 
 echo "[transaction-read-burst64-residual-smoothing] print plan"
@@ -26,6 +26,8 @@ plan="$(
 )"
 grep -F "name=burst64-check" <<<"${plan}" >/dev/null
 grep -F "max_burst64_429_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "max_backend_429_rate=0.005" <<<"${plan}" >/dev/null
+grep -F "max_accepted_p95_ms=120" <<<"${plan}" >/dev/null
 grep -F "min_burst80_429_rate=0.10" <<<"${plan}" >/dev/null
 grep -F "max_reject_streak=4" <<<"${plan}" >/dev/null
 
@@ -41,10 +43,11 @@ summary_tsv="${output_dir}/burst64-check-burst64-residual-smoothing.tsv"
 test "${report_md}" = "${output_dir}/burst64-check-burst64-residual-smoothing.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "burst 64 total 429 budget: <= 0.10" "${report_md}" >/dev/null
-grep -F $'residual-v2\tpass\t0.080\t0.095\t0.220\t0.330\t145\t220\t4\t0.04\t0\t0' "${summary_tsv}" >/dev/null
+grep -F "backend 429 budget: <= 0.005" "${report_md}" >/dev/null
+grep -F $'residual-v2\tpass\t0.080\t0.095\t0.220\t0.330\t118\t220\t4\t0.04\t0\t0.004\t25' "${summary_tsv}" >/dev/null
 
 echo "[transaction-read-burst64-residual-smoothing] fail report"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $3 = 0.125; $8 = 7 } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $3 = 0.125; $8 = 7; $11 = 0.006 } { print }' \
   "${input_tsv}" >"${input_tsv}.fail"
 if BURST64_SMOOTHING_NAME=burst64-fail \
   BURST64_SMOOTHING_INPUT_TSV="${input_tsv}.fail" \

--- a/tools/test/check-transaction-read-fairness-budget.sh
+++ b/tools/test/check-transaction-read-fairness-budget.sh
@@ -13,9 +13,9 @@ input_tsv="${temp_dir}/fairness.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${input_tsv}" <<'TSV'
-arrival_rate	total_requests	backend_fairness_429_count	backend_429_count	edge_429_count	unknown_429_count	five_xx_count	cold_account_p95_ms	accepted_p95_ms
-8	1000	5	5	0	0	0	420	260
-16	2000	12	12	0	0	0	610	330
+endpoint	arrival_rate	total_requests	backend_fairness_429_count	backend_429_count	edge_429_count	unknown_429_count	five_xx_count	cold_account_p95_ms	accepted_p95_ms	rejection_reason
+active	16	2000	8	8	0	0	0	210	105	fairness-limiter-active
+archive	16	2000	12	12	0	0	0	610	118	fairness-limiter-archive
 TSV
 
 echo "[transaction-read-fairness-budget] print plan"
@@ -26,6 +26,7 @@ plan="$(
     "${runner}" --print-plan
 )"
 grep -F "arrival_rate=16" <<<"${plan}" >/dev/null
+grep -F "required_endpoints=active,archive" <<<"${plan}" >/dev/null
 grep -F "max_fairness_429_rate=0.01" <<<"${plan}" >/dev/null
 grep -F "max_edge_429_rate=0" <<<"${plan}" >/dev/null
 grep -F "cold_account_p95_ms=750" <<<"${plan}" >/dev/null
@@ -42,12 +43,15 @@ summary_tsv="${output_dir}/fairness-check-fairness-budget.tsv"
 test "${report_md}" = "${output_dir}/fairness-check-fairness-budget.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "arrival16 backend fairness budget: < 0.01" "${report_md}" >/dev/null
+grep -F "required endpoints: active,archive" "${report_md}" >/dev/null
+grep -F "rejection reason must include endpoint" "${report_md}" >/dev/null
 grep -F "cold account latency budget: <= 750ms" "${report_md}" >/dev/null
-grep -F $'arrival_rate\tstatus\tfairness_429_rate\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tcold_account_p95_ms\taccepted_p95_ms' "${summary_tsv}" >/dev/null
-grep -F $'16\tpass\t0.006000\t0.000000\t12\t0\t0\t610\t330' "${summary_tsv}" >/dev/null
+grep -F $'endpoint\tarrival_rate\tstatus\tfairness_429_rate\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tcold_account_p95_ms\taccepted_p95_ms\trejection_reason' "${summary_tsv}" >/dev/null
+grep -F $'active\t16\tpass\t0.004000\t0.000000\t8\t0\t0\t210\t105\tfairness-limiter-active' "${summary_tsv}" >/dev/null
+grep -F $'archive\t16\tpass\t0.006000\t0.000000\t12\t0\t0\t610\t118\tfairness-limiter-archive' "${summary_tsv}" >/dev/null
 
 echo "[transaction-read-fairness-budget] fairness over budget fails"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "16" { $3 = "25"; $4 = "25" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "archive" { $4 = "25"; $5 = "25" } { print }' \
   "${input_tsv}" >"${input_tsv}.fairness-fail"
 if FAIRNESS_BUDGET_NAME=fairness-over \
   FAIRNESS_BUDGET_INPUT_TSV="${input_tsv}.fairness-fail" \
@@ -58,12 +62,23 @@ if FAIRNESS_BUDGET_NAME=fairness-over \
 fi
 
 echo "[transaction-read-fairness-budget] cold latency regression fails"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "16" { $8 = "900" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "archive" { $9 = "900" } { print }' \
   "${input_tsv}" >"${input_tsv}.latency-fail"
 if FAIRNESS_BUDGET_NAME=fairness-latency \
   FAIRNESS_BUDGET_INPUT_TSV="${input_tsv}.latency-fail" \
   FAIRNESS_BUDGET_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "fairness budget unexpectedly passed cold account p95 regression" >&2
+  exit 1
+fi
+
+echo "[transaction-read-fairness-budget] mixed rejection reason fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "archive" { $11 = "fairness-limiter-active" } { print }' \
+  "${input_tsv}" >"${input_tsv}.reason-fail"
+if FAIRNESS_BUDGET_NAME=fairness-reason \
+  FAIRNESS_BUDGET_INPUT_TSV="${input_tsv}.reason-fail" \
+  FAIRNESS_BUDGET_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "fairness budget unexpectedly passed mixed active/archive rejection reason" >&2
   exit 1
 fi

--- a/tools/test/check-transaction-read-runtime-policy-budget.sh
+++ b/tools/test/check-transaction-read-runtime-policy-budget.sh
@@ -17,7 +17,8 @@ profile	burst_rate	total_429_rate	edge_429_rate	backend_429_rate	unknown_429_cou
 burst48	48	0.0367	0.0367	0	0	0	280	0.05	190	2	burst64-smoothing-v1
 burst64	64	0.0920	0.0880	0.0040	0	0	320	0.08	230	3	burst64-smoothing-v1
 burst96	96	0.4200	0.4100	0.0100	0	0	340	0.02	260	3	burst64-smoothing-v1
-vu16	16	0.1500	0.1400	0.0100	0	0	330	0.03	250	3	burst64-smoothing-v1
+vu16	16	0.1500	0.1400	0.0100	0	0	330	0.03	250	3	client-pacing-required
+paced-weighted-vu16	16	0.00014	0	0.00014	0	0	118	0.70	120	1	client-pacing-default
 TSV
 
 echo "[transaction-read-runtime-policy] print plan"
@@ -27,8 +28,9 @@ plan="$(
   RUNTIME_POLICY_OUTPUT_DIR="${output_dir}" \
     "${runner}" --print-plan
 )"
-grep -F "required_profiles=burst48,burst64,burst96,vu16" <<<"${plan}" >/dev/null
+grep -F "required_profiles=burst48,burst64,burst96,vu16,paced-weighted-vu16" <<<"${plan}" >/dev/null
 grep -F "burst64_429_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "paced_vu16_429_rate=0.005" <<<"${plan}" >/dev/null
 grep -F "reject_streak_max=3" <<<"${plan}" >/dev/null
 grep -F "accepted_p95_ms=350" <<<"${plan}" >/dev/null
 
@@ -44,9 +46,13 @@ summary_tsv="${output_dir}/runtime-policy-check-runtime-policy.tsv"
 test "${report_md}" = "${output_dir}/runtime-policy-check-runtime-policy.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "burst64 <= 10% 429" "${report_md}" >/dev/null
+grep -F "paced weighted VU16 <= 0.005 429" "${report_md}" >/dev/null
+grep -F "unpaced VU16 operating decision: client-pacing-required" "${report_md}" >/dev/null
 grep -F "Retry-After reject streak <= 3" "${report_md}" >/dev/null
-grep -F $'profile\tstatus\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tunknown_429_count\tfive_xx_count\taccepted_p95_ms\tdelayed_rate\tretry_after_p95_ms\treject_streak_max\tpolicy_candidate' "${summary_tsv}" >/dev/null
-grep -F $'burst64\tpass\t0.0920\t0.0880\t0.0040\t0\t0\t320\t0.08\t230\t3\tburst64-smoothing-v1' "${summary_tsv}" >/dev/null
+grep -F $'profile\tstatus\tdecision\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tunknown_429_count\tfive_xx_count\taccepted_p95_ms\tdelayed_rate\tretry_after_p95_ms\treject_streak_max\tpolicy_candidate' "${summary_tsv}" >/dev/null
+grep -F $'burst64\tpass\tburst64-smoothing\t0.0920\t0.0880\t0.0040\t0\t0\t320\t0.08\t230\t3\tburst64-smoothing-v1' "${summary_tsv}" >/dev/null
+grep -F $'vu16\tpass\tclient-pacing-required\t0.1500\t0.1400\t0.0100\t0\t0\t330\t0.03\t250\t3\tclient-pacing-required' "${summary_tsv}" >/dev/null
+grep -F $'paced-weighted-vu16\tpass\tclient-pacing-default\t0.00014\t0\t0.00014\t0\t0\t118\t0.70\t120\t1\tclient-pacing-default' "${summary_tsv}" >/dev/null
 
 echo "[transaction-read-runtime-policy] burst64 over budget fails"
 awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "burst64" { $3 = "0.1407" } { print }' \
@@ -67,5 +73,16 @@ if RUNTIME_POLICY_NAME=runtime-policy-streak \
   RUNTIME_POLICY_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "runtime policy unexpectedly passed reject streak over budget" >&2
+  exit 1
+fi
+
+echo "[transaction-read-runtime-policy] paced VU16 over budget fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "paced-weighted-vu16" { $3 = "0.020" } { print }' \
+  "${input_tsv}" >"${input_tsv}.paced-fail"
+if RUNTIME_POLICY_NAME=runtime-policy-paced \
+  RUNTIME_POLICY_INPUT_TSV="${input_tsv}.paced-fail" \
+  RUNTIME_POLICY_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "runtime policy unexpectedly passed paced weighted VU16 over budget" >&2
   exit 1
 fi

--- a/tools/test/run-transaction-read-burst64-residual-smoothing.sh
+++ b/tools/test/run-transaction-read-burst64-residual-smoothing.sh
@@ -11,9 +11,10 @@ Environment:
   BURST64_SMOOTHING_OUTPUT_DIR            default build/reports/k6/<gate>
   BURST64_SMOOTHING_MAX_BURST48_429_RATE  default 0.10
   BURST64_SMOOTHING_MAX_BURST64_429_RATE  default 0.10
+  BURST64_SMOOTHING_MAX_BACKEND_429_RATE  default 0.005
   BURST64_SMOOTHING_MIN_BURST80_429_RATE  default 0.10
   BURST64_SMOOTHING_MIN_BURST96_429_RATE  default 0.10
-  BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS   default 150
+  BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS   default 120
   BURST64_SMOOTHING_MAX_RETRY_P95_MS      default 250
   BURST64_SMOOTHING_MAX_REJECT_STREAK     default 4
   BURST64_SMOOTHING_MAX_DELAYED_RATE      default 0.05
@@ -43,9 +44,10 @@ input_tsv="${BURST64_SMOOTHING_INPUT_TSV:-}"
 output_dir="${BURST64_SMOOTHING_OUTPUT_DIR:-build/reports/k6/${name}}"
 max_burst48_429_rate="${BURST64_SMOOTHING_MAX_BURST48_429_RATE:-0.10}"
 max_burst64_429_rate="${BURST64_SMOOTHING_MAX_BURST64_429_RATE:-0.10}"
+max_backend_429_rate="${BURST64_SMOOTHING_MAX_BACKEND_429_RATE:-0.005}"
 min_burst80_429_rate="${BURST64_SMOOTHING_MIN_BURST80_429_RATE:-0.10}"
 min_burst96_429_rate="${BURST64_SMOOTHING_MIN_BURST96_429_RATE:-0.10}"
-max_accepted_p95_ms="${BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS:-150}"
+max_accepted_p95_ms="${BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS:-120}"
 max_retry_p95_ms="${BURST64_SMOOTHING_MAX_RETRY_P95_MS:-250}"
 max_reject_streak="${BURST64_SMOOTHING_MAX_REJECT_STREAK:-4}"
 max_delayed_rate="${BURST64_SMOOTHING_MAX_DELAYED_RATE:-0.05}"
@@ -112,6 +114,7 @@ print_plan() {
   echo "[transaction-read-burst64-residual-smoothing] policies=$(policies)"
   echo "[transaction-read-burst64-residual-smoothing] max_burst48_429_rate=${max_burst48_429_rate}"
   echo "[transaction-read-burst64-residual-smoothing] max_burst64_429_rate=${max_burst64_429_rate}"
+  echo "[transaction-read-burst64-residual-smoothing] max_backend_429_rate=${max_backend_429_rate}"
   echo "[transaction-read-burst64-residual-smoothing] min_burst80_429_rate=${min_burst80_429_rate}"
   echo "[transaction-read-burst64-residual-smoothing] min_burst96_429_rate=${min_burst96_429_rate}"
   echo "[transaction-read-burst64-residual-smoothing] max_accepted_p95_ms=${max_accepted_p95_ms}"
@@ -124,6 +127,7 @@ print_plan() {
 
 require_rate "BURST64_SMOOTHING_MAX_BURST48_429_RATE" "${max_burst48_429_rate}"
 require_rate "BURST64_SMOOTHING_MAX_BURST64_429_RATE" "${max_burst64_429_rate}"
+require_rate "BURST64_SMOOTHING_MAX_BACKEND_429_RATE" "${max_backend_429_rate}"
 require_rate "BURST64_SMOOTHING_MIN_BURST80_429_RATE" "${min_burst80_429_rate}"
 require_rate "BURST64_SMOOTHING_MIN_BURST96_429_RATE" "${min_burst96_429_rate}"
 require_rate "BURST64_SMOOTHING_MAX_DELAYED_RATE" "${max_delayed_rate}"
@@ -143,6 +147,7 @@ mkdir -p "${output_dir}"
 awk -F '\t' \
   -v max_burst48="${max_burst48_429_rate}" \
   -v max_burst64="${max_burst64_429_rate}" \
+  -v max_backend_429="${max_backend_429_rate}" \
   -v min_burst80="${min_burst80_429_rate}" \
   -v min_burst96="${min_burst96_429_rate}" \
   -v max_p95="${max_accepted_p95_ms}" \
@@ -158,7 +163,7 @@ awk -F '\t' \
     for (i = 1; i <= NF; i++) {
       col[$i] = i
     }
-    print "policy\tstatus\tburst48_429_rate\tburst64_429_rate\tburst80_429_rate\tburst96_429_rate\taccepted_p95_ms\tretry_after_p95_ms\treject_streak_max\tdelayed_rate\tfive_xx_count\tbackend_429_count"
+    print "policy\tstatus\tburst48_429_rate\tburst64_429_rate\tburst80_429_rate\tburst96_429_rate\taccepted_p95_ms\tretry_after_p95_ms\treject_streak_max\tdelayed_rate\tfive_xx_count\tbackend_429_rate\tbackend_429_count"
     next
   }
   {
@@ -172,19 +177,20 @@ awk -F '\t' \
     streak = value("reject_streak_max", "999999") + 0
     delayed = value("delayed_rate", "1") + 0
     five_xx = value("five_xx_count", "1") + 0
+    backend_429_rate = value("backend_429_rate", "1") + 0
     backend_429 = value("backend_429_count", "1") + 0
     status = "pass"
-    if (burst48 > max_burst48 || burst64 > max_burst64 || burst80 < min_burst80 || burst96 < min_burst96 || accepted_p95 > max_p95 || retry_p95 > max_retry_p95 || streak > max_streak || delayed > max_delayed || five_xx > 0 || backend_429 > 0) {
+    if (burst48 > max_burst48 || burst64 > max_burst64 || burst80 < min_burst80 || burst96 < min_burst96 || accepted_p95 > max_p95 || retry_p95 > max_retry_p95 || streak > max_streak || delayed > max_delayed || five_xx > 0 || backend_429_rate > max_backend_429) {
       status = "fail"
       fail_count++
     } else {
       pass_count++
     }
-    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
       policy, status, value("burst48_429_rate", "0"), value("burst64_429_rate", "0"),
       value("burst80_429_rate", "0"), value("burst96_429_rate", "0"), value("accepted_p95_ms", "0"),
       value("retry_after_p95_ms", "0"), value("reject_streak_max", "0"), value("delayed_rate", "0"),
-      value("five_xx_count", "0"), value("backend_429_count", "0")
+      value("five_xx_count", "0"), value("backend_429_rate", "0"), value("backend_429_count", "0")
   }
   END {
     if (fail_count == "") fail_count = 0
@@ -203,11 +209,11 @@ fi
 
 matrix_table="$(awk -F '\t' '
   BEGIN {
-    print "| Policy | Status | burst48 429 | burst64 429 | burst80 429 | burst96 429 | p95 ms | Retry p95 ms | Streak max | Delayed | 5xx | Backend 429 |"
-    print "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    print "| Policy | Status | burst48 429 | burst64 429 | burst80 429 | burst96 429 | p95 ms | Retry p95 ms | Streak max | Delayed | 5xx | Backend 429 rate | Backend 429 count |"
+    print "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
   }
   NR > 1 {
-    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
   }
 ' "${summary_tsv}")"
 
@@ -219,12 +225,13 @@ cat >"${report_md}" <<REPORT
 - gate_status=${gate_status}
 - burst 48 total 429 budget: <= ${max_burst48_429_rate}
 - burst 64 total 429 budget: <= ${max_burst64_429_rate}
+- backend 429 budget: <= ${max_backend_429_rate}
 - burst 80/96 policy: fail-fast overload lower bound >= ${min_burst80_429_rate}/${min_burst96_429_rate}
 - accepted p95 budget: <= ${max_accepted_p95_ms}ms
 - retry-after p95 budget: <= ${max_retry_p95_ms}ms
 - reject streak max: <= ${max_reject_streak}
 - delayed ratio budget: <= ${max_delayed_rate}
-- backend 429/5xx target: 0
+- 5xx target: 0
 
 ## Matrix
 

--- a/tools/test/run-transaction-read-fairness-budget.sh
+++ b/tools/test/run-transaction-read-fairness-budget.sh
@@ -10,6 +10,7 @@ Environment:
   FAIRNESS_BUDGET_INPUT_TSV               required arrival/fairness evidence TSV
   FAIRNESS_BUDGET_OUTPUT_DIR              default build/reports/k6/<name>
   FAIRNESS_BUDGET_ARRIVAL_RATE            default 16
+  FAIRNESS_BUDGET_REQUIRED_ENDPOINTS      default active,archive
   FAIRNESS_BUDGET_MAX_FAIRNESS_429_RATE   default 0.01
   FAIRNESS_BUDGET_MAX_EDGE_429_RATE       default 0
   FAIRNESS_BUDGET_COLD_P95_MS             default 750
@@ -39,6 +40,7 @@ name="${FAIRNESS_BUDGET_NAME:-transaction-read-fairness-budget-$(date +%Y-%m-%d-
 input_tsv="${FAIRNESS_BUDGET_INPUT_TSV:-}"
 output_dir="${FAIRNESS_BUDGET_OUTPUT_DIR:-build/reports/k6/${name}}"
 arrival_rate="${FAIRNESS_BUDGET_ARRIVAL_RATE:-16}"
+required_endpoints="${FAIRNESS_BUDGET_REQUIRED_ENDPOINTS:-active,archive}"
 max_fairness_rate="${FAIRNESS_BUDGET_MAX_FAIRNESS_429_RATE:-0.01}"
 max_edge_rate="${FAIRNESS_BUDGET_MAX_EDGE_429_RATE:-0}"
 cold_p95_budget_ms="${FAIRNESS_BUDGET_COLD_P95_MS:-750}"
@@ -74,6 +76,7 @@ print_plan() {
   echo "[transaction-read-fairness-budget] input_tsv=${input_tsv:-missing}"
   echo "[transaction-read-fairness-budget] output_dir=${output_dir}"
   echo "[transaction-read-fairness-budget] arrival_rate=${arrival_rate}"
+  echo "[transaction-read-fairness-budget] required_endpoints=${required_endpoints}"
   echo "[transaction-read-fairness-budget] max_fairness_429_rate=${max_fairness_rate}"
   echo "[transaction-read-fairness-budget] max_edge_429_rate=${max_edge_rate}"
   echo "[transaction-read-fairness-budget] cold_account_p95_ms=${cold_p95_budget_ms}"
@@ -102,6 +105,7 @@ mkdir -p "${output_dir}"
 
 awk -F '\t' \
   -v target_rate="${arrival_rate}" \
+  -v required_endpoints="${required_endpoints}" \
   -v max_fairness="${max_fairness_rate}" \
   -v max_edge="${max_edge_rate}" \
   -v cold_budget="${cold_p95_budget_ms}" \
@@ -111,13 +115,16 @@ function value(name, fallback) {
   return $(col[name])
 }
 BEGIN {
-  print "arrival_rate\tstatus\tfairness_429_rate\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tcold_account_p95_ms\taccepted_p95_ms"
+  split(required_endpoints, endpoint_items, ",")
+  for (i in endpoint_items) required_endpoint[endpoint_items[i]] = 1
+  print "endpoint\tarrival_rate\tstatus\tfairness_429_rate\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tcold_account_p95_ms\taccepted_p95_ms\trejection_reason"
 }
 NR == 1 {
   for (i = 1; i <= NF; i++) col[$i] = i
   next
 }
 {
+  endpoint = value("endpoint", "combined")
   rate = value("arrival_rate", "0") + 0
   total = value("total_requests", "0") + 0
   fairness_count = value("backend_fairness_429_count", "0") + 0
@@ -127,27 +134,45 @@ NR == 1 {
   five_xx_count = value("five_xx_count", "1") + 0
   cold_p95 = value("cold_account_p95_ms", "999999") + 0
   accepted_p95 = value("accepted_p95_ms", "999999") + 0
+  rejection_reason = value("rejection_reason", "fairness-limiter")
   fairness_rate = total > 0 ? fairness_count / total : 1
   edge_rate = total > 0 ? edge_count / total : 1
   status = "pass"
-  if (rate == target_rate) target_seen = 1
+  if (rate == target_rate) {
+    target_seen = 1
+    if (endpoint in required_endpoint) endpoint_seen[endpoint] = 1
+  }
   target_failed = fairness_rate >= max_fairness || edge_rate > max_edge || unknown_count > 0 || five_xx_count > 0 || cold_p95 > cold_budget || accepted_p95 > accepted_budget
+  if ((endpoint == "active" || endpoint == "archive") && rejection_reason !~ endpoint) {
+    target_failed = 1
+  }
   if (rate == target_rate && target_failed) {
     status = "fail"
   }
   if (status == "fail") fail_count++
-  printf "%s\t%s\t%.6f\t%.6f\t%s\t%s\t%s\t%s\t%s\n",
-    rate, status, fairness_rate, edge_rate, backend_count, unknown_count, five_xx_count, cold_p95, accepted_p95
+  printf "%s\t%s\t%s\t%.6f\t%.6f\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    endpoint, rate, status, fairness_rate, edge_rate, backend_count, unknown_count, five_xx_count, cold_p95, accepted_p95, rejection_reason
 }
 END {
+  missing_endpoints = ""
+  for (endpoint in required_endpoint) {
+    if (endpoint_seen[endpoint] != 1) {
+      if (missing_endpoints != "") missing_endpoints = missing_endpoints ","
+      missing_endpoints = missing_endpoints endpoint
+      fail_count++
+    }
+  }
+  if (missing_endpoints == "") missing_endpoints = "none"
   if (!target_seen) fail_count++
   print "fail_count=" (fail_count + 0) > "/dev/stderr"
   print "target_seen=" (target_seen + 0) > "/dev/stderr"
+  print "missing_endpoints=" missing_endpoints > "/dev/stderr"
 }
 ' "${input_tsv}" >"${summary_tsv}" 2>"${meta_file}"
 
 fail_count="$(awk -F '=' '/^fail_count=/ { print $2 }' "${meta_file}")"
 target_seen="$(awk -F '=' '/^target_seen=/ { print $2 }' "${meta_file}")"
+missing_endpoints="$(awk -F '=' '/^missing_endpoints=/ { print $2 }' "${meta_file}")"
 gate_status="pass"
 if [[ "${fail_count}" != "0" || "${target_seen}" != "1" ]]; then
   gate_status="fail"
@@ -155,11 +180,11 @@ fi
 
 fairness_table="$(awk -F '\t' '
   BEGIN {
-    print "| Rate | Status | Fairness 429 | Edge 429 | Backend 429 | Unknown 429 | 5xx | Cold p95 ms | Accepted p95 ms |"
-    print "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    print "| Endpoint | Rate | Status | Fairness 429 | Edge 429 | Backend 429 | Unknown 429 | 5xx | Cold p95 ms | Accepted p95 ms | Rejection reason |"
+    print "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
   }
   NR > 1 {
-    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
   }
 ' "${summary_tsv}")"
 
@@ -169,10 +194,13 @@ cat >"${report_md}" <<REPORT
 ## Summary
 
 - gate_status=${gate_status}
+- required endpoints: ${required_endpoints}
+- missing endpoints: ${missing_endpoints}
 - arrival16 backend fairness budget: < ${max_fairness_rate}
 - edge 429 budget: <= ${max_edge_rate}
 - cold account latency budget: <= ${cold_p95_budget_ms}ms
 - accepted p95 budget: <= ${accepted_p95_budget_ms}ms
+- rejection reason must include endpoint
 - hard-zero: unknown 429, 5xx
 
 ## Fairness Table

--- a/tools/test/run-transaction-read-runtime-policy-budget.sh
+++ b/tools/test/run-transaction-read-runtime-policy-budget.sh
@@ -9,11 +9,13 @@ Environment:
   RUNTIME_POLICY_NAME                 default transaction-read-runtime-policy-<timestamp>
   RUNTIME_POLICY_INPUT_TSV            required burst/VU runtime evidence TSV
   RUNTIME_POLICY_OUTPUT_DIR           default build/reports/k6/<name>
-  RUNTIME_POLICY_REQUIRED_PROFILES    default burst48,burst64,burst96,vu16
+  RUNTIME_POLICY_REQUIRED_PROFILES    default burst48,burst64,burst96,vu16,paced-weighted-vu16
   RUNTIME_POLICY_BURST64_429_RATE     default 0.10
+  RUNTIME_POLICY_PACED_VU16_429_RATE  default 0.005
   RUNTIME_POLICY_REJECT_STREAK_MAX    default 3
   RUNTIME_POLICY_ACCEPTED_P95_MS      default 350
   RUNTIME_POLICY_DELAYED_RATE         default 0.25
+  RUNTIME_POLICY_MIN_PACED_DELAYED_RATE default 0.50
   RUNTIME_POLICY_RETRY_AFTER_P95_MS   default 300
 USAGE
 }
@@ -39,11 +41,13 @@ done
 name="${RUNTIME_POLICY_NAME:-transaction-read-runtime-policy-$(date +%Y-%m-%d-%H%M%S)}"
 input_tsv="${RUNTIME_POLICY_INPUT_TSV:-}"
 output_dir="${RUNTIME_POLICY_OUTPUT_DIR:-build/reports/k6/${name}}"
-required_profiles="${RUNTIME_POLICY_REQUIRED_PROFILES:-burst48,burst64,burst96,vu16}"
+required_profiles="${RUNTIME_POLICY_REQUIRED_PROFILES:-burst48,burst64,burst96,vu16,paced-weighted-vu16}"
 burst64_429_rate="${RUNTIME_POLICY_BURST64_429_RATE:-0.10}"
+paced_vu16_429_rate="${RUNTIME_POLICY_PACED_VU16_429_RATE:-0.005}"
 reject_streak_max="${RUNTIME_POLICY_REJECT_STREAK_MAX:-3}"
 accepted_p95_ms="${RUNTIME_POLICY_ACCEPTED_P95_MS:-350}"
 delayed_rate="${RUNTIME_POLICY_DELAYED_RATE:-0.25}"
+min_paced_delayed_rate="${RUNTIME_POLICY_MIN_PACED_DELAYED_RATE:-0.50}"
 retry_after_p95_ms="${RUNTIME_POLICY_RETRY_AFTER_P95_MS:-300}"
 summary_tsv="${output_dir}/${name}-runtime-policy.tsv"
 report_md="${output_dir}/${name}-runtime-policy.md"
@@ -77,18 +81,22 @@ print_plan() {
   echo "[transaction-read-runtime-policy] output_dir=${output_dir}"
   echo "[transaction-read-runtime-policy] required_profiles=${required_profiles}"
   echo "[transaction-read-runtime-policy] burst64_429_rate=${burst64_429_rate}"
+  echo "[transaction-read-runtime-policy] paced_vu16_429_rate=${paced_vu16_429_rate}"
   echo "[transaction-read-runtime-policy] reject_streak_max=${reject_streak_max}"
   echo "[transaction-read-runtime-policy] accepted_p95_ms=${accepted_p95_ms}"
   echo "[transaction-read-runtime-policy] delayed_rate=${delayed_rate}"
+  echo "[transaction-read-runtime-policy] min_paced_delayed_rate=${min_paced_delayed_rate}"
   echo "[transaction-read-runtime-policy] retry_after_p95_ms=${retry_after_p95_ms}"
   echo "[transaction-read-runtime-policy] summary_tsv=${summary_tsv}"
   echo "[transaction-read-runtime-policy] report_md=${report_md}"
 }
 
 require_rate "RUNTIME_POLICY_BURST64_429_RATE" "${burst64_429_rate}"
+require_rate "RUNTIME_POLICY_PACED_VU16_429_RATE" "${paced_vu16_429_rate}"
 require_non_negative_number "RUNTIME_POLICY_REJECT_STREAK_MAX" "${reject_streak_max}"
 require_non_negative_number "RUNTIME_POLICY_ACCEPTED_P95_MS" "${accepted_p95_ms}"
 require_rate "RUNTIME_POLICY_DELAYED_RATE" "${delayed_rate}"
+require_rate "RUNTIME_POLICY_MIN_PACED_DELAYED_RATE" "${min_paced_delayed_rate}"
 require_non_negative_number "RUNTIME_POLICY_RETRY_AFTER_P95_MS" "${retry_after_p95_ms}"
 
 print_plan
@@ -105,9 +113,11 @@ mkdir -p "${output_dir}"
 
 awk -F '\t' \
   -v burst64_budget="${burst64_429_rate}" \
+  -v paced_vu16_budget="${paced_vu16_429_rate}" \
   -v max_streak="${reject_streak_max}" \
   -v p95_budget="${accepted_p95_ms}" \
   -v delayed_budget="${delayed_rate}" \
+  -v min_paced_delayed="${min_paced_delayed_rate}" \
   -v retry_budget="${retry_after_p95_ms}" \
   -v required_profiles="${required_profiles}" '
 function value(name, fallback) {
@@ -117,7 +127,7 @@ function value(name, fallback) {
 BEGIN {
   split(required_profiles, required, ",")
   for (i in required) required_seen[required[i]] = 0
-  print "profile\tstatus\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tunknown_429_count\tfive_xx_count\taccepted_p95_ms\tdelayed_rate\tretry_after_p95_ms\treject_streak_max\tpolicy_candidate"
+  print "profile\tstatus\tdecision\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tunknown_429_count\tfive_xx_count\taccepted_p95_ms\tdelayed_rate\tretry_after_p95_ms\treject_streak_max\tpolicy_candidate"
 }
 NR == 1 {
   for (i = 1; i <= NF; i++) col[$i] = i
@@ -135,13 +145,20 @@ NR == 1 {
   retry_p95 = value("retry_after_p95_ms", "999999") + 0
   streak = value("reject_streak_max", "999999") + 0
   candidate = value("policy_candidate", "n/a")
+  decision = candidate
   required_seen[profile] = 1
   status = "pass"
+  if (profile == "burst64") decision = "burst64-smoothing"
+  if (profile == "vu16") decision = "client-pacing-required"
+  if (profile == "paced-weighted-vu16") decision = "client-pacing-default"
   if (profile == "burst64" && total_429 > burst64_budget) status = "fail"
-  if (unknown_count > 0 || five_xx_count > 0 || p95 > p95_budget || delayed > delayed_budget || retry_p95 > retry_budget || streak > max_streak) status = "fail"
+  if (profile == "paced-weighted-vu16" && total_429 > paced_vu16_budget) status = "fail"
+  if (profile == "paced-weighted-vu16" && delayed < min_paced_delayed) status = "fail"
+  if (profile != "paced-weighted-vu16" && delayed > delayed_budget) status = "fail"
+  if (unknown_count > 0 || five_xx_count > 0 || p95 > p95_budget || retry_p95 > retry_budget || streak > max_streak) status = "fail"
   if (status == "fail") fail_count++
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-    profile, status, value("total_429_rate", "0"), value("edge_429_rate", "0"), value("backend_429_rate", "0"),
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    profile, status, decision, value("total_429_rate", "0"), value("edge_429_rate", "0"), value("backend_429_rate", "0"),
     unknown_count, five_xx_count, p95, value("delayed_rate", "0"), retry_p95, streak, candidate
 }
 END {
@@ -168,11 +185,11 @@ fi
 
 runtime_table="$(awk -F '\t' '
   BEGIN {
-    print "| Profile | Status | Total 429 | Edge 429 | Backend 429 | Unknown 429 | 5xx | Accepted p95 ms | Delayed | Retry-After p95 ms | Reject streak | Candidate |"
-    print "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
+    print "| Profile | Status | Decision | Total 429 | Edge 429 | Backend 429 | Unknown 429 | 5xx | Accepted p95 ms | Delayed | Retry-After p95 ms | Reject streak | Candidate |"
+    print "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
   }
   NR > 1 {
-    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
   }
 ' "${summary_tsv}")"
 
@@ -185,9 +202,12 @@ cat >"${report_md}" <<REPORT
 - required profiles: ${required_profiles}
 - missing profiles: ${missing_profiles}
 - burst64 <= 10% 429: ${burst64_429_rate}
+- paced weighted VU16 <= 0.005 429: ${paced_vu16_429_rate}
+- unpaced VU16 operating decision: client-pacing-required
 - Retry-After reject streak <= 3: ${reject_streak_max}
 - accepted p95 budget: <= ${accepted_p95_ms}ms
 - delayed ratio budget: <= ${delayed_rate}
+- paced client delayed ratio floor: >= ${min_paced_delayed_rate}
 - Retry-After p95 budget: <= ${retry_after_p95_ms}ms
 - hard-zero: unknown 429, 5xx
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #652

## 🌿 Base Branch
- `main`

## 📝 Summary
- burst64 smoothing gate를 실제 목표인 total 429 <= 10%, backend 429 <= 0.5%, accepted p95 <= 120ms 기준으로 재보정했습니다.
- unpaced VU16은 `client-pacing-required`, paced weighted VU16은 `client-pacing-default`로 분리해 운영 정책을 report에 남기도록 했습니다.
- fairness limiter budget을 active/archive endpoint별로 분리하고 rejection reason이 endpoint를 포함하도록 gate를 보강했습니다.

## 🛠 Changes
- burst64 residual smoothing runner/check에 backend 429 rate budget과 p95 120ms budget을 추가했습니다.
- runtime policy runner/check에 paced weighted VU16 profile, pacing delayed floor, policy decision column을 추가했습니다.
- fairness budget runner/check에 active/archive endpoint 필수성과 reason 분리 검증을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-burst64-residual-smoothing.sh`
- `bash tools/test/check-transaction-read-runtime-policy-budget.sh`
- `bash tools/test/check-transaction-read-fairness-budget.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` => `3`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 evidence TSV가 새 컬럼(`backend_429_rate`, `paced-weighted-vu16`, `endpoint`, `rejection_reason`)을 채우지 않으면 gate가 실패합니다. 의도된 운영 계약 강화입니다.
- 롤백 방법: 이 PR revert 후 기존 gate 계약으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?