### PR TITLE
[Test] OCI k6 auth preflight and evidence manifest hardening

### DIFF
--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -5,6 +5,9 @@ echo "[k6-transaction-100m] shell syntax"
 bash -n tools/test/run-k6-transaction-100m-loadtest.sh
 bash -n tools/test/archive-k6-transaction-100m-result.sh
 
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
 echo "[k6-transaction-100m] compose config"
 docker compose -f compose.yml -f compose.t3micro.yml -f compose.loadtest.yml config >/dev/null
 
@@ -44,6 +47,8 @@ grep -F "archive output dir=docs/performance-results/k6-smoke" <<<"${plan}" >/de
 grep -F "summary gate=true" <<<"${plan}" >/dev/null
 grep -F "archive failed summary=true" <<<"${plan}" >/dev/null
 grep -F "backend readiness gate=true base=http://localhost:18080 path=/actuator/health/readiness timeout=120" <<<"${plan}" >/dev/null
+grep -F "auth token required=false token=missing source=missing" <<<"${plan}" >/dev/null
+grep -F "auth preflight=false url=not-configured expected_status=200 timeout=5" <<<"${plan}" >/dev/null
 grep -F "postgres health gate=true required_status=healthy" <<<"${plan}" >/dev/null
 grep -F "postgres recovery gate=true stable_seconds=10" <<<"${plan}" >/dev/null
 grep -F "postgres recovery noise window seconds=30" <<<"${plan}" >/dev/null
@@ -122,6 +127,56 @@ capacity_archive_plan="$(
 )"
 grep -F "run purpose=capacity" <<<"${capacity_archive_plan}" >/dev/null
 grep -F "archive output dir=docs/performance-results/k6-capacity" <<<"${capacity_archive_plan}" >/dev/null
+grep -F "auth token required=true token=missing source=missing" <<<"${capacity_archive_plan}" >/dev/null
+
+echo "[k6-transaction-100m] auth preflight"
+auth_token_file="${temp_dir}/k6-token.secret"
+printf "secret-token-value\n" >"${auth_token_file}"
+auth_file_plan="$(
+  K6_REPORT_NAME=transaction-100m-auth-file-check \
+  K6_RUN_PURPOSE=capacity \
+  K6_OBSERVABILITY_MODE=summary-only \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=transaction-k6-remote \
+  K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+  K6_AUTH_TOKEN_FILE="${auth_token_file}" \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "auth token required=true token=present source=file" <<<"${auth_file_plan}" >/dev/null
+if grep -F "secret-token-value" <<<"${auth_file_plan}" >/dev/null; then
+  echo "auth token leaked into k6 plan output" >&2
+  exit 1
+fi
+if K6_RUN_PURPOSE=capacity \
+  K6_OBSERVABILITY_MODE=summary-only \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=transaction-k6-remote \
+  K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+    tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >/dev/null 2>&1; then
+  echo "missing K6_AUTH_TOKEN unexpectedly passed auth preflight" >&2
+  exit 1
+fi
+K6_RUN_PURPOSE=capacity \
+K6_OBSERVABILITY_MODE=summary-only \
+K6_GENERATOR_MODE=docker-context \
+K6_DOCKER_CONTEXT=transaction-k6-remote \
+K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+K6_AUTH_TOKEN_FILE="${auth_token_file}" \
+K6_AUTH_PREFLIGHT=false \
+  tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >/dev/null
+if K6_RUN_PURPOSE=capacity \
+  K6_OBSERVABILITY_MODE=summary-only \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=transaction-k6-remote \
+  K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+  K6_AUTH_TOKEN_FILE="${auth_token_file}" \
+  K6_AUTH_PREFLIGHT=true \
+  K6_AUTH_PREFLIGHT_URL=http://127.0.0.1:1/api/v1/transactions \
+  K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS=1 \
+    tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >/dev/null 2>&1; then
+  echo "unreachable auth status preflight unexpectedly passed" >&2
+  exit 1
+fi
 
 overload_plan="$(
   K6_REPORT_NAME=transaction-100m-overload-check \
@@ -401,8 +456,6 @@ grep -F "hot deep cursor p95 ms" ops/k6/transaction-read-100m.js >/dev/null
 grep -F "cold deep cursor p95 ms" ops/k6/transaction-read-100m.js >/dev/null
 
 echo "[k6-transaction-100m] summary hard gate"
-temp_dir="$(mktemp -d)"
-trap 'rm -rf "${temp_dir}"' EXIT
 summary_ok="${temp_dir}/summary-ok.json"
 summary_zero="${temp_dir}/summary-zero.json"
 summary_interrupted="${temp_dir}/summary-interrupted.json"

--- a/tools/test/check-transaction-read-production-evidence-pack.sh
+++ b/tools/test/check-transaction-read-production-evidence-pack.sh
@@ -13,13 +13,13 @@ input_tsv="${temp_dir}/production-evidence.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${input_tsv}" <<'TSV'
-scenario	run_id	duration_min	source_ips	k6_summary_ref	nginx_aggregate_ref	nginx_499_aggregate_ref	spring_429_ref	hikari_log_ref	hikari_closure_ref	postgres_explain_ref	postgres_activity_ref	postgres_wait_ref	prometheus_timeline_ref	source_fairness_ref	cache_state_ref	deploy_event_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max
-hikari-soak	oci-001	30	1	oci/k6/hikari.json	oci/nginx/hikari.tsv	oci/nginx/hikari-499.tsv	oci/spring/hikari-429.tsv	oci/hikari/hikari.log	oci/hikari/hikari-closure.md	oci/pg/hikari-explain.txt	oci/pg/hikari-activity.tsv	oci/pg/hikari-wait.tsv	oci/prom/hikari.json	n/a	n/a	n/a	0.01	0	0	0	0	0	0
-cold-warm	oci-002	10	1	oci/k6/cold-warm.json	oci/nginx/cold-warm.tsv	oci/nginx/cold-warm-499.tsv	oci/spring/cold-warm-429.tsv	oci/hikari/cold-warm.log	n/a	oci/pg/cold-warm-explain.txt	oci/pg/cold-warm-activity.tsv	oci/pg/cold-warm-wait.tsv	oci/prom/cold-warm.json	n/a	oci/cache/cold-warm.tsv	n/a	0.02	0	0	0	0	0	0
-mixed-workload	oci-003	30	1	oci/k6/mixed.json	oci/nginx/mixed.tsv	oci/nginx/mixed-499.tsv	oci/spring/mixed-429.tsv	oci/hikari/mixed.log	n/a	oci/pg/mixed-explain.txt	oci/pg/mixed-activity.tsv	oci/pg/mixed-wait.tsv	oci/prom/mixed.json	n/a	n/a	n/a	0.08	0	0	0	0	0	0
-real-ip-multisource	oci-004	10	2	oci/k6/real-ip.json	oci/nginx/real-ip.tsv	oci/nginx/real-ip-499.tsv	oci/spring/real-ip-429.tsv	oci/hikari/real-ip.log	n/a	oci/pg/real-ip-explain.txt	oci/pg/real-ip-activity.tsv	oci/pg/real-ip-wait.tsv	oci/prom/real-ip.json	oci/source/real-ip-fairness.tsv	n/a	n/a	0.07	0	0	0	0	0	0
-deploy-drain	oci-005	5	1	oci/k6/deploy-drain.json	oci/nginx/deploy-drain.tsv	oci/nginx/deploy-drain-499.tsv	oci/spring/deploy-drain-429.tsv	oci/hikari/deploy-drain.log	n/a	oci/pg/deploy-drain-explain.txt	oci/pg/deploy-drain-activity.tsv	oci/pg/deploy-drain-wait.tsv	oci/prom/deploy-drain.json	n/a	n/a	oci/deploy/drain-events.tsv	0.04	0	0	0	0	0	0
-p999-long	oci-006	30	1	oci/k6/p999.json	oci/nginx/p999.tsv	oci/nginx/p999-499.tsv	oci/spring/p999-429.tsv	oci/hikari/p999.log	n/a	oci/pg/p999-explain.txt	oci/pg/p999-activity.tsv	oci/pg/p999-wait.tsv	oci/prom/p999.json	n/a	n/a	n/a	0.06	0	0	0	0	0	0
+scenario	run_id	duration_min	source_ips	k6_summary_ref	nginx_aggregate_ref	nginx_499_aggregate_ref	spring_429_ref	hikari_log_ref	hikari_closure_ref	postgres_explain_ref	postgres_activity_ref	postgres_wait_ref	prometheus_timeline_ref	artifact_manifest_ref	mixed_workload_ref	p999_latency_ref	source_fairness_ref	cache_state_ref	deploy_event_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max
+hikari-soak	oci-001	30	1	oci/k6/hikari.json	oci/nginx/hikari.tsv	oci/nginx/hikari-499.tsv	oci/spring/hikari-429.tsv	oci/hikari/hikari.log	oci/hikari/hikari-closure.md	oci/pg/hikari-explain.txt	oci/pg/hikari-activity.tsv	oci/pg/hikari-wait.tsv	oci/prom/hikari.json	oci/manifests/hikari.env	n/a	n/a	n/a	n/a	n/a	0.01	0	0	0	0	0	0
+cold-warm	oci-002	10	1	oci/k6/cold-warm.json	oci/nginx/cold-warm.tsv	oci/nginx/cold-warm-499.tsv	oci/spring/cold-warm-429.tsv	oci/hikari/cold-warm.log	n/a	oci/pg/cold-warm-explain.txt	oci/pg/cold-warm-activity.tsv	oci/pg/cold-warm-wait.tsv	oci/prom/cold-warm.json	oci/manifests/cold-warm.env	n/a	n/a	n/a	oci/cache/cold-warm.tsv	n/a	0.02	0	0	0	0	0	0
+mixed-workload	oci-003	30	1	oci/k6/mixed.json	oci/nginx/mixed.tsv	oci/nginx/mixed-499.tsv	oci/spring/mixed-429.tsv	oci/hikari/mixed.log	n/a	oci/pg/mixed-explain.txt	oci/pg/mixed-activity.tsv	oci/pg/mixed-wait.tsv	oci/prom/mixed.json	oci/manifests/mixed.env	oci/mixed/outbox-lag.tsv	n/a	n/a	n/a	n/a	0.08	0	0	0	0	0	0
+real-ip-multisource	oci-004	10	2	oci/k6/real-ip.json	oci/nginx/real-ip.tsv	oci/nginx/real-ip-499.tsv	oci/spring/real-ip-429.tsv	oci/hikari/real-ip.log	n/a	oci/pg/real-ip-explain.txt	oci/pg/real-ip-activity.tsv	oci/pg/real-ip-wait.tsv	oci/prom/real-ip.json	oci/manifests/real-ip.env	n/a	n/a	oci/source/real-ip-fairness.tsv	n/a	n/a	0.07	0	0	0	0	0	0
+deploy-drain	oci-005	5	1	oci/k6/deploy-drain.json	oci/nginx/deploy-drain.tsv	oci/nginx/deploy-drain-499.tsv	oci/spring/deploy-drain-429.tsv	oci/hikari/deploy-drain.log	n/a	oci/pg/deploy-drain-explain.txt	oci/pg/deploy-drain-activity.tsv	oci/pg/deploy-drain-wait.tsv	oci/prom/deploy-drain.json	oci/manifests/deploy-drain.env	n/a	n/a	n/a	n/a	oci/deploy/drain-events.tsv	0.04	0	0	0	0	0	0
+p999-long	oci-006	30	1	oci/k6/p999.json	oci/nginx/p999.tsv	oci/nginx/p999-499.tsv	oci/spring/p999-429.tsv	oci/hikari/p999.log	n/a	oci/pg/p999-explain.txt	oci/pg/p999-activity.tsv	oci/pg/p999-wait.tsv	oci/prom/p999.json	oci/manifests/p999.env	n/a	oci/latency/p999.tsv	n/a	n/a	n/a	0.06	0	0	0	0	0	0
 TSV
 
 echo "[transaction-read-production-evidence-pack] print plan"
@@ -32,7 +32,7 @@ plan="$(
 grep -F "name=production-check" <<<"${plan}" >/dev/null
 grep -F "required_scenarios=hikari-soak,cold-warm,mixed-workload,real-ip-multisource,deploy-drain,p999-long" <<<"${plan}" >/dev/null
 grep -F "min_real_source_ips=2" <<<"${plan}" >/dev/null
-grep -F "required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref,hikari_closure_ref(hikari-soak)" <<<"${plan}" >/dev/null
+grep -F "required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref,artifact_manifest_ref,hikari_closure_ref(hikari-soak)" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] pass report"
 output="$(
@@ -54,12 +54,15 @@ grep -F $'real-ip-multisource\tpass\tok\toci-004\t10\t2' "${summary_tsv}" >/dev/
 grep -F "oci/pg/real-ip-activity.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/pg/real-ip-wait.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/hikari/hikari-closure.md" "${summary_tsv}" >/dev/null
+grep -F "oci/manifests/real-ip.env" "${summary_tsv}" >/dev/null
+grep -F "oci/mixed/outbox-lag.tsv" "${summary_tsv}" >/dev/null
+grep -F "oci/latency/p999.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/source/real-ip-fairness.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/deploy/drain-events.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/cache/cold-warm.tsv" "${summary_tsv}" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] hard-zero fail"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload" { $20 = 1; $21 = 1; $22 = 1; $23 = 1; $24 = 1 } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload" { $22 = 1; $23 = 1; $24 = 1; $25 = 1; $26 = 1; $27 = 1 } { print }' \
   "${input_tsv}" >"${input_tsv}.hard-zero-fail"
 if PROD_EVIDENCE_PACK_NAME=production-hard-zero-fail \
   PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.hard-zero-fail" \
@@ -80,7 +83,7 @@ grep -F "hikari-warning>0" "${output_dir}/production-hard-zero-fail-production-e
 grep -F "pool-pending>0" "${output_dir}/production-hard-zero-fail-production-evidence-pack.tsv" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] missing ref fail"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long" { $12 = "n/a"; $13 = "n/a"; $14 = "n/a" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long" { $12 = "n/a"; $13 = "n/a"; $14 = "n/a"; $15 = "n/a"; $17 = "n/a" } { print }' \
   "${input_tsv}" >"${input_tsv}.missing-ref"
 if PROD_EVIDENCE_PACK_NAME=production-missing-ref \
   PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.missing-ref" \
@@ -96,6 +99,8 @@ PROD_EVIDENCE_PACK_OUTPUT_DIR="${output_dir}" \
 grep -F "postgres_activity_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
 grep -F "postgres_wait_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
 grep -F "prometheus_timeline_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
+grep -F "artifact_manifest_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
+grep -F "p999_latency_ref-missing" "${output_dir}/production-missing-ref-production-evidence-pack.tsv" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] missing Hikari closure ref fail"
 awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "hikari-soak" { $10 = "n/a" } { print }' \
@@ -114,7 +119,7 @@ PROD_EVIDENCE_PACK_OUTPUT_DIR="${output_dir}" \
 grep -F "hikari_closure_ref-missing" "${output_dir}/production-missing-hikari-closure-production-evidence-pack.tsv" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] source fail"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "real-ip-multisource" { $4 = 1; $15 = "n/a" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "real-ip-multisource" { $4 = 1; $18 = "n/a" } { print }' \
   "${input_tsv}" >"${input_tsv}.source-fail"
 if PROD_EVIDENCE_PACK_NAME=production-source-fail \
   PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.source-fail" \

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE' >&2
-usage: tools/test/run-k6-transaction-100m-loadtest.sh [--print-plan|--no-up] [--no-deps]
+usage: tools/test/run-k6-transaction-100m-loadtest.sh [--print-plan|--auth-preflight-only|--no-up] [--no-deps]
 
 Required environment:
   K6_HOT_ACCOUNT_ID
@@ -51,6 +51,14 @@ Optional environment:
   K6_HOT_DEEP_P99_THRESHOLD_MS default K6_HOT_P99_THRESHOLD_MS
   K6_COLD_DEEP_P99_THRESHOLD_MS default K6_COLD_P99_THRESHOLD_MS
   K6_AUTH_TOKEN        bearer token, optional when bootstrap header auth is enabled
+  K6_AUTH_TOKEN_FILE   optional bearer token file; content is never printed
+  K6_AUTH_TOKEN_REQUIRED true|false|auto, default auto; auto requires token for docker-context non-smoke
+  K6_AUTH_PREFLIGHT    true|false|auto, default auto; auto runs when a preflight URL/path is configured
+  K6_AUTH_PREFLIGHT_URL full URL for token status smoke, optional
+  K6_AUTH_PREFLIGHT_PATH path appended to K6_AUTH_PREFLIGHT_BASE_URL, optional
+  K6_AUTH_PREFLIGHT_BASE_URL default remote base URL or backend readiness base URL
+  K6_AUTH_PREFLIGHT_EXPECTED_STATUS default 200
+  K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS default 5
   K6_BASE_URL          optional backend base URL for local generator; default k6 script value
   K6_ARCHIVE_RESULTS   copy markdown summary to docs/performance-results, default true
   K6_ARCHIVE_FAILED_SUMMARY archive summary even when hard gate fails, default true
@@ -228,6 +236,90 @@ require_run_purpose() {
   esac
 }
 
+auth_token_source="missing"
+
+resolve_auth_token() {
+  # secret-safe: token 값은 env/file에서만 읽고 plan/report에는 존재 여부만 남긴다.
+  if [[ -n "${K6_AUTH_TOKEN}" ]]; then
+    auth_token_source="env"
+    return 0
+  fi
+  if [[ -z "${K6_AUTH_TOKEN_FILE}" ]]; then
+    auth_token_source="missing"
+    return 0
+  fi
+  if [[ ! -s "${K6_AUTH_TOKEN_FILE}" ]]; then
+    echo "K6_AUTH_TOKEN_FILE must be a non-empty file" >&2
+    exit 1
+  fi
+
+  K6_AUTH_TOKEN="$(LC_ALL=C tr -d '\r\n' <"${K6_AUTH_TOKEN_FILE}")"
+  if [[ -z "${K6_AUTH_TOKEN}" ]]; then
+    echo "K6_AUTH_TOKEN_FILE did not contain a token" >&2
+    exit 1
+  fi
+  auth_token_source="file"
+  export K6_AUTH_TOKEN
+}
+
+effective_auth_token_required() {
+  case "${K6_AUTH_TOKEN_REQUIRED}" in
+    true|false)
+      echo "${K6_AUTH_TOKEN_REQUIRED}"
+      ;;
+    auto)
+      if [[ "${K6_GENERATOR_MODE}" == "docker-context" && "${K6_RUN_PURPOSE}" != "smoke" ]]; then
+        echo "true"
+      else
+        echo "false"
+      fi
+      ;;
+  esac
+}
+
+auth_preflight_url() {
+  if [[ -n "${K6_AUTH_PREFLIGHT_URL}" ]]; then
+    echo "${K6_AUTH_PREFLIGHT_URL}"
+    return 0
+  fi
+  if [[ -n "${K6_AUTH_PREFLIGHT_PATH}" ]]; then
+    local base_url="${K6_AUTH_PREFLIGHT_BASE_URL:-}"
+    if [[ -z "${base_url}" ]]; then
+      if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
+        base_url="${K6_REMOTE_BASE_URL}"
+      else
+        base_url="${K6_BACKEND_READINESS_BASE_URL}"
+      fi
+    fi
+    echo "${base_url%/}/${K6_AUTH_PREFLIGHT_PATH#/}"
+    return 0
+  fi
+  echo ""
+}
+
+effective_auth_preflight_enabled() {
+  case "${K6_AUTH_PREFLIGHT}" in
+    true|false)
+      echo "${K6_AUTH_PREFLIGHT}"
+      ;;
+    auto)
+      if [[ -n "$(auth_preflight_url)" ]]; then
+        echo "true"
+      else
+        echo "false"
+      fi
+      ;;
+  esac
+}
+
+auth_token_presence() {
+  if [[ -n "${K6_AUTH_TOKEN}" ]]; then
+    echo "present"
+  else
+    echo "missing"
+  fi
+}
+
 mode="run"
 run_dependencies="true"
 summary_gate_json=""
@@ -236,6 +328,9 @@ while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --print-plan)
       mode="print-plan"
+      ;;
+    --auth-preflight-only)
+      mode="auth-preflight-only"
       ;;
     --assert-summary)
       if [[ "$#" -lt 3 ]]; then
@@ -371,6 +466,15 @@ K6_BACKEND_READINESS_GATE="${K6_BACKEND_READINESS_GATE:-true}"
 K6_BACKEND_READINESS_BASE_URL="${K6_BACKEND_READINESS_BASE_URL:-http://localhost:${LOADTEST_BACKEND_PORT:-18080}}"
 K6_BACKEND_READINESS_PATH="${K6_BACKEND_READINESS_PATH:-/actuator/health/readiness}"
 K6_BACKEND_READINESS_TIMEOUT_SECONDS="${K6_BACKEND_READINESS_TIMEOUT_SECONDS:-120}"
+K6_AUTH_TOKEN="${K6_AUTH_TOKEN:-}"
+K6_AUTH_TOKEN_FILE="${K6_AUTH_TOKEN_FILE:-}"
+K6_AUTH_TOKEN_REQUIRED="${K6_AUTH_TOKEN_REQUIRED:-auto}"
+K6_AUTH_PREFLIGHT="${K6_AUTH_PREFLIGHT:-auto}"
+K6_AUTH_PREFLIGHT_URL="${K6_AUTH_PREFLIGHT_URL:-}"
+K6_AUTH_PREFLIGHT_PATH="${K6_AUTH_PREFLIGHT_PATH:-}"
+K6_AUTH_PREFLIGHT_BASE_URL="${K6_AUTH_PREFLIGHT_BASE_URL:-}"
+K6_AUTH_PREFLIGHT_EXPECTED_STATUS="${K6_AUTH_PREFLIGHT_EXPECTED_STATUS:-200}"
+K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS="${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS:-5}"
 K6_DOCKER_CONTEXT="${K6_DOCKER_CONTEXT:-}"
 K6_REMOTE_BASE_URL="${K6_REMOTE_BASE_URL:-}"
 K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-}"
@@ -399,7 +503,8 @@ loadtest_postgres_exporter_cpus="${LOADTEST_POSTGRES_EXPORTER_CPUS:-0.10}"
 loadtest_postgres_exporter_memory="${LOADTEST_POSTGRES_EXPORTER_MEMORY:-128m}"
 loadtest_postgres_container="${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}"
 loadtest_backend_container="${LOADTEST_BACKEND_CONTAINER_NAME:-aquila-bank-backend-loadtest}"
-export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_BURST_HEADROOM_PREFLIGHT K6_BURST_MIN_HEADROOM_VUS K6_WARMUP_DURATION K6_WARMUP_MODE K6_WARMUP_RATE K6_WARMUP_TIME_UNIT K6_WARMUP_PRE_ALLOCATED_VUS K6_WARMUP_MAX_VUS K6_LIMIT K6_HOT_ACCOUNT_IDS K6_COLD_ACCOUNT_IDS K6_HOT_DEEP_CURSOR_BOOKED_AT K6_HOT_DEEP_CURSOR_ID K6_COLD_DEEP_CURSOR_BOOKED_AT K6_COLD_DEEP_CURSOR_ID K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HOT_DEEP_P95_THRESHOLD_MS K6_COLD_DEEP_P95_THRESHOLD_MS K6_HOT_DEEP_P99_THRESHOLD_MS K6_COLD_DEEP_P99_THRESHOLD_MS K6_HOT_DEEP_P999_THRESHOLD_MS K6_COLD_DEEP_P999_THRESHOLD_MS K6_HOT_DEEP_MAX_THRESHOLD_MS K6_COLD_DEEP_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_ARCHIVE_FAILED_SUMMARY K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_BURST_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_MAX_RETRY_AFTER_SLEEP_MS K6_RETRY_AFTER_ADAPTIVE_PACING K6_RETRY_AFTER_ADAPTIVE_MAX_MULTIPLIER K6_PREEMPTIVE_PACING K6_PREEMPTIVE_PACING_RPS K6_PREEMPTIVE_PACING_MAX_SLEEP_MS K6_PREEMPTIVE_PACING_JITTER_MS K6_WORKLOAD_SHAPE K6_WORKLOAD_SEED K6_WORKLOAD_WEIGHTS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_BASE_URL K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REMOTE_PREFLIGHT K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS K6_REMOTE_PREFLIGHT_IMAGE K6_REMOTE_READINESS_PATH K6_REMOTE_ARTIFACT_IMAGE K6_REMOTE_COLLECT_ARTIFACTS K6_REPORT_NAME K6_RUN_ID
+resolve_auth_token
+export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_BURST_HEADROOM_PREFLIGHT K6_BURST_MIN_HEADROOM_VUS K6_WARMUP_DURATION K6_WARMUP_MODE K6_WARMUP_RATE K6_WARMUP_TIME_UNIT K6_WARMUP_PRE_ALLOCATED_VUS K6_WARMUP_MAX_VUS K6_LIMIT K6_HOT_ACCOUNT_IDS K6_COLD_ACCOUNT_IDS K6_HOT_DEEP_CURSOR_BOOKED_AT K6_HOT_DEEP_CURSOR_ID K6_COLD_DEEP_CURSOR_BOOKED_AT K6_COLD_DEEP_CURSOR_ID K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HOT_DEEP_P95_THRESHOLD_MS K6_COLD_DEEP_P95_THRESHOLD_MS K6_HOT_DEEP_P99_THRESHOLD_MS K6_COLD_DEEP_P99_THRESHOLD_MS K6_HOT_DEEP_P999_THRESHOLD_MS K6_COLD_DEEP_P999_THRESHOLD_MS K6_HOT_DEEP_MAX_THRESHOLD_MS K6_COLD_DEEP_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_ARCHIVE_FAILED_SUMMARY K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_BURST_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_MAX_RETRY_AFTER_SLEEP_MS K6_RETRY_AFTER_ADAPTIVE_PACING K6_RETRY_AFTER_ADAPTIVE_MAX_MULTIPLIER K6_PREEMPTIVE_PACING K6_PREEMPTIVE_PACING_RPS K6_PREEMPTIVE_PACING_MAX_SLEEP_MS K6_PREEMPTIVE_PACING_JITTER_MS K6_WORKLOAD_SHAPE K6_WORKLOAD_SEED K6_WORKLOAD_WEIGHTS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_BASE_URL K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_AUTH_TOKEN K6_AUTH_TOKEN_REQUIRED K6_AUTH_PREFLIGHT K6_AUTH_PREFLIGHT_URL K6_AUTH_PREFLIGHT_PATH K6_AUTH_PREFLIGHT_BASE_URL K6_AUTH_PREFLIGHT_EXPECTED_STATUS K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_WORKDIR K6_REMOTE_PREFLIGHT K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS K6_REMOTE_PREFLIGHT_IMAGE K6_REMOTE_READINESS_PATH K6_REMOTE_ARTIFACT_IMAGE K6_REMOTE_COLLECT_ARTIFACTS K6_REPORT_NAME K6_RUN_ID
 
 require_positive_integer K6_VUS
 require_positive_integer K6_RATE
@@ -450,6 +555,14 @@ require_bool_value() {
     exit 1
   fi
 }
+require_auto_bool_value() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ "${value}" != "true" && "${value}" != "false" && "${value}" != "auto" ]]; then
+    echo "${name} must be true, false, or auto" >&2
+    exit 1
+  fi
+}
 require_bool_value K6_OUTBOX_PREFLIGHT
 require_bool_value K6_EXPLAIN_SNAPSHOT
 require_bool_value K6_ARCHIVE_RESULTS
@@ -457,10 +570,18 @@ require_bool_value K6_ARCHIVE_FAILED_SUMMARY
 require_bool_value K6_SUMMARY_GATE
 require_bool_value K6_BURST_HEADROOM_PREFLIGHT
 require_bool_value K6_BACKEND_READINESS_GATE
+require_auto_bool_value K6_AUTH_TOKEN_REQUIRED
+require_auto_bool_value K6_AUTH_PREFLIGHT
 require_bool_value K6_POSTGRES_HEALTH_GATE
 require_bool_value K6_POSTGRES_RECOVERY_GATE
 require_bool_value K6_POSTGRES_EXPORTER_STABLE_GATE
 require_positive_integer K6_BACKEND_READINESS_TIMEOUT_SECONDS
+require_positive_integer K6_AUTH_PREFLIGHT_EXPECTED_STATUS
+require_positive_integer K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS
+if ((K6_AUTH_PREFLIGHT_EXPECTED_STATUS < 100 || K6_AUTH_PREFLIGHT_EXPECTED_STATUS > 599)); then
+  echo "K6_AUTH_PREFLIGHT_EXPECTED_STATUS must be an HTTP status code" >&2
+  exit 1
+fi
 require_non_negative_integer K6_POSTGRES_RECOVERY_STABLE_SECONDS
 require_non_negative_integer K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS
 require_positive_integer K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS
@@ -656,6 +777,12 @@ print_plan() {
   else
     echo "[k6-transaction-100m] backend readiness gate=${K6_BACKEND_READINESS_GATE} base=${K6_BACKEND_READINESS_BASE_URL} path=${K6_BACKEND_READINESS_PATH} timeout=${K6_BACKEND_READINESS_TIMEOUT_SECONDS}"
   fi
+  echo "[k6-transaction-100m] auth token required=$(effective_auth_token_required) token=$(auth_token_presence) source=${auth_token_source}"
+  if [[ -n "$(auth_preflight_url)" ]]; then
+    echo "[k6-transaction-100m] auth preflight=$(effective_auth_preflight_enabled) url=configured expected_status=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} timeout=${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}"
+  else
+    echo "[k6-transaction-100m] auth preflight=$(effective_auth_preflight_enabled) url=not-configured expected_status=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} timeout=${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}"
+  fi
   echo "[k6-transaction-100m] postgres health gate=${K6_POSTGRES_HEALTH_GATE} required_status=healthy"
   echo "[k6-transaction-100m] postgres recovery gate=${K6_POSTGRES_RECOVERY_GATE} stable_seconds=${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
   echo "[k6-transaction-100m] postgres recovery noise window seconds=${K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS}"
@@ -701,15 +828,60 @@ print_plan() {
   echo "[k6-transaction-100m] archive output dir=${archive_output_dir}"
 }
 
+assert_auth_preflight() {
+  local token_required preflight_enabled preflight_url status
+  token_required="$(effective_auth_token_required)"
+  if [[ "${token_required}" == "true" && -z "${K6_AUTH_TOKEN}" ]]; then
+    echo "K6_AUTH_TOKEN is required before OCI k6 run; set K6_AUTH_TOKEN or K6_AUTH_TOKEN_FILE" >&2
+    exit 1
+  fi
+
+  preflight_enabled="$(effective_auth_preflight_enabled)"
+  if [[ "${preflight_enabled}" != "true" ]]; then
+    echo "[k6-transaction-100m] auth preflight skipped"
+    return 0
+  fi
+  if [[ -z "${K6_AUTH_TOKEN}" ]]; then
+    echo "K6_AUTH_TOKEN is required when K6_AUTH_PREFLIGHT=true" >&2
+    exit 1
+  fi
+
+  preflight_url="$(auth_preflight_url)"
+  if [[ -z "${preflight_url}" ]]; then
+    echo "K6_AUTH_PREFLIGHT_URL or K6_AUTH_PREFLIGHT_PATH is required when K6_AUTH_PREFLIGHT=true" >&2
+    exit 1
+  fi
+
+  require_command curl
+  echo "[k6-transaction-100m] auth status preflight: expected_status=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} timeout=${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}"
+  status="$(
+    curl -sS -o /dev/null -w "%{http_code}" \
+      --max-time "${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}" \
+      -H "Authorization: Bearer ${K6_AUTH_TOKEN}" \
+      "${preflight_url}" 2>/dev/null || true
+  )"
+  status="${status:0:3}"
+  if [[ "${status}" != "${K6_AUTH_PREFLIGHT_EXPECTED_STATUS}" ]]; then
+    echo "auth status preflight failed: expected=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} actual=${status:-000}" >&2
+    exit 1
+  fi
+}
+
 print_plan
 
 if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if [[ "${mode}" == "auth-preflight-only" ]]; then
+  assert_auth_preflight
   exit 0
 fi
 if [[ "${mode}" == "assert-summary" ]]; then
   assert_k6_summary_gate "${summary_gate_json}" "${summary_gate_log}" 0
   exit $?
 fi
+
+assert_auth_preflight
 
 if [[ -z "${K6_HOT_ACCOUNT_ID:-}" && -z "${K6_HOT_ACCOUNT_IDS:-}" ]]; then
   echo "K6_HOT_ACCOUNT_ID or K6_HOT_ACCOUNT_IDS is required" >&2

--- a/tools/test/run-transaction-read-production-evidence-pack.sh
+++ b/tools/test/run-transaction-read-production-evidence-pack.sh
@@ -103,7 +103,7 @@ print_plan() {
   echo "[transaction-read-production-evidence-pack] required_scenarios=${required_scenarios}"
   echo "[transaction-read-production-evidence-pack] min_real_source_ips=${min_real_source_ips}"
   echo "[transaction-read-production-evidence-pack] max_edge_429_rate=${max_edge_429_rate}"
-  echo "[transaction-read-production-evidence-pack] required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref,hikari_closure_ref(hikari-soak)"
+  echo "[transaction-read-production-evidence-pack] required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref,artifact_manifest_ref,hikari_closure_ref(hikari-soak)"
   echo "[transaction-read-production-evidence-pack] hard_zero=backend_429_count,unknown_429_count,five_xx_count,nginx_499_count,hikari_validation_warnings,db_pool_pending_max"
   echo "[transaction-read-production-evidence-pack] summary_tsv=${summary_tsv}"
   echo "[transaction-read-production-evidence-pack] report_md=${report_md}"
@@ -142,8 +142,8 @@ function require_ref(name) {
 BEGIN {
   split(required_scenarios, required_items, ",")
   for (i in required_items) required[required_items[i]] = 1
-  split("scenario run_id duration_min source_ips k6_summary_ref nginx_aggregate_ref nginx_499_aggregate_ref spring_429_ref hikari_log_ref hikari_closure_ref postgres_explain_ref postgres_activity_ref postgres_wait_ref prometheus_timeline_ref edge_429_rate backend_429_count unknown_429_count five_xx_count nginx_499_count hikari_validation_warnings db_pool_pending_max", header_items, " ")
-  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tk6_summary_ref\tnginx_aggregate_ref\tnginx_499_aggregate_ref\tspring_429_ref\thikari_log_ref\thikari_closure_ref\tpostgres_explain_ref\tpostgres_activity_ref\tpostgres_wait_ref\tprometheus_timeline_ref\tsource_fairness_ref\tcache_state_ref\tdeploy_event_ref"
+  split("scenario run_id duration_min source_ips k6_summary_ref nginx_aggregate_ref nginx_499_aggregate_ref spring_429_ref hikari_log_ref hikari_closure_ref postgres_explain_ref postgres_activity_ref postgres_wait_ref prometheus_timeline_ref artifact_manifest_ref mixed_workload_ref p999_latency_ref source_fairness_ref cache_state_ref deploy_event_ref edge_429_rate backend_429_count unknown_429_count five_xx_count nginx_499_count hikari_validation_warnings db_pool_pending_max", header_items, " ")
+  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tk6_summary_ref\tnginx_aggregate_ref\tnginx_499_aggregate_ref\tspring_429_ref\thikari_log_ref\thikari_closure_ref\tpostgres_explain_ref\tpostgres_activity_ref\tpostgres_wait_ref\tprometheus_timeline_ref\tartifact_manifest_ref\tmixed_workload_ref\tp999_latency_ref\tsource_fairness_ref\tcache_state_ref\tdeploy_event_ref"
 }
 NR == 1 {
   for (i = 1; i <= NF; i++) col[$i] = i
@@ -170,14 +170,7 @@ NR == 1 {
   require_ref("postgres_activity_ref")
   require_ref("postgres_wait_ref")
   require_ref("prometheus_timeline_ref")
-
-  hikari_closure_ref = value("hikari_closure_ref", "n/a")
-  if (scenario == "hikari-soak") {
-    if (hikari_closure_ref == "" || hikari_closure_ref == "n/a") add_reason("hikari_closure_ref-missing")
-    else if (unsafe_ref(hikari_closure_ref)) add_reason("hikari_closure_ref-unsafe")
-  } else if (hikari_closure_ref != "" && hikari_closure_ref != "n/a" && unsafe_ref(hikari_closure_ref)) {
-    add_reason("hikari_closure_ref-unsafe")
-  }
+  require_ref("artifact_manifest_ref")
 
   if (value("edge_429_rate", "1") + 0 > max_edge_429_rate) add_reason("edge429>" max_edge_429_rate)
   if (value("backend_429_count", "1") + 0 > 0) add_reason("backend429>0")
@@ -190,7 +183,14 @@ NR == 1 {
   source_fairness_ref = value("source_fairness_ref", "n/a")
   cache_state_ref = value("cache_state_ref", "n/a")
   deploy_event_ref = value("deploy_event_ref", "n/a")
+  artifact_manifest_ref = value("artifact_manifest_ref", "n/a")
+  hikari_closure_ref = value("hikari_closure_ref", "n/a")
+  mixed_workload_ref = value("mixed_workload_ref", "n/a")
+  p999_latency_ref = value("p999_latency_ref", "n/a")
 
+  if (scenario == "hikari-soak") require_ref("hikari_closure_ref")
+  if (scenario == "mixed-workload") require_ref("mixed_workload_ref")
+  if (scenario == "p999-long") require_ref("p999_latency_ref")
   if (scenario == "real-ip-multisource") {
     if (value("source_ips", "0") + 0 < min_real_source_ips) add_reason("source-ips<" min_real_source_ips)
     if (source_fairness_ref == "" || source_fairness_ref == "n/a") add_reason("source-fairness-missing")
@@ -206,7 +206,7 @@ NR == 1 {
   }
 
   if (status == "fail") fail_count++
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
     scenario, status, reason, value("run_id", ""),
     value("duration_min", "0"), value("source_ips", "0"), value("edge_429_rate", "0"),
     value("backend_429_count", "0"), value("unknown_429_count", "0"),
@@ -216,7 +216,9 @@ NR == 1 {
     value("nginx_499_aggregate_ref", ""), value("spring_429_ref", ""),
     value("hikari_log_ref", ""), hikari_closure_ref, value("postgres_explain_ref", ""),
     value("postgres_activity_ref", ""), value("postgres_wait_ref", ""),
-    value("prometheus_timeline_ref", ""), source_fairness_ref, cache_state_ref, deploy_event_ref
+    value("prometheus_timeline_ref", ""), artifact_manifest_ref, mixed_workload_ref,
+    p999_latency_ref, source_fairness_ref, cache_state_ref,
+    deploy_event_ref
 }
 END {
   missing = ""
@@ -273,6 +275,10 @@ cat >"${report_md}" <<REPORT
 - PostgreSQL activity sampler
 - PostgreSQL wait timeline
 - Prometheus timeline
+- OCI artifact manifest
+- Hikari zero-budget closure artifact for hikari-soak runs
+- mixed workload interference artifact for mixed-workload runs
+- p99.9 latency artifact for p999-long runs
 - source fairness artifact for real multi-source runs
 - cache state artifact for cold/warm runs
 - deploy event artifact for drain runs


### PR DESCRIPTION
## 🔗 Related Issue
- close #654

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI docker-context/capacity k6 실행에서 `K6_AUTH_TOKEN` 누락 시 401 성능 run을 만들기 전에 fail-fast하도록 auth preflight를 추가했습니다.
- `K6_AUTH_TOKEN_FILE`과 HTTP status preflight를 추가해 token 값을 plan/log에 출력하지 않고 status 200 계약으로만 확인합니다.
- production evidence pack manifest에 scenario별 OCI artifact manifest 및 closure/interference/p99.9 refs를 필수화했습니다.

## 🛠 Changes
- `run-k6-transaction-100m-loadtest.sh`에 `--auth-preflight-only`, `K6_AUTH_TOKEN_REQUIRED`, `K6_AUTH_TOKEN_FILE`, `K6_AUTH_PREFLIGHT_*` 계약을 추가했습니다.
- k6 check에 token 누락 fail-fast, token file secret-safe plan, unreachable status preflight 실패 검증을 추가했습니다.
- production evidence pack TSV에 `artifact_manifest_ref`, `hikari_closure_ref`, `mixed_workload_ref`, `p999_latency_ref`를 추가하고 scenario별 필수 ref로 검증합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-k6-transaction-100m-loadtest.sh`
- `bash tools/test/check-transaction-read-production-evidence-pack.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` => `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: OCI capacity/profile/benchmark docker-context run은 이제 token이 없으면 즉시 실패합니다. 기존 evidence TSV도 새 ref 컬럼을 채워야 합니다.
- 롤백 방법: 이 PR revert 후 기존 k6/evidence manifest 계약으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?