### PR TITLE
[Fix] OCI A1 Hikari validation warning zero-budget closure

### DIFF
--- a/tools/test/check-hikari-idle-in-transaction-attribution.sh
+++ b/tools/test/check-hikari-idle-in-transaction-attribution.sh
@@ -16,6 +16,7 @@ hikari_log_zero="${temp_dir}/hikari-zero.log"
 config_tsv="${temp_dir}/config.tsv"
 http_status_tsv="${temp_dir}/http-status.tsv"
 http_status_5xx_tsv="${temp_dir}/http-status-5xx.tsv"
+http_status_pending_tsv="${temp_dir}/http-status-pending.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${pg_tsv}" <<'TSV'
@@ -52,11 +53,19 @@ TSV
 cat >"${http_status_tsv}" <<'TSV'
 key	value
 five_xx_count	0
+db_pool_pending_max	0
 TSV
 
 cat >"${http_status_5xx_tsv}" <<'TSV'
 key	value
 five_xx_count	1
+db_pool_pending_max	0
+TSV
+
+cat >"${http_status_pending_tsv}" <<'TSV'
+key	value
+five_xx_count	0
+db_pool_pending_max	1
 TSV
 
 echo "[hikari-idle-attribution] print plan"
@@ -99,6 +108,7 @@ grep -F "config_status=pass" "${report_md}" >/dev/null
 grep -F "warning_count=3" "${report_md}" >/dev/null
 grep -F "idle_in_transaction_samples=2" "${report_md}" >/dev/null
 grep -F "five_xx_count=0" "${report_md}" >/dev/null
+grep -F "db_pool_pending_max=0" "${report_md}" >/dev/null
 grep -F "OCI A1 lifetime alignment" "${report_md}" >/dev/null
 grep -F "PostgreSQL PID/query/requestId correlation" "${report_md}" >/dev/null
 grep -F $'warning_time_utc\tstatus\tpid\trequest_id\tstate\twait_event_type\twait_event\txact_age_seconds\tquery\tcause' "${summary_tsv}" >/dev/null
@@ -124,7 +134,8 @@ grep -F "warning_count=0" "${zero_report_md}" >/dev/null
 grep -F "expected_warning_count=0" "${zero_report_md}" >/dev/null
 grep -F "idle_in_transaction_samples=0" "${zero_report_md}" >/dev/null
 grep -F "five_xx_count=0" "${zero_report_md}" >/dev/null
-grep -F "zero-budget hard target: Hikari warning 0, idle in transaction 0, 5xx 0" "${zero_report_md}" >/dev/null
+grep -F "db_pool_pending_max=0" "${zero_report_md}" >/dev/null
+grep -F "zero-budget hard target: Hikari warning 0, idle in transaction 0, DB pool pending 0, 5xx 0" "${zero_report_md}" >/dev/null
 grep -F "30m soak Hikari warning budget: 0" "${zero_report_md}" >/dev/null
 
 echo "[hikari-idle-attribution] 30m zero warning with idle transaction fails"
@@ -152,6 +163,20 @@ if HIKARI_IDLE_ATTRIBUTION_NAME=hikari-zero-5xx-fail \
   HIKARI_IDLE_ATTRIBUTION_SOAK_DURATION_MIN=30 \
     "${runner}" >/dev/null 2>&1; then
   echo "hikari attribution unexpectedly passed zero-warning run with 5xx" >&2
+  exit 1
+fi
+
+echo "[hikari-idle-attribution] 30m zero warning with DB pool pending fails"
+if HIKARI_IDLE_ATTRIBUTION_NAME=hikari-zero-pending-fail \
+  HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV="${pg_zero_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG="${hikari_log_zero}" \
+  HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV="${config_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV="${http_status_pending_tsv}" \
+  HIKARI_IDLE_ATTRIBUTION_OUTPUT_DIR="${output_dir}" \
+  HIKARI_IDLE_ATTRIBUTION_EXPECT_WARNING_COUNT=0 \
+  HIKARI_IDLE_ATTRIBUTION_SOAK_DURATION_MIN=30 \
+    "${runner}" >/dev/null 2>&1; then
+  echo "hikari attribution unexpectedly passed zero-warning run with DB pool pending" >&2
   exit 1
 fi
 

--- a/tools/test/check-transaction-read-production-evidence-pack.sh
+++ b/tools/test/check-transaction-read-production-evidence-pack.sh
@@ -32,6 +32,7 @@ plan="$(
 grep -F "name=production-check" <<<"${plan}" >/dev/null
 grep -F "required_scenarios=hikari-soak,cold-warm,mixed-workload,real-ip-multisource,deploy-drain,p999-long" <<<"${plan}" >/dev/null
 grep -F "min_real_source_ips=2" <<<"${plan}" >/dev/null
+grep -F "min_hikari_soak_duration_min=30" <<<"${plan}" >/dev/null
 grep -F "required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref,artifact_manifest_ref,hikari_closure_ref(hikari-soak)" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] pass report"
@@ -60,6 +61,22 @@ grep -F "oci/latency/p999.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/source/real-ip-fairness.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/deploy/drain-events.tsv" "${summary_tsv}" >/dev/null
 grep -F "oci/cache/cold-warm.tsv" "${summary_tsv}" >/dev/null
+
+echo "[transaction-read-production-evidence-pack] Hikari 30m duration fail"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "hikari-soak" { $3 = 10 } { print }' \
+  "${input_tsv}" >"${input_tsv}.hikari-duration-fail"
+if PROD_EVIDENCE_PACK_NAME=production-hikari-duration-fail \
+  PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.hikari-duration-fail" \
+  PROD_EVIDENCE_PACK_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "production evidence pack unexpectedly passed short Hikari soak duration" >&2
+  exit 1
+fi
+PROD_EVIDENCE_PACK_NAME=production-hikari-duration-fail \
+PROD_EVIDENCE_PACK_INPUT_TSV="${input_tsv}.hikari-duration-fail" \
+PROD_EVIDENCE_PACK_OUTPUT_DIR="${output_dir}" \
+  "${runner}" >/dev/null 2>&1 || true
+grep -F "hikari-soak-duration<30" "${output_dir}/production-hikari-duration-fail-production-evidence-pack.tsv" >/dev/null
 
 echo "[transaction-read-production-evidence-pack] hard-zero fail"
 awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload" { $22 = 1; $23 = 1; $24 = 1; $25 = 1; $26 = 1; $27 = 1 } { print }' \

--- a/tools/test/run-hikari-idle-in-transaction-attribution.sh
+++ b/tools/test/run-hikari-idle-in-transaction-attribution.sh
@@ -10,7 +10,7 @@ Environment:
   HIKARI_IDLE_ATTRIBUTION_PG_ACTIVITY_TSV            required pg_stat_activity sampler TSV
   HIKARI_IDLE_ATTRIBUTION_HIKARI_LOG                 required Hikari warning log
   HIKARI_IDLE_ATTRIBUTION_CONFIG_TSV                 required key/value timeout config TSV
-  HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV            optional key/value HTTP status TSV; required when EXPECT_WARNING_COUNT=0
+  HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV            optional key/value HTTP/pool TSV; required when EXPECT_WARNING_COUNT=0
   HIKARI_IDLE_ATTRIBUTION_OUTPUT_DIR                 default build/reports/k6/<name>
   HIKARI_IDLE_ATTRIBUTION_CORRELATION_WINDOW_SECONDS default 5
   HIKARI_IDLE_ATTRIBUTION_EXPECT_WARNING_COUNT       optional exact warning count, use 0 for 30m soak removal gate
@@ -152,6 +152,7 @@ idle_in_transaction_samples="$(
 )"
 
 five_xx_count="0"
+db_pool_pending_max="0"
 if [[ -n "${http_status_tsv}" ]]; then
   five_xx_count="$(
     awk -F '\t' '
@@ -161,6 +162,14 @@ if [[ -n "${http_status_tsv}" ]]; then
     ' "${http_status_tsv}"
   )"
   require_non_negative_integer "HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV five_xx_count" "${five_xx_count}"
+  db_pool_pending_max="$(
+    awk -F '\t' '
+      NR == 1 { next }
+      $1 == "db_pool_pending_max" { print $2; found = 1 }
+      END { if (!found) print "missing" }
+    ' "${http_status_tsv}"
+  )"
+  require_non_negative_integer "HIKARI_IDLE_ATTRIBUTION_HTTP_STATUS_TSV db_pool_pending_max" "${db_pool_pending_max}"
 fi
 
 awk -F '\t' '
@@ -283,7 +292,7 @@ if [[ -n "${expected_warning_count}" && "${warning_count}" != "${expected_warnin
   gate_status="fail"
 fi
 if [[ "${expected_warning_count}" == "0" ]]; then
-  if [[ "${idle_in_transaction_samples}" != "0" || "${five_xx_count}" != "0" ]]; then
+  if [[ "${idle_in_transaction_samples}" != "0" || "${five_xx_count}" != "0" || "${db_pool_pending_max}" != "0" ]]; then
     gate_status="fail"
   fi
 fi
@@ -314,12 +323,13 @@ cat >"${report_md}" <<REPORT
 - unattributed_warning_count=${unattributed_count}
 - idle_in_transaction_samples=${idle_in_transaction_samples}
 - five_xx_count=${five_xx_count}
+- db_pool_pending_max=${db_pool_pending_max}
 - sampler: pg_stat_activity
 - correlation window seconds: ${correlation_window_seconds}
 - soak_duration_min=${soak_duration_min}
 - OCI A1 lifetime alignment: maxLifetime < NAT idle, keepalive < maxLifetime, scheduled worker <= PostgreSQL idle timeout
 - ${soak_duration_min}m soak Hikari warning budget: ${expected_warning_count:-attribution-required}
-- zero-budget hard target: Hikari warning 0, idle in transaction 0, 5xx 0
+- zero-budget hard target: Hikari warning 0, idle in transaction 0, DB pool pending 0, 5xx 0
 
 ## Correlation
 

--- a/tools/test/run-transaction-read-production-evidence-pack.sh
+++ b/tools/test/run-transaction-read-production-evidence-pack.sh
@@ -11,6 +11,7 @@ Environment:
   PROD_EVIDENCE_PACK_OUTPUT_DIR           default build/reports/k6/<name>
   PROD_EVIDENCE_PACK_REQUIRED_SCENARIOS   default hikari-soak,cold-warm,mixed-workload,real-ip-multisource,deploy-drain,p999-long
   PROD_EVIDENCE_PACK_MIN_REAL_SOURCE_IPS  default 2
+  PROD_EVIDENCE_PACK_MIN_HIKARI_SOAK_MIN  default 30
   PROD_EVIDENCE_PACK_MAX_EDGE_429_RATE    default 0.10
 USAGE
 }
@@ -38,6 +39,7 @@ input_tsv="${PROD_EVIDENCE_PACK_INPUT_TSV:-}"
 output_dir="${PROD_EVIDENCE_PACK_OUTPUT_DIR:-build/reports/k6/${name}}"
 required_scenarios="${PROD_EVIDENCE_PACK_REQUIRED_SCENARIOS:-hikari-soak,cold-warm,mixed-workload,real-ip-multisource,deploy-drain,p999-long}"
 min_real_source_ips="${PROD_EVIDENCE_PACK_MIN_REAL_SOURCE_IPS:-2}"
+min_hikari_soak_duration_min="${PROD_EVIDENCE_PACK_MIN_HIKARI_SOAK_MIN:-30}"
 max_edge_429_rate="${PROD_EVIDENCE_PACK_MAX_EDGE_429_RATE:-0.10}"
 summary_tsv="${output_dir}/${name}-production-evidence-pack.tsv"
 report_md="${output_dir}/${name}-production-evidence-pack.md"
@@ -93,6 +95,7 @@ scenario_list() {
 }
 
 require_non_negative_integer "PROD_EVIDENCE_PACK_MIN_REAL_SOURCE_IPS" "${min_real_source_ips}"
+require_non_negative_integer "PROD_EVIDENCE_PACK_MIN_HIKARI_SOAK_MIN" "${min_hikari_soak_duration_min}"
 require_rate "PROD_EVIDENCE_PACK_MAX_EDGE_429_RATE" "${max_edge_429_rate}"
 
 print_plan() {
@@ -102,6 +105,7 @@ print_plan() {
   echo "[transaction-read-production-evidence-pack] scenarios=$(scenario_list)"
   echo "[transaction-read-production-evidence-pack] required_scenarios=${required_scenarios}"
   echo "[transaction-read-production-evidence-pack] min_real_source_ips=${min_real_source_ips}"
+  echo "[transaction-read-production-evidence-pack] min_hikari_soak_duration_min=${min_hikari_soak_duration_min}"
   echo "[transaction-read-production-evidence-pack] max_edge_429_rate=${max_edge_429_rate}"
   echo "[transaction-read-production-evidence-pack] required_refs=k6_summary_ref,nginx_aggregate_ref,nginx_499_aggregate_ref,spring_429_ref,hikari_log_ref,postgres_explain_ref,postgres_activity_ref,postgres_wait_ref,prometheus_timeline_ref,artifact_manifest_ref,hikari_closure_ref(hikari-soak)"
   echo "[transaction-read-production-evidence-pack] hard_zero=backend_429_count,unknown_429_count,five_xx_count,nginx_499_count,hikari_validation_warnings,db_pool_pending_max"
@@ -121,6 +125,7 @@ mkdir -p "${output_dir}"
 awk -F '\t' \
   -v required_scenarios="${required_scenarios}" \
   -v min_real_source_ips="${min_real_source_ips}" \
+  -v min_hikari_soak_duration_min="${min_hikari_soak_duration_min}" \
   -v max_edge_429_rate="${max_edge_429_rate}" '
 function value(name, fallback) {
   if (!(name in col) || col[name] == "") return fallback
@@ -188,7 +193,12 @@ NR == 1 {
   mixed_workload_ref = value("mixed_workload_ref", "n/a")
   p999_latency_ref = value("p999_latency_ref", "n/a")
 
-  if (scenario == "hikari-soak") require_ref("hikari_closure_ref")
+  if (scenario == "hikari-soak") {
+    require_ref("hikari_closure_ref")
+    if (value("duration_min", "0") + 0 < min_hikari_soak_duration_min) {
+      add_reason("hikari-soak-duration<" min_hikari_soak_duration_min)
+    }
+  }
   if (scenario == "mixed-workload") require_ref("mixed_workload_ref")
   if (scenario == "p999-long") require_ref("p999_latency_ref")
   if (scenario == "real-ip-multisource") {
@@ -260,6 +270,7 @@ cat >"${report_md}" <<REPORT
 - required scenarios: ${required_scenarios}
 - missing scenarios: ${missing_scenarios:-none}
 - min real source IPs: ${min_real_source_ips}
+- min Hikari soak duration min: ${min_hikari_soak_duration_min}
 - max edge 429 rate: ${max_edge_429_rate}
 - hard-zero: backend 429, unknown 429, 499, 5xx, Hikari warning, Hikari pending
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #660

## 🌿 Base Branch
- `main`

## 📝 Summary
- main659 이후 남은 Hikari validation warning zero-budget closure 기준에 DB pool pending hard-zero를 추가했습니다.
- production evidence pack에서 Hikari soak evidence가 30분 미만이면 통과하지 못하도록 계약을 강화했습니다.

## 🛠 Changes
- Hikari idle attribution runner/check가 `db_pool_pending_max`를 읽고 zero-warning soak에서 pending > 0을 실패 처리합니다.
- Hikari zero-budget report의 hard target 문구를 warning 0, idle transaction 0, DB pool pending 0, 5xx 0으로 고정했습니다.
- production evidence pack에 `PROD_EVIDENCE_PACK_MIN_HIKARI_SOAK_MIN` 기본 30분 gate를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-hikari-idle-in-transaction-attribution.sh`
- `bash tools/test/check-transaction-read-production-evidence-pack.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` => `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Hikari closure evidence TSV는 `db_pool_pending_max`를 포함해야 하고, production evidence pack의 `hikari-soak` scenario는 기본 30분 이상이어야 합니다.
- 롤백 방법: 이 PR revert 후 이전 evidence gate 계약으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?