### PR TITLE
[Perf] transaction read defensive policy retune

### DIFF
--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuard.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuard.java
@@ -21,6 +21,8 @@ public class T3MicroSaturationGuard {
   private final Counter rejectedCounter;
   private final ConcurrentMap<String, Counter> backgroundWorkerPauseCounters =
       new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, AtomicInteger> protectedSaturationStreaks =
+      new ConcurrentHashMap<>();
   private final AtomicInteger saturatedGauge = new AtomicInteger();
 
   public T3MicroSaturationGuard(
@@ -72,14 +74,26 @@ public class T3MicroSaturationGuard {
       return T3MicroSaturationDecision.allowed(T3MicroSaturationSnapshot.empty());
     }
     T3MicroSaturationSnapshot snapshot = snapshot();
-    if (!protectedPath(path)) {
+    String protectedPathPrefix = protectedPathPrefix(path);
+    if (protectedPathPrefix == null) {
       return T3MicroSaturationDecision.allowed(snapshot);
     }
     if (snapshot.saturated() || readReplicaPoolSaturated(path, snapshot)) {
+      int streak =
+          protectedSaturationStreaks
+              .computeIfAbsent(protectedPathPrefix, ignored -> new AtomicInteger())
+              .incrementAndGet();
+      if (streak < properties.hysteresis().consecutiveSaturatedSamples()) {
+        // 짧은 spike 1회는 false-positive가 잦아 연속 포화일 때만 request reject.
+        saturatedGauge.set(0);
+        acceptedCounter.increment();
+        return T3MicroSaturationDecision.allowed(snapshot);
+      }
       saturatedGauge.set(1);
       rejectedCounter.increment();
       return T3MicroSaturationDecision.rejected(properties.retryAfterSeconds(), snapshot);
     }
+    protectedSaturationStreaks.remove(protectedPathPrefix);
     saturatedGauge.set(0);
     acceptedCounter.increment();
     return T3MicroSaturationDecision.allowed(snapshot);
@@ -129,8 +143,11 @@ public class T3MicroSaturationGuard {
         jvmPressureSaturated);
   }
 
-  private boolean protectedPath(String path) {
-    return properties.protectedPathPrefixes().stream().anyMatch(path::startsWith);
+  private String protectedPathPrefix(String path) {
+    return properties.protectedPathPrefixes().stream()
+        .filter(path::startsWith)
+        .findFirst()
+        .orElse(null);
   }
 
   private boolean readReplicaPoolSaturated(String path, T3MicroSaturationSnapshot snapshot) {

--- a/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuardProperties.java
+++ b/back/src/main/java/com/aquilabank/global/ops/T3MicroSaturationGuardProperties.java
@@ -13,7 +13,8 @@ public record T3MicroSaturationGuardProperties(
     QueryTimeout queryTimeout,
     JvmPressure jvmPressure,
     BackgroundWorkers backgroundWorkers,
-    ReadReplicaPool readReplicaPool) {
+    ReadReplicaPool readReplicaPool,
+    Hysteresis hysteresis) {
 
   public T3MicroSaturationGuardProperties {
     enabled = enabled == null ? Boolean.TRUE : enabled;
@@ -38,6 +39,7 @@ public record T3MicroSaturationGuardProperties(
         readReplicaPool == null
             ? new ReadReplicaPool(true, List.of("/api/v1/transactions"))
             : readReplicaPool;
+    hysteresis = hysteresis == null ? new Hysteresis(2) : hysteresis;
   }
 
   public record Pool(int activeThresholdPercent, int awaitingThreadsThreshold) {
@@ -99,6 +101,14 @@ public record T3MicroSaturationGuardProperties(
           protectedPathPrefixes == null || protectedPathPrefixes.isEmpty()
               ? List.of("/api/v1/transactions")
               : List.copyOf(protectedPathPrefixes);
+    }
+  }
+
+  public record Hysteresis(int consecutiveSaturatedSamples) {
+
+    public Hysteresis {
+      consecutiveSaturatedSamples =
+          consecutiveSaturatedSamples > 0 ? consecutiveSaturatedSamples : 2;
     }
   }
 }

--- a/back/src/test/java/com/aquilabank/global/ops/T3MicroSaturationGuardTest.java
+++ b/back/src/test/java/com/aquilabank/global/ops/T3MicroSaturationGuardTest.java
@@ -61,6 +61,43 @@ class T3MicroSaturationGuardTest {
   }
 
   @Test
+  void rejectsOnlyAfterConsecutiveSaturatedSamplesWhenHysteresisRequiresTwoSamples() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    MutableClock clock = new MutableClock(Instant.parse("2026-05-03T00:00:00Z"));
+    T3MicroQueryTimeoutSignal timeoutSignal = new T3MicroQueryTimeoutSignal(clock, meterRegistry);
+    timeoutSignal.record();
+    T3MicroSaturationGuard guard =
+        new T3MicroSaturationGuard(
+            propertiesWithHysteresis(2),
+            new MutableDbPoolProbe(new DbPoolSaturationSnapshot(4, 4, 1)),
+            new MutableServletThreadProbe(new ServletThreadSaturationSnapshot(16, 16)),
+            new MutableJvmPressureProbe(JvmPressureSnapshot.empty()),
+            timeoutSignal,
+            meterRegistry);
+
+    T3MicroSaturationDecision firstDecision = guard.check("/api/v1/transactions");
+    T3MicroSaturationDecision secondDecision = guard.check("/api/v1/transactions");
+
+    assertThat(firstDecision.allowed()).isTrue();
+    assertThat(firstDecision.snapshot().saturated()).isTrue();
+    assertThat(secondDecision.allowed()).isFalse();
+    assertThat(
+            meterRegistry
+                .find("aquila.t3micro.saturation.guard.requests")
+                .tag("outcome", "accepted")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry
+                .find("aquila.t3micro.saturation.guard.requests")
+                .tag("outcome", "rejected")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
   void allowsRequestWhenQueryTimeoutSignalExpires() {
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     MutableClock clock = new MutableClock(Instant.parse("2026-04-22T00:00:00Z"));
@@ -225,7 +262,8 @@ class T3MicroSaturationGuardTest {
                 new T3MicroSaturationGuardProperties.JvmPressure(true, 90, 10, 3, 250),
                 new T3MicroSaturationGuardProperties.BackgroundWorkers(true),
                 new T3MicroSaturationGuardProperties.ReadReplicaPool(
-                    true, List.of("/api/v1/transactions"))),
+                    true, List.of("/api/v1/transactions")),
+                new T3MicroSaturationGuardProperties.Hysteresis(1)),
             new MutableDbPoolProbe(new DbPoolSaturationSnapshot(4, 4, 1)),
             new MutableServletThreadProbe(new ServletThreadSaturationSnapshot(16, 16)),
             new MutableJvmPressureProbe(JvmPressureSnapshot.empty()),
@@ -267,6 +305,20 @@ class T3MicroSaturationGuardTest {
     return propertiesWithJvmPressureAndReadReplicaPool(true, prefixes);
   }
 
+  private T3MicroSaturationGuardProperties propertiesWithHysteresis(int consecutiveSamples) {
+    return new T3MicroSaturationGuardProperties(
+        true,
+        2,
+        List.of("/api/v1/transactions", "/api/v1/notifications"),
+        new T3MicroSaturationGuardProperties.Pool(80, 1),
+        new T3MicroSaturationGuardProperties.ServletThreads(80),
+        new T3MicroSaturationGuardProperties.QueryTimeout(10, 1),
+        new T3MicroSaturationGuardProperties.JvmPressure(true, 90, 10, 3, 250),
+        new T3MicroSaturationGuardProperties.BackgroundWorkers(true),
+        new T3MicroSaturationGuardProperties.ReadReplicaPool(true, List.of("/api/v1/transactions")),
+        new T3MicroSaturationGuardProperties.Hysteresis(consecutiveSamples));
+  }
+
   private T3MicroSaturationGuardProperties propertiesWithJvmPressureAndReadReplicaPool(
       boolean enabled, List<String> prefixes) {
     return new T3MicroSaturationGuardProperties(
@@ -278,7 +330,8 @@ class T3MicroSaturationGuardTest {
         new T3MicroSaturationGuardProperties.QueryTimeout(10, 1),
         new T3MicroSaturationGuardProperties.JvmPressure(enabled, 90, 10, 3, 250),
         new T3MicroSaturationGuardProperties.BackgroundWorkers(true),
-        new T3MicroSaturationGuardProperties.ReadReplicaPool(true, prefixes));
+        new T3MicroSaturationGuardProperties.ReadReplicaPool(true, prefixes),
+        new T3MicroSaturationGuardProperties.Hysteresis(1));
   }
 
   private T3MicroSaturationGuardProperties propertiesWithBackgroundWorkers(boolean enabled) {
@@ -291,8 +344,8 @@ class T3MicroSaturationGuardTest {
         new T3MicroSaturationGuardProperties.QueryTimeout(10, 1),
         new T3MicroSaturationGuardProperties.JvmPressure(true, 90, 10, 3, 250),
         new T3MicroSaturationGuardProperties.BackgroundWorkers(enabled),
-        new T3MicroSaturationGuardProperties.ReadReplicaPool(
-            true, List.of("/api/v1/transactions")));
+        new T3MicroSaturationGuardProperties.ReadReplicaPool(true, List.of("/api/v1/transactions")),
+        new T3MicroSaturationGuardProperties.Hysteresis(1));
   }
 
   private static final class MutableDbPoolProbe implements DbPoolSaturationProbe {

--- a/back/src/test/java/com/aquilabank/global/web/T3MicroSaturationInterceptorTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/T3MicroSaturationInterceptorTest.java
@@ -81,7 +81,8 @@ class T3MicroSaturationInterceptorTest {
             new T3MicroSaturationGuardProperties.JvmPressure(true, 90, 10, 3, 250),
             new T3MicroSaturationGuardProperties.BackgroundWorkers(true),
             new T3MicroSaturationGuardProperties.ReadReplicaPool(
-                true, List.of("/api/v1/transactions"))),
+                true, List.of("/api/v1/transactions")),
+            new T3MicroSaturationGuardProperties.Hysteresis(1)),
         (DbPoolSaturationProbe) () -> pool,
         (ServletThreadSaturationProbe) () -> servletThreads,
         (JvmPressureProbe) gcWindow -> JvmPressureSnapshot.empty(),

--- a/tools/test/check-transaction-read-burst64-residual-smoothing.sh
+++ b/tools/test/check-transaction-read-burst64-residual-smoothing.sh
@@ -30,6 +30,7 @@ grep -F "max_backend_429_rate=0.005" <<<"${plan}" >/dev/null
 grep -F "max_accepted_p95_ms=120" <<<"${plan}" >/dev/null
 grep -F "min_burst80_429_rate=0.10" <<<"${plan}" >/dev/null
 grep -F "max_reject_streak=4" <<<"${plan}" >/dev/null
+grep -F "observed_main659_burst64_429_rate=0.12824" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-burst64-residual-smoothing] pass report"
 output="$(
@@ -43,6 +44,7 @@ summary_tsv="${output_dir}/burst64-check-burst64-residual-smoothing.tsv"
 test "${report_md}" = "${output_dir}/burst64-check-burst64-residual-smoothing.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "burst 64 total 429 budget: <= 0.10" "${report_md}" >/dev/null
+grep -F "main659 observed burst64 429: 0.12824" "${report_md}" >/dev/null
 grep -F "backend 429 budget: <= 0.005" "${report_md}" >/dev/null
 grep -F $'residual-v2\tpass\t0.080\t0.095\t0.220\t0.330\t118\t220\t4\t0.04\t0\t0.004\t25' "${summary_tsv}" >/dev/null
 

--- a/tools/test/check-transaction-read-fairness-budget.sh
+++ b/tools/test/check-transaction-read-fairness-budget.sh
@@ -13,9 +13,11 @@ input_tsv="${temp_dir}/fairness.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${input_tsv}" <<'TSV'
-endpoint	arrival_rate	total_requests	backend_fairness_429_count	backend_429_count	edge_429_count	unknown_429_count	five_xx_count	cold_account_p95_ms	accepted_p95_ms	rejection_reason
-active	16	2000	8	8	0	0	0	210	105	fairness-limiter-active
-archive	16	2000	12	12	0	0	0	610	118	fairness-limiter-archive
+traffic_shape	endpoint	arrival_rate	total_requests	backend_fairness_429_count	backend_429_count	edge_429_count	unknown_429_count	five_xx_count	cold_account_p95_ms	accepted_p95_ms	rejection_reason
+arrival16	active	16	2000	1	1	0	0	0	210	105	fairness-limiter-active
+arrival16	archive	16	2000	1	1	0	0	0	610	118	fairness-limiter-archive
+burst64	active	64	5000	20	20	150	0	0	220	112	fairness-limiter-active
+burst64	archive	64	5000	20	20	150	0	0	620	119	fairness-limiter-archive
 TSV
 
 echo "[transaction-read-fairness-budget] print plan"
@@ -27,7 +29,8 @@ plan="$(
 )"
 grep -F "arrival_rate=16" <<<"${plan}" >/dev/null
 grep -F "required_endpoints=active,archive" <<<"${plan}" >/dev/null
-grep -F "max_fairness_429_rate=0.01" <<<"${plan}" >/dev/null
+grep -F "max_fairness_429_rate=0.001" <<<"${plan}" >/dev/null
+grep -F "max_burst64_backend_429_rate=0.005" <<<"${plan}" >/dev/null
 grep -F "max_edge_429_rate=0" <<<"${plan}" >/dev/null
 grep -F "cold_account_p95_ms=750" <<<"${plan}" >/dev/null
 
@@ -42,27 +45,40 @@ report_md="$(tail -1 <<<"${output}")"
 summary_tsv="${output_dir}/fairness-check-fairness-budget.tsv"
 test "${report_md}" = "${output_dir}/fairness-check-fairness-budget.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
-grep -F "arrival16 backend fairness budget: < 0.01" "${report_md}" >/dev/null
+grep -F "arrival16 backend fairness budget: < 0.001" "${report_md}" >/dev/null
+grep -F "burst64 backend 429 budget: <= 0.005" "${report_md}" >/dev/null
 grep -F "required endpoints: active,archive" "${report_md}" >/dev/null
 grep -F "rejection reason must include endpoint" "${report_md}" >/dev/null
 grep -F "cold account latency budget: <= 750ms" "${report_md}" >/dev/null
-grep -F $'endpoint\tarrival_rate\tstatus\tfairness_429_rate\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tcold_account_p95_ms\taccepted_p95_ms\trejection_reason' "${summary_tsv}" >/dev/null
-grep -F $'active\t16\tpass\t0.004000\t0.000000\t8\t0\t0\t210\t105\tfairness-limiter-active' "${summary_tsv}" >/dev/null
-grep -F $'archive\t16\tpass\t0.006000\t0.000000\t12\t0\t0\t610\t118\tfairness-limiter-archive' "${summary_tsv}" >/dev/null
+grep -F $'traffic_shape\tendpoint\tarrival_rate\tstatus\tfairness_429_rate\tbackend_429_rate\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tcold_account_p95_ms\taccepted_p95_ms\trejection_reason' "${summary_tsv}" >/dev/null
+grep -F $'arrival16\tactive\t16\tpass\t0.000500\t0.000500\t0.000000\t1\t0\t0\t210\t105\tfairness-limiter-active' "${summary_tsv}" >/dev/null
+grep -F $'arrival16\tarchive\t16\tpass\t0.000500\t0.000500\t0.000000\t1\t0\t0\t610\t118\tfairness-limiter-archive' "${summary_tsv}" >/dev/null
+grep -F $'burst64\tactive\t64\tpass\t0.004000\t0.004000\t0.030000\t20\t0\t0\t220\t112\tfairness-limiter-active' "${summary_tsv}" >/dev/null
 
 echo "[transaction-read-fairness-budget] fairness over budget fails"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "archive" { $4 = "25"; $5 = "25" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "arrival16" && $2 == "archive" { $5 = "3"; $6 = "3" } { print }' \
   "${input_tsv}" >"${input_tsv}.fairness-fail"
 if FAIRNESS_BUDGET_NAME=fairness-over \
   FAIRNESS_BUDGET_INPUT_TSV="${input_tsv}.fairness-fail" \
   FAIRNESS_BUDGET_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
-  echo "fairness budget unexpectedly passed fairness 429 over 1%" >&2
+  echo "fairness budget unexpectedly passed arrival16 fairness 429 over 0.1%" >&2
+  exit 1
+fi
+
+echo "[transaction-read-fairness-budget] burst64 backend budget fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "burst64" && $2 == "archive" { $5 = "30"; $6 = "30" } { print }' \
+  "${input_tsv}" >"${input_tsv}.burst64-fail"
+if FAIRNESS_BUDGET_NAME=fairness-burst64 \
+  FAIRNESS_BUDGET_INPUT_TSV="${input_tsv}.burst64-fail" \
+  FAIRNESS_BUDGET_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "fairness budget unexpectedly passed burst64 backend 429 over 0.5%" >&2
   exit 1
 fi
 
 echo "[transaction-read-fairness-budget] cold latency regression fails"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "archive" { $9 = "900" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "arrival16" && $2 == "archive" { $10 = "900" } { print }' \
   "${input_tsv}" >"${input_tsv}.latency-fail"
 if FAIRNESS_BUDGET_NAME=fairness-latency \
   FAIRNESS_BUDGET_INPUT_TSV="${input_tsv}.latency-fail" \
@@ -73,7 +89,7 @@ if FAIRNESS_BUDGET_NAME=fairness-latency \
 fi
 
 echo "[transaction-read-fairness-budget] mixed rejection reason fails"
-awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "archive" { $11 = "fairness-limiter-active" } { print }' \
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "arrival16" && $2 == "archive" { $12 = "fairness-limiter-active" } { print }' \
   "${input_tsv}" >"${input_tsv}.reason-fail"
 if FAIRNESS_BUDGET_NAME=fairness-reason \
   FAIRNESS_BUDGET_INPUT_TSV="${input_tsv}.reason-fail" \

--- a/tools/test/check-transaction-read-runtime-policy-budget.sh
+++ b/tools/test/check-transaction-read-runtime-policy-budget.sh
@@ -30,7 +30,7 @@ plan="$(
 )"
 grep -F "required_profiles=burst48,burst64,burst96,vu16,paced-weighted-vu16" <<<"${plan}" >/dev/null
 grep -F "burst64_429_rate=0.10" <<<"${plan}" >/dev/null
-grep -F "paced_vu16_429_rate=0.005" <<<"${plan}" >/dev/null
+grep -F "paced_vu16_429_rate=0.001" <<<"${plan}" >/dev/null
 grep -F "reject_streak_max=3" <<<"${plan}" >/dev/null
 grep -F "accepted_p95_ms=350" <<<"${plan}" >/dev/null
 
@@ -46,7 +46,7 @@ summary_tsv="${output_dir}/runtime-policy-check-runtime-policy.tsv"
 test "${report_md}" = "${output_dir}/runtime-policy-check-runtime-policy.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "burst64 <= 10% 429" "${report_md}" >/dev/null
-grep -F "paced weighted VU16 <= 0.005 429" "${report_md}" >/dev/null
+grep -F "paced weighted VU16 <= 0.001 429" "${report_md}" >/dev/null
 grep -F "unpaced VU16 operating decision: client-pacing-required" "${report_md}" >/dev/null
 grep -F "Retry-After reject streak <= 3" "${report_md}" >/dev/null
 grep -F $'profile\tstatus\tdecision\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tunknown_429_count\tfive_xx_count\taccepted_p95_ms\tdelayed_rate\tretry_after_p95_ms\treject_streak_max\tpolicy_candidate' "${summary_tsv}" >/dev/null

--- a/tools/test/run-transaction-read-burst64-residual-smoothing.sh
+++ b/tools/test/run-transaction-read-burst64-residual-smoothing.sh
@@ -18,6 +18,7 @@ Environment:
   BURST64_SMOOTHING_MAX_RETRY_P95_MS      default 250
   BURST64_SMOOTHING_MAX_REJECT_STREAK     default 4
   BURST64_SMOOTHING_MAX_DELAYED_RATE      default 0.05
+  BURST64_SMOOTHING_OBSERVED_BURST64_429_RATE default 0.12824 (main659 failed boundary)
 USAGE
 }
 
@@ -51,6 +52,7 @@ max_accepted_p95_ms="${BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS:-120}"
 max_retry_p95_ms="${BURST64_SMOOTHING_MAX_RETRY_P95_MS:-250}"
 max_reject_streak="${BURST64_SMOOTHING_MAX_REJECT_STREAK:-4}"
 max_delayed_rate="${BURST64_SMOOTHING_MAX_DELAYED_RATE:-0.05}"
+observed_main659_burst64_429_rate="${BURST64_SMOOTHING_OBSERVED_BURST64_429_RATE:-0.12824}"
 summary_tsv="${output_dir}/${name}-burst64-residual-smoothing.tsv"
 report_md="${output_dir}/${name}-burst64-residual-smoothing.md"
 
@@ -121,6 +123,7 @@ print_plan() {
   echo "[transaction-read-burst64-residual-smoothing] max_retry_p95_ms=${max_retry_p95_ms}"
   echo "[transaction-read-burst64-residual-smoothing] max_reject_streak=${max_reject_streak}"
   echo "[transaction-read-burst64-residual-smoothing] max_delayed_rate=${max_delayed_rate}"
+  echo "[transaction-read-burst64-residual-smoothing] observed_main659_burst64_429_rate=${observed_main659_burst64_429_rate}"
   echo "[transaction-read-burst64-residual-smoothing] summary_tsv=${summary_tsv}"
   echo "[transaction-read-burst64-residual-smoothing] report_md=${report_md}"
 }
@@ -131,6 +134,7 @@ require_rate "BURST64_SMOOTHING_MAX_BACKEND_429_RATE" "${max_backend_429_rate}"
 require_rate "BURST64_SMOOTHING_MIN_BURST80_429_RATE" "${min_burst80_429_rate}"
 require_rate "BURST64_SMOOTHING_MIN_BURST96_429_RATE" "${min_burst96_429_rate}"
 require_rate "BURST64_SMOOTHING_MAX_DELAYED_RATE" "${max_delayed_rate}"
+require_rate "BURST64_SMOOTHING_OBSERVED_BURST64_429_RATE" "${observed_main659_burst64_429_rate}"
 require_non_negative_number "BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS" "${max_accepted_p95_ms}"
 require_non_negative_number "BURST64_SMOOTHING_MAX_RETRY_P95_MS" "${max_retry_p95_ms}"
 require_non_negative_number "BURST64_SMOOTHING_MAX_REJECT_STREAK" "${max_reject_streak}"
@@ -225,6 +229,7 @@ cat >"${report_md}" <<REPORT
 - gate_status=${gate_status}
 - burst 48 total 429 budget: <= ${max_burst48_429_rate}
 - burst 64 total 429 budget: <= ${max_burst64_429_rate}
+- main659 observed burst64 429: ${observed_main659_burst64_429_rate}
 - backend 429 budget: <= ${max_backend_429_rate}
 - burst 80/96 policy: fail-fast overload lower bound >= ${min_burst80_429_rate}/${min_burst96_429_rate}
 - accepted p95 budget: <= ${max_accepted_p95_ms}ms

--- a/tools/test/run-transaction-read-fairness-budget.sh
+++ b/tools/test/run-transaction-read-fairness-budget.sh
@@ -11,7 +11,8 @@ Environment:
   FAIRNESS_BUDGET_OUTPUT_DIR              default build/reports/k6/<name>
   FAIRNESS_BUDGET_ARRIVAL_RATE            default 16
   FAIRNESS_BUDGET_REQUIRED_ENDPOINTS      default active,archive
-  FAIRNESS_BUDGET_MAX_FAIRNESS_429_RATE   default 0.01
+  FAIRNESS_BUDGET_MAX_FAIRNESS_429_RATE   default 0.001
+  FAIRNESS_BUDGET_MAX_BURST64_BACKEND_429_RATE default 0.005
   FAIRNESS_BUDGET_MAX_EDGE_429_RATE       default 0
   FAIRNESS_BUDGET_COLD_P95_MS             default 750
   FAIRNESS_BUDGET_ACCEPTED_P95_MS         default 350
@@ -41,7 +42,8 @@ input_tsv="${FAIRNESS_BUDGET_INPUT_TSV:-}"
 output_dir="${FAIRNESS_BUDGET_OUTPUT_DIR:-build/reports/k6/${name}}"
 arrival_rate="${FAIRNESS_BUDGET_ARRIVAL_RATE:-16}"
 required_endpoints="${FAIRNESS_BUDGET_REQUIRED_ENDPOINTS:-active,archive}"
-max_fairness_rate="${FAIRNESS_BUDGET_MAX_FAIRNESS_429_RATE:-0.01}"
+max_fairness_rate="${FAIRNESS_BUDGET_MAX_FAIRNESS_429_RATE:-0.001}"
+max_burst64_backend_rate="${FAIRNESS_BUDGET_MAX_BURST64_BACKEND_429_RATE:-0.005}"
 max_edge_rate="${FAIRNESS_BUDGET_MAX_EDGE_429_RATE:-0}"
 cold_p95_budget_ms="${FAIRNESS_BUDGET_COLD_P95_MS:-750}"
 accepted_p95_budget_ms="${FAIRNESS_BUDGET_ACCEPTED_P95_MS:-350}"
@@ -78,6 +80,7 @@ print_plan() {
   echo "[transaction-read-fairness-budget] arrival_rate=${arrival_rate}"
   echo "[transaction-read-fairness-budget] required_endpoints=${required_endpoints}"
   echo "[transaction-read-fairness-budget] max_fairness_429_rate=${max_fairness_rate}"
+  echo "[transaction-read-fairness-budget] max_burst64_backend_429_rate=${max_burst64_backend_rate}"
   echo "[transaction-read-fairness-budget] max_edge_429_rate=${max_edge_rate}"
   echo "[transaction-read-fairness-budget] cold_account_p95_ms=${cold_p95_budget_ms}"
   echo "[transaction-read-fairness-budget] accepted_p95_ms=${accepted_p95_budget_ms}"
@@ -87,6 +90,7 @@ print_plan() {
 
 require_positive_integer "FAIRNESS_BUDGET_ARRIVAL_RATE" "${arrival_rate}"
 require_rate "FAIRNESS_BUDGET_MAX_FAIRNESS_429_RATE" "${max_fairness_rate}"
+require_rate "FAIRNESS_BUDGET_MAX_BURST64_BACKEND_429_RATE" "${max_burst64_backend_rate}"
 require_rate "FAIRNESS_BUDGET_MAX_EDGE_429_RATE" "${max_edge_rate}"
 require_positive_integer "FAIRNESS_BUDGET_COLD_P95_MS" "${cold_p95_budget_ms}"
 require_positive_integer "FAIRNESS_BUDGET_ACCEPTED_P95_MS" "${accepted_p95_budget_ms}"
@@ -107,6 +111,7 @@ awk -F '\t' \
   -v target_rate="${arrival_rate}" \
   -v required_endpoints="${required_endpoints}" \
   -v max_fairness="${max_fairness_rate}" \
+  -v max_burst64_backend="${max_burst64_backend_rate}" \
   -v max_edge="${max_edge_rate}" \
   -v cold_budget="${cold_p95_budget_ms}" \
   -v accepted_budget="${accepted_p95_budget_ms}" '
@@ -117,13 +122,14 @@ function value(name, fallback) {
 BEGIN {
   split(required_endpoints, endpoint_items, ",")
   for (i in endpoint_items) required_endpoint[endpoint_items[i]] = 1
-  print "endpoint\tarrival_rate\tstatus\tfairness_429_rate\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tcold_account_p95_ms\taccepted_p95_ms\trejection_reason"
+  print "traffic_shape\tendpoint\tarrival_rate\tstatus\tfairness_429_rate\tbackend_429_rate\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tcold_account_p95_ms\taccepted_p95_ms\trejection_reason"
 }
 NR == 1 {
   for (i = 1; i <= NF; i++) col[$i] = i
   next
 }
 {
+  traffic_shape = value("traffic_shape", "arrival16")
   endpoint = value("endpoint", "combined")
   rate = value("arrival_rate", "0") + 0
   total = value("total_requests", "0") + 0
@@ -136,22 +142,33 @@ NR == 1 {
   accepted_p95 = value("accepted_p95_ms", "999999") + 0
   rejection_reason = value("rejection_reason", "fairness-limiter")
   fairness_rate = total > 0 ? fairness_count / total : 1
+  backend_rate = total > 0 ? backend_count / total : 1
   edge_rate = total > 0 ? edge_count / total : 1
   status = "pass"
-  if (rate == target_rate) {
+  if (traffic_shape == "arrival16" && rate == target_rate) {
     target_seen = 1
     if (endpoint in required_endpoint) endpoint_seen[endpoint] = 1
   }
-  target_failed = fairness_rate >= max_fairness || edge_rate > max_edge || unknown_count > 0 || five_xx_count > 0 || cold_p95 > cold_budget || accepted_p95 > accepted_budget
+  if (traffic_shape == "burst64") {
+    burst64_seen = 1
+    if (endpoint in required_endpoint) burst64_endpoint_seen[endpoint] = 1
+  }
+  target_failed = unknown_count > 0 || five_xx_count > 0 || cold_p95 > cold_budget || accepted_p95 > accepted_budget
+  if (traffic_shape == "arrival16" && rate == target_rate) {
+    target_failed = target_failed || fairness_rate >= max_fairness || edge_rate > max_edge
+  }
+  if (traffic_shape == "burst64") {
+    target_failed = target_failed || backend_rate > max_burst64_backend
+  }
   if ((endpoint == "active" || endpoint == "archive") && rejection_reason !~ endpoint) {
     target_failed = 1
   }
-  if (rate == target_rate && target_failed) {
+  if (((traffic_shape == "arrival16" && rate == target_rate) || traffic_shape == "burst64") && target_failed) {
     status = "fail"
   }
   if (status == "fail") fail_count++
-  printf "%s\t%s\t%s\t%.6f\t%.6f\t%s\t%s\t%s\t%s\t%s\t%s\n",
-    endpoint, rate, status, fairness_rate, edge_rate, backend_count, unknown_count, five_xx_count, cold_p95, accepted_p95, rejection_reason
+  printf "%s\t%s\t%s\t%s\t%.6f\t%.6f\t%.6f\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    traffic_shape, endpoint, rate, status, fairness_rate, backend_rate, edge_rate, backend_count, unknown_count, five_xx_count, cold_p95, accepted_p95, rejection_reason
 }
 END {
   missing_endpoints = ""
@@ -161,9 +178,15 @@ END {
       missing_endpoints = missing_endpoints endpoint
       fail_count++
     }
+    if (burst64_endpoint_seen[endpoint] != 1) {
+      if (missing_endpoints != "") missing_endpoints = missing_endpoints ","
+      missing_endpoints = missing_endpoints "burst64:" endpoint
+      fail_count++
+    }
   }
   if (missing_endpoints == "") missing_endpoints = "none"
   if (!target_seen) fail_count++
+  if (!burst64_seen) fail_count++
   print "fail_count=" (fail_count + 0) > "/dev/stderr"
   print "target_seen=" (target_seen + 0) > "/dev/stderr"
   print "missing_endpoints=" missing_endpoints > "/dev/stderr"
@@ -180,11 +203,11 @@ fi
 
 fairness_table="$(awk -F '\t' '
   BEGIN {
-    print "| Endpoint | Rate | Status | Fairness 429 | Edge 429 | Backend 429 | Unknown 429 | 5xx | Cold p95 ms | Accepted p95 ms | Rejection reason |"
-    print "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
+    print "| Shape | Endpoint | Rate | Status | Fairness 429 | Backend 429 | Edge 429 | Backend count | Unknown 429 | 5xx | Cold p95 ms | Accepted p95 ms | Rejection reason |"
+    print "| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
   }
   NR > 1 {
-    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
   }
 ' "${summary_tsv}")"
 
@@ -197,6 +220,7 @@ cat >"${report_md}" <<REPORT
 - required endpoints: ${required_endpoints}
 - missing endpoints: ${missing_endpoints}
 - arrival16 backend fairness budget: < ${max_fairness_rate}
+- burst64 backend 429 budget: <= ${max_burst64_backend_rate}
 - edge 429 budget: <= ${max_edge_rate}
 - cold account latency budget: <= ${cold_p95_budget_ms}ms
 - accepted p95 budget: <= ${accepted_p95_budget_ms}ms

--- a/tools/test/run-transaction-read-runtime-policy-budget.sh
+++ b/tools/test/run-transaction-read-runtime-policy-budget.sh
@@ -11,7 +11,7 @@ Environment:
   RUNTIME_POLICY_OUTPUT_DIR           default build/reports/k6/<name>
   RUNTIME_POLICY_REQUIRED_PROFILES    default burst48,burst64,burst96,vu16,paced-weighted-vu16
   RUNTIME_POLICY_BURST64_429_RATE     default 0.10
-  RUNTIME_POLICY_PACED_VU16_429_RATE  default 0.005
+  RUNTIME_POLICY_PACED_VU16_429_RATE  default 0.001
   RUNTIME_POLICY_REJECT_STREAK_MAX    default 3
   RUNTIME_POLICY_ACCEPTED_P95_MS      default 350
   RUNTIME_POLICY_DELAYED_RATE         default 0.25
@@ -43,7 +43,7 @@ input_tsv="${RUNTIME_POLICY_INPUT_TSV:-}"
 output_dir="${RUNTIME_POLICY_OUTPUT_DIR:-build/reports/k6/${name}}"
 required_profiles="${RUNTIME_POLICY_REQUIRED_PROFILES:-burst48,burst64,burst96,vu16,paced-weighted-vu16}"
 burst64_429_rate="${RUNTIME_POLICY_BURST64_429_RATE:-0.10}"
-paced_vu16_429_rate="${RUNTIME_POLICY_PACED_VU16_429_RATE:-0.005}"
+paced_vu16_429_rate="${RUNTIME_POLICY_PACED_VU16_429_RATE:-0.001}"
 reject_streak_max="${RUNTIME_POLICY_REJECT_STREAK_MAX:-3}"
 accepted_p95_ms="${RUNTIME_POLICY_ACCEPTED_P95_MS:-350}"
 delayed_rate="${RUNTIME_POLICY_DELAYED_RATE:-0.25}"
@@ -202,7 +202,7 @@ cat >"${report_md}" <<REPORT
 - required profiles: ${required_profiles}
 - missing profiles: ${missing_profiles}
 - burst64 <= 10% 429: ${burst64_429_rate}
-- paced weighted VU16 <= 0.005 429: ${paced_vu16_429_rate}
+- paced weighted VU16 <= 0.001 429: ${paced_vu16_429_rate}
 - unpaced VU16 operating decision: client-pacing-required
 - Retry-After reject streak <= 3: ${reject_streak_max}
 - accepted p95 budget: <= ${accepted_p95_ms}ms


### PR DESCRIPTION
## 🔗 Related Issue
- close #661

## 🌿 Base Branch
- `main`

## 📝 Summary
- main659 burst64 실패 경계와 VU16 pacing budget을 production gate 기준으로 재보정했습니다.
- arrival16 fairness와 burst64 backend budget을 분리하고, saturation guard에 연속 포화 hysteresis를 추가했습니다.

## 🛠 Changes
- burst64 smoothing report에 main659 observed burst64 429 `0.12824`를 명시해 실패 경계를 추적합니다.
- paced weighted VU16 허용 budget을 `0.005`에서 `0.001`로 낮췄습니다.
- fairness gate를 `arrival16 < 0.1%`, `burst64 backend <= 0.5%`로 분리했습니다.
- T3 saturation guard가 보호 경로별 연속 saturated sample 기준을 만족할 때만 reject하도록 hysteresis를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-burst64-residual-smoothing.sh`
- `bash tools/test/check-transaction-read-runtime-policy-budget.sh`
- `bash tools/test/check-transaction-read-fairness-budget.sh`
- `tools/test/with-resource-lock.sh back-saturation-hysteresis ./back/gradlew -p back test --tests com.aquilabank.global.ops.T3MicroSaturationGuardTest`
- pre-commit: `./back/gradlew -p back check`
- `git diff --check`
- `git rev-list --count main..HEAD` => `4`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: paced VU16/fairness gate가 더 엄격해져 기존 evidence TSV가 실패할 수 있습니다. saturation guard는 기본 constructor binding에서 연속 2회 포화 후 reject합니다.
- 롤백 방법: 이 PR revert 후 이전 defensive policy gate와 즉시 saturation reject 동작으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?