### PR TITLE
[Perf] OCI transaction read source evidence closure

### DIFF
--- a/tools/test/check-oci-real-multisource-public-evidence.sh
+++ b/tools/test/check-oci-real-multisource-public-evidence.sh
@@ -53,38 +53,44 @@ multi-source	198.51.100.13	REJECTED	80
 TSV
 
 cat >"${source_evidence_tsv}" <<'TSV'
-source_name	docker_context	realip_remote_addr	edge_429_rate	backend_429_rate	accepted_p95_ms	five_xx_count
-source-a	oci-k6-a	198.51.100.10	0.081	0	154.0	0
-source-b	oci-k6-b	198.51.100.11	0.089	0	158.0	0
+source_name	run_id	docker_context	realip_remote_addr	edge_429_rate	backend_429_rate	accepted_p95_ms	five_xx_count	artifact_uri
+source-a	oci-source-evidence-20260503	oci-k6-a	198.51.100.10	0.081	0	154.0	0	oci://aquila-evidence/transaction-read/oci-source-evidence-20260503/source-a
+source-b	oci-source-evidence-20260503	oci-k6-b	198.51.100.11	0.089	0	158.0	0	oci://aquila-evidence/transaction-read/oci-source-evidence-20260503/source-b
 TSV
 
 echo "[oci-real-multisource-public-evidence] print plan"
 plan="$(
   OCI_REAL_MULTISOURCE_NAME=real-multi-check \
+  OCI_REAL_MULTISOURCE_RUN_ID=oci-source-evidence-20260503 \
   OCI_REAL_MULTISOURCE_CONTEXTS=oci-k6-a,oci-k6-b \
   OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON="${single_summary}" \
   OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON="${multi_summary}" \
   OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV="${status_tsv}" \
   OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV="${source_evidence_tsv}" \
+  OCI_REAL_MULTISOURCE_ARTIFACT_URI=oci://aquila-evidence/transaction-read/oci-source-evidence-20260503 \
   OCI_REAL_MULTISOURCE_OUTPUT_DIR="${output_dir}" \
     "${runner}" --print-plan
 )"
 grep -F "name=real-multi-check" <<<"${plan}" >/dev/null
+grep -F "run_id=oci-source-evidence-20260503" <<<"${plan}" >/dev/null
 grep -F "docker_context_count=2" <<<"${plan}" >/dev/null
 grep -F "true_multi_source_required=true" <<<"${plan}" >/dev/null
 grep -F "minimum_remote_docker_contexts=2" <<<"${plan}" >/dev/null
 grep -F "source_evidence_tsv=${source_evidence_tsv}" <<<"${plan}" >/dev/null
+grep -F "artifact_uri=oci://aquila-evidence/transaction-read/oci-source-evidence-20260503" <<<"${plan}" >/dev/null
 grep -F "multi_source_runner=tools/test/run-k6-transaction-100m-multisource.sh" <<<"${plan}" >/dev/null
 grep -F "replay_gate=tools/test/run-oci-real-ip-multisource-capacity-replay.sh" <<<"${plan}" >/dev/null
 
 echo "[oci-real-multisource-public-evidence] pass report"
 output="$(
   OCI_REAL_MULTISOURCE_NAME=real-multi-check \
+  OCI_REAL_MULTISOURCE_RUN_ID=oci-source-evidence-20260503 \
   OCI_REAL_MULTISOURCE_CONTEXTS=oci-k6-a,oci-k6-b \
   OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON="${single_summary}" \
   OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON="${multi_summary}" \
   OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV="${status_tsv}" \
   OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV="${source_evidence_tsv}" \
+  OCI_REAL_MULTISOURCE_ARTIFACT_URI=oci://aquila-evidence/transaction-read/oci-source-evidence-20260503 \
   OCI_REAL_MULTISOURCE_OUTPUT_DIR="${output_dir}" \
     "${runner}"
 )"
@@ -93,6 +99,8 @@ contexts_tsv="${output_dir}/real-multi-check-real-multisource-contexts.tsv"
 source_summary_tsv="${output_dir}/real-multi-check-real-multisource-source-summary.tsv"
 test "${report_md}" = "${output_dir}/real-multi-check-real-multisource-public-evidence.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "actual execution run id: oci-source-evidence-20260503" "${report_md}" >/dev/null
+grep -F "artifact reference: oci://aquila-evidence/transaction-read/oci-source-evidence-20260503" "${report_md}" >/dev/null
 grep -F "docker context count: 2" "${report_md}" >/dev/null
 grep -F "single-source vs multi-source comparison: fixed" "${report_md}" >/dev/null
 grep -F "real IP bucket split: verified" "${report_md}" >/dev/null
@@ -101,17 +109,19 @@ grep -F "true multi-source public traffic evidence: fixed" "${report_md}" >/dev/
 grep -F $'index\tdocker_context' "${contexts_tsv}" >/dev/null
 grep -F $'1\toci-k6-a' "${contexts_tsv}" >/dev/null
 grep -F $'2\toci-k6-b' "${contexts_tsv}" >/dev/null
-grep -F $'source_name\tdocker_context\trealip_remote_addr\tedge_429_rate\tbackend_429_rate\taccepted_p95_ms\tfive_xx_count' "${source_summary_tsv}" >/dev/null
-grep -F $'source-a\toci-k6-a\t198.51.100.10\t0.081\t0\t154.0\t0' "${source_summary_tsv}" >/dev/null
-grep -F $'source-b\toci-k6-b\t198.51.100.11\t0.089\t0\t158.0\t0' "${source_summary_tsv}" >/dev/null
+grep -F $'source_name\trun_id\tdocker_context\trealip_remote_addr\tedge_429_rate\tbackend_429_rate\taccepted_p95_ms\tfive_xx_count\tartifact_uri' "${source_summary_tsv}" >/dev/null
+grep -F $'source-a\toci-source-evidence-20260503\toci-k6-a\t198.51.100.10\t0.081\t0\t154.0\t0\toci://aquila-evidence/transaction-read/oci-source-evidence-20260503/source-a' "${source_summary_tsv}" >/dev/null
+grep -F $'source-b\toci-source-evidence-20260503\toci-k6-b\t198.51.100.11\t0.089\t0\t158.0\t0\toci://aquila-evidence/transaction-read/oci-source-evidence-20260503/source-b' "${source_summary_tsv}" >/dev/null
 
 echo "[oci-real-multisource-public-evidence] one context fails"
 if OCI_REAL_MULTISOURCE_NAME=real-multi-one-context \
+  OCI_REAL_MULTISOURCE_RUN_ID=oci-source-evidence-20260503 \
   OCI_REAL_MULTISOURCE_CONTEXTS=oci-k6-a \
   OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON="${single_summary}" \
   OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON="${multi_summary}" \
   OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV="${status_tsv}" \
   OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV="${source_evidence_tsv}" \
+  OCI_REAL_MULTISOURCE_ARTIFACT_URI=oci://aquila-evidence/transaction-read/oci-source-evidence-20260503 \
   OCI_REAL_MULTISOURCE_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "real multi-source public evidence unexpectedly passed one context" >&2
@@ -121,13 +131,31 @@ fi
 echo "[oci-real-multisource-public-evidence] one source evidence fails"
 awk -F '\t' 'NR == 1 || $1 == "source-a"' "${source_evidence_tsv}" >"${source_evidence_tsv}.one-source"
 if OCI_REAL_MULTISOURCE_NAME=real-multi-one-source \
+  OCI_REAL_MULTISOURCE_RUN_ID=oci-source-evidence-20260503 \
   OCI_REAL_MULTISOURCE_CONTEXTS=oci-k6-a,oci-k6-b \
   OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON="${single_summary}" \
   OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON="${multi_summary}" \
   OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV="${status_tsv}" \
   OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV="${source_evidence_tsv}.one-source" \
+  OCI_REAL_MULTISOURCE_ARTIFACT_URI=oci://aquila-evidence/transaction-read/oci-source-evidence-20260503 \
   OCI_REAL_MULTISOURCE_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "real multi-source public evidence unexpectedly passed one source evidence row" >&2
+  exit 1
+fi
+
+echo "[oci-real-multisource-public-evidence] blank source artifact fails"
+awk -F '\t' 'BEGIN { OFS = "\t" } NR == 1 { print; next } { if ($1 == "source-b") $9 = ""; print }' "${source_evidence_tsv}" >"${source_evidence_tsv}.blank-artifact"
+if OCI_REAL_MULTISOURCE_NAME=real-multi-blank-artifact \
+  OCI_REAL_MULTISOURCE_RUN_ID=oci-source-evidence-20260503 \
+  OCI_REAL_MULTISOURCE_CONTEXTS=oci-k6-a,oci-k6-b \
+  OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON="${single_summary}" \
+  OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON="${multi_summary}" \
+  OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV="${status_tsv}" \
+  OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV="${source_evidence_tsv}.blank-artifact" \
+  OCI_REAL_MULTISOURCE_ARTIFACT_URI=oci://aquila-evidence/transaction-read/oci-source-evidence-20260503 \
+  OCI_REAL_MULTISOURCE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "real multi-source public evidence unexpectedly passed blank source artifact" >&2
   exit 1
 fi

--- a/tools/test/check-transaction-read-100m-multi-account-fixture.sh
+++ b/tools/test/check-transaction-read-100m-multi-account-fixture.sh
@@ -40,27 +40,34 @@ TSV
 echo "[transaction-100m-multi-account] print plan"
 plan="$(
   MULTI_ACCOUNT_FIXTURE_NAME=multi-account-check \
+  MULTI_ACCOUNT_RUN_ID=oci-100m-source-evidence-20260503 \
   MULTI_ACCOUNT_HOT_ACCOUNT_IDS=910000001,910000003,910000005 \
   MULTI_ACCOUNT_COLD_ACCOUNT_IDS=910000002,910000004 \
   MULTI_ACCOUNT_ACCOUNT_RESULT_TSV="${account_result_tsv}" \
+  MULTI_ACCOUNT_ARTIFACT_URI=oci://aquila-evidence/transaction-read/oci-100m-source-evidence-20260503 \
   MULTI_ACCOUNT_OUTPUT_DIR="${output_dir}" \
     "${runner}" --print-plan
 )"
+grep -F "run_id=oci-100m-source-evidence-20260503" <<<"${plan}" >/dev/null
 grep -F "hot_account_count=3" <<<"${plan}" >/dev/null
 grep -F "cold_account_count=2" <<<"${plan}" >/dev/null
+grep -F "minimum_total_account_count=4" <<<"${plan}" >/dev/null
 grep -F "target_total_rows=100000000" <<<"${plan}" >/dev/null
 grep -F "total_rows=100000000" <<<"${plan}" >/dev/null
 grep -F "hot_rows_per_account=33000000 hot_rows_remainder=0" <<<"${plan}" >/dev/null
 grep -F "cold_rows_per_account=500000" <<<"${plan}" >/dev/null
 grep -F "account_result_tsv=${account_result_tsv}" <<<"${plan}" >/dev/null
+grep -F "artifact_uri=oci://aquila-evidence/transaction-read/oci-100m-source-evidence-20260503" <<<"${plan}" >/dev/null
 grep -F "k6_env=K6_HOT_ACCOUNT_IDS=910000001,910000003,910000005 K6_COLD_ACCOUNT_IDS=910000002,910000004" <<<"${plan}" >/dev/null
 
 echo "[transaction-100m-multi-account] manifest report"
 output="$(
   MULTI_ACCOUNT_FIXTURE_NAME=multi-account-check \
+  MULTI_ACCOUNT_RUN_ID=oci-100m-source-evidence-20260503 \
   MULTI_ACCOUNT_HOT_ACCOUNT_IDS=910000001,910000003,910000005 \
   MULTI_ACCOUNT_COLD_ACCOUNT_IDS=910000002,910000004 \
   MULTI_ACCOUNT_ACCOUNT_RESULT_TSV="${account_result_tsv}" \
+  MULTI_ACCOUNT_ARTIFACT_URI=oci://aquila-evidence/transaction-read/oci-100m-source-evidence-20260503 \
   MULTI_ACCOUNT_OUTPUT_DIR="${output_dir}" \
     "${runner}"
 )"
@@ -69,6 +76,8 @@ manifest_json="${output_dir}/multi-account-check-multi-account-fixture.json"
 distribution_tsv="${output_dir}/multi-account-check-multi-account-distribution.tsv"
 account_summary_tsv="${output_dir}/multi-account-check-multi-account-account-summary.tsv"
 test "${report_md}" = "${output_dir}/multi-account-check-multi-account-fixture.md"
+grep -F '"runId":"oci-100m-source-evidence-20260503"' "${manifest_json}" >/dev/null
+grep -F '"artifactUri":"oci://aquila-evidence/transaction-read/oci-100m-source-evidence-20260503"' "${manifest_json}" >/dev/null
 grep -F '"hotAccountIds":["910000001","910000003","910000005"]' "${manifest_json}" >/dev/null
 grep -F '"coldAccountIds":["910000002","910000004"]' "${manifest_json}" >/dev/null
 grep -F '"targetTotalRows":100000000' "${manifest_json}" >/dev/null
@@ -78,19 +87,33 @@ grep -F '"coldRowsPerAccount":500000' "${manifest_json}" >/dev/null
 grep -F $'account_group\taccount_id\tplanned_rows' "${distribution_tsv}" >/dev/null
 grep -F $'hot\t910000001\t33000000' "${distribution_tsv}" >/dev/null
 grep -F $'cold\t910000004\t500000' "${distribution_tsv}" >/dev/null
-grep -F $'all\t5\t100000000\t29\t0.004' "${account_summary_tsv}" >/dev/null
+grep -F $'scope\taccount_count\tplanned_rows\tplanned_row_skew_ratio\taccepted_p95_spread_ms\trejected_429_spread' "${account_summary_tsv}" >/dev/null
+grep -F $'all\t5\t100000000\t66.000\t29\t0.004' "${account_summary_tsv}" >/dev/null
+grep -F "actual execution run id: oci-100m-source-evidence-20260503" "${report_md}" >/dev/null
+grep -F "artifact reference: oci://aquila-evidence/transaction-read/oci-100m-source-evidence-20260503" "${report_md}" >/dev/null
 grep -F "per-account fairness metric: aquila_transaction_fairness_429_count{account_id,account_group}" "${report_md}" >/dev/null
 grep -F "global throughput and per-account fairness are reported separately" "${report_md}" >/dev/null
 grep -F "account result summary: ${account_summary_tsv}" "${report_md}" >/dev/null
 
-echo "[transaction-100m-multi-account] missing account result fails when required"
+echo "[transaction-100m-multi-account] missing account result fails by default"
 if MULTI_ACCOUNT_FIXTURE_NAME=multi-account-missing-result \
   MULTI_ACCOUNT_HOT_ACCOUNT_IDS=910000001,910000003,910000005 \
   MULTI_ACCOUNT_COLD_ACCOUNT_IDS=910000002,910000004 \
-  MULTI_ACCOUNT_REQUIRE_ACCOUNT_RESULT_TSV=true \
+  MULTI_ACCOUNT_ARTIFACT_URI=oci://aquila-evidence/transaction-read/missing-result \
   MULTI_ACCOUNT_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "multi-account fixture unexpectedly passed missing account result TSV" >&2
+  exit 1
+fi
+
+echo "[transaction-100m-multi-account] missing artifact reference fails by default"
+if MULTI_ACCOUNT_FIXTURE_NAME=multi-account-missing-artifact \
+  MULTI_ACCOUNT_HOT_ACCOUNT_IDS=910000001,910000003,910000005 \
+  MULTI_ACCOUNT_COLD_ACCOUNT_IDS=910000002,910000004 \
+  MULTI_ACCOUNT_ACCOUNT_RESULT_TSV="${account_result_tsv}" \
+  MULTI_ACCOUNT_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "multi-account fixture unexpectedly passed missing artifact URI" >&2
   exit 1
 fi
 
@@ -98,8 +121,22 @@ echo "[transaction-100m-multi-account] single hot account fails"
 if MULTI_ACCOUNT_FIXTURE_NAME=multi-account-fail \
   MULTI_ACCOUNT_HOT_ACCOUNT_IDS=910000001 \
   MULTI_ACCOUNT_COLD_ACCOUNT_IDS=910000002,910000004 \
+  MULTI_ACCOUNT_ACCOUNT_RESULT_TSV="${account_result_tsv}" \
+  MULTI_ACCOUNT_ARTIFACT_URI=oci://aquila-evidence/transaction-read/single-hot \
   MULTI_ACCOUNT_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "multi-account fixture unexpectedly passed single hot account" >&2
+  exit 1
+fi
+
+echo "[transaction-100m-multi-account] single cold account fails"
+if MULTI_ACCOUNT_FIXTURE_NAME=multi-account-single-cold \
+  MULTI_ACCOUNT_HOT_ACCOUNT_IDS=910000001,910000003,910000005 \
+  MULTI_ACCOUNT_COLD_ACCOUNT_IDS=910000002 \
+  MULTI_ACCOUNT_ACCOUNT_RESULT_TSV="${account_result_tsv}" \
+  MULTI_ACCOUNT_ARTIFACT_URI=oci://aquila-evidence/transaction-read/single-cold \
+  MULTI_ACCOUNT_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "multi-account fixture unexpectedly passed single cold account" >&2
   exit 1
 fi

--- a/tools/test/run-oci-real-multisource-public-evidence.sh
+++ b/tools/test/run-oci-real-multisource-public-evidence.sh
@@ -7,11 +7,13 @@ usage: tools/test/run-oci-real-multisource-public-evidence.sh [--print-plan]
 
 Environment:
   OCI_REAL_MULTISOURCE_NAME                       default oci-real-multisource-public-<timestamp>
+  OCI_REAL_MULTISOURCE_RUN_ID                     default same as OCI_REAL_MULTISOURCE_NAME
   OCI_REAL_MULTISOURCE_CONTEXTS                   required comma-separated remote Docker contexts, at least 2
   OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON required single-source k6 summary JSON
   OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON  required multi-source k6 summary JSON
   OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV           required TSV: run,realip_remote_addr,limit_req_status,count
-  OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV        required TSV: source_name,docker_context,realip_remote_addr,edge_429_rate,backend_429_rate,accepted_p95_ms,five_xx_count
+  OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV        required TSV: source_name,run_id,docker_context,realip_remote_addr,edge_429_rate,backend_429_rate,accepted_p95_ms,five_xx_count,artifact_uri
+  OCI_REAL_MULTISOURCE_ARTIFACT_URI               required evidence artifact reference
   OCI_REAL_MULTISOURCE_OUTPUT_DIR                 default build/reports/k6/<name>
 USAGE
 }
@@ -35,11 +37,13 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 name="${OCI_REAL_MULTISOURCE_NAME:-oci-real-multisource-public-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${OCI_REAL_MULTISOURCE_RUN_ID:-${name}}"
 contexts_csv="${OCI_REAL_MULTISOURCE_CONTEXTS:-}"
 single_summary="${OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON:-}"
 multi_summary="${OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON:-}"
 nginx_status_tsv="${OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV:-}"
 source_evidence_tsv="${OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV:-}"
+artifact_uri="${OCI_REAL_MULTISOURCE_ARTIFACT_URI:-}"
 output_dir="${OCI_REAL_MULTISOURCE_OUTPUT_DIR:-build/reports/k6/${name}}"
 multi_source_runner="tools/test/run-k6-transaction-100m-multisource.sh"
 replay_gate="tools/test/run-oci-real-ip-multisource-capacity-replay.sh"
@@ -54,6 +58,15 @@ require_file() {
   local file="$2"
   if [[ -z "${file}" || ! -s "${file}" ]]; then
     echo "${key} is required and must be a non-empty file: ${file:-missing}" >&2
+    exit 1
+  fi
+}
+
+require_non_empty() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "${key} is required" >&2
     exit 1
   fi
 }
@@ -79,10 +92,10 @@ parse_contexts() {
 
 validate_source_evidence() {
   require_file "OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV" "${source_evidence_tsv}"
-  awk -F '\t' -v min_sources="${#contexts[@]}" '
+  awk -F '\t' -v min_sources="${#contexts[@]}" -v expected_run_id="${run_id}" '
     NR == 1 {
       for (i = 1; i <= NF; i++) col[$i] = i
-      split("source_name docker_context realip_remote_addr edge_429_rate backend_429_rate accepted_p95_ms five_xx_count", required, " ")
+      split("source_name run_id docker_context realip_remote_addr edge_429_rate backend_429_rate accepted_p95_ms five_xx_count artifact_uri", required, " ")
       for (i in required) {
         if (!(required[i] in col)) {
           printf "missing required column: %s\n", required[i] > "/dev/stderr"
@@ -94,15 +107,21 @@ validate_source_evidence() {
     }
     {
       source_name = $(col["source_name"])
+      source_run_id = $(col["run_id"])
       context = $(col["docker_context"])
       real_ip = $(col["realip_remote_addr"])
+      source_artifact_uri = $(col["artifact_uri"])
       edge_429 = $(col["edge_429_rate"]) + 0
       backend_429 = $(col["backend_429_rate"]) + 0
       p95 = $(col["accepted_p95_ms"]) + 0
       five_xx = $(col["five_xx_count"]) + 0
-      if (source_name == "" || context == "" || real_ip == "") {
-        print "source evidence contains blank source/context/real IP" > "/dev/stderr"
+      if (source_name == "" || source_run_id == "" || context == "" || real_ip == "" || source_artifact_uri == "") {
+        print "source evidence contains blank source/run/context/real IP/artifact" > "/dev/stderr"
         exit 3
+      }
+      if (source_run_id != expected_run_id) {
+        printf "source evidence run id mismatch: source=%s run_id=%s expected=%s\n", source_name, source_run_id, expected_run_id > "/dev/stderr"
+        exit 7
       }
       if (edge_429 < 0 || edge_429 > 1 || backend_429 < 0 || backend_429 > 1 || p95 <= 0 || five_xx != 0) {
         printf "source evidence metric out of contract: source=%s edge429=%s backend429=%s p95=%s five_xx=%s\n", source_name, edge_429, backend_429, p95, five_xx > "/dev/stderr"
@@ -130,6 +149,7 @@ validate_source_evidence() {
 print_plan() {
   parse_contexts
   echo "[oci-real-multisource-public-evidence] name=${name}"
+  echo "[oci-real-multisource-public-evidence] run_id=${run_id}"
   echo "[oci-real-multisource-public-evidence] docker_contexts=${contexts_csv}"
   echo "[oci-real-multisource-public-evidence] docker_context_count=${#contexts[@]}"
   echo "[oci-real-multisource-public-evidence] true_multi_source_required=true"
@@ -138,6 +158,7 @@ print_plan() {
   echo "[oci-real-multisource-public-evidence] multi_source_summary=${multi_summary:-missing}"
   echo "[oci-real-multisource-public-evidence] nginx_status_tsv=${nginx_status_tsv:-missing}"
   echo "[oci-real-multisource-public-evidence] source_evidence_tsv=${source_evidence_tsv:-missing}"
+  echo "[oci-real-multisource-public-evidence] artifact_uri=${artifact_uri:-missing}"
   echo "[oci-real-multisource-public-evidence] multi_source_runner=${multi_source_runner}"
   echo "[oci-real-multisource-public-evidence] replay_gate=${replay_gate}"
   echo "[oci-real-multisource-public-evidence] contexts_tsv=${contexts_tsv}"
@@ -157,6 +178,7 @@ require_file "OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON" "${single_summary
 require_file "OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON" "${multi_summary}"
 require_file "OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV" "${nginx_status_tsv}"
 require_file "OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV" "${source_evidence_tsv}"
+require_non_empty "OCI_REAL_MULTISOURCE_ARTIFACT_URI" "${artifact_uri}"
 mkdir -p "${output_dir}"
 
 {
@@ -185,6 +207,8 @@ cat >"${report_md}" <<REPORT
 ## Summary
 
 - gate_status=pass
+- actual execution run id: ${run_id}
+- artifact reference: ${artifact_uri}
 - docker context count: ${#contexts[@]}
 - true multi-source public traffic evidence: fixed
 - single-source vs multi-source comparison: fixed

--- a/tools/test/run-transaction-read-100m-multi-account-fixture.sh
+++ b/tools/test/run-transaction-read-100m-multi-account-fixture.sh
@@ -7,14 +7,19 @@ usage: tools/test/run-transaction-read-100m-multi-account-fixture.sh [--print-pl
 
 Environment:
   MULTI_ACCOUNT_FIXTURE_NAME            default transaction-100m-multi-account-<timestamp>
+  MULTI_ACCOUNT_RUN_ID                  default same as MULTI_ACCOUNT_FIXTURE_NAME
   MULTI_ACCOUNT_HOT_ACCOUNT_IDS         comma-separated hot account ids, min 2
-  MULTI_ACCOUNT_COLD_ACCOUNT_IDS        comma-separated cold account ids, min 1
+  MULTI_ACCOUNT_COLD_ACCOUNT_IDS        comma-separated cold account ids, min 2
+  MULTI_ACCOUNT_MIN_TOTAL_ACCOUNT_COUNT default 4
+  MULTI_ACCOUNT_MIN_COLD_ACCOUNT_COUNT  default 2
   MULTI_ACCOUNT_TARGET_TOTAL_ROWS       default 100000000
   MULTI_ACCOUNT_HOT_ROWS_PER_ACCOUNT    default derived from target total rows
   MULTI_ACCOUNT_COLD_ROWS_PER_ACCOUNT   default 500000
   MULTI_ACCOUNT_ENFORCE_TARGET_TOTAL_ROWS default true
-  MULTI_ACCOUNT_ACCOUNT_RESULT_TSV      optional TSV: account_group,account_id,planned_rows,accepted_p95_ms,rejected_429_rate
-  MULTI_ACCOUNT_REQUIRE_ACCOUNT_RESULT_TSV default false
+  MULTI_ACCOUNT_ACCOUNT_RESULT_TSV      TSV: account_group,account_id,planned_rows,accepted_p95_ms,rejected_429_rate
+  MULTI_ACCOUNT_REQUIRE_ACCOUNT_RESULT_TSV default true
+  MULTI_ACCOUNT_ARTIFACT_URI            required evidence artifact reference
+  MULTI_ACCOUNT_REQUIRE_ARTIFACT_URI    default true
   MULTI_ACCOUNT_HOT_FROM                default 2026-04-01T00:00:00Z
   MULTI_ACCOUNT_HOT_TO                  default 2026-04-30T00:00:00Z
   MULTI_ACCOUNT_COLD_FROM               default 2026-01-01T00:00:00Z
@@ -42,14 +47,19 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 name="${MULTI_ACCOUNT_FIXTURE_NAME:-transaction-100m-multi-account-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${MULTI_ACCOUNT_RUN_ID:-${name}}"
 hot_ids="${MULTI_ACCOUNT_HOT_ACCOUNT_IDS:-}"
 cold_ids="${MULTI_ACCOUNT_COLD_ACCOUNT_IDS:-}"
+min_total_account_count="${MULTI_ACCOUNT_MIN_TOTAL_ACCOUNT_COUNT:-4}"
+min_cold_account_count="${MULTI_ACCOUNT_MIN_COLD_ACCOUNT_COUNT:-2}"
 target_total_rows="${MULTI_ACCOUNT_TARGET_TOTAL_ROWS:-100000000}"
 hot_rows_per_account="${MULTI_ACCOUNT_HOT_ROWS_PER_ACCOUNT:-}"
 cold_rows_per_account="${MULTI_ACCOUNT_COLD_ROWS_PER_ACCOUNT:-500000}"
 enforce_target_total_rows="${MULTI_ACCOUNT_ENFORCE_TARGET_TOTAL_ROWS:-true}"
 account_result_tsv="${MULTI_ACCOUNT_ACCOUNT_RESULT_TSV:-}"
-require_account_result_tsv="${MULTI_ACCOUNT_REQUIRE_ACCOUNT_RESULT_TSV:-false}"
+require_account_result_tsv="${MULTI_ACCOUNT_REQUIRE_ACCOUNT_RESULT_TSV:-true}"
+artifact_uri="${MULTI_ACCOUNT_ARTIFACT_URI:-}"
+require_artifact_uri="${MULTI_ACCOUNT_REQUIRE_ARTIFACT_URI:-true}"
 hot_from="${MULTI_ACCOUNT_HOT_FROM:-2026-04-01T00:00:00Z}"
 hot_to="${MULTI_ACCOUNT_HOT_TO:-2026-04-30T00:00:00Z}"
 cold_from="${MULTI_ACCOUNT_COLD_FROM:-2026-01-01T00:00:00Z}"
@@ -75,6 +85,15 @@ require_bool() {
   local value="$2"
   if [[ "${value}" != "true" && "${value}" != "false" ]]; then
     echo "${key} must be true or false: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_non_empty() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "${key} is required" >&2
     exit 1
   fi
 }
@@ -138,14 +157,22 @@ json_array() {
 }
 
 validate_account_csv "MULTI_ACCOUNT_HOT_ACCOUNT_IDS" "${hot_ids}" 2
-validate_account_csv "MULTI_ACCOUNT_COLD_ACCOUNT_IDS" "${cold_ids}" 1
+validate_account_csv "MULTI_ACCOUNT_COLD_ACCOUNT_IDS" "${cold_ids}" "${min_cold_account_count}"
+require_positive_integer "MULTI_ACCOUNT_MIN_TOTAL_ACCOUNT_COUNT" "${min_total_account_count}"
+require_positive_integer "MULTI_ACCOUNT_MIN_COLD_ACCOUNT_COUNT" "${min_cold_account_count}"
 require_positive_integer "MULTI_ACCOUNT_TARGET_TOTAL_ROWS" "${target_total_rows}"
 require_positive_integer "MULTI_ACCOUNT_COLD_ROWS_PER_ACCOUNT" "${cold_rows_per_account}"
 require_bool "MULTI_ACCOUNT_ENFORCE_TARGET_TOTAL_ROWS" "${enforce_target_total_rows}"
 require_bool "MULTI_ACCOUNT_REQUIRE_ACCOUNT_RESULT_TSV" "${require_account_result_tsv}"
+require_bool "MULTI_ACCOUNT_REQUIRE_ARTIFACT_URI" "${require_artifact_uri}"
 
 hot_count="$(csv_count "${hot_ids}")"
 cold_count="$(csv_count "${cold_ids}")"
+total_account_count="$((hot_count + cold_count))"
+if ((total_account_count < min_total_account_count)); then
+  echo "multi-account fixture requires at least ${min_total_account_count} accounts: total=${total_account_count}" >&2
+  exit 1
+fi
 cold_total_rows="$((cold_count * cold_rows_per_account))"
 hot_rows_remainder=0
 if [[ -z "${hot_rows_per_account}" ]]; then
@@ -168,16 +195,23 @@ fi
 if [[ "${require_account_result_tsv}" == "true" ]]; then
   require_file "MULTI_ACCOUNT_ACCOUNT_RESULT_TSV" "${account_result_tsv}"
 fi
+if [[ "${require_artifact_uri}" == "true" ]]; then
+  require_non_empty "MULTI_ACCOUNT_ARTIFACT_URI" "${artifact_uri}"
+fi
 
 print_plan() {
   echo "[transaction-100m-multi-account] name=${name}"
+  echo "[transaction-100m-multi-account] run_id=${run_id}"
   echo "[transaction-100m-multi-account] hot_account_count=${hot_count}"
   echo "[transaction-100m-multi-account] cold_account_count=${cold_count}"
+  echo "[transaction-100m-multi-account] total_account_count=${total_account_count}"
+  echo "[transaction-100m-multi-account] minimum_total_account_count=${min_total_account_count}"
   echo "[transaction-100m-multi-account] target_total_rows=${target_total_rows}"
   echo "[transaction-100m-multi-account] total_rows=${total_rows}"
   echo "[transaction-100m-multi-account] hot_rows_per_account=${hot_rows_per_account} hot_rows_remainder=${hot_rows_remainder}"
   echo "[transaction-100m-multi-account] cold_rows_per_account=${cold_rows_per_account}"
   echo "[transaction-100m-multi-account] account_result_tsv=${account_result_tsv:-missing}"
+  echo "[transaction-100m-multi-account] artifact_uri=${artifact_uri:-missing}"
   echo "[transaction-100m-multi-account] k6_env=K6_HOT_ACCOUNT_IDS=${hot_ids} K6_COLD_ACCOUNT_IDS=${cold_ids}"
   echo "[transaction-100m-multi-account] k6_command=${k6_runner}"
   echo "[transaction-100m-multi-account] manifest_json=${manifest_json}"
@@ -218,9 +252,9 @@ write_distribution_tsv() {
 
 write_account_summary_tsv() {
   {
-    printf "scope\taccount_count\tplanned_rows\taccepted_p95_spread_ms\trejected_429_spread\n"
+    printf "scope\taccount_count\tplanned_rows\tplanned_row_skew_ratio\taccepted_p95_spread_ms\trejected_429_spread\n"
     if [[ -z "${account_result_tsv}" ]]; then
-      printf "all\t0\t0\t0\t0\n"
+      printf "all\t0\t0\t0.000\t0\t0\n"
       return 0
     fi
     require_file "MULTI_ACCOUNT_ACCOUNT_RESULT_TSV" "${account_result_tsv}"
@@ -238,7 +272,10 @@ write_account_summary_tsv() {
       }
       {
         count++
-        rows += $(col["planned_rows"])
+        planned_rows = $(col["planned_rows"]) + 0
+        rows += planned_rows
+        if (count == 1 || planned_rows < min_rows) min_rows = planned_rows
+        if (count == 1 || planned_rows > max_rows) max_rows = planned_rows
         p95 = $(col["accepted_p95_ms"]) + 0
         rejected = $(col["rejected_429_rate"]) + 0
         if (count == 1 || p95 < min_p95) min_p95 = p95
@@ -255,7 +292,8 @@ write_account_summary_tsv() {
           printf "account result planned rows mismatch: rows=%s expected=%s\n", rows, expected_total > "/dev/stderr"
           exit 4
         }
-        printf "all\t%d\t%d\t%.0f\t%.3f\n", count, rows, max_p95 - min_p95, max_rejected - min_rejected
+        skew_ratio = (min_rows > 0) ? max_rows / min_rows : 0
+        printf "all\t%d\t%d\t%.3f\t%.0f\t%.3f\n", count, rows, skew_ratio, max_p95 - min_p95, max_rejected - min_rejected
       }
     ' "${account_result_tsv}"
   } >"${account_summary_tsv}"
@@ -265,7 +303,7 @@ write_distribution_tsv
 write_account_summary_tsv
 
 cat >"${manifest_json}" <<JSON
-{"name":"${name}","hotAccountIds":$(json_array "${hot_ids}"),"coldAccountIds":$(json_array "${cold_ids}"),"targetTotalRows":${target_total_rows},"hotRowsPerAccount":${hot_rows_per_account},"hotRowsRemainder":${hot_rows_remainder},"coldRowsPerAccount":${cold_rows_per_account},"totalRows":${total_rows},"hotWindow":{"from":"${hot_from}","to":"${hot_to}"},"coldWindow":{"from":"${cold_from}","to":"${cold_to}"}}
+{"name":"${name}","runId":"${run_id}","artifactUri":"${artifact_uri}","hotAccountIds":$(json_array "${hot_ids}"),"coldAccountIds":$(json_array "${cold_ids}"),"minimumTotalAccountCount":${min_total_account_count},"targetTotalRows":${target_total_rows},"hotRowsPerAccount":${hot_rows_per_account},"hotRowsRemainder":${hot_rows_remainder},"coldRowsPerAccount":${cold_rows_per_account},"totalRows":${total_rows},"hotWindow":{"from":"${hot_from}","to":"${hot_to}"},"coldWindow":{"from":"${cold_from}","to":"${cold_to}"}}
 JSON
 
 cat >"${report_md}" <<REPORT
@@ -274,8 +312,12 @@ cat >"${report_md}" <<REPORT
 ## Summary
 
 - fixture: ${name}
+- actual execution run id: ${run_id}
+- artifact reference: ${artifact_uri}
 - hot account count: ${hot_count}
 - cold account count: ${cold_count}
+- total account count: ${total_account_count}
+- minimum total account count: ${min_total_account_count}
 - target total rows: ${target_total_rows}
 - total planned rows: ${total_rows}
 - hot rows per account: ${hot_rows_per_account} (+1 for first ${hot_rows_remainder} hot accounts)


### PR DESCRIPTION
## 🔗 Related Issue
- close #662

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI 100M transaction read source/account evidence closure gate를 actual execution artifact 기준으로 강화했습니다.
- 단일 account/source 또는 run id/artifact 없는 결과가 closure evidence로 통과하지 않도록 고정했습니다.

## 🛠 Changes
- multi-account fixture evidence에 run id, artifact URI, 최소 4개 account, cold account 2개 이상, planned row skew summary를 추가했습니다.
- real multi-source public evidence에 run id, artifact URI, source row별 run/artifact 검증을 추가했습니다.
- shell checker에 missing result/artifact, single hot/cold account, one context/source, blank source artifact 실패 케이스를 고정했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-100m-multi-account-fixture.sh`
- `bash tools/test/check-oci-real-multisource-public-evidence.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` -> `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: actual execution artifact 입력이 필수화되어 기존 dry-run 성격 사용자는 명시적으로 evidence TSV/URI를 제공해야 합니다.
- 롤백 방법: 이 PR의 두 커밋을 revert하면 기존 summary-only 계약으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
