### PR TITLE
[Fix] staging replay OCI secret wiring 복구

### DIFF
--- a/.github/workflows/transaction-read-model-staging-replay.yml
+++ b/.github/workflows/transaction-read-model-staging-replay.yml
@@ -63,7 +63,7 @@ concurrency:
 jobs:
   replay:
     name: Replay Hot And Cold Transaction Queries
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, oci-a1-staging]
     timeout-minutes: 30
     environment:
       name: staging

--- a/.github/workflows/transaction-read-model-staging-replay.yml
+++ b/.github/workflows/transaction-read-model-staging-replay.yml
@@ -71,6 +71,89 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Load OCI A1 staging env
+        env:
+          OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}
+          HOT_ACCOUNT_ID_INPUT: ${{ inputs.hot_account_id }}
+          HOT_FROM_INPUT: ${{ inputs.hot_from }}
+          HOT_TO_INPUT: ${{ inputs.hot_to }}
+          COLD_ACCOUNT_ID_INPUT: ${{ inputs.cold_account_id }}
+          COLD_FROM_INPUT: ${{ inputs.cold_from }}
+          COLD_TO_INPUT: ${{ inputs.cold_to }}
+          ITERATIONS_INPUT: ${{ inputs.iterations }}
+          PAGE_LIMIT_INPUT: ${{ inputs.page_limit }}
+          EXPECTED_TOTAL_ROWS_INPUT: ${{ inputs.expected_total_rows }}
+          HOT_P95_THRESHOLD_MS_INPUT: ${{ inputs.hot_p95_threshold_ms }}
+          COLD_P95_THRESHOLD_MS_INPUT: ${{ inputs.cold_p95_threshold_ms }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${OCI_A1_STAGING_ENV}" ]]; then
+            echo "::error::Missing OCI_A1_STAGING_ENV environment secret."
+            exit 1
+          fi
+
+          staging_env_path="${RUNNER_TEMP}/oci-a1-staging.env"
+          printf '%s\n' "${OCI_A1_STAGING_ENV}" >"${staging_env_path}"
+          chmod 600 "${staging_env_path}"
+
+          set -a
+          # workflow_dispatch replay도 staging-deploy와 같은 unified staging secret contract를 사용한다.
+          source "${staging_env_path}"
+          set +a
+
+          STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-${STAGING_OCI_A1_DATABASE_URL:-}}"
+          HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID_INPUT}"
+          HOT_FROM="${HOT_FROM_INPUT}"
+          HOT_TO="${HOT_TO_INPUT}"
+          COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID_INPUT}"
+          COLD_FROM="${COLD_FROM_INPUT}"
+          COLD_TO="${COLD_TO_INPUT}"
+          ITERATIONS="${ITERATIONS_INPUT}"
+          PAGE_LIMIT="${PAGE_LIMIT_INPUT}"
+          EXPECTED_TOTAL_ROWS="${EXPECTED_TOTAL_ROWS_INPUT}"
+          HOT_P95_THRESHOLD_MS="${HOT_P95_THRESHOLD_MS_INPUT}"
+          COLD_P95_THRESHOLD_MS="${COLD_P95_THRESHOLD_MS_INPUT}"
+
+          missing=()
+          [[ -z "${STAGING_BASE_URL:-}" ]] && missing+=("STAGING_BASE_URL")
+          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
+          [[ -z "${STAGING_RDS_DATABASE_URL:-}" ]] && missing+=("STAGING_RDS_DATABASE_URL")
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing OCI A1 staging replay env keys: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          env_names=(
+            STAGING_BASE_URL
+            STAGING_REPLAY_TOKEN
+            STAGING_OCI_A1_DATABASE_URL
+            STAGING_RDS_DATABASE_URL
+            HOT_ACCOUNT_ID
+            HOT_FROM
+            HOT_TO
+            COLD_ACCOUNT_ID
+            COLD_FROM
+            COLD_TO
+            ITERATIONS
+            PAGE_LIMIT
+            EXPECTED_TOTAL_ROWS
+            HOT_P95_THRESHOLD_MS
+            COLD_P95_THRESHOLD_MS
+          )
+
+          for name in "${env_names[@]}"; do
+            value="${!name:-}"
+            if [[ -n "${value}" ]]; then
+              case "${name}" in
+                STAGING_BASE_URL|STAGING_REPLAY_TOKEN|*DATABASE_URL)
+                  echo "::add-mask::${value}"
+                  ;;
+              esac
+              printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
+            fi
+          done
+
       - name: Install PostgreSQL client
         shell: bash
         run: |
@@ -82,21 +165,6 @@ jobs:
           sudo apt-get install -y postgresql-client
 
       - name: Run staging replay
-        env:
-          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
-          STAGING_REPLAY_TOKEN: ${{ secrets.STAGING_REPLAY_TOKEN }}
-          STAGING_RDS_DATABASE_URL: ${{ secrets.STAGING_RDS_DATABASE_URL }}
-          HOT_ACCOUNT_ID: ${{ inputs.hot_account_id }}
-          HOT_FROM: ${{ inputs.hot_from }}
-          HOT_TO: ${{ inputs.hot_to }}
-          COLD_ACCOUNT_ID: ${{ inputs.cold_account_id }}
-          COLD_FROM: ${{ inputs.cold_from }}
-          COLD_TO: ${{ inputs.cold_to }}
-          ITERATIONS: ${{ inputs.iterations }}
-          PAGE_LIMIT: ${{ inputs.page_limit }}
-          EXPECTED_TOTAL_ROWS: ${{ inputs.expected_total_rows }}
-          HOT_P95_THRESHOLD_MS: ${{ inputs.hot_p95_threshold_ms }}
-          COLD_P95_THRESHOLD_MS: ${{ inputs.cold_p95_threshold_ms }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/transaction-read-replica-staging-smoke.yml
+++ b/.github/workflows/transaction-read-replica-staging-smoke.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   smoke:
     name: Verify Transaction Read Replica Lag And Route
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, oci-a1-staging]
     timeout-minutes: 10
     environment:
       name: staging

--- a/.github/workflows/transaction-read-replica-staging-smoke.yml
+++ b/.github/workflows/transaction-read-replica-staging-smoke.yml
@@ -44,6 +44,72 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Load OCI A1 staging env
+        env:
+          OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}
+          TRANSACTION_ARCHIVE_ACCOUNT_ID_INPUT: ${{ inputs.archive_account_id }}
+          TRANSACTION_ARCHIVE_FROM_INPUT: ${{ inputs.archive_from }}
+          TRANSACTION_ARCHIVE_TO_INPUT: ${{ inputs.archive_to }}
+          PAGE_LIMIT_INPUT: ${{ inputs.page_limit }}
+          REPLICA_LAG_THRESHOLD_MS_INPUT: ${{ inputs.replica_lag_threshold_ms }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${OCI_A1_STAGING_ENV}" ]]; then
+            echo "::error::Missing OCI_A1_STAGING_ENV environment secret."
+            exit 1
+          fi
+
+          staging_env_path="${RUNNER_TEMP}/oci-a1-staging.env"
+          printf '%s\n' "${OCI_A1_STAGING_ENV}" >"${staging_env_path}"
+          chmod 600 "${staging_env_path}"
+
+          set -a
+          # replica smoke도 staging-deploy와 같은 unified staging secret contract를 사용한다.
+          source "${staging_env_path}"
+          set +a
+
+          STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-${STAGING_OCI_A1_DATABASE_URL:-}}"
+          TRANSACTION_ARCHIVE_ACCOUNT_ID="${TRANSACTION_ARCHIVE_ACCOUNT_ID_INPUT}"
+          TRANSACTION_ARCHIVE_FROM="${TRANSACTION_ARCHIVE_FROM_INPUT}"
+          TRANSACTION_ARCHIVE_TO="${TRANSACTION_ARCHIVE_TO_INPUT}"
+          PAGE_LIMIT="${PAGE_LIMIT_INPUT}"
+          REPLICA_LAG_THRESHOLD_MS="${REPLICA_LAG_THRESHOLD_MS_INPUT}"
+
+          missing=()
+          [[ -z "${STAGING_BASE_URL:-}" ]] && missing+=("STAGING_BASE_URL")
+          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
+          [[ -z "${STAGING_RDS_DATABASE_URL:-}" ]] && missing+=("STAGING_RDS_DATABASE_URL")
+          [[ -z "${STAGING_RDS_REPLICA_DATABASE_URL:-}" ]] && missing+=("STAGING_RDS_REPLICA_DATABASE_URL")
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing OCI A1 staging replica smoke env keys: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          env_names=(
+            STAGING_BASE_URL
+            STAGING_REPLAY_TOKEN
+            STAGING_RDS_DATABASE_URL
+            STAGING_RDS_REPLICA_DATABASE_URL
+            TRANSACTION_ARCHIVE_ACCOUNT_ID
+            TRANSACTION_ARCHIVE_FROM
+            TRANSACTION_ARCHIVE_TO
+            PAGE_LIMIT
+            REPLICA_LAG_THRESHOLD_MS
+          )
+
+          for name in "${env_names[@]}"; do
+            value="${!name:-}"
+            if [[ -n "${value}" ]]; then
+              case "${name}" in
+                STAGING_BASE_URL|STAGING_REPLAY_TOKEN|*DATABASE_URL)
+                  echo "::add-mask::${value}"
+                  ;;
+              esac
+              printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
+            fi
+          done
+
       - name: Install PostgreSQL client
         shell: bash
         run: |
@@ -55,16 +121,6 @@ jobs:
           sudo apt-get install -y postgresql-client
 
       - name: Run transaction read replica staging smoke
-        env:
-          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
-          STAGING_REPLAY_TOKEN: ${{ secrets.STAGING_REPLAY_TOKEN }}
-          STAGING_RDS_DATABASE_URL: ${{ secrets.STAGING_RDS_DATABASE_URL }}
-          STAGING_RDS_REPLICA_DATABASE_URL: ${{ secrets.STAGING_RDS_REPLICA_DATABASE_URL }}
-          TRANSACTION_ARCHIVE_ACCOUNT_ID: ${{ inputs.archive_account_id }}
-          TRANSACTION_ARCHIVE_FROM: ${{ inputs.archive_from }}
-          TRANSACTION_ARCHIVE_TO: ${{ inputs.archive_to }}
-          PAGE_LIMIT: ${{ inputs.page_limit }}
-          REPLICA_LAG_THRESHOLD_MS: ${{ inputs.replica_lag_threshold_ms }}
         shell: bash
         run: |
           set -euo pipefail

--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -80,6 +80,39 @@ write_distribution_failure_report() {
   } >"$SUMMARY_MD"
 }
 
+write_planner_guard_failure_report() {
+  local detail guidance
+  detail="Planner stats freshness guard failed"
+  guidance="Run ANALYZE on reported tables before replay."
+
+  jq -n \
+    --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg baseUrl "$STAGING_BASE_URL" \
+    --arg phase "planner-stats" \
+    --arg status "planner_stats_guard_failed" \
+    --arg detail "$detail" \
+    --arg guidance "$guidance" \
+    '{
+      generatedAt: $generatedAt,
+      baseUrl: $baseUrl,
+      phase: $phase,
+      status: $status,
+      detail: $detail,
+      guidance: $guidance,
+      failed: true
+    }' >"$SUMMARY_JSON"
+
+  {
+    echo "# Transaction Read Model Staging Replay"
+    echo
+    echo "- status: failed"
+    echo "- phase: planner-stats"
+    echo "- failure: planner_stats_guard_failed"
+    echo "- detail: ${detail}"
+    echo "- guidance: ${guidance}"
+  } >"$SUMMARY_MD"
+}
+
 require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
 }
@@ -153,6 +186,7 @@ run_planner_stats_guard() {
     STATS_MAX_AGE_HOURS="$PLANNER_STATS_MAX_AGE_HOURS" \
     STATS_MAX_MODIFIED_RATIO="$PLANNER_STATS_MAX_MODIFIED_RATIO" \
     "$PLANNER_STATS_GUARD_SCRIPT"; then
+    write_planner_guard_failure_report
     fail "Planner stats freshness guard failed. Run ANALYZE on reported tables before replay."
   fi
 }

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -147,6 +147,48 @@ if grep -F "secret-token-value" <<<"${auth_file_plan}" >/dev/null; then
   echo "auth token leaked into k6 plan output" >&2
   exit 1
 fi
+
+auth_env_plan="$(
+  STAGING_REPLAY_TOKEN="env-secret-token-value" \
+  K6_REPORT_NAME=transaction-100m-auth-env-name-check \
+  K6_RUN_PURPOSE=capacity \
+  K6_OBSERVABILITY_MODE=summary-only \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=transaction-k6-remote \
+  K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+  K6_AUTH_TOKEN_ENV_NAME=STAGING_REPLAY_TOKEN \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "auth token required=true token=present source=env:STAGING_REPLAY_TOKEN" <<<"${auth_env_plan}" >/dev/null
+if grep -F "env-secret-token-value" <<<"${auth_env_plan}" >/dev/null; then
+  echo "env auth token leaked into k6 plan output" >&2
+  exit 1
+fi
+
+issuer_script="${temp_dir}/issue-loadtest-token.sh"
+cat >"${issuer_script}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'issuer-secret-token-value\n'
+EOF
+chmod +x "${issuer_script}"
+
+auth_issuer_plan="$(
+  K6_REPORT_NAME=transaction-100m-auth-issuer-check \
+  K6_RUN_PURPOSE=capacity \
+  K6_OBSERVABILITY_MODE=summary-only \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=transaction-k6-remote \
+  K6_REMOTE_BASE_URL=http://192.0.2.10:8080 \
+  K6_AUTH_TOKEN_ISSUER_COMMAND="${issuer_script}" \
+    tools/test/run-k6-transaction-100m-loadtest.sh --print-plan
+)"
+grep -F "auth token required=true token=present source=issuer-command" <<<"${auth_issuer_plan}" >/dev/null
+if grep -F "issuer-secret-token-value" <<<"${auth_issuer_plan}" >/dev/null; then
+  echo "issuer auth token leaked into k6 plan output" >&2
+  exit 1
+fi
+
 if K6_RUN_PURPOSE=capacity \
   K6_OBSERVABILITY_MODE=summary-only \
   K6_GENERATOR_MODE=docker-context \

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -51,7 +51,9 @@ Optional environment:
   K6_HOT_DEEP_P99_THRESHOLD_MS default K6_HOT_P99_THRESHOLD_MS
   K6_COLD_DEEP_P99_THRESHOLD_MS default K6_COLD_P99_THRESHOLD_MS
   K6_AUTH_TOKEN        bearer token, optional when bootstrap header auth is enabled
+  K6_AUTH_TOKEN_ENV_NAME optional env var name containing bearer token; value is never printed
   K6_AUTH_TOKEN_FILE   optional bearer token file; content is never printed
+  K6_AUTH_TOKEN_ISSUER_COMMAND optional restricted command that prints bearer token to stdout
   K6_AUTH_TOKEN_REQUIRED true|false|auto, default auto; auto requires token for docker-context non-smoke
   K6_AUTH_PREFLIGHT    true|false|auto, default auto; auto runs when a preflight URL/path is configured
   K6_AUTH_PREFLIGHT_URL full URL for token status smoke, optional
@@ -239,13 +241,42 @@ require_run_purpose() {
 auth_token_source="missing"
 
 resolve_auth_token() {
-  # secret-safe: token 값은 env/file에서만 읽고 plan/report에는 존재 여부만 남긴다.
+  # secret-safe: token 값은 env/file/issuer에서만 읽고 plan/report에는 존재 여부만 남긴다.
   if [[ -n "${K6_AUTH_TOKEN}" ]]; then
     auth_token_source="env"
     return 0
   fi
+  if [[ -n "${K6_AUTH_TOKEN_ENV_NAME}" ]]; then
+    if ! [[ "${K6_AUTH_TOKEN_ENV_NAME}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      echo "K6_AUTH_TOKEN_ENV_NAME must be a valid environment variable name" >&2
+      exit 1
+    fi
+    K6_AUTH_TOKEN="${!K6_AUTH_TOKEN_ENV_NAME:-}"
+    if [[ -z "${K6_AUTH_TOKEN}" ]]; then
+      echo "K6_AUTH_TOKEN_ENV_NAME points to an empty environment variable" >&2
+      exit 1
+    fi
+    auth_token_source="env:${K6_AUTH_TOKEN_ENV_NAME}"
+    export K6_AUTH_TOKEN
+    return 0
+  fi
   if [[ -z "${K6_AUTH_TOKEN_FILE}" ]]; then
-    auth_token_source="missing"
+    if [[ -z "${K6_AUTH_TOKEN_ISSUER_COMMAND}" ]]; then
+      auth_token_source="missing"
+      return 0
+    fi
+    K6_AUTH_TOKEN="$(
+      bash -c "${K6_AUTH_TOKEN_ISSUER_COMMAND}" 2>/dev/null | LC_ALL=C tr -d '\r\n'
+    )" || {
+      echo "K6_AUTH_TOKEN_ISSUER_COMMAND failed" >&2
+      exit 1
+    }
+    if [[ -z "${K6_AUTH_TOKEN}" ]]; then
+      echo "K6_AUTH_TOKEN_ISSUER_COMMAND did not return a token" >&2
+      exit 1
+    fi
+    auth_token_source="issuer-command"
+    export K6_AUTH_TOKEN
     return 0
   fi
   if [[ ! -s "${K6_AUTH_TOKEN_FILE}" ]]; then
@@ -467,7 +498,9 @@ K6_BACKEND_READINESS_BASE_URL="${K6_BACKEND_READINESS_BASE_URL:-http://localhost
 K6_BACKEND_READINESS_PATH="${K6_BACKEND_READINESS_PATH:-/actuator/health/readiness}"
 K6_BACKEND_READINESS_TIMEOUT_SECONDS="${K6_BACKEND_READINESS_TIMEOUT_SECONDS:-120}"
 K6_AUTH_TOKEN="${K6_AUTH_TOKEN:-}"
+K6_AUTH_TOKEN_ENV_NAME="${K6_AUTH_TOKEN_ENV_NAME:-}"
 K6_AUTH_TOKEN_FILE="${K6_AUTH_TOKEN_FILE:-}"
+K6_AUTH_TOKEN_ISSUER_COMMAND="${K6_AUTH_TOKEN_ISSUER_COMMAND:-}"
 K6_AUTH_TOKEN_REQUIRED="${K6_AUTH_TOKEN_REQUIRED:-auto}"
 K6_AUTH_PREFLIGHT="${K6_AUTH_PREFLIGHT:-auto}"
 K6_AUTH_PREFLIGHT_URL="${K6_AUTH_PREFLIGHT_URL:-}"

--- a/tools/test/run-transaction-read-model-staging-replay-guard.sh
+++ b/tools/test/run-transaction-read-model-staging-replay-guard.sh
@@ -43,9 +43,11 @@ exit 0
 EOF
 chmod +x "${bin_dir}/psql"
 
+guard_report_dir="${temp_dir}/guard-report"
 set +e
 output="$(
   PATH="${bin_dir}:${PATH}" \
+  REPORT_DIR="${guard_report_dir}" \
   GUARD_MARKER_PATH="${temp_dir}/guard-called" \
   PSQL_MARKER_PATH="${psql_marker}" \
   PLANNER_STATS_GUARD_SCRIPT="${guard_script}" \
@@ -69,6 +71,9 @@ if [ "${status}" -eq 0 ]; then
 fi
 
 grep -F "Planner stats freshness guard failed" <<<"${output}" >/dev/null
+grep -F "planner_stats_guard_failed" "${guard_report_dir}/summary.md" >/dev/null
+grep -F "Run ANALYZE on reported tables before replay." "${guard_report_dir}/summary.md" >/dev/null
+test -f "${guard_report_dir}/summary.json"
 [ -f "${temp_dir}/guard-called" ] || {
   echo "planner stats guard was not called" >&2
   exit 1

--- a/tools/test/run-transaction-read-workflow-oci-secret-wiring.sh
+++ b/tools/test/run-transaction-read-workflow-oci-secret-wiring.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflows=(
+  ".github/workflows/transaction-read-model-staging-replay.yml"
+  ".github/workflows/transaction-read-replica-staging-smoke.yml"
+)
+
+echo "[transaction-read-workflow-oci-secret-wiring] yaml syntax"
+for workflow in "${workflows[@]}"; do
+  ruby -e "require 'yaml'; YAML.load_file(ARGV.fetch(0)); puts 'ok'" "${workflow}" >/dev/null
+done
+
+echo "[transaction-read-workflow-oci-secret-wiring] unified staging env wiring"
+ruby <<'RUBY'
+require "yaml"
+
+def assert(condition, message)
+  abort(message) unless condition
+end
+
+def workflow(path)
+  YAML.load_file(path)
+end
+
+def only_uses_unified_secret!(path)
+  text = File.read(path)
+  forbidden = [
+    "secrets.STAGING_BASE_URL",
+    "secrets.STAGING_REPLAY_TOKEN",
+    "secrets.STAGING_RDS_DATABASE_URL",
+    "secrets.STAGING_RDS_REPLICA_DATABASE_URL"
+  ]
+  forbidden.each do |pattern|
+    assert(!text.include?(pattern), "#{path} must not directly read #{pattern}")
+  end
+end
+
+def check_load_step!(path, job_name, run_step_name, required_env_names)
+  data = workflow(path)
+  steps = data.fetch("jobs").fetch(job_name).fetch("steps")
+  names = steps.map { |step| step["name"] }
+  load_index = names.index("Load OCI A1 staging env")
+  run_index = names.index(run_step_name)
+
+  assert(load_index, "#{path} missing Load OCI A1 staging env step")
+  assert(run_index, "#{path} missing #{run_step_name} step")
+  assert(load_index < run_index, "#{path} must load staging env before #{run_step_name}")
+
+  load_step = steps.fetch(load_index)
+  load_env = load_step.fetch("env")
+  load_run = load_step.fetch("run")
+
+  assert(load_env.fetch("OCI_A1_STAGING_ENV").include?("secrets.OCI_A1_STAGING_ENV"),
+    "#{path} must read only OCI_A1_STAGING_ENV secret")
+  assert(load_run.include?('source "${staging_env_path}"'), "#{path} must source staging env file")
+  assert(load_run.include?("::add-mask::${value}"), "#{path} must mask exported secret values")
+  assert(load_run.include?("GITHUB_ENV"), "#{path} must persist restored env through GITHUB_ENV")
+  assert(load_run.include?('STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-${STAGING_OCI_A1_DATABASE_URL:-}}"'),
+    "#{path} must fallback STAGING_RDS_DATABASE_URL to STAGING_OCI_A1_DATABASE_URL")
+
+  required_env_names.each do |name|
+    assert(load_run.include?(name), "#{path} must export #{name}")
+  end
+
+  run_step = steps.fetch(run_index)
+  run_env = run_step["env"] || {}
+  %w[STAGING_BASE_URL STAGING_REPLAY_TOKEN STAGING_RDS_DATABASE_URL STAGING_RDS_REPLICA_DATABASE_URL].each do |name|
+    assert(!run_env.key?(name), "#{path} #{run_step_name} must not scatter #{name} env mapping")
+  end
+end
+
+replay = ".github/workflows/transaction-read-model-staging-replay.yml"
+replica = ".github/workflows/transaction-read-replica-staging-smoke.yml"
+
+[replay, replica].each { |path| only_uses_unified_secret!(path) }
+
+check_load_step!(
+  replay,
+  "replay",
+  "Run staging replay",
+  %w[
+    STAGING_BASE_URL
+    STAGING_REPLAY_TOKEN
+    STAGING_OCI_A1_DATABASE_URL
+    STAGING_RDS_DATABASE_URL
+    HOT_ACCOUNT_ID
+    HOT_FROM
+    HOT_TO
+    COLD_ACCOUNT_ID
+    COLD_FROM
+    COLD_TO
+    ITERATIONS
+    PAGE_LIMIT
+    EXPECTED_TOTAL_ROWS
+    HOT_P95_THRESHOLD_MS
+    COLD_P95_THRESHOLD_MS
+  ]
+)
+
+check_load_step!(
+  replica,
+  "smoke",
+  "Run transaction read replica staging smoke",
+  %w[
+    STAGING_BASE_URL
+    STAGING_REPLAY_TOKEN
+    STAGING_RDS_DATABASE_URL
+    STAGING_RDS_REPLICA_DATABASE_URL
+    TRANSACTION_ARCHIVE_ACCOUNT_ID
+    TRANSACTION_ARCHIVE_FROM
+    TRANSACTION_ARCHIVE_TO
+    PAGE_LIMIT
+    REPLICA_LAG_THRESHOLD_MS
+  ]
+)
+RUBY

--- a/tools/test/run-transaction-read-workflow-oci-secret-wiring.sh
+++ b/tools/test/run-transaction-read-workflow-oci-secret-wiring.sh
@@ -38,7 +38,12 @@ end
 
 def check_load_step!(path, job_name, run_step_name, required_env_names)
   data = workflow(path)
-  steps = data.fetch("jobs").fetch(job_name).fetch("steps")
+  job = data.fetch("jobs").fetch(job_name)
+  runner_labels = Array(job.fetch("runs-on"))
+  assert(runner_labels.include?("self-hosted") && runner_labels.include?("oci-a1-staging"),
+    "#{path} #{job_name} must run on OCI A1 self-hosted staging runner")
+
+  steps = job.fetch("steps")
   names = steps.map { |step| step["name"] }
   load_index = names.index("Load OCI A1 staging env")
   run_index = names.index(run_step_name)


### PR DESCRIPTION
## 🔗 Related Issue
- close #669

## 🌿 Base Branch
- `main`

## 📝 Summary
- `transaction-read-model-staging-replay`와 `transaction-read-replica-staging-smoke` workflow_dispatch가 개별 `STAGING_*` secrets 대신 unified `OCI_A1_STAGING_ENV`를 source하도록 복구했습니다.
- replay/smoke workflow를 OCI self-hosted runner로 고정해 staging DB 접근 경로와 실행 위치를 일치시켰습니다.
- k6 OCI/capacity 실행은 GitHub Environment secret env name 또는 제한된 issuer command에서 token을 가져오고, auth preflight 200 계약을 유지하도록 token source를 확장했습니다.
- planner stats guard 실패도 summary artifact로 남기도록 해 workflow 실패 원인을 추적 가능하게 했습니다.

## 🛠 Changes
- replay/smoke workflow에 `Load OCI A1 staging env` step 추가
- replay/smoke workflow `runs-on`을 `[self-hosted, oci-a1-staging]`으로 변경
- `STAGING_RDS_DATABASE_URL`는 `STAGING_OCI_A1_DATABASE_URL` fallback을 사용하도록 staging-deploy 계약과 정렬
- token/DB URL/base URL은 `::add-mask::` 처리 후 `GITHUB_ENV`로만 전달
- workflow contract test 추가: 개별 `secrets.STAGING_*` 직접 참조와 hosted runner 회귀 차단
- k6 runner에 `K6_AUTH_TOKEN_ENV_NAME`, `K6_AUTH_TOKEN_ISSUER_COMMAND` source 추가
- k6 plan/report에서 token 값과 issuer command 출력 없이 source/presence만 노출
- planner stats freshness guard 실패 시 `summary.md`/`summary.json` artifact 생성

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/run-transaction-read-workflow-oci-secret-wiring.sh`
- `bash tools/test/run-transaction-read-model-staging-replay-guard.sh`
- `bash tools/test/check-k6-transaction-100m-loadtest.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` = `4`
- workflow_dispatch run `25274410158`: `Load OCI A1 staging env` 성공, `Run staging replay`까지 진입, 이후 GitHub-hosted runner에서 PostgreSQL 연결 timeout으로 planner stats guard 실패
- workflow_dispatch run `25274516650`: planner stats guard 실패 시 `summary.md`/`summary.json` artifact 업로드 확인
- workflow_dispatch run `25274610848`: OCI self-hosted runner에서 `Load OCI A1 staging env` 성공, planner stats freshness guard 실패 시 `summary.md`/`summary.json` artifact 업로드 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: workflow_dispatch가 `OCI_A1_STAGING_ENV` 내부 필수 키 누락 시 더 이른 단계에서 fail-fast합니다. 이는 run `25274101555`처럼 빈 값으로 늦게 실패하는 문제를 의도적으로 차단합니다.
- 남은 차단점: replay는 빈 secret 실패를 벗어나 planner stats guard까지 도달했습니다. 현재 staging DB 통계가 freshness guard를 통과하지 못하므로, `ANALYZE` 또는 통계 갱신 후 100M estimate/API replay와 #668 계열 perf closure를 계속 진행해야 합니다.
- 롤백 방법: 이 PR revert. 기존 개별 `secrets.STAGING_*` 직접 참조와 기존 k6 token source 계약으로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? secret source/masking/token logging 계약 반영
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? DB schema/API 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? workflow contract test와 failure artifact 반영
