### PR TITLE
[Fix] staging replay DB URL resolver 적용

### DIFF
--- a/.github/workflows/transaction-read-model-staging-replay.yml
+++ b/.github/workflows/transaction-read-model-staging-replay.yml
@@ -153,7 +153,7 @@ jobs:
             value="${!name:-}"
             if [[ -n "${value}" ]]; then
               case "${name}" in
-                STAGING_BASE_URL|STAGING_REPLAY_TOKEN|*DATABASE_URL)
+                STAGING_BASE_URL|STAGING_REPLAY_TOKEN|*DATABASE_URL|*_ENV_B64)
                   echo "::add-mask::${value}"
                   ;;
               esac

--- a/.github/workflows/transaction-read-model-staging-replay.yml
+++ b/.github/workflows/transaction-read-model-staging-replay.yml
@@ -103,6 +103,9 @@ jobs:
           set +a
 
           STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-${STAGING_OCI_A1_DATABASE_URL:-}}"
+          POSTGRES_CONTAINER_NAME="${POSTGRES_CONTAINER_NAME:-aquila-postgres}"
+          POSTGRES_NETWORK_ALIAS="${POSTGRES_NETWORK_ALIAS:-aquila-postgres}"
+          POSTGRES_HOST_BIND="${POSTGRES_HOST_BIND:-127.0.0.1:5432}"
           HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID_INPUT}"
           HOT_FROM="${HOT_FROM_INPUT}"
           HOT_TO="${HOT_TO_INPUT}"
@@ -118,17 +121,21 @@ jobs:
           missing=()
           [[ -z "${STAGING_BASE_URL:-}" ]] && missing+=("STAGING_BASE_URL")
           [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
-          [[ -z "${STAGING_RDS_DATABASE_URL:-}" ]] && missing+=("STAGING_RDS_DATABASE_URL")
+          [[ -z "${STAGING_RDS_DATABASE_URL:-}" && -z "${STAGING_OCI_A1_DATABASE_URL:-}" && -z "${OCI_A1_BACKEND_ENV_B64:-}" ]] && missing+=("STAGING_RDS_DATABASE_URL")
           if (( ${#missing[@]} > 0 )); then
             printf '::error::Missing OCI A1 staging replay env keys: %s\n' "${missing[*]}"
             exit 1
           fi
 
           env_names=(
+            OCI_A1_BACKEND_ENV_B64
             STAGING_BASE_URL
             STAGING_REPLAY_TOKEN
             STAGING_OCI_A1_DATABASE_URL
             STAGING_RDS_DATABASE_URL
+            POSTGRES_CONTAINER_NAME
+            POSTGRES_NETWORK_ALIAS
+            POSTGRES_HOST_BIND
             HOT_ACCOUNT_ID
             HOT_FROM
             HOT_TO
@@ -163,6 +170,15 @@ jobs:
           fi
           sudo apt-get update
           sudo apt-get install -y postgresql-client
+
+      - name: Resolve OCI A1 staging database URL
+        shell: bash
+        run: |
+          set -euo pipefail
+          # backend가 Docker alias DB를 쓰면 workflow_dispatch도 host-local psql URL로 재산출한다.
+          resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"
+          echo "::add-mask::${resolved_database_url}"
+          printf 'STAGING_OCI_A1_DATABASE_URL=%s\n' "${resolved_database_url}" >>"${GITHUB_ENV}"
 
       - name: Run staging replay
         shell: bash

--- a/tools/test/run-transaction-read-workflow-oci-secret-wiring.sh
+++ b/tools/test/run-transaction-read-workflow-oci-secret-wiring.sh
@@ -60,6 +60,10 @@ def check_load_step!(path, job_name, run_step_name, required_env_names)
     "#{path} must read only OCI_A1_STAGING_ENV secret")
   assert(load_run.include?('source "${staging_env_path}"'), "#{path} must source staging env file")
   assert(load_run.include?("::add-mask::${value}"), "#{path} must mask exported secret values")
+  if load_run.include?("OCI_A1_BACKEND_ENV_B64")
+    assert(load_run.include?("*_ENV_B64"),
+      "#{path} must mask backend env base64 secrets before persisting them")
+  end
   assert(load_run.include?("GITHUB_ENV"), "#{path} must persist restored env through GITHUB_ENV")
   assert(load_run.include?('STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-${STAGING_OCI_A1_DATABASE_URL:-}}"'),
     "#{path} must fallback STAGING_RDS_DATABASE_URL to STAGING_OCI_A1_DATABASE_URL")

--- a/tools/test/run-transaction-read-workflow-oci-secret-wiring.sh
+++ b/tools/test/run-transaction-read-workflow-oci-secret-wiring.sh
@@ -75,6 +75,37 @@ def check_load_step!(path, job_name, run_step_name, required_env_names)
   end
 end
 
+def check_replay_db_resolver!(path)
+  data = workflow(path)
+  steps = data.fetch("jobs").fetch("replay").fetch("steps")
+  names = steps.map { |step| step["name"] }
+  load_index = names.index("Load OCI A1 staging env")
+  resolver_index = names.index("Resolve OCI A1 staging database URL")
+  replay_index = names.index("Run staging replay")
+
+  assert(resolver_index, "#{path} missing Resolve OCI A1 staging database URL step")
+  assert(load_index < resolver_index, "#{path} must resolve DB URL after env load")
+  assert(resolver_index < replay_index, "#{path} must resolve DB URL before staging replay")
+
+  load_run = steps.fetch(load_index).fetch("run")
+  %w[
+    OCI_A1_BACKEND_ENV_B64
+    POSTGRES_CONTAINER_NAME
+    POSTGRES_NETWORK_ALIAS
+    POSTGRES_HOST_BIND
+  ].each do |name|
+    assert(load_run.include?(name), "#{path} must export #{name} for DB URL resolver")
+  end
+
+  resolver_run = steps.fetch(resolver_index).fetch("run")
+  assert(resolver_run.include?("tools/ops/resolve-oci-a1-staging-database-url.sh"),
+    "#{path} DB URL resolver step must call resolver script")
+  assert(resolver_run.include?("::add-mask::${resolved_database_url}"),
+    "#{path} DB URL resolver step must mask resolved database URL")
+  assert(resolver_run.include?("STAGING_OCI_A1_DATABASE_URL=%s"),
+    "#{path} DB URL resolver step must rewrite STAGING_OCI_A1_DATABASE_URL")
+end
+
 replay = ".github/workflows/transaction-read-model-staging-replay.yml"
 replica = ".github/workflows/transaction-read-replica-staging-smoke.yml"
 
@@ -100,8 +131,14 @@ check_load_step!(
     EXPECTED_TOTAL_ROWS
     HOT_P95_THRESHOLD_MS
     COLD_P95_THRESHOLD_MS
+    OCI_A1_BACKEND_ENV_B64
+    POSTGRES_CONTAINER_NAME
+    POSTGRES_NETWORK_ALIAS
+    POSTGRES_HOST_BIND
   ]
 )
+
+check_replay_db_resolver!(replay)
 
 check_load_step!(
   replica,


### PR DESCRIPTION
## 🔗 Related Issue
- close #671

## 🌿 Base Branch
- `main`

## 📝 Summary
- `transaction-read-model-staging-replay` workflow_dispatch가 staging deploy와 같은 OCI DB URL resolver를 실행하도록 맞췄습니다.
- unified env의 public DB URL을 그대로 쓰지 않고, self-hosted runner에서 접근 가능한 host-local DB URL을 `STAGING_OCI_A1_DATABASE_URL`로 다시 기록합니다.
- resolver 입력인 backend env base64도 GitHub step env 로그에 노출되지 않도록 mask 계약을 보강했습니다.

## 🛠 Changes
- replay workflow에 `Resolve OCI A1 staging database URL` step 추가
- replay env load 단계에서 `OCI_A1_BACKEND_ENV_B64`, `POSTGRES_CONTAINER_NAME`, `POSTGRES_NETWORK_ALIAS`, `POSTGRES_HOST_BIND`를 보존
- DB URL resolver 누락/순서/masking/GITHUB_ENV rewrite를 contract test로 고정
- `*_ENV_B64` 값을 `::add-mask::` 처리해 다음 step env 출력에서 secret-safe하게 유지

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/run-transaction-read-workflow-oci-secret-wiring.sh`
- `bash tools/test/run-oci-a1-staging-database-url-resolver.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` = `2`
- workflow_dispatch run `25275556829`: PR 브랜치에서 DB timeout은 해소됨. 단, backend env base64 마스킹 누락 확인 후 추가 수정.
- workflow_dispatch run `25275601559`: `OCI_A1_BACKEND_ENV_B64`/URL/token 마스킹 확인, `psql` timeout 없이 planner stats guard까지 진입. 현재 실패 원인은 `transaction_read_model`, `transaction_read_model_archive` stale analyze age로 `ANALYZE` 필요.

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `OCI_A1_BACKEND_ENV_B64` 또는 `POSTGRES_HOST_BIND`가 staging env에 없으면 resolver가 명시 URL fallback을 사용하거나 fail-fast합니다.
- 보안 후속: run `25275556829`에서 backend env base64가 마스킹 전 로그에 노출된 정황이 있어, 해당 로그 접근 권한 범위에 따라 backend DB/JWT 관련 secret rotation을 검토해야 합니다. run `25275601559`에서는 마스킹을 확인했습니다.
- 남은 차단점: DB 접속 timeout은 해소됐고, 현재 replay 실패는 planner stats freshness guard입니다. `tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target hot` 및 `--target archive` 실행 후 replay를 재실행해야 합니다.
- 롤백 방법: 이 PR revert. workflow_dispatch replay가 기존처럼 unified env의 DB URL을 직접 사용합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? secret masking/DB URL rewrite 계약 유지, backend env base64 마스킹 보강
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? DB schema/API 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? workflow contract test 반영
