### PR TITLE
[Fix] staging replay planner stats stale 자동 복구

### DIFF
--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -384,11 +384,11 @@ run_replay() {
 
 p95_ms() {
   local file="$1"
-  local count index
+  local count percentile_index
   count="$(wc -l <"$file" | tr -d ' ')"
   [ "$count" -gt 0 ] || fail "No latency samples in ${file}"
-  index=$(((count * 95 + 99) / 100))
-  sort -n "$file" | awk -v index="$index" 'NR == index { print; exit }'
+  percentile_index=$(((count * 95 + 99) / 100))
+  sort -n "$file" | awk -v percentile_index="$percentile_index" 'NR == percentile_index { print; exit }'
 }
 
 write_summary() {

--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -25,6 +25,8 @@ COLD_P95_THRESHOLD_MS="${COLD_P95_THRESHOLD_MS:-750}"
 PLANNER_STATS_GUARD_SCRIPT="${PLANNER_STATS_GUARD_SCRIPT:-tools/ops/transaction-read-model-planner-stats-freshness-guard.sh}"
 PLANNER_STATS_MAX_AGE_HOURS="${PLANNER_STATS_MAX_AGE_HOURS:-24}"
 PLANNER_STATS_MAX_MODIFIED_RATIO="${PLANNER_STATS_MAX_MODIFIED_RATIO:-0.05}"
+PLANNER_STATS_AUTO_ANALYZE="${PLANNER_STATS_AUTO_ANALYZE:-true}"
+PLANNER_STATS_ANALYZE_SCRIPT="${PLANNER_STATS_ANALYZE_SCRIPT:-tools/ops/transaction-read-model-chunk-lifecycle.sh}"
 
 fail() {
   echo "::error::$*" >&2
@@ -138,6 +140,15 @@ require_ratio_between_zero_and_one() {
     || fail "${name} must be greater than 0 and less than 1"
 }
 
+require_bool() {
+  local name="$1"
+  local value="${!name:-}"
+  case "$value" in
+    true|false) ;;
+    *) fail "${name} must be true or false" ;;
+  esac
+}
+
 psql_scalar() {
   local sql="$1"
   psql "$STAGING_DATABASE_URL" -v ON_ERROR_STOP=1 --no-align --tuples-only --command "$sql"
@@ -170,25 +181,48 @@ validate_inputs() {
   require_positive_integer COLD_P95_THRESHOLD_MS
   require_positive_integer PLANNER_STATS_MAX_AGE_HOURS
   require_ratio_between_zero_and_one PLANNER_STATS_MAX_MODIFIED_RATIO
+  require_bool PLANNER_STATS_AUTO_ANALYZE
 
   if [ "$PAGE_LIMIT" -gt 100 ]; then
     fail "PAGE_LIMIT must be 100 or less"
   fi
 
   [ -x "$PLANNER_STATS_GUARD_SCRIPT" ] || fail "Planner stats guard script is not executable: ${PLANNER_STATS_GUARD_SCRIPT}"
+  if [ "$PLANNER_STATS_AUTO_ANALYZE" = "true" ]; then
+    [ -x "$PLANNER_STATS_ANALYZE_SCRIPT" ] || fail "Planner stats analyze script is not executable: ${PLANNER_STATS_ANALYZE_SCRIPT}"
+  fi
 
   STAGING_BASE_URL="${STAGING_BASE_URL%/}"
 }
 
+run_planner_stats_analyze() {
+  notice "Planner stats freshness guard failed; running ANALYZE before replay."
+  # stats refresh는 replay evidence 정확도 목적이며, chunk lifecycle script의 lock/statement timeout을 사용합니다.
+  DATABASE_URL="$STAGING_DATABASE_URL" \
+    "$PLANNER_STATS_ANALYZE_SCRIPT" --action analyze --target both
+}
+
 run_planner_stats_guard() {
   # `reltuples` estimate는 stale stats에 취약해서 replay 전에 ANALYZE 필요 여부를 먼저 차단합니다.
-  if ! DATABASE_URL="$STAGING_DATABASE_URL" \
+  if DATABASE_URL="$STAGING_DATABASE_URL" \
     STATS_MAX_AGE_HOURS="$PLANNER_STATS_MAX_AGE_HOURS" \
     STATS_MAX_MODIFIED_RATIO="$PLANNER_STATS_MAX_MODIFIED_RATIO" \
     "$PLANNER_STATS_GUARD_SCRIPT"; then
-    write_planner_guard_failure_report
-    fail "Planner stats freshness guard failed. Run ANALYZE on reported tables before replay."
+    return 0
   fi
+
+  if [ "$PLANNER_STATS_AUTO_ANALYZE" = "true" ]; then
+    run_planner_stats_analyze
+    if DATABASE_URL="$STAGING_DATABASE_URL" \
+      STATS_MAX_AGE_HOURS="$PLANNER_STATS_MAX_AGE_HOURS" \
+      STATS_MAX_MODIFIED_RATIO="$PLANNER_STATS_MAX_MODIFIED_RATIO" \
+      "$PLANNER_STATS_GUARD_SCRIPT"; then
+      return 0
+    fi
+  fi
+
+  write_planner_guard_failure_report
+  fail "Planner stats freshness guard failed. Run ANALYZE on reported tables before replay."
 }
 
 verify_staging_distribution() {

--- a/tools/test/run-transaction-read-model-staging-replay-guard.sh
+++ b/tools/test/run-transaction-read-model-staging-replay-guard.sh
@@ -51,6 +51,7 @@ output="$(
   GUARD_MARKER_PATH="${temp_dir}/guard-called" \
   PSQL_MARKER_PATH="${psql_marker}" \
   PLANNER_STATS_GUARD_SCRIPT="${guard_script}" \
+  PLANNER_STATS_AUTO_ANALYZE=false \
   STAGING_BASE_URL="https://staging.example.com" \
   STAGING_REPLAY_TOKEN="token" \
   STAGING_RDS_DATABASE_URL="postgres://user:pass@localhost:5432/db" \
@@ -83,6 +84,82 @@ if [ -f "${psql_marker}" ]; then
   echo "psql must not run before planner stats guard passes" >&2
   exit 1
 fi
+
+echo "[transaction-staging-replay-guard] stale stats auto analyze retries guard"
+guard_retry_script="${temp_dir}/planner-guard-retry.sh"
+cat >"${guard_retry_script}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+count_file="${GUARD_RETRY_COUNT_PATH}"
+count=0
+if [ -f "${count_file}" ]; then
+  count="$(cat "${count_file}")"
+fi
+count=$((count + 1))
+echo "${count}" >"${count_file}"
+if [ "${count}" -eq 1 ]; then
+  exit 19
+fi
+exit 0
+EOF
+chmod +x "${guard_retry_script}"
+
+analyze_script="${temp_dir}/analyze.sh"
+cat >"${analyze_script}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${DATABASE_URL:-}" != "postgres://user:pass@localhost:5432/db" ]; then
+  echo "analyze DATABASE_URL mismatch: ${DATABASE_URL:-}" >&2
+  exit 1
+fi
+if [ "$*" != "--action analyze --target both" ]; then
+  echo "unexpected analyze args: $*" >&2
+  exit 1
+fi
+echo "analyze-called" >"${ANALYZE_MARKER_PATH}"
+EOF
+chmod +x "${analyze_script}"
+
+cat >"${bin_dir}/psql" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '0\n'
+EOF
+chmod +x "${bin_dir}/psql"
+
+auto_report_dir="${temp_dir}/auto-report"
+set +e
+auto_output="$(
+  PATH="${bin_dir}:${PATH}" \
+  REPORT_DIR="${auto_report_dir}" \
+  GUARD_RETRY_COUNT_PATH="${temp_dir}/guard-retry-count" \
+  ANALYZE_MARKER_PATH="${temp_dir}/analyze-called" \
+  PLANNER_STATS_GUARD_SCRIPT="${guard_retry_script}" \
+  PLANNER_STATS_ANALYZE_SCRIPT="${analyze_script}" \
+  STAGING_BASE_URL="https://staging.example.com" \
+  STAGING_REPLAY_TOKEN="token" \
+  STAGING_RDS_DATABASE_URL="postgres://user:pass@localhost:5432/db" \
+  EXPECTED_TOTAL_ROWS="100" \
+  HOT_ACCOUNT_ID="101" \
+  HOT_FROM="2026-04-01T00:00:00Z" \
+  HOT_TO="2026-04-15T00:00:00Z" \
+  COLD_ACCOUNT_ID="202" \
+  COLD_FROM="2026-03-01T00:00:00Z" \
+  COLD_TO="2026-03-31T00:00:00Z" \
+  "${script}" 2>&1
+)"
+auto_status=$?
+set -e
+
+if [ "${auto_status}" -eq 0 ]; then
+  echo "auto analyze replay unexpectedly succeeded" >&2
+  exit 1
+fi
+
+grep -F "Planner stats freshness guard failed; running ANALYZE before replay." <<<"${auto_output}" >/dev/null
+grep -F "fixture_missing" <<<"${auto_output}" >/dev/null
+grep -Fx "2" "${temp_dir}/guard-retry-count" >/dev/null
+grep -F "analyze-called" "${temp_dir}/analyze-called" >/dev/null
 
 echo "[transaction-staging-replay-guard] empty fixture failure writes report"
 guard_success_script="${temp_dir}/planner-guard-success.sh"

--- a/tools/test/run-transaction-read-model-staging-replay-guard.sh
+++ b/tools/test/run-transaction-read-model-staging-replay-guard.sh
@@ -10,6 +10,10 @@ echo "[transaction-staging-replay-guard] distribution estimate uses leaf partiti
 grep -F "pg_partition_tree(('public.' || target.table_name)::regclass)" "${script}" >/dev/null
 grep -F "tree.isleaf" "${script}" >/dev/null
 grep -F "SUM(GREATEST(c.reltuples, 0))" "${script}" >/dev/null
+if grep -F "awk -v index=" "${script}" >/dev/null; then
+  echo "p95 calculation must not use gawk builtin name as variable" >&2
+  exit 1
+fi
 
 temp_dir="$(mktemp -d)"
 trap 'rm -rf "${temp_dir}"' EXIT


### PR DESCRIPTION
## 🔗 Related Issue
- close #673

## 🌿 Base Branch
- `main`

## 📝 Summary
- staging replay가 planner stats freshness guard에서 `stale_analyze_age`를 만나면 bounded `ANALYZE`를 한 번 실행한 뒤 guard를 재검증하도록 했습니다.
- `PLANNER_STATS_AUTO_ANALYZE=false`로 기존 fail-fast 동작도 유지할 수 있습니다.
- replay p95 계산에서 gawk builtin 이름 `index`와 충돌하던 변수명을 제거했습니다.

## 🛠 Changes
- `transaction-read-model-staging-replay.sh`에 `PLANNER_STATS_AUTO_ANALYZE` 기본값 `true` 추가
- stale guard 실패 시 `transaction-read-model-chunk-lifecycle.sh --action analyze --target both` 실행
- ANALYZE 후 planner stats guard를 한 번 더 호출하고, 재실패 시 기존 summary artifact 실패 경로 유지
- replay guard test에 auto-analyze retry 계약 추가
- p95 계산 awk 변수명을 `index`에서 `percentile_index`로 변경

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/run-transaction-read-model-staging-replay-guard.sh`
- `bash tools/test/run-transaction-read-model-chunk-lifecycle.sh`
- `git diff --check`
- `git rev-list --count main..HEAD` = `2`
- workflow_dispatch run `25275743937`: stale stats 감지 후 ANALYZE 실행, guard 재검증 통과 확인. 이후 p95 awk 변수명 충돌 확인 후 두 번째 commit으로 수정.
- workflow_dispatch run `25275793201`: 성공. artifact 업로드 확인, estimated total rows `100000032`, hot first/cursor p95 `15ms`/`13ms`, cold first/cursor p95 `14ms`/`14ms`.

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: replay 실행 시간이 stale stats 상태에서 ANALYZE 시간만큼 증가합니다. ANALYZE는 기존 chunk lifecycle script의 lock/statement timeout을 사용합니다.
- 롤백 방법: 이 PR revert 또는 workflow/env에서 `PLANNER_STATS_AUTO_ANALYZE=false` 설정.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? secret 출력 없음
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? DB schema/API 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? replay guard contract test 반영
