### PR TITLE
[Perf] off-host k6 capacity workflow 복구

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -1,0 +1,256 @@
+name: OCI k6 service auth token
+
+on:
+  workflow_dispatch:
+    inputs:
+      hot_account_id:
+        description: "Hot account id for authenticated transaction read"
+        required: true
+        default: "910000001"
+        type: string
+      hot_from:
+        description: "Hot account from timestamp"
+        required: true
+        default: "2026-04-01T00:00:00Z"
+        type: string
+      hot_to:
+        description: "Hot account to timestamp"
+        required: true
+        default: "2026-04-30T00:00:00Z"
+        type: string
+      cold_account_id:
+        description: "Cold account id for authenticated transaction read"
+        required: true
+        default: "910000002"
+        type: string
+      cold_from:
+        description: "Cold account from timestamp"
+        required: true
+        default: "2026-01-01T00:00:00Z"
+        type: string
+      cold_to:
+        description: "Cold account to timestamp"
+        required: true
+        default: "2026-01-31T00:00:00Z"
+        type: string
+      vus:
+        description: "k6 virtual users"
+        required: false
+        default: "8"
+        type: string
+      duration:
+        description: "k6 duration"
+        required: false
+        default: "1m"
+        type: string
+      scenario_mode:
+        description: "k6 scenario mode"
+        required: false
+        default: "constant-vus"
+        type: choice
+        options:
+          - constant-vus
+          - constant-arrival-rate
+          - burst
+      docker_context:
+        description: "Remote Docker context name for off-host k6"
+        required: false
+        type: string
+      remote_base_url:
+        description: "Backend URL reachable from off-host k6"
+        required: false
+        type: string
+      remote_prometheus_rw_url:
+        description: "Prometheus remote-write URL reachable from off-host k6"
+        required: false
+        type: string
+      remote_workdir:
+        description: "Repository path on remote Docker context host"
+        required: false
+        default: "/srv/aquila-bank"
+        type: string
+      report_name:
+        description: "Optional k6 report name"
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - ".github/workflows/oci-k6-service-auth-token.yml"
+      - "tools/test/check-oci-k6-service-auth-token-workflow.sh"
+      - "tools/test/run-k6-transaction-100m-loadtest.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: OCI k6 service auth token contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate workflow contract
+        run: bash tools/test/check-oci-k6-service-auth-token-workflow.sh
+
+  authenticated-k6:
+    name: Authenticated OCI k6 capacity
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, oci-a1-staging]
+    timeout-minutes: 45
+    environment:
+      name: staging
+    env:
+      K6_REPORT_NAME: ${{ inputs.report_name || format('oci-k6-service-auth-token-{0}', github.run_id) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load OCI k6 service auth env
+        env:
+          OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}
+          HOT_ACCOUNT_ID_INPUT: ${{ inputs.hot_account_id }}
+          HOT_FROM_INPUT: ${{ inputs.hot_from }}
+          HOT_TO_INPUT: ${{ inputs.hot_to }}
+          COLD_ACCOUNT_ID_INPUT: ${{ inputs.cold_account_id }}
+          COLD_FROM_INPUT: ${{ inputs.cold_from }}
+          COLD_TO_INPUT: ${{ inputs.cold_to }}
+          VUS_INPUT: ${{ inputs.vus }}
+          DURATION_INPUT: ${{ inputs.duration }}
+          SCENARIO_MODE_INPUT: ${{ inputs.scenario_mode }}
+          DOCKER_CONTEXT_INPUT: ${{ inputs.docker_context }}
+          REMOTE_BASE_URL_INPUT: ${{ inputs.remote_base_url }}
+          REMOTE_PROMETHEUS_RW_URL_INPUT: ${{ inputs.remote_prometheus_rw_url }}
+          REMOTE_WORKDIR_INPUT: ${{ inputs.remote_workdir }}
+          CAPACITY_K6_DOCKER_CONTEXT_VAR: ${{ vars.CAPACITY_K6_DOCKER_CONTEXT }}
+          CAPACITY_K6_REMOTE_BASE_URL_VAR: ${{ vars.CAPACITY_K6_REMOTE_BASE_URL }}
+          CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_VAR: ${{ vars.CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL }}
+          CAPACITY_K6_REMOTE_WORKDIR_VAR: ${{ vars.CAPACITY_K6_REMOTE_WORKDIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${OCI_A1_STAGING_ENV}" ]]; then
+            echo "::error::Missing OCI_A1_STAGING_ENV environment secret."
+            exit 1
+          fi
+
+          staging_env_path="${RUNNER_TEMP}/oci-a1-staging-k6-service-auth.env"
+          printf '%s\n' "${OCI_A1_STAGING_ENV}" >"${staging_env_path}"
+          chmod 600 "${staging_env_path}"
+
+          set -a
+          # k6 capacity도 staging replay와 같은 unified staging secret contract를 사용한다.
+          source "${staging_env_path}"
+          set +a
+
+          K6_RUN_ID="${K6_REPORT_NAME}"
+          K6_RUN_PURPOSE="capacity"
+          K6_OBSERVABILITY_MODE="prometheus"
+          K6_GENERATOR_MODE="docker-context"
+          K6_DOCKER_CONTEXT="${DOCKER_CONTEXT_INPUT:-${CAPACITY_K6_DOCKER_CONTEXT:-${CAPACITY_K6_DOCKER_CONTEXT_VAR:-}}}"
+          K6_REMOTE_BASE_URL="${REMOTE_BASE_URL_INPUT:-${CAPACITY_K6_REMOTE_BASE_URL:-${CAPACITY_K6_REMOTE_BASE_URL_VAR:-}}}"
+          K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${REMOTE_PROMETHEUS_RW_URL_INPUT:-${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_VAR:-}}}"
+          K6_REMOTE_WORKDIR="${REMOTE_WORKDIR_INPUT:-${CAPACITY_K6_REMOTE_WORKDIR:-${CAPACITY_K6_REMOTE_WORKDIR_VAR:-/srv/aquila-bank}}}"
+          K6_REMOTE_PREFLIGHT="true"
+          K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"
+          K6_AUTH_TOKEN_REQUIRED="true"
+          K6_AUTH_PREFLIGHT="true"
+          K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${HOT_ACCOUNT_ID_INPUT}&from=${HOT_FROM_INPUT}&to=${HOT_TO_INPUT}&limit=1"
+          K6_AUTH_PREFLIGHT_EXPECTED_STATUS="200"
+          K6_HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID_INPUT}"
+          K6_HOT_FROM="${HOT_FROM_INPUT}"
+          K6_HOT_TO="${HOT_TO_INPUT}"
+          K6_COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID_INPUT}"
+          K6_COLD_FROM="${COLD_FROM_INPUT}"
+          K6_COLD_TO="${COLD_TO_INPUT}"
+          K6_VUS="${VUS_INPUT}"
+          K6_DURATION="${DURATION_INPUT}"
+          K6_SCENARIO_MODE="${SCENARIO_MODE_INPUT}"
+
+          if ! [[ "${K6_REPORT_NAME}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::K6 report name must contain only letters, numbers, dot, underscore, or hyphen."
+            exit 1
+          fi
+
+          missing=()
+          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
+          [[ -z "${K6_DOCKER_CONTEXT}" ]] && missing+=("K6_DOCKER_CONTEXT")
+          [[ -z "${K6_REMOTE_BASE_URL}" ]] && missing+=("K6_REMOTE_BASE_URL")
+          [[ -z "${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" ]] && missing+=("K6_REMOTE_PROMETHEUS_RW_SERVER_URL")
+          [[ -z "${K6_HOT_ACCOUNT_ID}" ]] && missing+=("K6_HOT_ACCOUNT_ID")
+          [[ -z "${K6_HOT_FROM}" ]] && missing+=("K6_HOT_FROM")
+          [[ -z "${K6_HOT_TO}" ]] && missing+=("K6_HOT_TO")
+          [[ -z "${K6_COLD_ACCOUNT_ID}" ]] && missing+=("K6_COLD_ACCOUNT_ID")
+          [[ -z "${K6_COLD_FROM}" ]] && missing+=("K6_COLD_FROM")
+          [[ -z "${K6_COLD_TO}" ]] && missing+=("K6_COLD_TO")
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing OCI k6 service auth env keys: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          env_names=(
+            STAGING_REPLAY_TOKEN
+            K6_REPORT_NAME
+            K6_RUN_ID
+            K6_RUN_PURPOSE
+            K6_OBSERVABILITY_MODE
+            K6_GENERATOR_MODE
+            K6_DOCKER_CONTEXT
+            K6_REMOTE_BASE_URL
+            K6_REMOTE_PROMETHEUS_RW_SERVER_URL
+            K6_REMOTE_WORKDIR
+            K6_REMOTE_PREFLIGHT
+            K6_AUTH_TOKEN_ENV_NAME
+            K6_AUTH_TOKEN_REQUIRED
+            K6_AUTH_PREFLIGHT
+            K6_AUTH_PREFLIGHT_PATH
+            K6_AUTH_PREFLIGHT_EXPECTED_STATUS
+            K6_HOT_ACCOUNT_ID
+            K6_HOT_FROM
+            K6_HOT_TO
+            K6_COLD_ACCOUNT_ID
+            K6_COLD_FROM
+            K6_COLD_TO
+            K6_VUS
+            K6_DURATION
+            K6_SCENARIO_MODE
+          )
+
+          for name in "${env_names[@]}"; do
+            value="${!name:-}"
+            if [[ -n "${value}" ]]; then
+              case "${name}" in
+                STAGING_REPLAY_TOKEN|K6_REMOTE_*|*TOKEN*|*DATABASE_URL|*_ENV_B64)
+                  echo "::add-mask::${value}"
+                  ;;
+              esac
+              printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
+            fi
+          done
+
+      - name: Run auth preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="build/reports/k6/${K6_REPORT_NAME}"
+          mkdir -p "${report_dir}"
+          tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >"${report_dir}/auth-preflight.log" 2>&1
+
+      - name: Run authenticated k6 capacity
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="build/reports/k6/${K6_REPORT_NAME}"
+          mkdir -p "${report_dir}"
+          tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${report_dir}/k6-capacity.log" 2>&1
+
+      - name: Upload OCI k6 auth artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oci-k6-service-auth-token-${{ github.run_id }}
+          path: |
+            build/reports/k6/${{ env.K6_REPORT_NAME }}/
+            build/reports/k6/${{ env.K6_REPORT_NAME }}*
+          if-no-files-found: ignore

--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate workflow contract
         run: bash tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -105,7 +105,7 @@ jobs:
       K6_REPORT_NAME: ${{ inputs.report_name || format('oci-k6-service-auth-token-{0}', github.run_id) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load OCI k6 service auth env
         env:
@@ -247,7 +247,7 @@ jobs:
 
       - name: Upload OCI k6 auth artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oci-k6-service-auth-token-${{ github.run_id }}
           path: |

--- a/.github/workflows/offhost-100m-capacity-prerequisite.yml
+++ b/.github/workflows/offhost-100m-capacity-prerequisite.yml
@@ -46,26 +46,108 @@ jobs:
   prerequisite:
     name: required off-host capacity env
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    env:
-      CAPACITY_NAME: ci-offhost-100m-capacity-prerequisite
-      CAPACITY_K6_GENERATOR_MODE: docker-context
-      CAPACITY_REMOTE_PREFLIGHT: "false"
-      CAPACITY_K6_DOCKER_CONTEXT: ${{ inputs.docker_context || vars.CAPACITY_K6_DOCKER_CONTEXT }}
-      CAPACITY_K6_REMOTE_BASE_URL: ${{ inputs.remote_base_url || vars.CAPACITY_K6_REMOTE_BASE_URL }}
-      CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL: ${{ inputs.remote_prometheus_rw_url || vars.CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL }}
-      CAPACITY_K6_REMOTE_WORKDIR: ${{ inputs.remote_workdir || vars.CAPACITY_K6_REMOTE_WORKDIR || '/srv/aquila-bank' }}
+    runs-on: [self-hosted, oci-a1-staging]
+    timeout-minutes: 10
+    environment:
+      name: staging
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Required prerequisite check
-        run: tools/test/run-transaction-100m-capacity-gates.sh --print-plan
+      - name: Load off-host capacity env
+        env:
+          OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}
+          DOCKER_CONTEXT_INPUT: ${{ inputs.docker_context }}
+          REMOTE_BASE_URL_INPUT: ${{ inputs.remote_base_url }}
+          REMOTE_PROMETHEUS_RW_URL_INPUT: ${{ inputs.remote_prometheus_rw_url }}
+          REMOTE_WORKDIR_INPUT: ${{ inputs.remote_workdir }}
+          CAPACITY_K6_DOCKER_CONTEXT_VAR: ${{ vars.CAPACITY_K6_DOCKER_CONTEXT }}
+          CAPACITY_K6_REMOTE_BASE_URL_VAR: ${{ vars.CAPACITY_K6_REMOTE_BASE_URL }}
+          CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_VAR: ${{ vars.CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL }}
+          CAPACITY_K6_REMOTE_WORKDIR_VAR: ${{ vars.CAPACITY_K6_REMOTE_WORKDIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="build/reports/k6/ci-offhost-100m-capacity-prerequisite"
+          mkdir -p "${report_dir}"
 
-      - name: Upload prerequisite failure artifact
+          if [[ -n "${OCI_A1_STAGING_ENV}" ]]; then
+            staging_env_path="${RUNNER_TEMP}/oci-a1-staging-offhost-capacity.env"
+            printf '%s\n' "${OCI_A1_STAGING_ENV}" >"${staging_env_path}"
+            chmod 600 "${staging_env_path}"
+
+            set -a
+            # off-host capacity도 staging-deploy와 같은 unified staging secret contract를 사용한다.
+            source "${staging_env_path}"
+            set +a
+          fi
+
+          CAPACITY_NAME="ci-offhost-100m-capacity-prerequisite"
+          CAPACITY_K6_GENERATOR_MODE="docker-context"
+          CAPACITY_REMOTE_PREFLIGHT="true"
+          CAPACITY_PREREQUISITE_FAILURE_REPORT_PATH="${report_dir}/capacity-prerequisite-failure.env"
+          CAPACITY_K6_DOCKER_CONTEXT="${DOCKER_CONTEXT_INPUT:-${CAPACITY_K6_DOCKER_CONTEXT:-${CAPACITY_K6_DOCKER_CONTEXT_VAR:-}}}"
+          CAPACITY_K6_REMOTE_BASE_URL="${REMOTE_BASE_URL_INPUT:-${CAPACITY_K6_REMOTE_BASE_URL:-${CAPACITY_K6_REMOTE_BASE_URL_VAR:-}}}"
+          CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${REMOTE_PROMETHEUS_RW_URL_INPUT:-${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_VAR:-}}}"
+          CAPACITY_K6_REMOTE_WORKDIR="${REMOTE_WORKDIR_INPUT:-${CAPACITY_K6_REMOTE_WORKDIR:-${CAPACITY_K6_REMOTE_WORKDIR_VAR:-/srv/aquila-bank}}}"
+
+          missing=()
+          [[ -z "${CAPACITY_K6_DOCKER_CONTEXT}" ]] && missing+=("CAPACITY_K6_DOCKER_CONTEXT")
+          [[ -z "${CAPACITY_K6_REMOTE_BASE_URL}" ]] && missing+=("CAPACITY_K6_REMOTE_BASE_URL")
+          [[ -z "${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" ]] && missing+=("CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL")
+          if (( ${#missing[@]} > 0 )); then
+            {
+              echo "CAPACITY_PREREQUISITE_STATUS=failed"
+              echo "CAPACITY_PREREQUISITE_FAILURE_REASON=missing-required-env"
+              printf 'CAPACITY_PREREQUISITE_MISSING=%s\n' "${missing[*]}"
+            } >"${CAPACITY_PREREQUISITE_FAILURE_REPORT_PATH}"
+            printf '::error::Missing off-host capacity env keys: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          env_names=(
+            CAPACITY_NAME
+            CAPACITY_K6_GENERATOR_MODE
+            CAPACITY_REMOTE_PREFLIGHT
+            CAPACITY_PREREQUISITE_FAILURE_REPORT_PATH
+            CAPACITY_K6_DOCKER_CONTEXT
+            CAPACITY_K6_REMOTE_BASE_URL
+            CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL
+            CAPACITY_K6_REMOTE_WORKDIR
+          )
+
+          for name in "${env_names[@]}"; do
+            value="${!name:-}"
+            if [[ -n "${value}" ]]; then
+              case "${name}" in
+                CAPACITY_K6_*|*TOKEN*|*DATABASE_URL|*_ENV_B64)
+                  echo "::add-mask::${value}"
+                  ;;
+              esac
+              printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
+            fi
+          done
+
+      - name: Run off-host remote preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="build/reports/k6/ci-offhost-100m-capacity-prerequisite"
+          mkdir -p "${report_dir}"
+          tools/test/run-offhost-capacity-env-doctor.sh >"${report_dir}/offhost-capacity-preflight.log" 2>&1
+
+      - name: Required prerequisite check
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="build/reports/k6/ci-offhost-100m-capacity-prerequisite"
+          mkdir -p "${report_dir}"
+          tools/test/run-transaction-100m-capacity-gates.sh --print-plan >"${report_dir}/capacity-prerequisite-plan.log" 2>&1
+
+      - name: Upload prerequisite artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: offhost-capacity-prerequisite-failure
-          path: build/reports/k6/ci-offhost-100m-capacity-prerequisite/capacity-prerequisite-failure.env
+          name: offhost-capacity-prerequisite
+          path: build/reports/k6/ci-offhost-100m-capacity-prerequisite/
           if-no-files-found: ignore

--- a/.github/workflows/offhost-100m-capacity-prerequisite.yml
+++ b/.github/workflows/offhost-100m-capacity-prerequisite.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate workflow contract
         run: tools/test/check-offhost-capacity-prerequisite-required-gate.sh
@@ -52,7 +52,7 @@ jobs:
       name: staging
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load off-host capacity env
         env:
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload prerequisite artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: offhost-capacity-prerequisite
           path: build/reports/k6/ci-offhost-100m-capacity-prerequisite/

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/oci-k6-service-auth-token.yml"
+
+echo "[oci-k6-service-auth] workflow exists"
+test -f "${workflow}"
+
+echo "[oci-k6-service-auth] workflow contract"
+grep -F "name: OCI k6 service auth token" "${workflow}" >/dev/null
+grep -F "workflow_dispatch:" "${workflow}" >/dev/null
+grep -F "pull_request:" "${workflow}" >/dev/null
+grep -F "OCI k6 service auth token contract" "${workflow}" >/dev/null
+grep -F "tools/test/check-oci-k6-service-auth-token-workflow.sh" "${workflow}" >/dev/null
+grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
+grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
+grep -F "environment:" "${workflow}" >/dev/null
+grep -F "name: staging" "${workflow}" >/dev/null
+grep -F 'OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}' "${workflow}" >/dev/null
+grep -F "Load OCI k6 service auth env" "${workflow}" >/dev/null
+grep -F "STAGING_REPLAY_TOKEN" "${workflow}" >/dev/null
+grep -F 'K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"' "${workflow}" >/dev/null
+grep -F 'K6_AUTH_PREFLIGHT="true"' "${workflow}" >/dev/null
+grep -F "K6_AUTH_PREFLIGHT_PATH" "${workflow}" >/dev/null
+grep -F "Run auth preflight" "${workflow}" >/dev/null
+grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
+grep -F "Run authenticated k6 capacity" "${workflow}" >/dev/null
+grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${workflow}" >/dev/null
+grep -F "actions/upload-artifact@" "${workflow}" >/dev/null
+grep -F "oci-k6-service-auth-token" "${workflow}" >/dev/null
+
+auth_preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"
+k6_run_line="$(grep -n -- "--no-up --no-deps" "${workflow}" | head -1 | cut -d: -f1)"
+if [[ -z "${auth_preflight_line}" || -z "${k6_run_line}" || "${auth_preflight_line}" -ge "${k6_run_line}" ]]; then
+  echo "auth preflight must run before authenticated k6 capacity" >&2
+  exit 1
+fi
+
+if grep -F 'secrets.STAGING_REPLAY_TOKEN' "${workflow}" >/dev/null; then
+  echo "workflow must read the unified staging env secret, not a standalone replay token secret" >&2
+  exit 1
+fi
+if grep -F 'K6_AUTH_TOKEN:' "${workflow}" >/dev/null; then
+  echo "workflow must not map token value directly into K6_AUTH_TOKEN" >&2
+  exit 1
+fi

--- a/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+++ b/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
@@ -14,12 +14,24 @@ grep -F "off-host capacity prerequisite contract" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
 grep -F "tools/test/check-offhost-capacity-prerequisite-required-gate.sh" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
-grep -F "CAPACITY_K6_GENERATOR_MODE: docker-context" "${workflow}" >/dev/null
-grep -F "CAPACITY_REMOTE_PREFLIGHT: \"false\"" "${workflow}" >/dev/null
+grep -F "environment:" "${workflow}" >/dev/null
+grep -F "name: staging" "${workflow}" >/dev/null
+grep -F 'OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}' "${workflow}" >/dev/null
+grep -F "Load off-host capacity env" "${workflow}" >/dev/null
+grep -F "CAPACITY_K6_DOCKER_CONTEXT_VAR" "${workflow}" >/dev/null
+grep -F 'CAPACITY_REMOTE_PREFLIGHT="true"' "${workflow}" >/dev/null
+grep -F "Run off-host remote preflight" "${workflow}" >/dev/null
+grep -F "tools/test/run-offhost-capacity-env-doctor.sh" "${workflow}" >/dev/null
+grep -F "offhost-capacity-preflight.log" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-100m-capacity-gates.sh --print-plan" "${workflow}" >/dev/null
-grep -F "capacity-prerequisite-failure.env" "${workflow}" >/dev/null
-grep -F "actions/upload-artifact@v4" "${workflow}" >/dev/null
-grep -F "offhost-capacity-prerequisite-failure" "${workflow}" >/dev/null
+grep -F "capacity-prerequisite-plan.log" "${workflow}" >/dev/null
+grep -F "actions/upload-artifact@" "${workflow}" >/dev/null
+grep -F "offhost-capacity-prerequisite" "${workflow}" >/dev/null
+grep -F "build/reports/k6/ci-offhost-100m-capacity-prerequisite/" "${workflow}" >/dev/null
+if grep -F 'CAPACITY_K6_DOCKER_CONTEXT: ${{ inputs.docker_context || vars.CAPACITY_K6_DOCKER_CONTEXT }}' "${workflow}" >/dev/null; then
+  echo "off-host workflow must not rely only on dispatch inputs and repository vars" >&2
+  exit 1
+fi
 
 echo "[offhost-capacity-prerequisite] local fail-fast contract"
 temp_dir="$(mktemp -d)"


### PR DESCRIPTION
## 🔗 Related Issue
- close #675

## 🌿 Base Branch
- `main`

## 📝 Summary
- off-host 100m capacity prerequisite workflow가 staging composite env에서 `CAPACITY_K6_*` 값을 복원하도록 수정했습니다.
- OCI k6 authenticated capacity workflow를 추가해 `STAGING_REPLAY_TOKEN` 값을 직접 노출하지 않고 `K6_AUTH_TOKEN_ENV_NAME` 경로로 preflight 후 k6를 실행합니다.

## 🛠 Changes
- `offhost-100m-capacity-prerequisite.yml` dispatch job을 OCI staging environment/self-hosted runner 기준으로 전환하고 remote preflight 로그와 capacity plan artifact를 업로드합니다.
- `oci-k6-service-auth-token.yml` workflow_dispatch를 추가해 auth preflight 200 이후 `tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps`를 실행합니다.
- 두 workflow의 secret-safe contract를 검증하는 shell 계약 테스트를 추가/강화했습니다.
- 이 PR이 추가/변경하는 workflow의 checkout/upload-artifact action을 Node 24 runtime 라인으로 맞췄습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-offhost-capacity-prerequisite-required-gate.sh`
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash -n tools/test/check-offhost-capacity-prerequisite-required-gate.sh`
- `bash -n tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file) }' .github/workflows/offhost-100m-capacity-prerequisite.yml .github/workflows/oci-k6-service-auth-token.yml`
- `rg -n "actions/(checkout|upload-artifact|setup-node)@v4" .github/workflows/offhost-100m-capacity-prerequisite.yml .github/workflows/oci-k6-service-auth-token.yml` 결과 없음(exit 1)

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `oci-a1-staging` self-hosted runner에 remote Docker context가 없으면 workflow_dispatch preflight가 실패합니다. 이 경우 artifact의 `offhost-capacity-preflight.log`로 context/backend/Prometheus 단계 중 실패 위치를 확인합니다.
- 롤백 방법: 이 PR의 commit들을 revert하면 기존 prerequisite workflow 상태로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?