### PR TITLE
[CI] GitHub Actions Node 24 migration

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: back
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload Jacoco full report
         if: always() && hashFiles('back/build/reports/jacoco/pr/jacocoPrReport.xml') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jacoco-pr-report
           path: |

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -25,10 +25,10 @@ jobs:
         working-directory: front
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: yarn

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: back
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 21
         uses: actions/setup-java@v4
@@ -48,10 +48,10 @@ jobs:
         working-directory: front
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: yarn

--- a/.github/workflows/nginx-runtime-gate.yml
+++ b/.github/workflows/nginx-runtime-gate.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install nginx and openssl
         shell: bash

--- a/.github/workflows/oci-a1-runner-doctor.yml
+++ b/.github/workflows/oci-a1-runner-doctor.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check OCI self-hosted runner prerequisites
         shell: bash

--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -28,7 +28,7 @@ jobs:
       target_sha: ${{ steps.resolve.outputs.target_sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -163,7 +163,7 @@ jobs:
       PROMOTION_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Checkout promotion SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.TARGET_SHA }}
           fetch-depth: 0

--- a/.github/workflows/production-t3micro-capacity-smoke.yml
+++ b/.github/workflows/production-t3micro-capacity-smoke.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 21
         uses: actions/setup-java@v4

--- a/.github/workflows/sse-multinode-drain-smoke.yml
+++ b/.github/workflows/sse-multinode-drain-smoke.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 21
         uses: actions/setup-java@v4

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -37,7 +37,7 @@ jobs:
       image_tag: ${{ steps.validate.outputs.image_tag }}
     steps:
       - name: Checkout deploy SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
@@ -137,7 +137,7 @@ jobs:
       backend_image: ${{ steps.images.outputs.backend_image }}
     steps:
       - name: Checkout deploy SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.deploy_sha }}
           fetch-depth: 0
@@ -213,7 +213,7 @@ jobs:
       frontend_image: ${{ steps.images.outputs.frontend_image }}
     steps:
       - name: Checkout deploy SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.deploy_sha }}
           fetch-depth: 0
@@ -311,7 +311,7 @@ jobs:
       should_deploy: ${{ steps.validate.outputs.should_deploy }}
     steps:
       - name: Checkout deploy SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.deploy_sha }}
           fetch-depth: 0
@@ -357,7 +357,7 @@ jobs:
       transaction_replay_result: ${{ steps.resolve-transaction-replay-result.outputs.result }}
     steps:
       - name: Checkout deploy SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.DEPLOY_SHA }}
           fetch-depth: 0
@@ -635,7 +635,7 @@ jobs:
 
       - name: Upload transaction replay report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: transaction-read-model-staging-replay
           path: build/reports/transaction-staging-replay/
@@ -671,7 +671,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout deploy SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.DEPLOY_SHA }}
           fetch-depth: 0

--- a/.github/workflows/transaction-100m-fixture-dump-publish.yml
+++ b/.github/workflows/transaction-100m-fixture-dump-publish.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 21
         uses: actions/setup-java@v4
@@ -82,7 +82,7 @@ jobs:
         run: tools/test/validate-transaction-100m-fixture-artifact.sh --verify
 
       - name: Upload fixture dump artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.fixture_name }}
           path: |

--- a/.github/workflows/transaction-read-model-staging-replay.yml
+++ b/.github/workflows/transaction-read-model-staging-replay.yml
@@ -69,7 +69,7 @@ jobs:
       name: staging
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load OCI A1 staging env
         env:
@@ -198,7 +198,7 @@ jobs:
 
       - name: Upload replay report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: transaction-read-model-staging-replay
           path: build/reports/transaction-staging-replay/

--- a/.github/workflows/transaction-read-replica-staging-smoke.yml
+++ b/.github/workflows/transaction-read-replica-staging-smoke.yml
@@ -42,7 +42,7 @@ jobs:
       name: staging
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load OCI A1 staging env
         env:
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload smoke report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: transaction-read-replica-staging-smoke
           path: build/reports/transaction-read-replica-staging-smoke/

--- a/.github/workflows/transaction-read-stepped-burst-gate.yml
+++ b/.github/workflows/transaction-read-stepped-burst-gate.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check stepped burst gate
         run: bash tools/test/check-transaction-read-stepped-burst-gate.sh

--- a/.github/workflows/workflow-contract-ci.yml
+++ b/.github/workflows/workflow-contract-ci.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check CI runtime optimization contract
         run: bash tools/test/check-ci-runtime-optimization-contract.sh

--- a/tools/test/check-ci-runtime-optimization-contract.sh
+++ b/tools/test/check-ci-runtime-optimization-contract.sh
@@ -10,6 +10,7 @@ staging_deploy="${ROOT_DIR}/.github/workflows/staging-deploy.yml"
 backend_runtime_dockerfile="${ROOT_DIR}/back/Dockerfile.runtime"
 backend_dockerignore="${ROOT_DIR}/back/.dockerignore"
 workflow_contract_ci="${ROOT_DIR}/.github/workflows/workflow-contract-ci.yml"
+workflow_dir="${ROOT_DIR}/.github/workflows"
 query_plan_gate="${ROOT_DIR}/tools/test/run-transaction-query-plan-regression-gate.sh"
 flyway_migration_gate="${ROOT_DIR}/tools/test/check-flyway-backward-compatible-migrations.sh"
 
@@ -37,6 +38,22 @@ require_not_contains() {
   local needle="$2"
   if grep -Fq -- "${needle}" "${path}"; then
     printf '[ci-runtime-contract] %s must not contain: %s\n' "${path#${ROOT_DIR}/}" "${needle}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+require_workflows_contains() {
+  local needle="$1"
+  if ! grep -R -Fq -- "${needle}" "${workflow_dir}"; then
+    printf '[ci-runtime-contract] workflows must contain: %s\n' "${needle}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+require_workflows_not_contains() {
+  local needle="$1"
+  if grep -R -Fq -- "${needle}" "${workflow_dir}"; then
+    printf '[ci-runtime-contract] workflows must not contain: %s\n' "${needle}" >&2
     failures=$((failures + 1))
   fi
 }
@@ -93,6 +110,13 @@ if (( failures == 0 )); then
   require_contains "${backend_runtime_dockerfile}" 'ARG JAR_FILE=build/libs/*.jar'
   require_contains "${backend_runtime_dockerfile}" 'COPY ${JAR_FILE} /app/app.jar'
   require_contains "${backend_dockerignore}" "!build/libs/*.jar"
+
+  require_workflows_not_contains "actions/checkout@v4"
+  require_workflows_not_contains "actions/upload-artifact@v4"
+  require_workflows_not_contains "actions/setup-node@v4"
+  require_workflows_contains "actions/checkout@v5"
+  require_workflows_contains "actions/upload-artifact@v7"
+  require_workflows_contains "actions/setup-node@v6"
 fi
 
 if (( failures > 0 )); then


### PR DESCRIPTION
## 🔗 Related Issue
- close #677

## 🌿 Base Branch
- `main`

## 📝 Summary
- GitHub Actions에서 Node 20 deprecation annotation을 내는 `checkout@v4`, `upload-artifact@v4`, `setup-node@v4`를 Node 24 runtime 라인으로 갱신했습니다.
- 앱 빌드 대상 Node 버전은 기존 `node-version: "20"`을 유지하고, action 런타임만 migration했습니다.

## 🛠 Changes
- `actions/checkout@v4`를 `actions/checkout@v5`로 변경했습니다.
- `actions/upload-artifact@v4`를 `actions/upload-artifact@v7`로 변경했습니다.
- `actions/setup-node@v4`를 `actions/setup-node@v6`로 변경했습니다.
- `tools/test/check-ci-runtime-optimization-contract.sh`에 v4 재도입 방지 gate를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-ci-runtime-optimization-contract.sh`
- `bash tools/test/check-offhost-capacity-prerequisite-required-gate.sh`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file) }' .github/workflows/*.yml`
- `rg -n "actions/(checkout|upload-artifact|setup-node)@v4" .github/workflows` 결과 없음(exit 1)

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `checkout@v5`, `setup-node@v6`, `upload-artifact@v7`은 GitHub Actions runner v2.327.1 이상이 필요합니다. self-hosted runner가 낮으면 runner 업데이트가 필요합니다.
- 롤백 방법: 이 commit을 revert하면 기존 action version으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?