### PR TITLE
[CI] production promotion OCI runner 직접 배포 전환

### DIFF
--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: read
   deployments: write
+  packages: read
 
 concurrency:
   group: production-promotion
@@ -26,6 +27,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       target_sha: ${{ steps.resolve.outputs.target_sha }}
+      image_tag: ${{ steps.resolve.outputs.image_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -67,6 +69,7 @@ jobs:
           fi
 
           echo "target_sha=${target_sha}" >> "${GITHUB_OUTPUT}"
+          echo "image_tag=${target_sha:0:12}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify staging deployment success
         env:
@@ -154,12 +157,13 @@ jobs:
     name: Promote SHA To Production
     needs:
       - guard
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    runs-on: [self-hosted, oci-a1-staging]
+    timeout-minutes: 35
     environment:
       name: production
     env:
       TARGET_SHA: ${{ needs.guard.outputs.target_sha }}
+      IMAGE_TAG: ${{ needs.guard.outputs.image_tag }}
       PROMOTION_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Checkout promotion SHA
@@ -177,6 +181,20 @@ jobs:
             echo "::error::Checked out ${checked_out_sha}, expected ${TARGET_SHA}."
             exit 1
           fi
+
+      - name: Resolve OCI A1 production image names
+        shell: bash
+        run: |
+          set -euo pipefail
+          owner_lc="${GITHUB_REPOSITORY_OWNER,,}"
+          printf 'BACKEND_IMAGE=ghcr.io/%s/aquila-bank-backend\n' "${owner_lc}" >>"${GITHUB_ENV}"
+          printf 'FRONTEND_IMAGE=ghcr.io/%s/aquila-bank-frontend\n' "${owner_lc}" >>"${GITHUB_ENV}"
+
+      - name: Check OCI self-hosted runner prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          ops/deploy/oci/check-self-hosted-runner.sh
 
       - name: Run Alertmanager receiver secret smoke
         env:
@@ -273,6 +291,85 @@ jobs:
 
           echo "deployment_id=${deployment_id}" >> "${GITHUB_OUTPUT}"
 
+      - name: Load OCI A1 production env
+        env:
+          OCI_A1_PRODUCTION_ENV: ${{ secrets.OCI_A1_PRODUCTION_ENV }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${OCI_A1_PRODUCTION_ENV}" ]]; then
+            echo "::error::Missing OCI_A1_PRODUCTION_ENV environment secret."
+            exit 1
+          fi
+
+          production_env_path="${RUNNER_TEMP}/oci-a1-production.env"
+          printf '%s\n' "${OCI_A1_PRODUCTION_ENV}" >"${production_env_path}"
+          chmod 600 "${production_env_path}"
+
+          set -a
+          # production 배포 설정은 Environment secret 하나에 shell env 파일 형식으로 격리한다.
+          source "${production_env_path}"
+          set +a
+
+          OCI_A1_CAPACITY_PROFILE_ENABLED="${OCI_A1_CAPACITY_PROFILE_ENABLED:-true}"
+          PRODUCTION_BASE_URL="${PRODUCTION_BASE_URL:-${STAGING_BASE_URL:-}}"
+          PRODUCTION_SMOKE_SHA_PATH="${PRODUCTION_SMOKE_SHA_PATH:-${STAGING_SMOKE_SHA_PATH:-/actuator/info}}"
+          PRODUCTION_SMOKE_HEALTH_PATH="${PRODUCTION_SMOKE_HEALTH_PATH:-${STAGING_SMOKE_HEALTH_PATH:-/actuator/health}}"
+          PRODUCTION_SMOKE_READ_PATH="${PRODUCTION_SMOKE_READ_PATH:-${STAGING_SMOKE_READ_PATH:-}}"
+          PRODUCTION_SMOKE_WRITE_PATH="${PRODUCTION_SMOKE_WRITE_PATH:-${STAGING_SMOKE_WRITE_PATH:-}}"
+          PRODUCTION_SMOKE_WRITE_METHOD="${PRODUCTION_SMOKE_WRITE_METHOD:-${STAGING_SMOKE_WRITE_METHOD:-POST}}"
+          PRODUCTION_SMOKE_WRITE_BODY="${PRODUCTION_SMOKE_WRITE_BODY:-${STAGING_SMOKE_WRITE_BODY:-{}}}"
+          PRODUCTION_SMOKE_AUTH_HEADER_NAME="${PRODUCTION_SMOKE_AUTH_HEADER_NAME:-${STAGING_SMOKE_AUTH_HEADER_NAME:-}}"
+          PRODUCTION_SMOKE_AUTH_HEADER_VALUE="${PRODUCTION_SMOKE_AUTH_HEADER_VALUE:-${STAGING_SMOKE_AUTH_HEADER_VALUE:-}}"
+          PRODUCTION_SMOKE_TIMEOUT_SECONDS="${PRODUCTION_SMOKE_TIMEOUT_SECONDS:-${STAGING_SMOKE_TIMEOUT_SECONDS:-5}}"
+
+          missing=()
+          [[ -z "${OCI_A1_BACKEND_ENV_B64:-}" ]] && missing+=("OCI_A1_BACKEND_ENV_B64")
+          [[ -z "${PRODUCTION_BASE_URL:-}" ]] && missing+=("PRODUCTION_BASE_URL")
+          [[ -z "${PRODUCTION_SMOKE_READ_PATH:-}" ]] && missing+=("PRODUCTION_SMOKE_READ_PATH")
+          [[ -z "${PRODUCTION_SMOKE_WRITE_PATH:-}" ]] && missing+=("PRODUCTION_SMOKE_WRITE_PATH")
+
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing OCI A1 production env keys: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          env_names=(
+            OCI_A1_BACKEND_ENV_B64
+            OCI_A1_FRONTEND_ENV_B64
+            OCI_A1_CAPACITY_PROFILE_ENABLED
+            PRODUCTION_BASE_URL
+            PRODUCTION_SMOKE_SHA_PATH
+            PRODUCTION_SMOKE_HEALTH_PATH
+            PRODUCTION_SMOKE_READ_PATH
+            PRODUCTION_SMOKE_WRITE_PATH
+            PRODUCTION_SMOKE_WRITE_METHOD
+            PRODUCTION_SMOKE_WRITE_BODY
+            PRODUCTION_SMOKE_AUTH_HEADER_NAME
+            PRODUCTION_SMOKE_AUTH_HEADER_VALUE
+            PRODUCTION_SMOKE_TIMEOUT_SECONDS
+            PRODUCTION_ROLLBACK_WEBHOOK_URL
+            PRODUCTION_ROLLBACK_TOKEN
+            PRODUCTION_ROLLBACK_TARGET_SHA
+          )
+
+          for name in "${env_names[@]}"; do
+            value="${!name:-}"
+            if [[ -n "${value}" ]]; then
+              echo "::add-mask::${value}"
+            fi
+            if [[ "${value}" == *$'\n'* ]]; then
+              delimiter="AQUILA_${name}_EOF_$(date +%s%N)"
+              {
+                printf '%s<<%s\n' "${name}" "${delimiter}"
+                printf '%s\n' "${value}"
+                printf '%s\n' "${delimiter}"
+              } >>"${GITHUB_ENV}"
+            else
+              printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
+            fi
+          done
+
       - name: Mark production deployment in progress
         env:
           GH_TOKEN: ${{ github.token }}
@@ -292,60 +389,24 @@ jobs:
           )"
           gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - <<< "${payload}"
 
-      - name: Dispatch production deploy hook
+      - name: Run OCI A1 production blue-green deploy locally
         env:
-          PRODUCTION_DEPLOY_WEBHOOK_URL: ${{ secrets.PRODUCTION_DEPLOY_WEBHOOK_URL }}
-          PRODUCTION_DEPLOY_TOKEN: ${{ secrets.PRODUCTION_DEPLOY_TOKEN }}
+          GITHUB_ACTOR_VALUE: ${{ github.actor }}
+          GITHUB_TOKEN_VALUE: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
+          github_token_b64="$(printf '%s' "${GITHUB_TOKEN_VALUE}" | base64 -w0)"
 
-          if [ -z "${PRODUCTION_DEPLOY_WEBHOOK_URL}" ]; then
-            echo "::error::Missing PRODUCTION_DEPLOY_WEBHOOK_URL environment secret."
-            exit 1
-          fi
+          export GITHUB_ACTOR="${GITHUB_ACTOR_VALUE}"
+          export GITHUB_TOKEN_B64="${github_token_b64}"
+          export BACKEND_ENV_B64="${OCI_A1_BACKEND_ENV_B64}"
+          export FRONTEND_ENV_B64="${OCI_A1_FRONTEND_ENV_B64:-}"
+          export OCI_A1_CAPACITY_PROFILE_ENABLED="${OCI_A1_CAPACITY_PROFILE_ENABLED}"
 
-          if [ -z "${PRODUCTION_DEPLOY_TOKEN}" ]; then
-            echo "::error::Missing PRODUCTION_DEPLOY_TOKEN environment secret."
-            exit 1
-          fi
-
-          payload="$(
-            jq -n \
-              --arg sha "${TARGET_SHA}" \
-              --arg repository "${GITHUB_REPOSITORY}" \
-              --arg run_url "${PROMOTION_LOG_URL}" \
-              --arg trigger "${GITHUB_EVENT_NAME}" \
-              --arg ref "${GITHUB_REF_NAME}" \
-              '{
-                sha: $sha,
-                repository: $repository,
-                environment: "production",
-                runUrl: $run_url,
-                trigger: $trigger,
-                ref: $ref
-              }'
-          )"
-
-          curl --fail-with-body --show-error --silent \
-            --request POST \
-            --header "Authorization: Bearer ${PRODUCTION_DEPLOY_TOKEN}" \
-            --header "Content-Type: application/json" \
-            --data "${payload}" \
-            "${PRODUCTION_DEPLOY_WEBHOOK_URL}"
+          ops/deploy/oci/bluegreen-deploy.sh
 
       - name: Run production post-deploy smoke
-        env:
-          PRODUCTION_BASE_URL: ${{ secrets.PRODUCTION_BASE_URL }}
-          PRODUCTION_SMOKE_SHA_PATH: ${{ secrets.PRODUCTION_SMOKE_SHA_PATH }}
-          PRODUCTION_SMOKE_HEALTH_PATH: ${{ secrets.PRODUCTION_SMOKE_HEALTH_PATH }}
-          PRODUCTION_SMOKE_READ_PATH: ${{ secrets.PRODUCTION_SMOKE_READ_PATH }}
-          PRODUCTION_SMOKE_WRITE_PATH: ${{ secrets.PRODUCTION_SMOKE_WRITE_PATH }}
-          PRODUCTION_SMOKE_WRITE_METHOD: ${{ secrets.PRODUCTION_SMOKE_WRITE_METHOD }}
-          PRODUCTION_SMOKE_WRITE_BODY: ${{ secrets.PRODUCTION_SMOKE_WRITE_BODY }}
-          PRODUCTION_SMOKE_AUTH_HEADER_NAME: ${{ secrets.PRODUCTION_SMOKE_AUTH_HEADER_NAME }}
-          PRODUCTION_SMOKE_AUTH_HEADER_VALUE: ${{ secrets.PRODUCTION_SMOKE_AUTH_HEADER_VALUE }}
-          PRODUCTION_SMOKE_TIMEOUT_SECONDS: ${{ secrets.PRODUCTION_SMOKE_TIMEOUT_SECONDS }}
         shell: bash
         run: tools/ops/production-postdeploy-smoke.sh
 

--- a/tools/ops/bootstrap-production-github-environment.sh
+++ b/tools/ops/bootstrap-production-github-environment.sh
@@ -53,12 +53,11 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 required_secrets=(
+  OCI_A1_PRODUCTION_ENV
   ALERTMANAGER_RECEIVER_SLACK_ENABLED
   ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED
   ALERTMANAGER_RECEIVER_WEBHOOK_ENABLED
   ALERTMANAGER_RECEIVER_WEBHOOK_URL
-  PRODUCTION_DEPLOY_WEBHOOK_URL
-  PRODUCTION_DEPLOY_TOKEN
   PRODUCTION_BASE_URL
   PRODUCTION_SMOKE_SHA_PATH
   PRODUCTION_SMOKE_HEALTH_PATH
@@ -145,10 +144,42 @@ value_of() {
   printf '%s' "${!name:-}"
 }
 
+secret_value_of() {
+  local name="$1"
+  if [[ "${name}" == "OCI_A1_PRODUCTION_ENV" ]]; then
+    local env_path="${OCI_A1_PRODUCTION_ENV_FILE:-}"
+    if [[ -n "${env_path}" ]] && ! is_placeholder "${env_path}"; then
+      if [[ ! -f "${env_path}" ]]; then
+        echo "::error::OCI_A1_PRODUCTION_ENV_FILE does not exist: ${env_path}"
+        exit 1
+      fi
+      cat "${env_path}"
+      return
+    fi
+  fi
+
+  value_of "${name}"
+}
+
+is_secret_name() {
+  local name="$1"
+  local item
+  for item in "${required_secrets[@]}" "${optional_secrets[@]}"; do
+    if [[ "${item}" == "${name}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 require_value() {
   local name="$1"
   local value
-  value="$(value_of "$name")"
+  if is_secret_name "${name}"; then
+    value="$(secret_value_of "${name}")"
+  else
+    value="$(value_of "$name")"
+  fi
   if [[ -z "${value}" ]] || is_placeholder "${value}"; then
     echo "::error::${name} must be set in ${env_file} before writing production ${environment}."
     exit 1
@@ -192,7 +223,7 @@ gh api --method PUT "repos/${repo}/environments/${environment}" -F wait_timer=0 
 
 if [[ "${vars_only}" != "true" ]]; then
   for name in "${required_secrets[@]}" "${optional_secrets[@]}"; do
-    value="$(value_of "${name}")"
+    value="$(secret_value_of "${name}")"
     if [[ -z "${value}" ]] || is_placeholder "${value}"; then
       continue
     fi

--- a/tools/ops/production-github-environment.env.example
+++ b/tools/ops/production-github-environment.env.example
@@ -3,6 +3,10 @@
 # Do not commit real token, password, webhook, or production URL values.
 
 # Required environment secrets
+# OCI_A1_PRODUCTION_ENV stores the shell env file consumed by production-promotion.yml.
+# Set OCI_A1_PRODUCTION_ENV directly, or set OCI_A1_PRODUCTION_ENV_FILE to a local file path.
+OCI_A1_PRODUCTION_ENV="<required-oci-a1-production-env-content>"
+OCI_A1_PRODUCTION_ENV_FILE=
 ALERTMANAGER_RECEIVER_SLACK_ENABLED=false
 ALERTMANAGER_RECEIVER_SLACK_WEBHOOK_URL="<required-if-slack-enabled>"
 ALERTMANAGER_RECEIVER_PAGERDUTY_ENABLED=false
@@ -15,8 +19,6 @@ TRANSACTION_READ_REPLICA_USERNAME="<required-if-read-replica-enabled>"
 TRANSACTION_READ_REPLICA_PASSWORD="<required-if-read-replica-enabled>"
 OUTBOX_KAFKA_BOOTSTRAP_SERVERS="<required-if-outbox-kafka-enabled>"
 NOTIFICATION_INBOX_CONSUMER_BOOTSTRAP_SERVERS="<required-if-notification-inbox-consumer-enabled>"
-PRODUCTION_DEPLOY_WEBHOOK_URL="<required-production-deploy-webhook-url>"
-PRODUCTION_DEPLOY_TOKEN="<required-production-deploy-token>"
 PRODUCTION_BASE_URL="<required-production-base-url>"
 PRODUCTION_SMOKE_SHA_PATH=/actuator/info
 PRODUCTION_SMOKE_HEALTH_PATH=/actuator/health

--- a/tools/test/check-production-github-environment-bootstrap.sh
+++ b/tools/test/check-production-github-environment-bootstrap.sh
@@ -13,11 +13,20 @@ test -f "${example}"
 grep -F "tools/ops/production-github-environment.env.example" .env.example >/dev/null
 grep -F "tools/ops/production-github-environment.env" .gitignore >/dev/null
 grep -F "Do not commit real token" "${example}" >/dev/null
+grep -F "OCI_A1_PRODUCTION_ENV" "${example}" >/dev/null
 grep -F "gh secret set" "${script}" >/dev/null
 grep -F "gh variable set" "${script}" >/dev/null
 grep -F "gh api --method PUT" "${script}" >/dev/null
 grep -F -- "-F wait_timer=0" "${script}" >/dev/null
 grep -F -- "--vars-only" "${script}" >/dev/null
+if grep -F "PRODUCTION_DEPLOY_WEBHOOK_URL" "${example}" "${script}" "${workflow}" >/dev/null; then
+  echo "production env bootstrap must not require public deploy webhook URL" >&2
+  exit 1
+fi
+if grep -F "PRODUCTION_DEPLOY_TOKEN" "${example}" "${script}" "${workflow}" >/dev/null; then
+  echo "production env bootstrap must not require public deploy hook token" >&2
+  exit 1
+fi
 
 echo "[production-env-bootstrap] workflow key coverage"
 ruby <<'RUBY'
@@ -45,7 +54,15 @@ RUBY
 echo "[production-env-bootstrap] print plan"
 plan="$("${script}" --print-plan)"
 grep -F "[production-env-bootstrap] repo=AquilaXk/aquila-bank environment=production" <<<"${plan}" >/dev/null
-grep -F "PRODUCTION_DEPLOY_WEBHOOK_URL" <<<"${plan}" >/dev/null
+grep -F "OCI_A1_PRODUCTION_ENV" <<<"${plan}" >/dev/null
+if grep -F "PRODUCTION_DEPLOY_WEBHOOK_URL" <<<"${plan}" >/dev/null; then
+  echo "production env bootstrap plan must not include deploy webhook URL" >&2
+  exit 1
+fi
+if grep -F "PRODUCTION_DEPLOY_TOKEN" <<<"${plan}" >/dev/null; then
+  echo "production env bootstrap plan must not include deploy hook token" >&2
+  exit 1
+fi
 grep -F "OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_MAX" <<<"${plan}" >/dev/null
 
 echo "[production-env-bootstrap] placeholder env refuses writes"

--- a/tools/test/run-production-high-traffic-config-gate.sh
+++ b/tools/test/run-production-high-traffic-config-gate.sh
@@ -32,11 +32,12 @@ promote_env = promote.fetch('env')
 abort('production promote job must receive guard image tag') unless promote_env.fetch('IMAGE_TAG').include?('needs.guard.outputs.image_tag')
 
 workflow_text = File.read('.github/workflows/production-promotion.yml')
-%w[
-  PRODUCTION_DEPLOY_WEBHOOK_URL
-  PRODUCTION_DEPLOY_TOKEN
-  Dispatch production deploy hook
-].each do |forbidden|
+forbidden_contracts = [
+  'PRODUCTION_DEPLOY_WEBHOOK_URL',
+  'PRODUCTION_DEPLOY_TOKEN',
+  'Dispatch production deploy hook',
+]
+forbidden_contracts.each do |forbidden|
   abort("production promotion must not use public deploy hook contract: #{forbidden}") if workflow_text.include?(forbidden)
 end
 

--- a/tools/test/run-production-high-traffic-config-gate.sh
+++ b/tools/test/run-production-high-traffic-config-gate.sh
@@ -15,21 +15,62 @@ require 'yaml'
 workflow = YAML.load_file('.github/workflows/production-promotion.yml')
 guard_steps = workflow.fetch('jobs').fetch('guard').fetch('steps')
 guard_step_names = guard_steps.map { |step| step['name'] }
+guard_outputs = workflow.fetch('jobs').fetch('guard').fetch('outputs')
+abort('guard must expose image_tag output for OCI deploy') unless guard_outputs.fetch('image_tag').include?('steps.resolve.outputs.image_tag')
 staging_success_index = guard_step_names.index('Verify staging deployment success') or abort('staging deployment success guard missing')
 replay_evidence_index = guard_step_names.index('Verify staging 100m replay evidence success') or abort('staging 100m replay evidence guard missing')
 abort('staging replay evidence guard must run after staging deployment guard') unless staging_success_index < replay_evidence_index
 replay_evidence_run = guard_steps.fetch(replay_evidence_index).fetch('run')
 abort('staging replay evidence guard must query separate environment') unless replay_evidence_run.include?('staging-100m-replay')
 abort('staging replay evidence guard must require success') unless replay_evidence_run.include?('No successful staging 100m replay evidence')
+resolve_step = guard_steps.fetch(guard_step_names.index('Resolve promotion target SHA'))
+abort('resolve step must write 12-char image tag') unless resolve_step.fetch('run').include?('image_tag=${target_sha:0:12}')
 
-steps = workflow.fetch('jobs').fetch('promote').fetch('steps')
+promote = workflow.fetch('jobs').fetch('promote')
+abort('production promote job must run on OCI self-hosted runner') unless promote.fetch('runs-on') == ['self-hosted', 'oci-a1-staging']
+promote_env = promote.fetch('env')
+abort('production promote job must receive guard image tag') unless promote_env.fetch('IMAGE_TAG').include?('needs.guard.outputs.image_tag')
+
+workflow_text = File.read('.github/workflows/production-promotion.yml')
+%w[
+  PRODUCTION_DEPLOY_WEBHOOK_URL
+  PRODUCTION_DEPLOY_TOKEN
+  Dispatch production deploy hook
+].each do |forbidden|
+  abort("production promotion must not use public deploy hook contract: #{forbidden}") if workflow_text.include?(forbidden)
+end
+
+steps = promote.fetch('steps')
 step_names = steps.map { |step| step['name'] }
 target_name = 'Run production high-traffic config gate'
 target_index = step_names.index(target_name) or abort("missing step: #{target_name}")
 alert_index = step_names.index('Run Alertmanager receiver secret smoke') or abort('alertmanager smoke missing')
 deploy_index = step_names.index('Create production deployment') or abort('production deployment step missing')
+load_env_index = step_names.index('Load OCI A1 production env') or abort('production env load step missing')
+direct_deploy_index = step_names.index('Run OCI A1 production blue-green deploy locally') or abort('direct OCI production deploy step missing')
+in_progress_index = step_names.index('Mark production deployment in progress') or abort('production in-progress step missing')
+smoke_index = step_names.index('Run production post-deploy smoke') or abort('production smoke step missing')
 abort('high-traffic gate must run after alertmanager smoke') unless alert_index < target_index
 abort('high-traffic gate must run before production deployment') unless target_index < deploy_index
+abort('production env must load after deployment record is created') unless deploy_index < load_env_index
+abort('direct deploy must run after in-progress status') unless in_progress_index < direct_deploy_index
+abort('direct deploy must run before production smoke') unless direct_deploy_index < smoke_index
+
+load_step = steps.fetch(load_env_index)
+abort('production env load must read unified production secret') unless load_step.fetch('env').fetch('OCI_A1_PRODUCTION_ENV').include?('secrets.OCI_A1_PRODUCTION_ENV')
+load_run = load_step.fetch('run')
+abort('production env load must require backend env b64') unless load_run.include?('OCI_A1_BACKEND_ENV_B64')
+abort('production env load must export deploy env through GITHUB_ENV') unless load_run.include?('GITHUB_ENV')
+
+direct_deploy_step = steps.fetch(direct_deploy_index)
+direct_deploy_env = direct_deploy_step.fetch('env')
+abort('direct deploy must receive GitHub actor') unless direct_deploy_env.fetch('GITHUB_ACTOR_VALUE').include?('github.actor')
+abort('direct deploy must receive GitHub token') unless direct_deploy_env.fetch('GITHUB_TOKEN_VALUE').include?('github.token')
+direct_deploy_run = direct_deploy_step.fetch('run')
+abort('direct deploy must base64-wrap GitHub token') unless direct_deploy_run.include?('GITHUB_TOKEN_B64')
+abort('direct deploy must export backend env') unless direct_deploy_run.include?('BACKEND_ENV_B64')
+abort('direct deploy must export frontend env') unless direct_deploy_run.include?('FRONTEND_ENV_B64')
+abort('direct deploy must call local bluegreen script') unless direct_deploy_run.include?('ops/deploy/oci/bluegreen-deploy.sh')
 
 step = steps.fetch(target_index)
 run = step.fetch('run')


### PR DESCRIPTION
## 🔗 Related Issue
- close #686

## 🌿 Base Branch
- `main`

## 📝 Summary
- production promotion에서 public deploy hook URL/token 의존을 제거했습니다.
- production Environment 승인 후 OCI A1 self-hosted runner에서 기존 blue-green deploy script를 직접 실행하도록 전환했습니다.

## 🛠 Changes
- `production-promotion.yml` promote job을 `[self-hosted, oci-a1-staging]` runner로 변경했습니다.
- guard job이 promotion SHA 기반 12자 image tag를 출력하도록 추가했습니다.
- `PRODUCTION_DEPLOY_WEBHOOK_URL`, `PRODUCTION_DEPLOY_TOKEN` 계약을 제거하고 `OCI_A1_PRODUCTION_ENV` unified secret을 추가했습니다.
- bootstrap script/example에서 deploy hook secret 요구를 제거하고 production OCI env file secret 업로드를 지원했습니다.
- workflow/bootstrap contract test에 direct deploy wiring 검증을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/run-production-high-traffic-config-gate.sh`
- `bash tools/test/check-production-github-environment-bootstrap.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/production-promotion.yml'); puts 'ok'"`\n- `git rev-list --count origin/main..HEAD` => `2`\n\n## 📸 Screenshot / API Example\n- 없음\n\n## ⚠️ Risk & Rollback\n- 예상 리스크: production Environment에 `OCI_A1_PRODUCTION_ENV` secret이 없으면 승인 후 promotion job이 배포 전 fail-fast 합니다.\n- 롤백 방법: 이 PR revert 후 기존 production-promotion webhook 계약으로 되돌립니다.\n\n## ☑️ Checklist\n- [x] base branch가 `main`인지 확인했는가?\n- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?\n- [x] 하나의 리뷰 목적을 유지했는가?\n- [x] PR 범위 밖 변경은 포함하지 않았는가?\n- [x] 커밋을 논리 단위로 정리했는가?\n- [x] 필요한 테스트를 수행했는가?\n- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?\n- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?\n- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?\n- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?