### PR TITLE
[Perf] transaction read edge budget evidence gates

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -226,6 +226,7 @@ jobs:
           K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT}"
           K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT}"
           K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT}"
+          K6_NGINX_ACCESS_LOG="${K6_NGINX_ACCESS_LOG:-${NGINX_ACCESS_LOG:-}}"
 
           if ! [[ "${K6_REPORT_NAME}" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "::error::K6 report name must contain only letters, numbers, dot, underscore, or hyphen."
@@ -281,6 +282,7 @@ jobs:
             K6_BURST_429_RATE_THRESHOLD
             K6_BACKEND_429_RATE_THRESHOLD
             K6_OVERLOAD_503_RATE_THRESHOLD
+            K6_NGINX_ACCESS_LOG
           )
 
           for name in "${env_names[@]}"; do
@@ -310,6 +312,22 @@ jobs:
           report_dir="build/reports/k6/${K6_REPORT_NAME}"
           mkdir -p "${report_dir}"
           tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${report_dir}/k6-capacity.log" 2>&1
+
+      - name: Build transaction read Nginx aggregate artifact
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="build/reports/k6/${K6_REPORT_NAME}"
+          mkdir -p "${report_dir}"
+          if [[ -z "${K6_NGINX_ACCESS_LOG:-}" || ! -s "${K6_NGINX_ACCESS_LOG:-}" ]]; then
+            echo "::notice::K6_NGINX_ACCESS_LOG is missing or empty; transaction-read-nginx-access-aggregate artifact skipped."
+            exit 0
+          fi
+          NGINX_ACCESS_AGGREGATE_NAME="${K6_REPORT_NAME}" \
+          NGINX_ACCESS_AGGREGATE_LOG="${K6_NGINX_ACCESS_LOG}" \
+          NGINX_ACCESS_AGGREGATE_OUTPUT_DIR="${report_dir}/transaction-read-nginx-access-aggregate" \
+            tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh
 
       - name: Upload OCI k6 auth artifact
         if: always()

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -54,6 +54,10 @@ grep -F "Run auth preflight" "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
 grep -F "Run authenticated k6 capacity" "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${workflow}" >/dev/null
+grep -F "Build transaction read Nginx aggregate artifact" "${workflow}" >/dev/null
+grep -F "K6_NGINX_ACCESS_LOG" "${workflow}" >/dev/null
+grep -F "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
+grep -F "transaction-read-nginx-access-aggregate" "${workflow}" >/dev/null
 grep -F "actions/upload-artifact@" "${workflow}" >/dev/null
 grep -F "oci-k6-service-auth-token" "${workflow}" >/dev/null
 

--- a/tools/test/check-transaction-read-48-64-capacity-gate.sh
+++ b/tools/test/check-transaction-read-48-64-capacity-gate.sh
@@ -24,6 +24,7 @@ write_summary() {
   local transaction_503_count="${8:-0}"
   local dropped_iterations="${9:-0}"
   local interrupted_iterations="${10:-0}"
+  local retry_after_p95="${11:-0}"
   cat >"${summary_dir}/rate-${rate}-summary.json" <<JSON
 {
   "metrics": {
@@ -35,6 +36,7 @@ write_summary() {
     "aquila_transaction_429_rate": {"values": {"rate": ${transaction_429_rate}}},
     "aquila_transaction_503_rate": {"values": {"rate": ${transaction_503_rate}}},
     "aquila_transaction_503_count": {"values": {"count": ${transaction_503_count}}},
+    "aquila_transaction_retry_after_sleep_ms": {"values": {"p(95)": ${retry_after_p95}}},
     "aquila_transaction_hot_first_ms": {"values": {"p(95)": ${hot_first_p95}}},
     "aquila_transaction_hot_cursor_ms": {"values": {"p(95)": ${hot_cursor_p95}}},
     "aquila_transaction_cold_first_ms": {"values": {"p(95)": ${cold_first_p95}}},
@@ -44,10 +46,11 @@ write_summary() {
 JSON
 }
 
-write_summary 52 0.020 72 88 95 120
-write_summary 56 0.060 81 102 110 145
-write_summary 60 0.091 91 130 138 180
-write_summary 64 0.120 110 190 210 260
+write_summary 32 0.000 62 78 84 96 0 0 0 0 0
+write_summary 48 0.030 72 88 95 120 0 0 0 0 80
+write_summary 64 0.095 88 96 92 99 0 0 0 0 180
+write_summary 80 0.180 91 130 138 180 0 0 0 0 220
+write_summary 96 0.260 110 190 210 260 0 0 0 0 240
 
 echo "[transaction-read-48-64-capacity] print plan"
 plan="$(
@@ -59,17 +62,16 @@ plan="$(
     "${runner}" --print-plan
 )"
 grep -F "gate=capacity-check" <<<"${plan}" >/dev/null
-grep -F "lower_anchor_rate=48" <<<"${plan}" >/dev/null
-grep -F "rates=52,56,60,64" <<<"${plan}" >/dev/null
+grep -F "lower_anchor_rate=32" <<<"${plan}" >/dev/null
+grep -F "rates=32,48,64,80,96" <<<"${plan}" >/dev/null
 grep -F "summary_dir=${summary_dir}" <<<"${plan}" >/dev/null
 grep -F "output_dir=${output_dir}" <<<"${plan}" >/dev/null
 grep -F "run_k6=false" <<<"${plan}" >/dev/null
 grep -F "warn_rate=0.08" <<<"${plan}" >/dev/null
 grep -F "fail_rate=0.10" <<<"${plan}" >/dev/null
-grep -F "report_md=${output_dir}/capacity-check-48-64-capacity.md" <<<"${plan}" >/dev/null
+grep -F "report_md=${output_dir}/capacity-check-burst-reject-curve.md" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-48-64-capacity] aggregate boundary"
-set +e
 output="$(
   CAPACITY_48_64_GATE_NAME=capacity-check \
   CAPACITY_48_64_SUMMARY_DIR="${summary_dir}" \
@@ -78,26 +80,22 @@ output="$(
   CAPACITY_48_64_FAIL_RATE=0.10 \
     "${runner}"
 )"
-status=$?
-set -e
-if [[ "${status}" -eq 0 ]]; then
-  echo "48-64 boundary unexpectedly passed despite 64 it/s fail sample" >&2
-  exit 1
-fi
 report_md="$(tail -1 <<<"${output}")"
-summary_tsv="${output_dir}/capacity-check-48-64-capacity.tsv"
-test "${report_md}" = "${output_dir}/capacity-check-48-64-capacity.md"
-grep -F $'rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\thttp_req_duration_p95_ms\tfirst_p95_ms\tdeep_p95_ms\tdropped_iterations\tinterrupted_iterations\tgenerator_headroom_status\treport_md\tsummary_json' "${summary_tsv}" >/dev/null
-grep -F $'52\tpass\t0.020\t0\t0\t88\t95\t120\t0\t0\tpass' "${summary_tsv}" >/dev/null
-grep -F $'56\tpass\t0.060\t0\t0\t102\t110\t145\t0\t0\tpass' "${summary_tsv}" >/dev/null
-grep -F $'60\twarn\t0.091\t0\t0\t130\t138\t180\t0\t0\tpass' "${summary_tsv}" >/dev/null
-grep -F $'64\tfail\t0.120\t0\t0\t190\t210\t260\t0\t0\tpass' "${summary_tsv}" >/dev/null
-grep -F "gate_status=fail" "${report_md}" >/dev/null
-grep -F "lower_anchor_rate=48" "${report_md}" >/dev/null
-grep -F "stable_pass_rate=56" "${report_md}" >/dev/null
-grep -F "max_non_fail_rate=60" "${report_md}" >/dev/null
-grep -F "first_fail_rate=64" "${report_md}" >/dev/null
-grep -F "| 64 | fail | 0.120 | 0 | 0 | 190 | 210 | 260 | pass |" "${report_md}" >/dev/null
+summary_tsv="${output_dir}/capacity-check-burst-reject-curve.tsv"
+test "${report_md}" = "${output_dir}/capacity-check-burst-reject-curve.md"
+grep -F $'rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\thttp_req_duration_p95_ms\tfirst_p95_ms\tdeep_p95_ms\tretry_after_p95_ms\tdropped_iterations\tinterrupted_iterations\tgenerator_headroom_status\treport_md\tsummary_json' "${summary_tsv}" >/dev/null
+grep -F $'32\tpass\t0.000\t0\t0\t78\t84\t96\t0\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'48\tpass\t0.030\t0\t0\t88\t95\t120\t80\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'64\twarn\t0.095\t0\t0\t96\t92\t99\t180\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'80\toverload\t0.180\t0\t0\t130\t138\t180\t220\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F $'96\toverload\t0.260\t0\t0\t190\t210\t260\t240\t0\t0\tpass' "${summary_tsv}" >/dev/null
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "lower_anchor_rate=32" "${report_md}" >/dev/null
+grep -F "stable_pass_rate=48" "${report_md}" >/dev/null
+grep -F "max_non_fail_rate=64" "${report_md}" >/dev/null
+grep -F "first_overload_rate=80" "${report_md}" >/dev/null
+grep -F "| 64 | warn | 0.095 | 0 | 0 | 96 | 92 | 99 | 180 | pass |" "${report_md}" >/dev/null
+grep -F "| 96 | overload | 0.260 | 0 | 0 | 190 | 210 | 260 | 240 | pass |" "${report_md}" >/dev/null
 
 echo "[transaction-read-48-64-capacity] generator headroom fail"
 write_summary 64 0.020 80 90 100 120 0 0 1 0
@@ -112,14 +110,15 @@ fi
 echo "[transaction-read-48-64-capacity] runner contract"
 grep -F "run-transaction-read-burst-429-budget-gate.sh" "${runner}" >/dev/null
 grep -F "CAPACITY_48_64_RATES" "${runner}" >/dev/null
-grep -F "52,56,60,64" "${runner}" >/dev/null
+grep -F "32,48,64,80,96" "${runner}" >/dev/null
 grep -F "lower_anchor_rate" "${runner}" >/dev/null
 grep -F "stable_pass_rate" "${runner}" >/dev/null
 grep -F "max_non_fail_rate" "${runner}" >/dev/null
-grep -F "first_fail_rate" "${runner}" >/dev/null
+grep -F "first_overload_rate" "${runner}" >/dev/null
 grep -F "http_req_duration" "${runner}" >/dev/null
 grep -F "first_p95_ms" "${runner}" >/dev/null
 grep -F "deep_p95_ms" "${runner}" >/dev/null
+grep -F "retry_after_p95_ms" "${runner}" >/dev/null
 grep -F "generator_headroom_status" "${runner}" >/dev/null
 
 echo "[transaction-read-48-64-capacity] invalid input fails"

--- a/tools/test/check-transaction-read-arrival-16-edge-budget-gate.sh
+++ b/tools/test/check-transaction-read-arrival-16-edge-budget-gate.sh
@@ -54,12 +54,16 @@ plan="$(
   ARRIVAL16_EDGE_BUDGET_NAME=arrival16-check \
   ARRIVAL16_EDGE_BUDGET_SUMMARY_DIR="${summary_dir}" \
   ARRIVAL16_EDGE_BUDGET_OUTPUT_DIR="${output_dir}" \
+  ARRIVAL16_EDGE_BUDGET_PACING_INPUT_REF=oci://evidence/pacing-input.json \
+  ARRIVAL16_EDGE_BUDGET_PACING_SUMMARY_REF=oci://evidence/pacing-summary.json \
     "${runner}" --print-plan
 )"
 grep -F "name=arrival16-check" <<<"${plan}" >/dev/null
 grep -F "summary_dir=${summary_dir}" <<<"${plan}" >/dev/null
 grep -F "arrival_rate=16" <<<"${plan}" >/dev/null
-grep -F "vu16_429_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "vu16_probe_mode=observe" <<<"${plan}" >/dev/null
+grep -F "pacing_input_ref=oci://evidence/pacing-input.json" <<<"${plan}" >/dev/null
+grep -F "pacing_summary_ref=oci://evidence/pacing-summary.json" <<<"${plan}" >/dev/null
 grep -F "burst_rates=48,64,80,96" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-arrival-16-edge-budget] report"
@@ -67,18 +71,22 @@ output="$(
   ARRIVAL16_EDGE_BUDGET_NAME=arrival16-check \
   ARRIVAL16_EDGE_BUDGET_SUMMARY_DIR="${summary_dir}" \
   ARRIVAL16_EDGE_BUDGET_OUTPUT_DIR="${output_dir}" \
+  ARRIVAL16_EDGE_BUDGET_PACING_INPUT_REF=oci://evidence/pacing-input.json \
+  ARRIVAL16_EDGE_BUDGET_PACING_SUMMARY_REF=oci://evidence/pacing-summary.json \
     "${runner}"
 )"
 report_md="$(tail -1 <<<"${output}")"
 summary_tsv="${output_dir}/arrival16-check-edge-budget.tsv"
 test "${report_md}" = "${output_dir}/arrival16-check-edge-budget.md"
-grep -F $'scenario\tstatus\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tedge_delayed_rate\tedge_delayed_count\t5xx_count\taccepted_p95_ms\tbudget' "${summary_tsv}" >/dev/null
-grep -F $'arrival-16\tpass\t0.000\t0.000\t0.000\t0.18\t220\t0\t260\t429<=0.000 delayed<0.25 5xx=0' "${summary_tsv}" >/dev/null
-grep -F $'vu16-soak-2m\tpass\t0.080\t0.070\t0.010\t0.10\t340\t0\t275\t429<0.10 delayed<0.25 5xx=0' "${summary_tsv}" >/dev/null
-grep -F $'burst-48\tpass\t0.280\t0.260\t0.020\t0.05\t120\t0\t195\t429<0.35 5xx=0' "${summary_tsv}" >/dev/null
+grep -F $'scenario\tgate_role\tstatus\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tedge_delayed_rate\tedge_delayed_count\t5xx_count\taccepted_p95_ms\tbudget\tpacing_input_ref\tpacing_summary_ref' "${summary_tsv}" >/dev/null
+grep -F $'arrival-16\tstrict\tpass\t0.000\t0.000\t0.000\t0.18\t220\t0\t260\t429<=0.000 delayed<0.25 5xx=0\toci://evidence/pacing-input.json\toci://evidence/pacing-summary.json' "${summary_tsv}" >/dev/null
+grep -F $'vu16-saturation-probe\tobserve\tobserve\t0.080\t0.070\t0.010\t0.10\t340\t0\t275\t429 observed, not a strict gate\toci://evidence/pacing-input.json\toci://evidence/pacing-summary.json' "${summary_tsv}" >/dev/null
+grep -F $'burst-48\tcurve\tpass\t0.280\t0.260\t0.020\t0.05\t120\t0\t195\t429<0.35 5xx=0\toci://evidence/pacing-input.json\toci://evidence/pacing-summary.json' "${summary_tsv}" >/dev/null
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "arrival-16 target: 429 = 0, 5xx = 0, edge delayed < 0.25" "${report_md}" >/dev/null
-grep -F "VU16 soak target: 429 < 0.10" "${report_md}" >/dev/null
+grep -F "VU16 saturation probe: observe-only, not a strict gate" "${report_md}" >/dev/null
+grep -F "preemptive pacing input: oci://evidence/pacing-input.json" "${report_md}" >/dev/null
+grep -F "preemptive pacing summary: oci://evidence/pacing-summary.json" "${report_md}" >/dev/null
 grep -F "burst reject curve" "${report_md}" >/dev/null
 
 echo "[transaction-read-arrival-16-edge-budget] fail report"
@@ -92,7 +100,7 @@ if ARRIVAL16_EDGE_BUDGET_NAME=arrival16-fail \
 fi
 
 echo "[transaction-read-arrival-16-edge-budget] invalid input fails"
-if ARRIVAL16_EDGE_BUDGET_SUMMARY_DIR="${summary_dir}" ARRIVAL16_EDGE_BUDGET_VU16_429_RATE=1.5 "${runner}" --print-plan >/dev/null 2>&1; then
-  echo "invalid VU16 429 rate unexpectedly succeeded" >&2
+if ARRIVAL16_EDGE_BUDGET_SUMMARY_DIR="${summary_dir}" ARRIVAL16_EDGE_BUDGET_VU16_PROBE_MODE=strict "${runner}" --print-plan >/dev/null 2>&1; then
+  echo "invalid VU16 probe mode unexpectedly succeeded" >&2
   exit 1
 fi

--- a/tools/test/check-transaction-read-burst64-residual-smoothing.sh
+++ b/tools/test/check-transaction-read-burst64-residual-smoothing.sh
@@ -13,8 +13,8 @@ input_tsv="${temp_dir}/burst64.tsv"
 output_dir="${temp_dir}/output"
 
 cat >"${input_tsv}" <<'TSV'
-policy	burst48_429_rate	burst64_429_rate	burst80_429_rate	burst96_429_rate	accepted_p95_ms	retry_after_p95_ms	reject_streak_max	delayed_rate	five_xx_count	backend_429_rate	backend_429_count
-residual-v2	0.080	0.095	0.220	0.330	118	220	4	0.04	0	0.004	25
+policy	burst48_edge_429_rate	burst64_edge_429_rate	burst80_edge_429_rate	burst96_edge_429_rate	accepted_p95_ms	retry_after_p95_ms	reject_streak_max	delayed_rate	five_xx_count	backend_429_rate	backend_429_count
+residual-v2	0.080	0.095	0.220	0.330	98	220	4	0.04	0	0.004	25
 TSV
 
 echo "[transaction-read-burst64-residual-smoothing] print plan"
@@ -27,7 +27,7 @@ plan="$(
 grep -F "name=burst64-check" <<<"${plan}" >/dev/null
 grep -F "max_burst64_429_rate=0.10" <<<"${plan}" >/dev/null
 grep -F "max_backend_429_rate=0.005" <<<"${plan}" >/dev/null
-grep -F "max_accepted_p95_ms=120" <<<"${plan}" >/dev/null
+grep -F "max_accepted_p95_ms=100" <<<"${plan}" >/dev/null
 grep -F "min_burst80_429_rate=0.10" <<<"${plan}" >/dev/null
 grep -F "max_reject_streak=4" <<<"${plan}" >/dev/null
 grep -F "observed_main659_burst64_429_rate=0.12824" <<<"${plan}" >/dev/null
@@ -43,10 +43,11 @@ report_md="$(tail -1 <<<"${output}")"
 summary_tsv="${output_dir}/burst64-check-burst64-residual-smoothing.tsv"
 test "${report_md}" = "${output_dir}/burst64-check-burst64-residual-smoothing.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
-grep -F "burst 64 total 429 budget: <= 0.10" "${report_md}" >/dev/null
+grep -F "burst 64 edge 429 budget: <= 0.10" "${report_md}" >/dev/null
 grep -F "main659 observed burst64 429: 0.12824" "${report_md}" >/dev/null
 grep -F "backend 429 budget: <= 0.005" "${report_md}" >/dev/null
-grep -F $'residual-v2\tpass\t0.080\t0.095\t0.220\t0.330\t118\t220\t4\t0.04\t0\t0.004\t25' "${summary_tsv}" >/dev/null
+grep -F $'policy\tstatus\tburst48_edge_429_rate\tburst64_edge_429_rate\tburst80_edge_429_rate\tburst96_edge_429_rate\taccepted_p95_ms\tretry_after_p95_ms\treject_streak_max\tdelayed_rate\tfive_xx_count\tbackend_429_rate\tbackend_429_count' "${summary_tsv}" >/dev/null
+grep -F $'residual-v2\tpass\t0.080\t0.095\t0.220\t0.330\t98\t220\t4\t0.04\t0\t0.004\t25' "${summary_tsv}" >/dev/null
 
 echo "[transaction-read-burst64-residual-smoothing] fail report"
 awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $3 = 0.125; $8 = 7; $11 = 0.006 } { print }' \

--- a/tools/test/run-transaction-read-48-64-capacity-gate.sh
+++ b/tools/test/run-transaction-read-48-64-capacity-gate.sh
@@ -7,8 +7,8 @@ usage: tools/test/run-transaction-read-48-64-capacity-gate.sh [--print-plan]
 
 Environment:
   CAPACITY_48_64_GATE_NAME                  default transaction-read-48-64-capacity-<timestamp>
-  CAPACITY_48_64_LOWER_ANCHOR_RATE         default 48
-  CAPACITY_48_64_RATES                     default 52,56,60,64
+  CAPACITY_48_64_LOWER_ANCHOR_RATE         default 32
+  CAPACITY_48_64_RATES                     default 32,48,64,80,96
   CAPACITY_48_64_DURATION                  default 20s
   CAPACITY_48_64_WARN_RATE                 default 0.08
   CAPACITY_48_64_FAIL_RATE                 default 0.10
@@ -43,9 +43,9 @@ while [[ "$#" -gt 0 ]]; do
   shift
 done
 
-gate_name="${CAPACITY_48_64_GATE_NAME:-transaction-read-48-64-capacity-$(date +%Y-%m-%d-%H%M%S)}"
-lower_anchor_rate="${CAPACITY_48_64_LOWER_ANCHOR_RATE:-48}"
-rates="${CAPACITY_48_64_RATES:-52,56,60,64}"
+gate_name="${CAPACITY_48_64_GATE_NAME:-transaction-read-burst-reject-curve-$(date +%Y-%m-%d-%H%M%S)}"
+lower_anchor_rate="${CAPACITY_48_64_LOWER_ANCHOR_RATE:-32}"
+rates="${CAPACITY_48_64_RATES:-32,48,64,80,96}"
 duration="${CAPACITY_48_64_DURATION:-20s}"
 warn_rate="${CAPACITY_48_64_WARN_RATE:-0.08}"
 fail_rate="${CAPACITY_48_64_FAIL_RATE:-0.10}"
@@ -53,8 +53,8 @@ run_k6="${CAPACITY_48_64_RUN_K6:-false}"
 summary_dir="${CAPACITY_48_64_SUMMARY_DIR:-}"
 output_dir="${CAPACITY_48_64_OUTPUT_DIR:-build/reports/k6/${gate_name}}"
 max_retry_after_sleep_seconds="${CAPACITY_48_64_MAX_RETRY_AFTER_SLEEP_SECONDS:-1}"
-summary_tsv="${output_dir}/${gate_name}-48-64-capacity.tsv"
-report_md="${output_dir}/${gate_name}-48-64-capacity.md"
+summary_tsv="${output_dir}/${gate_name}-burst-reject-curve.tsv"
+report_md="${output_dir}/${gate_name}-burst-reject-curve.md"
 single_gate="tools/test/run-transaction-read-burst-429-budget-gate.sh"
 
 require_positive_integer_value() {
@@ -220,13 +220,13 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 mkdir -p "${output_dir}"
-printf "rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\thttp_req_duration_p95_ms\tfirst_p95_ms\tdeep_p95_ms\tdropped_iterations\tinterrupted_iterations\tgenerator_headroom_status\treport_md\tsummary_json\n" >"${summary_tsv}"
+printf "rate\tstatus\ttransaction_429_rate\ttransaction_503_rate\ttransaction_503_count\thttp_req_duration_p95_ms\tfirst_p95_ms\tdeep_p95_ms\tretry_after_p95_ms\tdropped_iterations\tinterrupted_iterations\tgenerator_headroom_status\treport_md\tsummary_json\n" >"${summary_tsv}"
 
 gate_status="pass"
 stable_pass_rate="${lower_anchor_rate}"
 max_non_fail_rate="${lower_anchor_rate}"
-first_fail_rate="none"
-summary_table=$'| rate | status | 429 rate | 503 rate | 503 count | http p95 ms | first p95 ms | deep p95 ms | generator headroom |\n| --- | --- | --- | --- | --- | --- | --- | --- | --- |'
+first_overload_rate="none"
+summary_table=$'| rate | status | 429 rate | 503 rate | 503 count | http p95 ms | first p95 ms | deep p95 ms | retry-after p95 ms | generator headroom |\n| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |'
 IFS=',' read -r -a rate_items <<<"${rates}"
 for rate in "${rate_items[@]}"; do
   single_name="${gate_name}-rate-${rate}"
@@ -261,6 +261,7 @@ for rate in "${rate_items[@]}"; do
   transaction_503_rate="$(metric_value "${summary_json}" aquila_transaction_503_rate rate)"
   transaction_503_count="$(metric_value "${summary_json}" aquila_transaction_503_count count)"
   http_req_duration_p95="$(metric_value "${summary_json}" http_req_duration "p(95)")"
+  retry_after_p95="$(metric_value "${summary_json}" aquila_transaction_retry_after_sleep_ms "p(95)")"
   hot_first_p95="$(metric_value "${summary_json}" aquila_transaction_hot_first_ms "p(95)")"
   hot_cursor_p95="$(metric_value "${summary_json}" aquila_transaction_hot_cursor_ms "p(95)")"
   cold_first_p95="$(metric_value "${summary_json}" aquila_transaction_cold_first_ms "p(95)")"
@@ -275,46 +276,47 @@ for rate in "${rate_items[@]}"; do
   fi
 
   rate_status="$(status_for_rate "${transaction_429_rate}")"
-  if [[ "${single_status}" -ne 0 ]] || [[ "${generator_headroom_status}" == "fail" ]] \
+  if (( rate > 64 )) && number_greater_than "${transaction_429_rate}" "${fail_rate}"; then
+    rate_status="overload"
+  fi
+  if [[ "${generator_headroom_status}" == "fail" ]] \
       || number_greater_than "${transaction_503_rate}" "0" \
       || number_greater_than "${transaction_503_count}" "0"; then
+    rate_status="fail"
+  fi
+  if (( rate <= 64 )) && [[ "${single_status}" -ne 0 ]]; then
     rate_status="fail"
   fi
 
   case "${rate_status}" in
     fail)
       gate_status="fail"
-      if [[ "${first_fail_rate}" == "none" ]]; then
-        first_fail_rate="${rate}"
+      ;;
+    overload)
+      if [[ "${first_overload_rate}" == "none" ]]; then
+        first_overload_rate="${rate}"
       fi
       ;;
     warn)
-      if [[ "${gate_status}" == "pass" ]]; then
-        gate_status="warn"
-      fi
-      if [[ "${first_fail_rate}" == "none" ]]; then
-        max_non_fail_rate="${rate}"
-      fi
+      max_non_fail_rate="${rate}"
       ;;
     pass)
-      if [[ "${first_fail_rate}" == "none" ]]; then
-        stable_pass_rate="${rate}"
-        max_non_fail_rate="${rate}"
-      fi
+      stable_pass_rate="${rate}"
+      max_non_fail_rate="${rate}"
       ;;
   esac
 
   single_report="${single_output_dir}/${single_name}-burst-429-budget.md"
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
     "${rate}" "${rate_status}" "${transaction_429_rate}" "${transaction_503_rate}" \
     "${transaction_503_count}" "${http_req_duration_p95}" "${first_p95}" "${deep_p95}" \
-    "${dropped_iterations}" "${interrupted_iterations}" "${generator_headroom_status}" \
+    "${retry_after_p95}" "${dropped_iterations}" "${interrupted_iterations}" "${generator_headroom_status}" \
     "${single_report}" "${summary_json}" >>"${summary_tsv}"
-  summary_table="${summary_table}"$'\n'"| ${rate} | ${rate_status} | ${transaction_429_rate} | ${transaction_503_rate} | ${transaction_503_count} | ${http_req_duration_p95} | ${first_p95} | ${deep_p95} | ${generator_headroom_status} |"
+  summary_table="${summary_table}"$'\n'"| ${rate} | ${rate_status} | ${transaction_429_rate} | ${transaction_503_rate} | ${transaction_503_count} | ${http_req_duration_p95} | ${first_p95} | ${deep_p95} | ${retry_after_p95} | ${generator_headroom_status} |"
 done
 
 cat >"${report_md}" <<REPORT
-# Transaction Read 48-64 Capacity Boundary Gate
+# Transaction Read Burst Reject Curve Gate
 
 ## Summary
 
@@ -327,7 +329,7 @@ cat >"${report_md}" <<REPORT
 - fail threshold: ${fail_rate}
 - stable_pass_rate=${stable_pass_rate}
 - max_non_fail_rate=${max_non_fail_rate}
-- first_fail_rate=${first_fail_rate}
+- first_overload_rate=${first_overload_rate}
 
 ## Result Table
 
@@ -340,9 +342,9 @@ ${summary_table}
 
 ## Notes
 
-- 48 it/s는 최근 통과 anchor로 두고 52/56/60/64 it/s 경계만 자동 측정합니다.
-- 429는 admission 보호 신호로 budget 관리하고, 503과 generator headroom 실패는 hard fail로 처리합니다.
-- p95는 HTTP overhead와 first/deep cursor 비용을 함께 해석할 수 있도록 report에 포함합니다.
+- burst 32/48/64/80/96은 같은 evidence pack에 묶어 edge reject curve를 비교합니다.
+- 64 이하에서 429 budget을 넘으면 hard fail이고, 80 이상은 overload curve로 기록하되 503/headroom 실패는 hard fail입니다.
+- p95와 retry-after p95는 accepted latency와 client backoff 비용을 함께 해석할 수 있도록 report에 포함합니다.
 REPORT
 
 echo "${report_md}"

--- a/tools/test/run-transaction-read-arrival-16-edge-budget-gate.sh
+++ b/tools/test/run-transaction-read-arrival-16-edge-budget-gate.sh
@@ -13,9 +13,11 @@ Environment:
   ARRIVAL16_EDGE_BUDGET_BURST_RATES       default 48,64,80,96
   ARRIVAL16_EDGE_BUDGET_DELAYED_RATE      default 0.25
   ARRIVAL16_EDGE_BUDGET_ARRIVAL_429_RATE  default 0.000
-  ARRIVAL16_EDGE_BUDGET_VU16_429_RATE     default 0.10
+  ARRIVAL16_EDGE_BUDGET_VU16_PROBE_MODE   default observe
   ARRIVAL16_EDGE_BUDGET_BURST_429_CURVE   default 48:0.35,64:0.45,80:0.60,96:0.70
   ARRIVAL16_EDGE_BUDGET_ACCEPTED_P95_MS   default 350
+  ARRIVAL16_EDGE_BUDGET_PACING_INPUT_REF  optional preemptive pacing input artifact ref
+  ARRIVAL16_EDGE_BUDGET_PACING_SUMMARY_REF optional preemptive pacing summary artifact ref
 USAGE
 }
 
@@ -44,9 +46,11 @@ arrival_rate="${ARRIVAL16_EDGE_BUDGET_ARRIVAL_RATE:-16}"
 burst_rates="${ARRIVAL16_EDGE_BUDGET_BURST_RATES:-48,64,80,96}"
 delayed_rate="${ARRIVAL16_EDGE_BUDGET_DELAYED_RATE:-0.25}"
 arrival_429_rate="${ARRIVAL16_EDGE_BUDGET_ARRIVAL_429_RATE:-0.000}"
-vu16_429_rate="${ARRIVAL16_EDGE_BUDGET_VU16_429_RATE:-0.10}"
+vu16_probe_mode="${ARRIVAL16_EDGE_BUDGET_VU16_PROBE_MODE:-observe}"
 burst_429_curve="${ARRIVAL16_EDGE_BUDGET_BURST_429_CURVE:-48:0.35,64:0.45,80:0.60,96:0.70}"
 accepted_p95_ms="${ARRIVAL16_EDGE_BUDGET_ACCEPTED_P95_MS:-350}"
+pacing_input_ref="${ARRIVAL16_EDGE_BUDGET_PACING_INPUT_REF:-missing}"
+pacing_summary_ref="${ARRIVAL16_EDGE_BUDGET_PACING_SUMMARY_REF:-missing}"
 summary_tsv="${output_dir}/${name}-edge-budget.tsv"
 report_md="${output_dir}/${name}-edge-budget.md"
 
@@ -105,6 +109,15 @@ require_curve() {
     require_positive_integer "${name}" "${rate}"
     require_rate "${name}" "${budget}"
   done
+}
+
+require_probe_mode() {
+  local name="$1"
+  local value="$2"
+  if [[ "${value}" != "observe" ]]; then
+    echo "${name} must be observe: ${value}" >&2
+    exit 1
+  fi
 }
 
 number_greater_than() {
@@ -174,9 +187,11 @@ print_plan() {
   echo "[transaction-read-arrival-16-edge-budget] burst_rates=${burst_rates}"
   echo "[transaction-read-arrival-16-edge-budget] delayed_rate=${delayed_rate}"
   echo "[transaction-read-arrival-16-edge-budget] arrival_429_rate=${arrival_429_rate}"
-  echo "[transaction-read-arrival-16-edge-budget] vu16_429_rate=${vu16_429_rate}"
+  echo "[transaction-read-arrival-16-edge-budget] vu16_probe_mode=${vu16_probe_mode}"
   echo "[transaction-read-arrival-16-edge-budget] burst_429_curve=${burst_429_curve}"
   echo "[transaction-read-arrival-16-edge-budget] accepted_p95_ms=${accepted_p95_ms}"
+  echo "[transaction-read-arrival-16-edge-budget] pacing_input_ref=${pacing_input_ref}"
+  echo "[transaction-read-arrival-16-edge-budget] pacing_summary_ref=${pacing_summary_ref}"
   echo "[transaction-read-arrival-16-edge-budget] summary_tsv=${summary_tsv}"
   echo "[transaction-read-arrival-16-edge-budget] report_md=${report_md}"
 }
@@ -185,7 +200,7 @@ require_positive_integer "ARRIVAL16_EDGE_BUDGET_ARRIVAL_RATE" "${arrival_rate}"
 require_csv_positive_integers "ARRIVAL16_EDGE_BUDGET_BURST_RATES" "${burst_rates}"
 require_rate "ARRIVAL16_EDGE_BUDGET_DELAYED_RATE" "${delayed_rate}"
 require_rate "ARRIVAL16_EDGE_BUDGET_ARRIVAL_429_RATE" "${arrival_429_rate}"
-require_rate "ARRIVAL16_EDGE_BUDGET_VU16_429_RATE" "${vu16_429_rate}"
+require_probe_mode "ARRIVAL16_EDGE_BUDGET_VU16_PROBE_MODE" "${vu16_probe_mode}"
 require_curve "ARRIVAL16_EDGE_BUDGET_BURST_429_CURVE" "${burst_429_curve}"
 require_positive_integer "ARRIVAL16_EDGE_BUDGET_ACCEPTED_P95_MS" "${accepted_p95_ms}"
 
@@ -208,16 +223,17 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 mkdir -p "${output_dir}"
-printf "scenario\tstatus\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tedge_delayed_rate\tedge_delayed_count\t5xx_count\taccepted_p95_ms\tbudget\n" >"${summary_tsv}"
-summary_table=$'| Scenario | Status | Total 429 | Edge 429 | Backend 429 | Edge delayed | 5xx | Accepted p95 ms | Budget |\n| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |'
+printf "scenario\tgate_role\tstatus\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tedge_delayed_rate\tedge_delayed_count\t5xx_count\taccepted_p95_ms\tbudget\tpacing_input_ref\tpacing_summary_ref\n" >"${summary_tsv}"
+summary_table=$'| Scenario | Role | Status | Total 429 | Edge 429 | Backend 429 | Edge delayed | 5xx | Accepted p95 ms | Budget |\n| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |'
 gate_status="pass"
 
 append_row() {
   local scenario="$1"
-  local summary_json="$2"
-  local max_429="$3"
-  local max_delayed="$4"
-  local budget="$5"
+  local role="$2"
+  local summary_json="$3"
+  local max_429="$4"
+  local max_delayed="$5"
+  local budget="$6"
 
   if [[ ! -s "${summary_json}" ]]; then
     echo "summary missing for ${scenario}: ${summary_json}" >&2
@@ -234,32 +250,37 @@ append_row() {
   p95="$(accepted_p95 "${summary_json}")"
 
   status="pass"
-  if number_greater_than "${total_429}" "${max_429}" \
-      || number_greater_than "${delayed}" "${max_delayed}" \
-      || number_greater_than "${five_xx}" "0" \
-      || number_greater_than "${p95}" "${accepted_p95_ms}"; then
-    status="fail"
-    gate_status="fail"
+  if [[ "${role}" == "observe" ]]; then
+    status="observe"
+  elif number_greater_than "${total_429}" "${max_429}" \
+        || number_greater_than "${delayed}" "${max_delayed}" \
+        || number_greater_than "${five_xx}" "0" \
+        || number_greater_than "${p95}" "${accepted_p95_ms}"; then
+      status="fail"
+      gate_status="fail"
   fi
 
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
-    "${scenario}" "${status}" "${total_429}" "${edge_429}" "${backend_429}" \
-    "${delayed}" "${delayed_count}" "${five_xx}" "${p95}" "${budget}" >>"${summary_tsv}"
-  summary_table="${summary_table}"$'\n'"| ${scenario} | ${status} | ${total_429} | ${edge_429} | ${backend_429} | ${delayed} | ${five_xx} | ${p95} | ${budget} |"
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "${scenario}" "${role}" "${status}" "${total_429}" "${edge_429}" "${backend_429}" \
+    "${delayed}" "${delayed_count}" "${five_xx}" "${p95}" "${budget}" "${pacing_input_ref}" \
+    "${pacing_summary_ref}" >>"${summary_tsv}"
+  summary_table="${summary_table}"$'\n'"| ${scenario} | ${role} | ${status} | ${total_429} | ${edge_429} | ${backend_429} | ${delayed} | ${five_xx} | ${p95} | ${budget} |"
 }
 
 append_row \
   "arrival-${arrival_rate}" \
+  "strict" \
   "${summary_dir%/}/arrival-${arrival_rate}-summary.json" \
   "${arrival_429_rate}" \
   "${delayed_rate}" \
   "429<=${arrival_429_rate} delayed<${delayed_rate} 5xx=0"
 append_row \
-  "vu16-soak-2m" \
+  "vu16-saturation-probe" \
+  "observe" \
   "${summary_dir%/}/vu16-soak-2m-summary.json" \
-  "${vu16_429_rate}" \
-  "${delayed_rate}" \
-  "429<${vu16_429_rate} delayed<${delayed_rate} 5xx=0"
+  "1" \
+  "1" \
+  "429 observed, not a strict gate"
 
 IFS=',' read -r -a rate_items <<<"${burst_rates}"
 for rate in "${rate_items[@]}"; do
@@ -270,6 +291,7 @@ for rate in "${rate_items[@]}"; do
   fi
   append_row \
     "burst-${rate}" \
+    "curve" \
     "${summary_dir%/}/burst-${rate}-summary.json" \
     "${budget}" \
     "${delayed_rate}" \
@@ -283,9 +305,11 @@ cat >"${report_md}" <<REPORT
 
 - gate_status=${gate_status}
 - arrival-16 target: 429 = 0, 5xx = 0, edge delayed < ${delayed_rate}
-- VU16 soak target: 429 < ${vu16_429_rate}
+- VU16 saturation probe: observe-only, not a strict gate
 - accepted p95 target: < ${accepted_p95_ms}ms
 - burst reject curve: ${burst_429_curve}
+- preemptive pacing input: ${pacing_input_ref}
+- preemptive pacing summary: ${pacing_summary_ref}
 
 ## Result Table
 
@@ -294,7 +318,7 @@ ${summary_table}
 ## Contract Notes
 
 - arrival-16은 정상 capacity 후보라 429를 허용하지 않는다.
-- VU16 soak는 steady shared-client 압박을 반영하되 429 budget을 10% 미만으로 제한한다.
+- VU16 constant-vus는 saturation probe로만 기록하고 arrival-rate strict gate와 섞지 않는다.
 - burst-48/64/80/96은 overload 방어 곡선으로 분리해 fail-fast 429가 어느 지점에서 증가하는지 기록한다.
 
 ## Artifacts

--- a/tools/test/run-transaction-read-burst64-residual-smoothing.sh
+++ b/tools/test/run-transaction-read-burst64-residual-smoothing.sh
@@ -14,7 +14,7 @@ Environment:
   BURST64_SMOOTHING_MAX_BACKEND_429_RATE  default 0.005
   BURST64_SMOOTHING_MIN_BURST80_429_RATE  default 0.10
   BURST64_SMOOTHING_MIN_BURST96_429_RATE  default 0.10
-  BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS   default 120
+  BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS   default 100
   BURST64_SMOOTHING_MAX_RETRY_P95_MS      default 250
   BURST64_SMOOTHING_MAX_REJECT_STREAK     default 4
   BURST64_SMOOTHING_MAX_DELAYED_RATE      default 0.05
@@ -48,7 +48,7 @@ max_burst64_429_rate="${BURST64_SMOOTHING_MAX_BURST64_429_RATE:-0.10}"
 max_backend_429_rate="${BURST64_SMOOTHING_MAX_BACKEND_429_RATE:-0.005}"
 min_burst80_429_rate="${BURST64_SMOOTHING_MIN_BURST80_429_RATE:-0.10}"
 min_burst96_429_rate="${BURST64_SMOOTHING_MIN_BURST96_429_RATE:-0.10}"
-max_accepted_p95_ms="${BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS:-120}"
+max_accepted_p95_ms="${BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS:-100}"
 max_retry_p95_ms="${BURST64_SMOOTHING_MAX_RETRY_P95_MS:-250}"
 max_reject_streak="${BURST64_SMOOTHING_MAX_REJECT_STREAK:-4}"
 max_delayed_rate="${BURST64_SMOOTHING_MAX_DELAYED_RATE:-0.05}"
@@ -163,19 +163,24 @@ awk -F '\t' \
     if (!(name in col) || col[name] == "") return fallback
     return $(col[name])
   }
+  function value_any(primary, legacy, fallback) {
+    if ((primary in col) && col[primary] != "") return $(col[primary])
+    if ((legacy in col) && col[legacy] != "") return $(col[legacy])
+    return fallback
+  }
   NR == 1 {
     for (i = 1; i <= NF; i++) {
       col[$i] = i
     }
-    print "policy\tstatus\tburst48_429_rate\tburst64_429_rate\tburst80_429_rate\tburst96_429_rate\taccepted_p95_ms\tretry_after_p95_ms\treject_streak_max\tdelayed_rate\tfive_xx_count\tbackend_429_rate\tbackend_429_count"
+    print "policy\tstatus\tburst48_edge_429_rate\tburst64_edge_429_rate\tburst80_edge_429_rate\tburst96_edge_429_rate\taccepted_p95_ms\tretry_after_p95_ms\treject_streak_max\tdelayed_rate\tfive_xx_count\tbackend_429_rate\tbackend_429_count"
     next
   }
   {
     policy = value("policy", "unknown")
-    burst48 = value("burst48_429_rate", "1") + 0
-    burst64 = value("burst64_429_rate", "1") + 0
-    burst80 = value("burst80_429_rate", "0") + 0
-    burst96 = value("burst96_429_rate", "0") + 0
+    burst48 = value_any("burst48_edge_429_rate", "burst48_429_rate", "1") + 0
+    burst64 = value_any("burst64_edge_429_rate", "burst64_429_rate", "1") + 0
+    burst80 = value_any("burst80_edge_429_rate", "burst80_429_rate", "0") + 0
+    burst96 = value_any("burst96_edge_429_rate", "burst96_429_rate", "0") + 0
     accepted_p95 = value("accepted_p95_ms", "999999") + 0
     retry_p95 = value("retry_after_p95_ms", "999999") + 0
     streak = value("reject_streak_max", "999999") + 0
@@ -184,15 +189,15 @@ awk -F '\t' \
     backend_429_rate = value("backend_429_rate", "1") + 0
     backend_429 = value("backend_429_count", "1") + 0
     status = "pass"
-    if (burst48 > max_burst48 || burst64 > max_burst64 || burst80 < min_burst80 || burst96 < min_burst96 || accepted_p95 > max_p95 || retry_p95 > max_retry_p95 || streak > max_streak || delayed > max_delayed || five_xx > 0 || backend_429_rate > max_backend_429) {
+    if (burst48 > max_burst48 || burst64 > max_burst64 || burst80 < min_burst80 || burst96 < min_burst96 || accepted_p95 >= max_p95 || retry_p95 > max_retry_p95 || streak > max_streak || delayed > max_delayed || five_xx > 0 || backend_429_rate > max_backend_429) {
       status = "fail"
       fail_count++
     } else {
       pass_count++
     }
     printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-      policy, status, value("burst48_429_rate", "0"), value("burst64_429_rate", "0"),
-      value("burst80_429_rate", "0"), value("burst96_429_rate", "0"), value("accepted_p95_ms", "0"),
+      policy, status, value_any("burst48_edge_429_rate", "burst48_429_rate", "0"), value_any("burst64_edge_429_rate", "burst64_429_rate", "0"),
+      value_any("burst80_edge_429_rate", "burst80_429_rate", "0"), value_any("burst96_edge_429_rate", "burst96_429_rate", "0"), value("accepted_p95_ms", "0"),
       value("retry_after_p95_ms", "0"), value("reject_streak_max", "0"), value("delayed_rate", "0"),
       value("five_xx_count", "0"), value("backend_429_rate", "0"), value("backend_429_count", "0")
   }
@@ -213,7 +218,7 @@ fi
 
 matrix_table="$(awk -F '\t' '
   BEGIN {
-    print "| Policy | Status | burst48 429 | burst64 429 | burst80 429 | burst96 429 | p95 ms | Retry p95 ms | Streak max | Delayed | 5xx | Backend 429 rate | Backend 429 count |"
+    print "| Policy | Status | burst48 edge 429 | burst64 edge 429 | burst80 edge 429 | burst96 edge 429 | p95 ms | Retry p95 ms | Streak max | Delayed | 5xx | Backend 429 rate | Backend 429 count |"
     print "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
   }
   NR > 1 {
@@ -227,12 +232,12 @@ cat >"${report_md}" <<REPORT
 ## Summary
 
 - gate_status=${gate_status}
-- burst 48 total 429 budget: <= ${max_burst48_429_rate}
-- burst 64 total 429 budget: <= ${max_burst64_429_rate}
+- burst 48 edge 429 budget: <= ${max_burst48_429_rate}
+- burst 64 edge 429 budget: <= ${max_burst64_429_rate}
 - main659 observed burst64 429: ${observed_main659_burst64_429_rate}
 - backend 429 budget: <= ${max_backend_429_rate}
 - burst 80/96 policy: fail-fast overload lower bound >= ${min_burst80_429_rate}/${min_burst96_429_rate}
-- accepted p95 budget: <= ${max_accepted_p95_ms}ms
+- accepted p95 budget: < ${max_accepted_p95_ms}ms
 - retry-after p95 budget: <= ${max_retry_p95_ms}ms
 - reject streak max: <= ${max_reject_streak}
 - delayed ratio budget: <= ${max_delayed_rate}
@@ -244,7 +249,7 @@ ${matrix_table}
 
 ## Contract Notes
 
-- burst64는 residual 총 429 10% 이하를 pass 경계로 둔다.
+- burst64는 edge 429 10% 이하와 accepted p95 < 100ms를 pass 경계로 둔다.
 - burst80 이상은 낮은 latency의 fail-fast overload로 남기며 accepted delay를 늘려 pass 처리하지 않는다.
 - backend 429와 5xx는 edge smoothing 후보에서 즉시 탈락한다.
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #688

## 🌿 Base Branch
- main

## 📝 Summary
- transaction read edge budget gate를 burst64 edge 429/accepted p95 기준으로 강화합니다.
- arrival-rate 16/s strict gate와 VU16 saturation probe를 분리하고, Nginx access aggregate artifact를 OCI k6 workflow에 연결합니다.

## 🛠 Changes
- burst64 residual smoothing 기본 accepted p95 budget을 100ms 미만으로 낮추고 edge 429 컬럼을 표준화했습니다.
- arrival-16 strict row, VU16 observe-only saturation row, pacing input/summary ref를 edge budget report에 남깁니다.
- burst 32/48/64/80/96 reject curve TSV에 retry-after p95를 포함하고 overload row를 evidence로 기록합니다.
- OCI k6 service auth workflow가 Nginx JSON access log가 있을 때 aggregate TSV/Markdown artifact를 생성하도록 했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- bash tools/test/check-transaction-read-burst64-residual-smoothing.sh
- bash tools/test/check-transaction-read-arrival-16-edge-budget-gate.sh
- bash tools/test/check-transaction-read-48-64-capacity-gate.sh
- bash tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh
- bash tools/test/check-oci-k6-service-auth-token-workflow.sh

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 48-64 capacity gate artifact filename이 burst-reject-curve 명칭으로 바뀌어 외부 참조가 있으면 갱신이 필요할 수 있습니다.
- 롤백 방법: 이 PR의 두 커밋을 revert하면 이전 gate/workflow 계약으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 main인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?