### PR TITLE
[CI] staging deploy skipped-success 상태 hardening

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -70,6 +70,51 @@ jobs:
           echo "deploy_sha=${DEPLOY_SHA}" >> "${GITHUB_OUTPUT}"
           echo "image_tag=${DEPLOY_SHA:0:12}" >> "${GITHUB_OUTPUT}"
 
+  record-noop:
+    name: Record No-Op Staging Deploy
+    needs:
+      - prepare
+    if: >-
+      always() &&
+      (
+        needs.prepare.result == 'skipped' ||
+        (
+          needs.prepare.result == 'success' &&
+          needs.prepare.outputs.should_deploy != 'true'
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Record no-op staging deploy
+        env:
+          WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          PREPARE_RESULT: ${{ needs.prepare.result }}
+          PREPARE_SHOULD_DEPLOY: ${{ needs.prepare.outputs.should_deploy }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          reason="not-main-push-success"
+          if [[ "${PREPARE_RESULT}" == "success" && "${PREPARE_SHOULD_DEPLOY}" != "true" ]]; then
+            reason="stale-main-sha"
+          fi
+
+          {
+            echo "## Staging Deploy No-Op"
+            echo "- status: skipped"
+            echo "- reason: ${reason}"
+            echo "- prepare_result: ${PREPARE_RESULT}"
+            echo "- prepare_should_deploy: ${PREPARE_SHOULD_DEPLOY:-unset}"
+            echo "- workflow_run_conclusion: ${WORKFLOW_RUN_CONCLUSION}"
+            echo "- workflow_run_head_branch: ${WORKFLOW_RUN_HEAD_BRANCH}"
+            echo "- workflow_run_event: ${WORKFLOW_RUN_EVENT}"
+            echo "- deployment_created: false"
+            echo "- staging_success_recorded: false"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "::notice::Staging deploy no-op reason=${reason}"
+
   create-deployment:
     name: Create Staging Deployment
     needs:

--- a/tools/test/run-staging-deploy-transaction-replay-gate.sh
+++ b/tools/test/run-staging-deploy-transaction-replay-gate.sh
@@ -12,6 +12,7 @@ require 'yaml'
 
 workflow = YAML.load_file('.github/workflows/staging-deploy.yml')
 jobs = workflow.fetch('jobs')
+noop_job = jobs.fetch('record-noop')
 deploy_job = jobs.fetch('deploy-and-verify')
 finalize_job = jobs.fetch('finalize-deployment')
 steps = deploy_job.fetch('steps')
@@ -28,6 +29,21 @@ deploy_name = 'Run OCI A1 blue-green deploy locally'
 resolver_name = 'Resolve OCI A1 staging database URL'
 load_env_name = 'Load OCI A1 staging env'
 prerequisite_name = 'Check OCI self-hosted runner prerequisites'
+
+noop_needs = Array(noop_job.fetch('needs'))
+abort('no-op deploy recorder must depend on prepare') unless noop_needs.include?('prepare')
+noop_if = noop_job.fetch('if')
+abort('no-op deploy recorder must run with always guard') unless noop_if.include?('always()')
+abort('no-op deploy recorder must cover skipped prepare') unless noop_if.include?("needs.prepare.result == 'skipped'")
+abort('no-op deploy recorder must cover prepare should_deploy=false') unless noop_if.include?("needs.prepare.outputs.should_deploy != 'true'")
+noop_steps = noop_job.fetch('steps')
+noop_step = noop_steps.find { |step| step['name'] == 'Record no-op staging deploy' } or abort('missing no-op staging deploy record step')
+noop_run = noop_step.fetch('run')
+abort('no-op summary must declare staging deploy no-op') unless noop_run.include?('Staging Deploy No-Op')
+abort('no-op summary must record skipped status') unless noop_run.include?('status: skipped')
+abort('no-op summary must record skipped reason') unless noop_run.include?('reason=')
+abort('no-op summary must record that deployment was not created') unless noop_run.include?('deployment_created: false')
+abort('no-op summary must record that staging success was not recorded') unless noop_run.include?('staging_success_recorded: false')
 
 replay_index = step_names.index(replay_name) or abort("missing step: #{replay_name}")
 replay_result_index = step_names.index(replay_result_name) or abort("missing step: #{replay_result_name}")
@@ -118,7 +134,7 @@ abort('replay summary must run even after replay failure') unless append_replay_
 append_replay_summary_run = append_replay_summary_step.fetch('run')
 abort('replay summary must append summary.md to GITHUB_STEP_SUMMARY') unless append_replay_summary_run.include?('build/reports/transaction-staging-replay/summary.md') && append_replay_summary_run.include?('GITHUB_STEP_SUMMARY')
 abort('replay report upload must run even after replay failure') unless upload_replay_report_step.fetch('if').include?('always()')
-abort('replay report upload must use upload-artifact') unless upload_replay_report_step.fetch('uses') == 'actions/upload-artifact@v4'
+abort('replay report upload must use upload-artifact') unless upload_replay_report_step.fetch('uses') == 'actions/upload-artifact@v7'
 upload_with = upload_replay_report_step.fetch('with')
 abort('replay report upload name must be stable') unless upload_with.fetch('name') == 'transaction-read-model-staging-replay'
 abort('replay report upload path must include replay report directory') unless upload_with.fetch('path') == 'build/reports/transaction-staging-replay/'


### PR DESCRIPTION
## 🔗 Related Issue
close #691

## 🌿 Base Branch
- `main`

## 📝 Summary
- 실제 staging deploy가 없던 `workflow_run` 성공 케이스를 명시적 no-op job으로 기록합니다.
- deploy/build job이 skipped된 run을 staging deploy success로 오판하지 않도록 step summary와 notice에 근거를 남깁니다.

## 🛠 Changes
- `record-noop` job 추가: prepare skipped 또는 `should_deploy=false` 경로를 `status: skipped`로 기록
- staging replay gate contract test에 no-op 기록 조건과 upload-artifact v7 계약 반영

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"`

## 📸 Screenshot / API Example
없음

## ⚠️ Risk & Rollback
- 예상 리스크: no-op job이 추가되어 staging deploy workflow graph에 skipped/non-deploy 상태 기록 job이 보입니다.
- 롤백 방법: 이 PR 커밋을 revert하면 기존 staging deploy workflow 동작으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
