### PR TITLE
[Perf] transaction read edge execution evidence wiring

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -43,6 +43,16 @@ on:
         required: false
         default: "1m"
         type: string
+      arrival_rate:
+        description: "k6 constant-arrival-rate iterations per time unit"
+        required: false
+        default: "16"
+        type: string
+      time_unit:
+        description: "k6 constant-arrival-rate time unit"
+        required: false
+        default: "1s"
+        type: string
       scenario_mode:
         description: "k6 scenario mode"
         required: false
@@ -64,6 +74,26 @@ on:
       max_vus:
         description: "k6 max VUs"
         required: false
+        type: string
+      preemptive_pacing:
+        description: "Enable request-before token pacing"
+        required: false
+        default: false
+        type: boolean
+      preemptive_pacing_rps:
+        description: "Global preemptive pacing RPS budget"
+        required: false
+        default: "16"
+        type: string
+      preemptive_pacing_max_sleep_ms:
+        description: "Max preemptive pacing sleep per request"
+        required: false
+        default: "250"
+        type: string
+      preemptive_pacing_jitter_ms:
+        description: "Preemptive pacing jitter"
+        required: false
+        default: "25"
         type: string
       overload_mode:
         description: "Treat 429 as capacity rejection; empty auto-enables for burst"
@@ -100,6 +130,10 @@ on:
         description: "Repository path on remote Docker context host"
         required: false
         type: string
+      nginx_access_log:
+        description: "Nginx JSON access log path for aggregate artifact"
+        required: false
+        type: string
       report_name:
         description: "Optional k6 report name"
         required: false
@@ -109,6 +143,8 @@ on:
       - ".github/workflows/oci-k6-service-auth-token.yml"
       - "tools/test/check-oci-k6-service-auth-token-workflow.sh"
       - "tools/test/run-k6-transaction-100m-loadtest.sh"
+      - "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh"
+      - "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh"
 
 permissions:
   contents: read
@@ -149,14 +185,21 @@ jobs:
           COLD_TO_INPUT: ${{ inputs.cold_to }}
           VUS_INPUT: ${{ inputs.vus }}
           DURATION_INPUT: ${{ inputs.duration }}
+          ARRIVAL_RATE_INPUT: ${{ inputs.arrival_rate }}
+          TIME_UNIT_INPUT: ${{ inputs.time_unit }}
           SCENARIO_MODE_INPUT: ${{ inputs.scenario_mode }}
           BURST_RATE_INPUT: ${{ inputs.burst_rate }}
           PRE_ALLOCATED_VUS_INPUT: ${{ inputs.pre_allocated_vus }}
           MAX_VUS_INPUT: ${{ inputs.max_vus }}
+          PREEMPTIVE_PACING_INPUT: ${{ inputs.preemptive_pacing }}
+          PREEMPTIVE_PACING_RPS_INPUT: ${{ inputs.preemptive_pacing_rps }}
+          PREEMPTIVE_PACING_MAX_SLEEP_MS_INPUT: ${{ inputs.preemptive_pacing_max_sleep_ms }}
+          PREEMPTIVE_PACING_JITTER_MS_INPUT: ${{ inputs.preemptive_pacing_jitter_ms }}
           OVERLOAD_MODE_INPUT: ${{ inputs.overload_mode }}
           BURST_429_RATE_THRESHOLD_INPUT: ${{ inputs.burst_429_rate_threshold }}
           BACKEND_429_RATE_THRESHOLD_INPUT: ${{ inputs.backend_429_rate_threshold }}
           OVERLOAD_503_RATE_THRESHOLD_INPUT: ${{ inputs.overload_503_rate_threshold }}
+          NGINX_ACCESS_LOG_INPUT: ${{ inputs.nginx_access_log }}
           DOCKER_CONTEXT_INPUT: ${{ inputs.docker_context }}
           REMOTE_BASE_URL_INPUT: ${{ inputs.remote_base_url }}
           REMOTE_PROMETHEUS_RW_URL_INPUT: ${{ inputs.remote_prometheus_rw_url }}
@@ -165,6 +208,7 @@ jobs:
           CAPACITY_K6_REMOTE_BASE_URL_VAR: ${{ vars.CAPACITY_K6_REMOTE_BASE_URL }}
           CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_VAR: ${{ vars.CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL }}
           CAPACITY_K6_REMOTE_WORKDIR_VAR: ${{ vars.CAPACITY_K6_REMOTE_WORKDIR }}
+          CAPACITY_K6_NGINX_ACCESS_LOG_VAR: ${{ vars.CAPACITY_K6_NGINX_ACCESS_LOG }}
         shell: bash
         run: |
           set -euo pipefail
@@ -189,6 +233,7 @@ jobs:
           DEFAULT_K6_DOCKER_CONTEXT="default"
           DEFAULT_K6_REMOTE_BASE_URL="${STAGING_BASE_URL:-}"
           DEFAULT_K6_REMOTE_PROMETHEUS_RW_SERVER_URL="http://172.17.0.2:9090/api/v1/write"
+          DEFAULT_K6_NGINX_ACCESS_LOG="/var/log/nginx/access.log"
           K6_DOCKER_CONTEXT="${DOCKER_CONTEXT_INPUT:-${CAPACITY_K6_DOCKER_CONTEXT_VAR:-${DEFAULT_K6_DOCKER_CONTEXT}}}"
           K6_REMOTE_BASE_URL="${REMOTE_BASE_URL_INPUT:-${CAPACITY_K6_REMOTE_BASE_URL:-${CAPACITY_K6_REMOTE_BASE_URL_VAR:-${DEFAULT_K6_REMOTE_BASE_URL}}}}"
           K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${REMOTE_PROMETHEUS_RW_URL_INPUT:-${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_VAR:-${DEFAULT_K6_REMOTE_PROMETHEUS_RW_SERVER_URL}}}}"
@@ -215,6 +260,8 @@ jobs:
           K6_VUS="${VUS_INPUT}"
           K6_DURATION="${DURATION_INPUT}"
           K6_SCENARIO_MODE="${SCENARIO_MODE_INPUT}"
+          K6_RATE="${ARRIVAL_RATE_INPUT}"
+          K6_TIME_UNIT="${TIME_UNIT_INPUT}"
           K6_OVERLOAD_MODE="${OVERLOAD_MODE_INPUT}"
           if [[ -z "${K6_OVERLOAD_MODE}" && "${K6_SCENARIO_MODE}" == "burst" ]]; then
             K6_OVERLOAD_MODE="true"
@@ -223,10 +270,14 @@ jobs:
           K6_BURST_RATE="${BURST_RATE_INPUT}"
           K6_PRE_ALLOCATED_VUS="${PRE_ALLOCATED_VUS_INPUT}"
           K6_MAX_VUS="${MAX_VUS_INPUT}"
+          K6_PREEMPTIVE_PACING="${PREEMPTIVE_PACING_INPUT}"
+          K6_PREEMPTIVE_PACING_RPS="${PREEMPTIVE_PACING_RPS_INPUT}"
+          K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="${PREEMPTIVE_PACING_MAX_SLEEP_MS_INPUT}"
+          K6_PREEMPTIVE_PACING_JITTER_MS="${PREEMPTIVE_PACING_JITTER_MS_INPUT}"
           K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT}"
           K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT}"
           K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT}"
-          K6_NGINX_ACCESS_LOG="${K6_NGINX_ACCESS_LOG:-${NGINX_ACCESS_LOG:-}}"
+          K6_NGINX_ACCESS_LOG="${NGINX_ACCESS_LOG_INPUT:-${K6_NGINX_ACCESS_LOG:-${NGINX_ACCESS_LOG:-${CAPACITY_K6_NGINX_ACCESS_LOG:-${CAPACITY_K6_NGINX_ACCESS_LOG_VAR:-${DEFAULT_K6_NGINX_ACCESS_LOG}}}}}}"
 
           if ! [[ "${K6_REPORT_NAME}" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "::error::K6 report name must contain only letters, numbers, dot, underscore, or hyphen."
@@ -275,10 +326,16 @@ jobs:
             K6_VUS
             K6_DURATION
             K6_SCENARIO_MODE
+            K6_RATE
+            K6_TIME_UNIT
             K6_OVERLOAD_MODE
             K6_BURST_RATE
             K6_PRE_ALLOCATED_VUS
             K6_MAX_VUS
+            K6_PREEMPTIVE_PACING
+            K6_PREEMPTIVE_PACING_RPS
+            K6_PREEMPTIVE_PACING_MAX_SLEEP_MS
+            K6_PREEMPTIVE_PACING_JITTER_MS
             K6_BURST_429_RATE_THRESHOLD
             K6_BACKEND_429_RATE_THRESHOLD
             K6_OVERLOAD_503_RATE_THRESHOLD
@@ -296,6 +353,55 @@ jobs:
               printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
             fi
           done
+
+      - name: Write k6 pacing evidence artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="build/reports/k6/${K6_REPORT_NAME}"
+          mkdir -p "${report_dir}"
+          pacing_input="${report_dir}/k6-pacing-input.json"
+          pacing_summary="${report_dir}/k6-pacing-summary.md"
+          cat >"${pacing_input}" <<JSON
+          {
+            "k6_run_id": "${K6_RUN_ID}",
+            "scenario_mode": "${K6_SCENARIO_MODE}",
+            "constant_arrival_rate": {
+              "rate": "${K6_RATE}",
+              "time_unit": "${K6_TIME_UNIT}",
+              "gate_role": "strict"
+            },
+            "constant_vus": {
+              "vus": "${K6_VUS}",
+              "duration": "${K6_DURATION}",
+              "gate_role": "saturation_probe"
+            },
+            "burst": {
+              "rate": "${K6_BURST_RATE}",
+              "pre_allocated_vus": "${K6_PRE_ALLOCATED_VUS:-}",
+              "max_vus": "${K6_MAX_VUS:-}",
+              "overload_mode": "${K6_OVERLOAD_MODE}"
+            },
+            "preemptive_pacing": {
+              "enabled": ${K6_PREEMPTIVE_PACING},
+              "rps": "${K6_PREEMPTIVE_PACING_RPS}",
+              "max_sleep_ms": "${K6_PREEMPTIVE_PACING_MAX_SLEEP_MS}",
+              "jitter_ms": "${K6_PREEMPTIVE_PACING_JITTER_MS}"
+            }
+          }
+          JSON
+          cat >"${pacing_summary}" <<SUMMARY
+          # k6 Pacing Evidence
+
+          - k6_run_id=${K6_RUN_ID}
+          - scenario_mode=${K6_SCENARIO_MODE}
+          - arrival-rate gate: ${K6_RATE}/${K6_TIME_UNIT}
+          - constant-vus saturation probe: vus=${K6_VUS}, duration=${K6_DURATION}
+          - burst probe: rate=${K6_BURST_RATE}, preAllocatedVUs=${K6_PRE_ALLOCATED_VUS:-}, maxVUs=${K6_MAX_VUS:-}
+          - preemptive pacing: enabled=${K6_PREEMPTIVE_PACING}, rps=${K6_PREEMPTIVE_PACING_RPS}, maxSleepMs=${K6_PREEMPTIVE_PACING_MAX_SLEEP_MS}, jitterMs=${K6_PREEMPTIVE_PACING_JITTER_MS}
+          SUMMARY
+          printf 'K6_PACING_INPUT_REF=%s\n' "${pacing_input}" >>"${GITHUB_ENV}"
+          printf 'K6_PACING_SUMMARY_REF=%s\n' "${pacing_summary}" >>"${GITHUB_ENV}"
 
       - name: Run auth preflight
         shell: bash

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -34,12 +34,29 @@ grep -F 'K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"' "${workflow}" >/dev/null
 grep -F 'K6_AUTH_PREFLIGHT="true"' "${workflow}" >/dev/null
 grep -F "K6_AUTH_PREFLIGHT_PATH" "${workflow}" >/dev/null
 grep -F "burst_rate:" "${workflow}" >/dev/null
+grep -F "arrival_rate:" "${workflow}" >/dev/null
+grep -F "time_unit:" "${workflow}" >/dev/null
 grep -F "pre_allocated_vus:" "${workflow}" >/dev/null
 grep -F "max_vus:" "${workflow}" >/dev/null
+grep -F "preemptive_pacing:" "${workflow}" >/dev/null
+grep -F "preemptive_pacing_rps:" "${workflow}" >/dev/null
+grep -F "preemptive_pacing_max_sleep_ms:" "${workflow}" >/dev/null
+grep -F "preemptive_pacing_jitter_ms:" "${workflow}" >/dev/null
+grep -F "nginx_access_log:" "${workflow}" >/dev/null
 grep -F "burst_429_rate_threshold:" "${workflow}" >/dev/null
 grep -F "backend_429_rate_threshold:" "${workflow}" >/dev/null
 grep -F "overload_503_rate_threshold:" "${workflow}" >/dev/null
+grep -F "ARRIVAL_RATE_INPUT" "${workflow}" >/dev/null
+grep -F "TIME_UNIT_INPUT" "${workflow}" >/dev/null
+grep -F "PREEMPTIVE_PACING_INPUT" "${workflow}" >/dev/null
+grep -F "PREEMPTIVE_PACING_RPS_INPUT" "${workflow}" >/dev/null
+grep -F "PREEMPTIVE_PACING_MAX_SLEEP_MS_INPUT" "${workflow}" >/dev/null
+grep -F "PREEMPTIVE_PACING_JITTER_MS_INPUT" "${workflow}" >/dev/null
+grep -F "NGINX_ACCESS_LOG_INPUT" "${workflow}" >/dev/null
 grep -F "OVERLOAD_MODE_INPUT" "${workflow}" >/dev/null
+grep -F 'DEFAULT_K6_NGINX_ACCESS_LOG="/var/log/nginx/access.log"' "${workflow}" >/dev/null
+grep -F 'K6_RATE="${ARRIVAL_RATE_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_TIME_UNIT="${TIME_UNIT_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_OVERLOAD_MODE="${OVERLOAD_MODE_INPUT}"' "${workflow}" >/dev/null
 grep -F 'if [[ -z "${K6_OVERLOAD_MODE}" && "${K6_SCENARIO_MODE}" == "burst" ]]; then' "${workflow}" >/dev/null
 grep -F 'K6_OVERLOAD_MODE="true"' "${workflow}" >/dev/null
@@ -47,9 +64,19 @@ grep -F 'K6_OVERLOAD_MODE="${K6_OVERLOAD_MODE:-false}"' "${workflow}" >/dev/null
 grep -F 'K6_BURST_RATE="${BURST_RATE_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_PRE_ALLOCATED_VUS="${PRE_ALLOCATED_VUS_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_MAX_VUS="${MAX_VUS_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_PREEMPTIVE_PACING="${PREEMPTIVE_PACING_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_PREEMPTIVE_PACING_RPS="${PREEMPTIVE_PACING_RPS_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="${PREEMPTIVE_PACING_MAX_SLEEP_MS_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_PREEMPTIVE_PACING_JITTER_MS="${PREEMPTIVE_PACING_JITTER_MS_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_NGINX_ACCESS_LOG="${NGINX_ACCESS_LOG_INPUT:-${K6_NGINX_ACCESS_LOG:-${NGINX_ACCESS_LOG:-${CAPACITY_K6_NGINX_ACCESS_LOG:-${CAPACITY_K6_NGINX_ACCESS_LOG_VAR:-${DEFAULT_K6_NGINX_ACCESS_LOG}}}}}}"' "${workflow}" >/dev/null
+grep -F "Write k6 pacing evidence artifact" "${workflow}" >/dev/null
+grep -F "k6-pacing-input.json" "${workflow}" >/dev/null
+grep -F "k6-pacing-summary.md" "${workflow}" >/dev/null
+grep -F "K6_PACING_INPUT_REF" "${workflow}" >/dev/null
+grep -F "K6_PACING_SUMMARY_REF" "${workflow}" >/dev/null
 grep -F "Run auth preflight" "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
 grep -F "Run authenticated k6 capacity" "${workflow}" >/dev/null
@@ -57,6 +84,7 @@ grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${wo
 grep -F "Build transaction read Nginx aggregate artifact" "${workflow}" >/dev/null
 grep -F "K6_NGINX_ACCESS_LOG" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
 grep -F "transaction-read-nginx-access-aggregate" "${workflow}" >/dev/null
 grep -F "actions/upload-artifact@" "${workflow}" >/dev/null
 grep -F "oci-k6-service-auth-token" "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-48-64-capacity-gate.sh
+++ b/tools/test/check-transaction-read-48-64-capacity-gate.sh
@@ -111,6 +111,10 @@ echo "[transaction-read-48-64-capacity] runner contract"
 grep -F "run-transaction-read-burst-429-budget-gate.sh" "${runner}" >/dev/null
 grep -F "CAPACITY_48_64_RATES" "${runner}" >/dev/null
 grep -F "32,48,64,80,96" "${runner}" >/dev/null
+grep -F 'rate-32-summary.json' "${runner}" >/dev/null
+grep -F 'rate-48-summary.json' "${runner}" >/dev/null
+grep -F 'rate-80-summary.json' "${runner}" >/dev/null
+grep -F 'rate-96-summary.json' "${runner}" >/dev/null
 grep -F "lower_anchor_rate" "${runner}" >/dev/null
 grep -F "stable_pass_rate" "${runner}" >/dev/null
 grep -F "max_non_fail_rate" "${runner}" >/dev/null

--- a/tools/test/check-transaction-read-burst64-residual-smoothing.sh
+++ b/tools/test/check-transaction-read-burst64-residual-smoothing.sh
@@ -30,7 +30,7 @@ grep -F "max_backend_429_rate=0.005" <<<"${plan}" >/dev/null
 grep -F "max_accepted_p95_ms=100" <<<"${plan}" >/dev/null
 grep -F "min_burst80_429_rate=0.10" <<<"${plan}" >/dev/null
 grep -F "max_reject_streak=4" <<<"${plan}" >/dev/null
-grep -F "observed_main659_burst64_429_rate=0.12824" <<<"${plan}" >/dev/null
+grep -F "observed_burst64_429_rate=0.2719614922" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-burst64-residual-smoothing] pass report"
 output="$(
@@ -44,7 +44,7 @@ summary_tsv="${output_dir}/burst64-check-burst64-residual-smoothing.tsv"
 test "${report_md}" = "${output_dir}/burst64-check-burst64-residual-smoothing.md"
 grep -F "gate_status=pass" "${report_md}" >/dev/null
 grep -F "burst 64 edge 429 budget: <= 0.10" "${report_md}" >/dev/null
-grep -F "main659 observed burst64 429: 0.12824" "${report_md}" >/dev/null
+grep -F "latest observed burst64 429: 0.2719614922" "${report_md}" >/dev/null
 grep -F "backend 429 budget: <= 0.005" "${report_md}" >/dev/null
 grep -F $'policy\tstatus\tburst48_edge_429_rate\tburst64_edge_429_rate\tburst80_edge_429_rate\tburst96_edge_429_rate\taccepted_p95_ms\tretry_after_p95_ms\treject_streak_max\tdelayed_rate\tfive_xx_count\tbackend_429_rate\tbackend_429_count' "${summary_tsv}" >/dev/null
 grep -F $'residual-v2\tpass\t0.080\t0.095\t0.220\t0.330\t98\t220\t4\t0.04\t0\t0.004\t25' "${summary_tsv}" >/dev/null

--- a/tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh
+++ b/tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh
@@ -29,6 +29,7 @@ plan="$(
 )"
 grep -F "name=nginx-agg-check" <<<"${plan}" >/dev/null
 grep -F "aggregate_key=k6_run_id,status,limit_req_status,upstream_status,reject_source,upstream_reject_source,upstream_reject_reason" <<<"${plan}" >/dev/null
+grep -F "summary_json=${output_dir}/nginx-agg-check-nginx-access-aggregate.json" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-nginx-access-aggregate] report"
 output="$(
@@ -39,14 +40,18 @@ output="$(
 )"
 report_md="$(tail -1 <<<"${output}")"
 summary_tsv="${output_dir}/nginx-agg-check-nginx-access-aggregate.tsv"
+summary_json="${output_dir}/nginx-agg-check-nginx-access-aggregate.json"
 test "${report_md}" = "${output_dir}/nginx-agg-check-nginx-access-aggregate.md"
 grep -F "aggregate key: k6_run_id/status/limit_req_status/upstream_status/reject_source/upstream_reject_source/upstream_reject_reason" "${report_md}" >/dev/null
 grep -F "transaction_read_rows=4" "${report_md}" >/dev/null
 grep -F "delayed ratio: 0.500000" "${report_md}" >/dev/null
+grep -F "summary JSON: ${summary_json}" "${report_md}" >/dev/null
 grep -F $'k6_run_id\tstatus\tlimit_req_status\tupstream_status\treject_source\treject_reason\tupstream_reject_source\tupstream_reject_reason\tcount\tdelayed_count\trejected_count\trequest_p95_ms\tupstream_p95_ms' "${summary_tsv}" >/dev/null
 grep -F $'run-a\t200\tDELAYED\t200\tnone\tnone\tnone\tnone\t1\t1\t0\t180.000\t82.000' "${summary_tsv}" >/dev/null
 grep -F $'run-a\t429\tREJECTED\tnone\tnginx-edge\tedge-rate-limit\tnone\tedge-rate-limit\t1\t0\t1\t1.000\t0.000' "${summary_tsv}" >/dev/null
 grep -F $'run-b\t499\tDELAYED\tnone\tnone\tnone\tnone\tnone\t1\t1\t0\t30100.000\t0.000' "${summary_tsv}" >/dev/null
+jq -e '.[] | select(.k6_run_id == "run-a" and .status == 429 and .limit_req_status == "REJECTED" and .rejected_count == 1)' "${summary_json}" >/dev/null
+jq -e '.[] | select(.k6_run_id == "run-b" and .status == 499 and .limit_req_status == "DELAYED" and .count == 1)' "${summary_json}" >/dev/null
 
 echo "[transaction-read-nginx-access-aggregate] invalid json fails"
 printf '{bad-json\n' >"${access_log}.bad"

--- a/tools/test/run-transaction-read-48-64-capacity-gate.sh
+++ b/tools/test/run-transaction-read-48-64-capacity-gate.sh
@@ -18,10 +18,11 @@ Environment:
   CAPACITY_48_64_MAX_RETRY_AFTER_SLEEP_SECONDS default 1
 
 Summary input when CAPACITY_48_64_RUN_K6=false:
-  ${CAPACITY_48_64_SUMMARY_DIR}/rate-52-summary.json
-  ${CAPACITY_48_64_SUMMARY_DIR}/rate-56-summary.json
-  ${CAPACITY_48_64_SUMMARY_DIR}/rate-60-summary.json
+  ${CAPACITY_48_64_SUMMARY_DIR}/rate-32-summary.json
+  ${CAPACITY_48_64_SUMMARY_DIR}/rate-48-summary.json
   ${CAPACITY_48_64_SUMMARY_DIR}/rate-64-summary.json
+  ${CAPACITY_48_64_SUMMARY_DIR}/rate-80-summary.json
+  ${CAPACITY_48_64_SUMMARY_DIR}/rate-96-summary.json
 USAGE
 }
 

--- a/tools/test/run-transaction-read-burst64-residual-smoothing.sh
+++ b/tools/test/run-transaction-read-burst64-residual-smoothing.sh
@@ -18,7 +18,7 @@ Environment:
   BURST64_SMOOTHING_MAX_RETRY_P95_MS      default 250
   BURST64_SMOOTHING_MAX_REJECT_STREAK     default 4
   BURST64_SMOOTHING_MAX_DELAYED_RATE      default 0.05
-  BURST64_SMOOTHING_OBSERVED_BURST64_429_RATE default 0.12824 (main659 failed boundary)
+  BURST64_SMOOTHING_OBSERVED_BURST64_429_RATE default 0.2719614922 (run 25281461692 failed boundary)
 USAGE
 }
 
@@ -52,7 +52,7 @@ max_accepted_p95_ms="${BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS:-100}"
 max_retry_p95_ms="${BURST64_SMOOTHING_MAX_RETRY_P95_MS:-250}"
 max_reject_streak="${BURST64_SMOOTHING_MAX_REJECT_STREAK:-4}"
 max_delayed_rate="${BURST64_SMOOTHING_MAX_DELAYED_RATE:-0.05}"
-observed_main659_burst64_429_rate="${BURST64_SMOOTHING_OBSERVED_BURST64_429_RATE:-0.12824}"
+observed_burst64_429_rate="${BURST64_SMOOTHING_OBSERVED_BURST64_429_RATE:-0.2719614922}"
 summary_tsv="${output_dir}/${name}-burst64-residual-smoothing.tsv"
 report_md="${output_dir}/${name}-burst64-residual-smoothing.md"
 
@@ -123,7 +123,7 @@ print_plan() {
   echo "[transaction-read-burst64-residual-smoothing] max_retry_p95_ms=${max_retry_p95_ms}"
   echo "[transaction-read-burst64-residual-smoothing] max_reject_streak=${max_reject_streak}"
   echo "[transaction-read-burst64-residual-smoothing] max_delayed_rate=${max_delayed_rate}"
-  echo "[transaction-read-burst64-residual-smoothing] observed_main659_burst64_429_rate=${observed_main659_burst64_429_rate}"
+  echo "[transaction-read-burst64-residual-smoothing] observed_burst64_429_rate=${observed_burst64_429_rate}"
   echo "[transaction-read-burst64-residual-smoothing] summary_tsv=${summary_tsv}"
   echo "[transaction-read-burst64-residual-smoothing] report_md=${report_md}"
 }
@@ -134,7 +134,7 @@ require_rate "BURST64_SMOOTHING_MAX_BACKEND_429_RATE" "${max_backend_429_rate}"
 require_rate "BURST64_SMOOTHING_MIN_BURST80_429_RATE" "${min_burst80_429_rate}"
 require_rate "BURST64_SMOOTHING_MIN_BURST96_429_RATE" "${min_burst96_429_rate}"
 require_rate "BURST64_SMOOTHING_MAX_DELAYED_RATE" "${max_delayed_rate}"
-require_rate "BURST64_SMOOTHING_OBSERVED_BURST64_429_RATE" "${observed_main659_burst64_429_rate}"
+require_rate "BURST64_SMOOTHING_OBSERVED_BURST64_429_RATE" "${observed_burst64_429_rate}"
 require_non_negative_number "BURST64_SMOOTHING_MAX_ACCEPTED_P95_MS" "${max_accepted_p95_ms}"
 require_non_negative_number "BURST64_SMOOTHING_MAX_RETRY_P95_MS" "${max_retry_p95_ms}"
 require_non_negative_number "BURST64_SMOOTHING_MAX_REJECT_STREAK" "${max_reject_streak}"
@@ -234,7 +234,7 @@ cat >"${report_md}" <<REPORT
 - gate_status=${gate_status}
 - burst 48 edge 429 budget: <= ${max_burst48_429_rate}
 - burst 64 edge 429 budget: <= ${max_burst64_429_rate}
-- main659 observed burst64 429: ${observed_main659_burst64_429_rate}
+- latest observed burst64 429: ${observed_burst64_429_rate}
 - backend 429 budget: <= ${max_backend_429_rate}
 - burst 80/96 policy: fail-fast overload lower bound >= ${min_burst80_429_rate}/${min_burst96_429_rate}
 - accepted p95 budget: < ${max_accepted_p95_ms}ms

--- a/tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh
+++ b/tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh
@@ -34,6 +34,7 @@ name="${NGINX_ACCESS_AGGREGATE_NAME:-transaction-read-nginx-access-aggregate-$(d
 access_log="${NGINX_ACCESS_AGGREGATE_LOG:-}"
 output_dir="${NGINX_ACCESS_AGGREGATE_OUTPUT_DIR:-build/reports/k6/${name}}"
 summary_tsv="${output_dir}/${name}-nginx-access-aggregate.tsv"
+summary_json="${output_dir}/${name}-nginx-access-aggregate.json"
 report_md="${output_dir}/${name}-nginx-access-aggregate.md"
 
 print_plan() {
@@ -42,6 +43,7 @@ print_plan() {
   echo "[transaction-read-nginx-access-aggregate] output_dir=${output_dir}"
   echo "[transaction-read-nginx-access-aggregate] aggregate_key=k6_run_id,status,limit_req_status,upstream_status,reject_source,upstream_reject_source,upstream_reject_reason"
   echo "[transaction-read-nginx-access-aggregate] summary_tsv=${summary_tsv}"
+  echo "[transaction-read-nginx-access-aggregate] summary_json=${summary_json}"
   echo "[transaction-read-nginx-access-aggregate] report_md=${report_md}"
 }
 
@@ -141,6 +143,20 @@ mkdir -p "${output_dir}"
   ' "${access_log}" | awk -F '\t' 'BEGIN { OFS = FS } { printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.3f\t%.3f\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13 }'
 } >"${summary_tsv}"
 
+jq -Rn '
+  def number_or_string:
+    if test("^-?[0-9]+([.][0-9]+)?$") then tonumber else . end;
+  (input | split("\t")) as $headers
+  | [
+      inputs
+      | split("\t") as $row
+      | reduce range(0; $headers | length) as $i (
+          {};
+          .[$headers[$i]] = (($row[$i] // "") | number_or_string)
+        )
+    ]
+' <"${summary_tsv}" >"${summary_json}"
+
 transaction_read_rows="$(awk -F '\t' 'NR > 1 { count += $9 } END { print count + 0 }' "${summary_tsv}")"
 delayed_count="$(awk -F '\t' 'NR > 1 { count += $10 } END { print count + 0 }' "${summary_tsv}")"
 rejected_count="$(awk -F '\t' 'NR > 1 { count += $11 } END { print count + 0 }' "${summary_tsv}")"
@@ -191,6 +207,7 @@ ${aggregate_table}
 ## Artifacts
 
 - summary TSV: ${summary_tsv}
+- summary JSON: ${summary_json}
 - access log: ${access_log}
 REPORT
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #696

## 🌿 Base Branch
- `main`

## 📝 Summary
- service-auth k6 workflow에 arrival-rate 16/s, preemptive pacing, Nginx access log 입력을 분리 배선했습니다.
- k6 run artifact에 pacing input/summary와 Nginx access aggregate TSV/JSON/MD가 함께 남도록 했습니다.
- run 25281461692의 burst64 edge 429 27.20% 실패 경계를 residual evidence 계약에 반영했습니다.

## 🛠 Changes
- `.github/workflows/oci-k6-service-auth-token.yml` workflow_dispatch 입력과 artifact 생성 step 추가
- `run-transaction-read-nginx-access-aggregate-artifact.sh` JSON artifact 생성 추가
- burst64 residual smoothing / burst reject curve 계약 문구와 테스트 갱신

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh`
- `bash tools/test/check-transaction-read-arrival-16-edge-budget-gate.sh`
- `bash tools/test/check-transaction-read-48-64-capacity-gate.sh`
- `bash tools/test/check-transaction-read-burst64-residual-smoothing.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: workflow_dispatch 입력이 늘어나므로 self-hosted k6 실행자가 새 env 값을 받는다. 기본값은 기존 동작과 호환되며 Nginx access log는 표준 `/var/log/nginx/access.log` fallback을 사용한다.
- 롤백 방법: 이 PR revert 후 이전 k6 workflow 계약으로 복구한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?