### PR TITLE
[Ops] transaction read admission budget profile 운영 문서화

### DIFF
--- a/ops/nginx/README.md
+++ b/ops/nginx/README.md
@@ -77,6 +77,42 @@ bash tools/ops/render-nginx-runtime-config.sh /tmp/aquila-bank-nginx.conf ops/ng
 - `fail-fast` profile은 `96r/s`, `burst=12`, `nodelay`로 delayed ratio ceiling 검증이나 latency 우선 rollback에 사용합니다.
 - 실제 서비스 트래픽 특성에 따라 `rate`와 `burst`는 조정하되, 로그인/토큰 재발급/SSE 재연결 패턴과 shared IP 영향을 같이 확인합니다.
 
+## Transaction Read Admission Budget Profile
+
+운영 판단은 traffic profile과 Nginx runtime budget profile을 분리합니다. traffic profile은 k6/evidence gate의 해석 기준이고, runtime profile은 `NGINX_TRANSACTION_READ_BUDGET_PROFILE` 또는 `OCI_A1_TRANSACTION_READ_BUDGET_PROFILE` 값입니다.
+
+| Traffic profile | 목적 | 실행 evidence | 통과 기준 | 승격 판단 |
+| --- | --- | --- | --- | --- |
+| normal profile | 정상 client/paced traffic 확인 | arrival-rate `16/s` strict gate, preemptive pacing input/summary, Nginx aggregate TSV/JSON/MD | edge 429 `0`, backend 429 `<= 0.5%`, 5xx `0`, accepted p95 `< 100ms` | staging promotion 기본 조건 |
+| saturation profile | constant-vus가 어느 지점에서 보호되는지 관측 | VU16 constant-vus saturation probe, generator headroom, host CPU/network | observe-only. edge 429는 실패로 보지 않지만 backend 429 `<= 0.5%`, 5xx `0`, accepted p95 `< 100ms`, generator headroom pass | 단독 production promotion 근거로 사용하지 않음 |
+| overload profile | burst와 fail-fast 보호 확인 | burst64 gate, burst `32/48/64/80/96` reject curve, Retry-After p95, Nginx source split | burst64 edge 429 `<= 10%`, backend 429 `<= 0.5%`, 5xx `0`, accepted p95 `< 100ms`, Retry-After p95 `<= 250ms` | production 승격 전 보호 조건 |
+
+Runtime budget profile 선택 기준:
+
+- `burst64`: 기본 운영 후보. arrival-rate 16/s 정상 구간을 delay queue 없이 통과시키고 burst64에서 edge 429 `<= 10%`를 목표로 합니다.
+- `balanced`: single-source/shared-IP 환경에서 정상 traffic의 edge 429가 높고 accepted latency budget이 남을 때 임시 완화 후보입니다. delay queue를 쓰므로 p95/p99.9와 499를 같이 확인합니다.
+- `fail-fast`: latency queueing이나 deploy/drain 499 위험이 더 클 때 rollback 후보입니다. 429는 더 빠르게 반환될 수 있으나 5xx와 backend saturation을 숨기지 않아야 합니다.
+
+Staging promotion 조건:
+
+- 같은 main SHA가 실제 staging image로 배포된 evidence가 있어야 합니다.
+- 100M replay와 normal profile gate가 통과해야 합니다.
+- burst64 overload profile은 edge 429 `<= 10%`, backend 429 `<= 0.5%`, 5xx `0`, accepted p95 `< 100ms`를 만족해야 합니다.
+- k6 summary, Nginx aggregate TSV/JSON/MD, pacing input/summary가 같은 run id artifact에 있어야 합니다.
+
+Production promotion hold 조건:
+
+- burst64 edge 429가 `10%`를 초과하거나 backend 429가 `0.5%`를 초과하면 보류합니다.
+- 499 또는 5xx가 1건이라도 있으면 deploy/drain closure를 먼저 수행합니다.
+- Nginx aggregate, source split, host metrics 중 하나라도 빠지면 evidence incomplete로 보류합니다.
+- `default` Docker context만 사용한 결과는 off-host/multi-source 공정성 evidence로 보지 않습니다.
+
+Profile 변경 rollback:
+
+- runtime 값 변경은 `OCI_A1_TRANSACTION_READ_BUDGET_PROFILE` 또는 `NGINX_TRANSACTION_READ_BUDGET_PROFILE`만 우선 조정합니다.
+- latency queueing과 499가 문제면 `fail-fast`, single-source edge 429가 문제이고 latency budget이 남으면 `balanced`를 임시 후보로 사용합니다.
+- 개별 `rate`/`burst` override는 profile 결과를 artifact로 남긴 뒤 적용하고, 다음 staging run에서 normal/overload profile을 다시 통과해야 유지합니다.
+
 ## Multi-Node Load Balancer 기준
 
 - backend upstream은 `aquila_bank_backend_api`, `aquila_bank_backend_sse` 두 개로 분리합니다.
@@ -121,6 +157,7 @@ bash tools/ops/render-nginx-runtime-config.sh /tmp/aquila-bank-nginx.conf ops/ng
 bash tools/test/check-nginx-sse-proxy.sh
 bash tools/test/run-nginx-runtime-template-gate.sh
 bash tools/test/check-transaction-read-short-burst-smoothing-matrix.sh
+bash tools/test/check-transaction-read-admission-budget-profile-doc.sh
 tools/test/run-sse-multinode-drain-smoke.sh --print-plan
 tools/test/run-sse-multinode-drain-smoke.sh
 ```
@@ -128,4 +165,5 @@ tools/test/run-sse-multinode-drain-smoke.sh
 - `check-nginx-sse-proxy.sh`는 template directive drift만 확인합니다.
 - `run-nginx-runtime-template-gate.sh`는 env render 후 unresolved placeholder를 막고, `nginx` binary가 있으면 `nginx -t`까지 수행합니다.
 - `check-transaction-read-short-burst-smoothing-matrix.sh`는 `nodelay`와 shallow delay queue 후보를 429/p95/p99/Retry-After/5xx 기준으로 비교합니다.
+- `check-transaction-read-admission-budget-profile-doc.sh`는 normal/saturation/overload profile과 promotion hold 기준이 문서에서 빠지지 않았는지 확인합니다.
 - strict gate는 PR workflow `Nginx Runtime Gate`에서 `nginx`와 `openssl`을 설치한 뒤 같은 script를 `NGINX_RUNTIME_GATE_STRICT=true`로 실행합니다.

--- a/tools/test/check-transaction-read-admission-budget-profile-doc.sh
+++ b/tools/test/check-transaction-read-admission-budget-profile-doc.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+doc="ops/nginx/README.md"
+
+echo "[transaction-read-admission-budget-profile-doc] doc exists"
+test -f "${doc}"
+
+echo "[transaction-read-admission-budget-profile-doc] profile contract"
+grep -F "## Transaction Read Admission Budget Profile" "${doc}" >/dev/null
+grep -F "normal profile" "${doc}" >/dev/null
+grep -F "saturation profile" "${doc}" >/dev/null
+grep -F "overload profile" "${doc}" >/dev/null
+grep -F 'NGINX_TRANSACTION_READ_BUDGET_PROFILE' "${doc}" >/dev/null
+grep -F 'OCI_A1_TRANSACTION_READ_BUDGET_PROFILE' "${doc}" >/dev/null
+grep -F '`burst64`' "${doc}" >/dev/null
+grep -F '`balanced`' "${doc}" >/dev/null
+grep -F '`fail-fast`' "${doc}" >/dev/null
+
+echo "[transaction-read-admission-budget-profile-doc] thresholds"
+grep -F 'arrival-rate `16/s` strict gate' "${doc}" >/dev/null
+grep -F 'edge 429 `0`' "${doc}" >/dev/null
+grep -F 'burst64 edge 429 `<= 10%`' "${doc}" >/dev/null
+grep -F 'backend 429 `<= 0.5%`' "${doc}" >/dev/null
+grep -F '5xx `0`' "${doc}" >/dev/null
+grep -F 'accepted p95 `< 100ms`' "${doc}" >/dev/null
+grep -F 'Retry-After p95 `<= 250ms`' "${doc}" >/dev/null
+
+echo "[transaction-read-admission-budget-profile-doc] promotion and rollback"
+grep -F "Staging promotion 조건" "${doc}" >/dev/null
+grep -F "Production promotion hold 조건" "${doc}" >/dev/null
+grep -F "Nginx aggregate TSV/JSON/MD" "${doc}" >/dev/null
+grep -F '`default` Docker context' "${doc}" >/dev/null
+grep -F "Profile 변경 rollback" "${doc}" >/dev/null
+grep -F "evidence incomplete" "${doc}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #700

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction-read admission 판단을 normal/saturation/overload traffic profile로 분리해 운영 기준을 문서화했습니다.
- `burst64`, `balanced`, `fail-fast` runtime profile의 사용 조건과 rollback 방향을 명시했습니다.
- staging promotion 조건과 production promotion hold 조건을 분리하고 문서 검증 check를 추가했습니다.

## 🛠 Changes
- `ops/nginx/README.md`에 admission budget profile 운영 기준 추가
- `tools/test/check-transaction-read-admission-budget-profile-doc.sh` 문서 계약 검증 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-admission-budget-profile-doc.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 문서/검증 추가만 포함하며 runtime 값은 변경하지 않는다.
- 롤백 방법: 이 PR revert로 문서와 check script를 제거한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?