### PR TITLE
[CI] oci k6 workflow dispatch input 상한 초과 수정

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -80,21 +80,6 @@ on:
         required: false
         default: false
         type: boolean
-      preemptive_pacing_rps:
-        description: "Global preemptive pacing RPS budget"
-        required: false
-        default: "16"
-        type: string
-      preemptive_pacing_max_sleep_ms:
-        description: "Max preemptive pacing sleep per request"
-        required: false
-        default: "250"
-        type: string
-      preemptive_pacing_jitter_ms:
-        description: "Preemptive pacing jitter"
-        required: false
-        default: "25"
-        type: string
       overload_mode:
         description: "Treat 429 as capacity rejection; empty auto-enables for burst"
         required: false
@@ -192,9 +177,6 @@ jobs:
           PRE_ALLOCATED_VUS_INPUT: ${{ inputs.pre_allocated_vus }}
           MAX_VUS_INPUT: ${{ inputs.max_vus }}
           PREEMPTIVE_PACING_INPUT: ${{ inputs.preemptive_pacing }}
-          PREEMPTIVE_PACING_RPS_INPUT: ${{ inputs.preemptive_pacing_rps }}
-          PREEMPTIVE_PACING_MAX_SLEEP_MS_INPUT: ${{ inputs.preemptive_pacing_max_sleep_ms }}
-          PREEMPTIVE_PACING_JITTER_MS_INPUT: ${{ inputs.preemptive_pacing_jitter_ms }}
           OVERLOAD_MODE_INPUT: ${{ inputs.overload_mode }}
           BURST_429_RATE_THRESHOLD_INPUT: ${{ inputs.burst_429_rate_threshold }}
           BACKEND_429_RATE_THRESHOLD_INPUT: ${{ inputs.backend_429_rate_threshold }}
@@ -271,9 +253,9 @@ jobs:
           K6_PRE_ALLOCATED_VUS="${PRE_ALLOCATED_VUS_INPUT}"
           K6_MAX_VUS="${MAX_VUS_INPUT}"
           K6_PREEMPTIVE_PACING="${PREEMPTIVE_PACING_INPUT}"
-          K6_PREEMPTIVE_PACING_RPS="${PREEMPTIVE_PACING_RPS_INPUT}"
-          K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="${PREEMPTIVE_PACING_MAX_SLEEP_MS_INPUT}"
-          K6_PREEMPTIVE_PACING_JITTER_MS="${PREEMPTIVE_PACING_JITTER_MS_INPUT}"
+          K6_PREEMPTIVE_PACING_RPS="${K6_PREEMPTIVE_PACING_RPS:-16}"
+          K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="${K6_PREEMPTIVE_PACING_MAX_SLEEP_MS:-250}"
+          K6_PREEMPTIVE_PACING_JITTER_MS="${K6_PREEMPTIVE_PACING_JITTER_MS:-25}"
           K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT}"
           K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT}"
           K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT}"

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -10,6 +10,17 @@ echo "[oci-k6-service-auth] workflow contract"
 grep -F "name: OCI k6 service auth token" "${workflow}" >/dev/null
 grep -F "workflow_dispatch:" "${workflow}" >/dev/null
 grep -F "pull_request:" "${workflow}" >/dev/null
+dispatch_input_count="$(awk '
+  /^  workflow_dispatch:/ { in_dispatch = 1; next }
+  in_dispatch && /^    inputs:/ { in_inputs = 1; next }
+  in_inputs && /^  [A-Za-z_]/ { exit }
+  in_inputs && /^      [A-Za-z0-9_]+:/ { count++ }
+  END { print count + 0 }
+' "${workflow}")"
+if [[ "${dispatch_input_count}" -gt 25 ]]; then
+  echo "workflow_dispatch inputs must be 25 or fewer, got ${dispatch_input_count}" >&2
+  exit 1
+fi
 grep -F "OCI k6 service auth token contract" "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-k6-service-auth-token-workflow.sh" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
@@ -39,9 +50,6 @@ grep -F "time_unit:" "${workflow}" >/dev/null
 grep -F "pre_allocated_vus:" "${workflow}" >/dev/null
 grep -F "max_vus:" "${workflow}" >/dev/null
 grep -F "preemptive_pacing:" "${workflow}" >/dev/null
-grep -F "preemptive_pacing_rps:" "${workflow}" >/dev/null
-grep -F "preemptive_pacing_max_sleep_ms:" "${workflow}" >/dev/null
-grep -F "preemptive_pacing_jitter_ms:" "${workflow}" >/dev/null
 grep -F "nginx_access_log:" "${workflow}" >/dev/null
 grep -F "burst_429_rate_threshold:" "${workflow}" >/dev/null
 grep -F "backend_429_rate_threshold:" "${workflow}" >/dev/null
@@ -49,9 +57,6 @@ grep -F "overload_503_rate_threshold:" "${workflow}" >/dev/null
 grep -F "ARRIVAL_RATE_INPUT" "${workflow}" >/dev/null
 grep -F "TIME_UNIT_INPUT" "${workflow}" >/dev/null
 grep -F "PREEMPTIVE_PACING_INPUT" "${workflow}" >/dev/null
-grep -F "PREEMPTIVE_PACING_RPS_INPUT" "${workflow}" >/dev/null
-grep -F "PREEMPTIVE_PACING_MAX_SLEEP_MS_INPUT" "${workflow}" >/dev/null
-grep -F "PREEMPTIVE_PACING_JITTER_MS_INPUT" "${workflow}" >/dev/null
 grep -F "NGINX_ACCESS_LOG_INPUT" "${workflow}" >/dev/null
 grep -F "OVERLOAD_MODE_INPUT" "${workflow}" >/dev/null
 grep -F 'DEFAULT_K6_NGINX_ACCESS_LOG="/var/log/nginx/access.log"' "${workflow}" >/dev/null
@@ -65,9 +70,9 @@ grep -F 'K6_BURST_RATE="${BURST_RATE_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_PRE_ALLOCATED_VUS="${PRE_ALLOCATED_VUS_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_MAX_VUS="${MAX_VUS_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_PREEMPTIVE_PACING="${PREEMPTIVE_PACING_INPUT}"' "${workflow}" >/dev/null
-grep -F 'K6_PREEMPTIVE_PACING_RPS="${PREEMPTIVE_PACING_RPS_INPUT}"' "${workflow}" >/dev/null
-grep -F 'K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="${PREEMPTIVE_PACING_MAX_SLEEP_MS_INPUT}"' "${workflow}" >/dev/null
-grep -F 'K6_PREEMPTIVE_PACING_JITTER_MS="${PREEMPTIVE_PACING_JITTER_MS_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_PREEMPTIVE_PACING_RPS="${K6_PREEMPTIVE_PACING_RPS:-16}"' "${workflow}" >/dev/null
+grep -F 'K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="${K6_PREEMPTIVE_PACING_MAX_SLEEP_MS:-250}"' "${workflow}" >/dev/null
+grep -F 'K6_PREEMPTIVE_PACING_JITTER_MS="${K6_PREEMPTIVE_PACING_JITTER_MS:-25}"' "${workflow}" >/dev/null
 grep -F 'K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT}"' "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #702

## 🌿 Base Branch
- `main`

## 📝 Summary
- `oci-k6-service-auth-token.yml`의 `workflow_dispatch.inputs`를 GitHub Actions 상한 25개 이하로 되돌립니다.
- pacing evidence 기능은 유지하되 세부 pacing 숫자 3개는 dispatch UI 입력이 아니라 기존 `K6_*` env 기본값 경로로 처리합니다.

## 🛠 Changes
- `preemptive_pacing_rps`, `preemptive_pacing_max_sleep_ms`, `preemptive_pacing_jitter_ms` dispatch input 제거
- 제거한 값은 `K6_PREEMPTIVE_PACING_RPS/MAX_SLEEP_MS/JITTER_MS` env 값 또는 기본값 `16/250/25`로 유지
- workflow contract test에 `workflow_dispatch.inputs <= 25` 검증 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `git diff --check -- .github/workflows/oci-k6-service-auth-token.yml tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `git rev-list --count origin/main..HEAD` -> `1`
- 수동 확인: `workflow_dispatch.inputs` count `25`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: dispatch UI에서 pacing 세부 숫자를 직접 넘기던 경로는 env 값 또는 기본값 경로로 바뀐다.
- 롤백 방법: 이 PR의 merge commit을 revert한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A