### PR TITLE
[CI] k6 Nginx aggregate artifact container log wiring

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -385,6 +385,13 @@ jobs:
           printf 'K6_PACING_INPUT_REF=%s\n' "${pacing_input}" >>"${GITHUB_ENV}"
           printf 'K6_PACING_SUMMARY_REF=%s\n' "${pacing_summary}" >>"${GITHUB_ENV}"
 
+      - name: Capture transaction read Nginx log window
+        shell: bash
+        run: |
+          set -euo pipefail
+          K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          printf 'K6_NGINX_LOG_SINCE=%s\n' "${K6_NGINX_LOG_SINCE}" >>"${GITHUB_ENV}"
+
       - name: Run auth preflight
         shell: bash
         run: |
@@ -407,10 +414,33 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -n "${K6_NGINX_ACCESS_LOG:-}" && -s "${K6_NGINX_ACCESS_LOG}" ]]; then
-            exit 0
+            original_log="${K6_NGINX_ACCESS_LOG}"
+          else
+            original_log=""
           fi
 
-          candidate_log="${RUNNER_TEMP}/${K6_RUN_ID}-nginx-access.log"
+          candidate_raw_log="${RUNNER_TEMP}/${K6_RUN_ID}-nginx-access.raw.jsonl"
+          candidate_run_log="${RUNNER_TEMP}/${K6_RUN_ID}-nginx-access.jsonl"
+
+          select_current_run_log() {
+            if [[ ! -s "${candidate_raw_log}" ]]; then
+              return 1
+            fi
+            grep -F "\"k6_run_id\":\"${K6_RUN_ID}\"" "${candidate_raw_log}" >"${candidate_run_log}" || true
+            if [[ -s "${candidate_run_log}" ]]; then
+              printf 'K6_NGINX_ACCESS_LOG=%s\n' "${candidate_run_log}" >>"${GITHUB_ENV}"
+              return 0
+            fi
+            return 1
+          }
+
+          if [[ -n "${original_log}" ]]; then
+            cp "${original_log}" "${candidate_raw_log}"
+            if select_current_run_log; then
+              exit 0
+            fi
+          fi
+
           container_candidates=(
             "${K6_NGINX_CONTAINER:-}"
             "${NGINX_CONTAINER:-}"
@@ -428,9 +458,14 @@ jobs:
           for container in "${container_candidates[@]}"; do
             [[ -z "${container}" ]] && continue
             if docker exec "${container}" test -s /var/log/nginx/access.log 2>/dev/null; then
-              docker cp "${container}:/var/log/nginx/access.log" "${candidate_log}"
-              if [[ -s "${candidate_log}" ]]; then
-                printf 'K6_NGINX_ACCESS_LOG=%s\n' "${candidate_log}" >>"${GITHUB_ENV}"
+              if docker cp "${container}:/var/log/nginx/access.log" "${candidate_raw_log}" 2>/dev/null; then
+                if select_current_run_log; then
+                  exit 0
+                fi
+              fi
+            fi
+            if docker logs --since "${K6_NGINX_LOG_SINCE:-1h}" "${container}" >"${candidate_raw_log}" 2>/dev/null; then
+              if select_current_run_log; then
                 exit 0
               fi
             fi
@@ -446,11 +481,12 @@ jobs:
           report_dir="build/reports/k6/${K6_REPORT_NAME}"
           mkdir -p "${report_dir}"
           if [[ -z "${K6_NGINX_ACCESS_LOG:-}" || ! -s "${K6_NGINX_ACCESS_LOG:-}" ]]; then
-            echo "::notice::K6_NGINX_ACCESS_LOG is missing or empty; transaction-read-nginx-access-aggregate artifact skipped."
-            exit 0
+            echo "::error::K6_NGINX_ACCESS_LOG is missing or empty; transaction-read-nginx-access-aggregate artifact required."
+            exit 1
           fi
           NGINX_ACCESS_AGGREGATE_NAME="${K6_REPORT_NAME}" \
           NGINX_ACCESS_AGGREGATE_LOG="${K6_NGINX_ACCESS_LOG}" \
+          NGINX_ACCESS_AGGREGATE_RUN_ID="${K6_RUN_ID}" \
           NGINX_ACCESS_AGGREGATE_OUTPUT_DIR="${report_dir}/transaction-read-nginx-access-aggregate" \
             tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh
 

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -85,18 +85,26 @@ grep -F "k6-pacing-summary.md" "${workflow}" >/dev/null
 grep -F "K6_PACING_INPUT_REF" "${workflow}" >/dev/null
 grep -F "K6_PACING_SUMMARY_REF" "${workflow}" >/dev/null
 grep -F '"gate_role": "saturation_probe"' "${workflow}" >/dev/null
+grep -F "Capture transaction read Nginx log window" "${workflow}" >/dev/null
+grep -F 'K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' "${workflow}" >/dev/null
 grep -F "Run auth preflight" "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
 grep -F "Run authenticated k6 capacity" "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${workflow}" >/dev/null
 grep -F "Resolve transaction read Nginx access log" "${workflow}" >/dev/null
+grep -F 'candidate_raw_log="${RUNNER_TEMP}/${K6_RUN_ID}-nginx-access.raw.jsonl"' "${workflow}" >/dev/null
+grep -F 'candidate_run_log="${RUNNER_TEMP}/${K6_RUN_ID}-nginx-access.jsonl"' "${workflow}" >/dev/null
+grep -F 'grep -F "\"k6_run_id\":\"${K6_RUN_ID}\"" "${candidate_raw_log}" >"${candidate_run_log}"' "${workflow}" >/dev/null
 grep -F 'container_candidates=(' "${workflow}" >/dev/null
 grep -F '"${K6_NGINX_CONTAINER:-}"' "${workflow}" >/dev/null
 grep -F "docker ps --format '{{.Names}}'" "${workflow}" >/dev/null
 grep -F 'docker exec "${container}" test -s /var/log/nginx/access.log' "${workflow}" >/dev/null
-grep -F 'docker cp "${container}:/var/log/nginx/access.log" "${candidate_log}"' "${workflow}" >/dev/null
+grep -F 'docker cp "${container}:/var/log/nginx/access.log" "${candidate_raw_log}"' "${workflow}" >/dev/null
+grep -F 'docker logs --since "${K6_NGINX_LOG_SINCE:-1h}" "${container}" >"${candidate_raw_log}"' "${workflow}" >/dev/null
 grep -F "Build transaction read Nginx aggregate artifact" "${workflow}" >/dev/null
 grep -F "K6_NGINX_ACCESS_LOG" "${workflow}" >/dev/null
+grep -F 'echo "::error::K6_NGINX_ACCESS_LOG is missing or empty; transaction-read-nginx-access-aggregate artifact required."' "${workflow}" >/dev/null
+grep -F 'NGINX_ACCESS_AGGREGATE_RUN_ID="${K6_RUN_ID}"' "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
 grep -F "transaction-read-nginx-access-aggregate" "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh
+++ b/tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh
@@ -29,6 +29,7 @@ plan="$(
 )"
 grep -F "name=nginx-agg-check" <<<"${plan}" >/dev/null
 grep -F "aggregate_key=k6_run_id,status,limit_req_status,upstream_status,reject_source,upstream_reject_source,upstream_reject_reason" <<<"${plan}" >/dev/null
+grep -F "run_id_filter=none" <<<"${plan}" >/dev/null
 grep -F "summary_json=${output_dir}/nginx-agg-check-nginx-access-aggregate.json" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-nginx-access-aggregate] report"
@@ -52,6 +53,28 @@ grep -F $'run-a\t429\tREJECTED\tnone\tnginx-edge\tedge-rate-limit\tnone\tedge-ra
 grep -F $'run-b\t499\tDELAYED\tnone\tnone\tnone\tnone\tnone\t1\t1\t0\t30100.000\t0.000' "${summary_tsv}" >/dev/null
 jq -e '.[] | select(.k6_run_id == "run-a" and .status == 429 and .limit_req_status == "REJECTED" and .rejected_count == 1)' "${summary_json}" >/dev/null
 jq -e '.[] | select(.k6_run_id == "run-b" and .status == 499 and .limit_req_status == "DELAYED" and .count == 1)' "${summary_json}" >/dev/null
+
+echo "[transaction-read-nginx-access-aggregate] run id filter"
+filtered_output_dir="${temp_dir}/filtered-output"
+filtered_output="$(
+  NGINX_ACCESS_AGGREGATE_NAME=nginx-agg-filtered \
+  NGINX_ACCESS_AGGREGATE_LOG="${access_log}" \
+  NGINX_ACCESS_AGGREGATE_RUN_ID=run-a \
+  NGINX_ACCESS_AGGREGATE_OUTPUT_DIR="${filtered_output_dir}" \
+    "${runner}"
+)"
+filtered_report_md="$(tail -1 <<<"${filtered_output}")"
+filtered_summary_tsv="${filtered_output_dir}/nginx-agg-filtered-nginx-access-aggregate.tsv"
+filtered_summary_json="${filtered_output_dir}/nginx-agg-filtered-nginx-access-aggregate.json"
+grep -F "run_id_filter=run-a" "${filtered_report_md}" >/dev/null
+grep -F "transaction_read_rows=3" "${filtered_report_md}" >/dev/null
+grep -F "499 count: 0" "${filtered_report_md}" >/dev/null
+grep -F $'run-a\t200\tPASSED\t200\tnone\tnone\tnone\tnone\t1\t0\t0\t91.000\t80.000' "${filtered_summary_tsv}" >/dev/null
+if grep -F $'run-b\t499' "${filtered_summary_tsv}" >/dev/null; then
+  echo "filtered aggregate must not include another k6 run id" >&2
+  exit 1
+fi
+jq -e 'all(.[]; .k6_run_id == "run-a")' "${filtered_summary_json}" >/dev/null
 
 echo "[transaction-read-nginx-access-aggregate] invalid json fails"
 printf '{bad-json\n' >"${access_log}.bad"

--- a/tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh
+++ b/tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh
@@ -8,6 +8,7 @@ usage: tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh [--pri
 Environment:
   NGINX_ACCESS_AGGREGATE_NAME       default transaction-read-nginx-access-aggregate-<timestamp>
   NGINX_ACCESS_AGGREGATE_LOG        required Nginx JSON access log
+  NGINX_ACCESS_AGGREGATE_RUN_ID     optional k6 run id filter
   NGINX_ACCESS_AGGREGATE_OUTPUT_DIR default build/reports/k6/<artifact>
 USAGE
 }
@@ -32,6 +33,7 @@ done
 
 name="${NGINX_ACCESS_AGGREGATE_NAME:-transaction-read-nginx-access-aggregate-$(date +%Y-%m-%d-%H%M%S)}"
 access_log="${NGINX_ACCESS_AGGREGATE_LOG:-}"
+run_id_filter="${NGINX_ACCESS_AGGREGATE_RUN_ID:-}"
 output_dir="${NGINX_ACCESS_AGGREGATE_OUTPUT_DIR:-build/reports/k6/${name}}"
 summary_tsv="${output_dir}/${name}-nginx-access-aggregate.tsv"
 summary_json="${output_dir}/${name}-nginx-access-aggregate.json"
@@ -40,6 +42,7 @@ report_md="${output_dir}/${name}-nginx-access-aggregate.md"
 print_plan() {
   echo "[transaction-read-nginx-access-aggregate] name=${name}"
   echo "[transaction-read-nginx-access-aggregate] access_log=${access_log:-missing}"
+  echo "[transaction-read-nginx-access-aggregate] run_id_filter=${run_id_filter:-none}"
   echo "[transaction-read-nginx-access-aggregate] output_dir=${output_dir}"
   echo "[transaction-read-nginx-access-aggregate] aggregate_key=k6_run_id,status,limit_req_status,upstream_status,reject_source,upstream_reject_source,upstream_reject_reason"
   echo "[transaction-read-nginx-access-aggregate] summary_tsv=${summary_tsv}"
@@ -68,7 +71,7 @@ fi
 mkdir -p "${output_dir}"
 {
   printf "k6_run_id\tstatus\tlimit_req_status\tupstream_status\treject_source\treject_reason\tupstream_reject_source\tupstream_reject_reason\tcount\tdelayed_count\trejected_count\trequest_p95_ms\tupstream_p95_ms\n"
-  jq -r -s '
+  jq -r -s --arg run_id_filter "${run_id_filter}" '
     def clean($value; $fallback):
       (($value // $fallback) | tostring) as $text
       | if $text == "" then $fallback else $text end;
@@ -88,6 +91,7 @@ mkdir -p "${output_dir}"
         else $values[((($values | length) - 1) * 0.95 | floor)]
         end;
     map(select((.request // "") | contains("/api/v1/transactions")))
+    | map(select(($run_id_filter == "") or (run_id == $run_id_filter)))
     | sort_by(
         run_id,
         status_text,
@@ -187,6 +191,7 @@ cat >"${report_md}" <<REPORT
 ## Summary
 
 - aggregate key: k6_run_id/status/limit_req_status/upstream_status/reject_source/upstream_reject_source/upstream_reject_reason
+- run_id_filter=${run_id_filter:-none}
 - transaction_read_rows=${transaction_read_rows}
 - delayed count: ${delayed_count}
 - delayed ratio: ${delayed_ratio}


### PR DESCRIPTION
## 🔗 Related Issue
- close #706

## 🌿 Base Branch
- `main`

## 📝 Summary
- k6 Nginx aggregate artifact가 host access log missing/empty일 때 success no-op으로 빠지는 경로를 harden했습니다.
- aggregate runner는 이제 `NGINX_ACCESS_AGGREGATE_RUN_ID`로 현재 k6 run id만 집계하고, workflow는 host/container file/stdout log에서 run-id scoped JSONL을 수집합니다.

## 🛠 Changes
- aggregate TSV/JSON/MD runner에 run id filter 추가
- k6 실행 전 Nginx log window 시작 시각 저장
- Nginx container `/var/log/nginx/access.log`와 `docker logs --since` fallback 추가
- current run transaction read log가 없으면 aggregate step을 evidence failure로 처리

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh`
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `git diff --check origin/main...HEAD`
- `git rev-list --count main..HEAD` -> `2`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Nginx run-id log가 실제로 없으면 이제 workflow가 실패합니다. 이는 artifact 누락을 success로 숨기지 않기 위한 의도된 동작입니다.
- 롤백 방법: 이 PR을 revert하면 이전 no-op fallback 동작으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?