### PR TITLE
[Perf] transaction read burst reject curve matrix 실행

### DIFF
--- a/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
+++ b/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
@@ -1,0 +1,418 @@
+name: OCI k6 burst reject curve matrix
+
+on:
+  workflow_dispatch:
+    inputs:
+      hot_account_id:
+        description: "Hot account id for authenticated transaction read"
+        required: true
+        default: "910000001"
+        type: string
+      hot_from:
+        description: "Hot account from timestamp"
+        required: true
+        default: "2026-04-01T00:00:00Z"
+        type: string
+      hot_to:
+        description: "Hot account to timestamp"
+        required: true
+        default: "2026-04-30T00:00:00Z"
+        type: string
+      cold_account_id:
+        description: "Cold account id for authenticated transaction read"
+        required: true
+        default: "910000002"
+        type: string
+      cold_from:
+        description: "Cold account from timestamp"
+        required: true
+        default: "2026-01-01T00:00:00Z"
+        type: string
+      cold_to:
+        description: "Cold account to timestamp"
+        required: true
+        default: "2026-01-31T00:00:00Z"
+        type: string
+      duration:
+        description: "k6 burst duration"
+        required: false
+        default: "1m"
+        type: string
+      burst_rates:
+        description: "Comma-separated burst arrival rates per second"
+        required: false
+        default: "32,48,64,80,96"
+        type: string
+      docker_context:
+        description: "Remote Docker context name for off-host k6"
+        required: false
+        type: string
+      remote_base_url:
+        description: "Backend URL reachable from off-host k6"
+        required: false
+        type: string
+      remote_prometheus_rw_url:
+        description: "Prometheus remote-write URL reachable from off-host k6"
+        required: false
+        type: string
+      remote_workdir:
+        description: "Repository path on remote Docker context host"
+        required: false
+        type: string
+      nginx_access_log:
+        description: "Nginx JSON access log path for aggregate artifact"
+        required: false
+        type: string
+      burst_429_rate_threshold:
+        description: "Max total/edge 429 rate for burst64 matrix gate"
+        required: false
+        default: "0.10"
+        type: string
+      backend_429_rate_threshold:
+        description: "Max backend 429 rate for burst64 matrix gate"
+        required: false
+        default: "0.005"
+        type: string
+      overload_503_rate_threshold:
+        description: "Max 503 rate for k6 overload mode"
+        required: false
+        default: "0"
+        type: string
+      report_name:
+        description: "Optional matrix report name"
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - ".github/workflows/oci-k6-burst-reject-curve-matrix.yml"
+      - "tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh"
+      - "tools/test/run-oci-k6-burst-reject-curve-matrix.sh"
+      - "tools/test/check-oci-k6-burst-reject-curve-matrix.sh"
+      - "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh"
+      - "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh"
+      - "tools/test/run-k6-transaction-100m-loadtest.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: OCI k6 burst reject curve matrix contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate workflow contract
+        run: bash tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
+
+  burst-matrix:
+    name: Authenticated OCI k6 burst reject curve matrix
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, oci-a1-staging]
+    timeout-minutes: 90
+    environment:
+      name: staging
+    env:
+      K6_MATRIX_REPORT_NAME: ${{ inputs.report_name || format('oci-k6-burst-reject-curve-matrix-{0}', github.run_id) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Load OCI k6 burst matrix env
+        env:
+          OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}
+          HOT_ACCOUNT_ID_INPUT: ${{ inputs.hot_account_id }}
+          HOT_FROM_INPUT: ${{ inputs.hot_from }}
+          HOT_TO_INPUT: ${{ inputs.hot_to }}
+          COLD_ACCOUNT_ID_INPUT: ${{ inputs.cold_account_id }}
+          COLD_FROM_INPUT: ${{ inputs.cold_from }}
+          COLD_TO_INPUT: ${{ inputs.cold_to }}
+          DURATION_INPUT: ${{ inputs.duration }}
+          BURST_RATES_INPUT: ${{ inputs.burst_rates }}
+          BURST_429_RATE_THRESHOLD_INPUT: ${{ inputs.burst_429_rate_threshold }}
+          BACKEND_429_RATE_THRESHOLD_INPUT: ${{ inputs.backend_429_rate_threshold }}
+          OVERLOAD_503_RATE_THRESHOLD_INPUT: ${{ inputs.overload_503_rate_threshold }}
+          NGINX_ACCESS_LOG_INPUT: ${{ inputs.nginx_access_log }}
+          DOCKER_CONTEXT_INPUT: ${{ inputs.docker_context }}
+          REMOTE_BASE_URL_INPUT: ${{ inputs.remote_base_url }}
+          REMOTE_PROMETHEUS_RW_URL_INPUT: ${{ inputs.remote_prometheus_rw_url }}
+          REMOTE_WORKDIR_INPUT: ${{ inputs.remote_workdir }}
+          CAPACITY_K6_DOCKER_CONTEXT_VAR: ${{ vars.CAPACITY_K6_DOCKER_CONTEXT }}
+          CAPACITY_K6_REMOTE_BASE_URL_VAR: ${{ vars.CAPACITY_K6_REMOTE_BASE_URL }}
+          CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_VAR: ${{ vars.CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL }}
+          CAPACITY_K6_REMOTE_WORKDIR_VAR: ${{ vars.CAPACITY_K6_REMOTE_WORKDIR }}
+          CAPACITY_K6_NGINX_ACCESS_LOG_VAR: ${{ vars.CAPACITY_K6_NGINX_ACCESS_LOG }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${OCI_A1_STAGING_ENV}" ]]; then
+            echo "::error::Missing OCI_A1_STAGING_ENV environment secret."
+            exit 1
+          fi
+
+          staging_env_path="${RUNNER_TEMP}/oci-a1-staging-k6-burst-matrix.env"
+          printf '%s\n' "${OCI_A1_STAGING_ENV}" >"${staging_env_path}"
+          chmod 600 "${staging_env_path}"
+
+          set -a
+          # k6 burst matrix도 staging replay와 같은 unified staging secret contract 사용.
+          source "${staging_env_path}"
+          set +a
+
+          K6_BURST_RATES="${BURST_RATES_INPUT:-32,48,64,80,96}"
+          K6_RUN_PURPOSE="capacity"
+          K6_OBSERVABILITY_MODE="prometheus"
+          K6_GENERATOR_MODE="docker-context"
+          DEFAULT_K6_DOCKER_CONTEXT="default"
+          DEFAULT_K6_REMOTE_BASE_URL="${STAGING_BASE_URL:-}"
+          DEFAULT_K6_REMOTE_PROMETHEUS_RW_SERVER_URL="http://172.17.0.2:9090/api/v1/write"
+          DEFAULT_K6_NGINX_ACCESS_LOG="/var/log/nginx/access.log"
+          K6_DOCKER_CONTEXT="${DOCKER_CONTEXT_INPUT:-${CAPACITY_K6_DOCKER_CONTEXT_VAR:-${DEFAULT_K6_DOCKER_CONTEXT}}}"
+          K6_REMOTE_BASE_URL="${REMOTE_BASE_URL_INPUT:-${CAPACITY_K6_REMOTE_BASE_URL:-${CAPACITY_K6_REMOTE_BASE_URL_VAR:-${DEFAULT_K6_REMOTE_BASE_URL}}}}"
+          K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${REMOTE_PROMETHEUS_RW_URL_INPUT:-${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL_VAR:-${DEFAULT_K6_REMOTE_PROMETHEUS_RW_SERVER_URL}}}}"
+          K6_REMOTE_WORKDIR="${REMOTE_WORKDIR_INPUT:-${CAPACITY_K6_REMOTE_WORKDIR_VAR:-}}"
+          if [[ -z "${K6_REMOTE_WORKDIR}" ]]; then
+            if [[ "${K6_DOCKER_CONTEXT}" == "default" ]]; then
+              K6_REMOTE_WORKDIR="${GITHUB_WORKSPACE}"
+            else
+              K6_REMOTE_WORKDIR="${CAPACITY_K6_REMOTE_WORKDIR:-${GITHUB_WORKSPACE}}"
+            fi
+          fi
+          K6_REMOTE_PREFLIGHT="true"
+          K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"
+          K6_AUTH_TOKEN_REQUIRED="true"
+          K6_AUTH_PREFLIGHT="true"
+          K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${HOT_ACCOUNT_ID_INPUT}&from=${HOT_FROM_INPUT}&to=${HOT_TO_INPUT}&limit=1"
+          K6_AUTH_PREFLIGHT_EXPECTED_STATUS="200"
+          K6_HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID_INPUT}"
+          K6_HOT_FROM="${HOT_FROM_INPUT}"
+          K6_HOT_TO="${HOT_TO_INPUT}"
+          K6_COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID_INPUT}"
+          K6_COLD_FROM="${COLD_FROM_INPUT}"
+          K6_COLD_TO="${COLD_TO_INPUT}"
+          K6_DURATION="${DURATION_INPUT}"
+          K6_VUS="8"
+          K6_RATE="16"
+          K6_TIME_UNIT="1s"
+          K6_PREEMPTIVE_PACING="false"
+          K6_NGINX_ACCESS_LOG="${NGINX_ACCESS_LOG_INPUT:-${K6_NGINX_ACCESS_LOG:-${NGINX_ACCESS_LOG:-${CAPACITY_K6_NGINX_ACCESS_LOG:-${CAPACITY_K6_NGINX_ACCESS_LOG_VAR:-${DEFAULT_K6_NGINX_ACCESS_LOG}}}}}}"
+
+          if ! [[ "${K6_MATRIX_REPORT_NAME}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::K6 matrix report name must contain only letters, numbers, dot, underscore, or hyphen."
+            exit 1
+          fi
+
+          missing=()
+          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
+          [[ -z "${K6_DOCKER_CONTEXT}" ]] && missing+=("K6_DOCKER_CONTEXT")
+          [[ -z "${K6_REMOTE_BASE_URL}" ]] && missing+=("K6_REMOTE_BASE_URL")
+          [[ -z "${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" ]] && missing+=("K6_REMOTE_PROMETHEUS_RW_SERVER_URL")
+          [[ -z "${K6_HOT_ACCOUNT_ID}" ]] && missing+=("K6_HOT_ACCOUNT_ID")
+          [[ -z "${K6_HOT_FROM}" ]] && missing+=("K6_HOT_FROM")
+          [[ -z "${K6_HOT_TO}" ]] && missing+=("K6_HOT_TO")
+          [[ -z "${K6_COLD_ACCOUNT_ID}" ]] && missing+=("K6_COLD_ACCOUNT_ID")
+          [[ -z "${K6_COLD_FROM}" ]] && missing+=("K6_COLD_FROM")
+          [[ -z "${K6_COLD_TO}" ]] && missing+=("K6_COLD_TO")
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing OCI k6 burst matrix env keys: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          env_names=(
+            STAGING_REPLAY_TOKEN
+            K6_MATRIX_REPORT_NAME
+            K6_BURST_RATES
+            K6_RUN_PURPOSE
+            K6_OBSERVABILITY_MODE
+            K6_GENERATOR_MODE
+            K6_DOCKER_CONTEXT
+            K6_REMOTE_BASE_URL
+            K6_REMOTE_PROMETHEUS_RW_SERVER_URL
+            K6_REMOTE_WORKDIR
+            K6_REMOTE_PREFLIGHT
+            K6_AUTH_TOKEN_ENV_NAME
+            K6_AUTH_TOKEN_REQUIRED
+            K6_AUTH_PREFLIGHT
+            K6_AUTH_PREFLIGHT_PATH
+            K6_AUTH_PREFLIGHT_EXPECTED_STATUS
+            K6_HOT_ACCOUNT_ID
+            K6_HOT_FROM
+            K6_HOT_TO
+            K6_COLD_ACCOUNT_ID
+            K6_COLD_FROM
+            K6_COLD_TO
+            K6_DURATION
+            K6_VUS
+            K6_RATE
+            K6_TIME_UNIT
+            K6_PREEMPTIVE_PACING
+            K6_NGINX_ACCESS_LOG
+            BURST_429_RATE_THRESHOLD_INPUT
+            BACKEND_429_RATE_THRESHOLD_INPUT
+            OVERLOAD_503_RATE_THRESHOLD_INPUT
+          )
+
+          for name in "${env_names[@]}"; do
+            value="${!name:-}"
+            if [[ -n "${value}" ]]; then
+              case "${name}" in
+                STAGING_REPLAY_TOKEN|K6_REMOTE_*|*TOKEN*|*DATABASE_URL|*_ENV_B64)
+                  echo "::add-mask::${value}"
+                  ;;
+              esac
+              printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
+            fi
+          done
+
+      - name: Run authenticated k6 burst matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix_dir="build/reports/k6/${K6_MATRIX_REPORT_NAME}"
+          mkdir -p "${matrix_dir}"
+          matrix_input_tsv="${matrix_dir}/burst-reject-curve-input.tsv"
+          printf "burst_rate\tk6_run_id\tsummary_json\tnginx_aggregate_json\tnginx_aggregate_tsv\tnginx_aggregate_md\n" >"${matrix_input_tsv}"
+
+          IFS="," read -r -a burst_rates <<<"${K6_BURST_RATES}"
+          k6_failure_count=0
+
+          resolve_current_run_nginx_log() {
+            if [[ -n "${K6_NGINX_ACCESS_LOG:-}" && -s "${K6_NGINX_ACCESS_LOG}" ]]; then
+              original_log="${K6_NGINX_ACCESS_LOG}"
+            else
+              original_log=""
+            fi
+
+            candidate_raw_log="${RUNNER_TEMP}/${K6_RUN_ID}-nginx-access.raw.jsonl"
+            candidate_run_log="${RUNNER_TEMP}/${K6_RUN_ID}-nginx-access.jsonl"
+
+            select_current_run_log() {
+              if [[ ! -s "${candidate_raw_log}" ]]; then
+                return 1
+              fi
+              grep -F "\"k6_run_id\":\"${K6_RUN_ID}\"" "${candidate_raw_log}" >"${candidate_run_log}" || true
+              if [[ -s "${candidate_run_log}" ]]; then
+                K6_NGINX_ACCESS_LOG="${candidate_run_log}"
+                export K6_NGINX_ACCESS_LOG
+                return 0
+              fi
+              return 1
+            }
+
+            if [[ -n "${original_log}" ]]; then
+              cp "${original_log}" "${candidate_raw_log}"
+              if select_current_run_log; then
+                return 0
+              fi
+            fi
+
+            container_candidates=(
+              "${K6_NGINX_CONTAINER:-}"
+              "${NGINX_CONTAINER:-}"
+              "aquila-bank-nginx"
+              "aquila-nginx"
+              "nginx"
+            )
+
+            if command -v docker >/dev/null 2>&1; then
+              while IFS= read -r container; do
+                container_candidates+=("${container}")
+              done < <(docker ps --format '{{.Names}}' 2>/dev/null | grep -E 'nginx|proxy' || true)
+            fi
+
+            for container in "${container_candidates[@]}"; do
+              [[ -z "${container}" ]] && continue
+              if docker exec "${container}" test -s /var/log/nginx/access.log 2>/dev/null; then
+                if docker cp "${container}:/var/log/nginx/access.log" "${candidate_raw_log}" 2>/dev/null; then
+                  if select_current_run_log; then
+                    return 0
+                  fi
+                fi
+              fi
+              if docker logs --since "${K6_NGINX_LOG_SINCE:-1h}" "${container}" >"${candidate_raw_log}" 2>/dev/null; then
+                if select_current_run_log; then
+                  return 0
+                fi
+              fi
+            done
+
+            echo "::error::K6_NGINX_ACCESS_LOG is missing or empty and no Nginx container access log was found for ${K6_RUN_ID}."
+            return 1
+          }
+
+          for burst_rate in "${burst_rates[@]}"; do
+            burst_rate="${burst_rate//[[:space:]]/}"
+            if ! [[ "${burst_rate}" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid burst rate: ${burst_rate}"
+              exit 1
+            fi
+
+            K6_REPORT_NAME="${K6_MATRIX_REPORT_NAME}-burst${burst_rate}"
+            K6_RUN_ID="${K6_REPORT_NAME}"
+            K6_SCENARIO_MODE="burst"
+            K6_BURST_RATE="${burst_rate}"
+            K6_PRE_ALLOCATED_VUS="${burst_rate}"
+            K6_MAX_VUS="$((burst_rate * 2))"
+            K6_OVERLOAD_MODE="true"
+            K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT:-0.10}"
+            K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT:-0.005}"
+            K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT:-0}"
+            export K6_REPORT_NAME K6_RUN_ID K6_SCENARIO_MODE K6_BURST_RATE K6_PRE_ALLOCATED_VUS K6_MAX_VUS
+            export K6_OVERLOAD_MODE K6_BURST_429_RATE_THRESHOLD K6_BACKEND_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD
+
+            report_dir="build/reports/k6/${K6_REPORT_NAME}"
+            mkdir -p "${report_dir}"
+
+            K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+            export K6_NGINX_LOG_SINCE
+
+            tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >"${report_dir}/auth-preflight.log" 2>&1
+
+            set +e
+            K6_BURST_429_RATE_THRESHOLD="1" \
+              tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps >"${report_dir}/k6-capacity.log" 2>&1
+            k6_exit=$?
+            set -e
+            if [[ "${k6_exit}" != "0" ]]; then
+              k6_failure_count=$((k6_failure_count + 1))
+              echo "::warning::Burst ${burst_rate} k6 run exited ${k6_exit}; matrix evidence will still be packed when summaries exist."
+            fi
+
+            resolve_current_run_nginx_log
+
+            NGINX_ACCESS_AGGREGATE_NAME="${K6_REPORT_NAME}" \
+            NGINX_ACCESS_AGGREGATE_LOG="${K6_NGINX_ACCESS_LOG}" \
+            NGINX_ACCESS_AGGREGATE_RUN_ID="${K6_RUN_ID}" \
+            NGINX_ACCESS_AGGREGATE_OUTPUT_DIR="${report_dir}/transaction-read-nginx-access-aggregate" \
+              tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh
+
+            summary_json="build/reports/k6/${K6_REPORT_NAME}-summary.json"
+            aggregate_json="${report_dir}/transaction-read-nginx-access-aggregate/${K6_REPORT_NAME}-nginx-access-aggregate.json"
+            aggregate_tsv="${report_dir}/transaction-read-nginx-access-aggregate/${K6_REPORT_NAME}-nginx-access-aggregate.tsv"
+            aggregate_md="${report_dir}/transaction-read-nginx-access-aggregate/${K6_REPORT_NAME}-nginx-access-aggregate.md"
+            printf "%s\t%s\t%s\t%s\t%s\t%s\n" "${burst_rate}" "${K6_RUN_ID}" "${summary_json}" "${aggregate_json}" "${aggregate_tsv}" "${aggregate_md}" >>"${matrix_input_tsv}"
+          done
+
+          OCI_K6_BURST_MATRIX_NAME="${K6_MATRIX_REPORT_NAME}" \
+          OCI_K6_BURST_MATRIX_INPUT_TSV="${matrix_input_tsv}" \
+          OCI_K6_BURST_MATRIX_OUTPUT_DIR="${matrix_dir}/burst-reject-curve-matrix" \
+          OCI_K6_BURST_MATRIX_BURST64_429_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT:-0.10}" \
+          OCI_K6_BURST_MATRIX_BACKEND_429_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT:-0.005}" \
+            tools/test/run-oci-k6-burst-reject-curve-matrix.sh
+
+          if [[ "${k6_failure_count}" != "0" ]]; then
+            echo "::error::${k6_failure_count} burst k6 run(s) exited non-zero."
+            exit 1
+          fi
+
+      - name: Upload OCI k6 burst reject curve matrix artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: oci-k6-burst-reject-curve-matrix-${{ github.run_id }}
+          path: |
+            build/reports/k6/${{ env.K6_MATRIX_REPORT_NAME }}/
+            build/reports/k6/${{ env.K6_MATRIX_REPORT_NAME }}*
+          if-no-files-found: error

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/oci-k6-burst-reject-curve-matrix.yml"
+
+echo "[oci-k6-burst-reject-curve-matrix] workflow exists"
+test -f "${workflow}"
+
+echo "[oci-k6-burst-reject-curve-matrix] workflow contract"
+grep -F "name: OCI k6 burst reject curve matrix" "${workflow}" >/dev/null
+grep -F "workflow_dispatch:" "${workflow}" >/dev/null
+grep -F "pull_request:" "${workflow}" >/dev/null
+dispatch_input_count="$(awk '
+  /^  workflow_dispatch:/ { in_dispatch = 1; next }
+  in_dispatch && /^    inputs:/ { in_inputs = 1; next }
+  in_inputs && /^  [A-Za-z_]/ { exit }
+  in_inputs && /^      [A-Za-z0-9_]+:/ { count++ }
+  END { print count + 0 }
+' "${workflow}")"
+if [[ "${dispatch_input_count}" -gt 25 ]]; then
+  echo "workflow_dispatch inputs must be 25 or fewer, got ${dispatch_input_count}" >&2
+  exit 1
+fi
+grep -F "OCI k6 burst reject curve matrix contract" "${workflow}" >/dev/null
+grep -F "tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-oci-k6-burst-reject-curve-matrix.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-k6-transaction-100m-loadtest.sh" "${workflow}" >/dev/null
+grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
+grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
+grep -F "environment:" "${workflow}" >/dev/null
+grep -F "name: staging" "${workflow}" >/dev/null
+grep -F 'OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}' "${workflow}" >/dev/null
+grep -F "Load OCI k6 burst matrix env" "${workflow}" >/dev/null
+grep -F 'DEFAULT_K6_DOCKER_CONTEXT="default"' "${workflow}" >/dev/null
+grep -F 'DEFAULT_K6_REMOTE_BASE_URL="${STAGING_BASE_URL:-}"' "${workflow}" >/dev/null
+grep -F 'DEFAULT_K6_REMOTE_PROMETHEUS_RW_SERVER_URL="http://172.17.0.2:9090/api/v1/write"' "${workflow}" >/dev/null
+grep -F 'DEFAULT_K6_NGINX_ACCESS_LOG="/var/log/nginx/access.log"' "${workflow}" >/dev/null
+grep -F "STAGING_REPLAY_TOKEN" "${workflow}" >/dev/null
+grep -F 'K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"' "${workflow}" >/dev/null
+grep -F 'K6_AUTH_PREFLIGHT="true"' "${workflow}" >/dev/null
+grep -F 'K6_RUN_PURPOSE="capacity"' "${workflow}" >/dev/null
+grep -F 'K6_OBSERVABILITY_MODE="prometheus"' "${workflow}" >/dev/null
+grep -F 'K6_GENERATOR_MODE="docker-context"' "${workflow}" >/dev/null
+grep -F "burst_rates:" "${workflow}" >/dev/null
+grep -F 'default: "32,48,64,80,96"' "${workflow}" >/dev/null
+grep -F 'K6_MATRIX_REPORT_NAME: ${{ inputs.report_name || format(' "${workflow}" >/dev/null
+grep -F 'BURST_RATES_INPUT: ${{ inputs.burst_rates }}' "${workflow}" >/dev/null
+grep -F 'K6_BURST_RATES="${BURST_RATES_INPUT:-32,48,64,80,96}"' "${workflow}" >/dev/null
+grep -F "Run authenticated k6 burst matrix" "${workflow}" >/dev/null
+grep -F 'IFS="," read -r -a burst_rates <<<"${K6_BURST_RATES}"' "${workflow}" >/dev/null
+grep -F 'matrix_input_tsv="${matrix_dir}/burst-reject-curve-input.tsv"' "${workflow}" >/dev/null
+grep -F $'printf "burst_rate\\tk6_run_id\\tsummary_json\\tnginx_aggregate_json\\tnginx_aggregate_tsv\\tnginx_aggregate_md\\n" >"${matrix_input_tsv}"' "${workflow}" >/dev/null
+grep -F 'for burst_rate in "${burst_rates[@]}"; do' "${workflow}" >/dev/null
+grep -F 'K6_REPORT_NAME="${K6_MATRIX_REPORT_NAME}-burst${burst_rate}"' "${workflow}" >/dev/null
+grep -F 'K6_RUN_ID="${K6_REPORT_NAME}"' "${workflow}" >/dev/null
+grep -F 'K6_SCENARIO_MODE="burst"' "${workflow}" >/dev/null
+grep -F 'K6_BURST_RATE="${burst_rate}"' "${workflow}" >/dev/null
+grep -F 'K6_PRE_ALLOCATED_VUS="${burst_rate}"' "${workflow}" >/dev/null
+grep -F 'K6_MAX_VUS="$((burst_rate * 2))"' "${workflow}" >/dev/null
+grep -F 'K6_OVERLOAD_MODE="true"' "${workflow}" >/dev/null
+grep -F 'K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT:-0.10}"' "${workflow}" >/dev/null
+grep -F 'K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT:-0.005}"' "${workflow}" >/dev/null
+grep -F 'K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT:-0}"' "${workflow}" >/dev/null
+grep -F 'K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' "${workflow}" >/dev/null
+grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
+grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${workflow}" >/dev/null
+grep -F 'candidate_raw_log="${RUNNER_TEMP}/${K6_RUN_ID}-nginx-access.raw.jsonl"' "${workflow}" >/dev/null
+grep -F 'candidate_run_log="${RUNNER_TEMP}/${K6_RUN_ID}-nginx-access.jsonl"' "${workflow}" >/dev/null
+grep -F 'grep -F "\"k6_run_id\":\"${K6_RUN_ID}\"" "${candidate_raw_log}" >"${candidate_run_log}"' "${workflow}" >/dev/null
+grep -F 'container_candidates=(' "${workflow}" >/dev/null
+grep -F 'docker exec "${container}" test -s /var/log/nginx/access.log' "${workflow}" >/dev/null
+grep -F 'docker cp "${container}:/var/log/nginx/access.log" "${candidate_raw_log}"' "${workflow}" >/dev/null
+grep -F 'docker logs --since "${K6_NGINX_LOG_SINCE:-1h}" "${container}" >"${candidate_raw_log}"' "${workflow}" >/dev/null
+grep -F 'NGINX_ACCESS_AGGREGATE_RUN_ID="${K6_RUN_ID}"' "${workflow}" >/dev/null
+grep -F 'NGINX_ACCESS_AGGREGATE_OUTPUT_DIR="${report_dir}/transaction-read-nginx-access-aggregate"' "${workflow}" >/dev/null
+grep -F 'summary_json="build/reports/k6/${K6_REPORT_NAME}-summary.json"' "${workflow}" >/dev/null
+grep -F 'aggregate_json="${report_dir}/transaction-read-nginx-access-aggregate/${K6_REPORT_NAME}-nginx-access-aggregate.json"' "${workflow}" >/dev/null
+grep -F 'aggregate_tsv="${report_dir}/transaction-read-nginx-access-aggregate/${K6_REPORT_NAME}-nginx-access-aggregate.tsv"' "${workflow}" >/dev/null
+grep -F 'aggregate_md="${report_dir}/transaction-read-nginx-access-aggregate/${K6_REPORT_NAME}-nginx-access-aggregate.md"' "${workflow}" >/dev/null
+grep -F 'printf "%s\t%s\t%s\t%s\t%s\t%s\n" "${burst_rate}" "${K6_RUN_ID}" "${summary_json}" "${aggregate_json}" "${aggregate_tsv}" "${aggregate_md}" >>"${matrix_input_tsv}"' "${workflow}" >/dev/null
+grep -F 'OCI_K6_BURST_MATRIX_NAME="${K6_MATRIX_REPORT_NAME}"' "${workflow}" >/dev/null
+grep -F 'OCI_K6_BURST_MATRIX_INPUT_TSV="${matrix_input_tsv}"' "${workflow}" >/dev/null
+grep -F 'OCI_K6_BURST_MATRIX_OUTPUT_DIR="${matrix_dir}/burst-reject-curve-matrix"' "${workflow}" >/dev/null
+grep -F "tools/test/run-oci-k6-burst-reject-curve-matrix.sh" "${workflow}" >/dev/null
+grep -F "actions/upload-artifact@v7" "${workflow}" >/dev/null
+grep -F "oci-k6-burst-reject-curve-matrix" "${workflow}" >/dev/null
+
+preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"
+k6_run_line="$(grep -n -- "--no-up --no-deps" "${workflow}" | head -1 | cut -d: -f1)"
+matrix_line="$(grep -n -- "run-oci-k6-burst-reject-curve-matrix.sh" "${workflow}" | tail -1 | cut -d: -f1)"
+if [[ -z "${preflight_line}" || -z "${k6_run_line}" || "${preflight_line}" -ge "${k6_run_line}" ]]; then
+  echo "auth preflight must run before authenticated k6 burst run" >&2
+  exit 1
+fi
+if [[ -z "${matrix_line}" || "${k6_run_line}" -ge "${matrix_line}" ]]; then
+  echo "matrix pack runner must run after burst k6 runs" >&2
+  exit 1
+fi
+
+if grep -F 'secrets.STAGING_REPLAY_TOKEN' "${workflow}" >/dev/null; then
+  echo "workflow must read the unified staging env secret, not a standalone replay token secret" >&2
+  exit 1
+fi
+if grep -F 'K6_AUTH_TOKEN:' "${workflow}" >/dev/null; then
+  echo "workflow must not map token value directly into K6_AUTH_TOKEN" >&2
+  exit 1
+fi

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-oci-k6-burst-reject-curve-matrix.sh"
+
+echo "[oci-k6-burst-reject-curve-matrix] shell syntax"
+bash -n "${runner}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+write_summary() {
+  local rate="$1"
+  local total_429="$2"
+  local edge_429="$3"
+  local backend_429="$4"
+  local backend_429_count="$5"
+  local k6_503_count="$6"
+  local accepted_count="$7"
+  local accepted_p95="$8"
+  local retry_after_p95="$9"
+  local reject_streak_max="${10}"
+  local summary_json="${temp_dir}/burst-${rate}-summary.json"
+
+  cat >"${summary_json}" <<JSON
+{
+  "metrics": {
+    "http_req_duration": {"values": {"p(95)": ${accepted_p95}}},
+    "aquila_transaction_429_rate": {"values": {"rate": ${total_429}}},
+    "aquila_transaction_edge_429_rate": {"values": {"rate": ${edge_429}}},
+    "aquila_transaction_backend_429_rate": {"values": {"rate": ${backend_429}}},
+    "aquila_transaction_backend_429_count": {"values": {"count": ${backend_429_count}}},
+    "aquila_transaction_503_count": {"values": {"count": ${k6_503_count}}},
+    "aquila_transaction_accepted_200_count": {"values": {"count": ${accepted_count}}},
+    "aquila_transaction_retry_after_sleep_ms": {"values": {"p(95)": ${retry_after_p95}}},
+    "aquila_transaction_retry_after_reject_streak": {"values": {"max": ${reject_streak_max}}}
+  }
+}
+JSON
+}
+
+write_aggregate() {
+  local rate="$1"
+  local run_id="$2"
+  local edge_429_count="$3"
+  local nginx_499_count="$4"
+  local nginx_5xx_count="$5"
+  local aggregate_tsv="${temp_dir}/burst-${rate}-nginx.tsv"
+  local aggregate_json="${temp_dir}/burst-${rate}-nginx.json"
+  local aggregate_md="${temp_dir}/burst-${rate}-nginx.md"
+
+  cat >"${aggregate_tsv}" <<TSV
+k6_run_id	status	limit_req_status	upstream_status	reject_source	reject_reason	upstream_reject_source	upstream_reject_reason	count	delayed_count	rejected_count	request_p95_ms	upstream_p95_ms
+${run_id}	200	PASSED	200	none	none	none	none	100	0	0	8.000	7.000
+${run_id}	429	REJECTED	none	nginx-edge	edge-rate-limit	none	edge-rate-limit	${edge_429_count}	0	${edge_429_count}	1.000	0.000
+${run_id}	499	DELAYED	none	none	none	none	none	${nginx_499_count}	${nginx_499_count}	0	30000.000	0.000
+${run_id}	503	PASSED	503	backend	backend-unavailable	backend	backend-unavailable	${nginx_5xx_count}	0	0	20.000	19.000
+TSV
+
+  jq -Rn '
+    def number_or_string:
+      if test("^-?[0-9]+([.][0-9]+)?$") then tonumber else . end;
+    (input | split("\t")) as $headers
+    | [
+        inputs
+        | split("\t") as $row
+        | reduce range(0; $headers | length) as $i (
+            {};
+            .[$headers[$i]] = (($row[$i] // "") | number_or_string)
+          )
+      ]
+  ' <"${aggregate_tsv}" >"${aggregate_json}"
+
+  cat >"${aggregate_md}" <<MD
+# Burst ${rate} Nginx Aggregate
+
+- k6_run_id=${run_id}
+- edge_429_count=${edge_429_count}
+- nginx_499_count=${nginx_499_count}
+- nginx_5xx_count=${nginx_5xx_count}
+MD
+}
+
+input_tsv="${temp_dir}/burst-reject-curve-input.tsv"
+{
+  printf "burst_rate\tk6_run_id\tsummary_json\tnginx_aggregate_json\tnginx_aggregate_tsv\tnginx_aggregate_md\n"
+  for rate in 32 48 64 80 96; do
+    case "${rate}" in
+      32)
+        write_summary "${rate}" 0.00 0.00 0.00 0 0 5760 5.1 0 0
+        write_aggregate "${rate}" "matrix-burst32" 0 0 0
+        ;;
+      48)
+        write_summary "${rate}" 0.03 0.028 0.002 1 0 5700 6.2 25 1
+        write_aggregate "${rate}" "matrix-burst48" 168 0 0
+        ;;
+      64)
+        write_summary "${rate}" 0.08 0.075 0.003 2 0 5650 7.5 40 2
+        write_aggregate "${rate}" "matrix-burst64" 465 0 0
+        ;;
+      80)
+        write_summary "${rate}" 0.22 0.216 0.004 3 0 5400 11.7 55 4
+        write_aggregate "${rate}" "matrix-burst80" 1120 0 0
+        ;;
+      96)
+        write_summary "${rate}" 0.35 0.346 0.004 4 0 5100 18.3 80 6
+        write_aggregate "${rate}" "matrix-burst96" 1840 0 0
+        ;;
+    esac
+    printf "%s\tmatrix-burst%s\t%s\t%s\t%s\t%s\n" \
+      "${rate}" \
+      "${rate}" \
+      "${temp_dir}/burst-${rate}-summary.json" \
+      "${temp_dir}/burst-${rate}-nginx.json" \
+      "${temp_dir}/burst-${rate}-nginx.tsv" \
+      "${temp_dir}/burst-${rate}-nginx.md"
+  done
+} >"${input_tsv}"
+
+output_dir="${temp_dir}/output"
+
+echo "[oci-k6-burst-reject-curve-matrix] print plan"
+plan="$(
+  OCI_K6_BURST_MATRIX_NAME=burst-matrix-check \
+  OCI_K6_BURST_MATRIX_INPUT_TSV="${input_tsv}" \
+  OCI_K6_BURST_MATRIX_OUTPUT_DIR="${output_dir}" \
+    "${runner}" --print-plan
+)"
+grep -F "name=burst-matrix-check" <<<"${plan}" >/dev/null
+grep -F "required_burst_rates=32,48,64,80,96" <<<"${plan}" >/dev/null
+grep -F "gate=burst64 total/edge 429 <= 0.10, backend 429 <= 0.005, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < 100ms" <<<"${plan}" >/dev/null
+grep -F "summary_tsv=${output_dir}/burst-matrix-check-burst-reject-curve.tsv" <<<"${plan}" >/dev/null
+
+echo "[oci-k6-burst-reject-curve-matrix] report"
+output="$(
+  OCI_K6_BURST_MATRIX_NAME=burst-matrix-check \
+  OCI_K6_BURST_MATRIX_INPUT_TSV="${input_tsv}" \
+  OCI_K6_BURST_MATRIX_OUTPUT_DIR="${output_dir}" \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+summary_tsv="${output_dir}/burst-matrix-check-burst-reject-curve.tsv"
+summary_json="${output_dir}/burst-matrix-check-burst-reject-curve.json"
+test "${report_md}" = "${output_dir}/burst-matrix-check-burst-reject-curve.md"
+grep -F $'burst_rate\tstatus\tk6_run_id\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tbackend_429_count\tk6_503_count\tnginx_5xx_count\tnginx_499_count\taccepted_count\taccepted_p95_ms\tretry_after_p95_ms\treject_streak_max\tsummary_json\tnginx_aggregate_json\tnginx_aggregate_tsv\tnginx_aggregate_md' "${summary_tsv}" >/dev/null
+grep -F $'64\tpass\tmatrix-burst64\t0.080000\t0.075000\t0.003000\t2\t0\t0\t0\t5650\t7.500\t40.000\t2' "${summary_tsv}" >/dev/null
+grep -F $'80\tobserve\tmatrix-burst80\t0.220000\t0.216000\t0.004000\t3\t0\t0\t0\t5400\t11.700\t55.000\t4' "${summary_tsv}" >/dev/null
+grep -F "burst64 gate: pass" "${report_md}" >/dev/null
+grep -F "burst80/96: overload observation rows; 429 ceiling is not applied" "${report_md}" >/dev/null
+grep -F "matrix input TSV: ${input_tsv}" "${report_md}" >/dev/null
+jq -e '.items | length == 5' "${summary_json}" >/dev/null
+jq -e '.items[] | select(.burst_rate == 64 and .status == "pass" and .edge_429_rate == 0.075 and .nginx_499_count == 0)' "${summary_json}" >/dev/null
+jq -e '.items[] | select(.burst_rate == 80 and .status == "observe" and .total_429_rate == 0.22)' "${summary_json}" >/dev/null
+
+echo "[oci-k6-burst-reject-curve-matrix] missing required rate fails"
+missing_input="${temp_dir}/missing-input.tsv"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 || $1 != "48" { print }' "${input_tsv}" >"${missing_input}"
+if OCI_K6_BURST_MATRIX_NAME=burst-matrix-missing \
+  OCI_K6_BURST_MATRIX_INPUT_TSV="${missing_input}" \
+  OCI_K6_BURST_MATRIX_OUTPUT_DIR="${temp_dir}/missing-output" \
+    "${runner}" >"${temp_dir}/missing.log" 2>&1; then
+  echo "missing burst rate evidence unexpectedly passed" >&2
+  exit 1
+fi
+grep -F "missing burst rate evidence: 48" "${temp_dir}/missing.log" >/dev/null
+
+echo "[oci-k6-burst-reject-curve-matrix] burst64 gate fails"
+bad_summary="${temp_dir}/burst-64-summary-bad.json"
+jq '.metrics.aquila_transaction_429_rate.values.rate = 0.11' \
+  "${temp_dir}/burst-64-summary.json" >"${bad_summary}"
+bad_input="${temp_dir}/bad-input.tsv"
+awk -F '\t' -v bad_summary="${bad_summary}" '
+  BEGIN { OFS = FS }
+  NR == 1 { print; next }
+  $1 == "64" { $3 = bad_summary }
+  { print }
+' "${input_tsv}" >"${bad_input}"
+if OCI_K6_BURST_MATRIX_NAME=burst-matrix-bad \
+  OCI_K6_BURST_MATRIX_INPUT_TSV="${bad_input}" \
+  OCI_K6_BURST_MATRIX_OUTPUT_DIR="${temp_dir}/bad-output" \
+    "${runner}" >"${temp_dir}/bad.log" 2>&1; then
+  echo "burst64 gate unexpectedly passed" >&2
+  exit 1
+fi
+grep -F "burst64 gate failed: total_429_rate=0.110000 > 0.100000" "${temp_dir}/bad.log" >/dev/null

--- a/tools/test/run-oci-k6-burst-reject-curve-matrix.sh
+++ b/tools/test/run-oci-k6-burst-reject-curve-matrix.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-oci-k6-burst-reject-curve-matrix.sh [--print-plan]
+
+Environment:
+  OCI_K6_BURST_MATRIX_NAME            default oci-k6-burst-reject-curve-matrix-<timestamp>
+  OCI_K6_BURST_MATRIX_INPUT_TSV       required TSV: burst_rate/k6_run_id/summary_json/nginx_aggregate_json/nginx_aggregate_tsv/nginx_aggregate_md
+  OCI_K6_BURST_MATRIX_REQUIRED_RATES  default 32,48,64,80,96
+  OCI_K6_BURST_MATRIX_OUTPUT_DIR      default build/reports/k6/<name>
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${OCI_K6_BURST_MATRIX_NAME:-oci-k6-burst-reject-curve-matrix-$(date +%Y-%m-%d-%H%M%S)}"
+input_tsv="${OCI_K6_BURST_MATRIX_INPUT_TSV:-}"
+required_burst_rates="${OCI_K6_BURST_MATRIX_REQUIRED_RATES:-32,48,64,80,96}"
+output_dir="${OCI_K6_BURST_MATRIX_OUTPUT_DIR:-build/reports/k6/${name}}"
+summary_tsv="${output_dir}/${name}-burst-reject-curve.tsv"
+summary_json="${output_dir}/${name}-burst-reject-curve.json"
+report_md="${output_dir}/${name}-burst-reject-curve.md"
+burst64_429_threshold="${OCI_K6_BURST_MATRIX_BURST64_429_THRESHOLD:-0.10}"
+backend_429_threshold="${OCI_K6_BURST_MATRIX_BACKEND_429_THRESHOLD:-0.005}"
+accepted_p95_threshold_ms="${OCI_K6_BURST_MATRIX_ACCEPTED_P95_THRESHOLD_MS:-100}"
+
+IFS=',' read -r -a required_rate_items <<<"${required_burst_rates}"
+
+print_plan() {
+  echo "[oci-k6-burst-reject-curve-matrix] name=${name}"
+  echo "[oci-k6-burst-reject-curve-matrix] input_tsv=${input_tsv:-missing}"
+  echo "[oci-k6-burst-reject-curve-matrix] required_burst_rates=${required_burst_rates}"
+  echo "[oci-k6-burst-reject-curve-matrix] output_dir=${output_dir}"
+  echo "[oci-k6-burst-reject-curve-matrix] gate=burst64 total/edge 429 <= ${burst64_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms"
+  echo "[oci-k6-burst-reject-curve-matrix] summary_tsv=${summary_tsv}"
+  echo "[oci-k6-burst-reject-curve-matrix] summary_json=${summary_json}"
+  echo "[oci-k6-burst-reject-curve-matrix] report_md=${report_md}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  if [[ -z "${input_tsv}" || ! -s "${input_tsv}" ]]; then
+    echo "OCI_K6_BURST_MATRIX_INPUT_TSV is required" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+if [[ -z "${input_tsv}" || ! -s "${input_tsv}" ]]; then
+  echo "OCI_K6_BURST_MATRIX_INPUT_TSV is required" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+expected_header=$'burst_rate\tk6_run_id\tsummary_json\tnginx_aggregate_json\tnginx_aggregate_tsv\tnginx_aggregate_md'
+actual_header="$(head -n 1 "${input_tsv}")"
+if [[ "${actual_header}" != "${expected_header}" ]]; then
+  echo "invalid input TSV header: ${actual_header}" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+raw_tsv="${output_dir}/${name}-burst-reject-curve.raw.tsv"
+failures_file="${output_dir}/${name}-burst-reject-curve.failures"
+: >"${failures_file}"
+
+gt() {
+  awk -v left="$1" -v right="$2" 'BEGIN { exit !(left > right) }'
+}
+
+gte() {
+  awk -v left="$1" -v right="$2" 'BEGIN { exit !(left >= right) }'
+}
+
+metric_required() {
+  local summary_file="$1"
+  local metric_name="$2"
+  local value_name="$3"
+  jq -er --arg metric_name "${metric_name}" --arg value_name "${value_name}" '
+    .metrics[$metric_name].values[$value_name]
+    | if type == "number" then . else tonumber end
+  ' "${summary_file}"
+}
+
+metric_optional() {
+  local summary_file="$1"
+  local metric_name="$2"
+  local value_name="$3"
+  local fallback="$4"
+  jq -er --arg metric_name "${metric_name}" --arg value_name "${value_name}" --arg fallback "${fallback}" '
+    (.metrics[$metric_name].values[$value_name] // ($fallback | tonumber))
+    | if type == "number" then . else tonumber end
+  ' "${summary_file}"
+}
+
+accepted_p95_metric() {
+  local summary_file="$1"
+  local expected_response_p95
+  expected_response_p95="$(jq -er '.metrics["http_req_duration{expected_response:true}"].values["p(95)"] // empty' "${summary_file}" 2>/dev/null || true)"
+  if [[ -n "${expected_response_p95}" ]]; then
+    printf "%s\n" "${expected_response_p95}"
+    return
+  fi
+  metric_required "${summary_file}" "http_req_duration" "p(95)"
+}
+
+nginx_status_count() {
+  local aggregate_json="$1"
+  local run_id="$2"
+  local status_pattern="$3"
+  jq -er --arg run_id "${run_id}" --arg status_pattern "${status_pattern}" '
+    [
+      .[]
+      | select(((.k6_run_id // "unknown") | tostring) == $run_id)
+      | select(((.status // "0") | tostring) | test($status_pattern))
+      | (.count // 0 | tonumber)
+    ]
+    | add // 0
+  ' "${aggregate_json}"
+}
+
+record_failure() {
+  local message="$1"
+  echo "${message}" | tee -a "${failures_file}" >&2
+}
+
+{
+  printf "burst_rate\tstatus\tk6_run_id\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tbackend_429_count\tk6_503_count\tnginx_5xx_count\tnginx_499_count\taccepted_count\taccepted_p95_ms\tretry_after_p95_ms\treject_streak_max\tsummary_json\tnginx_aggregate_json\tnginx_aggregate_tsv\tnginx_aggregate_md\n"
+
+  while IFS=$'\t' read -r burst_rate k6_run_id summary_file aggregate_json aggregate_tsv aggregate_md extra; do
+    if [[ -z "${burst_rate}" && -z "${k6_run_id}" ]]; then
+      continue
+    fi
+    if [[ -n "${extra:-}" ]]; then
+      echo "invalid input TSV row for burst ${burst_rate}: too many columns" >&2
+      exit 1
+    fi
+    if [[ ! "${burst_rate}" =~ ^[0-9]+$ ]]; then
+      echo "invalid burst rate: ${burst_rate}" >&2
+      exit 1
+    fi
+    for file in "${summary_file}" "${aggregate_json}" "${aggregate_tsv}" "${aggregate_md}"; do
+      if [[ -z "${file}" || ! -s "${file}" ]]; then
+        echo "missing burst ${burst_rate} evidence file: ${file:-empty}" >&2
+        exit 1
+      fi
+    done
+    if ! jq -e --arg run_id "${k6_run_id}" '
+      type == "array"
+      and any(.[]; ((.k6_run_id // "unknown") | tostring) == $run_id)
+    ' "${aggregate_json}" >/dev/null; then
+      echo "Nginx aggregate has no row for k6_run_id=${k6_run_id}" >&2
+      exit 1
+    fi
+
+    total_429_rate="$(metric_required "${summary_file}" "aquila_transaction_429_rate" "rate")"
+    edge_429_rate="$(metric_required "${summary_file}" "aquila_transaction_edge_429_rate" "rate")"
+    backend_429_rate="$(metric_required "${summary_file}" "aquila_transaction_backend_429_rate" "rate")"
+    backend_429_count="$(metric_optional "${summary_file}" "aquila_transaction_backend_429_count" "count" "0")"
+    k6_503_count="$(metric_optional "${summary_file}" "aquila_transaction_503_count" "count" "0")"
+    accepted_count="$(metric_optional "${summary_file}" "aquila_transaction_accepted_200_count" "count" "0")"
+    accepted_p95_ms="$(accepted_p95_metric "${summary_file}")"
+    retry_after_p95_ms="$(metric_optional "${summary_file}" "aquila_transaction_retry_after_sleep_ms" "p(95)" "0")"
+    reject_streak_max="$(metric_optional "${summary_file}" "aquila_transaction_retry_after_reject_streak" "max" "0")"
+    nginx_499_count="$(nginx_status_count "${aggregate_json}" "${k6_run_id}" "^499$")"
+    nginx_5xx_count="$(nginx_status_count "${aggregate_json}" "${k6_run_id}" "^5")"
+
+    status="pass"
+    if gt "${burst_rate}" "64"; then
+      status="observe"
+    fi
+    if gt "${k6_503_count}" "0"; then
+      status="fail"
+      record_failure "burst${burst_rate} gate failed: k6_503_count=${k6_503_count} > 0"
+    fi
+    if gt "${nginx_5xx_count}" "0"; then
+      status="fail"
+      record_failure "burst${burst_rate} gate failed: nginx_5xx_count=${nginx_5xx_count} > 0"
+    fi
+    if gt "${nginx_499_count}" "0"; then
+      status="fail"
+      record_failure "burst${burst_rate} gate failed: nginx_499_count=${nginx_499_count} > 0"
+    fi
+    if [[ "${burst_rate}" == "64" ]]; then
+      if gt "${total_429_rate}" "${burst64_429_threshold}"; then
+        status="fail"
+        record_failure "$(printf 'burst64 gate failed: total_429_rate=%.6f > %.6f' "${total_429_rate}" "${burst64_429_threshold}")"
+      fi
+      if gt "${edge_429_rate}" "${burst64_429_threshold}"; then
+        status="fail"
+        record_failure "$(printf 'burst64 gate failed: edge_429_rate=%.6f > %.6f' "${edge_429_rate}" "${burst64_429_threshold}")"
+      fi
+      if gt "${backend_429_rate}" "${backend_429_threshold}"; then
+        status="fail"
+        record_failure "$(printf 'burst64 gate failed: backend_429_rate=%.6f > %.6f' "${backend_429_rate}" "${backend_429_threshold}")"
+      fi
+      if gte "${accepted_p95_ms}" "${accepted_p95_threshold_ms}"; then
+        status="fail"
+        record_failure "$(printf 'burst64 gate failed: accepted_p95_ms=%.3f >= %.3f' "${accepted_p95_ms}" "${accepted_p95_threshold_ms}")"
+      fi
+    fi
+
+    printf "%s\t%s\t%s\t%.6f\t%.6f\t%.6f\t%.0f\t%.0f\t%.0f\t%.0f\t%.0f\t%.3f\t%.3f\t%.0f\t%s\t%s\t%s\t%s\n" \
+      "${burst_rate}" \
+      "${status}" \
+      "${k6_run_id}" \
+      "${total_429_rate}" \
+      "${edge_429_rate}" \
+      "${backend_429_rate}" \
+      "${backend_429_count}" \
+      "${k6_503_count}" \
+      "${nginx_5xx_count}" \
+      "${nginx_499_count}" \
+      "${accepted_count}" \
+      "${accepted_p95_ms}" \
+      "${retry_after_p95_ms}" \
+      "${reject_streak_max}" \
+      "${summary_file}" \
+      "${aggregate_json}" \
+      "${aggregate_tsv}" \
+      "${aggregate_md}"
+  done < <(tail -n +2 "${input_tsv}")
+} >"${raw_tsv}"
+
+{
+  head -n 1 "${raw_tsv}"
+  for required_rate in "${required_rate_items[@]}"; do
+    row_count="$(awk -F '\t' -v rate="${required_rate}" 'NR > 1 && $1 == rate { count += 1 } END { print count + 0 }' "${raw_tsv}")"
+    if [[ "${row_count}" == "0" ]]; then
+      echo "missing burst rate evidence: ${required_rate}" >&2
+      exit 1
+    fi
+    if [[ "${row_count}" != "1" ]]; then
+      echo "duplicate burst rate evidence: ${required_rate}" >&2
+      exit 1
+    fi
+    awk -F '\t' -v rate="${required_rate}" 'NR > 1 && $1 == rate { print }' "${raw_tsv}"
+  done
+} >"${summary_tsv}"
+
+jq -Rn --arg name "${name}" --arg input_tsv "${input_tsv}" --arg required_burst_rates "${required_burst_rates}" '
+  def number_or_string:
+    if test("^-?[0-9]+([.][0-9]+)?$") then tonumber else . end;
+  (input | split("\t")) as $headers
+  | [
+      inputs
+      | split("\t") as $row
+      | reduce range(0; $headers | length) as $i (
+          {};
+          .[$headers[$i]] = (($row[$i] // "") | number_or_string)
+        )
+    ] as $items
+  | {
+      name: $name,
+      input_tsv: $input_tsv,
+      required_burst_rates: ($required_burst_rates | split(",") | map(tonumber)),
+      items: $items
+    }
+' <"${summary_tsv}" >"${summary_json}"
+
+burst64_status="$(awk -F '\t' 'NR > 1 && $1 == "64" { print $2 }' "${summary_tsv}")"
+if [[ -s "${failures_file}" ]]; then
+  burst64_gate="fail"
+else
+  burst64_gate="${burst64_status:-missing}"
+fi
+
+matrix_table="$(awk -F '\t' '
+  BEGIN {
+    print "| Burst | Status | Total 429 | Edge 429 | Backend 429 | k6 503 | Nginx 5xx | Nginx 499 | Accepted p95 ms | Retry-after p95 ms | Reject streak max |"
+    print "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+  }
+  NR > 1 {
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $4, $5, $6, $8, $9, $10, $12, $13, $14
+  }
+' "${summary_tsv}")"
+
+cat >"${report_md}" <<REPORT
+# OCI k6 Burst Reject Curve Matrix
+
+## Summary
+
+- matrix input TSV: ${input_tsv}
+- required burst rates: ${required_burst_rates}
+- burst64 gate: ${burst64_gate}
+- burst80/96: overload observation rows; 429 ceiling is not applied
+
+## Matrix
+
+${matrix_table}
+
+## Gate
+
+- burst64: total/edge 429 <= ${burst64_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms
+- all bursts: k6 503 = 0, nginx 5xx = 0, nginx 499 = 0
+- burst80/96: reject curve observation only for 429 budget; still fails on 5xx/499
+
+## Artifacts
+
+- summary TSV: ${summary_tsv}
+- summary JSON: ${summary_json}
+REPORT
+
+echo "${report_md}"
+if [[ -s "${failures_file}" ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #708

## 🌿 Base Branch
- `main`

## 📝 Summary
- burst 32/48/64/80/96 k6 실행 결과를 한 evidence pack으로 묶는 workflow를 추가합니다.
- k6 summary와 Nginx aggregate TSV/JSON/MD를 matrix TSV/JSON/MD로 요약해 429 source, 5xx/499, accepted p95, retry-after/reject streak를 같은 run group에서 확인합니다.

## 🛠 Changes
- `tools/test/run-oci-k6-burst-reject-curve-matrix.sh` runner와 contract test를 추가했습니다.
- `.github/workflows/oci-k6-burst-reject-curve-matrix.yml` workflow_dispatch와 PR contract job을 추가했습니다.
- burst64 gate는 matrix runner에서 판단하고, burst80/96은 429 ceiling 없이 overload observation으로 기록합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix.sh`
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh`
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/oci-k6-burst-reject-curve-matrix.yml')"`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: workflow_dispatch는 staging self-hosted runner와 Nginx access log/run id에 의존하므로, log가 없으면 artifact 누락을 실패로 처리합니다.
- 롤백 방법: 이 PR의 두 커밋을 revert하면 workflow/runner 추가가 제거됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? 영향 없음
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? workflow artifact 반영