### PR TITLE
[Perf] external off-host generator host metrics closure

### DIFF
--- a/.github/workflows/offhost-100m-capacity-prerequisite.yml
+++ b/.github/workflows/offhost-100m-capacity-prerequisite.yml
@@ -35,6 +35,10 @@ on:
         description: "Source-level 429/latency/5xx TSV evidence ref"
         required: false
         type: string
+      host_metrics_run_id:
+        description: "Run id used inside generator/target host metrics TSV"
+        required: false
+        type: string
       generator_host_metrics_tsv:
         description: "Generator host CPU/network TSV evidence ref"
         required: false
@@ -51,6 +55,8 @@ on:
       - "tools/test/check-offhost-capacity-env-doctor.sh"
       - "tools/test/offhost-capacity.env.example"
       - "tools/test/check-offhost-capacity-prerequisite-required-gate.sh"
+      - "tools/test/run-oci-offhost-host-metrics-evidence.sh"
+      - "tools/test/check-oci-offhost-host-metrics-evidence.sh"
       - "tools/test/run-transaction-100m-offhost-capacity-baseline-report.sh"
       - "tools/test/run-t3micro-defensive-gates-aggregate-report.sh"
 
@@ -91,6 +97,7 @@ jobs:
           VU16_SUMMARY_JSON_INPUT: ${{ inputs.vu16_summary_json }}
           BURST_MATRIX_TSV_INPUT: ${{ inputs.burst_matrix_tsv }}
           SOURCE_EVIDENCE_TSV_INPUT: ${{ inputs.source_evidence_tsv }}
+          HOST_METRICS_RUN_ID_INPUT: ${{ inputs.host_metrics_run_id }}
           GENERATOR_HOST_METRICS_TSV_INPUT: ${{ inputs.generator_host_metrics_tsv }}
           TARGET_HOST_METRICS_TSV_INPUT: ${{ inputs.target_host_metrics_tsv }}
           CAPACITY_K6_DOCKER_CONTEXT_VAR: ${{ vars.CAPACITY_K6_DOCKER_CONTEXT }}
@@ -123,6 +130,7 @@ jobs:
           CAPACITY_NAME="ci-offhost-100m-capacity-prerequisite"
           CAPACITY_K6_GENERATOR_MODE="docker-context"
           CAPACITY_REMOTE_PREFLIGHT="true"
+          CAPACITY_REQUIRE_HOST_METRICS="true"
           CAPACITY_PREREQUISITE_FAILURE_REPORT_PATH="${report_dir}/capacity-prerequisite-failure.env"
           DEFAULT_CAPACITY_K6_DOCKER_CONTEXT="default"
           DEFAULT_CAPACITY_K6_REMOTE_BASE_URL="${STAGING_BASE_URL:-}"
@@ -143,6 +151,7 @@ jobs:
           CAPACITY_K6_VU16_SUMMARY_JSON="${VU16_SUMMARY_JSON_INPUT:-${CAPACITY_K6_VU16_SUMMARY_JSON:-${CAPACITY_K6_VU16_SUMMARY_JSON_VAR:-}}}"
           CAPACITY_K6_BURST_MATRIX_TSV="${BURST_MATRIX_TSV_INPUT:-${CAPACITY_K6_BURST_MATRIX_TSV:-${CAPACITY_K6_BURST_MATRIX_TSV_VAR:-}}}"
           CAPACITY_K6_SOURCE_EVIDENCE_TSV="${SOURCE_EVIDENCE_TSV_INPUT:-${CAPACITY_K6_SOURCE_EVIDENCE_TSV:-${CAPACITY_K6_SOURCE_EVIDENCE_TSV_VAR:-}}}"
+          CAPACITY_K6_HOST_METRICS_RUN_ID="${HOST_METRICS_RUN_ID_INPUT:-${CAPACITY_K6_HOST_METRICS_RUN_ID:-${CAPACITY_NAME}}}"
           CAPACITY_K6_GENERATOR_HOST_METRICS_TSV="${GENERATOR_HOST_METRICS_TSV_INPUT:-${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV:-${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV_VAR:-${CAPACITY_K6_HOST_METRICS_TSV}}}}"
           CAPACITY_K6_TARGET_HOST_METRICS_TSV="${TARGET_HOST_METRICS_TSV_INPUT:-${CAPACITY_K6_TARGET_HOST_METRICS_TSV:-${CAPACITY_K6_TARGET_HOST_METRICS_TSV_VAR:-}}}"
 
@@ -150,6 +159,8 @@ jobs:
           [[ -z "${CAPACITY_K6_DOCKER_CONTEXT}" ]] && missing+=("CAPACITY_K6_DOCKER_CONTEXT")
           [[ -z "${CAPACITY_K6_REMOTE_BASE_URL}" ]] && missing+=("CAPACITY_K6_REMOTE_BASE_URL")
           [[ -z "${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" ]] && missing+=("CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL")
+          [[ -z "${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV}" ]] && missing+=("CAPACITY_K6_GENERATOR_HOST_METRICS_TSV")
+          [[ -z "${CAPACITY_K6_TARGET_HOST_METRICS_TSV}" ]] && missing+=("CAPACITY_K6_TARGET_HOST_METRICS_TSV")
           if (( ${#missing[@]} > 0 )); then
             {
               echo "CAPACITY_PREREQUISITE_STATUS=failed"
@@ -164,6 +175,7 @@ jobs:
             CAPACITY_NAME
             CAPACITY_K6_GENERATOR_MODE
             CAPACITY_REMOTE_PREFLIGHT
+            CAPACITY_REQUIRE_HOST_METRICS
             CAPACITY_PREREQUISITE_FAILURE_REPORT_PATH
             CAPACITY_K6_DOCKER_CONTEXT
             CAPACITY_K6_REMOTE_BASE_URL
@@ -173,6 +185,7 @@ jobs:
             CAPACITY_K6_VU16_SUMMARY_JSON
             CAPACITY_K6_BURST_MATRIX_TSV
             CAPACITY_K6_SOURCE_EVIDENCE_TSV
+            CAPACITY_K6_HOST_METRICS_RUN_ID
             CAPACITY_K6_GENERATOR_HOST_METRICS_TSV
             CAPACITY_K6_TARGET_HOST_METRICS_TSV
           )
@@ -196,6 +209,19 @@ jobs:
           report_dir="build/reports/k6/ci-offhost-100m-capacity-prerequisite"
           mkdir -p "${report_dir}"
           tools/test/run-offhost-capacity-env-doctor.sh >"${report_dir}/offhost-capacity-preflight.log" 2>&1
+
+      - name: Build off-host host metrics evidence artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="build/reports/k6/ci-offhost-100m-capacity-prerequisite"
+          mkdir -p "${report_dir}"
+          OCI_OFFHOST_HOST_METRICS_NAME="${CAPACITY_NAME}" \
+          OCI_OFFHOST_HOST_METRICS_RUN_ID="${CAPACITY_K6_HOST_METRICS_RUN_ID}" \
+          OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV}" \
+          OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${CAPACITY_K6_TARGET_HOST_METRICS_TSV}" \
+          OCI_OFFHOST_HOST_METRICS_OUTPUT_DIR="${report_dir}/offhost-host-metrics-evidence" \
+            tools/test/run-oci-offhost-host-metrics-evidence.sh
 
       - name: Required prerequisite check
         shell: bash

--- a/tools/test/check-oci-offhost-host-metrics-evidence.sh
+++ b/tools/test/check-oci-offhost-host-metrics-evidence.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-oci-offhost-host-metrics-evidence.sh"
+
+echo "[oci-offhost-host-metrics-evidence] shell syntax"
+bash -n "${runner}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+generator_tsv="${temp_dir}/generator-host-metrics.tsv"
+target_tsv="${temp_dir}/target-host-metrics.tsv"
+output_dir="${temp_dir}/output"
+
+cat >"${generator_tsv}" <<'TSV'
+run_id	host_role	host_name	docker_context	cpu_pct	rx_mbps	tx_mbps	artifact_uri	sample_count	cpu_pct_max	rx_mbps_max	tx_mbps_max
+offhost-run-20260503	generator	k6-generator-a	oci-k6-generator-a	41.2	18.5	21.1	oci://aquila-evidence/transaction-read/offhost-run-20260503/host/k6-generator-a	18	55.4	24.2	30.7
+offhost-run-20260503	generator	k6-generator-b	oci-k6-generator-b	39.8	17.9	20.4	oci://aquila-evidence/transaction-read/offhost-run-20260503/host/k6-generator-b	18	52.1	23.8	29.9
+TSV
+
+cat >"${target_tsv}" <<'TSV'
+run_id	host_role	host_name	docker_context	cpu_pct	rx_mbps	tx_mbps	artifact_uri	sample_count	cpu_pct_max	rx_mbps_max	tx_mbps_max
+offhost-run-20260503	target	oci-a1-staging	target	63.5	38.2	44.6	oci://aquila-evidence/transaction-read/offhost-run-20260503/host/target	18	71.0	45.2	51.8
+TSV
+
+echo "[oci-offhost-host-metrics-evidence] print plan"
+plan="$(
+  OCI_OFFHOST_HOST_METRICS_NAME=offhost-host-check \
+  OCI_OFFHOST_HOST_METRICS_RUN_ID=offhost-run-20260503 \
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${generator_tsv}" \
+  OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${target_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_OUTPUT_DIR="${output_dir}" \
+    "${runner}" --print-plan
+)"
+grep -F "name=offhost-host-check" <<<"${plan}" >/dev/null
+grep -F "run_id=offhost-run-20260503" <<<"${plan}" >/dev/null
+grep -F "generator_host_metrics_tsv=${generator_tsv}" <<<"${plan}" >/dev/null
+grep -F "target_host_metrics_tsv=${target_tsv}" <<<"${plan}" >/dev/null
+grep -F "required_columns=run_id,host_role,host_name,docker_context,cpu_pct,rx_mbps,tx_mbps,artifact_uri" <<<"${plan}" >/dev/null
+grep -F "combined_tsv=${output_dir}/offhost-host-check-host-metrics.tsv" <<<"${plan}" >/dev/null
+
+echo "[oci-offhost-host-metrics-evidence] pass report"
+output="$(
+  OCI_OFFHOST_HOST_METRICS_NAME=offhost-host-check \
+  OCI_OFFHOST_HOST_METRICS_RUN_ID=offhost-run-20260503 \
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${generator_tsv}" \
+  OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${target_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_OUTPUT_DIR="${output_dir}" \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+combined_tsv="${output_dir}/offhost-host-check-host-metrics.tsv"
+combined_json="${output_dir}/offhost-host-check-host-metrics.json"
+test "${report_md}" = "${output_dir}/offhost-host-check-host-metrics.md"
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "generator host metrics: verified" "${report_md}" >/dev/null
+grep -F "target host metrics: verified" "${report_md}" >/dev/null
+grep -F "combined host metrics TSV: ${combined_tsv}" "${report_md}" >/dev/null
+grep -F $'run_id\thost_role\thost_name\tdocker_context\tcpu_pct\trx_mbps\ttx_mbps\tartifact_uri\tsource_file' "${combined_tsv}" >/dev/null
+grep -F $'offhost-run-20260503\tgenerator\tk6-generator-a\toci-k6-generator-a\t41.2\t18.5\t21.1\toci://aquila-evidence/transaction-read/offhost-run-20260503/host/k6-generator-a\t' "${combined_tsv}" >/dev/null
+grep -F $'offhost-run-20260503\ttarget\toci-a1-staging\ttarget\t63.5\t38.2\t44.6\toci://aquila-evidence/transaction-read/offhost-run-20260503/host/target\t' "${combined_tsv}" >/dev/null
+jq -e '.items | length == 3' "${combined_json}" >/dev/null
+jq -e '.items[] | select(.host_role == "generator" and .host_name == "k6-generator-b" and .cpu_pct == 39.8)' "${combined_json}" >/dev/null
+jq -e '.summary.generator_count == 2 and .summary.target_count == 1 and .summary.gate_status == "pass"' "${combined_json}" >/dev/null
+
+echo "[oci-offhost-host-metrics-evidence] missing target fails"
+if OCI_OFFHOST_HOST_METRICS_NAME=offhost-host-missing-target \
+  OCI_OFFHOST_HOST_METRICS_RUN_ID=offhost-run-20260503 \
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${generator_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_OUTPUT_DIR="${temp_dir}/missing-output" \
+    "${runner}" >"${temp_dir}/missing-target.log" 2>&1; then
+  echo "off-host host metrics evidence unexpectedly passed without target metrics" >&2
+  exit 1
+fi
+grep -F "OCI_OFFHOST_TARGET_HOST_METRICS_TSV is required" "${temp_dir}/missing-target.log" >/dev/null
+
+echo "[oci-offhost-host-metrics-evidence] missing generator row fails"
+generator_without_rows="${temp_dir}/generator-without-rows.tsv"
+head -n 1 "${generator_tsv}" >"${generator_without_rows}"
+if OCI_OFFHOST_HOST_METRICS_NAME=offhost-host-missing-generator-row \
+  OCI_OFFHOST_HOST_METRICS_RUN_ID=offhost-run-20260503 \
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${generator_without_rows}" \
+  OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${target_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_OUTPUT_DIR="${temp_dir}/missing-generator-row-output" \
+    "${runner}" >"${temp_dir}/missing-generator-row.log" 2>&1; then
+  echo "off-host host metrics evidence unexpectedly passed without generator rows" >&2
+  exit 1
+fi
+grep -F "generator host metrics row is required" "${temp_dir}/missing-generator-row.log" >/dev/null
+
+echo "[oci-offhost-host-metrics-evidence] run id mismatch fails"
+bad_run_id_tsv="${temp_dir}/bad-run-id.tsv"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $1 = "other-run"; print }' "${target_tsv}" >"${bad_run_id_tsv}"
+if OCI_OFFHOST_HOST_METRICS_NAME=offhost-host-run-id-mismatch \
+  OCI_OFFHOST_HOST_METRICS_RUN_ID=offhost-run-20260503 \
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${generator_tsv}" \
+  OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${bad_run_id_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_OUTPUT_DIR="${temp_dir}/run-id-mismatch-output" \
+    "${runner}" >"${temp_dir}/run-id-mismatch.log" 2>&1; then
+  echo "off-host host metrics evidence unexpectedly passed mismatched run id" >&2
+  exit 1
+fi
+grep -F "host metric run id mismatch" "${temp_dir}/run-id-mismatch.log" >/dev/null
+
+echo "[oci-offhost-host-metrics-evidence] negative metric fails"
+bad_metric_tsv="${temp_dir}/bad-metric.tsv"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $5 = "-1"; print }' "${generator_tsv}" >"${bad_metric_tsv}"
+if OCI_OFFHOST_HOST_METRICS_NAME=offhost-host-bad-metric \
+  OCI_OFFHOST_HOST_METRICS_RUN_ID=offhost-run-20260503 \
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${bad_metric_tsv}" \
+  OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${target_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_OUTPUT_DIR="${temp_dir}/bad-metric-output" \
+    "${runner}" >"${temp_dir}/bad-metric.log" 2>&1; then
+  echo "off-host host metrics evidence unexpectedly passed negative metric" >&2
+  exit 1
+fi
+grep -F "host metric cpu/network values must be non-negative numbers" "${temp_dir}/bad-metric.log" >/dev/null

--- a/tools/test/check-offhost-capacity-env-doctor.sh
+++ b/tools/test/check-offhost-capacity-env-doctor.sh
@@ -44,6 +44,7 @@ CAPACITY_K6_BURST_MATRIX_TSV=build/reports/k6/offhost-check/burst-reject-curve.t
 CAPACITY_K6_SOURCE_EVIDENCE_TSV=build/reports/k6/offhost-check/source-evidence.tsv
 CAPACITY_K6_GENERATOR_HOST_METRICS_TSV=build/reports/k6/offhost-check/generator-host-metrics.tsv
 CAPACITY_K6_TARGET_HOST_METRICS_TSV=build/reports/k6/offhost-check/target-host-metrics.tsv
+CAPACITY_K6_HOST_METRICS_RUN_ID=offhost-check
 ENV
 
 echo "[offhost-capacity-env-doctor] plan"
@@ -64,6 +65,8 @@ grep -F "burst_matrix_tsv=build/reports/k6/offhost-check/burst-reject-curve.tsv"
 grep -F "source_evidence_tsv=build/reports/k6/offhost-check/source-evidence.tsv" <<<"${plan}" >/dev/null
 grep -F "generator_host_metrics_tsv=build/reports/k6/offhost-check/generator-host-metrics.tsv" <<<"${plan}" >/dev/null
 grep -F "target_host_metrics_tsv=build/reports/k6/offhost-check/target-host-metrics.tsv" <<<"${plan}" >/dev/null
+grep -F "host_metrics_run_id=offhost-check" <<<"${plan}" >/dev/null
+grep -F "require_host_metrics=true" <<<"${plan}" >/dev/null
 grep -F "timeout_seconds=15" <<<"${plan}" >/dev/null
 grep -F "check_connectivity=false" <<<"${plan}" >/dev/null
 
@@ -92,9 +95,23 @@ if OFFHOST_CAPACITY_ENV_FILE="${bad_env_file}" "${script}" --print-plan >/dev/nu
   exit 1
 fi
 
+missing_metrics_env_file="${temp_dir}/missing-metrics.env"
+cat >"${missing_metrics_env_file}" <<'ENV'
+CAPACITY_K6_DOCKER_CONTEXT=capacity-k6-remote
+CAPACITY_K6_REMOTE_BASE_URL=http://192.0.2.20:18080
+CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://192.0.2.20:9090/api/v1/write
+ENV
+if OFFHOST_CAPACITY_ENV_FILE="${missing_metrics_env_file}" OFFHOST_CAPACITY_CHECK_CONNECTIVITY=false "${script}" --print-plan >"${temp_dir}/missing-metrics.log" 2>&1; then
+  echo "missing off-host host metrics unexpectedly passed" >&2
+  exit 1
+fi
+grep -F "CAPACITY_K6_GENERATOR_HOST_METRICS_TSV is required when CAPACITY_REQUIRE_HOST_METRICS=true" "${temp_dir}/missing-metrics.log" >/dev/null
+
 echo "[offhost-capacity-env-doctor] runner contract"
 grep -F "OFFHOST_CAPACITY_ENV_FILE" "${script}" >/dev/null
 grep -F "OFFHOST_CAPACITY_CHECK_CONNECTIVITY" "${script}" >/dev/null
+grep -F "CAPACITY_REQUIRE_HOST_METRICS" "${script}" >/dev/null
+grep -F "CAPACITY_K6_HOST_METRICS_RUN_ID" "${script}" >/dev/null
 grep -F "CAPACITY_K6_HOST_METRICS_TSV" "${script}" >/dev/null
 grep -F "CAPACITY_K6_VU16_SUMMARY_JSON" "${script}" >/dev/null
 grep -F "CAPACITY_K6_BURST_MATRIX_TSV" "${script}" >/dev/null

--- a/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+++ b/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
@@ -23,12 +23,14 @@ grep -F "host_metrics_tsv:" "${workflow}" >/dev/null
 grep -F "vu16_summary_json:" "${workflow}" >/dev/null
 grep -F "burst_matrix_tsv:" "${workflow}" >/dev/null
 grep -F "source_evidence_tsv:" "${workflow}" >/dev/null
+grep -F "host_metrics_run_id:" "${workflow}" >/dev/null
 grep -F "generator_host_metrics_tsv:" "${workflow}" >/dev/null
 grep -F "target_host_metrics_tsv:" "${workflow}" >/dev/null
 grep -F "HOST_METRICS_TSV_INPUT" "${workflow}" >/dev/null
 grep -F "VU16_SUMMARY_JSON_INPUT" "${workflow}" >/dev/null
 grep -F "BURST_MATRIX_TSV_INPUT" "${workflow}" >/dev/null
 grep -F "SOURCE_EVIDENCE_TSV_INPUT" "${workflow}" >/dev/null
+grep -F "HOST_METRICS_RUN_ID_INPUT" "${workflow}" >/dev/null
 grep -F "GENERATOR_HOST_METRICS_TSV_INPUT" "${workflow}" >/dev/null
 grep -F "TARGET_HOST_METRICS_TSV_INPUT" "${workflow}" >/dev/null
 grep -F 'DEFAULT_CAPACITY_K6_DOCKER_CONTEXT="default"' "${workflow}" >/dev/null
@@ -47,12 +49,20 @@ grep -F 'CAPACITY_K6_HOST_METRICS_TSV="${HOST_METRICS_TSV_INPUT:-${CAPACITY_K6_H
 grep -F 'CAPACITY_K6_VU16_SUMMARY_JSON="${VU16_SUMMARY_JSON_INPUT:-${CAPACITY_K6_VU16_SUMMARY_JSON:-${CAPACITY_K6_VU16_SUMMARY_JSON_VAR:-}}}"' "${workflow}" >/dev/null
 grep -F 'CAPACITY_K6_BURST_MATRIX_TSV="${BURST_MATRIX_TSV_INPUT:-${CAPACITY_K6_BURST_MATRIX_TSV:-${CAPACITY_K6_BURST_MATRIX_TSV_VAR:-}}}"' "${workflow}" >/dev/null
 grep -F 'CAPACITY_K6_SOURCE_EVIDENCE_TSV="${SOURCE_EVIDENCE_TSV_INPUT:-${CAPACITY_K6_SOURCE_EVIDENCE_TSV:-${CAPACITY_K6_SOURCE_EVIDENCE_TSV_VAR:-}}}"' "${workflow}" >/dev/null
+grep -F 'CAPACITY_K6_HOST_METRICS_RUN_ID="${HOST_METRICS_RUN_ID_INPUT:-${CAPACITY_K6_HOST_METRICS_RUN_ID:-${CAPACITY_NAME}}}"' "${workflow}" >/dev/null
 grep -F 'CAPACITY_K6_GENERATOR_HOST_METRICS_TSV="${GENERATOR_HOST_METRICS_TSV_INPUT:-${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV:-${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV_VAR:-${CAPACITY_K6_HOST_METRICS_TSV}}}}"' "${workflow}" >/dev/null
 grep -F 'CAPACITY_K6_TARGET_HOST_METRICS_TSV="${TARGET_HOST_METRICS_TSV_INPUT:-${CAPACITY_K6_TARGET_HOST_METRICS_TSV:-${CAPACITY_K6_TARGET_HOST_METRICS_TSV_VAR:-}}}"' "${workflow}" >/dev/null
 grep -F 'CAPACITY_REMOTE_PREFLIGHT="true"' "${workflow}" >/dev/null
+grep -F 'CAPACITY_REQUIRE_HOST_METRICS="true"' "${workflow}" >/dev/null
 grep -F "Run off-host remote preflight" "${workflow}" >/dev/null
 grep -F "tools/test/run-offhost-capacity-env-doctor.sh" "${workflow}" >/dev/null
 grep -F "offhost-capacity-preflight.log" "${workflow}" >/dev/null
+grep -F "Build off-host host metrics evidence artifact" "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_HOST_METRICS_NAME="${CAPACITY_NAME}"' "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_HOST_METRICS_RUN_ID="${CAPACITY_K6_HOST_METRICS_RUN_ID}"' "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV}"' "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${CAPACITY_K6_TARGET_HOST_METRICS_TSV}"' "${workflow}" >/dev/null
+grep -F "tools/test/run-oci-offhost-host-metrics-evidence.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-100m-capacity-gates.sh --print-plan" "${workflow}" >/dev/null
 grep -F "capacity-prerequisite-plan.log" "${workflow}" >/dev/null
 grep -F "actions/upload-artifact@" "${workflow}" >/dev/null

--- a/tools/test/run-oci-offhost-host-metrics-evidence.sh
+++ b/tools/test/run-oci-offhost-host-metrics-evidence.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-oci-offhost-host-metrics-evidence.sh [--print-plan]
+
+Environment:
+  OCI_OFFHOST_HOST_METRICS_NAME          default oci-offhost-host-metrics-<timestamp>
+  OCI_OFFHOST_HOST_METRICS_RUN_ID        default same as name
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV required generator host CPU/network TSV
+  OCI_OFFHOST_TARGET_HOST_METRICS_TSV    required target app/DB host CPU/network TSV
+  OCI_OFFHOST_HOST_METRICS_OUTPUT_DIR    default build/reports/k6/<name>
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${OCI_OFFHOST_HOST_METRICS_NAME:-oci-offhost-host-metrics-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${OCI_OFFHOST_HOST_METRICS_RUN_ID:-${name}}"
+generator_host_metrics_tsv="${OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV:-}"
+target_host_metrics_tsv="${OCI_OFFHOST_TARGET_HOST_METRICS_TSV:-}"
+output_dir="${OCI_OFFHOST_HOST_METRICS_OUTPUT_DIR:-build/reports/k6/${name}}"
+combined_tsv="${output_dir}/${name}-host-metrics.tsv"
+combined_json="${output_dir}/${name}-host-metrics.json"
+report_md="${output_dir}/${name}-host-metrics.md"
+required_columns="run_id,host_role,host_name,docker_context,cpu_pct,rx_mbps,tx_mbps,artifact_uri"
+
+print_plan() {
+  echo "[oci-offhost-host-metrics-evidence] name=${name}"
+  echo "[oci-offhost-host-metrics-evidence] run_id=${run_id}"
+  echo "[oci-offhost-host-metrics-evidence] generator_host_metrics_tsv=${generator_host_metrics_tsv:-missing}"
+  echo "[oci-offhost-host-metrics-evidence] target_host_metrics_tsv=${target_host_metrics_tsv:-missing}"
+  echo "[oci-offhost-host-metrics-evidence] required_columns=${required_columns}"
+  echo "[oci-offhost-host-metrics-evidence] output_dir=${output_dir}"
+  echo "[oci-offhost-host-metrics-evidence] combined_tsv=${combined_tsv}"
+  echo "[oci-offhost-host-metrics-evidence] combined_json=${combined_json}"
+  echo "[oci-offhost-host-metrics-evidence] report_md=${report_md}"
+}
+
+require_file() {
+  local name="$1"
+  local file="$2"
+  if [[ -z "${file}" || ! -s "${file}" ]]; then
+    echo "${name} is required and must be a non-empty file: ${file:-missing}" >&2
+    exit 1
+  fi
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  require_file "OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV" "${generator_host_metrics_tsv}"
+  require_file "OCI_OFFHOST_TARGET_HOST_METRICS_TSV" "${target_host_metrics_tsv}"
+  exit 0
+fi
+
+require_file "OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV" "${generator_host_metrics_tsv}"
+require_file "OCI_OFFHOST_TARGET_HOST_METRICS_TSV" "${target_host_metrics_tsv}"
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+raw_tsv="${output_dir}/${name}-host-metrics.raw.tsv"
+
+awk -F '\t' -v OFS='\t' -v expected_run_id="${run_id}" '
+  function is_number(value) {
+    return value ~ /^[0-9]+([.][0-9]+)?$/
+  }
+  function read_source(file, expected_role) {
+    while ((getline line < file) > 0) {
+      split(line, row, FS)
+      if (FNR == 0) {
+        # no-op for shellcheck-like parsers
+      }
+      if (source_line[file] == 0) {
+        for (i = 1; i <= length(row); i++) {
+          columns[file, row[i]] = i
+        }
+        split("run_id host_role host_name docker_context cpu_pct rx_mbps tx_mbps artifact_uri", required, " ")
+        for (i in required) {
+          if (!((file, required[i]) in columns)) {
+            printf "missing required host metric column: %s\n", required[i] > "/dev/stderr"
+            exit 2
+          }
+        }
+        source_line[file]++
+        continue
+      }
+      source_line[file]++
+      run = row[columns[file, "run_id"]]
+      role = row[columns[file, "host_role"]]
+      host = row[columns[file, "host_name"]]
+      context = row[columns[file, "docker_context"]]
+      cpu = row[columns[file, "cpu_pct"]]
+      rx = row[columns[file, "rx_mbps"]]
+      tx = row[columns[file, "tx_mbps"]]
+      artifact = row[columns[file, "artifact_uri"]]
+      if (run != expected_run_id) {
+        printf "host metric run id mismatch: host=%s run_id=%s expected=%s\n", host, run, expected_run_id > "/dev/stderr"
+        exit 3
+      }
+      if (role != "generator" && role != "target") {
+        printf "host metric role must be generator or target: host=%s role=%s\n", host, role > "/dev/stderr"
+        exit 4
+      }
+      if (role != expected_role) {
+        printf "host metric role mismatch for %s: host=%s role=%s\n", expected_role, host, role > "/dev/stderr"
+        exit 5
+      }
+      if (host == "" || context == "" || artifact == "") {
+        print "host metric contains blank host/context/artifact" > "/dev/stderr"
+        exit 6
+      }
+      if (!is_number(cpu) || !is_number(rx) || !is_number(tx)) {
+        printf "host metric cpu/network values must be non-negative numbers: host=%s cpu=%s rx=%s tx=%s\n", host, cpu, rx, tx > "/dev/stderr"
+        exit 7
+      }
+      if (role == "generator") generator_count++
+      if (role == "target") target_count++
+      print run, role, host, context, cpu, rx, tx, artifact, file
+    }
+    close(file)
+  }
+  BEGIN {
+    print "run_id", "host_role", "host_name", "docker_context", "cpu_pct", "rx_mbps", "tx_mbps", "artifact_uri", "source_file"
+    read_source(ARGV[1], "generator")
+    read_source(ARGV[2], "target")
+    if (generator_count < 1) {
+      print "generator host metrics row is required" > "/dev/stderr"
+      exit 8
+    }
+    if (target_count < 1) {
+      print "target host metrics row is required" > "/dev/stderr"
+      exit 9
+    }
+  }
+' "${generator_host_metrics_tsv}" "${target_host_metrics_tsv}" >"${raw_tsv}"
+
+mv "${raw_tsv}" "${combined_tsv}"
+
+jq -Rn --arg name "${name}" --arg run_id "${run_id}" '
+  def number_or_string:
+    if test("^-?[0-9]+([.][0-9]+)?$") then tonumber else . end;
+  (input | split("\t")) as $headers
+  | [
+      inputs
+      | split("\t") as $row
+      | reduce range(0; $headers | length) as $i (
+          {};
+          .[$headers[$i]] = (($row[$i] // "") | number_or_string)
+        )
+    ] as $items
+  | {
+      name: $name,
+      run_id: $run_id,
+      summary: {
+        gate_status: "pass",
+        generator_count: ($items | map(select(.host_role == "generator")) | length),
+        target_count: ($items | map(select(.host_role == "target")) | length),
+        host_count: ($items | length)
+      },
+      items: $items
+    }
+' <"${combined_tsv}" >"${combined_json}"
+
+generator_count="$(awk -F '\t' 'NR > 1 && $2 == "generator" { count++ } END { print count + 0 }' "${combined_tsv}")"
+target_count="$(awk -F '\t' 'NR > 1 && $2 == "target" { count++ } END { print count + 0 }' "${combined_tsv}")"
+
+host_table="$(awk -F '\t' '
+  BEGIN {
+    print "| Role | Host | Docker context | CPU % | RX Mbps | TX Mbps | Artifact |"
+    print "| --- | --- | --- | ---: | ---: | ---: | --- |"
+  }
+  NR > 1 {
+    printf "| %s | %s | %s | %s | %s | %s | %s |\n", $2, $3, $4, $5, $6, $7, $8
+  }
+' "${combined_tsv}")"
+
+cat >"${report_md}" <<REPORT
+# OCI Off-Host Host Metrics Evidence
+
+## Summary
+
+- gate_status=pass
+- run_id=${run_id}
+- generator host metrics: verified
+- target host metrics: verified
+- generator host count: ${generator_count}
+- target host count: ${target_count}
+
+## Host Metrics
+
+${host_table}
+
+## Artifacts
+
+- generator host metrics TSV: ${generator_host_metrics_tsv}
+- target host metrics TSV: ${target_host_metrics_tsv}
+- combined host metrics TSV: ${combined_tsv}
+- combined host metrics JSON: ${combined_json}
+
+## Contract Notes
+
+- off-host generator와 app/DB target host CPU/network evidence를 같은 run id로 묶는다.
+- host metrics가 비어 있거나 generator/target role 중 하나라도 없으면 prerequisite가 실패해야 한다.
+REPORT
+
+echo "${report_md}"

--- a/tools/test/run-offhost-capacity-env-doctor.sh
+++ b/tools/test/run-offhost-capacity-env-doctor.sh
@@ -18,6 +18,8 @@ Environment:
   CAPACITY_K6_SOURCE_EVIDENCE_TSV optional source-level edge/backend 429 and latency TSV ref
   CAPACITY_K6_GENERATOR_HOST_METRICS_TSV optional generator host CPU/network TSV ref
   CAPACITY_K6_TARGET_HOST_METRICS_TSV optional app/DB target host CPU/network TSV ref
+  CAPACITY_K6_HOST_METRICS_RUN_ID optional host metrics run id ref
+  CAPACITY_REQUIRE_HOST_METRICS default true
   CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS default 30
   CAPACITY_REMOTE_PREFLIGHT_IMAGE default curlimages/curl:8.11.1
   CAPACITY_REMOTE_READINESS_PATH default /actuator/health/readiness
@@ -85,6 +87,8 @@ burst_matrix_tsv="${CAPACITY_K6_BURST_MATRIX_TSV:-${K6_BURST_MATRIX_TSV:-}}"
 source_evidence_tsv="${CAPACITY_K6_SOURCE_EVIDENCE_TSV:-${K6_SOURCE_EVIDENCE_TSV:-}}"
 generator_host_metrics_tsv="${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV:-${K6_GENERATOR_HOST_METRICS_TSV:-${host_metrics_tsv}}}"
 target_host_metrics_tsv="${CAPACITY_K6_TARGET_HOST_METRICS_TSV:-${K6_TARGET_HOST_METRICS_TSV:-}}"
+host_metrics_run_id="${CAPACITY_K6_HOST_METRICS_RUN_ID:-${K6_HOST_METRICS_RUN_ID:-${CAPACITY_NAME:-}}}"
+require_host_metrics="${CAPACITY_REQUIRE_HOST_METRICS:-true}"
 check_connectivity="${OFFHOST_CAPACITY_CHECK_CONNECTIVITY:-true}"
 timeout_seconds="${CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS:-${K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS:-30}}"
 preflight_image="${CAPACITY_REMOTE_PREFLIGHT_IMAGE:-${K6_REMOTE_PREFLIGHT_IMAGE:-curlimages/curl:8.11.1}}"
@@ -131,6 +135,7 @@ require_url() {
 
 require_bool "OFFHOST_CAPACITY_CHECK_CONNECTIVITY" "${check_connectivity}"
 require_bool "CAPACITY_K6_AUTH_TOKEN_REQUIRED" "${auth_token_required}"
+require_bool "CAPACITY_REQUIRE_HOST_METRICS" "${require_host_metrics}"
 require_positive_integer "CAPACITY_REMOTE_PREFLIGHT_TIMEOUT_SECONDS" "${timeout_seconds}"
 require_env_value "CAPACITY_K6_DOCKER_CONTEXT" "${docker_context}"
 require_env_value "CAPACITY_K6_REMOTE_BASE_URL" "${remote_base_url}"
@@ -139,6 +144,10 @@ require_url "CAPACITY_K6_REMOTE_BASE_URL" "${remote_base_url}"
 require_url "CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL" "${remote_prometheus_rw_url}"
 if [[ "${auth_token_required}" == "true" ]]; then
   require_env_value "CAPACITY_K6_AUTH_TOKEN" "${auth_token}"
+fi
+if [[ "${require_host_metrics}" == "true" ]]; then
+  require_env_value "CAPACITY_K6_GENERATOR_HOST_METRICS_TSV is required when CAPACITY_REQUIRE_HOST_METRICS=true" "${generator_host_metrics_tsv}"
+  require_env_value "CAPACITY_K6_TARGET_HOST_METRICS_TSV is required when CAPACITY_REQUIRE_HOST_METRICS=true" "${target_host_metrics_tsv}"
 fi
 
 print_plan() {
@@ -154,6 +163,8 @@ print_plan() {
   echo "[offhost-capacity-env-doctor] source_evidence_tsv=${source_evidence_tsv:-missing}"
   echo "[offhost-capacity-env-doctor] generator_host_metrics_tsv=${generator_host_metrics_tsv:-missing}"
   echo "[offhost-capacity-env-doctor] target_host_metrics_tsv=${target_host_metrics_tsv:-missing}"
+  echo "[offhost-capacity-env-doctor] host_metrics_run_id=${host_metrics_run_id:-missing}"
+  echo "[offhost-capacity-env-doctor] require_host_metrics=${require_host_metrics}"
   echo "[offhost-capacity-env-doctor] readiness_url=${readiness_url}"
   echo "[offhost-capacity-env-doctor] preflight_image=${preflight_image}"
   echo "[offhost-capacity-env-doctor] timeout_seconds=${timeout_seconds}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #710

## 🌿 Base Branch
- `main`

## 📝 Summary
- off-host prerequisite에서 generator/target host CPU/network metrics를 필수 evidence로 취급하도록 강화합니다.
- generator/app-DB host metrics TSV를 검증해 combined TSV/JSON/MD artifact로 남기는 runner를 추가했습니다.

## 🛠 Changes
- `tools/test/run-oci-offhost-host-metrics-evidence.sh` runner와 contract test를 추가했습니다.
- `run-offhost-capacity-env-doctor.sh`에 `CAPACITY_REQUIRE_HOST_METRICS=true` 기본 gate와 host metrics run id를 추가했습니다.
- `offhost-100m-capacity-prerequisite.yml`이 host metrics evidence pack을 생성하고 missing metrics를 실패 처리하도록 연결했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-offhost-host-metrics-evidence.sh`
- `bash tools/test/check-offhost-capacity-env-doctor.sh`
- `bash tools/test/check-offhost-capacity-prerequisite-required-gate.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: off-host prerequisite dispatch가 generator/target host metrics TSV를 제공하지 않으면 이제 실패합니다. 이는 no-op success 방지를 위한 의도된 동작입니다.
- 롤백 방법: 이 PR의 두 커밋을 revert하면 host metrics gate와 evidence pack runner가 제거됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? secret 값 출력 없음
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? GitHub Actions input `host_metrics_run_id` 추가
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? prerequisite artifact contract 반영