### PR TITLE
[Ops] transaction read admission profile promotion gate

### DIFF
--- a/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
+++ b/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
@@ -94,6 +94,7 @@ on:
 
 permissions:
   contents: read
+  deployments: write
 
 jobs:
   contract:
@@ -416,3 +417,47 @@ jobs:
             build/reports/k6/${{ env.K6_MATRIX_REPORT_NAME }}/
             build/reports/k6/${{ env.K6_MATRIX_REPORT_NAME }}*
           if-no-files-found: error
+
+      - name: Record transaction read admission profile evidence deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVIDENCE_ENVIRONMENT: staging-transaction-read-admission-profile
+          EVIDENCE_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_sha="$(git rev-parse HEAD)"
+          matrix_report="build/reports/k6/${K6_MATRIX_REPORT_NAME}/burst-reject-curve-matrix/${K6_MATRIX_REPORT_NAME}-burst-reject-curve-matrix.md"
+
+          deployment_payload="$(
+            jq -n \
+              --arg ref "${evidence_sha}" \
+              --arg environment "${EVIDENCE_ENVIRONMENT}" \
+              --arg description "transaction read burst boundary admission profile evidence" \
+              '{
+                "ref": $ref,
+                "environment": $environment,
+                "description": $description,
+                "auto_merge": false,
+                "required_contexts": []
+              }'
+          )"
+          deployment_id="$(
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments" \
+              --input - \
+              --jq ".id" <<<"${deployment_payload}"
+          )"
+
+          status_payload="$(
+            jq -n \
+              --arg log_url "${EVIDENCE_LOG_URL}" \
+              --arg description "transaction read burst boundary matrix passed: ${matrix_report}" \
+              '{
+                "state": "success",
+                "log_url": $log_url,
+                "description": $description,
+                "auto_inactive": false
+              }'
+          )"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+            --input - <<<"${status_payload}"

--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -153,6 +153,47 @@ jobs:
             exit 1
           fi
 
+      - name: Verify staging transaction read admission profile evidence success
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          deployment_ids="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments" \
+              -f environment=staging-transaction-read-admission-profile \
+              -f sha="${TARGET_SHA}" \
+              --paginate \
+              --jq ".[].id"
+          )"
+
+          if [ -z "${deployment_ids}" ]; then
+            echo "::error::No staging transaction read admission profile evidence found for ${TARGET_SHA}."
+            exit 1
+          fi
+
+          found_success=false
+          while IFS= read -r deployment_id; do
+            if [ -z "${deployment_id}" ]; then
+              continue
+            fi
+
+            state="$(
+              gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+                --jq ".[0].state // \"\""
+            )"
+            if [ "${state}" = "success" ]; then
+              found_success=true
+              break
+            fi
+          done <<< "${deployment_ids}"
+
+          if [ "${found_success}" != "true" ]; then
+            echo "::error::No successful staging transaction read admission profile evidence found for ${TARGET_SHA}."
+            exit 1
+          fi
+
   promote:
     name: Promote SHA To Production
     needs:

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
@@ -86,16 +86,27 @@ grep -F 'OCI_K6_BURST_MATRIX_OUTPUT_DIR="${matrix_dir}/burst-reject-curve-matrix
 grep -F "tools/test/run-oci-k6-burst-reject-curve-matrix.sh" "${workflow}" >/dev/null
 grep -F "actions/upload-artifact@v7" "${workflow}" >/dev/null
 grep -F "oci-k6-burst-reject-curve-matrix" "${workflow}" >/dev/null
+grep -F "deployments: write" "${workflow}" >/dev/null
+grep -F "Record transaction read admission profile evidence deployment" "${workflow}" >/dev/null
+grep -F "staging-transaction-read-admission-profile" "${workflow}" >/dev/null
+grep -F 'gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments"' "${workflow}" >/dev/null
+grep -F 'gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses"' "${workflow}" >/dev/null
+grep -F '"state": "success"' "${workflow}" >/dev/null
 
 preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"
 k6_run_line="$(grep -n -- "--no-up --no-deps" "${workflow}" | head -1 | cut -d: -f1)"
 matrix_line="$(grep -n -- "run-oci-k6-burst-reject-curve-matrix.sh" "${workflow}" | tail -1 | cut -d: -f1)"
+admission_deployment_line="$(grep -n -- "Record transaction read admission profile evidence deployment" "${workflow}" | head -1 | cut -d: -f1)"
 if [[ -z "${preflight_line}" || -z "${k6_run_line}" || "${preflight_line}" -ge "${k6_run_line}" ]]; then
   echo "auth preflight must run before authenticated k6 burst run" >&2
   exit 1
 fi
 if [[ -z "${matrix_line}" || "${k6_run_line}" -ge "${matrix_line}" ]]; then
   echo "matrix pack runner must run after burst k6 runs" >&2
+  exit 1
+fi
+if [[ -z "${admission_deployment_line}" || "${matrix_line}" -ge "${admission_deployment_line}" ]]; then
+  echo "admission profile evidence deployment must be recorded after burst matrix pack" >&2
   exit 1
 fi
 

--- a/tools/test/run-production-high-traffic-config-gate.sh
+++ b/tools/test/run-production-high-traffic-config-gate.sh
@@ -19,10 +19,15 @@ guard_outputs = workflow.fetch('jobs').fetch('guard').fetch('outputs')
 abort('guard must expose image_tag output for OCI deploy') unless guard_outputs.fetch('image_tag').include?('steps.resolve.outputs.image_tag')
 staging_success_index = guard_step_names.index('Verify staging deployment success') or abort('staging deployment success guard missing')
 replay_evidence_index = guard_step_names.index('Verify staging 100m replay evidence success') or abort('staging 100m replay evidence guard missing')
+admission_evidence_index = guard_step_names.index('Verify staging transaction read admission profile evidence success') or abort('staging transaction read admission profile evidence guard missing')
 abort('staging replay evidence guard must run after staging deployment guard') unless staging_success_index < replay_evidence_index
+abort('staging admission profile evidence guard must run after staging replay evidence guard') unless replay_evidence_index < admission_evidence_index
 replay_evidence_run = guard_steps.fetch(replay_evidence_index).fetch('run')
 abort('staging replay evidence guard must query separate environment') unless replay_evidence_run.include?('staging-100m-replay')
 abort('staging replay evidence guard must require success') unless replay_evidence_run.include?('No successful staging 100m replay evidence')
+admission_evidence_run = guard_steps.fetch(admission_evidence_index).fetch('run')
+abort('staging admission profile evidence guard must query separate environment') unless admission_evidence_run.include?('staging-transaction-read-admission-profile')
+abort('staging admission profile evidence guard must require success') unless admission_evidence_run.include?('No successful staging transaction read admission profile evidence')
 resolve_step = guard_steps.fetch(guard_step_names.index('Resolve promotion target SHA'))
 abort('resolve step must write 12-char image tag') unless resolve_step.fetch('run').include?('image_tag=${target_sha:0:12}')
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #712

## 🌿 Base Branch
- `main`

## 📝 Summary
- production promotion guard에 transaction read admission profile evidence 성공 조건을 추가합니다.
- OCI k6 burst reject curve matrix가 성공하면 같은 SHA에 `staging-transaction-read-admission-profile` deployment status를 기록합니다.

## 🛠 Changes
- `oci-k6-burst-reject-curve-matrix.yml`에 `deployments: write` 권한과 admission evidence deployment 기록 step 추가
- `production-promotion.yml` guard에 admission profile evidence success 조회 추가
- workflow contract test에 deployment status 기록/조회/순서 검증 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh`
- `bash tools/test/run-production-high-traffic-config-gate.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/oci-k6-burst-reject-curve-matrix.yml'); YAML.load_file('.github/workflows/production-promotion.yml'); puts 'ok'"`
- `git rev-list --count origin/main..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: burst matrix 성공 후 GitHub deployment API 권한 또는 환경 정책 문제로 evidence status 기록이 실패하면 production promotion이 차단됩니다.
- 롤백 방법: 이 PR revert 후 production promotion guard에서 기존 staging/staging-100m-replay evidence만 요구하도록 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
