### PR TITLE
[Fix] OCI burst matrix admission evidence deployment runner dependency

### DIFF
--- a/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
+++ b/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
@@ -427,6 +427,7 @@ jobs:
         run: |
           set -euo pipefail
           evidence_sha="$(git rev-parse HEAD)"
+          github_api_url="${GITHUB_API_URL:-https://api.github.com}"
           matrix_report="build/reports/k6/${K6_MATRIX_REPORT_NAME}/burst-reject-curve-matrix/${K6_MATRIX_REPORT_NAME}-burst-reject-curve-matrix.md"
 
           deployment_payload="$(
@@ -443,9 +444,14 @@ jobs:
               }'
           )"
           deployment_id="$(
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments" \
-              --input - \
-              --jq ".id" <<<"${deployment_payload}"
+            curl --fail-with-body --silent --show-error --location \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "${github_api_url}/repos/${GITHUB_REPOSITORY}/deployments" \
+              --data-binary "${deployment_payload}" \
+              | jq -er ".id"
           )"
 
           status_payload="$(
@@ -459,5 +465,11 @@ jobs:
                 "auto_inactive": false
               }'
           )"
-          gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
-            --input - <<<"${status_payload}"
+          curl --fail-with-body --silent --show-error --location \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${github_api_url}/repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+            --data-binary "${status_payload}" \
+            >/dev/null

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
@@ -89,8 +89,10 @@ grep -F "oci-k6-burst-reject-curve-matrix" "${workflow}" >/dev/null
 grep -F "deployments: write" "${workflow}" >/dev/null
 grep -F "Record transaction read admission profile evidence deployment" "${workflow}" >/dev/null
 grep -F "staging-transaction-read-admission-profile" "${workflow}" >/dev/null
-grep -F 'gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments"' "${workflow}" >/dev/null
-grep -F 'gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses"' "${workflow}" >/dev/null
+grep -F 'curl --fail-with-body --silent --show-error --location' "${workflow}" >/dev/null
+grep -F '"${github_api_url}/repos/${GITHUB_REPOSITORY}/deployments"' "${workflow}" >/dev/null
+grep -F '"${github_api_url}/repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses"' "${workflow}" >/dev/null
+grep -F 'Authorization: Bearer ${GH_TOKEN}' "${workflow}" >/dev/null
 grep -F '"state": "success"' "${workflow}" >/dev/null
 
 preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"
@@ -116,5 +118,9 @@ if grep -F 'secrets.STAGING_REPLAY_TOKEN' "${workflow}" >/dev/null; then
 fi
 if grep -F 'K6_AUTH_TOKEN:' "${workflow}" >/dev/null; then
   echo "workflow must not map token value directly into K6_AUTH_TOKEN" >&2
+  exit 1
+fi
+if grep -F 'gh api' "${workflow}" >/dev/null; then
+  echo "self-hosted OCI burst matrix workflow must not depend on GitHub CLI" >&2
   exit 1
 fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #714

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI self-hosted runner에 `gh` CLI가 없어 admission evidence deployment 기록이 실패한 문제를 수정합니다.
- burst matrix workflow의 deployment/status 기록을 GitHub CLI 대신 `curl` + GitHub REST API로 전환합니다.

## 🛠 Changes
- `oci-k6-burst-reject-curve-matrix.yml`의 evidence deployment 기록 step에서 `gh api` 제거
- `curl --fail-with-body`와 `jq`로 deployment id 파싱 및 success status 생성
- contract test에서 self-hosted workflow의 `gh api` 의존성 금지와 `curl` REST 호출 경로 검증 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/oci-k6-burst-reject-curve-matrix.yml'); puts 'ok'"`
- `git rev-list --count origin/main..HEAD`

## 📸 Screenshot / API Example
- 실패 run: https://github.com/AquilaXk/aquila-bank/actions/runs/25286351532
- 실패 원인: `Record transaction read admission profile evidence deployment` 단계에서 `gh: command not found`

## ⚠️ Risk & Rollback
- 예상 리스크: GitHub REST API 응답이 실패하면 `curl --fail-with-body`가 실패 body를 출력하고 workflow가 중단됩니다.
- 롤백 방법: 이 PR revert 후 `gh` CLI 설치 방식으로 별도 복구하거나 이전 workflow로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
