### PR TITLE
[Fix] OCI burst admission evidence status description limit

### DIFF
--- a/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
+++ b/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
@@ -457,7 +457,7 @@ jobs:
           status_payload="$(
             jq -n \
               --arg log_url "${EVIDENCE_LOG_URL}" \
-              --arg description "transaction read burst boundary matrix passed: ${matrix_report}" \
+              --arg description "transaction read burst matrix passed" \
               '{
                 "state": "success",
                 "log_url": $log_url,

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
@@ -93,6 +93,7 @@ grep -F 'curl --fail-with-body --silent --show-error --location' "${workflow}" >
 grep -F '"${github_api_url}/repos/${GITHUB_REPOSITORY}/deployments"' "${workflow}" >/dev/null
 grep -F '"${github_api_url}/repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses"' "${workflow}" >/dev/null
 grep -F 'Authorization: Bearer ${GH_TOKEN}' "${workflow}" >/dev/null
+grep -F 'description "transaction read burst matrix passed"' "${workflow}" >/dev/null
 grep -F '"state": "success"' "${workflow}" >/dev/null
 
 preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"
@@ -122,5 +123,9 @@ if grep -F 'K6_AUTH_TOKEN:' "${workflow}" >/dev/null; then
 fi
 if grep -F 'gh api' "${workflow}" >/dev/null; then
   echo "self-hosted OCI burst matrix workflow must not depend on GitHub CLI" >&2
+  exit 1
+fi
+if grep -F 'transaction read burst boundary matrix passed: ${matrix_report}' "${workflow}" >/dev/null; then
+  echo "deployment status description must stay short; do not include artifact path" >&2
   exit 1
 fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #714

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI burst matrix workflow의 admission evidence deployment status 생성이 HTTP 422로 실패한 문제를 마무리 수정합니다.
- 원인은 deployment status `description`에 artifact path 전체가 포함되어 202자로 길어진 점이며, 짧은 고정 문구로 변경합니다.

## 🛠 Changes
- `oci-k6-burst-reject-curve-matrix.yml` status description을 `transaction read burst matrix passed`로 단축
- contract test에 긴 artifact-path description 금지 조건 추가
- 기존 `curl` 기반 deployment/status REST 호출 계약 유지

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/oci-k6-burst-reject-curve-matrix.yml'); puts 'ok'"`
- `git rev-list --count origin/main..HEAD`

## 📸 Screenshot / API Example
- 실패 run: https://github.com/AquilaXk/aquila-bank/actions/runs/25286858790
- 실패 지점: deployment 객체 생성 후 status POST HTTP 422
- 확인: deployment `4563207446`에 수동 success status `13030144576` 기록 완료

## ⚠️ Risk & Rollback
- 예상 리스크: 없음. status description만 짧게 바꾸며 k6 실행/threshold/artifact 경로는 변경하지 않습니다.
- 롤백 방법: 이 PR revert. 단, 긴 description으로 되돌리면 동일 422가 재발할 수 있습니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
