### PR TITLE
[CI] burst matrix observation row gate policy hardening

### DIFF
--- a/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
+++ b/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
@@ -43,6 +43,11 @@ on:
         required: false
         default: "32,48,64,80,96"
         type: string
+      promotion_target_rate:
+        description: "Promotion target burst arrival rate per second"
+        required: false
+        default: "64"
+        type: string
       docker_context:
         description: "Remote Docker context name for off-host k6"
         required: false
@@ -132,6 +137,7 @@ jobs:
           COLD_TO_INPUT: ${{ inputs.cold_to }}
           DURATION_INPUT: ${{ inputs.duration }}
           BURST_RATES_INPUT: ${{ inputs.burst_rates }}
+          PROMOTION_TARGET_RATE_INPUT: ${{ inputs.promotion_target_rate }}
           BURST_429_RATE_THRESHOLD_INPUT: ${{ inputs.burst_429_rate_threshold }}
           BACKEND_429_RATE_THRESHOLD_INPUT: ${{ inputs.backend_429_rate_threshold }}
           OVERLOAD_503_RATE_THRESHOLD_INPUT: ${{ inputs.overload_503_rate_threshold }}
@@ -163,6 +169,7 @@ jobs:
           set +a
 
           K6_BURST_RATES="${BURST_RATES_INPUT:-32,48,64,80,96}"
+          K6_BURST_MATRIX_PROMOTION_TARGET_RATE="${PROMOTION_TARGET_RATE_INPUT:-64}"
           K6_RUN_PURPOSE="capacity"
           K6_OBSERVABILITY_MODE="prometheus"
           K6_GENERATOR_MODE="docker-context"
@@ -250,6 +257,7 @@ jobs:
             K6_TIME_UNIT
             K6_PREEMPTIVE_PACING
             K6_NGINX_ACCESS_LOG
+            K6_BURST_MATRIX_PROMOTION_TARGET_RATE
             BURST_429_RATE_THRESHOLD_INPUT
             BACKEND_429_RATE_THRESHOLD_INPUT
             OVERLOAD_503_RATE_THRESHOLD_INPUT
@@ -399,6 +407,7 @@ jobs:
           OCI_K6_BURST_MATRIX_NAME="${K6_MATRIX_REPORT_NAME}" \
           OCI_K6_BURST_MATRIX_INPUT_TSV="${matrix_input_tsv}" \
           OCI_K6_BURST_MATRIX_OUTPUT_DIR="${matrix_dir}/burst-reject-curve-matrix" \
+          OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE="${K6_BURST_MATRIX_PROMOTION_TARGET_RATE}" \
           OCI_K6_BURST_MATRIX_BURST64_429_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT:-0.10}" \
           OCI_K6_BURST_MATRIX_BACKEND_429_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT:-0.005}" \
             tools/test/run-oci-k6-burst-reject-curve-matrix.sh
@@ -457,7 +466,7 @@ jobs:
           status_payload="$(
             jq -n \
               --arg log_url "${EVIDENCE_LOG_URL}" \
-              --arg description "transaction read burst matrix passed" \
+              --arg description "transaction read burst matrix target ${K6_BURST_MATRIX_PROMOTION_TARGET_RATE} passed" \
               '{
                 "state": "success",
                 "log_url": $log_url,

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
@@ -45,9 +45,14 @@ grep -F 'K6_OBSERVABILITY_MODE="prometheus"' "${workflow}" >/dev/null
 grep -F 'K6_GENERATOR_MODE="docker-context"' "${workflow}" >/dev/null
 grep -F "burst_rates:" "${workflow}" >/dev/null
 grep -F 'default: "32,48,64,80,96"' "${workflow}" >/dev/null
+grep -F "promotion_target_rate:" "${workflow}" >/dev/null
+grep -F 'description: "Promotion target burst arrival rate per second"' "${workflow}" >/dev/null
+grep -F 'default: "64"' "${workflow}" >/dev/null
 grep -F 'K6_MATRIX_REPORT_NAME: ${{ inputs.report_name || format(' "${workflow}" >/dev/null
 grep -F 'BURST_RATES_INPUT: ${{ inputs.burst_rates }}' "${workflow}" >/dev/null
+grep -F 'PROMOTION_TARGET_RATE_INPUT: ${{ inputs.promotion_target_rate }}' "${workflow}" >/dev/null
 grep -F 'K6_BURST_RATES="${BURST_RATES_INPUT:-32,48,64,80,96}"' "${workflow}" >/dev/null
+grep -F 'K6_BURST_MATRIX_PROMOTION_TARGET_RATE="${PROMOTION_TARGET_RATE_INPUT:-64}"' "${workflow}" >/dev/null
 grep -F "Run authenticated k6 burst matrix" "${workflow}" >/dev/null
 grep -F 'IFS="," read -r -a burst_rates <<<"${K6_BURST_RATES}"' "${workflow}" >/dev/null
 grep -F 'matrix_input_tsv="${matrix_dir}/burst-reject-curve-input.tsv"' "${workflow}" >/dev/null
@@ -63,6 +68,7 @@ grep -F 'K6_OVERLOAD_MODE="true"' "${workflow}" >/dev/null
 grep -F 'K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT:-0.10}"' "${workflow}" >/dev/null
 grep -F 'K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT:-0.005}"' "${workflow}" >/dev/null
 grep -F 'K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT:-0}"' "${workflow}" >/dev/null
+grep -F 'K6_BURST_MATRIX_PROMOTION_TARGET_RATE' "${workflow}" >/dev/null
 grep -F 'K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${workflow}" >/dev/null
@@ -83,6 +89,7 @@ grep -F 'printf "%s\t%s\t%s\t%s\t%s\t%s\n" "${burst_rate}" "${K6_RUN_ID}" "${sum
 grep -F 'OCI_K6_BURST_MATRIX_NAME="${K6_MATRIX_REPORT_NAME}"' "${workflow}" >/dev/null
 grep -F 'OCI_K6_BURST_MATRIX_INPUT_TSV="${matrix_input_tsv}"' "${workflow}" >/dev/null
 grep -F 'OCI_K6_BURST_MATRIX_OUTPUT_DIR="${matrix_dir}/burst-reject-curve-matrix"' "${workflow}" >/dev/null
+grep -F 'OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE="${K6_BURST_MATRIX_PROMOTION_TARGET_RATE}"' "${workflow}" >/dev/null
 grep -F "tools/test/run-oci-k6-burst-reject-curve-matrix.sh" "${workflow}" >/dev/null
 grep -F "actions/upload-artifact@v7" "${workflow}" >/dev/null
 grep -F "oci-k6-burst-reject-curve-matrix" "${workflow}" >/dev/null
@@ -93,7 +100,7 @@ grep -F 'curl --fail-with-body --silent --show-error --location' "${workflow}" >
 grep -F '"${github_api_url}/repos/${GITHUB_REPOSITORY}/deployments"' "${workflow}" >/dev/null
 grep -F '"${github_api_url}/repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses"' "${workflow}" >/dev/null
 grep -F 'Authorization: Bearer ${GH_TOKEN}' "${workflow}" >/dev/null
-grep -F 'description "transaction read burst matrix passed"' "${workflow}" >/dev/null
+grep -F 'description "transaction read burst matrix target ${K6_BURST_MATRIX_PROMOTION_TARGET_RATE} passed"' "${workflow}" >/dev/null
 grep -F '"state": "success"' "${workflow}" >/dev/null
 
 preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix.sh
@@ -133,6 +133,7 @@ plan="$(
 )"
 grep -F "name=burst-matrix-check" <<<"${plan}" >/dev/null
 grep -F "required_burst_rates=32,48,64,80,96" <<<"${plan}" >/dev/null
+grep -F "promotion_target_rate=64" <<<"${plan}" >/dev/null
 grep -F "gate=burst64 total/edge 429 <= 0.10, backend 429 <= 0.005, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < 100ms" <<<"${plan}" >/dev/null
 grep -F "summary_tsv=${output_dir}/burst-matrix-check-burst-reject-curve.tsv" <<<"${plan}" >/dev/null
 
@@ -151,9 +152,11 @@ grep -F $'burst_rate\tstatus\tk6_run_id\ttotal_429_rate\tedge_429_rate\tbackend_
 grep -F $'64\tpass\tmatrix-burst64\t0.080000\t0.075000\t0.003000\t2\t0\t0\t0\t5650\t7.500\t40.000\t2' "${summary_tsv}" >/dev/null
 grep -F $'80\tobserve\tmatrix-burst80\t0.220000\t0.216000\t0.004000\t3\t0\t0\t0\t5400\t11.700\t55.000\t4' "${summary_tsv}" >/dev/null
 grep -F "burst64 gate: pass" "${report_md}" >/dev/null
-grep -F "burst80/96: overload observation rows; 429 ceiling is not applied" "${report_md}" >/dev/null
+grep -F "promotion target rate: 64" "${report_md}" >/dev/null
+grep -F "rows above target: overload observation rows; 429 ceiling is not applied" "${report_md}" >/dev/null
 grep -F "matrix input TSV: ${input_tsv}" "${report_md}" >/dev/null
 jq -e '.items | length == 5' "${summary_json}" >/dev/null
+jq -e '.promotion_target_rate == 64' "${summary_json}" >/dev/null
 jq -e '.items[] | select(.burst_rate == 64 and .status == "pass" and .edge_429_rate == 0.075 and .nginx_499_count == 0)' "${summary_json}" >/dev/null
 jq -e '.items[] | select(.burst_rate == 80 and .status == "observe" and .total_429_rate == 0.22)' "${summary_json}" >/dev/null
 
@@ -188,3 +191,14 @@ if OCI_K6_BURST_MATRIX_NAME=burst-matrix-bad \
   exit 1
 fi
 grep -F "burst64 gate failed: total_429_rate=0.110000 > 0.100000" "${temp_dir}/bad.log" >/dev/null
+
+echo "[oci-k6-burst-reject-curve-matrix] burst80 promotion target gate fails"
+if OCI_K6_BURST_MATRIX_NAME=burst-matrix-target80 \
+  OCI_K6_BURST_MATRIX_INPUT_TSV="${input_tsv}" \
+  OCI_K6_BURST_MATRIX_OUTPUT_DIR="${temp_dir}/target80-output" \
+  OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE=80 \
+    "${runner}" >"${temp_dir}/target80.log" 2>&1; then
+  echo "burst80 promotion target unexpectedly passed" >&2
+  exit 1
+fi
+grep -F "burst80 gate failed: total_429_rate=0.220000 > 0.100000" "${temp_dir}/target80.log" >/dev/null

--- a/tools/test/run-oci-k6-burst-reject-curve-matrix.sh
+++ b/tools/test/run-oci-k6-burst-reject-curve-matrix.sh
@@ -10,6 +10,7 @@ Environment:
   OCI_K6_BURST_MATRIX_INPUT_TSV       required TSV: burst_rate/k6_run_id/summary_json/nginx_aggregate_json/nginx_aggregate_tsv/nginx_aggregate_md
   OCI_K6_BURST_MATRIX_REQUIRED_RATES  default 32,48,64,80,96
   OCI_K6_BURST_MATRIX_OUTPUT_DIR      default build/reports/k6/<name>
+  OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE default 64
 USAGE
 }
 
@@ -41,15 +42,22 @@ report_md="${output_dir}/${name}-burst-reject-curve.md"
 burst64_429_threshold="${OCI_K6_BURST_MATRIX_BURST64_429_THRESHOLD:-0.10}"
 backend_429_threshold="${OCI_K6_BURST_MATRIX_BACKEND_429_THRESHOLD:-0.005}"
 accepted_p95_threshold_ms="${OCI_K6_BURST_MATRIX_ACCEPTED_P95_THRESHOLD_MS:-100}"
+promotion_target_rate="${OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE:-64}"
 
 IFS=',' read -r -a required_rate_items <<<"${required_burst_rates}"
+
+if ! [[ "${promotion_target_rate}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE must be a positive integer: ${promotion_target_rate}" >&2
+  exit 1
+fi
 
 print_plan() {
   echo "[oci-k6-burst-reject-curve-matrix] name=${name}"
   echo "[oci-k6-burst-reject-curve-matrix] input_tsv=${input_tsv:-missing}"
   echo "[oci-k6-burst-reject-curve-matrix] required_burst_rates=${required_burst_rates}"
+  echo "[oci-k6-burst-reject-curve-matrix] promotion_target_rate=${promotion_target_rate}"
   echo "[oci-k6-burst-reject-curve-matrix] output_dir=${output_dir}"
-  echo "[oci-k6-burst-reject-curve-matrix] gate=burst64 total/edge 429 <= ${burst64_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms"
+  echo "[oci-k6-burst-reject-curve-matrix] gate=burst${promotion_target_rate} total/edge 429 <= ${burst64_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms"
   echo "[oci-k6-burst-reject-curve-matrix] summary_tsv=${summary_tsv}"
   echo "[oci-k6-burst-reject-curve-matrix] summary_json=${summary_json}"
   echo "[oci-k6-burst-reject-curve-matrix] report_md=${report_md}"
@@ -187,7 +195,7 @@ record_failure() {
     nginx_5xx_count="$(nginx_status_count "${aggregate_json}" "${k6_run_id}" "^5")"
 
     status="pass"
-    if gt "${burst_rate}" "64"; then
+    if gt "${burst_rate}" "${promotion_target_rate}"; then
       status="observe"
     fi
     if gt "${k6_503_count}" "0"; then
@@ -202,22 +210,22 @@ record_failure() {
       status="fail"
       record_failure "burst${burst_rate} gate failed: nginx_499_count=${nginx_499_count} > 0"
     fi
-    if [[ "${burst_rate}" == "64" ]]; then
+    if [[ "${burst_rate}" == "${promotion_target_rate}" ]]; then
       if gt "${total_429_rate}" "${burst64_429_threshold}"; then
         status="fail"
-        record_failure "$(printf 'burst64 gate failed: total_429_rate=%.6f > %.6f' "${total_429_rate}" "${burst64_429_threshold}")"
+        record_failure "$(printf 'burst%s gate failed: total_429_rate=%.6f > %.6f' "${promotion_target_rate}" "${total_429_rate}" "${burst64_429_threshold}")"
       fi
       if gt "${edge_429_rate}" "${burst64_429_threshold}"; then
         status="fail"
-        record_failure "$(printf 'burst64 gate failed: edge_429_rate=%.6f > %.6f' "${edge_429_rate}" "${burst64_429_threshold}")"
+        record_failure "$(printf 'burst%s gate failed: edge_429_rate=%.6f > %.6f' "${promotion_target_rate}" "${edge_429_rate}" "${burst64_429_threshold}")"
       fi
       if gt "${backend_429_rate}" "${backend_429_threshold}"; then
         status="fail"
-        record_failure "$(printf 'burst64 gate failed: backend_429_rate=%.6f > %.6f' "${backend_429_rate}" "${backend_429_threshold}")"
+        record_failure "$(printf 'burst%s gate failed: backend_429_rate=%.6f > %.6f' "${promotion_target_rate}" "${backend_429_rate}" "${backend_429_threshold}")"
       fi
       if gte "${accepted_p95_ms}" "${accepted_p95_threshold_ms}"; then
         status="fail"
-        record_failure "$(printf 'burst64 gate failed: accepted_p95_ms=%.3f >= %.3f' "${accepted_p95_ms}" "${accepted_p95_threshold_ms}")"
+        record_failure "$(printf 'burst%s gate failed: accepted_p95_ms=%.3f >= %.3f' "${promotion_target_rate}" "${accepted_p95_ms}" "${accepted_p95_threshold_ms}")"
       fi
     fi
 
@@ -259,7 +267,13 @@ record_failure() {
   done
 } >"${summary_tsv}"
 
-jq -Rn --arg name "${name}" --arg input_tsv "${input_tsv}" --arg required_burst_rates "${required_burst_rates}" '
+promotion_target_row_count="$(awk -F '\t' -v rate="${promotion_target_rate}" 'NR > 1 && $1 == rate { count += 1 } END { print count + 0 }' "${summary_tsv}")"
+if [[ "${promotion_target_row_count}" == "0" ]]; then
+  echo "missing promotion target burst rate evidence: ${promotion_target_rate}" >&2
+  exit 1
+fi
+
+jq -Rn --arg name "${name}" --arg input_tsv "${input_tsv}" --arg required_burst_rates "${required_burst_rates}" --arg promotion_target_rate "${promotion_target_rate}" '
   def number_or_string:
     if test("^-?[0-9]+([.][0-9]+)?$") then tonumber else . end;
   (input | split("\t")) as $headers
@@ -275,15 +289,16 @@ jq -Rn --arg name "${name}" --arg input_tsv "${input_tsv}" --arg required_burst_
       name: $name,
       input_tsv: $input_tsv,
       required_burst_rates: ($required_burst_rates | split(",") | map(tonumber)),
+      promotion_target_rate: ($promotion_target_rate | tonumber),
       items: $items
     }
 ' <"${summary_tsv}" >"${summary_json}"
 
-burst64_status="$(awk -F '\t' 'NR > 1 && $1 == "64" { print $2 }' "${summary_tsv}")"
+promotion_target_status="$(awk -F '\t' -v rate="${promotion_target_rate}" 'NR > 1 && $1 == rate { print $2 }' "${summary_tsv}")"
 if [[ -s "${failures_file}" ]]; then
-  burst64_gate="fail"
+  promotion_target_gate="fail"
 else
-  burst64_gate="${burst64_status:-missing}"
+  promotion_target_gate="${promotion_target_status:-missing}"
 fi
 
 matrix_table="$(awk -F '\t' '
@@ -303,8 +318,9 @@ cat >"${report_md}" <<REPORT
 
 - matrix input TSV: ${input_tsv}
 - required burst rates: ${required_burst_rates}
-- burst64 gate: ${burst64_gate}
-- burst80/96: overload observation rows; 429 ceiling is not applied
+- promotion target rate: ${promotion_target_rate}
+- burst${promotion_target_rate} gate: ${promotion_target_gate}
+- rows above target: overload observation rows; 429 ceiling is not applied
 
 ## Matrix
 
@@ -312,9 +328,9 @@ ${matrix_table}
 
 ## Gate
 
-- burst64: total/edge 429 <= ${burst64_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms
+- burst${promotion_target_rate}: total/edge 429 <= ${burst64_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms
 - all bursts: k6 503 = 0, nginx 5xx = 0, nginx 499 = 0
-- burst80/96: reject curve observation only for 429 budget; still fails on 5xx/499
+- rows above target: reject curve observation only for 429 budget; still fails on 5xx/499
 
 ## Artifacts
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #719

## 🌿 Base Branch
- `main`

## 📝 Summary
- burst matrix의 observation row가 promotion success로 오해되지 않도록 promotion target rate gate를 추가합니다.
- 기본 target은 기존과 동일하게 `64/s`이며, dispatch에서 `80` 이상을 target으로 지정하면 해당 rate가 429/5xx/499/p95 budget을 통과해야 workflow가 성공합니다.

## 🛠 Changes
- `run-oci-k6-burst-reject-curve-matrix.sh`에 `OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE` 추가
- `oci-k6-burst-reject-curve-matrix.yml`에 `promotion_target_rate` workflow_dispatch input 추가
- deployment status description에 target rate 포함
- contract test에 `promotion_target_rate=80` 실패 케이스 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix.sh`
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/oci-k6-burst-reject-curve-matrix.yml'); puts 'ok'"`
- `git rev-list --count origin/main..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `promotion_target_rate=80`로 실행하면 현재 evidence처럼 80/s budget을 초과하는 경우 workflow가 실패합니다. 이는 의도된 승격 차단입니다.
- 롤백 방법: 이 PR revert 후 burst64 고정 gate와 burst80/96 observation-only 정책으로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
