### PR TITLE
[CI] transaction read promotion profile pacing contract

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -127,6 +127,8 @@ on:
     paths:
       - ".github/workflows/oci-k6-service-auth-token.yml"
       - "tools/test/check-oci-k6-service-auth-token-workflow.sh"
+      - "tools/test/check-transaction-read-promotion-pacing-contract.sh"
+      - "tools/test/run-transaction-read-promotion-pacing-contract.sh"
       - "tools/test/run-k6-transaction-100m-loadtest.sh"
       - "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh"
       - "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh"
@@ -145,6 +147,9 @@ jobs:
 
       - name: Validate workflow contract
         run: bash tools/test/check-oci-k6-service-auth-token-workflow.sh
+
+      - name: Validate promotion pacing contract
+        run: bash tools/test/check-transaction-read-promotion-pacing-contract.sh
 
   authenticated-k6:
     name: Authenticated OCI k6 capacity
@@ -256,6 +261,12 @@ jobs:
           K6_PREEMPTIVE_PACING_RPS="${K6_PREEMPTIVE_PACING_RPS:-16}"
           K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="${K6_PREEMPTIVE_PACING_MAX_SLEEP_MS:-250}"
           K6_PREEMPTIVE_PACING_JITTER_MS="${K6_PREEMPTIVE_PACING_JITTER_MS:-25}"
+          K6_CONSTANT_VUS_GATE_ROLE="not-selected"
+          if [[ "${K6_SCENARIO_MODE}" == "constant-vus" && "${K6_PREEMPTIVE_PACING}" == "true" ]]; then
+            K6_CONSTANT_VUS_GATE_ROLE="paced-saturation-contract"
+          elif [[ "${K6_SCENARIO_MODE}" == "constant-vus" ]]; then
+            K6_CONSTANT_VUS_GATE_ROLE="saturation-observation"
+          fi
           K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT}"
           K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT}"
           K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT}"
@@ -318,6 +329,7 @@ jobs:
             K6_PREEMPTIVE_PACING_RPS
             K6_PREEMPTIVE_PACING_MAX_SLEEP_MS
             K6_PREEMPTIVE_PACING_JITTER_MS
+            K6_CONSTANT_VUS_GATE_ROLE
             K6_BURST_429_RATE_THRESHOLD
             K6_BACKEND_429_RATE_THRESHOLD
             K6_OVERLOAD_503_RATE_THRESHOLD
@@ -356,7 +368,7 @@ jobs:
             "constant_vus": {
               "vus": "${K6_VUS}",
               "duration": "${K6_DURATION}",
-              "gate_role": "saturation_probe"
+              "gate_role": "${K6_CONSTANT_VUS_GATE_ROLE}"
             },
             "burst": {
               "rate": "${K6_BURST_RATE}",
@@ -378,6 +390,7 @@ jobs:
           - k6_run_id=${K6_RUN_ID}
           - scenario_mode=${K6_SCENARIO_MODE}
           - arrival-rate gate: ${K6_RATE}/${K6_TIME_UNIT}
+          - constant-vus gate role: ${K6_CONSTANT_VUS_GATE_ROLE}
           - constant-vus saturation probe: vus=${K6_VUS}, duration=${K6_DURATION}
           - burst probe: rate=${K6_BURST_RATE}, preAllocatedVUs=${K6_PRE_ALLOCATED_VUS:-}, maxVUs=${K6_MAX_VUS:-}
           - preemptive pacing: enabled=${K6_PREEMPTIVE_PACING}, rps=${K6_PREEMPTIVE_PACING_RPS}, maxSleepMs=${K6_PREEMPTIVE_PACING_MAX_SLEEP_MS}, jitterMs=${K6_PREEMPTIVE_PACING_JITTER_MS}

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -23,6 +23,9 @@ if [[ "${dispatch_input_count}" -gt 25 ]]; then
 fi
 grep -F "OCI k6 service auth token contract" "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-k6-service-auth-token-workflow.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-transaction-read-promotion-pacing-contract.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-transaction-read-promotion-pacing-contract.sh" "${workflow}" >/dev/null
+grep -F "Validate promotion pacing contract" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
 grep -F "environment:" "${workflow}" >/dev/null
@@ -75,6 +78,9 @@ grep -F 'K6_PREEMPTIVE_PACING="${PREEMPTIVE_PACING_INPUT}"' "${workflow}" >/dev/
 grep -F 'K6_PREEMPTIVE_PACING_RPS="${K6_PREEMPTIVE_PACING_RPS:-16}"' "${workflow}" >/dev/null
 grep -F 'K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="${K6_PREEMPTIVE_PACING_MAX_SLEEP_MS:-250}"' "${workflow}" >/dev/null
 grep -F 'K6_PREEMPTIVE_PACING_JITTER_MS="${K6_PREEMPTIVE_PACING_JITTER_MS:-25}"' "${workflow}" >/dev/null
+grep -F 'K6_CONSTANT_VUS_GATE_ROLE="not-selected"' "${workflow}" >/dev/null
+grep -F 'K6_CONSTANT_VUS_GATE_ROLE="paced-saturation-contract"' "${workflow}" >/dev/null
+grep -F 'K6_CONSTANT_VUS_GATE_ROLE="saturation-observation"' "${workflow}" >/dev/null
 grep -F 'K6_BURST_429_RATE_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_BACKEND_429_RATE_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_OVERLOAD_503_RATE_THRESHOLD="${OVERLOAD_503_RATE_THRESHOLD_INPUT}"' "${workflow}" >/dev/null
@@ -84,7 +90,8 @@ grep -F "k6-pacing-input.json" "${workflow}" >/dev/null
 grep -F "k6-pacing-summary.md" "${workflow}" >/dev/null
 grep -F "K6_PACING_INPUT_REF" "${workflow}" >/dev/null
 grep -F "K6_PACING_SUMMARY_REF" "${workflow}" >/dev/null
-grep -F '"gate_role": "saturation_probe"' "${workflow}" >/dev/null
+grep -F '"gate_role": "${K6_CONSTANT_VUS_GATE_ROLE}"' "${workflow}" >/dev/null
+grep -F "constant-vus gate role: \${K6_CONSTANT_VUS_GATE_ROLE}" "${workflow}" >/dev/null
 grep -F "Capture transaction read Nginx log window" "${workflow}" >/dev/null
 grep -F 'K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' "${workflow}" >/dev/null
 grep -F "Run auth preflight" "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-promotion-pacing-contract.sh
+++ b/tools/test/check-transaction-read-promotion-pacing-contract.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-promotion-pacing-contract.sh"
+
+echo "[transaction-read-promotion-pacing] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+input_tsv="${temp_dir}/promotion-pacing.tsv"
+output_dir="${temp_dir}/output"
+
+cat >"${input_tsv}" <<'TSV'
+profile	gate_role	promotion_target_rate	burst_rate	preemptive_pacing	total_429_rate	edge_429_rate	backend_429_rate	backend_429_count	five_xx_count	nginx_499_count	accepted_p95_ms	pacing_sleep_p95_ms	summary_ref	nginx_aggregate_ref	pacing_summary_ref
+burst64	promotion-target	64	64	false	0.081851	0.081851	0.000000	0	0	0	3.223	0	oci://runs/target64/burst64-summary.json	oci://runs/target64/burst64-nginx.tsv	n/a
+burst80	overload-observation	64	80	false	0.158699	0.158699	0.000000	0	0	0	3.670	472.806	oci://runs/target80/burst80-summary.json	oci://runs/target80/burst80-nginx.tsv	n/a
+vu16-unpaced	saturation-observation	64	0	false	0.899085	0.899075	0.000010	1	0	0	25.491	0	oci://runs/vu16-unpaced/summary.json	oci://runs/vu16-unpaced/nginx.tsv	oci://runs/vu16-unpaced/pacing.md
+vu16-paced	paced-saturation-contract	64	0	true	0.000000	0.000000	0.000000	0	0	0	7.240	250.000	oci://runs/vu16-paced/summary.json	oci://runs/vu16-paced/nginx.tsv	oci://runs/vu16-paced/pacing.md
+TSV
+
+echo "[transaction-read-promotion-pacing] print plan"
+plan="$(
+  TRANSACTION_READ_PROMOTION_PACING_NAME=promotion-pacing-check \
+  TRANSACTION_READ_PROMOTION_PACING_INPUT_TSV="${input_tsv}" \
+  TRANSACTION_READ_PROMOTION_PACING_OUTPUT_DIR="${output_dir}" \
+    "${runner}" --print-plan
+)"
+grep -F "name=promotion-pacing-check" <<<"${plan}" >/dev/null
+grep -F "promotion_target_rate=64" <<<"${plan}" >/dev/null
+grep -F "max_promotion_429_rate=0.10" <<<"${plan}" >/dev/null
+grep -F "max_backend_429_rate=0.005" <<<"${plan}" >/dev/null
+grep -F "max_paced_vu16_429_rate=0.01" <<<"${plan}" >/dev/null
+grep -F "summary_tsv=${output_dir}/promotion-pacing-check-promotion-pacing.tsv" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-promotion-pacing] pass report"
+output="$(
+  TRANSACTION_READ_PROMOTION_PACING_NAME=promotion-pacing-check \
+  TRANSACTION_READ_PROMOTION_PACING_INPUT_TSV="${input_tsv}" \
+  TRANSACTION_READ_PROMOTION_PACING_OUTPUT_DIR="${output_dir}" \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+summary_tsv="${output_dir}/promotion-pacing-check-promotion-pacing.tsv"
+test "${report_md}" = "${output_dir}/promotion-pacing-check-promotion-pacing.md"
+grep -F $'profile\tgate_role\tstatus\treason\tpromotion_target_rate\tburst_rate\tpreemptive_pacing\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tbackend_429_count\tfive_xx_count\tnginx_499_count\taccepted_p95_ms\tpacing_sleep_p95_ms\tsummary_ref\tnginx_aggregate_ref\tpacing_summary_ref' "${summary_tsv}" >/dev/null
+grep -F $'burst64\tpromotion-target\tpass\tok\t64\t64\tfalse\t0.081851\t0.081851\t0.000000\t0\t0\t0\t3.223\t0\toci://runs/target64/burst64-summary.json\toci://runs/target64/burst64-nginx.tsv\tn/a' "${summary_tsv}" >/dev/null
+grep -F $'burst80\toverload-observation\tobserve\tok\t64\t80\tfalse\t0.158699\t0.158699\t0.000000\t0\t0\t0\t3.670\t472.806\toci://runs/target80/burst80-summary.json\toci://runs/target80/burst80-nginx.tsv\tn/a' "${summary_tsv}" >/dev/null
+grep -F $'vu16-unpaced\tsaturation-observation\tobserve\tok\t64\t0\tfalse\t0.899085\t0.899075\t0.000010\t1\t0\t0\t25.491\t0\toci://runs/vu16-unpaced/summary.json\toci://runs/vu16-unpaced/nginx.tsv\toci://runs/vu16-unpaced/pacing.md' "${summary_tsv}" >/dev/null
+grep -F $'vu16-paced\tpaced-saturation-contract\tpass\tok\t64\t0\ttrue\t0.000000\t0.000000\t0.000000\t0\t0\t0\t7.240\t250.000\toci://runs/vu16-paced/summary.json\toci://runs/vu16-paced/nginx.tsv\toci://runs/vu16-paced/pacing.md' "${summary_tsv}" >/dev/null
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "promotion target: burst64" "${report_md}" >/dev/null
+grep -F "VU16 unpaced: observation-only saturation probe" "${report_md}" >/dev/null
+grep -F "VU16 paced: safe saturation contract" "${report_md}" >/dev/null
+
+echo "[transaction-read-promotion-pacing] target80 promotion fails"
+target80_input="${temp_dir}/target80.tsv"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $3 = "80" } $1 == "burst80" { $2 = "promotion-target" } { print }' \
+  "${input_tsv}" >"${target80_input}"
+if TRANSACTION_READ_PROMOTION_PACING_NAME=promotion-pacing-target80 \
+  TRANSACTION_READ_PROMOTION_PACING_INPUT_TSV="${target80_input}" \
+  TRANSACTION_READ_PROMOTION_PACING_OUTPUT_DIR="${temp_dir}/target80-output" \
+  TRANSACTION_READ_PROMOTION_TARGET_RATE=80 \
+    "${runner}" >"${temp_dir}/target80.log" 2>&1; then
+  echo "target80 promotion unexpectedly passed" >&2
+  exit 1
+fi
+grep -F "burst80 reason=promotion-total429>0.10,promotion-edge429>0.10" "${temp_dir}/target80.log" >/dev/null
+
+echo "[transaction-read-promotion-pacing] paced VU16 regression fails"
+paced_fail_input="${temp_dir}/paced-fail.tsv"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "vu16-paced" { $6 = "0.020000"; $7 = "0.020000" } { print }' \
+  "${input_tsv}" >"${paced_fail_input}"
+if TRANSACTION_READ_PROMOTION_PACING_NAME=promotion-pacing-paced-fail \
+  TRANSACTION_READ_PROMOTION_PACING_INPUT_TSV="${paced_fail_input}" \
+  TRANSACTION_READ_PROMOTION_PACING_OUTPUT_DIR="${temp_dir}/paced-fail-output" \
+    "${runner}" >"${temp_dir}/paced-fail.log" 2>&1; then
+  echo "paced VU16 429 regression unexpectedly passed" >&2
+  exit 1
+fi
+grep -F "vu16-paced reason=paced-vu16-total429>0.01,paced-vu16-edge429>0.01" "${temp_dir}/paced-fail.log" >/dev/null
+
+echo "[transaction-read-promotion-pacing] unpaced strict role fails"
+strict_unpaced_input="${temp_dir}/strict-unpaced.tsv"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "vu16-unpaced" { $2 = "promotion-target" } { print }' \
+  "${input_tsv}" >"${strict_unpaced_input}"
+if TRANSACTION_READ_PROMOTION_PACING_NAME=promotion-pacing-strict-unpaced \
+  TRANSACTION_READ_PROMOTION_PACING_INPUT_TSV="${strict_unpaced_input}" \
+  TRANSACTION_READ_PROMOTION_PACING_OUTPUT_DIR="${temp_dir}/strict-unpaced-output" \
+    "${runner}" >"${temp_dir}/strict-unpaced.log" 2>&1; then
+  echo "unpaced VU16 strict role unexpectedly passed" >&2
+  exit 1
+fi
+grep -F "vu16-unpaced reason=vu16-unpaced-must-be-observation" "${temp_dir}/strict-unpaced.log" >/dev/null

--- a/tools/test/run-transaction-read-promotion-pacing-contract.sh
+++ b/tools/test/run-transaction-read-promotion-pacing-contract.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-promotion-pacing-contract.sh [--print-plan]
+
+Environment:
+  TRANSACTION_READ_PROMOTION_PACING_NAME          default transaction-read-promotion-pacing-<timestamp>
+  TRANSACTION_READ_PROMOTION_PACING_INPUT_TSV     required profile evidence TSV
+  TRANSACTION_READ_PROMOTION_PACING_OUTPUT_DIR    default build/reports/k6/<name>
+  TRANSACTION_READ_PROMOTION_TARGET_RATE          default 64
+  TRANSACTION_READ_PROMOTION_MAX_429_RATE         default 0.10
+  TRANSACTION_READ_PROMOTION_MAX_BACKEND_429_RATE default 0.005
+  TRANSACTION_READ_PROMOTION_MAX_PACED_VU16_429_RATE default 0.01
+  TRANSACTION_READ_PROMOTION_MAX_ACCEPTED_P95_MS  default 100
+  TRANSACTION_READ_PROMOTION_MAX_PACING_SLEEP_P95_MS default 300
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${TRANSACTION_READ_PROMOTION_PACING_NAME:-transaction-read-promotion-pacing-$(date +%Y-%m-%d-%H%M%S)}"
+input_tsv="${TRANSACTION_READ_PROMOTION_PACING_INPUT_TSV:-}"
+output_dir="${TRANSACTION_READ_PROMOTION_PACING_OUTPUT_DIR:-build/reports/k6/${name}}"
+promotion_target_rate="${TRANSACTION_READ_PROMOTION_TARGET_RATE:-64}"
+max_promotion_429_rate="${TRANSACTION_READ_PROMOTION_MAX_429_RATE:-0.10}"
+max_backend_429_rate="${TRANSACTION_READ_PROMOTION_MAX_BACKEND_429_RATE:-0.005}"
+max_paced_vu16_429_rate="${TRANSACTION_READ_PROMOTION_MAX_PACED_VU16_429_RATE:-0.01}"
+max_accepted_p95_ms="${TRANSACTION_READ_PROMOTION_MAX_ACCEPTED_P95_MS:-100}"
+max_pacing_sleep_p95_ms="${TRANSACTION_READ_PROMOTION_MAX_PACING_SLEEP_P95_MS:-300}"
+summary_tsv="${output_dir}/${name}-promotion-pacing.tsv"
+report_md="${output_dir}/${name}-promotion-pacing.md"
+failure_log="${output_dir}/${name}-promotion-pacing.failures"
+
+require_positive_integer() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${key} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_rate() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${key} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  fi
+  awk -v value="${value}" 'BEGIN { exit !(value >= 0 && value <= 1) }' || {
+    echo "${key} must be a rate between 0 and 1: ${value}" >&2
+    exit 1
+  }
+}
+
+require_non_negative_number() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${key} must be a non-negative number: ${value}" >&2
+    exit 1
+  fi
+}
+
+print_plan() {
+  echo "[transaction-read-promotion-pacing] name=${name}"
+  echo "[transaction-read-promotion-pacing] input_tsv=${input_tsv:-missing}"
+  echo "[transaction-read-promotion-pacing] output_dir=${output_dir}"
+  echo "[transaction-read-promotion-pacing] promotion_target_rate=${promotion_target_rate}"
+  echo "[transaction-read-promotion-pacing] max_promotion_429_rate=${max_promotion_429_rate}"
+  echo "[transaction-read-promotion-pacing] max_backend_429_rate=${max_backend_429_rate}"
+  echo "[transaction-read-promotion-pacing] max_paced_vu16_429_rate=${max_paced_vu16_429_rate}"
+  echo "[transaction-read-promotion-pacing] max_accepted_p95_ms=${max_accepted_p95_ms}"
+  echo "[transaction-read-promotion-pacing] max_pacing_sleep_p95_ms=${max_pacing_sleep_p95_ms}"
+  echo "[transaction-read-promotion-pacing] summary_tsv=${summary_tsv}"
+  echo "[transaction-read-promotion-pacing] report_md=${report_md}"
+}
+
+require_positive_integer "TRANSACTION_READ_PROMOTION_TARGET_RATE" "${promotion_target_rate}"
+require_rate "TRANSACTION_READ_PROMOTION_MAX_429_RATE" "${max_promotion_429_rate}"
+require_rate "TRANSACTION_READ_PROMOTION_MAX_BACKEND_429_RATE" "${max_backend_429_rate}"
+require_rate "TRANSACTION_READ_PROMOTION_MAX_PACED_VU16_429_RATE" "${max_paced_vu16_429_rate}"
+require_non_negative_number "TRANSACTION_READ_PROMOTION_MAX_ACCEPTED_P95_MS" "${max_accepted_p95_ms}"
+require_non_negative_number "TRANSACTION_READ_PROMOTION_MAX_PACING_SLEEP_P95_MS" "${max_pacing_sleep_p95_ms}"
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  if [[ -z "${input_tsv}" || ! -f "${input_tsv}" ]]; then
+    echo "TRANSACTION_READ_PROMOTION_PACING_INPUT_TSV is required" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+if [[ -z "${input_tsv}" || ! -f "${input_tsv}" ]]; then
+  echo "TRANSACTION_READ_PROMOTION_PACING_INPUT_TSV is required" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+
+awk -F '\t' \
+  -v OFS='\t' \
+  -v target="${promotion_target_rate}" \
+  -v max429="${max_promotion_429_rate}" \
+  -v maxBackend429="${max_backend_429_rate}" \
+  -v maxPaced429="${max_paced_vu16_429_rate}" \
+  -v maxP95="${max_accepted_p95_ms}" \
+  -v maxPacingSleep="${max_pacing_sleep_p95_ms}" \
+  -v summary="${summary_tsv}" \
+  -v failures="${failure_log}" '
+  function value(name, fallback) {
+    return ($(col[name]) == "" ? fallback : $(col[name]))
+  }
+  function gt(value, limit) {
+    return (value + 0) > (limit + 0)
+  }
+  function ge(value, limit) {
+    return (value + 0) >= (limit + 0)
+  }
+  function add_reason(reason) {
+    reasons = (reasons == "ok" ? reason : reasons "," reason)
+  }
+  function require_ref(field, reason) {
+    ref = value(field, "")
+    if (ref == "" || ref == "missing" || ref == "n/a") add_reason(reason)
+  }
+  function reset_row() {
+    reasons = "ok"
+    status = "pass"
+    profile = value("profile", "")
+    role = value("gate_role", "")
+    target_rate = value("promotion_target_rate", target)
+    burst_rate = value("burst_rate", "0")
+    pacing = value("preemptive_pacing", "false")
+    total429 = value("total_429_rate", "1")
+    edge429 = value("edge_429_rate", "1")
+    backend429 = value("backend_429_rate", "1")
+    backend429_count = value("backend_429_count", "0")
+    five_xx = value("five_xx_count", "1")
+    nginx499 = value("nginx_499_count", "1")
+    p95 = value("accepted_p95_ms", maxP95)
+    pacing_sleep = value("pacing_sleep_p95_ms", "0")
+  }
+  function enforce_common_hard_zero(prefix) {
+    if (gt(backend429, maxBackend429)) add_reason(prefix "backend429>" maxBackend429)
+    if (gt(five_xx, 0)) add_reason(prefix "5xx>0")
+    if (gt(nginx499, 0)) add_reason(prefix "499>0")
+  }
+  function write_row() {
+    if (reasons != "ok" && status != "observe") {
+      status = "fail"
+      gate_status = "fail"
+      print profile " reason=" reasons > failures
+    }
+    print profile, role, status, reasons, target_rate, burst_rate, pacing, total429, edge429, backend429, backend429_count, five_xx, nginx499, p95, pacing_sleep, value("summary_ref", ""), value("nginx_aggregate_ref", ""), value("pacing_summary_ref", "") >> summary
+  }
+  BEGIN {
+    gate_status = "pass"
+    promotion_count = 0
+    paced_count = 0
+    unpaced_count = 0
+    print "profile", "gate_role", "status", "reason", "promotion_target_rate", "burst_rate", "preemptive_pacing", "total_429_rate", "edge_429_rate", "backend_429_rate", "backend_429_count", "five_xx_count", "nginx_499_count", "accepted_p95_ms", "pacing_sleep_p95_ms", "summary_ref", "nginx_aggregate_ref", "pacing_summary_ref" > summary
+    print "" > failures
+    close(failures)
+    system("rm -f " failures)
+  }
+  NR == 1 {
+    for (i = 1; i <= NF; i++) col[$i] = i
+    next
+  }
+  NR > 1 {
+    reset_row()
+    if (profile == "vu16-unpaced") {
+      unpaced_count++
+      status = "observe"
+      if (role != "saturation-observation") {
+        status = "fail"
+        add_reason("vu16-unpaced-must-be-observation")
+      }
+      if (pacing != "false") {
+        status = "fail"
+        add_reason("vu16-unpaced-must-disable-pacing")
+      }
+      if (gt(five_xx, 0)) {
+        status = "fail"
+        add_reason("vu16-unpaced-5xx>0")
+      }
+      if (gt(nginx499, 0)) {
+        status = "fail"
+        add_reason("vu16-unpaced-499>0")
+      }
+    } else if (profile == "vu16-paced") {
+      paced_count++
+      if (role != "paced-saturation-contract") add_reason("paced-vu16-role-mismatch")
+      if (pacing != "true") add_reason("paced-vu16-pacing-disabled")
+      if (gt(total429, maxPaced429)) add_reason("paced-vu16-total429>" maxPaced429)
+      if (gt(edge429, maxPaced429)) add_reason("paced-vu16-edge429>" maxPaced429)
+      enforce_common_hard_zero("paced-vu16-")
+      if (ge(p95, maxP95)) add_reason("paced-vu16-p95>=" maxP95)
+      if (gt(pacing_sleep, maxPacingSleep)) add_reason("paced-vu16-pacing-sleep>" maxPacingSleep)
+      require_ref("pacing_summary_ref", "paced-vu16-pacing-summary-missing")
+    } else if (role == "promotion-target") {
+      promotion_count++
+      if (target_rate != target) add_reason("promotion-target-rate-mismatch")
+      if (burst_rate != target) add_reason("promotion-burst-rate-mismatch")
+      if (pacing != "false") add_reason("promotion-burst-must-not-use-vu-pacing")
+      if (gt(total429, max429)) add_reason("promotion-total429>" max429)
+      if (gt(edge429, max429)) add_reason("promotion-edge429>" max429)
+      enforce_common_hard_zero("promotion-")
+      if (ge(p95, maxP95)) add_reason("promotion-p95>=" maxP95)
+    } else if (role == "overload-observation") {
+      status = "observe"
+      if ((burst_rate + 0) <= (target + 0)) {
+        status = "fail"
+        add_reason("observation-burst-not-above-target")
+      }
+      enforce_common_hard_zero("observation-")
+    } else {
+      add_reason("unknown-gate-role")
+    }
+    write_row()
+  }
+  END {
+    if (promotion_count != 1) {
+      print "promotion-target reason=promotion-target-count!=" promotion_count > failures
+      gate_status = "fail"
+    }
+    if (paced_count != 1) {
+      print "vu16-paced reason=paced-vu16-count!=" paced_count > failures
+      gate_status = "fail"
+    }
+    if (unpaced_count != 1) {
+      print "vu16-unpaced reason=vu16-unpaced-count!=" unpaced_count > failures
+      gate_status = "fail"
+    }
+    print gate_status > (summary ".status")
+  }
+' "${input_tsv}"
+
+gate_status="$(cat "${summary_tsv}.status")"
+rm -f "${summary_tsv}.status"
+
+{
+  echo "# Transaction Read Promotion Pacing Contract"
+  echo
+  echo "## Summary"
+  echo
+  echo "- gate_status=${gate_status}"
+  echo "- promotion target: burst${promotion_target_rate}"
+  echo "- max promotion total/edge 429 rate: ${max_promotion_429_rate}"
+  echo "- max backend 429 rate: ${max_backend_429_rate}"
+  echo "- max paced VU16 total/edge 429 rate: ${max_paced_vu16_429_rate}"
+  echo "- VU16 unpaced: observation-only saturation probe"
+  echo "- VU16 paced: safe saturation contract"
+  echo
+  echo "## Matrix"
+  echo
+  echo "| Profile | Role | Status | Reason | Total 429 | Edge 429 | Backend 429 | 5xx | 499 | Accepted p95 ms | Pacing p95 ms |"
+  echo "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+  awk -F '\t' 'NR > 1 { printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $8, $9, $10, $12, $13, $14, $15 }' "${summary_tsv}"
+  echo
+  echo "## Contract Notes"
+  echo
+  echo "- burst64는 현재 promotion target이며 total/edge 429 10%, backend 429 0.5%, 5xx/499 0, accepted p95 100ms 미만을 요구한다."
+  echo "- burst80 이상은 명시 promotion target이 아니면 overload observation이며 429 초과를 success 신호로 해석하지 않는다."
+  echo "- VU16 unpaced는 단일 source saturation 진단으로만 남기고 promotion-safe evidence로 사용하지 않는다."
+  echo "- VU16 paced는 request-before token pacing이 켜진 safe saturation contract로 429/5xx/499 budget을 통과해야 한다."
+  echo
+  echo "## Artifacts"
+  echo
+  echo "- summary TSV: ${summary_tsv}"
+  echo "- input TSV: ${input_tsv}"
+} >"${report_md}"
+
+echo "${report_md}"
+
+if [[ "${gate_status}" == "fail" ]]; then
+  if [[ -s "${failure_log}" ]]; then
+    cat "${failure_log}" >&2
+  fi
+  echo "transaction read promotion pacing contract failed: ${summary_tsv}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #721

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction read capacity promotion 기준에서 burst64는 promotion target으로 유지하고, burst80 이상은 observation row가 promotion success로 오해되지 않도록 contract를 추가했습니다.
- VU16 unpaced는 observation-only saturation probe, VU16 paced는 safe saturation contract로 evidence role을 분리했습니다.

## 🛠 Changes
- `tools/test/run-transaction-read-promotion-pacing-contract.sh`로 burst/VU profile evidence TSV의 promotion/observation/paced contract를 검증합니다.
- `tools/test/check-transaction-read-promotion-pacing-contract.sh`로 target80 promotion 실패, paced VU16 429 회귀, unpaced strict role 회귀를 잡습니다.
- `oci-k6-service-auth-token.yml` PR contract job에 promotion pacing contract를 연결하고, constant-vus pacing evidence의 gate role을 `saturation-observation` / `paced-saturation-contract`로 분리합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/check-transaction-read-promotion-pacing-contract.sh`
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix.sh`
- `bash tools/test/check-transaction-read-arrival-16-edge-budget-gate.sh`
- `bash tools/test/check-ci-runtime-optimization-contract.sh`
- `git diff --check`
- `git rev-list --count origin/main..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: contract가 더 엄격해져 VU16/burst evidence role 누락 시 PR contract가 실패할 수 있습니다.
- 롤백 방법: 이 PR의 workflow/contract script 변경 commit을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
