### PR TITLE
[Perf] transaction read burst80 admission target closure

### DIFF
--- a/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
+++ b/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
@@ -46,7 +46,7 @@ on:
       promotion_target_rate:
         description: "Promotion target burst arrival rate per second"
         required: false
-        default: "64"
+        default: "80"
         type: string
       docker_context:
         description: "Remote Docker context name for off-host k6"
@@ -69,12 +69,12 @@ on:
         required: false
         type: string
       burst_429_rate_threshold:
-        description: "Max total/edge 429 rate for burst64 matrix gate"
+        description: "Max total/edge 429 rate for promotion target matrix gate"
         required: false
         default: "0.10"
         type: string
       backend_429_rate_threshold:
-        description: "Max backend 429 rate for burst64 matrix gate"
+        description: "Max backend 429 rate for promotion target matrix gate"
         required: false
         default: "0.005"
         type: string
@@ -169,7 +169,7 @@ jobs:
           set +a
 
           K6_BURST_RATES="${BURST_RATES_INPUT:-32,48,64,80,96}"
-          K6_BURST_MATRIX_PROMOTION_TARGET_RATE="${PROMOTION_TARGET_RATE_INPUT:-64}"
+          K6_BURST_MATRIX_PROMOTION_TARGET_RATE="${PROMOTION_TARGET_RATE_INPUT:-80}"
           K6_RUN_PURPOSE="capacity"
           K6_OBSERVABILITY_MODE="prometheus"
           K6_GENERATOR_MODE="docker-context"
@@ -408,7 +408,7 @@ jobs:
           OCI_K6_BURST_MATRIX_INPUT_TSV="${matrix_input_tsv}" \
           OCI_K6_BURST_MATRIX_OUTPUT_DIR="${matrix_dir}/burst-reject-curve-matrix" \
           OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE="${K6_BURST_MATRIX_PROMOTION_TARGET_RATE}" \
-          OCI_K6_BURST_MATRIX_BURST64_429_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT:-0.10}" \
+          OCI_K6_BURST_MATRIX_TARGET_429_THRESHOLD="${BURST_429_RATE_THRESHOLD_INPUT:-0.10}" \
           OCI_K6_BURST_MATRIX_BACKEND_429_THRESHOLD="${BACKEND_429_RATE_THRESHOLD_INPUT:-0.005}" \
             tools/test/run-oci-k6-burst-reject-curve-matrix.sh
 

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
@@ -47,12 +47,12 @@ grep -F "burst_rates:" "${workflow}" >/dev/null
 grep -F 'default: "32,48,64,80,96"' "${workflow}" >/dev/null
 grep -F "promotion_target_rate:" "${workflow}" >/dev/null
 grep -F 'description: "Promotion target burst arrival rate per second"' "${workflow}" >/dev/null
-grep -F 'default: "64"' "${workflow}" >/dev/null
+grep -F 'default: "80"' "${workflow}" >/dev/null
 grep -F 'K6_MATRIX_REPORT_NAME: ${{ inputs.report_name || format(' "${workflow}" >/dev/null
 grep -F 'BURST_RATES_INPUT: ${{ inputs.burst_rates }}' "${workflow}" >/dev/null
 grep -F 'PROMOTION_TARGET_RATE_INPUT: ${{ inputs.promotion_target_rate }}' "${workflow}" >/dev/null
 grep -F 'K6_BURST_RATES="${BURST_RATES_INPUT:-32,48,64,80,96}"' "${workflow}" >/dev/null
-grep -F 'K6_BURST_MATRIX_PROMOTION_TARGET_RATE="${PROMOTION_TARGET_RATE_INPUT:-64}"' "${workflow}" >/dev/null
+grep -F 'K6_BURST_MATRIX_PROMOTION_TARGET_RATE="${PROMOTION_TARGET_RATE_INPUT:-80}"' "${workflow}" >/dev/null
 grep -F "Run authenticated k6 burst matrix" "${workflow}" >/dev/null
 grep -F 'IFS="," read -r -a burst_rates <<<"${K6_BURST_RATES}"' "${workflow}" >/dev/null
 grep -F 'matrix_input_tsv="${matrix_dir}/burst-reject-curve-input.tsv"' "${workflow}" >/dev/null

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix.sh
@@ -100,12 +100,12 @@ input_tsv="${temp_dir}/burst-reject-curve-input.tsv"
         write_aggregate "${rate}" "matrix-burst48" 168 0 0
         ;;
       64)
-        write_summary "${rate}" 0.08 0.075 0.003 2 0 5650 7.5 40 2
+        write_summary "${rate}" 0.06 0.055 0.003 2 0 5650 7.5 40 2
         write_aggregate "${rate}" "matrix-burst64" 465 0 0
         ;;
       80)
-        write_summary "${rate}" 0.22 0.216 0.004 3 0 5400 11.7 55 4
-        write_aggregate "${rate}" "matrix-burst80" 1120 0 0
+        write_summary "${rate}" 0.08 0.076 0.004 3 0 5400 11.7 55 4
+        write_aggregate "${rate}" "matrix-burst80" 610 0 0
         ;;
       96)
         write_summary "${rate}" 0.35 0.346 0.004 4 0 5100 18.3 80 6
@@ -133,8 +133,8 @@ plan="$(
 )"
 grep -F "name=burst-matrix-check" <<<"${plan}" >/dev/null
 grep -F "required_burst_rates=32,48,64,80,96" <<<"${plan}" >/dev/null
-grep -F "promotion_target_rate=64" <<<"${plan}" >/dev/null
-grep -F "gate=burst64 total/edge 429 <= 0.10, backend 429 <= 0.005, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < 100ms" <<<"${plan}" >/dev/null
+grep -F "promotion_target_rate=80" <<<"${plan}" >/dev/null
+grep -F "gate=burst80 total/edge 429 <= 0.10, backend 429 <= 0.005, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < 100ms" <<<"${plan}" >/dev/null
 grep -F "summary_tsv=${output_dir}/burst-matrix-check-burst-reject-curve.tsv" <<<"${plan}" >/dev/null
 
 echo "[oci-k6-burst-reject-curve-matrix] report"
@@ -149,16 +149,18 @@ summary_tsv="${output_dir}/burst-matrix-check-burst-reject-curve.tsv"
 summary_json="${output_dir}/burst-matrix-check-burst-reject-curve.json"
 test "${report_md}" = "${output_dir}/burst-matrix-check-burst-reject-curve.md"
 grep -F $'burst_rate\tstatus\tk6_run_id\ttotal_429_rate\tedge_429_rate\tbackend_429_rate\tbackend_429_count\tk6_503_count\tnginx_5xx_count\tnginx_499_count\taccepted_count\taccepted_p95_ms\tretry_after_p95_ms\treject_streak_max\tsummary_json\tnginx_aggregate_json\tnginx_aggregate_tsv\tnginx_aggregate_md' "${summary_tsv}" >/dev/null
-grep -F $'64\tpass\tmatrix-burst64\t0.080000\t0.075000\t0.003000\t2\t0\t0\t0\t5650\t7.500\t40.000\t2' "${summary_tsv}" >/dev/null
-grep -F $'80\tobserve\tmatrix-burst80\t0.220000\t0.216000\t0.004000\t3\t0\t0\t0\t5400\t11.700\t55.000\t4' "${summary_tsv}" >/dev/null
-grep -F "burst64 gate: pass" "${report_md}" >/dev/null
-grep -F "promotion target rate: 64" "${report_md}" >/dev/null
+grep -F $'64\tpass\tmatrix-burst64\t0.060000\t0.055000\t0.003000\t2\t0\t0\t0\t5650\t7.500\t40.000\t2' "${summary_tsv}" >/dev/null
+grep -F $'80\tpass\tmatrix-burst80\t0.080000\t0.076000\t0.004000\t3\t0\t0\t0\t5400\t11.700\t55.000\t4' "${summary_tsv}" >/dev/null
+grep -F $'96\tobserve\tmatrix-burst96\t0.350000\t0.346000\t0.004000\t4\t0\t0\t0\t5100\t18.300\t80.000\t6' "${summary_tsv}" >/dev/null
+grep -F "burst80 gate: pass" "${report_md}" >/dev/null
+grep -F "promotion target rate: 80" "${report_md}" >/dev/null
 grep -F "rows above target: overload observation rows; 429 ceiling is not applied" "${report_md}" >/dev/null
 grep -F "matrix input TSV: ${input_tsv}" "${report_md}" >/dev/null
 jq -e '.items | length == 5' "${summary_json}" >/dev/null
-jq -e '.promotion_target_rate == 64' "${summary_json}" >/dev/null
-jq -e '.items[] | select(.burst_rate == 64 and .status == "pass" and .edge_429_rate == 0.075 and .nginx_499_count == 0)' "${summary_json}" >/dev/null
-jq -e '.items[] | select(.burst_rate == 80 and .status == "observe" and .total_429_rate == 0.22)' "${summary_json}" >/dev/null
+jq -e '.promotion_target_rate == 80' "${summary_json}" >/dev/null
+jq -e '.items[] | select(.burst_rate == 64 and .status == "pass" and .edge_429_rate == 0.055 and .nginx_499_count == 0)' "${summary_json}" >/dev/null
+jq -e '.items[] | select(.burst_rate == 80 and .status == "pass" and .total_429_rate == 0.08)' "${summary_json}" >/dev/null
+jq -e '.items[] | select(.burst_rate == 96 and .status == "observe" and .total_429_rate == 0.35)' "${summary_json}" >/dev/null
 
 echo "[oci-k6-burst-reject-curve-matrix] missing required rate fails"
 missing_input="${temp_dir}/missing-input.tsv"
@@ -172,7 +174,7 @@ if OCI_K6_BURST_MATRIX_NAME=burst-matrix-missing \
 fi
 grep -F "missing burst rate evidence: 48" "${temp_dir}/missing.log" >/dev/null
 
-echo "[oci-k6-burst-reject-curve-matrix] burst64 gate fails"
+echo "[oci-k6-burst-reject-curve-matrix] custom burst64 promotion target gate fails"
 bad_summary="${temp_dir}/burst-64-summary-bad.json"
 jq '.metrics.aquila_transaction_429_rate.values.rate = 0.11' \
   "${temp_dir}/burst-64-summary.json" >"${bad_summary}"
@@ -186,6 +188,7 @@ awk -F '\t' -v bad_summary="${bad_summary}" '
 if OCI_K6_BURST_MATRIX_NAME=burst-matrix-bad \
   OCI_K6_BURST_MATRIX_INPUT_TSV="${bad_input}" \
   OCI_K6_BURST_MATRIX_OUTPUT_DIR="${temp_dir}/bad-output" \
+  OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE=64 \
     "${runner}" >"${temp_dir}/bad.log" 2>&1; then
   echo "burst64 gate unexpectedly passed" >&2
   exit 1
@@ -193,10 +196,19 @@ fi
 grep -F "burst64 gate failed: total_429_rate=0.110000 > 0.100000" "${temp_dir}/bad.log" >/dev/null
 
 echo "[oci-k6-burst-reject-curve-matrix] burst80 promotion target gate fails"
+target80_bad_summary="${temp_dir}/burst-80-summary-bad.json"
+jq '.metrics.aquila_transaction_429_rate.values.rate = 0.22 | .metrics.aquila_transaction_edge_429_rate.values.rate = 0.216' \
+  "${temp_dir}/burst-80-summary.json" >"${target80_bad_summary}"
+target80_bad_input="${temp_dir}/target80-bad-input.tsv"
+awk -F '\t' -v bad_summary="${target80_bad_summary}" '
+  BEGIN { OFS = FS }
+  NR == 1 { print; next }
+  $1 == "80" { $3 = bad_summary }
+  { print }
+' "${input_tsv}" >"${target80_bad_input}"
 if OCI_K6_BURST_MATRIX_NAME=burst-matrix-target80 \
-  OCI_K6_BURST_MATRIX_INPUT_TSV="${input_tsv}" \
+  OCI_K6_BURST_MATRIX_INPUT_TSV="${target80_bad_input}" \
   OCI_K6_BURST_MATRIX_OUTPUT_DIR="${temp_dir}/target80-output" \
-  OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE=80 \
     "${runner}" >"${temp_dir}/target80.log" 2>&1; then
   echo "burst80 promotion target unexpectedly passed" >&2
   exit 1

--- a/tools/test/run-oci-k6-burst-reject-curve-matrix.sh
+++ b/tools/test/run-oci-k6-burst-reject-curve-matrix.sh
@@ -10,7 +10,8 @@ Environment:
   OCI_K6_BURST_MATRIX_INPUT_TSV       required TSV: burst_rate/k6_run_id/summary_json/nginx_aggregate_json/nginx_aggregate_tsv/nginx_aggregate_md
   OCI_K6_BURST_MATRIX_REQUIRED_RATES  default 32,48,64,80,96
   OCI_K6_BURST_MATRIX_OUTPUT_DIR      default build/reports/k6/<name>
-  OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE default 64
+  OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE default 80
+  OCI_K6_BURST_MATRIX_TARGET_429_THRESHOLD default 0.10
 USAGE
 }
 
@@ -39,10 +40,10 @@ output_dir="${OCI_K6_BURST_MATRIX_OUTPUT_DIR:-build/reports/k6/${name}}"
 summary_tsv="${output_dir}/${name}-burst-reject-curve.tsv"
 summary_json="${output_dir}/${name}-burst-reject-curve.json"
 report_md="${output_dir}/${name}-burst-reject-curve.md"
-burst64_429_threshold="${OCI_K6_BURST_MATRIX_BURST64_429_THRESHOLD:-0.10}"
+target_429_threshold="${OCI_K6_BURST_MATRIX_TARGET_429_THRESHOLD:-${OCI_K6_BURST_MATRIX_BURST64_429_THRESHOLD:-0.10}}"
 backend_429_threshold="${OCI_K6_BURST_MATRIX_BACKEND_429_THRESHOLD:-0.005}"
 accepted_p95_threshold_ms="${OCI_K6_BURST_MATRIX_ACCEPTED_P95_THRESHOLD_MS:-100}"
-promotion_target_rate="${OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE:-64}"
+promotion_target_rate="${OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE:-80}"
 
 IFS=',' read -r -a required_rate_items <<<"${required_burst_rates}"
 
@@ -57,7 +58,7 @@ print_plan() {
   echo "[oci-k6-burst-reject-curve-matrix] required_burst_rates=${required_burst_rates}"
   echo "[oci-k6-burst-reject-curve-matrix] promotion_target_rate=${promotion_target_rate}"
   echo "[oci-k6-burst-reject-curve-matrix] output_dir=${output_dir}"
-  echo "[oci-k6-burst-reject-curve-matrix] gate=burst${promotion_target_rate} total/edge 429 <= ${burst64_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms"
+  echo "[oci-k6-burst-reject-curve-matrix] gate=burst${promotion_target_rate} total/edge 429 <= ${target_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms"
   echo "[oci-k6-burst-reject-curve-matrix] summary_tsv=${summary_tsv}"
   echo "[oci-k6-burst-reject-curve-matrix] summary_json=${summary_json}"
   echo "[oci-k6-burst-reject-curve-matrix] report_md=${report_md}"
@@ -211,13 +212,13 @@ record_failure() {
       record_failure "burst${burst_rate} gate failed: nginx_499_count=${nginx_499_count} > 0"
     fi
     if [[ "${burst_rate}" == "${promotion_target_rate}" ]]; then
-      if gt "${total_429_rate}" "${burst64_429_threshold}"; then
+      if gt "${total_429_rate}" "${target_429_threshold}"; then
         status="fail"
-        record_failure "$(printf 'burst%s gate failed: total_429_rate=%.6f > %.6f' "${promotion_target_rate}" "${total_429_rate}" "${burst64_429_threshold}")"
+        record_failure "$(printf 'burst%s gate failed: total_429_rate=%.6f > %.6f' "${promotion_target_rate}" "${total_429_rate}" "${target_429_threshold}")"
       fi
-      if gt "${edge_429_rate}" "${burst64_429_threshold}"; then
+      if gt "${edge_429_rate}" "${target_429_threshold}"; then
         status="fail"
-        record_failure "$(printf 'burst%s gate failed: edge_429_rate=%.6f > %.6f' "${promotion_target_rate}" "${edge_429_rate}" "${burst64_429_threshold}")"
+        record_failure "$(printf 'burst%s gate failed: edge_429_rate=%.6f > %.6f' "${promotion_target_rate}" "${edge_429_rate}" "${target_429_threshold}")"
       fi
       if gt "${backend_429_rate}" "${backend_429_threshold}"; then
         status="fail"
@@ -328,7 +329,7 @@ ${matrix_table}
 
 ## Gate
 
-- burst${promotion_target_rate}: total/edge 429 <= ${burst64_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms
+- burst${promotion_target_rate}: total/edge 429 <= ${target_429_threshold}, backend 429 <= ${backend_429_threshold}, k6 503 = 0, nginx 5xx = 0, nginx 499 = 0, accepted p95 < ${accepted_p95_threshold_ms}ms
 - all bursts: k6 503 = 0, nginx 5xx = 0, nginx 499 = 0
 - rows above target: reject curve observation only for 429 budget; still fails on 5xx/499
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #726

## 🌿 Base Branch
- `main`

## 📝 Summary
- transaction read burst reject curve matrix의 promotion target 기본값을 64/s에서 80/s로 올립니다.
- burst80이 운영 목표 gate가 되어 total/edge 429, backend 429, 5xx, 499, accepted p95 budget을 artifact pack에서 닫도록 계약을 강화합니다.
- 최근 CI burst matrix 실패에서 burst80 total/edge 429가 15.8699%로 10% budget을 초과한 내역을 기준으로 기본 gate를 운영 목표와 일치시킵니다.

## 🛠 Changes
- workflow dispatch `promotion_target_rate` 기본값을 `80`으로 변경했습니다.
- runner 기본 `OCI_K6_BURST_MATRIX_PROMOTION_TARGET_RATE`를 `80`으로 변경했습니다.
- target 429 threshold env를 `OCI_K6_BURST_MATRIX_TARGET_429_THRESHOLD`로 일반화하고 기존 `BURST64` env fallback은 유지했습니다.
- contract fixture를 burst80 pass/fail 케이스로 재구성하고, 96/s는 overload 관측 row로 유지했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix.sh`
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh`
- `git diff --check`
- `git rev-list --count origin/main..HEAD` -> `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 현재 staging capacity가 80/s budget을 만족하지 못하면 workflow dispatch가 실패한다. 의도된 운영 목표 gate 실패다.
- 롤백 방법: 이 PR commit을 revert하거나, 임시 운영 확인이 필요할 때 workflow input `promotion_target_rate=64`로 명시 실행한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (N/A)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (N/A)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (workflow contract에 반영)
