### PR TITLE
[Perf] transaction read deploy drain 499/5xx closure

### DIFF
--- a/tools/test/check-transaction-read-deploy-drain-under-load-gate.sh
+++ b/tools/test/check-transaction-read-deploy-drain-under-load-gate.sh
@@ -18,8 +18,8 @@ touch "${artifact_dir}/k6.json" "${artifact_dir}/nginx.jsonl" "${artifact_dir}/s
   "${artifact_dir}/deploy.json" "${artifact_dir}/deploy-retry.json" "${artifact_dir}/deploy-499.tsv"
 
 cat >"${input_tsv}" <<TSV
-scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref
-deploy-drain	run-drain-001	2026-05-02T03:00:00Z	5	1	tools/test/run-staging-deploy-transaction-replay-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	${artifact_dir}/deploy.json	n/a	${artifact_dir}/timeline.json	0.04	0	0	0	0	0	0	470	${artifact_dir}/deploy-retry.json	2	${artifact_dir}/deploy-499.tsv
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	deploy_actions	deploy_499_budget_count	client_retry_success_count
+deploy-drain	run-drain-001	2026-05-02T03:00:00Z	5	1	tools/test/run-staging-deploy-transaction-replay-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	${artifact_dir}/deploy.json	n/a	${artifact_dir}/timeline.json	0.04	0	0	0	0	0	0	470	${artifact_dir}/deploy-retry.json	2	${artifact_dir}/deploy-499.tsv	backend-restart,blue-green-drain	0	2
 TSV
 
 echo "[transaction-read-deploy-drain] print plan"
@@ -32,6 +32,9 @@ plan="$(
 grep -F "name=deploy-drain-check" <<<"${plan}" >/dev/null
 grep -F "paced_load_required=true" <<<"${plan}" >/dev/null
 grep -F "actions=backend-restart,blue-green-drain" <<<"${plan}" >/dev/null
+grep -F "499_budget_count=0" <<<"${plan}" >/dev/null
+grep -F "client_retry_required=true" <<<"${plan}" >/dev/null
+grep -F "client_reconnect_required=true" <<<"${plan}" >/dev/null
 grep -F "execution_gate=tools/test/run-transaction-read-oci-evidence-execution-gate.sh" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-deploy-drain] pass report"
@@ -48,6 +51,10 @@ grep -F "paced load 중 backend restart/blue-green drain" "${report_md}" >/dev/n
 grep -F "5xx/499/unknown 429 hard-zero" "${report_md}" >/dev/null
 grep -F "deploy event artifact: required" "${report_md}" >/dev/null
 grep -F "deploy retry/reconnect and 499 budget artifact: required" "${report_md}" >/dev/null
+grep -F "deploy actions: backend-restart,blue-green-drain" "${report_md}" >/dev/null
+grep -F "499 budget count: 0" "${report_md}" >/dev/null
+grep -F "client retry success: required" "${report_md}" >/dev/null
+grep -F "client reconnect success: required" "${report_md}" >/dev/null
 
 echo "[transaction-read-deploy-drain] missing deploy event fails"
 awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $12 = "n/a"; print }' "${input_tsv}" >"${input_tsv}.missing-deploy"
@@ -66,5 +73,35 @@ if DEPLOY_DRAIN_GATE_NAME=deploy-drain-missing-retry \
   DEPLOY_DRAIN_GATE_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "deploy drain gate unexpectedly passed missing retry/reconnect evidence" >&2
+  exit 1
+fi
+
+echo "[transaction-read-deploy-drain] missing drain action fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $26 = "backend-restart"; print }' "${input_tsv}" >"${input_tsv}.missing-action"
+if DEPLOY_DRAIN_GATE_NAME=deploy-drain-missing-action \
+  DEPLOY_DRAIN_GATE_INPUT_TSV="${input_tsv}.missing-action" \
+  DEPLOY_DRAIN_GATE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "deploy drain gate unexpectedly passed missing blue-green drain action" >&2
+  exit 1
+fi
+
+echo "[transaction-read-deploy-drain] 499 budget count fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $27 = 1; print }' "${input_tsv}" >"${input_tsv}.budget"
+if DEPLOY_DRAIN_GATE_NAME=deploy-drain-budget \
+  DEPLOY_DRAIN_GATE_INPUT_TSV="${input_tsv}.budget" \
+  DEPLOY_DRAIN_GATE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "deploy drain gate unexpectedly passed non-zero 499 budget count" >&2
+  exit 1
+fi
+
+echo "[transaction-read-deploy-drain] client retry success fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $28 = 0; print }' "${input_tsv}" >"${input_tsv}.retry"
+if DEPLOY_DRAIN_GATE_NAME=deploy-drain-retry \
+  DEPLOY_DRAIN_GATE_INPUT_TSV="${input_tsv}.retry" \
+  DEPLOY_DRAIN_GATE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "deploy drain gate unexpectedly passed missing client retry success" >&2
   exit 1
 fi

--- a/tools/test/run-transaction-read-deploy-drain-under-load-gate.sh
+++ b/tools/test/run-transaction-read-deploy-drain-under-load-gate.sh
@@ -9,6 +9,7 @@ Environment:
   DEPLOY_DRAIN_GATE_NAME        default transaction-read-deploy-drain-under-load-<timestamp>
   DEPLOY_DRAIN_GATE_INPUT_TSV   required OCI evidence manifest with deploy-drain row
   DEPLOY_DRAIN_GATE_OUTPUT_DIR  default build/reports/k6/<name>
+  DEPLOY_DRAIN_GATE_499_BUDGET_COUNT default 0
 USAGE
 }
 
@@ -33,7 +34,9 @@ done
 name="${DEPLOY_DRAIN_GATE_NAME:-transaction-read-deploy-drain-under-load-$(date +%Y-%m-%d-%H%M%S)}"
 input_tsv="${DEPLOY_DRAIN_GATE_INPUT_TSV:-}"
 output_dir="${DEPLOY_DRAIN_GATE_OUTPUT_DIR:-build/reports/k6/${name}}"
+max_499_budget_count="${DEPLOY_DRAIN_GATE_499_BUDGET_COUNT:-0}"
 execution_gate="tools/test/run-transaction-read-oci-evidence-execution-gate.sh"
+summary_tsv="${output_dir}/${name}-deploy-drain-under-load.tsv"
 report_md="${output_dir}/${name}-deploy-drain-under-load.md"
 
 require_file() {
@@ -45,15 +48,30 @@ require_file() {
   fi
 }
 
+require_non_negative_integer() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${key} must be a non-negative integer: ${value}" >&2
+    exit 1
+  fi
+}
+
 print_plan() {
   echo "[transaction-read-deploy-drain] name=${name}"
   echo "[transaction-read-deploy-drain] input_tsv=${input_tsv:-missing}"
   echo "[transaction-read-deploy-drain] output_dir=${output_dir}"
   echo "[transaction-read-deploy-drain] paced_load_required=true"
   echo "[transaction-read-deploy-drain] actions=backend-restart,blue-green-drain"
+  echo "[transaction-read-deploy-drain] 499_budget_count=${max_499_budget_count}"
+  echo "[transaction-read-deploy-drain] client_retry_required=true"
+  echo "[transaction-read-deploy-drain] client_reconnect_required=true"
   echo "[transaction-read-deploy-drain] execution_gate=${execution_gate}"
+  echo "[transaction-read-deploy-drain] summary_tsv=${summary_tsv}"
   echo "[transaction-read-deploy-drain] report_md=${report_md}"
 }
+
+require_non_negative_integer "DEPLOY_DRAIN_GATE_499_BUDGET_COUNT" "${max_499_budget_count}"
 
 print_plan
 if [[ "${mode}" == "print-plan" ]]; then
@@ -74,6 +92,75 @@ gate_output="$(
 )"
 execution_report="$(tail -1 <<<"${gate_output}")"
 
+awk -F '\t' -v max_499_budget_count="${max_499_budget_count}" '
+function value(name, fallback) {
+  if (!(name in col) || col[name] == "") return fallback
+  return $(col[name])
+}
+function has_action(items, item) {
+  return index("," items ",", "," item ",") > 0
+}
+function add_reason(reason_value) {
+  if (reason == "ok") {
+    reason = reason_value
+  } else {
+    reason = reason "," reason_value
+  }
+  status = "fail"
+}
+BEGIN {
+  print "scenario\tstatus\treason\trun_id\tdeploy_actions\tnginx_499_count\tdeploy_499_budget_count\tclient_retry_success_count\tdeploy_reconnect_success_count\tdeploy_retry_contract_ref\tdeploy_499_budget_ref"
+}
+NR == 1 {
+  for (i = 1; i <= NF; i++) col[$i] = i
+  next
+}
+value("scenario", "") == "deploy-drain" {
+  row_count++
+  status = "pass"
+  reason = "ok"
+  deploy_actions = value("deploy_actions", "")
+  nginx_499_count = value("nginx_499_count", "999999") + 0
+  deploy_499_budget_count = value("deploy_499_budget_count", "999999") + 0
+  client_retry_success_count = value("client_retry_success_count", "0") + 0
+  deploy_reconnect_success_count = value("deploy_reconnect_success_count", "0") + 0
+
+  if (!has_action(deploy_actions, "backend-restart")) add_reason("backend-restart-action-missing")
+  if (!has_action(deploy_actions, "blue-green-drain")) add_reason("blue-green-drain-action-missing")
+  if (deploy_499_budget_count > max_499_budget_count) add_reason("499-budget-count>" max_499_budget_count)
+  if (nginx_499_count > deploy_499_budget_count) add_reason("499-count>budget")
+  if (client_retry_success_count <= 0) add_reason("client-retry-success-missing")
+  if (deploy_reconnect_success_count <= 0) add_reason("client-reconnect-success-missing")
+
+  if (status == "fail") fail_count++
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    value("scenario", ""),
+    status,
+    reason,
+    value("run_id", ""),
+    deploy_actions,
+    nginx_499_count,
+    deploy_499_budget_count,
+    client_retry_success_count,
+    deploy_reconnect_success_count,
+    value("deploy_retry_contract_ref", ""),
+    value("deploy_499_budget_ref", "")
+}
+END {
+  if (row_count != 1) {
+    print "deploy-drain\tfail\tdeploy-drain-row-count!=" row_count "\tn/a\tn/a\t0\t0\t0\t0\tn/a\tn/a"
+    fail_count++
+  }
+  print "fail_count=" (fail_count + 0) > "/dev/stderr"
+}
+' "${input_tsv}" >"${summary_tsv}" 2>"${summary_tsv}.meta"
+
+fail_count="$(awk -F '=' '/^fail_count=/ { print $2 }' "${summary_tsv}.meta")"
+if [[ "${fail_count}" != "0" ]]; then
+  echo "transaction read deploy drain evidence failed: ${summary_tsv}" >&2
+  exit 1
+fi
+
 cat >"${report_md}" <<REPORT
 # Transaction Read Deploy Drain Under Load
 
@@ -84,6 +171,10 @@ cat >"${report_md}" <<REPORT
 - 5xx/499/unknown 429 hard-zero
 - deploy event artifact: required
 - deploy retry/reconnect and 499 budget artifact: required
+- deploy actions: backend-restart,blue-green-drain
+- 499 budget count: ${max_499_budget_count}
+- client retry success: required
+- client reconnect success: required
 - execution gate report: ${execution_report}
 
 ## Contract Notes
@@ -91,11 +182,13 @@ cat >"${report_md}" <<REPORT
 - deploy/restart/drain은 정상 트래픽 pacing 중 실행한 evidence만 인정한다.
 - deploy event ref와 Nginx/Spring/Hikari/PostgreSQL timeline ref가 같은 run id로 묶여야 한다.
 - retry/reconnect contract와 499 budget ref로 client-visible drain 결과를 닫는다.
+- deploy action과 client retry 성공 count가 없으면 배포 중 client-visible 방어 증거로 인정하지 않는다.
 - unknown 429, 499, 5xx, Hikari warning은 execution gate에서 hard-zero로 검증한다.
 
 ## Artifacts
 
 - input TSV: ${input_tsv}
+- summary TSV: ${summary_tsv}
 - report: ${report_md}
 REPORT
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #725

## 🌿 Base Branch
- `main`

## 📝 Summary
- deploy/drain under load gate가 backend restart와 blue-green drain action을 같은 evidence row에 기록하도록 강화했습니다.
- 499 budget count 기본값을 0으로 고정하고, client retry/reconnect success를 hard gate로 검증합니다.
- 기존 5xx/499/unknown 429 hard-zero와 deploy event/retry/499 artifact ref 요구는 유지했습니다.

## 🛠 Changes
- `DEPLOY_DRAIN_GATE_499_BUDGET_COUNT` 기본값을 추가했습니다.
- deploy-drain runner가 deploy action, 499 budget count, client retry success count를 별도 summary TSV로 검증합니다.
- contract test에 missing drain action, non-zero 499 budget, missing client retry success 실패 케이스를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh`
- `git diff --check`
- `git rev-list --count origin/main..HEAD` -> `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 deploy-drain evidence TSV가 새 deploy action/retry/budget columns를 채우지 않으면 gate가 실패한다. 의도된 closure 강화다.
- 롤백 방법: 이 PR commit을 revert하거나 deploy-drain evidence TSV에 새 columns를 채워 재실행한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (N/A)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (N/A)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (artifact contract에 반영)
