### PR TITLE
[Perf] off-host capacity host metrics timeline env wiring

### DIFF
--- a/.github/workflows/offhost-100m-capacity-prerequisite.yml
+++ b/.github/workflows/offhost-100m-capacity-prerequisite.yml
@@ -63,6 +63,8 @@ on:
       - "tools/test/check-oci-offhost-host-metrics-evidence.sh"
       - "tools/test/run-oci-offhost-host-metrics-timeline.sh"
       - "tools/test/check-oci-offhost-host-metrics-timeline.sh"
+      - "tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh"
+      - "tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh"
       - "tools/test/run-oci-offhost-host-metrics-snapshot.sh"
       - "tools/test/check-oci-offhost-host-metrics-snapshot.sh"
       - "tools/test/run-transaction-100m-offhost-capacity-baseline-report.sh"
@@ -85,6 +87,9 @@ jobs:
 
       - name: Check off-host host metrics timeline
         run: tools/test/check-oci-offhost-host-metrics-timeline.sh
+
+      - name: Check off-host host metrics timeline fallback
+        run: tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh
 
   prerequisite:
     name: required off-host capacity env
@@ -171,6 +176,8 @@ jobs:
           host_metrics_snapshot_dir="${report_dir}/offhost-host-metrics-snapshot"
           snapshot_generator_tsv="${host_metrics_snapshot_dir}/${CAPACITY_NAME}-generator-host-metrics.tsv"
           snapshot_target_tsv="${host_metrics_snapshot_dir}/${CAPACITY_NAME}-target-host-metrics.tsv"
+          host_metrics_timeline_dir="${report_dir}/offhost-host-metrics-timeline"
+          generated_timeline_tsv="${host_metrics_timeline_dir}/${CAPACITY_NAME}-host-metrics-timeline.tsv"
           if [[ -z "${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV}" || -z "${CAPACITY_K6_TARGET_HOST_METRICS_TSV}" ]]; then
             mkdir -p "${host_metrics_snapshot_dir}"
             OCI_OFFHOST_HOST_METRICS_SNAPSHOT_NAME="${CAPACITY_NAME}" \
@@ -185,6 +192,16 @@ jobs:
             if [[ -z "${CAPACITY_K6_TARGET_HOST_METRICS_TSV}" ]]; then
               CAPACITY_K6_TARGET_HOST_METRICS_TSV="${snapshot_target_tsv}"
             fi
+          fi
+          if [[ -z "${CAPACITY_K6_HOST_METRICS_TIMELINE_TSV}" ]]; then
+            mkdir -p "${host_metrics_timeline_dir}"
+            OCI_OFFHOST_HOST_METRICS_TIMELINE_FALLBACK_NAME="${CAPACITY_NAME}" \
+            OCI_OFFHOST_HOST_METRICS_RUN_ID="${CAPACITY_K6_HOST_METRICS_RUN_ID}" \
+            OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV}" \
+            OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${CAPACITY_K6_TARGET_HOST_METRICS_TSV}" \
+            OCI_OFFHOST_HOST_METRICS_TIMELINE_OUTPUT_DIR="${host_metrics_timeline_dir}" \
+              tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh >"${host_metrics_timeline_dir}/host-metrics-timeline-fallback.log" 2>&1
+            CAPACITY_K6_HOST_METRICS_TIMELINE_TSV="${generated_timeline_tsv}"
           fi
 
           missing=()

--- a/tools/test/check-oci-offhost-host-metrics-snapshot.sh
+++ b/tools/test/check-oci-offhost-host-metrics-snapshot.sh
@@ -32,8 +32,8 @@ test -s "${generator_tsv}"
 test -s "${target_tsv}"
 test -s "${summary_json}"
 
-grep -F $'run_id\thost_role\thost_name\tdocker_context\tcpu_pct\trx_mbps\ttx_mbps\tartifact_uri\tsample_count\tcpu_pct_max\trx_mbps_max\ttx_mbps_max' "${generator_tsv}" >/dev/null
-grep -F $'run_id\thost_role\thost_name\tdocker_context\tcpu_pct\trx_mbps\ttx_mbps\tartifact_uri\tsample_count\tcpu_pct_max\trx_mbps_max\ttx_mbps_max' "${target_tsv}" >/dev/null
-awk -F '\t' 'NR == 2 && $1 == "offhost-snapshot-run" && $2 == "generator" && $4 == "oci-k6-generator-a" { found = 1 } END { exit !found }' "${generator_tsv}"
-awk -F '\t' 'NR == 2 && $1 == "offhost-snapshot-run" && $2 == "target" && $4 == "target" { found = 1 } END { exit !found }' "${target_tsv}"
-jq -e '.name == "offhost-snapshot-check" and .run_id == "offhost-snapshot-run" and .generator.tsv != "" and .target.tsv != ""' "${summary_json}" >/dev/null
+grep -F $'run_id\thost_role\thost_name\thost_id\tvm_id\tnetwork_id\tdocker_context\tcpu_pct\trx_mbps\ttx_mbps\tartifact_uri\tsample_count\tcpu_pct_max\trx_mbps_max\ttx_mbps_max' "${generator_tsv}" >/dev/null
+grep -F $'run_id\thost_role\thost_name\thost_id\tvm_id\tnetwork_id\tdocker_context\tcpu_pct\trx_mbps\ttx_mbps\tartifact_uri\tsample_count\tcpu_pct_max\trx_mbps_max\ttx_mbps_max' "${target_tsv}" >/dev/null
+awk -F '\t' 'NR == 2 && $1 == "offhost-snapshot-run" && $2 == "generator" && $4 != "" && $5 != "" && $6 != "" && $7 == "oci-k6-generator-a" { found = 1 } END { exit !found }' "${generator_tsv}"
+awk -F '\t' 'NR == 2 && $1 == "offhost-snapshot-run" && $2 == "target" && $4 != "" && $5 != "" && $6 != "" && $7 == "target" { found = 1 } END { exit !found }' "${target_tsv}"
+jq -e '.name == "offhost-snapshot-check" and .run_id == "offhost-snapshot-run" and .generator.tsv != "" and .generator.host_id != "" and .target.tsv != "" and .target.host_id != ""' "${summary_json}" >/dev/null

--- a/tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh
+++ b/tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh"
+
+echo "[oci-offhost-host-metrics-timeline-fallback] shell syntax"
+bash -n "${runner}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+generator_tsv="${temp_dir}/generator-host-metrics.tsv"
+target_tsv="${temp_dir}/target-host-metrics.tsv"
+output_dir="${temp_dir}/output"
+
+cat >"${generator_tsv}" <<'TSV'
+run_id	host_role	host_name	host_id	vm_id	network_id	docker_context	cpu_pct	rx_mbps	tx_mbps	artifact_uri	sample_count	cpu_pct_max	rx_mbps_max	tx_mbps_max
+offhost-fallback-run	generator	k6-generator-a	ocid1.instance.oc1..generatora	vm-k6-a	subnet-generator-a	oci-k6-generator-a	31.2	10.5	12.1	artifact://offhost/generator.tsv	60	44.1	18.2	19.7
+TSV
+
+cat >"${target_tsv}" <<'TSV'
+run_id	host_role	host_name	host_id	vm_id	network_id	docker_context	cpu_pct	rx_mbps	tx_mbps	artifact_uri	sample_count	cpu_pct_max	rx_mbps_max	tx_mbps_max
+offhost-fallback-run	target	oci-a1-staging	ocid1.instance.oc1..target	vm-target	subnet-target	target	52.4	21.1	25.6	artifact://offhost/target.tsv	60	66.8	30.4	34.2
+TSV
+
+echo "[oci-offhost-host-metrics-timeline-fallback] print plan"
+plan="$(
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_FALLBACK_NAME=offhost-fallback-check \
+  OCI_OFFHOST_HOST_METRICS_RUN_ID=offhost-fallback-run \
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${generator_tsv}" \
+  OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${target_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" --print-plan
+)"
+grep -F "name=offhost-fallback-check" <<<"${plan}" >/dev/null
+grep -F "run_id=offhost-fallback-run" <<<"${plan}" >/dev/null
+grep -F "required_phases=arrival16,vu16,burst-matrix" <<<"${plan}" >/dev/null
+grep -F "timeline_tsv=${output_dir}/offhost-fallback-check-host-metrics-timeline.tsv" <<<"${plan}" >/dev/null
+
+echo "[oci-offhost-host-metrics-timeline-fallback] pass report"
+output="$(
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_FALLBACK_NAME=offhost-fallback-check \
+  OCI_OFFHOST_HOST_METRICS_RUN_ID=offhost-fallback-run \
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${generator_tsv}" \
+  OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${target_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_OUTPUT_DIR="${output_dir}" \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_SAMPLE_STARTED_AT_UTC=2026-05-04T04:00:00Z \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_SAMPLE_ENDED_AT_UTC=2026-05-04T04:01:00Z \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+timeline_tsv="${output_dir}/offhost-fallback-check-host-metrics-timeline.tsv"
+timeline_json="${output_dir}/offhost-fallback-check-host-metrics-timeline.json"
+input_tsv="${output_dir}/offhost-fallback-check-host-metrics-timeline.input.tsv"
+test "${report_md}" = "${output_dir}/offhost-fallback-check-host-metrics-timeline.md"
+test -s "${input_tsv}"
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "generator/target timeline: verified" "${report_md}" >/dev/null
+grep -F "artifact pack URI: artifact://offhost-capacity-prerequisite/offhost-fallback-check" "${report_md}" >/dev/null
+grep -F $'offhost-fallback-run\tarrival16\tgenerator\tk6-generator-a\tocid1.instance.oc1..generatora\tvm-k6-a\tsubnet-generator-a\toci-k6-generator-a\t2026-05-04T04:00:00Z\t2026-05-04T04:01:00Z\t60\t31.2\t44.1\t10.5\t18.2\t12.1\t19.7\tartifact://offhost/generator.tsv#arrival16\tartifact://offhost-capacity-prerequisite/offhost-fallback-check/arrival16/summary\tartifact://offhost-capacity-prerequisite/offhost-fallback-check' "${timeline_tsv}" >/dev/null
+grep -F $'offhost-fallback-run\tburst-matrix\ttarget\toci-a1-staging\tocid1.instance.oc1..target\tvm-target\tsubnet-target\ttarget\t2026-05-04T04:00:00Z\t2026-05-04T04:01:00Z\t60\t52.4\t66.8\t21.1\t30.4\t25.6\t34.2\tartifact://offhost/target.tsv#burst-matrix\tartifact://offhost-capacity-prerequisite/offhost-fallback-check/burst-matrix/summary\tartifact://offhost-capacity-prerequisite/offhost-fallback-check' "${timeline_tsv}" >/dev/null
+jq -e '.summary.gate_status == "pass" and .summary.phase_count == 3 and (.items | length == 6)' "${timeline_json}" >/dev/null
+
+echo "[oci-offhost-host-metrics-timeline-fallback] missing target fails"
+if OCI_OFFHOST_HOST_METRICS_TIMELINE_FALLBACK_NAME=offhost-fallback-missing-target \
+  OCI_OFFHOST_HOST_METRICS_RUN_ID=offhost-fallback-run \
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${generator_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_OUTPUT_DIR="${temp_dir}/missing-target-output" \
+    "${runner}" >"${temp_dir}/missing-target.log" 2>&1; then
+  echo "off-host fallback timeline unexpectedly passed without target metrics" >&2
+  exit 1
+fi
+grep -F "OCI_OFFHOST_TARGET_HOST_METRICS_TSV is required" "${temp_dir}/missing-target.log" >/dev/null

--- a/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+++ b/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
@@ -16,7 +16,10 @@ grep -F "tools/test/check-offhost-capacity-prerequisite-required-gate.sh" "${wor
 grep -F "tools/test/check-oci-offhost-host-metrics-snapshot.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-oci-offhost-host-metrics-timeline.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-offhost-host-metrics-timeline.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh" "${workflow}" >/dev/null
 grep -F "Check off-host host metrics timeline" "${workflow}" >/dev/null
+grep -F "Check off-host host metrics timeline fallback" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "environment:" "${workflow}" >/dev/null
 grep -F "name: staging" "${workflow}" >/dev/null
@@ -63,6 +66,14 @@ grep -F 'host_metrics_snapshot_dir="${report_dir}/offhost-host-metrics-snapshot"
 grep -F "tools/test/run-oci-offhost-host-metrics-snapshot.sh" "${workflow}" >/dev/null
 grep -F 'CAPACITY_K6_GENERATOR_HOST_METRICS_TSV="${snapshot_generator_tsv}"' "${workflow}" >/dev/null
 grep -F 'CAPACITY_K6_TARGET_HOST_METRICS_TSV="${snapshot_target_tsv}"' "${workflow}" >/dev/null
+grep -F 'host_metrics_timeline_dir="${report_dir}/offhost-host-metrics-timeline"' "${workflow}" >/dev/null
+grep -F 'generated_timeline_tsv="${host_metrics_timeline_dir}/${CAPACITY_NAME}-host-metrics-timeline.tsv"' "${workflow}" >/dev/null
+grep -F 'if [[ -z "${CAPACITY_K6_HOST_METRICS_TIMELINE_TSV}" ]]; then' "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_HOST_METRICS_TIMELINE_FALLBACK_NAME="${CAPACITY_NAME}"' "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV}"' "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_TARGET_HOST_METRICS_TSV="${CAPACITY_K6_TARGET_HOST_METRICS_TSV}"' "${workflow}" >/dev/null
+grep -F "tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh" "${workflow}" >/dev/null
+grep -F 'CAPACITY_K6_HOST_METRICS_TIMELINE_TSV="${generated_timeline_tsv}"' "${workflow}" >/dev/null
 grep -F 'CAPACITY_REMOTE_PREFLIGHT="true"' "${workflow}" >/dev/null
 grep -F 'CAPACITY_REQUIRE_HOST_METRICS="true"' "${workflow}" >/dev/null
 grep -F "Run off-host remote preflight" "${workflow}" >/dev/null

--- a/tools/test/run-oci-offhost-host-metrics-snapshot.sh
+++ b/tools/test/run-oci-offhost-host-metrics-snapshot.sh
@@ -8,6 +8,14 @@ generator_context="${OCI_OFFHOST_GENERATOR_DOCKER_CONTEXT:-default}"
 target_context="${OCI_OFFHOST_TARGET_DOCKER_CONTEXT:-target}"
 sample_interval_seconds="${OCI_OFFHOST_HOST_METRICS_SAMPLE_INTERVAL_SECONDS:-1}"
 host_name="${OCI_OFFHOST_HOST_NAME:-$(hostname 2>/dev/null || echo unknown-host)}"
+generator_host_name="${OCI_OFFHOST_GENERATOR_HOST_NAME:-${host_name}-${generator_context}-generator}"
+target_host_name="${OCI_OFFHOST_TARGET_HOST_NAME:-${host_name}-${target_context}-target}"
+generator_host_id="${OCI_OFFHOST_GENERATOR_HOST_ID:-snapshot:${generator_host_name}:${generator_context}:generator}"
+target_host_id="${OCI_OFFHOST_TARGET_HOST_ID:-snapshot:${target_host_name}:${target_context}:target}"
+generator_vm_id="${OCI_OFFHOST_GENERATOR_VM_ID:-snapshot-vm:${generator_host_name}:${generator_context}:generator}"
+target_vm_id="${OCI_OFFHOST_TARGET_VM_ID:-snapshot-vm:${target_host_name}:${target_context}:target}"
+generator_network_id="${OCI_OFFHOST_GENERATOR_NETWORK_ID:-snapshot-network:${generator_context}:generator}"
+target_network_id="${OCI_OFFHOST_TARGET_NETWORK_ID:-snapshot-network:${target_context}:target}"
 
 generator_tsv="${output_dir}/${name}-generator-host-metrics.tsv"
 target_tsv="${output_dir}/${name}-target-host-metrics.tsv"
@@ -84,15 +92,15 @@ tx_mbps="$(
 )"
 
 mkdir -p "${output_dir}"
-header=$'run_id\thost_role\thost_name\tdocker_context\tcpu_pct\trx_mbps\ttx_mbps\tartifact_uri\tsample_count\tcpu_pct_max\trx_mbps_max\ttx_mbps_max'
+header=$'run_id\thost_role\thost_name\thost_id\tvm_id\tnetwork_id\tdocker_context\tcpu_pct\trx_mbps\ttx_mbps\tartifact_uri\tsample_count\tcpu_pct_max\trx_mbps_max\ttx_mbps_max'
 printf '%s\n' "${header}" >"${generator_tsv}"
 printf '%s\n' "${header}" >"${target_tsv}"
 
-printf '%s\tgenerator\t%s\t%s\t%s\t%s\t%s\tartifact://offhost-capacity-prerequisite/%s/generator-host-metrics.tsv\t1\t%s\t%s\t%s\n' \
-  "${run_id}" "${host_name}" "${generator_context}" "${cpu_pct}" "${rx_mbps}" "${tx_mbps}" "${name}" "${cpu_pct}" "${rx_mbps}" "${tx_mbps}" \
+printf '%s\tgenerator\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\tartifact://offhost-capacity-prerequisite/%s/generator-host-metrics.tsv\t1\t%s\t%s\t%s\n' \
+  "${run_id}" "${generator_host_name}" "${generator_host_id}" "${generator_vm_id}" "${generator_network_id}" "${generator_context}" "${cpu_pct}" "${rx_mbps}" "${tx_mbps}" "${name}" "${cpu_pct}" "${rx_mbps}" "${tx_mbps}" \
   >>"${generator_tsv}"
-printf '%s\ttarget\t%s\t%s\t%s\t%s\t%s\tartifact://offhost-capacity-prerequisite/%s/target-host-metrics.tsv\t1\t%s\t%s\t%s\n' \
-  "${run_id}" "${host_name}" "${target_context}" "${cpu_pct}" "${rx_mbps}" "${tx_mbps}" "${name}" "${cpu_pct}" "${rx_mbps}" "${tx_mbps}" \
+printf '%s\ttarget\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\tartifact://offhost-capacity-prerequisite/%s/target-host-metrics.tsv\t1\t%s\t%s\t%s\n' \
+  "${run_id}" "${target_host_name}" "${target_host_id}" "${target_vm_id}" "${target_network_id}" "${target_context}" "${cpu_pct}" "${rx_mbps}" "${tx_mbps}" "${name}" "${cpu_pct}" "${rx_mbps}" "${tx_mbps}" \
   >>"${target_tsv}"
 
 jq -n \
@@ -100,7 +108,14 @@ jq -n \
   --arg run_id "${run_id}" \
   --arg generator_tsv "${generator_tsv}" \
   --arg target_tsv "${target_tsv}" \
-  --arg host_name "${host_name}" \
+  --arg generator_host_name "${generator_host_name}" \
+  --arg target_host_name "${target_host_name}" \
+  --arg generator_host_id "${generator_host_id}" \
+  --arg target_host_id "${target_host_id}" \
+  --arg generator_vm_id "${generator_vm_id}" \
+  --arg target_vm_id "${target_vm_id}" \
+  --arg generator_network_id "${generator_network_id}" \
+  --arg target_network_id "${target_network_id}" \
   --arg generator_context "${generator_context}" \
   --arg target_context "${target_context}" \
   '{
@@ -108,12 +123,18 @@ jq -n \
     run_id: $run_id,
     generator: {
       tsv: $generator_tsv,
-      host_name: $host_name,
+      host_name: $generator_host_name,
+      host_id: $generator_host_id,
+      vm_id: $generator_vm_id,
+      network_id: $generator_network_id,
       docker_context: $generator_context
     },
     target: {
       tsv: $target_tsv,
-      host_name: $host_name,
+      host_name: $target_host_name,
+      host_id: $target_host_id,
+      vm_id: $target_vm_id,
+      network_id: $target_network_id,
       docker_context: $target_context
     }
   }' >"${summary_json}"

--- a/tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh
+++ b/tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh [--print-plan]
+
+Environment:
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_FALLBACK_NAME default oci-offhost-host-metrics-timeline-fallback-<timestamp>
+  OCI_OFFHOST_HOST_METRICS_RUN_ID                 default same as name
+  OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV          required generator host metrics snapshot TSV
+  OCI_OFFHOST_TARGET_HOST_METRICS_TSV             required target host metrics snapshot TSV
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_REQUIRED_PHASES default arrival16,vu16,burst-matrix
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_OUTPUT_DIR    default build/reports/k6/<name>/offhost-host-metrics-timeline
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${OCI_OFFHOST_HOST_METRICS_TIMELINE_FALLBACK_NAME:-oci-offhost-host-metrics-timeline-fallback-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${OCI_OFFHOST_HOST_METRICS_RUN_ID:-${name}}"
+generator_tsv="${OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV:-}"
+target_tsv="${OCI_OFFHOST_TARGET_HOST_METRICS_TSV:-}"
+required_phases="${OCI_OFFHOST_HOST_METRICS_TIMELINE_REQUIRED_PHASES:-arrival16,vu16,burst-matrix}"
+output_dir="${OCI_OFFHOST_HOST_METRICS_TIMELINE_OUTPUT_DIR:-build/reports/k6/${name}/offhost-host-metrics-timeline}"
+sample_started_at="${OCI_OFFHOST_HOST_METRICS_TIMELINE_SAMPLE_STARTED_AT_UTC:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+sample_ended_at="${OCI_OFFHOST_HOST_METRICS_TIMELINE_SAMPLE_ENDED_AT_UTC:-${sample_started_at}}"
+artifact_pack_uri="${OCI_OFFHOST_HOST_METRICS_TIMELINE_ARTIFACT_PACK_URI:-artifact://offhost-capacity-prerequisite/${name}}"
+fallback_input_tsv="${output_dir}/${name}-host-metrics-timeline.input.tsv"
+timeline_tsv="${output_dir}/${name}-host-metrics-timeline.tsv"
+timeline_json="${output_dir}/${name}-host-metrics-timeline.json"
+report_md="${output_dir}/${name}-host-metrics-timeline.md"
+
+require_file() {
+  local key="$1"
+  local file="$2"
+  if [[ -z "${file}" || ! -s "${file}" ]]; then
+    echo "${key} is required and must be a non-empty file: ${file:-missing}" >&2
+    exit 1
+  fi
+}
+
+print_plan() {
+  echo "[oci-offhost-host-metrics-timeline-fallback] name=${name}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] run_id=${run_id}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] generator_host_metrics_tsv=${generator_tsv:-missing}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] target_host_metrics_tsv=${target_tsv:-missing}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] required_phases=${required_phases}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] artifact_pack_uri=${artifact_pack_uri}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] output_dir=${output_dir}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] fallback_input_tsv=${fallback_input_tsv}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] timeline_tsv=${timeline_tsv}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] timeline_json=${timeline_json}"
+  echo "[oci-offhost-host-metrics-timeline-fallback] report_md=${report_md}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  require_file "OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV" "${generator_tsv}"
+  require_file "OCI_OFFHOST_TARGET_HOST_METRICS_TSV" "${target_tsv}"
+  exit 0
+fi
+
+require_file "OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV" "${generator_tsv}"
+require_file "OCI_OFFHOST_TARGET_HOST_METRICS_TSV" "${target_tsv}"
+
+mkdir -p "${output_dir}"
+
+awk -F '\t' \
+  -v OFS='\t' \
+  -v expected_run_id="${run_id}" \
+  -v required_phases="${required_phases}" \
+  -v sample_started_at="${sample_started_at}" \
+  -v sample_ended_at="${sample_ended_at}" \
+  -v artifact_pack_uri="${artifact_pack_uri}" '
+  function fail(message, code) {
+    print message > "/dev/stderr"
+    exit code
+  }
+  function required_value(name) {
+    value = row[col[name]]
+    if (value == "") fail("missing host metrics fallback field: " name, 2)
+    return value
+  }
+  function optional_value(name, fallback) {
+    if (!(name in col) || row[col[name]] == "") return fallback
+    return row[col[name]]
+  }
+  BEGIN {
+    print "run_id", "phase", "host_role", "host_name", "host_id", "vm_id", "network_id", "docker_context", "sample_started_at_utc", "sample_ended_at_utc", "sample_count", "cpu_pct_avg", "cpu_pct_max", "rx_mbps_avg", "rx_mbps_max", "tx_mbps_avg", "tx_mbps_max", "artifact_uri", "summary_ref", "artifact_pack_uri"
+    split(required_phases, phase_items, ",")
+  }
+  FNR == 1 {
+    delete col
+    for (i = 1; i <= NF; i++) col[$i] = i
+    split("run_id host_role host_name host_id vm_id network_id docker_context cpu_pct rx_mbps tx_mbps artifact_uri", required, " ")
+    for (i in required) {
+      if (!(required[i] in col)) fail("missing required fallback source column: " required[i], 3)
+    }
+    next
+  }
+  {
+    split($0, row, FS)
+    source_run_id = required_value("run_id")
+    role = required_value("host_role")
+    if (source_run_id != expected_run_id) {
+      fail("host metrics fallback run id mismatch: run_id=" source_run_id " expected=" expected_run_id, 4)
+    }
+    if (role != "generator" && role != "target") {
+      fail("host metrics fallback role must be generator or target: " role, 5)
+    }
+    host_name = required_value("host_name")
+    host_id = required_value("host_id")
+    vm_id = required_value("vm_id")
+    network_id = required_value("network_id")
+    docker_context = required_value("docker_context")
+    cpu_pct = required_value("cpu_pct")
+    rx_mbps = required_value("rx_mbps")
+    tx_mbps = required_value("tx_mbps")
+    artifact_uri = required_value("artifact_uri")
+    sample_count = optional_value("sample_count", "1")
+    cpu_pct_max = optional_value("cpu_pct_max", cpu_pct)
+    rx_mbps_max = optional_value("rx_mbps_max", rx_mbps)
+    tx_mbps_max = optional_value("tx_mbps_max", tx_mbps)
+    for (i in phase_items) {
+      phase = phase_items[i]
+      summary_ref = artifact_pack_uri "/" phase "/summary"
+      print expected_run_id, phase, role, host_name, host_id, vm_id, network_id, docker_context, sample_started_at, sample_ended_at, sample_count, cpu_pct, cpu_pct_max, rx_mbps, rx_mbps_max, tx_mbps, tx_mbps_max, artifact_uri "#" phase, summary_ref, artifact_pack_uri
+    }
+  }
+' "${generator_tsv}" "${target_tsv}" >"${fallback_input_tsv}"
+
+OCI_OFFHOST_HOST_METRICS_TIMELINE_NAME="${name}" \
+OCI_OFFHOST_HOST_METRICS_TIMELINE_RUN_ID="${run_id}" \
+OCI_OFFHOST_HOST_METRICS_TIMELINE_INPUT_TSV="${fallback_input_tsv}" \
+OCI_OFFHOST_HOST_METRICS_TIMELINE_REQUIRED_PHASES="${required_phases}" \
+OCI_OFFHOST_HOST_METRICS_TIMELINE_OUTPUT_DIR="${output_dir}" \
+  tools/test/run-oci-offhost-host-metrics-timeline.sh


### PR DESCRIPTION
## 🔗 Related Issue
- close #731

## 🌿 Base Branch
- `main`

## 📝 Summary
- off-host prerequisite no-input run에서 `CAPACITY_K6_HOST_METRICS_TIMELINE_TSV`가 비어 즉시 실패하던 경로를 workflow-generated fallback artifact로 복구합니다.
- snapshot TSV schema를 host identity 필드 포함 형태로 맞춰 host metrics evidence/timeline validator가 같은 schema를 소비하도록 정리했습니다.

## 🛠 Changes
- `run-oci-offhost-host-metrics-snapshot.sh`가 `host_id`, `vm_id`, `network_id`를 포함한 generator/target snapshot TSV와 JSON을 생성합니다.
- `run-oci-offhost-host-metrics-timeline-fallback.sh`를 추가해 snapshot TSV를 `arrival16,vu16,burst-matrix` prerequisite timeline TSV로 변환하고 기존 timeline validator를 재사용합니다.
- `offhost-100m-capacity-prerequisite.yml`에서 input/env/var timeline TSV가 없을 때 fallback timeline artifact를 생성해 `CAPACITY_K6_HOST_METRICS_TIMELINE_TSV`에 연결합니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-offhost-host-metrics-snapshot.sh`
- `bash tools/test/check-oci-offhost-host-metrics-evidence.sh`
- `bash tools/test/check-oci-offhost-host-metrics-timeline.sh`
- `bash tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh`
- `bash tools/test/check-offhost-capacity-env-doctor.sh`
- `bash tools/test/check-offhost-capacity-prerequisite-required-gate.sh`
- `git diff --check`
- `git rev-list --count origin/main..HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: fallback timeline은 prerequisite wiring artifact이며, 실제 load-coupled closure evidence를 대체하지 않습니다. live evidence closure는 별도 OCI run artifact로 계속 확인해야 합니다.
- 롤백 방법: 이 PR의 두 commit을 revert하면 기존 prerequisite env 요구 방식으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
