### PR TITLE
[Perf] transaction read 30m soak live evidence and Hikari alignment

### DIFF
--- a/.github/workflows/transaction-read-30m-soak-live-evidence.yml
+++ b/.github/workflows/transaction-read-30m-soak-live-evidence.yml
@@ -1,0 +1,93 @@
+name: Transaction Read 30m Soak Live Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      evidence_manifest_tsv:
+        description: "OCI evidence manifest TSV path on the self-hosted runner workspace"
+        required: true
+        type: string
+      report_name:
+        description: "Optional evidence report name"
+        required: false
+        type: string
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/transaction-read-30m-soak-live-evidence.yml"
+      - "tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh"
+      - "tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh"
+      - "tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh"
+      - "tools/test/run-transaction-read-oci-evidence-execution-gate.sh"
+      - "tools/test/check-transaction-read-oci-evidence-execution-gate.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: transaction-read-30m-soak-live-evidence-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: 30m Soak Live Evidence Contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Check 30m soak live evidence gate
+        run: bash tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh
+
+      - name: Check 30m soak live evidence workflow
+        run: bash tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
+
+  live-evidence:
+    name: 30m Soak Live Evidence Gate
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, oci-a1-staging]
+    timeout-minutes: 15
+    environment:
+      name: staging
+    env:
+      SOAK_30M_REPORT_NAME: ${{ inputs.report_name || format('transaction-read-30m-soak-live-evidence-{0}', github.run_id) }}
+      SOAK_30M_EVIDENCE_MANIFEST_TSV: ${{ inputs.evidence_manifest_tsv }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run 30m soak live evidence gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${SOAK_30M_REPORT_NAME}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::SOAK_30M_REPORT_NAME must contain only letters, numbers, dot, underscore, or hyphen."
+            exit 1
+          fi
+          if [[ -z "${SOAK_30M_EVIDENCE_MANIFEST_TSV}" || ! -s "${SOAK_30M_EVIDENCE_MANIFEST_TSV}" ]]; then
+            echo "::error::evidence_manifest_tsv is required and must point to a non-empty TSV on the runner."
+            exit 1
+          fi
+
+          report_dir="build/reports/k6/${SOAK_30M_REPORT_NAME}"
+          SOAK_30M_LIVE_NAME="${SOAK_30M_REPORT_NAME}" \
+          SOAK_30M_LIVE_INPUT_TSV="${SOAK_30M_EVIDENCE_MANIFEST_TSV}" \
+          SOAK_30M_LIVE_OUTPUT_DIR="${report_dir}" \
+            tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh
+
+          report_md="${report_dir}/${SOAK_30M_REPORT_NAME}-30m-soak-live-evidence.md"
+          {
+            echo "## Transaction Read 30m Soak Live Evidence"
+            echo
+            cat "${report_md}"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload 30m soak live evidence artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: transaction-read-30m-soak-live-evidence
+          path: build/reports/k6/${{ env.SOAK_30M_REPORT_NAME }}
+          if-no-files-found: error

--- a/back/src/main/resources/application-oci-a1.yml
+++ b/back/src/main/resources/application-oci-a1.yml
@@ -7,8 +7,8 @@ spring:
       # OCI A1 4 OCPU / 24GB 기준: DB connection은 admission floor보다 조금 크게 둔다.
       maximum-pool-size: ${OCI_A1_DB_POOL_MAX_SIZE:8}
       minimum-idle: ${OCI_A1_DB_POOL_MIN_IDLE:1}
-      # OCI idle close와 10m soak 경계 전 connection을 먼저 순환해 validation warning을 줄인다.
-      max-lifetime: ${OCI_A1_DB_MAX_LIFETIME_MS:600000}
+      # OCI NAT/PostgreSQL idle close 전 connection 선순환. 30m soak warning 0 기준.
+      max-lifetime: ${OCI_A1_DB_MAX_LIFETIME_MS:240000}
       keepalive-time: ${OCI_A1_DB_KEEPALIVE_TIME_MS:60000}
       validation-timeout: ${OCI_A1_DB_VALIDATION_TIMEOUT_MS:1000}
   task:

--- a/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
@@ -37,7 +37,7 @@ class OciA1CapacityProfileTest {
                   environment.getProperty("spring.datasource.hikari.minimum-idle", Integer.class))
               .isEqualTo(1);
           assertThat(environment.getProperty("spring.datasource.hikari.max-lifetime", Long.class))
-              .isEqualTo(600_000L);
+              .isEqualTo(240_000L);
           assertThat(environment.getProperty("spring.datasource.hikari.keepalive-time", Long.class))
               .isEqualTo(60_000L);
           assertThat(

--- a/tools/test/check-oci-a1-edge-backend-budget-matrix.sh
+++ b/tools/test/check-oci-a1-edge-backend-budget-matrix.sh
@@ -35,7 +35,7 @@ grep -F "backend_archive_admission_adaptive_max=10" <<<"${plan}" >/dev/null
 grep -F "weighted_vu16_max_429_rate=0.05" <<<"${plan}" >/dev/null
 grep -F "short_burst64_max_429_rate=0.10" <<<"${plan}" >/dev/null
 grep -F "hikari_max=8" <<<"${plan}" >/dev/null
-grep -F "hikari_max_lifetime_ms=600000" <<<"${plan}" >/dev/null
+grep -F "hikari_max_lifetime_ms=240000" <<<"${plan}" >/dev/null
 grep -F "hikari_keepalive_time_ms=60000" <<<"${plan}" >/dev/null
 grep -F "backend_api_keepalive_timeout_seconds=2" <<<"${plan}" >/dev/null
 grep -F "expected_429_source=edge-or-backend-admission" <<<"${plan}" >/dev/null
@@ -66,7 +66,7 @@ grep -F "| backend archive admission adaptive max | 10 |" "${report_md}" >/dev/n
 grep -F "| paced-weighted-vu16 max 429 rate | 0.05 |" "${report_md}" >/dev/null
 grep -F "| short-burst-64 max 429 rate | 0.10 |" "${report_md}" >/dev/null
 grep -F "| Hikari max pool | 8 |" "${report_md}" >/dev/null
-grep -F "| Hikari max lifetime ms | 600000 |" "${report_md}" >/dev/null
+grep -F "| Hikari max lifetime ms | 240000 |" "${report_md}" >/dev/null
 grep -F "| Hikari keepalive time ms | 60000 |" "${report_md}" >/dev/null
 grep -F "| Backend API keepalive timeout seconds | 2 |" "${report_md}" >/dev/null
 grep -F "| expected 429 source | edge-or-backend-admission |" "${report_md}" >/dev/null
@@ -92,7 +92,7 @@ grep -F 'limit_req zone=aquila_bank_transaction_archive_per_ip burst=${NGINX_TRA
 grep -F 'keepalive_timeout ${NGINX_BACKEND_API_KEEPALIVE_TIMEOUT_SECONDS}s;' ops/nginx/nginx.conf >/dev/null
 grep -F 'proxy_next_upstream error timeout http_502;' ops/nginx/nginx.conf >/dev/null
 grep -F 'maximum-pool-size: ${OCI_A1_DB_POOL_MAX_SIZE:8}' back/src/main/resources/application-oci-a1.yml >/dev/null
-grep -F 'max-lifetime: ${OCI_A1_DB_MAX_LIFETIME_MS:600000}' back/src/main/resources/application-oci-a1.yml >/dev/null
+grep -F 'max-lifetime: ${OCI_A1_DB_MAX_LIFETIME_MS:240000}' back/src/main/resources/application-oci-a1.yml >/dev/null
 grep -F 'keepalive-time: ${OCI_A1_DB_KEEPALIVE_TIME_MS:60000}' back/src/main/resources/application-oci-a1.yml >/dev/null
 grep -F 'max: ${OCI_A1_TRANSACTION_READ_ADMISSION_MAX:8}' back/src/main/resources/application-oci-a1.yml >/dev/null
 grep -F 'adaptive-max: ${OCI_A1_TRANSACTION_READ_ADMISSION_ADAPTIVE_MAX:12}' back/src/main/resources/application-oci-a1.yml >/dev/null

--- a/tools/test/check-transaction-read-10m-soak-slo-gate.sh
+++ b/tools/test/check-transaction-read-10m-soak-slo-gate.sh
@@ -98,7 +98,7 @@ if SOAK_10M_GATE_NAME=soak-fail \
 fi
 
 echo "[transaction-read-10m-soak] Hikari profile contract"
-grep -F 'max-lifetime: ${OCI_A1_DB_MAX_LIFETIME_MS:600000}' back/src/main/resources/application-oci-a1.yml >/dev/null
+grep -F 'max-lifetime: ${OCI_A1_DB_MAX_LIFETIME_MS:240000}' back/src/main/resources/application-oci-a1.yml >/dev/null
 grep -F 'keepalive-time: ${OCI_A1_DB_KEEPALIVE_TIME_MS:60000}' back/src/main/resources/application-oci-a1.yml >/dev/null
 grep -F 'validation-timeout: ${OCI_A1_DB_VALIDATION_TIMEOUT_MS:1000}' back/src/main/resources/application-oci-a1.yml >/dev/null
 

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh"
+
+echo "[transaction-read-30m-soak-live-evidence] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+input_tsv="${temp_dir}/30m-soak-live.tsv"
+output_dir="${temp_dir}/output"
+artifact_dir="${temp_dir}/artifacts"
+mkdir -p "${artifact_dir}"
+
+touch \
+  "${artifact_dir}/k6.json" \
+  "${artifact_dir}/nginx.jsonl" \
+  "${artifact_dir}/spring.json" \
+  "${artifact_dir}/hikari.log" \
+  "${artifact_dir}/postgres-wait.tsv" \
+  "${artifact_dir}/timeline.json" \
+  "${artifact_dir}/checkpoint.tsv" \
+  "${artifact_dir}/temp-files.tsv" \
+  "${artifact_dir}/nginx-upstream.tsv" \
+  "${artifact_dir}/hikari-config.tsv" \
+  "${artifact_dir}/hikari-zero-warning.md"
+
+cat >"${input_tsv}" <<TSV
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref
+hikari-lifetime	run-soak-live-001	2026-05-04T07:30:00Z	30	1	tools/test/run-transaction-read-weighted-10m-soak-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres-wait.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.01	0	0	0	0	0	0	420	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	82	210	610	0	0	14.1	${artifact_dir}/hikari-config.tsv	240000	60000	300000	350000	${artifact_dir}/hikari-zero-warning.md	n/a	0	n/a
+p999-long-correlation	run-soak-live-001	2026-05-04T07:30:00Z	30	1	tools/test/run-transaction-read-p999-spike-attribution.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres-wait.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.06	0	0	0	0	0	0	490	${artifact_dir}/checkpoint.tsv	${artifact_dir}/temp-files.tsv	${artifact_dir}/nginx-upstream.tsv	n/a	n/a	n/a	0	n/a	0	n/a	95	220	650	3	0	18.5	n/a	0	0	0	0	n/a	n/a	0	n/a
+TSV
+
+echo "[transaction-read-30m-soak-live-evidence] print plan"
+plan="$(
+  SOAK_30M_LIVE_NAME=soak-live-check \
+  SOAK_30M_LIVE_INPUT_TSV="${input_tsv}" \
+  SOAK_30M_LIVE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" --print-plan
+)"
+grep -F "name=soak-live-check" <<<"${plan}" >/dev/null
+grep -F "required_scenarios=hikari-lifetime,p999-long-correlation" <<<"${plan}" >/dev/null
+grep -F "min_duration_min=30" <<<"${plan}" >/dev/null
+grep -F "require_shared_run_id=true" <<<"${plan}" >/dev/null
+grep -F "latency_percentiles=p95,p99,p99.9,max" <<<"${plan}" >/dev/null
+grep -F "required_artifacts=hikari_log,postgres_wait,postgres_checkpoint,postgres_temp_file,nginx_upstream_latency,hikari_config,hikari_zero_warning_soak" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-30m-soak-live-evidence] pass report"
+output="$(
+  SOAK_30M_LIVE_NAME=soak-live-check \
+  SOAK_30M_LIVE_INPUT_TSV="${input_tsv}" \
+  SOAK_30M_LIVE_OUTPUT_DIR="${output_dir}" \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+summary_tsv="${output_dir}/soak-live-check-30m-soak-live-evidence.tsv"
+test "${report_md}" = "${output_dir}/soak-live-check-30m-soak-live-evidence.md"
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "shared run id: run-soak-live-001" "${report_md}" >/dev/null
+grep -F "latency percentiles: p95/p99/p99.9/max" "${report_md}" >/dev/null
+grep -F "Hikari pending: 0" "${report_md}" >/dev/null
+grep -F "Hikari validation warnings: 0" "${report_md}" >/dev/null
+grep -F "PostgreSQL wait/checkpoint/temp file artifacts: verified" "${report_md}" >/dev/null
+grep -F "Nginx upstream latency artifact: verified" "${report_md}" >/dev/null
+grep -F "Hikari lifetime alignment: verified" "${report_md}" >/dev/null
+grep -F $'run-soak-live-001\tpass\tok\t30\t30\t95\t220\t490\t650\t0\t0' "${summary_tsv}" >/dev/null
+
+echo "[transaction-read-30m-soak-live-evidence] shared run id mismatch fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long-correlation" { $2 = "run-soak-live-002" } { print }' \
+  "${input_tsv}" >"${input_tsv}.run-id-fail"
+if SOAK_30M_LIVE_NAME=soak-live-run-id-fail \
+  SOAK_30M_LIVE_INPUT_TSV="${input_tsv}.run-id-fail" \
+  SOAK_30M_LIVE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "30m soak live evidence unexpectedly passed split run ids" >&2
+  exit 1
+fi
+
+echo "[transaction-read-30m-soak-live-evidence] temp file artifact fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long-correlation" { $24 = "n/a" } { print }' \
+  "${input_tsv}" >"${input_tsv}.temp-file-fail"
+if SOAK_30M_LIVE_NAME=soak-live-temp-fail \
+  SOAK_30M_LIVE_INPUT_TSV="${input_tsv}.temp-file-fail" \
+  SOAK_30M_LIVE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "30m soak live evidence unexpectedly passed missing temp file artifact" >&2
+  exit 1
+fi
+
+echo "[transaction-read-30m-soak-live-evidence] Hikari warning fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "hikari-lifetime" { $20 = 1 } { print }' \
+  "${input_tsv}" >"${input_tsv}.hikari-warning-fail"
+if SOAK_30M_LIVE_NAME=soak-live-hikari-warning-fail \
+  SOAK_30M_LIVE_INPUT_TSV="${input_tsv}.hikari-warning-fail" \
+  SOAK_30M_LIVE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "30m soak live evidence unexpectedly passed Hikari validation warning" >&2
+  exit 1
+fi
+
+echo "[transaction-read-30m-soak-live-evidence] Hikari lifetime alignment fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "hikari-lifetime" { $40 = 360000 } { print }' \
+  "${input_tsv}" >"${input_tsv}.hikari-lifetime-fail"
+if SOAK_30M_LIVE_NAME=soak-live-hikari-lifetime-fail \
+  SOAK_30M_LIVE_INPUT_TSV="${input_tsv}.hikari-lifetime-fail" \
+  SOAK_30M_LIVE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "30m soak live evidence unexpectedly passed invalid Hikari lifetime alignment" >&2
+  exit 1
+fi
+
+echo "[transaction-read-30m-soak-live-evidence] p99.9 budget fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long-correlation" { $22 = 550 } { print }' \
+  "${input_tsv}" >"${input_tsv}.p999-fail"
+if SOAK_30M_LIVE_NAME=soak-live-p999-fail \
+  SOAK_30M_LIVE_INPUT_TSV="${input_tsv}.p999-fail" \
+  SOAK_30M_LIVE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "30m soak live evidence unexpectedly passed p99.9 budget violation" >&2
+  exit 1
+fi

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/transaction-read-30m-soak-live-evidence.yml"
+
+echo "[transaction-read-30m-soak-live-evidence-workflow] workflow exists"
+test -f "${workflow}"
+
+echo "[transaction-read-30m-soak-live-evidence-workflow] workflow contract"
+grep -F "name: Transaction Read 30m Soak Live Evidence" "${workflow}" >/dev/null
+grep -F "workflow_dispatch:" "${workflow}" >/dev/null
+grep -F "pull_request:" "${workflow}" >/dev/null
+dispatch_input_count="$(awk '
+  /^  workflow_dispatch:/ { in_dispatch = 1; next }
+  in_dispatch && /^    inputs:/ { in_inputs = 1; next }
+  in_inputs && /^  [A-Za-z_]/ { exit }
+  in_inputs && /^      [A-Za-z0-9_]+:/ { count++ }
+  END { print count + 0 }
+' "${workflow}")"
+if [[ "${dispatch_input_count}" -gt 25 ]]; then
+  echo "workflow_dispatch inputs must be 25 or fewer, got ${dispatch_input_count}" >&2
+  exit 1
+fi
+
+grep -F "evidence_manifest_tsv:" "${workflow}" >/dev/null
+grep -F 'description: "OCI evidence manifest TSV path on the self-hosted runner workspace"' "${workflow}" >/dev/null
+grep -F "report_name:" "${workflow}" >/dev/null
+grep -F "30m Soak Live Evidence Contract" "${workflow}" >/dev/null
+grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-transaction-read-oci-evidence-execution-gate.sh" "${workflow}" >/dev/null
+grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
+grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
+grep -F "environment:" "${workflow}" >/dev/null
+grep -F "name: staging" "${workflow}" >/dev/null
+grep -F 'SOAK_30M_REPORT_NAME: ${{ inputs.report_name || format(' "${workflow}" >/dev/null
+grep -F 'SOAK_30M_EVIDENCE_MANIFEST_TSV: ${{ inputs.evidence_manifest_tsv }}' "${workflow}" >/dev/null
+grep -F "Run 30m soak live evidence gate" "${workflow}" >/dev/null
+grep -F 'SOAK_30M_LIVE_NAME="${SOAK_30M_REPORT_NAME}"' "${workflow}" >/dev/null
+grep -F 'SOAK_30M_LIVE_INPUT_TSV="${SOAK_30M_EVIDENCE_MANIFEST_TSV}"' "${workflow}" >/dev/null
+grep -F 'SOAK_30M_LIVE_OUTPUT_DIR="${report_dir}"' "${workflow}" >/dev/null
+grep -F "tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh" "${workflow}" >/dev/null
+grep -F 'cat "${report_md}"' "${workflow}" >/dev/null
+grep -F "actions/upload-artifact@v7" "${workflow}" >/dev/null
+grep -F "transaction-read-30m-soak-live-evidence" "${workflow}" >/dev/null
+grep -F "if-no-files-found: error" "${workflow}" >/dev/null
+
+gate_line="$(grep -n "Run 30m soak live evidence gate" "${workflow}" | head -1 | cut -d: -f1)"
+upload_line="$(grep -n "Upload 30m soak live evidence artifact" "${workflow}" | head -1 | cut -d: -f1)"
+if [[ -z "${gate_line}" || -z "${upload_line}" || "${gate_line}" -ge "${upload_line}" ]]; then
+  echo "30m live evidence gate must run before artifact upload" >&2
+  exit 1
+fi
+
+if grep -F "fallback" "${workflow}" >/dev/null; then
+  echo "30m live evidence workflow must not accept fallback/snapshot evidence" >&2
+  exit 1
+fi
+if grep -F "secrets." "${workflow}" >/dev/null; then
+  echo "30m live evidence workflow must not require secrets; it validates artifact refs only" >&2
+  exit 1
+fi

--- a/tools/test/run-oci-a1-edge-backend-budget-matrix.sh
+++ b/tools/test/run-oci-a1-edge-backend-budget-matrix.sh
@@ -56,7 +56,7 @@ backend_archive_admission_adaptive_max=10
 weighted_vu16_max_429_rate=0.05
 short_burst64_max_429_rate=0.10
 hikari_max=8
-hikari_max_lifetime_ms=600000
+hikari_max_lifetime_ms=240000
 hikari_keepalive_time_ms=60000
 backend_api_keepalive_timeout_seconds=2
 expected_429_source="edge-or-backend-admission"
@@ -141,7 +141,7 @@ require_pattern 'OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_HOT_ADAPTIVE_MAX=${O
 require_pattern 'OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ARCHIVE_MAX=${OCI_A1_TRANSACTION_READ_ARCHIVE_ADMISSION_MAX:-6}' "${deploy_script}"
 require_pattern 'OPS_API_ADMISSION_CONTROL_TRANSACTION_READ_ARCHIVE_ADAPTIVE_MAX=${OCI_A1_TRANSACTION_READ_ARCHIVE_ADMISSION_ADAPTIVE_MAX:-10}' "${deploy_script}"
 require_pattern 'maximum-pool-size: ${OCI_A1_DB_POOL_MAX_SIZE:8}' "${oci_profile}"
-require_pattern 'max-lifetime: ${OCI_A1_DB_MAX_LIFETIME_MS:600000}' "${oci_profile}"
+require_pattern 'max-lifetime: ${OCI_A1_DB_MAX_LIFETIME_MS:240000}' "${oci_profile}"
 require_pattern 'keepalive-time: ${OCI_A1_DB_KEEPALIVE_TIME_MS:60000}' "${oci_profile}"
 require_pattern 'max: ${OCI_A1_TRANSACTION_READ_ADMISSION_MAX:8}' "${oci_profile}"
 require_pattern 'adaptive-max: ${OCI_A1_TRANSACTION_READ_ADMISSION_ADAPTIVE_MAX:12}' "${oci_profile}"

--- a/tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh
+++ b/tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh [--print-plan]
+
+Environment:
+  SOAK_30M_LIVE_NAME        default transaction-read-30m-soak-live-evidence-<timestamp>
+  SOAK_30M_LIVE_INPUT_TSV   required OCI evidence manifest with hikari-lifetime and p999-long-correlation rows
+  SOAK_30M_LIVE_OUTPUT_DIR  default build/reports/k6/<name>
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${SOAK_30M_LIVE_NAME:-transaction-read-30m-soak-live-evidence-$(date +%Y-%m-%d-%H%M%S)}"
+input_tsv="${SOAK_30M_LIVE_INPUT_TSV:-}"
+output_dir="${SOAK_30M_LIVE_OUTPUT_DIR:-build/reports/k6/${name}}"
+execution_gate="tools/test/run-transaction-read-oci-evidence-execution-gate.sh"
+execution_summary_tsv="${output_dir}/${name}-oci-evidence-execution.tsv"
+summary_tsv="${output_dir}/${name}-30m-soak-live-evidence.tsv"
+report_md="${output_dir}/${name}-30m-soak-live-evidence.md"
+
+require_file() {
+  local key="$1"
+  local file="$2"
+  if [[ -z "${file}" || ! -s "${file}" ]]; then
+    echo "${key} is required and must be a non-empty file: ${file:-missing}" >&2
+    exit 1
+  fi
+}
+
+print_plan() {
+  echo "[transaction-read-30m-soak-live-evidence] name=${name}"
+  echo "[transaction-read-30m-soak-live-evidence] input_tsv=${input_tsv:-missing}"
+  echo "[transaction-read-30m-soak-live-evidence] output_dir=${output_dir}"
+  echo "[transaction-read-30m-soak-live-evidence] required_scenarios=hikari-lifetime,p999-long-correlation"
+  echo "[transaction-read-30m-soak-live-evidence] min_duration_min=30"
+  echo "[transaction-read-30m-soak-live-evidence] require_shared_run_id=true"
+  echo "[transaction-read-30m-soak-live-evidence] latency_percentiles=p95,p99,p99.9,max"
+  echo "[transaction-read-30m-soak-live-evidence] required_artifacts=hikari_log,postgres_wait,postgres_checkpoint,postgres_temp_file,nginx_upstream_latency,hikari_config,hikari_zero_warning_soak"
+  echo "[transaction-read-30m-soak-live-evidence] execution_gate=${execution_gate}"
+  echo "[transaction-read-30m-soak-live-evidence] report_md=${report_md}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  require_file "SOAK_30M_LIVE_INPUT_TSV" "${input_tsv}"
+  exit 0
+fi
+
+require_file "SOAK_30M_LIVE_INPUT_TSV" "${input_tsv}"
+mkdir -p "${output_dir}"
+
+gate_output="$(
+  OCI_EVIDENCE_EXECUTION_NAME="${name}" \
+  OCI_EVIDENCE_EXECUTION_INPUT_TSV="${input_tsv}" \
+  OCI_EVIDENCE_EXECUTION_OUTPUT_DIR="${output_dir}" \
+  OCI_EVIDENCE_EXECUTION_REQUIRED_SCENARIOS=hikari-lifetime,p999-long-correlation \
+  OCI_EVIDENCE_EXECUTION_HIKARI_MIN_DURATION_MIN=30 \
+  OCI_EVIDENCE_EXECUTION_P999_MIN_DURATION_MIN=30 \
+  OCI_EVIDENCE_EXECUTION_MAX_POOL_PENDING=0 \
+    "${execution_gate}"
+)"
+execution_report="$(tail -1 <<<"${gate_output}")"
+
+awk -F '\t' '
+BEGIN {
+  print "run_id\tstatus\treason\thikari_duration_min\tp999_duration_min\tp95_ms\tp99_ms\tp999_ms\tmax_ms\thikari_pending_max\thikari_validation_warnings\tpostgres_wait_ref\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref"
+}
+NR == 1 { next }
+$1 == "hikari-lifetime" {
+  hikari_seen = 1
+  hikari_run_id = $4
+  hikari_duration = $5
+  hikari_pending = $22
+  hikari_warnings = $21
+  hikari_postgres_wait_ref = $12
+  hikari_config_ref = $30
+  hikari_max_lifetime = $31
+  hikari_keepalive = $32
+  postgres_idle = $33
+  oci_nat = $34
+  hikari_zero_warning = $35
+}
+$1 == "p999-long-correlation" {
+  p999_seen = 1
+  p999_run_id = $4
+  p999_duration = $5
+  p95 = $24
+  p99 = $25
+  p999 = $23
+  max = $26
+  p999_pending = $22
+  p999_warnings = $21
+  p999_postgres_wait_ref = $12
+  checkpoint_count = $27
+  temp_file_count = $28
+  upstream_p95 = $29
+}
+END {
+  status = "pass"
+  reason = "ok"
+  if (!hikari_seen) { status = "fail"; reason = "hikari-lifetime-missing" }
+  if (!p999_seen) { status = "fail"; reason = (reason == "ok" ? "p999-long-correlation-missing" : reason ",p999-long-correlation-missing") }
+  if (hikari_seen && p999_seen && hikari_run_id != p999_run_id) {
+    status = "fail"
+    reason = (reason == "ok" ? "run-id-mismatch" : reason ",run-id-mismatch")
+  }
+  pending = hikari_pending
+  if (p999_pending > pending) pending = p999_pending
+  warnings = hikari_warnings
+  if (p999_warnings > warnings) warnings = p999_warnings
+  postgres_wait_ref = (hikari_postgres_wait_ref != "" ? hikari_postgres_wait_ref : p999_postgres_wait_ref)
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    hikari_run_id, status, reason, hikari_duration, p999_duration, p95, p99, p999, max,
+    pending, warnings, postgres_wait_ref, checkpoint_count, temp_file_count, upstream_p95,
+    hikari_config_ref, hikari_max_lifetime, hikari_keepalive, postgres_idle, oci_nat, hikari_zero_warning
+  if (status == "fail") exit 2
+}
+' "${execution_summary_tsv}" >"${summary_tsv}"
+
+gate_status="$(awk -F '\t' 'NR == 2 { print $2 }' "${summary_tsv}")"
+run_id="$(awk -F '\t' 'NR == 2 { print $1 }' "${summary_tsv}")"
+hikari_pending="$(awk -F '\t' 'NR == 2 { print $10 }' "${summary_tsv}")"
+hikari_warnings="$(awk -F '\t' 'NR == 2 { print $11 }' "${summary_tsv}")"
+hikari_max_lifetime="$(awk -F '\t' 'NR == 2 { print $17 }' "${summary_tsv}")"
+hikari_keepalive="$(awk -F '\t' 'NR == 2 { print $18 }' "${summary_tsv}")"
+postgres_idle="$(awk -F '\t' 'NR == 2 { print $19 }' "${summary_tsv}")"
+oci_nat="$(awk -F '\t' 'NR == 2 { print $20 }' "${summary_tsv}")"
+
+cat >"${report_md}" <<REPORT
+# Transaction Read 30m Soak Live Evidence Gate
+
+## Summary
+
+- gate_status=${gate_status}
+- shared run id: ${run_id}
+- minimum duration: 30m
+- latency percentiles: p95/p99/p99.9/max
+- Hikari pending: ${hikari_pending}
+- Hikari validation warnings: ${hikari_warnings}
+- PostgreSQL wait/checkpoint/temp file artifacts: verified
+- Nginx upstream latency artifact: verified
+- Hikari lifetime alignment: verified
+- Hikari maxLifetime/keepaliveTime: ${hikari_max_lifetime}ms/${hikari_keepalive}ms
+- PostgreSQL/NAT idle basis: ${postgres_idle}ms/${oci_nat}ms
+- execution gate report: ${execution_report}
+
+## Contract Notes
+
+- 30m soak live evidence는 Hikari lifetime row와 p99.9 long correlation row가 같은 run id일 때만 인정한다.
+- p99.9 long correlation은 p95, p99, p99.9, max와 PostgreSQL checkpoint/temp file, Nginx upstream latency를 요구한다.
+- Hikari lifetime은 config ref, zero-warning soak ref, PostgreSQL/NAT timeout basis를 요구한다.
+- Hikari pending, Hikari validation warning, 5xx, 499, unknown 429는 execution gate에서 hard-zero로 검증한다.
+
+## Artifacts
+
+- input TSV: ${input_tsv}
+- execution report: ${execution_report}
+- execution summary TSV: ${execution_summary_tsv}
+- live evidence summary TSV: ${summary_tsv}
+REPORT
+
+echo "${report_md}"
+
+if [[ "${gate_status}" == "fail" ]]; then
+  echo "transaction read 30m soak live evidence gate failed: ${summary_tsv}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #737
- relates #679

## 🌿 Base Branch
- `main`

## 📝 Summary
- 30분 transaction read live soak evidence가 `hikari-lifetime`과 `p999-long-correlation`을 같은 run id로 묶도록 gate를 추가했습니다.
- OCI A1 Hikari 기본 `max-lifetime`을 240000ms로 낮춰 기존 30m zero-warning alignment gate와 profile 기본값을 맞췄습니다.
- self-hosted OCI A1 staging에서 evidence manifest TSV를 검증하는 workflow_dispatch live gate를 추가했습니다.

## 🛠 Changes
- `tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh` 및 check 추가
- `application-oci-a1.yml` Hikari `max-lifetime` 기본값 600000ms -> 240000ms
- OCI A1 budget/10m soak/backend profile 테스트 기대값 정렬
- `.github/workflows/transaction-read-30m-soak-live-evidence.yml` 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh`
- `bash tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh`
- `bash tools/test/check-hikari-idle-in-transaction-attribution.sh`
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-transaction-read-oci-evidence-orchestrator.sh`
- `bash tools/test/check-oci-a1-edge-backend-budget-matrix.sh`
- `bash tools/test/check-transaction-read-10m-soak-slo-gate.sh`
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh`
- `./back/gradlew -p back test --tests com.aquilabank.global.config.OciA1CapacityProfileTest`
- `git diff --check`
- `git rev-list --count origin/main..HEAD` -> `3`

전체 `./back/gradlew -p back check`는 pre-commit에서 실행됐지만 로컬 integration test 환경 문제로 실패했습니다. 실패 원인은 localhost PostgreSQL 연결 거부와 Testcontainers image not found이며, 이 PR 변경 범위와 직접 연결된 `OciA1CapacityProfileTest`는 별도 실행으로 통과했습니다.

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Hikari connection 순환이 기존보다 빨라져 장기 idle connection 유지가 줄어듭니다. OCI A1 작은 리소스 환경에서는 validation warning 재발 방어 목적입니다.
- 롤백 방법: 이 PR revert 후 `OCI_A1_DB_MAX_LIFETIME_MS` 운영 env override로 이전 값을 복구합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
