### PR TITLE
[Fix] OCI k6 service-auth 429 source gate summary path

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -515,7 +515,7 @@ jobs:
           set -euo pipefail
           report_dir="build/reports/k6/${K6_REPORT_NAME}"
           mkdir -p "${report_dir}"
-          summary_json="${report_dir}/${K6_REPORT_NAME}-summary.json"
+          summary_json="build/reports/k6/${K6_REPORT_NAME}-summary.json"
           aggregate_tsv="${report_dir}/transaction-read-nginx-access-aggregate/${K6_REPORT_NAME}-nginx-access-aggregate.tsv"
           if [[ -z "${summary_json}" || ! -s "${summary_json}" ]]; then
             echo "::error::k6 summary JSON is missing or empty; transaction-read-429-source artifact required."

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -118,7 +118,11 @@ grep -F 'NGINX_ACCESS_AGGREGATE_RUN_ID="${K6_RUN_ID}"' "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
 grep -F "Build transaction read 429 source gate artifact" "${workflow}" >/dev/null
-grep -F 'summary_json="${report_dir}/${K6_REPORT_NAME}-summary.json"' "${workflow}" >/dev/null
+grep -F 'summary_json="build/reports/k6/${K6_REPORT_NAME}-summary.json"' "${workflow}" >/dev/null
+if grep -F 'summary_json="${report_dir}/${K6_REPORT_NAME}-summary.json"' "${workflow}" >/dev/null; then
+  echo "429 source gate must use the root k6 summary JSON, not the nested report dir path" >&2
+  exit 1
+fi
 grep -F 'aggregate_tsv="${report_dir}/transaction-read-nginx-access-aggregate/${K6_REPORT_NAME}-nginx-access-aggregate.tsv"' "${workflow}" >/dev/null
 grep -F 'total_fail_rate="${K6_BURST_429_RATE_THRESHOLD}"' "${workflow}" >/dev/null
 grep -F 'edge_fail_rate="${K6_BURST_429_RATE_THRESHOLD}"' "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #739

## 🌿 Base Branch
- `main`

## 📝 Summary
- service-auth workflow의 `transaction-read-429-source` step이 잘못된 nested summary JSON 경로를 참조하던 문제를 수정했습니다.
- k6 runner가 실제로 수집하는 root `build/reports/k6/${K6_REPORT_NAME}-summary.json`를 source gate 입력으로 사용합니다.

## 🛠 Changes
- `.github/workflows/oci-k6-service-auth-token.yml`의 source gate summary path 수정
- workflow contract check에 root summary path 요구와 nested path 회귀 방지 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/check-transaction-read-429-source-gate.sh`
- `git diff --check`
- `git rev-list --count origin/main..HEAD` -> `1`

CI failure 참고:
- latest main `8dadf463`의 service-auth workflow_dispatch run `25307859502`, `25307858873`
- 실패 step: `Build transaction read 429 source gate artifact`
- 실패 메시지: `k6 summary JSON is missing or empty`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: source gate가 참조하는 summary 위치만 변경하므로 runtime traffic 영향은 없습니다.
- 롤백 방법: 이 PR revert 후 기존 nested summary path로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
