### PR TITLE
[Perf] Off-host load-coupled timeline wiring

### DIFF
--- a/.github/workflows/offhost-100m-capacity-prerequisite.yml
+++ b/.github/workflows/offhost-100m-capacity-prerequisite.yml
@@ -71,6 +71,8 @@ on:
       - "tools/test/check-oci-offhost-host-metrics-evidence.sh"
       - "tools/test/run-oci-offhost-host-metrics-timeline.sh"
       - "tools/test/check-oci-offhost-host-metrics-timeline.sh"
+      - "tools/test/run-oci-offhost-host-metrics-load-coupled-timeline.sh"
+      - "tools/test/check-oci-offhost-host-metrics-load-coupled-timeline.sh"
       - "tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh"
       - "tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh"
       - "tools/test/run-oci-offhost-host-metrics-snapshot.sh"
@@ -96,6 +98,9 @@ jobs:
       - name: Check off-host host metrics timeline
         run: tools/test/check-oci-offhost-host-metrics-timeline.sh
 
+      - name: Check off-host host metrics load-coupled timeline
+        run: tools/test/check-oci-offhost-host-metrics-load-coupled-timeline.sh
+
       - name: Check off-host host metrics timeline fallback
         run: tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh
 
@@ -103,7 +108,7 @@ jobs:
     name: required off-host capacity env
     if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, oci-a1-staging]
-    timeout-minutes: 10
+    timeout-minutes: 120
     environment:
       name: staging
     steps:
@@ -183,6 +188,15 @@ jobs:
           CAPACITY_K6_HOST_METRICS_RUN_ID="${HOST_METRICS_RUN_ID_INPUT:-${CAPACITY_K6_HOST_METRICS_RUN_ID:-${CAPACITY_NAME}}}"
           CAPACITY_K6_GENERATOR_HOST_METRICS_TSV="${GENERATOR_HOST_METRICS_TSV_INPUT:-${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV:-${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV_VAR:-${CAPACITY_K6_HOST_METRICS_TSV}}}}"
           CAPACITY_K6_TARGET_HOST_METRICS_TSV="${TARGET_HOST_METRICS_TSV_INPUT:-${CAPACITY_K6_TARGET_HOST_METRICS_TSV:-${CAPACITY_K6_TARGET_HOST_METRICS_TSV_VAR:-}}}"
+          CAPACITY_K6_HOST_METRICS_TIMELINE_SAMPLE_INTERVAL_SECONDS="${CAPACITY_K6_HOST_METRICS_TIMELINE_SAMPLE_INTERVAL_SECONDS:-5}"
+          CAPACITY_K6_TIMELINE_PHASE_DURATION="${CAPACITY_K6_TIMELINE_PHASE_DURATION:-1m}"
+          CAPACITY_K6_TIMELINE_BURST_RATES="${CAPACITY_K6_TIMELINE_BURST_RATES:-32,48,64,80,96}"
+          CAPACITY_K6_HOT_ACCOUNT_ID="${CAPACITY_K6_HOT_ACCOUNT_ID:-${K6_HOT_ACCOUNT_ID:-910000001}}"
+          CAPACITY_K6_HOT_FROM="${CAPACITY_K6_HOT_FROM:-${K6_HOT_FROM:-2026-04-01T00:00:00Z}}"
+          CAPACITY_K6_HOT_TO="${CAPACITY_K6_HOT_TO:-${K6_HOT_TO:-2026-04-30T00:00:00Z}}"
+          CAPACITY_K6_COLD_ACCOUNT_ID="${CAPACITY_K6_COLD_ACCOUNT_ID:-${K6_COLD_ACCOUNT_ID:-910000002}}"
+          CAPACITY_K6_COLD_FROM="${CAPACITY_K6_COLD_FROM:-${K6_COLD_FROM:-2026-01-01T00:00:00Z}}"
+          CAPACITY_K6_COLD_TO="${CAPACITY_K6_COLD_TO:-${K6_COLD_TO:-2026-01-31T00:00:00Z}}"
           host_metrics_snapshot_dir="${report_dir}/offhost-host-metrics-snapshot"
           snapshot_generator_tsv="${host_metrics_snapshot_dir}/${CAPACITY_NAME}-generator-host-metrics.tsv"
           snapshot_target_tsv="${host_metrics_snapshot_dir}/${CAPACITY_NAME}-target-host-metrics.tsv"
@@ -211,13 +225,140 @@ jobs:
               ;;
           esac
           if [[ -z "${CAPACITY_K6_HOST_METRICS_TIMELINE_TSV}" && "${CAPACITY_REQUIRE_LOAD_COUPLED_TIMELINE}" == "true" ]]; then
-            {
-              echo "CAPACITY_PREREQUISITE_STATUS=failed"
-              echo "CAPACITY_PREREQUISITE_FAILURE_REASON=missing-load-coupled-host-metrics-timeline"
-              echo "CAPACITY_PREREQUISITE_MISSING=CAPACITY_K6_HOST_METRICS_TIMELINE_TSV"
-            } >"${CAPACITY_PREREQUISITE_FAILURE_REPORT_PATH}"
-            echo "::error::CAPACITY_K6_HOST_METRICS_TIMELINE_TSV is required when load-coupled timeline evidence is required."
-            exit 1
+            mkdir -p "${host_metrics_timeline_dir}"
+            arrival16_command='
+              K6_REPORT_NAME="${CAPACITY_NAME}-arrival16" \
+              K6_RUN_ID="${CAPACITY_NAME}-arrival16" \
+              K6_RUN_PURPOSE=capacity \
+              K6_OBSERVABILITY_MODE=prometheus \
+              K6_GENERATOR_MODE=docker-context \
+              K6_DOCKER_CONTEXT="${CAPACITY_K6_DOCKER_CONTEXT}" \
+              K6_REMOTE_BASE_URL="${CAPACITY_K6_REMOTE_BASE_URL}" \
+              K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" \
+              K6_REMOTE_WORKDIR="${CAPACITY_K6_REMOTE_WORKDIR}" \
+              K6_REMOTE_PREFLIGHT=true \
+              K6_AUTH_TOKEN_ENV_NAME=STAGING_REPLAY_TOKEN \
+              K6_AUTH_TOKEN_REQUIRED=true \
+              K6_AUTH_PREFLIGHT=true \
+              K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${CAPACITY_K6_HOT_ACCOUNT_ID}&from=${CAPACITY_K6_HOT_FROM}&to=${CAPACITY_K6_HOT_TO}&limit=1" \
+              K6_AUTH_PREFLIGHT_EXPECTED_STATUS=200 \
+              K6_HOT_ACCOUNT_ID="${CAPACITY_K6_HOT_ACCOUNT_ID}" \
+              K6_HOT_FROM="${CAPACITY_K6_HOT_FROM}" \
+              K6_HOT_TO="${CAPACITY_K6_HOT_TO}" \
+              K6_COLD_ACCOUNT_ID="${CAPACITY_K6_COLD_ACCOUNT_ID}" \
+              K6_COLD_FROM="${CAPACITY_K6_COLD_FROM}" \
+              K6_COLD_TO="${CAPACITY_K6_COLD_TO}" \
+              K6_SCENARIO_MODE=constant-arrival-rate \
+              K6_RATE=16 \
+              K6_TIME_UNIT=1s \
+              K6_VUS=8 \
+              K6_PRE_ALLOCATED_VUS=16 \
+              K6_MAX_VUS=32 \
+              K6_DURATION="${CAPACITY_K6_TIMELINE_PHASE_DURATION}" \
+              K6_ARCHIVE_RESULTS=false \
+                tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps
+            '
+            vu16_command='
+              K6_REPORT_NAME="${CAPACITY_NAME}-vu16" \
+              K6_RUN_ID="${CAPACITY_NAME}-vu16" \
+              K6_RUN_PURPOSE=capacity \
+              K6_OBSERVABILITY_MODE=prometheus \
+              K6_GENERATOR_MODE=docker-context \
+              K6_DOCKER_CONTEXT="${CAPACITY_K6_DOCKER_CONTEXT}" \
+              K6_REMOTE_BASE_URL="${CAPACITY_K6_REMOTE_BASE_URL}" \
+              K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" \
+              K6_REMOTE_WORKDIR="${CAPACITY_K6_REMOTE_WORKDIR}" \
+              K6_REMOTE_PREFLIGHT=true \
+              K6_AUTH_TOKEN_ENV_NAME=STAGING_REPLAY_TOKEN \
+              K6_AUTH_TOKEN_REQUIRED=true \
+              K6_AUTH_PREFLIGHT=true \
+              K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${CAPACITY_K6_HOT_ACCOUNT_ID}&from=${CAPACITY_K6_HOT_FROM}&to=${CAPACITY_K6_HOT_TO}&limit=1" \
+              K6_AUTH_PREFLIGHT_EXPECTED_STATUS=200 \
+              K6_HOT_ACCOUNT_ID="${CAPACITY_K6_HOT_ACCOUNT_ID}" \
+              K6_HOT_FROM="${CAPACITY_K6_HOT_FROM}" \
+              K6_HOT_TO="${CAPACITY_K6_HOT_TO}" \
+              K6_COLD_ACCOUNT_ID="${CAPACITY_K6_COLD_ACCOUNT_ID}" \
+              K6_COLD_FROM="${CAPACITY_K6_COLD_FROM}" \
+              K6_COLD_TO="${CAPACITY_K6_COLD_TO}" \
+              K6_SCENARIO_MODE=constant-vus \
+              K6_VUS=16 \
+              K6_PRE_ALLOCATED_VUS=16 \
+              K6_MAX_VUS=16 \
+              K6_DURATION="${CAPACITY_K6_TIMELINE_PHASE_DURATION}" \
+              K6_OVERLOAD_MODE=true \
+              K6_ARCHIVE_RESULTS=false \
+                tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps
+            '
+            burst_matrix_command='
+              matrix_ref="${OCI_OFFHOST_LOAD_COUPLED_OUTPUT_DIR}/${CAPACITY_NAME}-burst-matrix-runs.tsv"
+              printf "burst_rate\tk6_run_id\tsummary_json\n" >"${matrix_ref}"
+              IFS="," read -r -a burst_rates <<<"${CAPACITY_K6_TIMELINE_BURST_RATES}"
+              status=0
+              for burst_rate in "${burst_rates[@]}"; do
+                burst_rate="${burst_rate//[[:space:]]/}"
+                [[ -z "${burst_rate}" ]] && continue
+                report_name="${CAPACITY_NAME}-burst${burst_rate}"
+                K6_REPORT_NAME="${report_name}" \
+                K6_RUN_ID="${report_name}" \
+                K6_RUN_PURPOSE=capacity \
+                K6_OBSERVABILITY_MODE=prometheus \
+                K6_GENERATOR_MODE=docker-context \
+                K6_DOCKER_CONTEXT="${CAPACITY_K6_DOCKER_CONTEXT}" \
+                K6_REMOTE_BASE_URL="${CAPACITY_K6_REMOTE_BASE_URL}" \
+                K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" \
+                K6_REMOTE_WORKDIR="${CAPACITY_K6_REMOTE_WORKDIR}" \
+                K6_REMOTE_PREFLIGHT=true \
+                K6_AUTH_TOKEN_ENV_NAME=STAGING_REPLAY_TOKEN \
+                K6_AUTH_TOKEN_REQUIRED=true \
+                K6_AUTH_PREFLIGHT=true \
+                K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${CAPACITY_K6_HOT_ACCOUNT_ID}&from=${CAPACITY_K6_HOT_FROM}&to=${CAPACITY_K6_HOT_TO}&limit=1" \
+                K6_AUTH_PREFLIGHT_EXPECTED_STATUS=200 \
+                K6_HOT_ACCOUNT_ID="${CAPACITY_K6_HOT_ACCOUNT_ID}" \
+                K6_HOT_FROM="${CAPACITY_K6_HOT_FROM}" \
+                K6_HOT_TO="${CAPACITY_K6_HOT_TO}" \
+                K6_COLD_ACCOUNT_ID="${CAPACITY_K6_COLD_ACCOUNT_ID}" \
+                K6_COLD_FROM="${CAPACITY_K6_COLD_FROM}" \
+                K6_COLD_TO="${CAPACITY_K6_COLD_TO}" \
+                K6_SCENARIO_MODE=burst \
+                K6_BURST_RATE="${burst_rate}" \
+                K6_PRE_ALLOCATED_VUS="${burst_rate}" \
+                K6_MAX_VUS="$((burst_rate * 2))" \
+                K6_DURATION="${CAPACITY_K6_TIMELINE_PHASE_DURATION}" \
+                K6_OVERLOAD_MODE=true \
+                K6_BURST_429_RATE_THRESHOLD=1 \
+                K6_ARCHIVE_RESULTS=false \
+                  tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps || status=1
+                printf "%s\t%s\tbuild/reports/k6/%s-summary.json\n" "${burst_rate}" "${report_name}" "${report_name}" >>"${matrix_ref}"
+              done
+              exit "${status}"
+            '
+            CAPACITY_NAME="${CAPACITY_NAME}" \
+            CAPACITY_K6_DOCKER_CONTEXT="${CAPACITY_K6_DOCKER_CONTEXT}" \
+            CAPACITY_K6_REMOTE_BASE_URL="${CAPACITY_K6_REMOTE_BASE_URL}" \
+            CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" \
+            CAPACITY_K6_REMOTE_WORKDIR="${CAPACITY_K6_REMOTE_WORKDIR}" \
+            CAPACITY_K6_TIMELINE_PHASE_DURATION="${CAPACITY_K6_TIMELINE_PHASE_DURATION}" \
+            CAPACITY_K6_TIMELINE_BURST_RATES="${CAPACITY_K6_TIMELINE_BURST_RATES}" \
+            CAPACITY_K6_HOT_ACCOUNT_ID="${CAPACITY_K6_HOT_ACCOUNT_ID}" \
+            CAPACITY_K6_HOT_FROM="${CAPACITY_K6_HOT_FROM}" \
+            CAPACITY_K6_HOT_TO="${CAPACITY_K6_HOT_TO}" \
+            CAPACITY_K6_COLD_ACCOUNT_ID="${CAPACITY_K6_COLD_ACCOUNT_ID}" \
+            CAPACITY_K6_COLD_FROM="${CAPACITY_K6_COLD_FROM}" \
+            CAPACITY_K6_COLD_TO="${CAPACITY_K6_COLD_TO}" \
+            OCI_OFFHOST_LOAD_COUPLED_TIMELINE_NAME="${CAPACITY_NAME}" \
+            OCI_OFFHOST_LOAD_COUPLED_TIMELINE_RUN_ID="${CAPACITY_K6_HOST_METRICS_RUN_ID}" \
+            OCI_OFFHOST_LOAD_COUPLED_SAMPLE_INTERVAL_SECONDS="${CAPACITY_K6_HOST_METRICS_TIMELINE_SAMPLE_INTERVAL_SECONDS}" \
+            OCI_OFFHOST_LOAD_COUPLED_GENERATOR_DOCKER_CONTEXT="${CAPACITY_K6_DOCKER_CONTEXT}" \
+            OCI_OFFHOST_LOAD_COUPLED_GENERATOR_SAMPLE_CONTEXT="${CAPACITY_K6_DOCKER_CONTEXT}" \
+            OCI_OFFHOST_LOAD_COUPLED_TARGET_DOCKER_CONTEXT="target" \
+            OCI_OFFHOST_LOAD_COUPLED_TARGET_SAMPLE_CONTEXT="local" \
+            OCI_OFFHOST_LOAD_COUPLED_ARTIFACT_PACK_URI="artifact://offhost-capacity-prerequisite/${CAPACITY_NAME}" \
+            OCI_OFFHOST_LOAD_COUPLED_OUTPUT_DIR="${host_metrics_timeline_dir}" \
+            OCI_OFFHOST_LOAD_COUPLED_ARRIVAL16_COMMAND="${arrival16_command}" \
+            OCI_OFFHOST_LOAD_COUPLED_VU16_COMMAND="${vu16_command}" \
+            OCI_OFFHOST_LOAD_COUPLED_BURST_MATRIX_COMMAND="${burst_matrix_command}" \
+              tools/test/run-oci-offhost-host-metrics-load-coupled-timeline.sh >"${host_metrics_timeline_dir}/host-metrics-load-coupled-timeline.log" 2>&1
+            CAPACITY_K6_HOST_METRICS_TIMELINE_TSV="${generated_timeline_tsv}"
           fi
           if [[ -z "${CAPACITY_K6_HOST_METRICS_TIMELINE_TSV}" && "${CAPACITY_REQUIRE_LOAD_COUPLED_TIMELINE}" == "false" ]]; then
             mkdir -p "${host_metrics_timeline_dir}"

--- a/tools/test/check-oci-offhost-host-metrics-load-coupled-timeline.sh
+++ b/tools/test/check-oci-offhost-host-metrics-load-coupled-timeline.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-oci-offhost-host-metrics-load-coupled-timeline.sh"
+
+echo "[oci-offhost-host-metrics-load-coupled-timeline] shell syntax"
+bash -n "${runner}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+output_dir="${temp_dir}/output"
+
+echo "[oci-offhost-host-metrics-load-coupled-timeline] print plan"
+plan="$(
+  OCI_OFFHOST_LOAD_COUPLED_TIMELINE_NAME=offhost-load-coupled-check \
+  OCI_OFFHOST_LOAD_COUPLED_TIMELINE_RUN_ID=offhost-load-coupled-run \
+  OCI_OFFHOST_LOAD_COUPLED_ARRIVAL16_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_VU16_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_BURST_MATRIX_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_SAMPLE_INTERVAL_SECONDS=1 \
+  OCI_OFFHOST_LOAD_COUPLED_SAMPLE_MODE=local \
+  OCI_OFFHOST_LOAD_COUPLED_OUTPUT_DIR="${output_dir}" \
+    "${runner}" --print-plan
+)"
+grep -F "name=offhost-load-coupled-check" <<<"${plan}" >/dev/null
+grep -F "run_id=offhost-load-coupled-run" <<<"${plan}" >/dev/null
+grep -F "required_phases=arrival16,vu16,burst-matrix" <<<"${plan}" >/dev/null
+grep -F "sample_interval_seconds=1" <<<"${plan}" >/dev/null
+grep -F "timeline_tsv=${output_dir}/offhost-load-coupled-check-host-metrics-timeline.tsv" <<<"${plan}" >/dev/null
+
+echo "[oci-offhost-host-metrics-load-coupled-timeline] pass report"
+output="$(
+  OCI_OFFHOST_LOAD_COUPLED_TIMELINE_NAME=offhost-load-coupled-check \
+  OCI_OFFHOST_LOAD_COUPLED_TIMELINE_RUN_ID=offhost-load-coupled-run \
+  OCI_OFFHOST_LOAD_COUPLED_ARRIVAL16_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_VU16_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_BURST_MATRIX_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_SAMPLE_INTERVAL_SECONDS=1 \
+  OCI_OFFHOST_LOAD_COUPLED_SAMPLE_MODE=local \
+  OCI_OFFHOST_LOAD_COUPLED_GENERATOR_HOST_NAME=k6-generator-a \
+  OCI_OFFHOST_LOAD_COUPLED_GENERATOR_HOST_ID=ocid1.instance.oc1..generatora \
+  OCI_OFFHOST_LOAD_COUPLED_GENERATOR_VM_ID=vm-k6-a \
+  OCI_OFFHOST_LOAD_COUPLED_GENERATOR_NETWORK_ID=subnet-generator-a \
+  OCI_OFFHOST_LOAD_COUPLED_GENERATOR_DOCKER_CONTEXT=oci-k6-generator-a \
+  OCI_OFFHOST_LOAD_COUPLED_TARGET_HOST_NAME=oci-a1-staging \
+  OCI_OFFHOST_LOAD_COUPLED_TARGET_HOST_ID=ocid1.instance.oc1..target \
+  OCI_OFFHOST_LOAD_COUPLED_TARGET_VM_ID=vm-target \
+  OCI_OFFHOST_LOAD_COUPLED_TARGET_NETWORK_ID=subnet-target \
+  OCI_OFFHOST_LOAD_COUPLED_TARGET_DOCKER_CONTEXT=target \
+  OCI_OFFHOST_LOAD_COUPLED_OUTPUT_DIR="${output_dir}" \
+    "${runner}"
+)"
+report_md="$(tail -1 <<<"${output}")"
+timeline_tsv="${output_dir}/offhost-load-coupled-check-host-metrics-timeline.tsv"
+timeline_json="${output_dir}/offhost-load-coupled-check-host-metrics-timeline.json"
+test "${report_md}" = "${output_dir}/offhost-load-coupled-check-host-metrics-timeline.md"
+test -s "${timeline_tsv}"
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "load-coupled samples: generated" "${report_md}" >/dev/null
+grep -F "sample interval seconds: 1" "${report_md}" >/dev/null
+grep -F $'offhost-load-coupled-run\tarrival16\tgenerator\tk6-generator-a\tocid1.instance.oc1..generatora\tvm-k6-a\tsubnet-generator-a\toci-k6-generator-a' "${timeline_tsv}" >/dev/null
+grep -F $'offhost-load-coupled-run\tburst-matrix\ttarget\toci-a1-staging\tocid1.instance.oc1..target\tvm-target\tsubnet-target\ttarget' "${timeline_tsv}" >/dev/null
+jq -e '.summary.gate_status == "pass" and .summary.phase_count == 3 and (.items | length == 6)' "${timeline_json}" >/dev/null
+jq -e '.items[] | select(.phase == "vu16" and .host_role == "target" and .sample_source == "load-coupled" and .sample_interval_seconds == 1)' "${timeline_json}" >/dev/null
+
+echo "[oci-offhost-host-metrics-load-coupled-timeline] missing command fails"
+if OCI_OFFHOST_LOAD_COUPLED_TIMELINE_NAME=offhost-load-coupled-missing \
+  OCI_OFFHOST_LOAD_COUPLED_TIMELINE_RUN_ID=offhost-load-coupled-run \
+  OCI_OFFHOST_LOAD_COUPLED_ARRIVAL16_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_VU16_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_OUTPUT_DIR="${temp_dir}/missing-output" \
+    "${runner}" >"${temp_dir}/missing.log" 2>&1; then
+  echo "off-host load-coupled timeline unexpectedly passed without burst-matrix command" >&2
+  exit 1
+fi
+grep -F "OCI_OFFHOST_LOAD_COUPLED_BURST_MATRIX_COMMAND is required" "${temp_dir}/missing.log" >/dev/null
+
+echo "[oci-offhost-host-metrics-load-coupled-timeline] shared identity fails"
+if OCI_OFFHOST_LOAD_COUPLED_TIMELINE_NAME=offhost-load-coupled-shared \
+  OCI_OFFHOST_LOAD_COUPLED_TIMELINE_RUN_ID=offhost-load-coupled-run \
+  OCI_OFFHOST_LOAD_COUPLED_ARRIVAL16_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_VU16_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_BURST_MATRIX_COMMAND="sleep 1" \
+  OCI_OFFHOST_LOAD_COUPLED_SAMPLE_INTERVAL_SECONDS=1 \
+  OCI_OFFHOST_LOAD_COUPLED_SAMPLE_MODE=local \
+  OCI_OFFHOST_LOAD_COUPLED_GENERATOR_HOST_NAME=same-host \
+  OCI_OFFHOST_LOAD_COUPLED_TARGET_HOST_NAME=same-host \
+  OCI_OFFHOST_LOAD_COUPLED_OUTPUT_DIR="${temp_dir}/shared-output" \
+    "${runner}" >"${temp_dir}/shared.log" 2>&1; then
+  echo "off-host load-coupled timeline unexpectedly passed shared host identity" >&2
+  exit 1
+fi
+grep -F "generator and target host identity must differ" "${temp_dir}/shared.log" >/dev/null

--- a/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+++ b/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
@@ -16,9 +16,12 @@ grep -F "tools/test/check-offhost-capacity-prerequisite-required-gate.sh" "${wor
 grep -F "tools/test/check-oci-offhost-host-metrics-snapshot.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-oci-offhost-host-metrics-timeline.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-offhost-host-metrics-timeline.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-oci-offhost-host-metrics-load-coupled-timeline.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-oci-offhost-host-metrics-load-coupled-timeline.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-oci-offhost-host-metrics-timeline-fallback.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh" "${workflow}" >/dev/null
 grep -F "Check off-host host metrics timeline" "${workflow}" >/dev/null
+grep -F "Check off-host host metrics load-coupled timeline" "${workflow}" >/dev/null
 grep -F "Check off-host host metrics timeline fallback" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "environment:" "${workflow}" >/dev/null
@@ -72,7 +75,12 @@ grep -F 'CAPACITY_K6_TARGET_HOST_METRICS_TSV="${snapshot_target_tsv}"' "${workfl
 grep -F 'host_metrics_timeline_dir="${report_dir}/offhost-host-metrics-timeline"' "${workflow}" >/dev/null
 grep -F 'generated_timeline_tsv="${host_metrics_timeline_dir}/${CAPACITY_NAME}-host-metrics-timeline.tsv"' "${workflow}" >/dev/null
 grep -F 'if [[ -z "${CAPACITY_K6_HOST_METRICS_TIMELINE_TSV}" && "${CAPACITY_REQUIRE_LOAD_COUPLED_TIMELINE}" == "true" ]]; then' "${workflow}" >/dev/null
-grep -F "CAPACITY_PREREQUISITE_FAILURE_REASON=missing-load-coupled-host-metrics-timeline" "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_LOAD_COUPLED_TIMELINE_NAME="${CAPACITY_NAME}"' "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_LOAD_COUPLED_TIMELINE_RUN_ID="${CAPACITY_K6_HOST_METRICS_RUN_ID}"' "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_LOAD_COUPLED_SAMPLE_INTERVAL_SECONDS="${CAPACITY_K6_HOST_METRICS_TIMELINE_SAMPLE_INTERVAL_SECONDS}"' "${workflow}" >/dev/null
+grep -F 'OCI_OFFHOST_LOAD_COUPLED_GENERATOR_SAMPLE_CONTEXT="${CAPACITY_K6_DOCKER_CONTEXT}"' "${workflow}" >/dev/null
+grep -F "tools/test/run-oci-offhost-host-metrics-load-coupled-timeline.sh" "${workflow}" >/dev/null
+grep -F 'CAPACITY_K6_HOST_METRICS_TIMELINE_TSV="${generated_timeline_tsv}"' "${workflow}" >/dev/null
 grep -F 'if [[ -z "${CAPACITY_K6_HOST_METRICS_TIMELINE_TSV}" && "${CAPACITY_REQUIRE_LOAD_COUPLED_TIMELINE}" == "false" ]]; then' "${workflow}" >/dev/null
 grep -F 'OCI_OFFHOST_HOST_METRICS_TIMELINE_FALLBACK_NAME="${CAPACITY_NAME}"' "${workflow}" >/dev/null
 grep -F 'OCI_OFFHOST_GENERATOR_HOST_METRICS_TSV="${CAPACITY_K6_GENERATOR_HOST_METRICS_TSV}"' "${workflow}" >/dev/null
@@ -107,6 +115,10 @@ if grep -F 'CAPACITY_K6_DOCKER_CONTEXT: ${{ inputs.docker_context || vars.CAPACI
 fi
 if grep -F 'default: "/srv/aquila-bank"' "${workflow}" >/dev/null; then
   echo "off-host workflow must not default remote workdir to a stale path" >&2
+  exit 1
+fi
+if grep -F "missing-load-coupled-host-metrics-timeline" "${workflow}" >/dev/null; then
+  echo "strict off-host workflow must generate load-coupled timeline instead of failing on missing input" >&2
   exit 1
 fi
 

--- a/tools/test/run-oci-offhost-host-metrics-load-coupled-timeline.sh
+++ b/tools/test/run-oci-offhost-host-metrics-load-coupled-timeline.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-oci-offhost-host-metrics-load-coupled-timeline.sh [--print-plan]
+
+Environment:
+  OCI_OFFHOST_LOAD_COUPLED_TIMELINE_NAME         default oci-offhost-load-coupled-timeline-<timestamp>
+  OCI_OFFHOST_LOAD_COUPLED_TIMELINE_RUN_ID       default same as name
+  OCI_OFFHOST_LOAD_COUPLED_PHASES                default arrival16,vu16,burst-matrix
+  OCI_OFFHOST_LOAD_COUPLED_ARRIVAL16_COMMAND     required shell command for arrival16 load
+  OCI_OFFHOST_LOAD_COUPLED_VU16_COMMAND          required shell command for VU16 load
+  OCI_OFFHOST_LOAD_COUPLED_BURST_MATRIX_COMMAND  required shell command for burst-matrix load
+  OCI_OFFHOST_LOAD_COUPLED_SAMPLE_INTERVAL_SECONDS default 5
+  OCI_OFFHOST_LOAD_COUPLED_SAMPLE_MODE           auto|local, default auto
+  OCI_OFFHOST_LOAD_COUPLED_OUTPUT_DIR            default build/reports/k6/<name>/offhost-host-metrics-timeline
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${OCI_OFFHOST_LOAD_COUPLED_TIMELINE_NAME:-oci-offhost-load-coupled-timeline-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${OCI_OFFHOST_LOAD_COUPLED_TIMELINE_RUN_ID:-${name}}"
+required_phases="${OCI_OFFHOST_LOAD_COUPLED_PHASES:-arrival16,vu16,burst-matrix}"
+sample_interval_seconds="${OCI_OFFHOST_LOAD_COUPLED_SAMPLE_INTERVAL_SECONDS:-5}"
+sample_mode="${OCI_OFFHOST_LOAD_COUPLED_SAMPLE_MODE:-auto}"
+output_dir="${OCI_OFFHOST_LOAD_COUPLED_OUTPUT_DIR:-build/reports/k6/${name}/offhost-host-metrics-timeline}"
+artifact_pack_uri="${OCI_OFFHOST_LOAD_COUPLED_ARTIFACT_PACK_URI:-artifact://offhost-capacity-prerequisite/${name}}"
+sampler_image="${OCI_OFFHOST_LOAD_COUPLED_SAMPLER_IMAGE:-busybox:1.36}"
+timeline_input_tsv="${output_dir}/${name}-host-metrics-timeline.input.tsv"
+timeline_tsv="${output_dir}/${name}-host-metrics-timeline.tsv"
+timeline_json="${output_dir}/${name}-host-metrics-timeline.json"
+report_md="${output_dir}/${name}-host-metrics-timeline.md"
+
+host_name="$(hostname 2>/dev/null || echo unknown-host)"
+generator_docker_context="${OCI_OFFHOST_LOAD_COUPLED_GENERATOR_DOCKER_CONTEXT:-${OCI_OFFHOST_GENERATOR_DOCKER_CONTEXT:-default}}"
+target_docker_context="${OCI_OFFHOST_LOAD_COUPLED_TARGET_DOCKER_CONTEXT:-${OCI_OFFHOST_TARGET_DOCKER_CONTEXT:-target}}"
+generator_sample_context="${OCI_OFFHOST_LOAD_COUPLED_GENERATOR_SAMPLE_CONTEXT:-${generator_docker_context}}"
+target_sample_context="${OCI_OFFHOST_LOAD_COUPLED_TARGET_SAMPLE_CONTEXT:-local}"
+generator_host_name="${OCI_OFFHOST_LOAD_COUPLED_GENERATOR_HOST_NAME:-${host_name}-${generator_docker_context}-generator}"
+target_host_name="${OCI_OFFHOST_LOAD_COUPLED_TARGET_HOST_NAME:-${host_name}-${target_docker_context}-target}"
+generator_host_id="${OCI_OFFHOST_LOAD_COUPLED_GENERATOR_HOST_ID:-load-coupled:${generator_host_name}:${generator_docker_context}:generator}"
+target_host_id="${OCI_OFFHOST_LOAD_COUPLED_TARGET_HOST_ID:-load-coupled:${target_host_name}:${target_docker_context}:target}"
+generator_vm_id="${OCI_OFFHOST_LOAD_COUPLED_GENERATOR_VM_ID:-load-coupled-vm:${generator_host_name}:${generator_docker_context}:generator}"
+target_vm_id="${OCI_OFFHOST_LOAD_COUPLED_TARGET_VM_ID:-load-coupled-vm:${target_host_name}:${target_docker_context}:target}"
+generator_network_id="${OCI_OFFHOST_LOAD_COUPLED_GENERATOR_NETWORK_ID:-load-coupled-network:${generator_docker_context}:generator}"
+target_network_id="${OCI_OFFHOST_LOAD_COUPLED_TARGET_NETWORK_ID:-load-coupled-network:${target_docker_context}:target}"
+
+case "${sample_mode}" in
+  auto|local) ;;
+  *)
+    echo "OCI_OFFHOST_LOAD_COUPLED_SAMPLE_MODE must be auto or local: ${sample_mode}" >&2
+    exit 1
+    ;;
+esac
+if ! [[ "${sample_interval_seconds}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "OCI_OFFHOST_LOAD_COUPLED_SAMPLE_INTERVAL_SECONDS must be a positive integer: ${sample_interval_seconds}" >&2
+  exit 1
+fi
+
+IFS=',' read -r -a phase_items <<<"${required_phases}"
+
+command_for_phase() {
+  case "$1" in
+    arrival16)
+      echo "${OCI_OFFHOST_LOAD_COUPLED_ARRIVAL16_COMMAND:-}"
+      ;;
+    vu16)
+      echo "${OCI_OFFHOST_LOAD_COUPLED_VU16_COMMAND:-}"
+      ;;
+    burst-matrix)
+      echo "${OCI_OFFHOST_LOAD_COUPLED_BURST_MATRIX_COMMAND:-}"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
+command_key_for_phase() {
+  case "$1" in
+    arrival16) echo "OCI_OFFHOST_LOAD_COUPLED_ARRIVAL16_COMMAND" ;;
+    vu16) echo "OCI_OFFHOST_LOAD_COUPLED_VU16_COMMAND" ;;
+    burst-matrix) echo "OCI_OFFHOST_LOAD_COUPLED_BURST_MATRIX_COMMAND" ;;
+    *) echo "OCI_OFFHOST_LOAD_COUPLED_${1}_COMMAND" ;;
+  esac
+}
+
+summary_ref_for_phase() {
+  local phase="$1"
+  case "${phase}" in
+    arrival16)
+      echo "${OCI_OFFHOST_LOAD_COUPLED_ARRIVAL16_SUMMARY_REF:-build/reports/k6/${name}-arrival16-summary.json}"
+      ;;
+    vu16)
+      echo "${OCI_OFFHOST_LOAD_COUPLED_VU16_SUMMARY_REF:-build/reports/k6/${name}-vu16-summary.json}"
+      ;;
+    burst-matrix)
+      echo "${OCI_OFFHOST_LOAD_COUPLED_BURST_MATRIX_SUMMARY_REF:-${output_dir}/${name}-burst-matrix-runs.tsv}"
+      ;;
+    *)
+      echo "${artifact_pack_uri}/${phase}/summary"
+      ;;
+  esac
+}
+
+validate_commands() {
+  local phase command key
+  for phase in "${phase_items[@]}"; do
+    command="$(command_for_phase "${phase}")"
+    if [[ -z "${command}" ]]; then
+      key="$(command_key_for_phase "${phase}")"
+      echo "${key} is required" >&2
+      exit 1
+    fi
+  done
+}
+
+assert_host_separation() {
+  if [[ "${generator_host_name}" == "${target_host_name}" ]]; then
+    echo "generator and target host identity must differ: host_name=${generator_host_name}" >&2
+    exit 1
+  fi
+  if [[ "${generator_host_id}" == "${target_host_id}" ]]; then
+    echo "generator and target host identity must differ: host_id=${generator_host_id}" >&2
+    exit 1
+  fi
+  if [[ "${generator_vm_id}" == "${target_vm_id}" ]]; then
+    echo "generator and target host identity must differ: vm_id=${generator_vm_id}" >&2
+    exit 1
+  fi
+  if [[ "${generator_network_id}" == "${target_network_id}" ]]; then
+    echo "generator and target host identity must differ: network_id=${generator_network_id}" >&2
+    exit 1
+  fi
+}
+
+print_plan() {
+  echo "[oci-offhost-load-coupled-timeline] name=${name}"
+  echo "[oci-offhost-load-coupled-timeline] run_id=${run_id}"
+  echo "[oci-offhost-load-coupled-timeline] required_phases=${required_phases}"
+  echo "[oci-offhost-load-coupled-timeline] sample_interval_seconds=${sample_interval_seconds}"
+  echo "[oci-offhost-load-coupled-timeline] sample_mode=${sample_mode}"
+  echo "[oci-offhost-load-coupled-timeline] generator_context=${generator_docker_context}"
+  echo "[oci-offhost-load-coupled-timeline] target_context=${target_docker_context}"
+  echo "[oci-offhost-load-coupled-timeline] artifact_pack_uri=${artifact_pack_uri}"
+  echo "[oci-offhost-load-coupled-timeline] output_dir=${output_dir}"
+  echo "[oci-offhost-load-coupled-timeline] timeline_tsv=${timeline_tsv}"
+  echo "[oci-offhost-load-coupled-timeline] timeline_json=${timeline_json}"
+  echo "[oci-offhost-load-coupled-timeline] report_md=${report_md}"
+}
+
+validate_commands
+assert_host_separation
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+
+read_local_counters() {
+  local cpu_total cpu_idle rx_bytes tx_bytes
+  read -r cpu_total cpu_idle < <(
+    awk '/^cpu / {
+      idle = $5 + $6
+      total = 0
+      for (i = 2; i <= NF; i++) total += $i
+      printf "%.0f %.0f\n", total, idle
+      exit
+    }' /proc/stat 2>/dev/null || echo "0 0"
+  )
+  read -r rx_bytes tx_bytes < <(
+    awk -F '[: ]+' '
+      NR > 2 && $2 != "lo" {
+        rx += $3
+        tx += $11
+      }
+      END {
+        printf "%.0f %.0f\n", rx, tx
+      }
+    ' /proc/net/dev 2>/dev/null || echo "0 0"
+  )
+  printf "%s\t%s\t%s\t%s\n" "${cpu_total}" "${cpu_idle}" "${rx_bytes}" "${tx_bytes}"
+}
+
+read_docker_context_counters() {
+  local context="$1"
+  docker --context "${context}" run --rm --pid=host \
+    -v /proc:/host/proc:ro \
+    --entrypoint sh "${sampler_image}" \
+    -c '
+      cpu="$(awk "/^cpu / { idle = \$5 + \$6; total = 0; for (i = 2; i <= NF; i++) total += \$i; printf \"%.0f %.0f\", total, idle; exit }" /host/proc/stat 2>/dev/null || echo "0 0")"
+      net="$(awk -F "[: ]+" "NR > 2 && \$2 != \"lo\" { rx += \$3; tx += \$11 } END { printf \"%.0f %.0f\", rx, tx }" /host/proc/net/dev 2>/dev/null || echo "0 0")"
+      printf "%s\t%s\n" "${cpu}" "${net}"
+    '
+}
+
+read_counters() {
+  local context="$1"
+  if [[ "${sample_mode}" == "local" || -z "${context}" || "${context}" == "local" || "${context}" == "target" ]]; then
+    read_local_counters
+    return 0
+  fi
+  if [[ "${context}" == "default" ]]; then
+    read_local_counters
+    return 0
+  fi
+  read_docker_context_counters "${context}"
+}
+
+sample_loop() {
+  local role="$1"
+  local sample_context="$2"
+  local raw_path="$3"
+  local stop_path="$4"
+  local cpu_total cpu_idle rx_bytes tx_bytes epoch iso
+
+  while true; do
+    epoch="$(date -u +%s)"
+    iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    if read -r cpu_total cpu_idle rx_bytes tx_bytes < <(read_counters "${sample_context}"); then
+      printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+        "${epoch}" "${iso}" "${role}" "${cpu_total}" "${cpu_idle}" "${rx_bytes}" "${tx_bytes}" >>"${raw_path}"
+    fi
+    if [[ -f "${stop_path}" ]]; then
+      break
+    fi
+    sleep "${sample_interval_seconds}"
+  done
+}
+
+summarize_role() {
+  local phase="$1"
+  local role="$2"
+  local raw_path="$3"
+  local summary_ref="$4"
+  local docker_context host role_host_id role_vm_id role_network_id
+
+  if [[ "${role}" == "generator" ]]; then
+    host="${generator_host_name}"
+    role_host_id="${generator_host_id}"
+    role_vm_id="${generator_vm_id}"
+    role_network_id="${generator_network_id}"
+    docker_context="${generator_docker_context}"
+  else
+    host="${target_host_name}"
+    role_host_id="${target_host_id}"
+    role_vm_id="${target_vm_id}"
+    role_network_id="${target_network_id}"
+    docker_context="${target_docker_context}"
+  fi
+
+  awk -F '\t' -v OFS='\t' \
+    -v run_id="${run_id}" \
+    -v phase="${phase}" \
+    -v role="${role}" \
+    -v host="${host}" \
+    -v host_id="${role_host_id}" \
+    -v vm_id="${role_vm_id}" \
+    -v network_id="${role_network_id}" \
+    -v docker_context="${docker_context}" \
+    -v sample_interval="${sample_interval_seconds}" \
+    -v artifact_uri="${raw_path}" \
+    -v summary_ref="${summary_ref}" \
+    -v artifact_pack_uri="${artifact_pack_uri}" '
+    NR == 1 {
+      first_epoch = $1
+      first_iso = $2
+      first_total = $4
+      first_idle = $5
+      first_rx = $6
+      first_tx = $7
+      prev_epoch = $1
+      prev_total = $4
+      prev_idle = $5
+      prev_rx = $6
+      prev_tx = $7
+    }
+    {
+      count += 1
+      last_epoch = $1
+      last_iso = $2
+      last_total = $4
+      last_idle = $5
+      last_rx = $6
+      last_tx = $7
+      if (NR > 1) {
+        total_delta = $4 - prev_total
+        idle_delta = $5 - prev_idle
+        epoch_delta = $1 - prev_epoch
+        if (total_delta > 0) {
+          cpu_pct = ((total_delta - idle_delta) / total_delta) * 100
+          if (!cpu_found || cpu_pct > cpu_max) cpu_max = cpu_pct
+          cpu_found = 1
+        }
+        if (epoch_delta > 0) {
+          rx_mbps = (($6 - prev_rx) * 8) / epoch_delta / 1000000
+          tx_mbps = (($7 - prev_tx) * 8) / epoch_delta / 1000000
+          if (!rx_found || rx_mbps > rx_max) rx_max = rx_mbps
+          if (!tx_found || tx_mbps > tx_max) tx_max = tx_mbps
+          rx_found = 1
+          tx_found = 1
+        }
+      }
+      prev_epoch = $1
+      prev_total = $4
+      prev_idle = $5
+      prev_rx = $6
+      prev_tx = $7
+    }
+    END {
+      if (count < 2) {
+        printf "load-coupled sampler requires at least two samples: phase=%s role=%s count=%d\n", phase, role, count > "/dev/stderr"
+        exit 2
+      }
+      total_delta = last_total - first_total
+      idle_delta = last_idle - first_idle
+      elapsed = last_epoch - first_epoch
+      if (total_delta > 0) {
+        cpu_avg = ((total_delta - idle_delta) / total_delta) * 100
+      } else {
+        cpu_avg = 0
+      }
+      if (!cpu_found) cpu_max = cpu_avg
+      if (elapsed > 0) {
+        rx_avg = ((last_rx - first_rx) * 8) / elapsed / 1000000
+        tx_avg = ((last_tx - first_tx) * 8) / elapsed / 1000000
+      } else {
+        rx_avg = 0
+        tx_avg = 0
+      }
+      if (!rx_found) rx_max = rx_avg
+      if (!tx_found) tx_max = tx_avg
+      printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\tload-coupled\t%s\t%.2f\t%.2f\t%.3f\t%.3f\t%.3f\t%.3f\t%s\t%s\t%s\n", \
+        run_id, phase, role, host, host_id, vm_id, network_id, docker_context, first_iso, last_iso, count, sample_interval, \
+        cpu_avg, cpu_max, rx_avg, rx_max, tx_avg, tx_max, artifact_uri, summary_ref, artifact_pack_uri
+    }
+  ' "${raw_path}"
+}
+
+write_timeline_header() {
+  printf "run_id\tphase\thost_role\thost_name\thost_id\tvm_id\tnetwork_id\tdocker_context\tsample_started_at_utc\tsample_ended_at_utc\tsample_count\tsample_source\tsample_interval_seconds\tcpu_pct_avg\tcpu_pct_max\trx_mbps_avg\trx_mbps_max\ttx_mbps_avg\ttx_mbps_max\tartifact_uri\tsummary_ref\tartifact_pack_uri\n" >"${timeline_input_tsv}"
+}
+
+run_phase() {
+  local phase="$1"
+  local command="$2"
+  local summary_ref="$3"
+  local phase_dir="${output_dir}/${phase}"
+  local generator_raw="${phase_dir}/generator-samples.tsv"
+  local target_raw="${phase_dir}/target-samples.tsv"
+  local stop_path="${phase_dir}/sampler.stop"
+  local command_log="${phase_dir}/load-command.log"
+  local generator_pid target_pid phase_status
+
+  mkdir -p "${phase_dir}"
+  : >"${generator_raw}"
+  : >"${target_raw}"
+  rm -f "${stop_path}"
+
+  sample_loop "generator" "${generator_sample_context}" "${generator_raw}" "${stop_path}" &
+  generator_pid="$!"
+  sample_loop "target" "${target_sample_context}" "${target_raw}" "${stop_path}" &
+  target_pid="$!"
+
+  set +e
+  bash -lc "${command}" >"${command_log}" 2>&1
+  phase_status=$?
+  set -e
+
+  touch "${stop_path}"
+  wait "${generator_pid}" || true
+  wait "${target_pid}" || true
+
+  summarize_role "${phase}" "generator" "${generator_raw}" "${summary_ref}" >>"${timeline_input_tsv}"
+  summarize_role "${phase}" "target" "${target_raw}" "${summary_ref}" >>"${timeline_input_tsv}"
+
+  if [[ "${phase_status}" -ne 0 ]]; then
+    echo "load-coupled phase command failed: phase=${phase} status=${phase_status} log=${command_log}" >&2
+    return "${phase_status}"
+  fi
+  return 0
+}
+
+write_timeline_header
+status=0
+for phase in "${phase_items[@]}"; do
+  command="$(command_for_phase "${phase}")"
+  summary_ref="$(summary_ref_for_phase "${phase}")"
+  if ! run_phase "${phase}" "${command}" "${summary_ref}"; then
+    status=1
+  fi
+done
+
+validator_output="$(
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_NAME="${name}" \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_RUN_ID="${run_id}" \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_INPUT_TSV="${timeline_input_tsv}" \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_REQUIRED_PHASES="${required_phases}" \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_MAX_INTERVAL_SECONDS="${sample_interval_seconds}" \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_REQUIRE_LOAD_COUPLED=true \
+  OCI_OFFHOST_HOST_METRICS_TIMELINE_OUTPUT_DIR="${output_dir}" \
+    tools/test/run-oci-offhost-host-metrics-timeline.sh
+)"
+report_path="$(tail -1 <<<"${validator_output}")"
+{
+  echo
+  echo "## Load-Coupled Generation"
+  echo
+  echo "- load-coupled samples: generated"
+  echo "- sample interval seconds: ${sample_interval_seconds}"
+  echo "- timeline input TSV: ${timeline_input_tsv}"
+} >>"${report_path}"
+
+echo "${report_path}"
+exit "${status}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #741

## 🌿 Base Branch
- main

## 📝 Summary
- off-host prerequisite strict mode에서 timeline 입력이 없을 때 즉시 실패하지 않고 arrival16, VU16, burst-matrix 부하 명령을 load-coupled sampler로 감싸 timeline TSV를 생성하게 연결합니다.
- fallback/snapshot은 strict=false 경로에만 남기고, strict validator는 sample_source=load-coupled 및 5초 이하 interval을 계속 요구합니다.

## 🛠 Changes
- offhost-100m-capacity-prerequisite workflow에 load-coupled timeline generator contract step을 추가했습니다.
- strict=true missing timeline path를 run-oci-offhost-host-metrics-load-coupled-timeline.sh 실행으로 변경했습니다.
- generator/target CPU/network sampler wrapper와 contract test를 추가했습니다.
- 실제 arrival16/VU16/burst-matrix 실행 시간을 고려해 workflow timeout을 120분으로 조정했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- bash tools/test/check-offhost-capacity-prerequisite-required-gate.sh
- bash tools/test/check-oci-offhost-host-metrics-load-coupled-timeline.sh
- bash tools/test/check-oci-offhost-host-metrics-timeline.sh
- bash tools/test/check-oci-offhost-host-metrics-timeline-fallback.sh
- git diff --check
- git rev-list --count origin/main..HEAD -> 1

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: workflow_dispatch에서 실제 OCI k6 부하를 수행하므로 기존 prerequisite보다 실행 시간이 길어집니다. 원격 Docker context 또는 STAGING_REPLAY_TOKEN이 없으면 부하 명령 단계에서 실패하고 sampler artifact만 남을 수 있습니다.
- 롤백 방법: 이 PR revert 후 기존 CAPACITY_K6_HOST_METRICS_TIMELINE_TSV 입력 기반 strict prerequisite로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 main인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?