### PR TITLE
[Perf] Transaction read 30m soak live evidence manifest wiring

### DIFF
--- a/.github/workflows/transaction-read-30m-soak-live-evidence.yml
+++ b/.github/workflows/transaction-read-30m-soak-live-evidence.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       evidence_manifest_tsv:
         description: "OCI evidence manifest TSV path on the self-hosted runner workspace"
-        required: true
+        required: false
         type: string
       report_name:
         description: "Optional evidence report name"
@@ -18,6 +18,8 @@ on:
       - ".github/workflows/transaction-read-30m-soak-live-evidence.yml"
       - "tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh"
       - "tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh"
+      - "tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh"
+      - "tools/test/check-transaction-read-30m-soak-live-evidence-manifest.sh"
       - "tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh"
       - "tools/test/run-transaction-read-oci-evidence-execution-gate.sh"
       - "tools/test/check-transaction-read-oci-evidence-execution-gate.sh"
@@ -42,6 +44,9 @@ jobs:
       - name: Check 30m soak live evidence gate
         run: bash tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh
 
+      - name: Check 30m soak live evidence manifest
+        run: bash tools/test/check-transaction-read-30m-soak-live-evidence-manifest.sh
+
       - name: Check 30m soak live evidence workflow
         run: bash tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
 
@@ -49,7 +54,7 @@ jobs:
     name: 30m Soak Live Evidence Gate
     if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, oci-a1-staging]
-    timeout-minutes: 15
+    timeout-minutes: 20
     environment:
       name: staging
     env:
@@ -59,7 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Run 30m soak live evidence gate
+      - name: Build 30m soak live evidence manifest
         shell: bash
         run: |
           set -euo pipefail
@@ -67,12 +72,27 @@ jobs:
             echo "::error::SOAK_30M_REPORT_NAME must contain only letters, numbers, dot, underscore, or hyphen."
             exit 1
           fi
-          if [[ -z "${SOAK_30M_EVIDENCE_MANIFEST_TSV}" || ! -s "${SOAK_30M_EVIDENCE_MANIFEST_TSV}" ]]; then
-            echo "::error::evidence_manifest_tsv is required and must point to a non-empty TSV on the runner."
-            exit 1
-          fi
 
           report_dir="build/reports/k6/${SOAK_30M_REPORT_NAME}"
+          generated_manifest_tsv="${report_dir}/manifest/${SOAK_30M_REPORT_NAME}-30m-soak-live-evidence-manifest.tsv"
+          if [[ -z "${SOAK_30M_EVIDENCE_MANIFEST_TSV}" ]]; then
+            SOAK_30M_MANIFEST_NAME="${SOAK_30M_REPORT_NAME}" \
+            SOAK_30M_MANIFEST_RUN_ID="${SOAK_30M_REPORT_NAME}" \
+            SOAK_30M_MANIFEST_OUTPUT_DIR="${report_dir}/manifest" \
+              tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh
+            SOAK_30M_EVIDENCE_MANIFEST_TSV="${generated_manifest_tsv}"
+          fi
+          printf 'SOAK_30M_EVIDENCE_MANIFEST_TSV=%s\n' "${SOAK_30M_EVIDENCE_MANIFEST_TSV}" >>"${GITHUB_ENV}"
+
+      - name: Run 30m soak live evidence gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="build/reports/k6/${SOAK_30M_REPORT_NAME}"
+          if [[ ! -s "${SOAK_30M_EVIDENCE_MANIFEST_TSV}" ]]; then
+            echo "::error::SOAK_30M_EVIDENCE_MANIFEST_TSV must point to a non-empty TSV on the runner: ${SOAK_30M_EVIDENCE_MANIFEST_TSV}"
+            exit 1
+          fi
           SOAK_30M_LIVE_NAME="${SOAK_30M_REPORT_NAME}" \
           SOAK_30M_LIVE_INPUT_TSV="${SOAK_30M_EVIDENCE_MANIFEST_TSV}" \
           SOAK_30M_LIVE_OUTPUT_DIR="${report_dir}" \
@@ -86,8 +106,9 @@ jobs:
           } >>"${GITHUB_STEP_SUMMARY}"
 
       - name: Upload 30m soak live evidence artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: transaction-read-30m-soak-live-evidence
           path: build/reports/k6/${{ env.SOAK_30M_REPORT_NAME }}
-          if-no-files-found: error
+          if-no-files-found: ignore

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-manifest.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-manifest.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh"
+gate="tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh"
+
+echo "[transaction-read-30m-soak-live-evidence-manifest] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+artifact_dir="${temp_dir}/artifacts"
+output_dir="${temp_dir}/output"
+mkdir -p "${artifact_dir}"
+
+for file in \
+  k6-summary.json \
+  nginx-aggregate.tsv \
+  spring-metrics.json \
+  hikari.log \
+  postgres-wait.tsv \
+  timeline.tsv \
+  postgres-checkpoint.tsv \
+  postgres-temp-file.tsv \
+  nginx-upstream.tsv \
+  hikari-config.tsv \
+  hikari-zero-warning.md; do
+  printf "artifact=%s\n" "${file}" >"${artifact_dir}/${file}"
+done
+
+echo "[transaction-read-30m-soak-live-evidence-manifest] print plan"
+plan="$(
+  SOAK_30M_MANIFEST_NAME=soak-manifest-check \
+  SOAK_30M_MANIFEST_RUN_ID=run-soak-manifest-001 \
+  SOAK_30M_MANIFEST_OUTPUT_DIR="${output_dir}" \
+    "${runner}" --print-plan
+)"
+grep -F "name=soak-manifest-check" <<<"${plan}" >/dev/null
+grep -F "run_id=run-soak-manifest-001" <<<"${plan}" >/dev/null
+grep -F "required_scenarios=hikari-lifetime,p999-long-correlation" <<<"${plan}" >/dev/null
+grep -F "manifest_tsv=${output_dir}/soak-manifest-check-30m-soak-live-evidence-manifest.tsv" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-30m-soak-live-evidence-manifest] pass report"
+output="$(
+  SOAK_30M_MANIFEST_NAME=soak-manifest-check \
+  SOAK_30M_MANIFEST_RUN_ID=run-soak-manifest-001 \
+  SOAK_30M_MANIFEST_EXECUTED_AT_UTC=2026-05-04T08:00:00Z \
+  SOAK_30M_MANIFEST_DURATION_MIN=30 \
+  SOAK_30M_MANIFEST_K6_SUMMARY_REF="${artifact_dir}/k6-summary.json" \
+  SOAK_30M_MANIFEST_NGINX_AGGREGATE_REF="${artifact_dir}/nginx-aggregate.tsv" \
+  SOAK_30M_MANIFEST_SPRING_METRICS_REF="${artifact_dir}/spring-metrics.json" \
+  SOAK_30M_MANIFEST_HIKARI_LOG_REF="${artifact_dir}/hikari.log" \
+  SOAK_30M_MANIFEST_POSTGRES_WAIT_REF="${artifact_dir}/postgres-wait.tsv" \
+  SOAK_30M_MANIFEST_TIMELINE_REF="${artifact_dir}/timeline.tsv" \
+  SOAK_30M_MANIFEST_POSTGRES_CHECKPOINT_REF="${artifact_dir}/postgres-checkpoint.tsv" \
+  SOAK_30M_MANIFEST_POSTGRES_TEMP_FILE_REF="${artifact_dir}/postgres-temp-file.tsv" \
+  SOAK_30M_MANIFEST_NGINX_UPSTREAM_LATENCY_REF="${artifact_dir}/nginx-upstream.tsv" \
+  SOAK_30M_MANIFEST_HIKARI_CONFIG_REF="${artifact_dir}/hikari-config.tsv" \
+  SOAK_30M_MANIFEST_HIKARI_ZERO_WARNING_SOAK_REF="${artifact_dir}/hikari-zero-warning.md" \
+  SOAK_30M_MANIFEST_P95_MS=95 \
+  SOAK_30M_MANIFEST_P99_MS=220 \
+  SOAK_30M_MANIFEST_P999_MS=490 \
+  SOAK_30M_MANIFEST_MAX_MS=650 \
+  SOAK_30M_MANIFEST_POSTGRES_CHECKPOINT_COUNT=3 \
+  SOAK_30M_MANIFEST_POSTGRES_TEMP_FILE_COUNT=0 \
+  SOAK_30M_MANIFEST_NGINX_UPSTREAM_P95_MS=18.5 \
+  SOAK_30M_MANIFEST_HIKARI_MAX_LIFETIME_MS=240000 \
+  SOAK_30M_MANIFEST_HIKARI_KEEPALIVE_TIME_MS=60000 \
+  SOAK_30M_MANIFEST_POSTGRES_IDLE_TIMEOUT_MS=300000 \
+  SOAK_30M_MANIFEST_OCI_NAT_IDLE_TIMEOUT_MS=350000 \
+  SOAK_30M_MANIFEST_OUTPUT_DIR="${output_dir}" \
+    "${runner}"
+)"
+manifest_tsv="$(tail -1 <<<"${output}")"
+report_md="${output_dir}/soak-manifest-check-30m-soak-live-evidence-manifest.md"
+test "${manifest_tsv}" = "${output_dir}/soak-manifest-check-30m-soak-live-evidence-manifest.tsv"
+test -s "${report_md}"
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "manifest rows: 2" "${report_md}" >/dev/null
+grep -F $'hikari-lifetime\trun-soak-manifest-001\t2026-05-04T08:00:00Z\t30' "${manifest_tsv}" >/dev/null
+grep -F $'p999-long-correlation\trun-soak-manifest-001\t2026-05-04T08:00:00Z\t30' "${manifest_tsv}" >/dev/null
+
+echo "[transaction-read-30m-soak-live-evidence-manifest] generated manifest passes live gate"
+gate_output="$(
+  SOAK_30M_LIVE_NAME=soak-manifest-live-check \
+  SOAK_30M_LIVE_INPUT_TSV="${manifest_tsv}" \
+  SOAK_30M_LIVE_OUTPUT_DIR="${temp_dir}/gate-output" \
+    "${gate}"
+)"
+gate_report="$(tail -1 <<<"${gate_output}")"
+grep -F "gate_status=pass" "${gate_report}" >/dev/null
+
+echo "[transaction-read-30m-soak-live-evidence-manifest] missing artifact fails"
+if SOAK_30M_MANIFEST_NAME=soak-manifest-missing \
+  SOAK_30M_MANIFEST_RUN_ID=run-soak-manifest-001 \
+  SOAK_30M_MANIFEST_K6_SUMMARY_REF="${artifact_dir}/missing-k6.json" \
+  SOAK_30M_MANIFEST_NGINX_AGGREGATE_REF="${artifact_dir}/nginx-aggregate.tsv" \
+  SOAK_30M_MANIFEST_SPRING_METRICS_REF="${artifact_dir}/spring-metrics.json" \
+  SOAK_30M_MANIFEST_HIKARI_LOG_REF="${artifact_dir}/hikari.log" \
+  SOAK_30M_MANIFEST_POSTGRES_WAIT_REF="${artifact_dir}/postgres-wait.tsv" \
+  SOAK_30M_MANIFEST_TIMELINE_REF="${artifact_dir}/timeline.tsv" \
+  SOAK_30M_MANIFEST_POSTGRES_CHECKPOINT_REF="${artifact_dir}/postgres-checkpoint.tsv" \
+  SOAK_30M_MANIFEST_POSTGRES_TEMP_FILE_REF="${artifact_dir}/postgres-temp-file.tsv" \
+  SOAK_30M_MANIFEST_NGINX_UPSTREAM_LATENCY_REF="${artifact_dir}/nginx-upstream.tsv" \
+  SOAK_30M_MANIFEST_HIKARI_CONFIG_REF="${artifact_dir}/hikari-config.tsv" \
+  SOAK_30M_MANIFEST_HIKARI_ZERO_WARNING_SOAK_REF="${artifact_dir}/hikari-zero-warning.md" \
+  SOAK_30M_MANIFEST_OUTPUT_DIR="${temp_dir}/missing-output" \
+    "${runner}" >"${temp_dir}/missing.log" 2>&1; then
+  echo "30m soak manifest unexpectedly passed missing k6 summary artifact" >&2
+  exit 1
+fi
+grep -F "SOAK_30M_MANIFEST_K6_SUMMARY_REF is required" "${temp_dir}/missing.log" >/dev/null
+grep -F "SOAK_30M_MANIFEST_FAILURE_REASON=missing-artifact" "${temp_dir}/missing-output/soak-manifest-missing-30m-soak-live-evidence-manifest-failure.env" >/dev/null

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
@@ -24,10 +24,13 @@ fi
 
 grep -F "evidence_manifest_tsv:" "${workflow}" >/dev/null
 grep -F 'description: "OCI evidence manifest TSV path on the self-hosted runner workspace"' "${workflow}" >/dev/null
+grep -F "required: false" "${workflow}" >/dev/null
 grep -F "report_name:" "${workflow}" >/dev/null
 grep -F "30m Soak Live Evidence Contract" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-manifest.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-oci-evidence-execution-gate.sh" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
@@ -35,6 +38,11 @@ grep -F "environment:" "${workflow}" >/dev/null
 grep -F "name: staging" "${workflow}" >/dev/null
 grep -F 'SOAK_30M_REPORT_NAME: ${{ inputs.report_name || format(' "${workflow}" >/dev/null
 grep -F 'SOAK_30M_EVIDENCE_MANIFEST_TSV: ${{ inputs.evidence_manifest_tsv }}' "${workflow}" >/dev/null
+grep -F "Build 30m soak live evidence manifest" "${workflow}" >/dev/null
+grep -F 'if [[ -z "${SOAK_30M_EVIDENCE_MANIFEST_TSV}" ]]; then' "${workflow}" >/dev/null
+grep -F 'SOAK_30M_MANIFEST_NAME="${SOAK_30M_REPORT_NAME}"' "${workflow}" >/dev/null
+grep -F 'tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh' "${workflow}" >/dev/null
+grep -F 'SOAK_30M_EVIDENCE_MANIFEST_TSV="${generated_manifest_tsv}"' "${workflow}" >/dev/null
 grep -F "Run 30m soak live evidence gate" "${workflow}" >/dev/null
 grep -F 'SOAK_30M_LIVE_NAME="${SOAK_30M_REPORT_NAME}"' "${workflow}" >/dev/null
 grep -F 'SOAK_30M_LIVE_INPUT_TSV="${SOAK_30M_EVIDENCE_MANIFEST_TSV}"' "${workflow}" >/dev/null
@@ -43,7 +51,8 @@ grep -F "tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh" "${work
 grep -F 'cat "${report_md}"' "${workflow}" >/dev/null
 grep -F "actions/upload-artifact@v7" "${workflow}" >/dev/null
 grep -F "transaction-read-30m-soak-live-evidence" "${workflow}" >/dev/null
-grep -F "if-no-files-found: error" "${workflow}" >/dev/null
+grep -F "if: always()" "${workflow}" >/dev/null
+grep -F "if-no-files-found: ignore" "${workflow}" >/dev/null
 
 gate_line="$(grep -n "Run 30m soak live evidence gate" "${workflow}" | head -1 | cut -d: -f1)"
 upload_line="$(grep -n "Upload 30m soak live evidence artifact" "${workflow}" | head -1 | cut -d: -f1)"
@@ -58,5 +67,9 @@ if grep -F "fallback" "${workflow}" >/dev/null; then
 fi
 if grep -F "secrets." "${workflow}" >/dev/null; then
   echo "30m live evidence workflow must not require secrets; it validates artifact refs only" >&2
+  exit 1
+fi
+if grep -F "evidence_manifest_tsv is required" "${workflow}" >/dev/null; then
+  echo "30m live evidence workflow must auto-build manifest when input is omitted" >&2
   exit 1
 fi

--- a/tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh
+++ b/tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh [--print-plan]
+
+Environment:
+  SOAK_30M_MANIFEST_NAME        default transaction-read-30m-soak-live-evidence-manifest-<timestamp>
+  SOAK_30M_MANIFEST_RUN_ID      default same as name
+  SOAK_30M_MANIFEST_OUTPUT_DIR  default build/reports/k6/<name>
+  SOAK_30M_MANIFEST_*_REF       local artifact refs for k6/nginx/spring/Hikari/PostgreSQL evidence
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${SOAK_30M_MANIFEST_NAME:-transaction-read-30m-soak-live-evidence-manifest-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${SOAK_30M_MANIFEST_RUN_ID:-${name}}"
+executed_at_utc="${SOAK_30M_MANIFEST_EXECUTED_AT_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+duration_min="${SOAK_30M_MANIFEST_DURATION_MIN:-30}"
+source_ips="${SOAK_30M_MANIFEST_SOURCE_IPS:-1}"
+output_dir="${SOAK_30M_MANIFEST_OUTPUT_DIR:-build/reports/k6/${name}}"
+manifest_tsv="${output_dir}/${name}-30m-soak-live-evidence-manifest.tsv"
+report_md="${output_dir}/${name}-30m-soak-live-evidence-manifest.md"
+failure_env="${output_dir}/${name}-30m-soak-live-evidence-manifest-failure.env"
+
+k6_summary_ref="${SOAK_30M_MANIFEST_K6_SUMMARY_REF:-${output_dir}/${name}-summary.json}"
+nginx_aggregate_ref="${SOAK_30M_MANIFEST_NGINX_AGGREGATE_REF:-${output_dir}/${name}-nginx-aggregate.tsv}"
+spring_metrics_ref="${SOAK_30M_MANIFEST_SPRING_METRICS_REF:-${output_dir}/${name}-spring-metrics.json}"
+hikari_log_ref="${SOAK_30M_MANIFEST_HIKARI_LOG_REF:-${output_dir}/${name}-hikari.log}"
+postgres_wait_ref="${SOAK_30M_MANIFEST_POSTGRES_WAIT_REF:-${output_dir}/${name}-postgres-wait.tsv}"
+timeline_ref="${SOAK_30M_MANIFEST_TIMELINE_REF:-${output_dir}/${name}-p999-timeline.tsv}"
+postgres_checkpoint_ref="${SOAK_30M_MANIFEST_POSTGRES_CHECKPOINT_REF:-${output_dir}/${name}-postgres-checkpoint.tsv}"
+postgres_temp_file_ref="${SOAK_30M_MANIFEST_POSTGRES_TEMP_FILE_REF:-${output_dir}/${name}-postgres-temp-file.tsv}"
+nginx_upstream_latency_ref="${SOAK_30M_MANIFEST_NGINX_UPSTREAM_LATENCY_REF:-${output_dir}/${name}-nginx-upstream-latency.tsv}"
+hikari_config_ref="${SOAK_30M_MANIFEST_HIKARI_CONFIG_REF:-${output_dir}/${name}-hikari-config.tsv}"
+hikari_zero_warning_soak_ref="${SOAK_30M_MANIFEST_HIKARI_ZERO_WARNING_SOAK_REF:-${output_dir}/${name}-hikari-zero-warning-soak.md}"
+
+edge_429_rate="${SOAK_30M_MANIFEST_EDGE_429_RATE:-0}"
+backend_429_count="${SOAK_30M_MANIFEST_BACKEND_429_COUNT:-0}"
+unknown_429_count="${SOAK_30M_MANIFEST_UNKNOWN_429_COUNT:-0}"
+five_xx_count="${SOAK_30M_MANIFEST_5XX_COUNT:-0}"
+nginx_499_count="${SOAK_30M_MANIFEST_NGINX_499_COUNT:-0}"
+hikari_validation_warnings="${SOAK_30M_MANIFEST_HIKARI_VALIDATION_WARNINGS:-0}"
+db_pool_pending_max="${SOAK_30M_MANIFEST_DB_POOL_PENDING_MAX:-0}"
+p95_ms="${SOAK_30M_MANIFEST_P95_MS:-0}"
+p99_ms="${SOAK_30M_MANIFEST_P99_MS:-0}"
+p999_ms="${SOAK_30M_MANIFEST_P999_MS:-0}"
+max_ms="${SOAK_30M_MANIFEST_MAX_MS:-0}"
+postgres_checkpoint_count="${SOAK_30M_MANIFEST_POSTGRES_CHECKPOINT_COUNT:-0}"
+postgres_temp_file_count="${SOAK_30M_MANIFEST_POSTGRES_TEMP_FILE_COUNT:-0}"
+nginx_upstream_p95_ms="${SOAK_30M_MANIFEST_NGINX_UPSTREAM_P95_MS:-0}"
+hikari_max_lifetime_ms="${SOAK_30M_MANIFEST_HIKARI_MAX_LIFETIME_MS:-240000}"
+hikari_keepalive_time_ms="${SOAK_30M_MANIFEST_HIKARI_KEEPALIVE_TIME_MS:-60000}"
+postgres_idle_timeout_ms="${SOAK_30M_MANIFEST_POSTGRES_IDLE_TIMEOUT_MS:-300000}"
+oci_nat_idle_timeout_ms="${SOAK_30M_MANIFEST_OCI_NAT_IDLE_TIMEOUT_MS:-350000}"
+
+require_non_negative_number() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "${key} must be a non-negative number: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_non_negative_integer() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${key} must be a non-negative integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+write_failure() {
+  local key="$1"
+  local ref="$2"
+  mkdir -p "${output_dir}"
+  {
+    echo "SOAK_30M_MANIFEST_STATUS=failed"
+    echo "SOAK_30M_MANIFEST_FAILURE_REASON=missing-artifact"
+    echo "SOAK_30M_MANIFEST_MISSING_KEY=${key}"
+    echo "SOAK_30M_MANIFEST_MISSING_REF=${ref}"
+    echo "SOAK_30M_MANIFEST_RUN_ID=${run_id}"
+  } >"${failure_env}"
+}
+
+is_uri_ref() {
+  [[ "$1" =~ ^[A-Za-z][A-Za-z0-9+.-]*:// ]]
+}
+
+require_artifact_ref() {
+  local key="$1"
+  local ref="$2"
+  if [[ -z "${ref}" ]]; then
+    write_failure "${key}" "missing"
+    echo "${key} is required and must be a non-empty artifact ref" >&2
+    exit 1
+  fi
+  if ! is_uri_ref "${ref}" && [[ ! -s "${ref}" ]]; then
+    write_failure "${key}" "${ref}"
+    echo "${key} is required and must point to a non-empty artifact: ${ref}" >&2
+    exit 1
+  fi
+}
+
+print_plan() {
+  echo "[transaction-read-30m-soak-live-evidence-manifest] name=${name}"
+  echo "[transaction-read-30m-soak-live-evidence-manifest] run_id=${run_id}"
+  echo "[transaction-read-30m-soak-live-evidence-manifest] output_dir=${output_dir}"
+  echo "[transaction-read-30m-soak-live-evidence-manifest] required_scenarios=hikari-lifetime,p999-long-correlation"
+  echo "[transaction-read-30m-soak-live-evidence-manifest] required_artifacts=k6_summary,nginx_aggregate,spring_metrics,hikari_log,postgres_wait,timeline,postgres_checkpoint,postgres_temp_file,nginx_upstream_latency,hikari_config,hikari_zero_warning_soak"
+  echo "[transaction-read-30m-soak-live-evidence-manifest] manifest_tsv=${manifest_tsv}"
+  echo "[transaction-read-30m-soak-live-evidence-manifest] report_md=${report_md}"
+  echo "[transaction-read-30m-soak-live-evidence-manifest] failure_env=${failure_env}"
+}
+
+require_non_negative_integer "SOAK_30M_MANIFEST_DURATION_MIN" "${duration_min}"
+require_non_negative_integer "SOAK_30M_MANIFEST_SOURCE_IPS" "${source_ips}"
+require_non_negative_number "SOAK_30M_MANIFEST_EDGE_429_RATE" "${edge_429_rate}"
+require_non_negative_integer "SOAK_30M_MANIFEST_BACKEND_429_COUNT" "${backend_429_count}"
+require_non_negative_integer "SOAK_30M_MANIFEST_UNKNOWN_429_COUNT" "${unknown_429_count}"
+require_non_negative_integer "SOAK_30M_MANIFEST_5XX_COUNT" "${five_xx_count}"
+require_non_negative_integer "SOAK_30M_MANIFEST_NGINX_499_COUNT" "${nginx_499_count}"
+require_non_negative_integer "SOAK_30M_MANIFEST_HIKARI_VALIDATION_WARNINGS" "${hikari_validation_warnings}"
+require_non_negative_integer "SOAK_30M_MANIFEST_DB_POOL_PENDING_MAX" "${db_pool_pending_max}"
+require_non_negative_number "SOAK_30M_MANIFEST_P95_MS" "${p95_ms}"
+require_non_negative_number "SOAK_30M_MANIFEST_P99_MS" "${p99_ms}"
+require_non_negative_number "SOAK_30M_MANIFEST_P999_MS" "${p999_ms}"
+require_non_negative_number "SOAK_30M_MANIFEST_MAX_MS" "${max_ms}"
+require_non_negative_integer "SOAK_30M_MANIFEST_POSTGRES_CHECKPOINT_COUNT" "${postgres_checkpoint_count}"
+require_non_negative_integer "SOAK_30M_MANIFEST_POSTGRES_TEMP_FILE_COUNT" "${postgres_temp_file_count}"
+require_non_negative_number "SOAK_30M_MANIFEST_NGINX_UPSTREAM_P95_MS" "${nginx_upstream_p95_ms}"
+require_non_negative_integer "SOAK_30M_MANIFEST_HIKARI_MAX_LIFETIME_MS" "${hikari_max_lifetime_ms}"
+require_non_negative_integer "SOAK_30M_MANIFEST_HIKARI_KEEPALIVE_TIME_MS" "${hikari_keepalive_time_ms}"
+require_non_negative_integer "SOAK_30M_MANIFEST_POSTGRES_IDLE_TIMEOUT_MS" "${postgres_idle_timeout_ms}"
+require_non_negative_integer "SOAK_30M_MANIFEST_OCI_NAT_IDLE_TIMEOUT_MS" "${oci_nat_idle_timeout_ms}"
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+require_artifact_ref "SOAK_30M_MANIFEST_K6_SUMMARY_REF" "${k6_summary_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_NGINX_AGGREGATE_REF" "${nginx_aggregate_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_SPRING_METRICS_REF" "${spring_metrics_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_HIKARI_LOG_REF" "${hikari_log_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_POSTGRES_WAIT_REF" "${postgres_wait_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_TIMELINE_REF" "${timeline_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_POSTGRES_CHECKPOINT_REF" "${postgres_checkpoint_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_POSTGRES_TEMP_FILE_REF" "${postgres_temp_file_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_NGINX_UPSTREAM_LATENCY_REF" "${nginx_upstream_latency_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_HIKARI_CONFIG_REF" "${hikari_config_ref}"
+require_artifact_ref "SOAK_30M_MANIFEST_HIKARI_ZERO_WARNING_SOAK_REF" "${hikari_zero_warning_soak_ref}"
+
+mkdir -p "${output_dir}"
+
+header=$'scenario\trun_id\texecuted_at_utc\tduration_min\tsource_ips\trun_script\tk6_summary_ref\tnginx_access_ref\tspring_metrics_ref\thikari_log_ref\tpostgres_wait_ref\tdeploy_event_ref\tcache_state_ref\ttimeline_ref\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tp999_ms\tpostgres_checkpoint_ref\tpostgres_temp_file_ref\tnginx_upstream_latency_ref\tworkload_mix_ref\tworkload_component_ref\toutbox_lag_ref\toutbox_lag_max\tdeploy_retry_contract_ref\tdeploy_reconnect_success_count\tdeploy_499_budget_ref\tp95_ms\tp99_ms\tmax_ms\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref\tworkload_components\tread_p999_ms\tread_429_source_ref'
+printf "%s\n" "${header}" >"${manifest_tsv}"
+
+printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+  "hikari-lifetime" "${run_id}" "${executed_at_utc}" "${duration_min}" "${source_ips}" \
+  "tools/test/run-transaction-read-weighted-10m-soak-gate.sh" \
+  "${k6_summary_ref}" "${nginx_aggregate_ref}" "${spring_metrics_ref}" "${hikari_log_ref}" "${postgres_wait_ref}" \
+  "n/a" "n/a" "${timeline_ref}" "${edge_429_rate}" "${backend_429_count}" "${unknown_429_count}" "${five_xx_count}" "${nginx_499_count}" \
+  "${hikari_validation_warnings}" "${db_pool_pending_max}" "${p999_ms}" "n/a" "n/a" "n/a" \
+  "n/a" "n/a" "n/a" "0" "n/a" "0" "n/a" \
+  "${p95_ms}" "${p99_ms}" "${max_ms}" "0" "0" "${nginx_upstream_p95_ms}" \
+  "${hikari_config_ref}" "${hikari_max_lifetime_ms}" "${hikari_keepalive_time_ms}" "${postgres_idle_timeout_ms}" "${oci_nat_idle_timeout_ms}" \
+  "${hikari_zero_warning_soak_ref}" "n/a" "0" "n/a" >>"${manifest_tsv}"
+
+printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+  "p999-long-correlation" "${run_id}" "${executed_at_utc}" "${duration_min}" "${source_ips}" \
+  "tools/test/run-transaction-read-p999-spike-attribution.sh" \
+  "${k6_summary_ref}" "${nginx_aggregate_ref}" "${spring_metrics_ref}" "${hikari_log_ref}" "${postgres_wait_ref}" \
+  "n/a" "n/a" "${timeline_ref}" "${edge_429_rate}" "${backend_429_count}" "${unknown_429_count}" "${five_xx_count}" "${nginx_499_count}" \
+  "${hikari_validation_warnings}" "${db_pool_pending_max}" "${p999_ms}" "${postgres_checkpoint_ref}" "${postgres_temp_file_ref}" "${nginx_upstream_latency_ref}" \
+  "n/a" "n/a" "n/a" "0" "n/a" "0" "n/a" \
+  "${p95_ms}" "${p99_ms}" "${max_ms}" "${postgres_checkpoint_count}" "${postgres_temp_file_count}" "${nginx_upstream_p95_ms}" \
+  "n/a" "0" "0" "0" "0" "n/a" "n/a" "0" "n/a" >>"${manifest_tsv}"
+
+cat >"${report_md}" <<REPORT
+# Transaction Read 30m Soak Live Evidence Manifest
+
+## Summary
+
+- gate_status=pass
+- run_id=${run_id}
+- duration_min=${duration_min}
+- manifest rows: 2
+- required scenarios: hikari-lifetime,p999-long-correlation
+- k6 summary: ${k6_summary_ref}
+- Hikari log: ${hikari_log_ref}
+- PostgreSQL wait/checkpoint/temp file: ${postgres_wait_ref} / ${postgres_checkpoint_ref} / ${postgres_temp_file_ref}
+- Nginx upstream latency: ${nginx_upstream_latency_ref}
+- p95/p99/p99.9/max: ${p95_ms}/${p99_ms}/${p999_ms}/${max_ms}
+
+## Artifacts
+
+- manifest TSV: ${manifest_tsv}
+- report: ${report_md}
+REPORT
+
+echo "${manifest_tsv}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #743

## 🌿 Base Branch
- main

## 📝 Summary
- 30m soak live evidence workflow에서 evidence_manifest_tsv 입력을 optional로 바꾸고, 입력이 없으면 runner workspace의 실제 artifact 파일로 manifest TSV를 자동 생성합니다.
- missing artifact는 silent skip이 아니라 failure env/report를 남기고, upload step은 always로 artifact pack을 남깁니다.

## 🛠 Changes
- 30m soak live evidence manifest builder와 contract test를 추가했습니다.
- workflow에 manifest auto-build step을 추가하고 gate step은 생성된 TSV를 사용하도록 분리했습니다.
- upload step을 always/ignore로 바꿔 실패 시에도 builder failure artifact를 수집하게 했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- bash tools/test/check-transaction-read-30m-soak-live-evidence-manifest.sh
- bash tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh
- bash tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
- ruby YAML parse for transaction-read-30m-soak-live-evidence.yml
- git diff --check
- git rev-list --count origin/main..HEAD -> 1

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: no-input workflow_dispatch는 이제 manifest 입력 누락이 아니라 실제 artifact 파일 누락에서 실패할 수 있습니다. 이 경우 manifest failure env가 artifact pack에 남습니다.
- 롤백 방법: 이 PR revert 후 evidence_manifest_tsv required 입력 기반 검증으로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 main인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?