### PR TITLE
[Perf] Off-host sampler VU16 observation gate threshold

### DIFF
--- a/.github/workflows/offhost-100m-capacity-prerequisite.yml
+++ b/.github/workflows/offhost-100m-capacity-prerequisite.yml
@@ -258,6 +258,7 @@ jobs:
               K6_ARCHIVE_RESULTS=false \
                 tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps
             '
+            # VU16 sampler는 promotion gate가 아니라 host timeline 수집용 observation phase다.
             vu16_command='
               K6_REPORT_NAME="${CAPACITY_NAME}-vu16" \
               K6_RUN_ID="${CAPACITY_NAME}-vu16" \
@@ -286,6 +287,7 @@ jobs:
               K6_MAX_VUS=16 \
               K6_DURATION="${CAPACITY_K6_TIMELINE_PHASE_DURATION}" \
               K6_OVERLOAD_MODE=true \
+              K6_OVERLOAD_429_RATE_THRESHOLD=1 \
               K6_ARCHIVE_RESULTS=false \
                 tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps
             '

--- a/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+++ b/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
@@ -79,6 +79,7 @@ grep -F 'OCI_OFFHOST_LOAD_COUPLED_TIMELINE_NAME="${CAPACITY_NAME}"' "${workflow}
 grep -F 'OCI_OFFHOST_LOAD_COUPLED_TIMELINE_RUN_ID="${CAPACITY_K6_HOST_METRICS_RUN_ID}"' "${workflow}" >/dev/null
 grep -F 'OCI_OFFHOST_LOAD_COUPLED_SAMPLE_INTERVAL_SECONDS="${CAPACITY_K6_HOST_METRICS_TIMELINE_SAMPLE_INTERVAL_SECONDS}"' "${workflow}" >/dev/null
 grep -F 'OCI_OFFHOST_LOAD_COUPLED_GENERATOR_SAMPLE_CONTEXT="${CAPACITY_K6_DOCKER_CONTEXT}"' "${workflow}" >/dev/null
+grep -F 'K6_OVERLOAD_429_RATE_THRESHOLD=1 \' "${workflow}" >/dev/null
 grep -F "tools/test/run-oci-offhost-host-metrics-load-coupled-timeline.sh" "${workflow}" >/dev/null
 grep -F 'CAPACITY_K6_HOST_METRICS_TIMELINE_TSV="${generated_timeline_tsv}"' "${workflow}" >/dev/null
 grep -F 'if [[ -z "${CAPACITY_K6_HOST_METRICS_TIMELINE_TSV}" && "${CAPACITY_REQUIRE_LOAD_COUPLED_TIMELINE}" == "false" ]]; then' "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #747
- Related: #679

## 🌿 Base Branch
- `main`

## 📝 Summary
- off-host load-coupled sampler의 VU16 phase를 promotion gate가 아닌 observation phase로 분리했습니다.
- 최신 main에서 실패한 run `25318480131`은 timeline artifact가 pass였지만 VU16 total/edge 429 threshold 때문에 workflow가 실패했습니다.
- 수정 브랜치 live run `25318919580`은 no-input strict prerequisite를 통과했고, 5초 이하 generator/target timeline artifact를 생성했습니다.

## 🛠 Changes
- VU16 sampler command에 `K6_OVERLOAD_429_RATE_THRESHOLD=1`을 추가했습니다.
- off-host prerequisite contract가 VU16 sampler observation threshold를 요구하도록 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-offhost-capacity-prerequisite-required-gate.sh`
- `bash tools/test/check-oci-offhost-host-metrics-load-coupled-timeline.sh`
- `git diff --check`
- `gh workflow run offhost-100m-capacity-prerequisite.yml --ref perf/offhost-sampler-vu16-observation-gate` -> run `25318919580` success

### live evidence
- run: https://github.com/AquilaXk/aquila-bank/actions/runs/25318919580
- headSha: `8eef31a07f388f366fd1f9512dd41ad16ec7f2cf`
- timeline: `gate_status=pass`, phases `arrival16,vu16,burst-matrix`, interval `5s`, generator/target verified
- VU16 sampler: total 429 rate `22.41%`, edge 429 rate `22.23%`, backend 429 rate `0.1788%`, 5xx `0`; sampler threshold `1`로 observation 처리

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: sampler workflow가 VU16 total/edge 429를 더 이상 failure로 보지 않으므로, promotion budget 판단은 service-auth/source gate와 burst matrix gate 결과를 별도로 봐야 합니다.
- 롤백 방법: 이 PR commit revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?