### PR TITLE
[Perf] Service-auth VU16 multi-account source gate wiring

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       hot_account_id:
-        description: "Hot account id for authenticated transaction read"
+        description: "Hot account id, or comma-separated hot account ids for fairness replay"
         required: true
         default: "910000001"
         type: string
@@ -19,7 +19,7 @@ on:
         default: "2026-04-30T00:00:00Z"
         type: string
       cold_account_id:
-        description: "Cold account id for authenticated transaction read"
+        description: "Cold account id, or comma-separated cold account ids for fairness replay"
         required: true
         default: "910000002"
         type: string
@@ -241,12 +241,20 @@ jobs:
           K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"
           K6_AUTH_TOKEN_REQUIRED="true"
           K6_AUTH_PREFLIGHT="true"
-          K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${HOT_ACCOUNT_ID_INPUT}&from=${HOT_FROM_INPUT}&to=${HOT_TO_INPUT}&limit=1"
+          K6_HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID_INPUT%%,*}"
+          K6_HOT_ACCOUNT_IDS="${K6_HOT_ACCOUNT_IDS:-}"
+          if [[ "${HOT_ACCOUNT_ID_INPUT}" == *,* ]]; then
+            K6_HOT_ACCOUNT_IDS="${HOT_ACCOUNT_ID_INPUT}"
+          fi
+          K6_COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID_INPUT%%,*}"
+          K6_COLD_ACCOUNT_IDS="${K6_COLD_ACCOUNT_IDS:-}"
+          if [[ "${COLD_ACCOUNT_ID_INPUT}" == *,* ]]; then
+            K6_COLD_ACCOUNT_IDS="${COLD_ACCOUNT_ID_INPUT}"
+          fi
+          K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${K6_HOT_ACCOUNT_ID}&from=${HOT_FROM_INPUT}&to=${HOT_TO_INPUT}&limit=1"
           K6_AUTH_PREFLIGHT_EXPECTED_STATUS="200"
-          K6_HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID_INPUT}"
           K6_HOT_FROM="${HOT_FROM_INPUT}"
           K6_HOT_TO="${HOT_TO_INPUT}"
-          K6_COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID_INPUT}"
           K6_COLD_FROM="${COLD_FROM_INPUT}"
           K6_COLD_TO="${COLD_TO_INPUT}"
           K6_VUS="${VUS_INPUT}"
@@ -316,9 +324,11 @@ jobs:
             K6_AUTH_PREFLIGHT_PATH
             K6_AUTH_PREFLIGHT_EXPECTED_STATUS
             K6_HOT_ACCOUNT_ID
+            K6_HOT_ACCOUNT_IDS
             K6_HOT_FROM
             K6_HOT_TO
             K6_COLD_ACCOUNT_ID
+            K6_COLD_ACCOUNT_IDS
             K6_COLD_FROM
             K6_COLD_TO
             K6_VUS
@@ -365,6 +375,12 @@ jobs:
           {
             "k6_run_id": "${K6_RUN_ID}",
             "scenario_mode": "${K6_SCENARIO_MODE}",
+            "accounts": {
+              "hot_account_id": "${K6_HOT_ACCOUNT_ID}",
+              "hot_account_ids": "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}",
+              "cold_account_id": "${K6_COLD_ACCOUNT_ID}",
+              "cold_account_ids": "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}"
+            },
             "constant_arrival_rate": {
               "rate": "${K6_RATE}",
               "time_unit": "${K6_TIME_UNIT}",
@@ -397,6 +413,8 @@ jobs:
           - arrival-rate gate: ${K6_RATE}/${K6_TIME_UNIT}
           - constant-vus gate role: ${K6_CONSTANT_VUS_GATE_ROLE}
           - constant-vus saturation probe: vus=${K6_VUS}, duration=${K6_DURATION}
+          - multi-account hot ids: ${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}
+          - multi-account cold ids: ${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}
           - burst probe: rate=${K6_BURST_RATE}, preAllocatedVUs=${K6_PRE_ALLOCATED_VUS:-}, maxVUs=${K6_MAX_VUS:-}
           - preemptive pacing: enabled=${K6_PREEMPTIVE_PACING}, rps=${K6_PREEMPTIVE_PACING_RPS}, maxSleepMs=${K6_PREEMPTIVE_PACING_MAX_SLEEP_MS}, jitterMs=${K6_PREEMPTIVE_PACING_JITTER_MS}
           SUMMARY

--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -434,7 +434,33 @@ jobs:
           set -euo pipefail
           report_dir="build/reports/k6/${K6_REPORT_NAME}"
           mkdir -p "${report_dir}"
-          tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >"${report_dir}/auth-preflight.log" 2>&1
+          auth_preflight_log="${report_dir}/auth-preflight.log"
+          : >"${auth_preflight_log}"
+
+          run_account_auth_preflight() {
+            local account_group="$1"
+            local account_ids="$2"
+            local from="$3"
+            local to="$4"
+            local account_id raw_account_id
+            IFS="," read -r -a accounts <<<"${account_ids}"
+            for raw_account_id in "${accounts[@]}"; do
+              account_id="${raw_account_id//[[:space:]]/}"
+              if [[ -z "${account_id}" ]]; then
+                continue
+              fi
+              if ! [[ "${account_id}" =~ ^[1-9][0-9]*$ ]]; then
+                echo "::error::Invalid ${account_group} account id for auth preflight: ${account_id}"
+                exit 1
+              fi
+              echo "[oci-k6-service-auth] auth preflight ${account_group} account=${account_id}" >>"${auth_preflight_log}"
+              K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${account_id}&from=${from}&to=${to}&limit=1" \
+                tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >>"${auth_preflight_log}" 2>&1
+            done
+          }
+
+          run_account_auth_preflight hot "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" "${K6_HOT_FROM}" "${K6_HOT_TO}"
+          run_account_auth_preflight cold "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" "${K6_COLD_FROM}" "${K6_COLD_TO}"
 
       - name: Run authenticated k6 capacity
         shell: bash

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -111,6 +111,13 @@ grep -F "multi-account cold ids: \${K6_COLD_ACCOUNT_IDS:-\${K6_COLD_ACCOUNT_ID}}
 grep -F "Capture transaction read Nginx log window" "${workflow}" >/dev/null
 grep -F 'K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' "${workflow}" >/dev/null
 grep -F "Run auth preflight" "${workflow}" >/dev/null
+grep -F "run_account_auth_preflight()" "${workflow}" >/dev/null
+grep -F 'local account_group="$1"' "${workflow}" >/dev/null
+grep -F 'local account_ids="$2"' "${workflow}" >/dev/null
+grep -F 'IFS="," read -r -a accounts <<<"${account_ids}"' "${workflow}" >/dev/null
+grep -F 'K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${account_id}&from=${from}&to=${to}&limit=1" \' "${workflow}" >/dev/null
+grep -F 'run_account_auth_preflight hot "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" "${K6_HOT_FROM}" "${K6_HOT_TO}"' "${workflow}" >/dev/null
+grep -F 'run_account_auth_preflight cold "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" "${K6_COLD_FROM}" "${K6_COLD_TO}"' "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
 grep -F "Run authenticated k6 capacity" "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${workflow}" >/dev/null

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -51,6 +51,8 @@ grep -F 'K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"' "${workflow}" >/dev/null
 grep -F 'K6_AUTH_PREFLIGHT="true"' "${workflow}" >/dev/null
 grep -F "K6_AUTH_PREFLIGHT_PATH" "${workflow}" >/dev/null
 grep -F "burst_rate:" "${workflow}" >/dev/null
+grep -F 'description: "Hot account id, or comma-separated hot account ids for fairness replay"' "${workflow}" >/dev/null
+grep -F 'description: "Cold account id, or comma-separated cold account ids for fairness replay"' "${workflow}" >/dev/null
 grep -F "arrival_rate:" "${workflow}" >/dev/null
 grep -F "time_unit:" "${workflow}" >/dev/null
 grep -F "pre_allocated_vus:" "${workflow}" >/dev/null
@@ -70,6 +72,13 @@ grep -F "OVERLOAD_MODE_INPUT" "${workflow}" >/dev/null
 grep -F 'DEFAULT_K6_NGINX_ACCESS_LOG="/var/log/nginx/access.log"' "${workflow}" >/dev/null
 grep -F 'K6_RATE="${ARRIVAL_RATE_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_TIME_UNIT="${TIME_UNIT_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID_INPUT%%,*}"' "${workflow}" >/dev/null
+grep -F 'if [[ "${HOT_ACCOUNT_ID_INPUT}" == *,* ]]; then' "${workflow}" >/dev/null
+grep -F 'K6_HOT_ACCOUNT_IDS="${HOT_ACCOUNT_ID_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID_INPUT%%,*}"' "${workflow}" >/dev/null
+grep -F 'if [[ "${COLD_ACCOUNT_ID_INPUT}" == *,* ]]; then' "${workflow}" >/dev/null
+grep -F 'K6_COLD_ACCOUNT_IDS="${COLD_ACCOUNT_ID_INPUT}"' "${workflow}" >/dev/null
+grep -F 'K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${K6_HOT_ACCOUNT_ID}&from=${HOT_FROM_INPUT}&to=${HOT_TO_INPUT}&limit=1"' "${workflow}" >/dev/null
 grep -F 'K6_OVERLOAD_MODE="${OVERLOAD_MODE_INPUT}"' "${workflow}" >/dev/null
 grep -F 'if [[ -z "${K6_OVERLOAD_MODE}" && "${K6_SCENARIO_MODE}" == "burst" ]]; then' "${workflow}" >/dev/null
 grep -F 'K6_OVERLOAD_MODE="true"' "${workflow}" >/dev/null
@@ -94,7 +103,11 @@ grep -F "k6-pacing-summary.md" "${workflow}" >/dev/null
 grep -F "K6_PACING_INPUT_REF" "${workflow}" >/dev/null
 grep -F "K6_PACING_SUMMARY_REF" "${workflow}" >/dev/null
 grep -F '"gate_role": "${K6_CONSTANT_VUS_GATE_ROLE}"' "${workflow}" >/dev/null
+grep -F '"hot_account_ids": "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}"' "${workflow}" >/dev/null
+grep -F '"cold_account_ids": "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}"' "${workflow}" >/dev/null
 grep -F "constant-vus gate role: \${K6_CONSTANT_VUS_GATE_ROLE}" "${workflow}" >/dev/null
+grep -F "multi-account hot ids: \${K6_HOT_ACCOUNT_IDS:-\${K6_HOT_ACCOUNT_ID}}" "${workflow}" >/dev/null
+grep -F "multi-account cold ids: \${K6_COLD_ACCOUNT_IDS:-\${K6_COLD_ACCOUNT_ID}}" "${workflow}" >/dev/null
 grep -F "Capture transaction read Nginx log window" "${workflow}" >/dev/null
 grep -F 'K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' "${workflow}" >/dev/null
 grep -F "Run auth preflight" "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #751
- Related #679

## 🌿 Base Branch
- `main`

## 📝 Summary
- service-auth VU16 saturation run이 단일 hot/cold 계정만 사용해 fairness-limiter source count를 자극하던 경로를 보완합니다.
- workflow_dispatch input 한도 때문에 새 입력은 늘리지 않고, 기존 `hot_account_id`/`cold_account_id`가 CSV 값을 받으면 첫 계정은 auth preflight에, 전체 CSV는 k6 multi-account runner에 전달합니다.

## 🛠 Changes
- `oci-k6-service-auth-token.yml`에서 hot/cold account input 설명을 CSV 허용으로 확장했습니다.
- CSV 입력 시 `K6_HOT_ACCOUNT_IDS`/`K6_COLD_ACCOUNT_IDS`를 export하고, preflight는 첫 account id만 사용합니다.
- pacing input/summary artifact에 multi-account hot/cold ids를 기록합니다.
- service-auth workflow contract test에 multi-account wiring 요구사항을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/check-transaction-read-429-source-gate.sh`
- `git diff --check`
- latest main arrival16 live run #25320060910: source artifact 생성, 429/5xx/499 0
- latest main VU16 live run #25320206186: source artifact 생성, fairness-limiter 23 > 20 및 nginx 499 1로 실패 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: CSV account id에 포함된 계정이 staging fixture에 없으면 live k6가 인증/조회 실패로 닫히지 않을 수 있습니다.
- 롤백 방법: 이 PR revert 후 기존 단일 account workflow 입력으로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?