### PR TITLE
[Perf] Transaction read fairness burst headroom

### DIFF
--- a/back/src/main/resources/application-oci-a1.yml
+++ b/back/src/main/resources/application-oci-a1.yml
@@ -28,6 +28,10 @@ server:
 transaction:
   read-replica:
     maximum-pool-size: ${OCI_A1_TRANSACTION_READ_REPLICA_POOL_MAX_SIZE:6}
+  read:
+    per-account:
+      # hot account의 first/cursor/deep cursor shape가 burst 중 서로 밀어내지 않도록 account 단위 여유만 둔다.
+      max-concurrency: ${OCI_A1_TRANSACTION_READ_PER_ACCOUNT_MAX_CONCURRENCY:3}
 
 oci-a1:
   transaction-read:

--- a/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
@@ -44,6 +44,10 @@ class OciA1CapacityProfileTest {
                   environment.getProperty(
                       "transaction.read-replica.maximum-pool-size", Integer.class))
               .isEqualTo(6);
+          assertThat(
+                  environment.getProperty(
+                      "transaction.read.per-account.max-concurrency", Integer.class))
+              .isEqualTo(3);
           assertThat(environment.getProperty("server.tomcat.threads.max", Integer.class))
               .isEqualTo(32);
           assertThat(environment.getProperty("server.tomcat.threads.min-spare", Integer.class))
@@ -143,6 +147,7 @@ class OciA1CapacityProfileTest {
                                 entry("OCI_A1_DB_MAX_LIFETIME_MS", "480000"),
                                 entry("OCI_A1_DB_KEEPALIVE_TIME_MS", "45000"),
                                 entry("OCI_A1_TRANSACTION_READ_REPLICA_POOL_MAX_SIZE", "5"),
+                                entry("OCI_A1_TRANSACTION_READ_PER_ACCOUNT_MAX_CONCURRENCY", "4"),
                                 entry("OCI_A1_SERVER_THREADS_MAX", "28"),
                                 entry("OCI_A1_SERVER_THREADS_MIN_SPARE", "3"),
                                 entry("OCI_A1_SERVER_ACCEPT_COUNT", "48"),
@@ -185,6 +190,10 @@ class OciA1CapacityProfileTest {
                       environment.getProperty(
                           "transaction.read-replica.maximum-pool-size", Integer.class))
                   .isEqualTo(5);
+              assertThat(
+                      environment.getProperty(
+                          "transaction.read.per-account.max-concurrency", Integer.class))
+                  .isEqualTo(4);
               assertThat(environment.getProperty("server.tomcat.threads.max", Integer.class))
                   .isEqualTo(28);
               assertThat(environment.getProperty("server.tomcat.threads.min-spare", Integer.class))

--- a/back/src/test/java/com/aquilabank/global/web/transaction/TransactionReadAccountFairnessLimiterTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/transaction/TransactionReadAccountFairnessLimiterTest.java
@@ -44,6 +44,33 @@ class TransactionReadAccountFairnessLimiterTest {
   }
 
   @Test
+  void allowsThreeConcurrentRequestsPerAccountForOciBurstShape() throws Exception {
+    TransactionReadAccountFairnessLimiter limiter = new TransactionReadAccountFairnessLimiter(3);
+    ExecutorService executor = Executors.newFixedThreadPool(3);
+    CountDownLatch ownersStarted = new CountDownLatch(3);
+    CountDownLatch releaseOwners = new CountDownLatch(1);
+    try {
+      Future<String> first = submitOwner(executor, limiter, ownersStarted, releaseOwners, "first");
+      Future<String> second =
+          submitOwner(executor, limiter, ownersStarted, releaseOwners, "second");
+      Future<String> third = submitOwner(executor, limiter, ownersStarted, releaseOwners, "third");
+      assertThat(ownersStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+      assertThatThrownBy(() -> limiter.execute(101L, () -> "rejected"))
+          .isInstanceOf(TransactionReadAccountFairnessRejectedException.class)
+          .hasMessage("transaction read account concurrency limit exceeded");
+
+      releaseOwners.countDown();
+      assertThat(first.get(1, TimeUnit.SECONDS)).isEqualTo("first");
+      assertThat(second.get(1, TimeUnit.SECONDS)).isEqualTo("second");
+      assertThat(third.get(1, TimeUnit.SECONDS)).isEqualTo("third");
+    } finally {
+      releaseOwners.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
   void separatesDifferentAccountsAndReleasesAfterFailure() {
     TransactionReadAccountFairnessLimiter limiter = new TransactionReadAccountFairnessLimiter(1);
 
@@ -76,5 +103,22 @@ class TransactionReadAccountFairnessLimiterTest {
       Thread.currentThread().interrupt();
       throw new IllegalStateException(ex);
     }
+  }
+
+  private static Future<String> submitOwner(
+      ExecutorService executor,
+      TransactionReadAccountFairnessLimiter limiter,
+      CountDownLatch ownersStarted,
+      CountDownLatch releaseOwners,
+      String result) {
+    return executor.submit(
+        () ->
+            limiter.execute(
+                101L,
+                () -> {
+                  ownersStarted.countDown();
+                  await(releaseOwners);
+                  return result;
+                }));
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #754
- relates #679

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI A1 profile에서 transaction read 계좌별 fairness 동시성 headroom을 2에서 3으로 명시한다.
- latest main burst matrix에서 burst64/96에 남은 backend `fairness-limiter` 429를 줄이기 위한 배포 설정 변경이다.

## 🛠 Changes
- `transaction.read.per-account.max-concurrency`를 OCI A1 profile 기본 3으로 추가했다.
- env override `OCI_A1_TRANSACTION_READ_PER_ACCOUNT_MAX_CONCURRENCY` binding 검증을 추가했다.
- fairness limiter가 계좌당 3개 동시 요청을 허용하고 4번째를 reject하는 단위 테스트를 추가했다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh backend-gradle ./back/gradlew -p back test --tests com.aquilabank.global.config.OciA1CapacityProfileTest --tests com.aquilabank.global.web.transaction.TransactionReadAccountFairnessLimiterTest` 통과
- `tools/test/with-resource-lock.sh backend-gradle ./back/gradlew -p back check` 통과
- commit hook `./back/gradlew -p back check` 통과
- latest main pre-change live matrix: https://github.com/AquilaXk/aquila-bank/actions/runs/25322435164
  - burst64: backend 429 1, reason `fairness-limiter`, 5xx 0, 499 0, accepted p95 4.650ms
  - burst80: total/edge/backend 429 0, 5xx 0, 499 0, accepted p95 4.264ms
  - burst96: backend 429 7, edge 429 1.5967%, 5xx 0, 499 0, accepted p95 5.295ms
- live burst matrix는 이 PR merge 후 staging deploy된 main SHA에서 재실행 필요

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 단일 account가 점유할 수 있는 transaction read in-flight가 2에서 3으로 늘어난다. 전체 endpoint admission, DB pool, worker budget은 변경하지 않아 총량 증가는 제한된다.
- 롤백 방법: `OCI_A1_TRANSACTION_READ_PER_ACCOUNT_MAX_CONCURRENCY=2`로 낮추거나 이 PR을 revert한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
