### PR TITLE
[Perf] Service-auth multi-account fixture authorization

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -134,6 +134,8 @@ on:
       - "tools/test/run-k6-transaction-100m-loadtest.sh"
       - "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh"
       - "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh"
+      - "tools/ops/staging-fixture-principal-bootstrap.sh"
+      - "tools/test/run-staging-fixture-principal-bootstrap-contract.sh"
 
 permissions:
   contents: read
@@ -155,6 +157,9 @@ jobs:
 
       - name: Validate transaction read 429 source gate
         run: bash tools/test/check-transaction-read-429-source-gate.sh
+
+      - name: Validate staging fixture principal bootstrap
+        run: bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh
 
   authenticated-k6:
     name: Authenticated OCI k6 capacity
@@ -292,6 +297,9 @@ jobs:
 
           missing=()
           [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
+          if [[ -z "${STAGING_OCI_A1_DATABASE_URL:-}" && -z "${STAGING_RDS_DATABASE_URL:-}" ]]; then
+            missing+=("STAGING_OCI_A1_DATABASE_URL")
+          fi
           [[ -z "${K6_DOCKER_CONTEXT}" ]] && missing+=("K6_DOCKER_CONTEXT")
           [[ -z "${K6_REMOTE_BASE_URL}" ]] && missing+=("K6_REMOTE_BASE_URL")
           [[ -z "${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" ]] && missing+=("K6_REMOTE_PROMETHEUS_RW_SERVER_URL")
@@ -308,6 +316,8 @@ jobs:
 
           env_names=(
             STAGING_REPLAY_TOKEN
+            STAGING_OCI_A1_DATABASE_URL
+            STAGING_RDS_DATABASE_URL
             K6_REPORT_NAME
             K6_RUN_ID
             K6_RUN_PURPOSE
@@ -427,6 +437,16 @@ jobs:
           set -euo pipefail
           K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           printf 'K6_NGINX_LOG_SINCE=%s\n' "${K6_NGINX_LOG_SINCE}" >>"${GITHUB_ENV}"
+
+      - name: Ensure service auth fixture principal
+        shell: bash
+        run: |
+          set -euo pipefail
+          HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
+          COLD_ACCOUNT_ID="${K6_COLD_ACCOUNT_ID}" \
+          HOT_ACCOUNT_IDS="${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" \
+          COLD_ACCOUNT_IDS="${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" \
+            tools/ops/staging-fixture-principal-bootstrap.sh
 
       - name: Run auth preflight
         shell: bash

--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -10,8 +10,10 @@ STAGING_REPLAY_USER_PASSWORD_HASH="${STAGING_REPLAY_USER_PASSWORD_HASH:-staging-
 STAGING_REPLAY_USER_DISPLAY_NAME="${STAGING_REPLAY_USER_DISPLAY_NAME:-Staging Fixture User}"
 HOT_ACCOUNT_ID="${HOT_ACCOUNT_ID:-${STAGING_REPLAY_HOT_ACCOUNT_ID:-}}"
 COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID:-${STAGING_REPLAY_COLD_ACCOUNT_ID:-}}"
-STAGING_REPLAY_HOT_ACCOUNT_NUMBER="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER:-STG-HOT-${HOT_ACCOUNT_ID}}"
-STAGING_REPLAY_COLD_ACCOUNT_NUMBER="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER:-STG-COLD-${COLD_ACCOUNT_ID}}"
+HOT_ACCOUNT_IDS="${HOT_ACCOUNT_IDS:-${STAGING_REPLAY_HOT_ACCOUNT_IDS:-${HOT_ACCOUNT_ID}}}"
+COLD_ACCOUNT_IDS="${COLD_ACCOUNT_IDS:-${STAGING_REPLAY_COLD_ACCOUNT_IDS:-${COLD_ACCOUNT_ID}}}"
+STAGING_REPLAY_HOT_ACCOUNT_NUMBER="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER:-}"
+STAGING_REPLAY_COLD_ACCOUNT_NUMBER="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER:-}"
 
 fail() {
   echo "::error::$*" >&2
@@ -34,6 +36,28 @@ require_positive_integer() {
   [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "${name} must be a positive integer"
 }
 
+normalize_account_ids() {
+  local name="$1"
+  local raw="${!name:-}"
+  local normalized=""
+  local item
+  local -a items
+  raw="${raw//[[:space:]]/}"
+  [ -n "${raw}" ] || fail "Missing required environment variable: ${name}"
+
+  IFS="," read -r -a items <<<"${raw}"
+  for item in "${items[@]}"; do
+    [ -n "${item}" ] || fail "${name} must not contain empty account ids"
+    [[ "${item}" =~ ^[1-9][0-9]*$ ]] || fail "${name} must contain only positive integer account ids"
+    if [[ -n "${normalized}" ]]; then
+      normalized+=","
+    fi
+    normalized+="${item}"
+  done
+
+  printf -v "${name}" '%s' "${normalized}"
+}
+
 require_max_length() {
   local name="$1"
   local value="${!name:-}"
@@ -43,22 +67,51 @@ require_max_length() {
   fi
 }
 
+require_account_number_lengths() {
+  local group_name="$1"
+  local account_ids="$2"
+  local first_account_number="$3"
+  local fallback_prefix="$4"
+  local account_id account_number
+  local index=0
+  local -a account_items
+
+  IFS="," read -r -a account_items <<<"${account_ids}"
+  for account_id in "${account_items[@]}"; do
+    ((index += 1))
+    if ((index == 1)); then
+      account_number="${first_account_number}"
+    else
+      account_number="${fallback_prefix}${account_id}"
+    fi
+    if ((${#account_number} > 20)); then
+      fail "${group_name} account number for account_id=${account_id} must be 20 characters or less"
+    fi
+  done
+}
+
 validate_inputs() {
   require_command psql
   require_env STAGING_DATABASE_URL
   require_env STAGING_REPLAY_LOGIN_ID
   require_env STAGING_REPLAY_USER_PASSWORD_HASH
   require_env STAGING_REPLAY_USER_DISPLAY_NAME
-  require_env HOT_ACCOUNT_ID
-  require_env COLD_ACCOUNT_ID
+  require_env HOT_ACCOUNT_IDS
+  require_env COLD_ACCOUNT_IDS
+  normalize_account_ids HOT_ACCOUNT_IDS
+  normalize_account_ids COLD_ACCOUNT_IDS
+  HOT_ACCOUNT_ID="${HOT_ACCOUNT_IDS%%,*}"
+  COLD_ACCOUNT_ID="${COLD_ACCOUNT_IDS%%,*}"
+  STAGING_REPLAY_HOT_ACCOUNT_NUMBER="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER:-STG-HOT-${HOT_ACCOUNT_ID}}"
+  STAGING_REPLAY_COLD_ACCOUNT_NUMBER="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER:-STG-COLD-${COLD_ACCOUNT_ID}}"
   require_positive_integer STAGING_REPLAY_USER_ID
-  require_positive_integer HOT_ACCOUNT_ID
-  require_positive_integer COLD_ACCOUNT_ID
   require_max_length STAGING_REPLAY_LOGIN_ID 80
   require_max_length STAGING_REPLAY_USER_PASSWORD_HASH 120
   require_max_length STAGING_REPLAY_USER_DISPLAY_NAME 80
   require_max_length STAGING_REPLAY_HOT_ACCOUNT_NUMBER 20
   require_max_length STAGING_REPLAY_COLD_ACCOUNT_NUMBER 20
+  require_account_number_lengths "HOT_ACCOUNT_IDS" "${HOT_ACCOUNT_IDS}" "${STAGING_REPLAY_HOT_ACCOUNT_NUMBER}" "STG-HOT-"
+  require_account_number_lengths "COLD_ACCOUNT_IDS" "${COLD_ACCOUNT_IDS}" "${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" "STG-COLD-"
 }
 
 ensure_fixture_principal() {
@@ -71,10 +124,42 @@ ensure_fixture_principal() {
     -v fixture_display_name="${STAGING_REPLAY_USER_DISPLAY_NAME}" \
     -v hot_account_id="${HOT_ACCOUNT_ID}" \
     -v cold_account_id="${COLD_ACCOUNT_ID}" \
+    -v hot_account_ids="${HOT_ACCOUNT_IDS}" \
+    -v cold_account_ids="${COLD_ACCOUNT_IDS}" \
     -v hot_account_number="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER}" \
     -v cold_account_number="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" <<'SQL'
       -- psql 변수(:name)는 -c 경로에서 치환되지 않아 stdin으로 전달한다.
       BEGIN;
+
+      CREATE TEMP TABLE staging_fixture_accounts ON COMMIT DROP AS
+      WITH raw_fixture_accounts AS (
+          SELECT
+              'hot' AS account_group,
+              0 AS group_rank,
+              hot.ordinal,
+              hot.account_id_text::bigint AS account_id
+          FROM regexp_split_to_table(:'hot_account_ids', ',') WITH ORDINALITY AS hot(account_id_text, ordinal)
+          UNION ALL
+          SELECT
+              'cold' AS account_group,
+              1 AS group_rank,
+              cold.ordinal,
+              cold.account_id_text::bigint AS account_id
+          FROM regexp_split_to_table(:'cold_account_ids', ',') WITH ORDINALITY AS cold(account_id_text, ordinal)
+      )
+      SELECT DISTINCT ON (account_id)
+          account_id,
+          CASE
+              WHEN account_group = 'hot' AND ordinal = 1 THEN :'hot_account_number'
+              WHEN account_group = 'cold' AND ordinal = 1 THEN :'cold_account_number'
+              ELSE concat('STG-', upper(account_group), '-', account_id::text)
+          END AS account_number,
+          CASE
+              WHEN account_group = 'hot' THEN 'Staging hot fixture account'
+              ELSE 'Staging cold fixture account'
+          END AS display_name
+      FROM raw_fixture_accounts
+      ORDER BY account_id, group_rank, ordinal;
 
       INSERT INTO bank_account (
           id,
@@ -86,9 +171,15 @@ ensure_fixture_principal() {
           updated_at
       )
       OVERRIDING SYSTEM VALUE
-      VALUES
-          (:hot_account_id, :'hot_account_number', 'Staging hot fixture account', 'ACTIVE', 'KRW', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-          (:cold_account_id, :'cold_account_number', 'Staging cold fixture account', 'ACTIVE', 'KRW', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      SELECT
+          account_id,
+          account_number,
+          display_name,
+          'ACTIVE',
+          'KRW',
+          CURRENT_TIMESTAMP,
+          CURRENT_TIMESTAMP
+      FROM staging_fixture_accounts
       ON CONFLICT (id)
       DO UPDATE
       SET account_status = 'ACTIVE',
@@ -102,9 +193,14 @@ ensure_fixture_principal() {
           currency_code,
           updated_at
       )
-      VALUES
-          (:hot_account_id, 0, 0, 0, 'KRW', CURRENT_TIMESTAMP),
-          (:cold_account_id, 0, 0, 0, 'KRW', CURRENT_TIMESTAMP)
+      SELECT
+          account_id,
+          0,
+          0,
+          0,
+          'KRW',
+          CURRENT_TIMESTAMP
+      FROM staging_fixture_accounts
       ON CONFLICT (account_id)
       DO UPDATE
       SET currency_code = EXCLUDED.currency_code,
@@ -144,9 +240,14 @@ ensure_fixture_principal() {
           created_at,
           updated_at
       )
-      VALUES
-          (:fixture_user_id, :hot_account_id, 'OWNER', 'ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-          (:fixture_user_id, :cold_account_id, 'OWNER', 'ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      SELECT
+          :fixture_user_id,
+          account_id,
+          'OWNER',
+          'ACTIVE',
+          CURRENT_TIMESTAMP,
+          CURRENT_TIMESTAMP
+      FROM staging_fixture_accounts
       ON CONFLICT (user_id, account_id)
       DO UPDATE
       SET membership_role = EXCLUDED.membership_role,
@@ -166,4 +267,4 @@ SQL
 validate_inputs
 ensure_fixture_principal
 
-echo "[staging-fixture-principal] ensured user_id=${STAGING_REPLAY_USER_ID} hot_account_id=${HOT_ACCOUNT_ID} cold_account_id=${COLD_ACCOUNT_ID}"
+echo "[staging-fixture-principal] ensured user_id=${STAGING_REPLAY_USER_ID} hot_account_ids=${HOT_ACCOUNT_IDS} cold_account_ids=${COLD_ACCOUNT_IDS}"

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -27,6 +27,8 @@ grep -F "tools/test/check-transaction-read-429-source-gate.sh" "${workflow}" >/d
 grep -F "tools/test/run-transaction-read-429-source-gate.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-promotion-pacing-contract.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-promotion-pacing-contract.sh" "${workflow}" >/dev/null
+grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-staging-fixture-principal-bootstrap-contract.sh" "${workflow}" >/dev/null
 grep -F "Validate promotion pacing contract" "${workflow}" >/dev/null
 grep -F "Validate transaction read 429 source gate" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
@@ -110,6 +112,11 @@ grep -F "multi-account hot ids: \${K6_HOT_ACCOUNT_IDS:-\${K6_HOT_ACCOUNT_ID}}" "
 grep -F "multi-account cold ids: \${K6_COLD_ACCOUNT_IDS:-\${K6_COLD_ACCOUNT_ID}}" "${workflow}" >/dev/null
 grep -F "Capture transaction read Nginx log window" "${workflow}" >/dev/null
 grep -F 'K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' "${workflow}" >/dev/null
+grep -F "Ensure service auth fixture principal" "${workflow}" >/dev/null
+grep -F 'STAGING_OCI_A1_DATABASE_URL' "${workflow}" >/dev/null
+grep -F 'HOT_ACCOUNT_IDS="${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" \' "${workflow}" >/dev/null
+grep -F 'COLD_ACCOUNT_IDS="${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" \' "${workflow}" >/dev/null
+grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
 grep -F "Run auth preflight" "${workflow}" >/dev/null
 grep -F "run_account_auth_preflight()" "${workflow}" >/dev/null
 grep -F 'local account_group="$1"' "${workflow}" >/dev/null
@@ -165,9 +172,11 @@ grep -F "transaction-read-nginx-access-aggregate" "${workflow}" >/dev/null
 grep -F "actions/upload-artifact@" "${workflow}" >/dev/null
 grep -F "oci-k6-service-auth-token" "${workflow}" >/dev/null
 
+fixture_principal_line="$(grep -n "Ensure service auth fixture principal" "${workflow}" | head -1 | cut -d: -f1)"
 auth_preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"
 k6_run_line="$(grep -n -- "--no-up --no-deps" "${workflow}" | head -1 | cut -d: -f1)"
-if [[ -z "${auth_preflight_line}" || -z "${k6_run_line}" || "${auth_preflight_line}" -ge "${k6_run_line}" ]]; then
+if [[ -z "${fixture_principal_line}" || -z "${auth_preflight_line}" || -z "${k6_run_line}" ||
+  "${fixture_principal_line}" -ge "${auth_preflight_line}" || "${auth_preflight_line}" -ge "${k6_run_line}" ]]; then
   echo "auth preflight must run before authenticated k6 capacity" >&2
   exit 1
 fi

--- a/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+++ b/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
@@ -36,9 +36,39 @@ run_bootstrap() {
     "${script}"
 }
 
+run_bootstrap_with_csv_accounts() {
+  env \
+    PATH="${tmp_dir}:${PATH}" \
+    PSQL_STUB_LOG="${psql_log}" \
+    PSQL_STDIN_LOG="${psql_stdin_log}" \
+    STAGING_OCI_A1_DATABASE_URL="postgresql://fixture-db/aquila" \
+    STAGING_REPLAY_USER_ID="55" \
+    STAGING_REPLAY_LOGIN_ID="staging-fixture-user" \
+    STAGING_REPLAY_USER_PASSWORD_HASH="fixturePasswordHashWithLetters" \
+    STAGING_REPLAY_USER_DISPLAY_NAME="Staging Fixture User" \
+    HOT_ACCOUNT_ID="1001" \
+    COLD_ACCOUNT_ID="1002" \
+    HOT_ACCOUNT_IDS="1001,1003,1005" \
+    COLD_ACCOUNT_IDS="1002,1004" \
+    "${script}"
+}
+
 assert_valid_secret_like_values_do_not_enter_arithmetic() {
   run_bootstrap >/dev/null
   grep -q -- "fixture_password_hash=fixturePasswordHashWithLetters" "${psql_log}"
+}
+
+assert_csv_account_ids_feed_fixture_sql() {
+  : >"${psql_log}"
+  : >"${psql_stdin_log}"
+
+  run_bootstrap_with_csv_accounts >/dev/null
+
+  grep -q -- "hot_account_ids=1001,1003,1005" "${psql_log}"
+  grep -q -- "cold_account_ids=1002,1004" "${psql_log}"
+  grep -q -- "regexp_split_to_table(:'hot_account_ids', ',')" "${psql_stdin_log}"
+  grep -q -- "regexp_split_to_table(:'cold_account_ids', ',')" "${psql_stdin_log}"
+  grep -q -- "INSERT INTO user_account_membership" "${psql_stdin_log}"
 }
 
 assert_too_long_password_hash_fails_before_psql() {
@@ -71,6 +101,7 @@ assert_too_long_password_hash_fails_before_psql() {
 }
 
 assert_valid_secret_like_values_do_not_enter_arithmetic
+assert_csv_account_ids_feed_fixture_sql
 assert_too_long_password_hash_fails_before_psql
 
 echo "[staging-fixture-principal-contract] ok"


### PR DESCRIPTION
## 🔗 Related Issue
- close #753

## 🌿 Base Branch
- `main`

## 📝 Summary
- service-auth multi-account VU16 live gate에서 CSV 계정 preflight가 403으로 막히던 fixture authorization 경로를 보강합니다.
- k6 auth preflight 전에 staging fixture principal bootstrap을 실행하고, bootstrap이 hot/cold CSV 계정 전체의 계정/잔액 스냅샷/멤버십을 보장하게 합니다.

## 🛠 Changes
- `staging-fixture-principal-bootstrap.sh`가 단일 계정 입력과 CSV 계정 입력을 모두 지원하도록 확장했습니다.
- service-auth workflow가 `STAGING_OCI_A1_DATABASE_URL` 또는 legacy RDS URL을 요구/전파하고, auth preflight 전에 CSV 계정 목록으로 fixture principal을 보장합니다.
- workflow/ops 계약 테스트에 CSV bootstrap과 preflight 이전 실행 순서를 고정했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인: N/A, live gate artifact는 main 병합 후 #753 재실행으로 확인

### 실행한 검증
- `bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/check-oci-a1-bluegreen-cd-contract.sh`
- `bash -n tools/ops/staging-fixture-principal-bootstrap.sh`
- `bash -n tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash -n tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: workflow dispatch 시 staging DB URL secret이 없으면 service-auth run이 auth preflight 전에 fail-fast 합니다. 이는 403 artifact를 만들기 전에 fixture 권한 보장 실패를 드러내기 위한 의도된 동작입니다.
- 롤백 방법: 이 PR revert 후 기존 service-auth workflow/fixture bootstrap 경로로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A, workflow/ops 경로 수정
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A, DB schema/API 변경 없음
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A, live evidence는 #753 재실행 artifact로 추적
