### PR TITLE
[Fix] OCI staging replay planner estimate tolerance

### DIFF
--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -11,6 +11,7 @@ STAGING_OCI_A1_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-}"
 STAGING_RDS_DATABASE_URL="${STAGING_RDS_DATABASE_URL:-}"
 STAGING_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-${STAGING_RDS_DATABASE_URL}}"
 EXPECTED_TOTAL_ROWS="${EXPECTED_TOTAL_ROWS:-100000000}"
+EXPECTED_TOTAL_ROWS_TOLERANCE="${EXPECTED_TOTAL_ROWS_TOLERANCE:-10000}"
 ITERATIONS="${ITERATIONS:-40}"
 PAGE_LIMIT="${PAGE_LIMIT:-50}"
 REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-5}"
@@ -41,11 +42,17 @@ fixture_restore_guidance() {
   printf '%s' "Restore OCI A1 100m fixture before replay: tools/test/run-transaction-100m-fresh-volume-restore-k6.sh --dry-run, then tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target both."
 }
 
+minimum_expected_total_rows() {
+  printf '%s\n' "$((EXPECTED_TOTAL_ROWS - EXPECTED_TOTAL_ROWS_TOLERANCE))"
+}
+
 write_distribution_failure_report() {
   local status="$1"
   local estimated_total="$2"
   local detail="$3"
   local guidance="$4"
+  local minimum_total_rows
+  minimum_total_rows="$(minimum_expected_total_rows)"
 
   echo "$estimated_total" >"${REPORT_DIR}/estimated-total-rows.txt"
   jq -n \
@@ -56,6 +63,8 @@ write_distribution_failure_report() {
     --arg detail "$detail" \
     --arg guidance "$guidance" \
     --argjson expectedTotalRows "$EXPECTED_TOTAL_ROWS" \
+    --argjson expectedTotalRowsTolerance "$EXPECTED_TOTAL_ROWS_TOLERANCE" \
+    --argjson minimumExpectedTotalRows "$minimum_total_rows" \
     --argjson estimatedTotalRows "$estimated_total" \
     '{
       generatedAt: $generatedAt,
@@ -65,6 +74,8 @@ write_distribution_failure_report() {
       detail: $detail,
       guidance: $guidance,
       expectedTotalRows: $expectedTotalRows,
+      expectedTotalRowsTolerance: $expectedTotalRowsTolerance,
+      minimumExpectedTotalRows: $minimumExpectedTotalRows,
       estimatedTotalRows: $estimatedTotalRows,
       failed: true
     }' >"$SUMMARY_JSON"
@@ -77,6 +88,8 @@ write_distribution_failure_report() {
     echo "- failure: ${status}"
     echo "- estimated total rows: ${estimated_total}"
     echo "- expected total rows: ${EXPECTED_TOTAL_ROWS}"
+    echo "- expected total rows tolerance: ${EXPECTED_TOTAL_ROWS_TOLERANCE}"
+    echo "- minimum expected total rows: ${minimum_total_rows}"
     echo "- detail: ${detail}"
     echo "- guidance: ${guidance}"
   } >"$SUMMARY_MD"
@@ -131,6 +144,12 @@ require_positive_integer() {
   [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "${name} must be a positive integer"
 }
 
+require_non_negative_integer() {
+  local name="$1"
+  local value="${!name:-}"
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "${name} must be a non-negative integer"
+}
+
 require_ratio_between_zero_and_one() {
   local name="$1"
   local value="${!name:-}"
@@ -172,6 +191,7 @@ validate_inputs() {
   require_env COLD_TO
 
   require_positive_integer EXPECTED_TOTAL_ROWS
+  require_non_negative_integer EXPECTED_TOTAL_ROWS_TOLERANCE
   require_positive_integer ITERATIONS
   require_positive_integer PAGE_LIMIT
   require_positive_integer REQUEST_TIMEOUT_SECONDS
@@ -185,6 +205,9 @@ validate_inputs() {
 
   if [ "$PAGE_LIMIT" -gt 100 ]; then
     fail "PAGE_LIMIT must be 100 or less"
+  fi
+  if [ "$EXPECTED_TOTAL_ROWS_TOLERANCE" -ge "$EXPECTED_TOTAL_ROWS" ]; then
+    fail "EXPECTED_TOTAL_ROWS_TOLERANCE must be less than EXPECTED_TOTAL_ROWS"
   fi
 
   [ -x "$PLANNER_STATS_GUARD_SCRIPT" ] || fail "Planner stats guard script is not executable: ${PLANNER_STATS_GUARD_SCRIPT}"
@@ -227,7 +250,8 @@ run_planner_stats_guard() {
 
 verify_staging_distribution() {
   # 1억 건 검증에서 full count는 OCI A1 PostgreSQL에 부담이 커서 planner 통계 estimate로 gate를 둡니다.
-  local estimated_total
+  local estimated_total minimum_total_rows
+  minimum_total_rows="$(minimum_expected_total_rows)"
   estimated_total="$(
     psql_scalar \
       "WITH target_parent(table_name) AS (
@@ -248,13 +272,13 @@ verify_staging_distribution() {
   )"
 
   [[ "$estimated_total" =~ ^[0-9]+$ ]] || fail "OCI A1 row estimate is not numeric: ${estimated_total}"
-  if [ "$estimated_total" -lt "$EXPECTED_TOTAL_ROWS" ]; then
+  if [ "$estimated_total" -lt "$minimum_total_rows" ]; then
     local status detail guidance
     status="estimate_below_expected"
     if [ "$estimated_total" -eq 0 ]; then
       status="fixture_missing"
     fi
-    detail="OCI A1 read model estimate ${estimated_total} is below expected ${EXPECTED_TOTAL_ROWS}"
+    detail="OCI A1 read model estimate ${estimated_total} is below minimum ${minimum_total_rows} (expected ${EXPECTED_TOTAL_ROWS}, tolerance ${EXPECTED_TOTAL_ROWS_TOLERANCE})"
     guidance="$(fixture_restore_guidance)"
     write_distribution_failure_report "$status" "$estimated_total" "$detail" "$guidance"
     fail "${status}: ${detail}. ${guidance}"
@@ -296,7 +320,7 @@ verify_staging_distribution() {
     fail "cold_account_missing: ${detail}. ${guidance}"
   fi
 
-  notice "OCI A1 read model estimate ${estimated_total} rows"
+  notice "OCI A1 read model estimate ${estimated_total} rows (expected=${EXPECTED_TOTAL_ROWS}, tolerance=${EXPECTED_TOTAL_ROWS_TOLERANCE}, minimum=${minimum_total_rows})"
   echo "$estimated_total" >"${REPORT_DIR}/estimated-total-rows.txt"
 }
 
@@ -392,8 +416,9 @@ p95_ms() {
 }
 
 write_summary() {
-  local estimated_total hot_first hot_cursor cold_first cold_cursor failed
+  local estimated_total minimum_total_rows hot_first hot_cursor cold_first cold_cursor failed
   estimated_total="$(cat "${REPORT_DIR}/estimated-total-rows.txt")"
+  minimum_total_rows="$(minimum_expected_total_rows)"
   hot_first="$(p95_ms "${REPORT_DIR}/hot_first.ms")"
   hot_cursor="$(p95_ms "${REPORT_DIR}/hot_cursor.ms")"
   cold_first="$(p95_ms "${REPORT_DIR}/cold_first.ms")"
@@ -411,6 +436,8 @@ write_summary() {
     --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg baseUrl "$STAGING_BASE_URL" \
     --argjson expectedTotalRows "$EXPECTED_TOTAL_ROWS" \
+    --argjson expectedTotalRowsTolerance "$EXPECTED_TOTAL_ROWS_TOLERANCE" \
+    --argjson minimumExpectedTotalRows "$minimum_total_rows" \
     --argjson estimatedTotalRows "$estimated_total" \
     --argjson iterations "$ITERATIONS" \
     --argjson pageLimit "$PAGE_LIMIT" \
@@ -425,6 +452,8 @@ write_summary() {
       generatedAt: $generatedAt,
       baseUrl: $baseUrl,
       expectedTotalRows: $expectedTotalRows,
+      expectedTotalRowsTolerance: $expectedTotalRowsTolerance,
+      minimumExpectedTotalRows: $minimumExpectedTotalRows,
       estimatedTotalRows: $estimatedTotalRows,
       iterations: $iterations,
       pageLimit: $pageLimit,
@@ -445,6 +474,9 @@ write_summary() {
     echo "# Transaction Read Model Staging Replay"
     echo
     echo "- estimated total rows: ${estimated_total}"
+    echo "- expected total rows: ${EXPECTED_TOTAL_ROWS}"
+    echo "- expected total rows tolerance: ${EXPECTED_TOTAL_ROWS_TOLERANCE}"
+    echo "- minimum expected total rows: ${minimum_total_rows}"
     echo "- iterations: ${ITERATIONS}"
     echo "- page limit: ${PAGE_LIMIT}"
     echo "- hot first p95: ${hot_first}ms / threshold ${HOT_P95_THRESHOLD_MS}ms"

--- a/tools/test/run-transaction-read-model-staging-replay-guard.sh
+++ b/tools/test/run-transaction-read-model-staging-replay-guard.sh
@@ -144,6 +144,7 @@ auto_output="$(
   STAGING_REPLAY_TOKEN="token" \
   STAGING_RDS_DATABASE_URL="postgres://user:pass@localhost:5432/db" \
   EXPECTED_TOTAL_ROWS="100" \
+  EXPECTED_TOTAL_ROWS_TOLERANCE="1" \
   HOT_ACCOUNT_ID="101" \
   HOT_FROM="2026-04-01T00:00:00Z" \
   HOT_TO="2026-04-15T00:00:00Z" \
@@ -165,7 +166,6 @@ grep -F "fixture_missing" <<<"${auto_output}" >/dev/null
 grep -Fx "2" "${temp_dir}/guard-retry-count" >/dev/null
 grep -F "analyze-called" "${temp_dir}/analyze-called" >/dev/null
 
-echo "[transaction-staging-replay-guard] empty fixture failure writes report"
 guard_success_script="${temp_dir}/planner-guard-success.sh"
 cat >"${guard_success_script}" <<'EOF'
 #!/usr/bin/env bash
@@ -174,6 +174,91 @@ exit 0
 EOF
 chmod +x "${guard_success_script}"
 
+echo "[transaction-staging-replay-guard] planner estimate tolerance allows replay"
+tolerance_bin_dir="${temp_dir}/tolerance-bin"
+mkdir -p "${tolerance_bin_dir}"
+
+cat >"${tolerance_bin_dir}/psql" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+count_file="${TOLERANCE_PSQL_COUNT_PATH}"
+count=0
+if [ -f "${count_file}" ]; then
+  count="$(cat "${count_file}")"
+fi
+count=$((count + 1))
+echo "${count}" >"${count_file}"
+
+case "${count}" in
+  1) printf '99\n' ;;
+  2) printf 't\n' ;;
+  3) printf 't\n' ;;
+  *)
+    echo "unexpected psql call: ${count}" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tolerance_bin_dir}/psql"
+
+cat >"${tolerance_bin_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output_file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output_file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+[ -n "${output_file}" ] || {
+  echo "missing --output" >&2
+  exit 1
+}
+printf '{"items":[{"id":"tx"}],"nextCursor":"cursor"}\n' >"${output_file}"
+printf '200 0.001'
+EOF
+chmod +x "${tolerance_bin_dir}/curl"
+
+tolerance_report_dir="${temp_dir}/tolerance-report"
+PATH="${tolerance_bin_dir}:${PATH}" \
+  REPORT_DIR="${tolerance_report_dir}" \
+  TOLERANCE_PSQL_COUNT_PATH="${temp_dir}/tolerance-psql-count" \
+  PLANNER_STATS_GUARD_SCRIPT="${guard_success_script}" \
+  PLANNER_STATS_AUTO_ANALYZE=false \
+  STAGING_BASE_URL="https://staging.example.com" \
+  STAGING_REPLAY_TOKEN="token" \
+  STAGING_RDS_DATABASE_URL="postgres://user:pass@localhost:5432/db" \
+  EXPECTED_TOTAL_ROWS="100" \
+  EXPECTED_TOTAL_ROWS_TOLERANCE="1" \
+  ITERATIONS="1" \
+  PAGE_LIMIT="1" \
+  HOT_P95_THRESHOLD_MS="100" \
+  COLD_P95_THRESHOLD_MS="100" \
+  HOT_ACCOUNT_ID="101" \
+  HOT_FROM="2026-04-01T00:00:00Z" \
+  HOT_TO="2026-04-15T00:00:00Z" \
+  COLD_ACCOUNT_ID="202" \
+  COLD_FROM="2026-03-01T00:00:00Z" \
+  COLD_TO="2026-03-31T00:00:00Z" \
+  "${script}"
+
+grep -Fx "3" "${temp_dir}/tolerance-psql-count" >/dev/null
+grep -Fx "99" "${tolerance_report_dir}/estimated-total-rows.txt" >/dev/null
+jq -e '.expectedTotalRows == 100
+  and .expectedTotalRowsTolerance == 1
+  and .minimumExpectedTotalRows == 99
+  and .estimatedTotalRows == 99
+  and .failed == false' "${tolerance_report_dir}/summary.json" >/dev/null
+grep -F "minimum expected total rows: 99" "${tolerance_report_dir}/summary.md" >/dev/null
+
+echo "[transaction-staging-replay-guard] empty fixture failure writes report"
 cat >"${bin_dir}/psql" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -191,6 +276,7 @@ empty_output="$(
   STAGING_REPLAY_TOKEN="token" \
   STAGING_RDS_DATABASE_URL="postgres://user:pass@localhost:5432/db" \
   EXPECTED_TOTAL_ROWS="100" \
+  EXPECTED_TOTAL_ROWS_TOLERANCE="1" \
   HOT_ACCOUNT_ID="101" \
   HOT_FROM="2026-04-01T00:00:00Z" \
   HOT_TO="2026-04-15T00:00:00Z" \
@@ -208,7 +294,7 @@ if [ "${empty_status}" -eq 0 ]; then
 fi
 
 grep -F "fixture_missing" <<<"${empty_output}" >/dev/null
-grep -F "OCI A1 read model estimate 0 is below expected 100" <<<"${empty_output}" >/dev/null
+grep -F "OCI A1 read model estimate 0 is below minimum 99" <<<"${empty_output}" >/dev/null
 grep -F "fixture_missing" "${empty_report_dir}/summary.md" >/dev/null
 grep -F "tools/test/run-transaction-100m-fresh-volume-restore-k6.sh --dry-run" "${empty_report_dir}/summary.md" >/dev/null
 grep -Fx "0" "${empty_report_dir}/estimated-total-rows.txt" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #759
- refs #679

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI A1 staging replay gate가 PostgreSQL planner estimate를 정확한 row count처럼 비교해 작은 통계 오차에서도 CD evidence를 차단하던 문제를 수정한다.
- `99,999,888 / 100,000,000` 같은 작은 estimate deficit은 명시 tolerance 안에서 통과시키고, fixture missing 또는 큰 부족분은 계속 실패시킨다.

## 🛠 Changes
- `transaction-read-model-staging-replay.sh`에 `EXPECTED_TOTAL_ROWS_TOLERANCE`와 minimum expected rows artifact 필드를 추가했다.
- distribution failure/success summary JSON, Markdown에 expected/tolerance/minimum/estimated 값을 함께 기록한다.
- staging replay guard test에 tolerance 통과 케이스와 hot/cold 존재 확인 유지 검증을 추가했다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/run-transaction-read-model-staging-replay-guard.sh`
- `bash tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: planner estimate tolerance가 너무 크게 설정되면 실제 fixture 부족을 늦게 발견할 수 있다. 기본값은 1억 건 대비 10,000 rows(0.01%)이고, tolerance가 expected 이상이면 실행 전 실패한다.
- 롤백 방법: 이 PR commit을 revert하면 기존 exact estimate gate로 돌아간다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A: 미완성 기능 아님)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (N/A: 영향 없음)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (N/A: 변경 없음)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (N/A: artifact 필드로 반영)
