### PR TITLE
[Fix] Service-auth fixture principal DB retry

### DIFF
--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -14,6 +14,8 @@ HOT_ACCOUNT_IDS="${HOT_ACCOUNT_IDS:-${STAGING_REPLAY_HOT_ACCOUNT_IDS:-${HOT_ACCO
 COLD_ACCOUNT_IDS="${COLD_ACCOUNT_IDS:-${STAGING_REPLAY_COLD_ACCOUNT_IDS:-${COLD_ACCOUNT_ID}}}"
 STAGING_REPLAY_HOT_ACCOUNT_NUMBER="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER:-}"
 STAGING_REPLAY_COLD_ACCOUNT_NUMBER="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER:-}"
+STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS="${STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS:-3}"
+STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS="${STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS:-5}"
 
 fail() {
   echo "::error::$*" >&2
@@ -34,6 +36,12 @@ require_positive_integer() {
   local name="$1"
   local value="${!name:-}"
   [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "${name} must be a positive integer"
+}
+
+require_non_negative_integer() {
+  local name="$1"
+  local value="${!name:-}"
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "${name} must be a non-negative integer"
 }
 
 normalize_account_ids() {
@@ -112,11 +120,15 @@ validate_inputs() {
   require_max_length STAGING_REPLAY_COLD_ACCOUNT_NUMBER 20
   require_account_number_lengths "HOT_ACCOUNT_IDS" "${HOT_ACCOUNT_IDS}" "${STAGING_REPLAY_HOT_ACCOUNT_NUMBER}" "STG-HOT-"
   require_account_number_lengths "COLD_ACCOUNT_IDS" "${COLD_ACCOUNT_IDS}" "${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" "STG-COLD-"
+  require_positive_integer STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS
+  require_non_negative_integer STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS
 }
 
 ensure_fixture_principal() {
   # replay JWT는 user_id claim을 고정하므로, smoke/replay 전에 권한 row도 같은 id로 고정합니다.
-  psql "${STAGING_DATABASE_URL}" \
+  local attempt=1
+  while true; do
+    if psql "${STAGING_DATABASE_URL}" \
     -v ON_ERROR_STOP=1 \
     -v fixture_user_id="${STAGING_REPLAY_USER_ID}" \
     -v fixture_login_id="${STAGING_REPLAY_LOGIN_ID}" \
@@ -262,6 +274,18 @@ ensure_fixture_principal() {
 
       COMMIT;
 SQL
+    then
+      return 0
+    fi
+
+    if ((attempt >= STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS)); then
+      fail "staging fixture principal psql failed after ${attempt} attempts"
+    fi
+
+    echo "::warning::staging fixture principal psql attempt ${attempt}/${STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS} failed; retrying in ${STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS}s" >&2
+    sleep "${STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS}"
+    ((attempt += 1))
+  done
 }
 
 validate_inputs

--- a/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+++ b/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
@@ -10,6 +10,19 @@ psql_stdin_log="${tmp_dir}/psql.stdin.sql"
 cat >"${tmp_dir}/psql" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+count_file="${PSQL_CALL_COUNT_FILE:-}"
+if [[ -n "${count_file}" ]]; then
+  count=0
+  if [[ -f "${count_file}" ]]; then
+    count="$(cat "${count_file}")"
+  fi
+  count=$((count + 1))
+  echo "${count}" >"${count_file}"
+  if [[ "${PSQL_FAIL_FIRST:-false}" == "true" && "${count}" -eq 1 ]]; then
+    echo 'psql: error: connection to server at "146.56.149.120", port 5432 failed: Connection timed out' >&2
+    exit 2
+  fi
+fi
 printf '%s\n' "$*" >>"${PSQL_STUB_LOG}"
 for arg in "$@"; do
   if [[ "$arg" == "--command" || "$arg" == "-c" ]]; then
@@ -17,7 +30,7 @@ for arg in "$@"; do
     exit 64
   fi
 done
-cat >"${PSQL_STDIN_LOG}"
+cat >>"${PSQL_STDIN_LOG}"
 SH
 chmod +x "${tmp_dir}/psql"
 
@@ -71,6 +84,35 @@ assert_csv_account_ids_feed_fixture_sql() {
   grep -q -- "INSERT INTO user_account_membership" "${psql_stdin_log}"
 }
 
+assert_transient_psql_timeout_retries_fixture_sql() {
+  local output="${tmp_dir}/retry.log"
+  local count_file="${tmp_dir}/psql-count"
+  : >"${psql_log}"
+  : >"${psql_stdin_log}"
+
+  env \
+    PATH="${tmp_dir}:${PATH}" \
+    PSQL_STUB_LOG="${psql_log}" \
+    PSQL_STDIN_LOG="${psql_stdin_log}" \
+    PSQL_CALL_COUNT_FILE="${count_file}" \
+    PSQL_FAIL_FIRST="true" \
+    STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS="2" \
+    STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS="0" \
+    STAGING_OCI_A1_DATABASE_URL="postgresql://fixture-db/aquila" \
+    STAGING_REPLAY_USER_ID="55" \
+    STAGING_REPLAY_LOGIN_ID="staging-fixture-user" \
+    STAGING_REPLAY_USER_PASSWORD_HASH="fixturePasswordHashWithLetters" \
+    STAGING_REPLAY_USER_DISPLAY_NAME="Staging Fixture User" \
+    HOT_ACCOUNT_ID="1001" \
+    COLD_ACCOUNT_ID="1002" \
+    "${script}" >"${output}" 2>&1
+
+  grep -q -- "staging fixture principal psql attempt 1/2 failed; retrying in 0s" "${output}"
+  grep -qx -- "2" "${count_file}"
+  grep -q -- "INSERT INTO user_account_membership" "${psql_stdin_log}"
+  grep -q -- "ensured user_id=55 hot_account_ids=1001 cold_account_ids=1002" "${output}"
+}
+
 assert_too_long_password_hash_fails_before_psql() {
   local log="${tmp_dir}/too-long.log"
   local long_hash
@@ -102,6 +144,7 @@ assert_too_long_password_hash_fails_before_psql() {
 
 assert_valid_secret_like_values_do_not_enter_arithmetic
 assert_csv_account_ids_feed_fixture_sql
+assert_transient_psql_timeout_retries_fixture_sql
 assert_too_long_password_hash_fails_before_psql
 
 echo "[staging-fixture-principal-contract] ok"


### PR DESCRIPTION
## 🔗 Related Issue
- close #761
- refs #679

## 🌿 Base Branch
- `main`

## 📝 Summary
- 최신 main service-auth k6 evidence run `25331231443`이 fixture principal bootstrap의 단발 PostgreSQL TCP timeout으로 k6 시작 전 실패한 문제를 수정한다.
- fixture principal bootstrap은 idempotent upsert 경로이므로 `psql` 실행을 제한된 횟수로 재시도하고, 재시도 성공 시 auth/k6/429 source artifact 단계로 진행한다.

## 🛠 Changes
- `staging-fixture-principal-bootstrap.sh`에 `STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS`, `STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS` 기반 bounded retry를 추가했다.
- 첫 `psql` timeout 후 두 번째 호출 성공 시 bootstrap이 통과하는 계약 테스트를 추가했다.
- 기존 CSV account id, stdin SQL variable substitution, validation-before-psql 계약은 유지했다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/check-transaction-read-429-source-gate.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: DB 연결 장애가 길게 지속되면 기본 3회 재시도만큼 실패 감지가 늦어진다. SQL은 기존과 동일한 idempotent upsert이며 retry 횟수와 sleep은 env로 제한된다.
- 롤백 방법: 이 PR commit을 revert하면 fixture principal bootstrap이 기존 단발 `psql` 실행으로 돌아간다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A: 미완성 기능 아님)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (N/A: 영향 없음)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (N/A: 변경 없음)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (N/A: workflow evidence 재실행 예정)
