### PR TITLE
[Fix] Service-auth staging DB URL resolver

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -438,6 +438,18 @@ jobs:
           K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           printf 'K6_NGINX_LOG_SINCE=%s\n' "${K6_NGINX_LOG_SINCE}" >>"${GITHUB_ENV}"
 
+      - name: Resolve OCI A1 staging database URL
+        shell: bash
+        run: |
+          set -euo pipefail
+          # backend env가 Docker alias DB를 쓰면 service-auth host psql용 URL도 staging deploy와 같은 방식으로 재산출한다.
+          if ! resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"; then
+            echo "::error::Failed to resolve service-auth staging database URL."
+            exit 1
+          fi
+          echo "::add-mask::${resolved_database_url}"
+          printf 'STAGING_OCI_A1_DATABASE_URL=%s\n' "${resolved_database_url}" >>"${GITHUB_ENV}"
+
       - name: Ensure service auth fixture principal
         shell: bash
         run: |

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -112,6 +112,9 @@ grep -F "multi-account hot ids: \${K6_HOT_ACCOUNT_IDS:-\${K6_HOT_ACCOUNT_ID}}" "
 grep -F "multi-account cold ids: \${K6_COLD_ACCOUNT_IDS:-\${K6_COLD_ACCOUNT_ID}}" "${workflow}" >/dev/null
 grep -F "Capture transaction read Nginx log window" "${workflow}" >/dev/null
 grep -F 'K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' "${workflow}" >/dev/null
+grep -F "Resolve OCI A1 staging database URL" "${workflow}" >/dev/null
+grep -F 'resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"' "${workflow}" >/dev/null
+grep -F 'printf '\''STAGING_OCI_A1_DATABASE_URL=%s\n'\'' "${resolved_database_url}" >>"${GITHUB_ENV}"' "${workflow}" >/dev/null
 grep -F "Ensure service auth fixture principal" "${workflow}" >/dev/null
 grep -F 'STAGING_OCI_A1_DATABASE_URL' "${workflow}" >/dev/null
 grep -F 'HOT_ACCOUNT_IDS="${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" \' "${workflow}" >/dev/null
@@ -173,10 +176,11 @@ grep -F "actions/upload-artifact@" "${workflow}" >/dev/null
 grep -F "oci-k6-service-auth-token" "${workflow}" >/dev/null
 
 fixture_principal_line="$(grep -n "Ensure service auth fixture principal" "${workflow}" | head -1 | cut -d: -f1)"
+resolver_line="$(grep -n "Resolve OCI A1 staging database URL" "${workflow}" | head -1 | cut -d: -f1)"
 auth_preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"
 k6_run_line="$(grep -n -- "--no-up --no-deps" "${workflow}" | head -1 | cut -d: -f1)"
-if [[ -z "${fixture_principal_line}" || -z "${auth_preflight_line}" || -z "${k6_run_line}" ||
-  "${fixture_principal_line}" -ge "${auth_preflight_line}" || "${auth_preflight_line}" -ge "${k6_run_line}" ]]; then
+if [[ -z "${resolver_line}" || -z "${fixture_principal_line}" || -z "${auth_preflight_line}" || -z "${k6_run_line}" ||
+  "${resolver_line}" -ge "${fixture_principal_line}" || "${fixture_principal_line}" -ge "${auth_preflight_line}" || "${auth_preflight_line}" -ge "${k6_run_line}" ]]; then
   echo "auth preflight must run before authenticated k6 capacity" >&2
   exit 1
 fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #763
- refs #679, #761

## 🌿 Base Branch
- `main`

## 📝 Summary
- #762 merge 후 service-auth latest-main run `25352125521`에서 fixture principal retry는 동작했지만, DB URL이 public endpoint로 남아 3회 모두 TCP timeout이 발생했다.
- service-auth workflow도 staging deploy와 같은 `Resolve OCI A1 staging database URL` 단계를 실행해 host psql용 DB URL을 `GITHUB_ENV`에 다시 기록한다.

## 🛠 Changes
- `oci-k6-service-auth-token.yml`에 DB URL resolver step을 추가하고 fixture principal bootstrap 전에 실행되도록 했다.
- workflow contract가 resolver step 존재와 `STAGING_OCI_A1_DATABASE_URL` rewrite, resolver -> fixture principal -> auth preflight -> k6 실행 순서를 검증하도록 확장했다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `bash tools/test/check-transaction-read-429-source-gate.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: resolver가 backend env/host bind 설정을 해석하지 못하면 service-auth workflow가 fixture principal 전에 명확히 실패한다. 이는 기존 timeout보다 빠른 실패이며 staging-deploy와 동일한 resolver 경로다.
- 롤백 방법: 이 PR commit을 revert하면 service-auth workflow가 기존 secret DB URL 직접 사용 경로로 돌아간다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A: 미완성 기능 아님)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (N/A: 영향 없음, secret URL은 mask 유지)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (N/A: 변경 없음)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (N/A: service-auth evidence 재실행 예정)
