### PR TITLE
[Fix] Service-auth DB resolver env propagation

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -315,6 +315,10 @@ jobs:
           fi
 
           env_names=(
+            OCI_A1_BACKEND_ENV_B64
+            POSTGRES_CONTAINER_NAME
+            POSTGRES_NETWORK_ALIAS
+            POSTGRES_HOST_BIND
             STAGING_REPLAY_TOKEN
             STAGING_OCI_A1_DATABASE_URL
             STAGING_RDS_DATABASE_URL

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -51,6 +51,10 @@ grep -F 'K6_REMOTE_WORKDIR="${CAPACITY_K6_REMOTE_WORKDIR:-${GITHUB_WORKSPACE}}"'
 grep -F "STAGING_REPLAY_TOKEN" "${workflow}" >/dev/null
 grep -F 'K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"' "${workflow}" >/dev/null
 grep -F 'K6_AUTH_PREFLIGHT="true"' "${workflow}" >/dev/null
+grep -F "OCI_A1_BACKEND_ENV_B64" "${workflow}" >/dev/null
+grep -F "POSTGRES_CONTAINER_NAME" "${workflow}" >/dev/null
+grep -F "POSTGRES_NETWORK_ALIAS" "${workflow}" >/dev/null
+grep -F "POSTGRES_HOST_BIND" "${workflow}" >/dev/null
 grep -F "K6_AUTH_PREFLIGHT_PATH" "${workflow}" >/dev/null
 grep -F "burst_rate:" "${workflow}" >/dev/null
 grep -F 'description: "Hot account id, or comma-separated hot account ids for fairness replay"' "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #765
- refs #679, #763

## 🌿 Base Branch
- `main`

## 📝 Summary
- service-auth live workflow의 DB URL resolver가 staging backend env와 PostgreSQL bind metadata를 받지 못해 public DB URL로 fallback하던 경로를 수정합니다.
- fixture principal bootstrap 이전에 resolver가 Docker alias DB URL을 host psql URL로 재작성할 수 있도록 필요한 env를 `GITHUB_ENV`로 전파합니다.

## 🛠 Changes
- `oci-k6-service-auth-token.yml`의 env persistence 목록에 `OCI_A1_BACKEND_ENV_B64`, `POSTGRES_CONTAINER_NAME`, `POSTGRES_NETWORK_ALIAS`, `POSTGRES_HOST_BIND`를 추가했습니다.
- service-auth workflow contract가 해당 resolver 입력 env 누락을 잡도록 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `bash tools/test/check-transaction-read-429-source-gate.sh`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: service-auth workflow env 전파 범위가 늘어나지만 기존 masking 규칙의 `*_ENV_B64` 대상이며, DB resolver 입력에 한정됩니다.
- 롤백 방법: 이 PR commit을 revert하면 service-auth workflow env persistence가 이전 상태로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A