### PR TITLE
[Fix] Service-auth CSV account item preflight

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -468,6 +468,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          command -v python3 >/dev/null || {
+            echo "::error::python3 is required for service-auth item preflight."
+            exit 1
+          }
           report_dir="build/reports/k6/${K6_REPORT_NAME}"
           mkdir -p "${report_dir}"
           auth_preflight_log="${report_dir}/auth-preflight.log"
@@ -492,6 +496,29 @@ jobs:
               echo "[oci-k6-service-auth] auth preflight ${account_group} account=${account_id}" >>"${auth_preflight_log}"
               K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${account_id}&from=${from}&to=${to}&limit=1" \
                 tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >>"${auth_preflight_log}" 2>&1
+              preflight_url="${K6_REMOTE_BASE_URL%/}/api/v1/transactions?accountId=${account_id}&from=${from}&to=${to}&limit=1"
+              preflight_body="${report_dir}/auth-preflight-${account_group}-${account_id}.json"
+              status="$(
+                curl -sS -o "${preflight_body}" -w "%{http_code}" \
+                  --max-time 5 \
+                  -H "Authorization: Bearer ${STAGING_REPLAY_TOKEN}" \
+                  "${preflight_url}" 2>>"${auth_preflight_log}" || true
+              )"
+              status="${status:0:3}"
+              if [[ ! "${status}" =~ ^2 ]]; then
+                echo "::error::auth item preflight failed: ${account_group} account=${account_id} expected 2xx actual=${status:-000}"
+                exit 1
+              fi
+              item_count="$(
+                python3 -c 'import json, sys; data = json.load(open(sys.argv[1], encoding="utf-8")); items = data.get("items"); print(len(items) if isinstance(items, list) else 0)' \
+                  "${preflight_body}"
+              )"
+              if (( item_count < 1 )); then
+                echo "::error::auth item preflight failed: ${account_group} account=${account_id} returned no items"
+                echo "[oci-k6-service-auth] auth item preflight failed ${account_group} account=${account_id} items=${item_count}" >>"${auth_preflight_log}"
+                exit 1
+              fi
+              echo "[oci-k6-service-auth] auth item preflight ${account_group} account=${account_id} items=${item_count}" >>"${auth_preflight_log}"
             done
           }
 

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -133,6 +133,12 @@ grep -F 'K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${account_id}&fro
 grep -F 'run_account_auth_preflight hot "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" "${K6_HOT_FROM}" "${K6_HOT_TO}"' "${workflow}" >/dev/null
 grep -F 'run_account_auth_preflight cold "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" "${K6_COLD_FROM}" "${K6_COLD_TO}"' "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
+grep -F 'preflight_url="${K6_REMOTE_BASE_URL%/}/api/v1/transactions?accountId=${account_id}&from=${from}&to=${to}&limit=1"' "${workflow}" >/dev/null
+grep -F 'preflight_body="${report_dir}/auth-preflight-${account_group}-${account_id}.json"' "${workflow}" >/dev/null
+grep -F 'curl -sS -o "${preflight_body}" -w "%{http_code}"' "${workflow}" >/dev/null
+grep -F -- '-H "Authorization: Bearer ${STAGING_REPLAY_TOKEN}"' "${workflow}" >/dev/null
+grep -F 'items = data.get("items")' "${workflow}" >/dev/null
+grep -F 'auth item preflight failed' "${workflow}" >/dev/null
 grep -F "Run authenticated k6 capacity" "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --no-up --no-deps" "${workflow}" >/dev/null
 grep -F "Resolve transaction read Nginx access log" "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #767
- refs #679

## 🌿 Base Branch
- `main`

## 📝 Summary
- service-auth CSV 다계좌 입력에서 status-only auth preflight가 빈 read-model 계정을 통과시키던 문제를 수정합니다.
- 각 hot/cold account/window에 대해 k6 실행 전 first-page JSON의 `items` 배열이 비어 있지 않은지 확인합니다.

## 🛠 Changes
- `Run auth preflight` 단계에 계정별 item preflight를 추가했습니다.
- 빈 결과 또는 non-2xx 응답은 `Run authenticated k6 capacity` 전에 명확한 에러로 실패합니다.
- workflow contract가 item preflight curl/body/items 검증 로직을 요구하도록 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `bash tools/test/check-transaction-read-429-source-gate.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/oci-k6-service-auth-token.yml"); puts "yaml ok"'`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: auth preflight에서 계정 수만큼 추가 GET 요청이 발생합니다. workflow_dispatch 검증 단계에 한정되며 k6 본 실행 전에 실패 원인을 더 빨리 분리합니다.
- 롤백 방법: 이 PR commit을 revert하면 status-only preflight로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A