### PR TITLE
[Fix] OCI k6 service-auth cold archive fixture contract 정렬

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -262,6 +262,25 @@ jobs:
           K6_HOT_TO="${HOT_TO_INPUT}"
           K6_COLD_FROM="${COLD_FROM_INPUT}"
           K6_COLD_TO="${COLD_TO_INPUT}"
+          derive_midpoint_cursor() {
+            python3 - "$1" "$2" <<'PY'
+from datetime import datetime, timezone
+import sys
+
+def parse(value):
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+start = parse(sys.argv[1])
+end = parse(sys.argv[2])
+if end <= start:
+    print(sys.argv[1])
+else:
+    midpoint = start + (end - start) / 2
+    print(midpoint.strftime("%Y-%m-%dT%H:%M:%SZ"))
+PY
+          }
+          K6_COLD_DEEP_CURSOR_BOOKED_AT="${K6_COLD_DEEP_CURSOR_BOOKED_AT:-$(derive_midpoint_cursor "${K6_COLD_FROM}" "${K6_COLD_TO}")}"
+          K6_COLD_DEEP_CURSOR_ID="${K6_COLD_DEEP_CURSOR_ID:-9223372036854775807}"
           K6_VUS="${VUS_INPUT}"
           K6_DURATION="${DURATION_INPUT}"
           K6_SCENARIO_MODE="${SCENARIO_MODE_INPUT}"
@@ -345,6 +364,8 @@ jobs:
             K6_COLD_ACCOUNT_IDS
             K6_COLD_FROM
             K6_COLD_TO
+            K6_COLD_DEEP_CURSOR_BOOKED_AT
+            K6_COLD_DEEP_CURSOR_ID
             K6_VUS
             K6_DURATION
             K6_SCENARIO_MODE

--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -482,6 +482,7 @@ jobs:
             local account_ids="$2"
             local from="$3"
             local to="$4"
+            local endpoint="$5"
             local account_id raw_account_id
             IFS="," read -r -a accounts <<<"${account_ids}"
             for raw_account_id in "${accounts[@]}"; do
@@ -494,9 +495,9 @@ jobs:
                 exit 1
               fi
               echo "[oci-k6-service-auth] auth preflight ${account_group} account=${account_id}" >>"${auth_preflight_log}"
-              K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${account_id}&from=${from}&to=${to}&limit=1" \
+              K6_AUTH_PREFLIGHT_PATH="${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1" \
                 tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >>"${auth_preflight_log}" 2>&1
-              preflight_url="${K6_REMOTE_BASE_URL%/}/api/v1/transactions?accountId=${account_id}&from=${from}&to=${to}&limit=1"
+              preflight_url="${K6_REMOTE_BASE_URL%/}/${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1"
               preflight_body="${report_dir}/auth-preflight-${account_group}-${account_id}.json"
               status="$(
                 curl -sS -o "${preflight_body}" -w "%{http_code}" \
@@ -522,8 +523,8 @@ jobs:
             done
           }
 
-          run_account_auth_preflight hot "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" "${K6_HOT_FROM}" "${K6_HOT_TO}"
-          run_account_auth_preflight cold "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" "${K6_COLD_FROM}" "${K6_COLD_TO}"
+          run_account_auth_preflight hot "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" "${K6_HOT_FROM}" "${K6_HOT_TO}" "api/v1/transactions"
+          run_account_auth_preflight cold "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" "${K6_COLD_FROM}" "${K6_COLD_TO}" "api/v1/transactions/archive"
 
       - name: Run authenticated k6 capacity
         shell: bash

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -56,6 +56,8 @@ grep -F "POSTGRES_CONTAINER_NAME" "${workflow}" >/dev/null
 grep -F "POSTGRES_NETWORK_ALIAS" "${workflow}" >/dev/null
 grep -F "POSTGRES_HOST_BIND" "${workflow}" >/dev/null
 grep -F "K6_AUTH_PREFLIGHT_PATH" "${workflow}" >/dev/null
+grep -F "K6_COLD_DEEP_CURSOR_BOOKED_AT" "${workflow}" >/dev/null
+grep -F "K6_COLD_DEEP_CURSOR_ID" "${workflow}" >/dev/null
 grep -F "burst_rate:" "${workflow}" >/dev/null
 grep -F 'description: "Hot account id, or comma-separated hot account ids for fairness replay"' "${workflow}" >/dev/null
 grep -F 'description: "Cold account id, or comma-separated cold account ids for fairness replay"' "${workflow}" >/dev/null
@@ -84,6 +86,9 @@ grep -F 'K6_HOT_ACCOUNT_IDS="${HOT_ACCOUNT_ID_INPUT}"' "${workflow}" >/dev/null
 grep -F 'K6_COLD_ACCOUNT_ID="${COLD_ACCOUNT_ID_INPUT%%,*}"' "${workflow}" >/dev/null
 grep -F 'if [[ "${COLD_ACCOUNT_ID_INPUT}" == *,* ]]; then' "${workflow}" >/dev/null
 grep -F 'K6_COLD_ACCOUNT_IDS="${COLD_ACCOUNT_ID_INPUT}"' "${workflow}" >/dev/null
+grep -F 'derive_midpoint_cursor()' "${workflow}" >/dev/null
+grep -F 'K6_COLD_DEEP_CURSOR_BOOKED_AT="${K6_COLD_DEEP_CURSOR_BOOKED_AT:-$(derive_midpoint_cursor "${K6_COLD_FROM}" "${K6_COLD_TO}")}"' "${workflow}" >/dev/null
+grep -F 'K6_COLD_DEEP_CURSOR_ID="${K6_COLD_DEEP_CURSOR_ID:-9223372036854775807}"' "${workflow}" >/dev/null
 grep -F 'K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${K6_HOT_ACCOUNT_ID}&from=${HOT_FROM_INPUT}&to=${HOT_TO_INPUT}&limit=1"' "${workflow}" >/dev/null
 grep -F 'K6_OVERLOAD_MODE="${OVERLOAD_MODE_INPUT}"' "${workflow}" >/dev/null
 grep -F 'if [[ -z "${K6_OVERLOAD_MODE}" && "${K6_SCENARIO_MODE}" == "burst" ]]; then' "${workflow}" >/dev/null

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -128,12 +128,13 @@ grep -F "Run auth preflight" "${workflow}" >/dev/null
 grep -F "run_account_auth_preflight()" "${workflow}" >/dev/null
 grep -F 'local account_group="$1"' "${workflow}" >/dev/null
 grep -F 'local account_ids="$2"' "${workflow}" >/dev/null
+grep -F 'local endpoint="$5"' "${workflow}" >/dev/null
 grep -F 'IFS="," read -r -a accounts <<<"${account_ids}"' "${workflow}" >/dev/null
-grep -F 'K6_AUTH_PREFLIGHT_PATH="api/v1/transactions?accountId=${account_id}&from=${from}&to=${to}&limit=1" \' "${workflow}" >/dev/null
-grep -F 'run_account_auth_preflight hot "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" "${K6_HOT_FROM}" "${K6_HOT_TO}"' "${workflow}" >/dev/null
-grep -F 'run_account_auth_preflight cold "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" "${K6_COLD_FROM}" "${K6_COLD_TO}"' "${workflow}" >/dev/null
+grep -F 'K6_AUTH_PREFLIGHT_PATH="${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1" \' "${workflow}" >/dev/null
+grep -F 'run_account_auth_preflight hot "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" "${K6_HOT_FROM}" "${K6_HOT_TO}" "api/v1/transactions"' "${workflow}" >/dev/null
+grep -F 'run_account_auth_preflight cold "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" "${K6_COLD_FROM}" "${K6_COLD_TO}" "api/v1/transactions/archive"' "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
-grep -F 'preflight_url="${K6_REMOTE_BASE_URL%/}/api/v1/transactions?accountId=${account_id}&from=${from}&to=${to}&limit=1"' "${workflow}" >/dev/null
+grep -F 'preflight_url="${K6_REMOTE_BASE_URL%/}/${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1"' "${workflow}" >/dev/null
 grep -F 'preflight_body="${report_dir}/auth-preflight-${account_group}-${account_id}.json"' "${workflow}" >/dev/null
 grep -F 'curl -sS -o "${preflight_body}" -w "%{http_code}"' "${workflow}" >/dev/null
 grep -F -- '-H "Authorization: Bearer ${STAGING_REPLAY_TOKEN}"' "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #771

## 🌿 Base Branch
- `main`

## 📝 Summary
- service-auth cold preflight가 active endpoint를 보던 문제를 hot/archive endpoint 분리로 정렬합니다.
- dispatch cold range 기준 midpoint cursor를 k6 env로 전달해 cold cursor/deep cursor가 fixture window 밖 기본값을 쓰지 않게 합니다.

## 🛠 Changes
- cold account preflight endpoint를 `/api/v1/transactions/archive`로 분리
- `K6_COLD_DEEP_CURSOR_BOOKED_AT` midpoint 계산 및 env 전파
- workflow contract check 보강

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `git diff --check origin/main..HEAD`
- `git rev-list --count origin/main..HEAD` = `2`, brief commit_plan = `2`
- 최신 main 실패 확인: `OCI k6 service auth token` run `25362145078`, `25362294369`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: workflow shell에서 `python3` midpoint 계산 실패 시 env load 단계에서 중단될 수 있음. 해당 runner는 기존 preflight에서도 `python3`를 요구합니다.
- 롤백 방법: 이 PR revert 후 이전 service-auth workflow로 복귀

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?