### PR TITLE
[Fix] OCI k6 service-auth workflow YAML 파싱 복구

### DIFF
--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -264,20 +264,20 @@ jobs:
           K6_COLD_TO="${COLD_TO_INPUT}"
           derive_midpoint_cursor() {
             python3 - "$1" "$2" <<'PY'
-from datetime import datetime, timezone
-import sys
+          from datetime import datetime, timezone
+          import sys
 
-def parse(value):
-    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+          def parse(value):
+              return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
 
-start = parse(sys.argv[1])
-end = parse(sys.argv[2])
-if end <= start:
-    print(sys.argv[1])
-else:
-    midpoint = start + (end - start) / 2
-    print(midpoint.strftime("%Y-%m-%dT%H:%M:%SZ"))
-PY
+          start = parse(sys.argv[1])
+          end = parse(sys.argv[2])
+          if end <= start:
+              print(sys.argv[1])
+          else:
+              midpoint = start + (end - start) / 2
+              print(midpoint.strftime("%Y-%m-%dT%H:%M:%SZ"))
+          PY
           }
           K6_COLD_DEEP_CURSOR_BOOKED_AT="${K6_COLD_DEEP_CURSOR_BOOKED_AT:-$(derive_midpoint_cursor "${K6_COLD_FROM}" "${K6_COLD_TO}")}"
           K6_COLD_DEEP_CURSOR_ID="${K6_COLD_DEEP_CURSOR_ID:-9223372036854775807}"

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -6,6 +6,9 @@ workflow=".github/workflows/oci-k6-service-auth-token.yml"
 echo "[oci-k6-service-auth] workflow exists"
 test -f "${workflow}"
 
+echo "[oci-k6-service-auth] yaml syntax"
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "ok"' "${workflow}" >/dev/null
+
 echo "[oci-k6-service-auth] workflow contract"
 grep -F "name: OCI k6 service auth token" "${workflow}" >/dev/null
 grep -F "workflow_dispatch:" "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #776

## 🌿 Base Branch
- `main`

## 📝 Summary
- #774 merge 이후 `.github/workflows/oci-k6-service-auth-token.yml`가 YAML parser에서 깨져 main push workflow가 `jobs: []` failure로 종료되던 문제를 복구합니다.
- heredoc Python 블록을 YAML `run: |` block indent 안으로 되돌리고, service-auth workflow contract에 YAML syntax gate를 추가했습니다.

## 🛠 Changes
- `oci-k6-service-auth-token.yml`의 `derive_midpoint_cursor` heredoc 본문/종료자 indent 복구
- `check-oci-k6-service-auth-token-workflow.sh`에 Ruby YAML parse 검증 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/oci-k6-service-auth-token.yml"); puts "ok"'`
- `bash tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `bash tools/test/check-transaction-read-promotion-pacing-contract.sh`
- `bash tools/test/check-transaction-read-429-source-gate.sh`
- `bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `bash tools/test/check-ci-runtime-optimization-contract.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: workflow YAML/contract 범위 변경만 포함하며 runtime 거래/인증/DB 로직 영향 없음.
- 롤백 방법: 이 PR commit revert. 단, revert 시 `oci-k6-service-auth-token.yml` YAML parse failure가 재발한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A