### PR TITLE
[Perf] transaction read real multisource live gate 추가

### DIFF
--- a/.github/workflows/transaction-read-real-multisource-public-evidence.yml
+++ b/.github/workflows/transaction-read-real-multisource-public-evidence.yml
@@ -1,0 +1,175 @@
+name: Transaction Read Real Multi-Source Public Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      real_multisource_run_id:
+        description: "Run id shared by all real multi-source public evidence artifacts"
+        required: true
+        type: string
+      real_multisource_contexts:
+        description: "Comma-separated remote Docker contexts, at least 2"
+        required: false
+        type: string
+      single_source_summary_json:
+        description: "Single-source diagnostic k6 summary JSON path"
+        required: false
+        type: string
+      multi_source_summary_json:
+        description: "Real multi-source k6 summary JSON path"
+        required: false
+        type: string
+      nginx_status_tsv:
+        description: "Nginx realip_remote_addr status TSV path"
+        required: false
+        type: string
+      source_evidence_tsv:
+        description: "Source-level edge/backend 429, latency, 5xx, fairness TSV path"
+        required: false
+        type: string
+      host_metrics_tsv:
+        description: "Generator/target host metrics TSV path"
+        required: false
+        type: string
+      host_metrics_timeline_tsv:
+        description: "Load-coupled host metrics timeline TSV path"
+        required: false
+        type: string
+      artifact_uri:
+        description: "Evidence artifact pack URI shared by source and host metrics"
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - ".github/workflows/transaction-read-real-multisource-public-evidence.yml"
+      - "tools/test/check-transaction-read-real-multisource-public-evidence-workflow.sh"
+      - "tools/test/run-oci-real-multisource-public-evidence.sh"
+      - "tools/test/check-oci-real-multisource-public-evidence.sh"
+      - "tools/test/run-oci-real-ip-multisource-capacity-replay.sh"
+      - "tools/test/check-oci-real-ip-multisource-capacity-replay.sh"
+      - "tools/test/run-oci-offhost-host-metrics-timeline.sh"
+      - "tools/test/check-oci-offhost-host-metrics-timeline.sh"
+      - "tools/test/run-k6-transaction-100m-multisource.sh"
+      - "tools/test/check-k6-transaction-100m-multisource.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: real multi-source public evidence contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate workflow contract
+        run: bash tools/test/check-transaction-read-real-multisource-public-evidence-workflow.sh
+
+      - name: Validate real multisource evidence contract
+        run: bash tools/test/check-oci-real-multisource-public-evidence.sh
+
+  live-evidence:
+    name: Real multi-source public evidence live gate
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, oci-a1-staging]
+    timeout-minutes: 30
+    environment:
+      name: staging
+    env:
+      OCI_REAL_MULTISOURCE_NAME: transaction-read-real-multisource-public-evidence-${{ github.run_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Load real multisource evidence env
+        env:
+          OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}
+          REAL_MULTISOURCE_RUN_ID_INPUT: ${{ inputs.real_multisource_run_id }}
+          REAL_MULTISOURCE_CONTEXTS_INPUT: ${{ inputs.real_multisource_contexts }}
+          SINGLE_SOURCE_SUMMARY_JSON_INPUT: ${{ inputs.single_source_summary_json }}
+          MULTI_SOURCE_SUMMARY_JSON_INPUT: ${{ inputs.multi_source_summary_json }}
+          NGINX_STATUS_TSV_INPUT: ${{ inputs.nginx_status_tsv }}
+          SOURCE_EVIDENCE_TSV_INPUT: ${{ inputs.source_evidence_tsv }}
+          HOST_METRICS_TSV_INPUT: ${{ inputs.host_metrics_tsv }}
+          HOST_METRICS_TIMELINE_TSV_INPUT: ${{ inputs.host_metrics_timeline_tsv }}
+          ARTIFACT_URI_INPUT: ${{ inputs.artifact_uri }}
+          OCI_REAL_MULTISOURCE_CONTEXTS_VAR: ${{ vars.OCI_REAL_MULTISOURCE_CONTEXTS }}
+          OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON_VAR: ${{ vars.OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON }}
+          OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON_VAR: ${{ vars.OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON }}
+          OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV_VAR: ${{ vars.OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV }}
+          OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV_VAR: ${{ vars.OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV }}
+          OCI_REAL_MULTISOURCE_HOST_METRICS_TSV_VAR: ${{ vars.OCI_REAL_MULTISOURCE_HOST_METRICS_TSV }}
+          OCI_REAL_MULTISOURCE_HOST_METRICS_TIMELINE_TSV_VAR: ${{ vars.OCI_REAL_MULTISOURCE_HOST_METRICS_TIMELINE_TSV }}
+          OCI_REAL_MULTISOURCE_ARTIFACT_URI_VAR: ${{ vars.OCI_REAL_MULTISOURCE_ARTIFACT_URI }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${OCI_A1_STAGING_ENV}" ]]; then
+            staging_env_path="${RUNNER_TEMP}/oci-real-multisource-public-evidence.env"
+            printf '%s\n' "${OCI_A1_STAGING_ENV}" >"${staging_env_path}"
+            chmod 600 "${staging_env_path}"
+
+            set -a
+            # live evidence도 staging-deploy와 같은 unified staging secret contract를 사용한다.
+            source "${staging_env_path}"
+            set +a
+          fi
+
+          OCI_REAL_MULTISOURCE_RUN_ID="${REAL_MULTISOURCE_RUN_ID_INPUT}"
+          OCI_REAL_MULTISOURCE_CONTEXTS="${REAL_MULTISOURCE_CONTEXTS_INPUT:-${OCI_REAL_MULTISOURCE_CONTEXTS_VAR:-}}"
+          OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON="${SINGLE_SOURCE_SUMMARY_JSON_INPUT:-${OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON_VAR:-}}"
+          OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON="${MULTI_SOURCE_SUMMARY_JSON_INPUT:-${OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON_VAR:-}}"
+          OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV="${NGINX_STATUS_TSV_INPUT:-${OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV_VAR:-}}"
+          OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV="${SOURCE_EVIDENCE_TSV_INPUT:-${OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV_VAR:-}}"
+          OCI_REAL_MULTISOURCE_HOST_METRICS_TSV="${HOST_METRICS_TSV_INPUT:-${OCI_REAL_MULTISOURCE_HOST_METRICS_TSV_VAR:-}}"
+          OCI_REAL_MULTISOURCE_HOST_METRICS_TIMELINE_TSV="${HOST_METRICS_TIMELINE_TSV_INPUT:-${OCI_REAL_MULTISOURCE_HOST_METRICS_TIMELINE_TSV_VAR:-}}"
+          OCI_REAL_MULTISOURCE_ARTIFACT_URI="${ARTIFACT_URI_INPUT:-${OCI_REAL_MULTISOURCE_ARTIFACT_URI_VAR:-}}"
+          OCI_REAL_MULTISOURCE_OUTPUT_DIR="build/reports/k6/${OCI_REAL_MULTISOURCE_NAME}"
+
+          missing=()
+          [[ -z "${OCI_REAL_MULTISOURCE_RUN_ID}" ]] && missing+=("OCI_REAL_MULTISOURCE_RUN_ID")
+          [[ -z "${OCI_REAL_MULTISOURCE_CONTEXTS}" ]] && missing+=("OCI_REAL_MULTISOURCE_CONTEXTS")
+          [[ -z "${OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON}" ]] && missing+=("OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON")
+          [[ -z "${OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON}" ]] && missing+=("OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON")
+          [[ -z "${OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV}" ]] && missing+=("OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV")
+          [[ -z "${OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV}" ]] && missing+=("OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV")
+          [[ -z "${OCI_REAL_MULTISOURCE_HOST_METRICS_TSV}" ]] && missing+=("OCI_REAL_MULTISOURCE_HOST_METRICS_TSV")
+          [[ -z "${OCI_REAL_MULTISOURCE_HOST_METRICS_TIMELINE_TSV}" ]] && missing+=("OCI_REAL_MULTISOURCE_HOST_METRICS_TIMELINE_TSV")
+          [[ -z "${OCI_REAL_MULTISOURCE_ARTIFACT_URI}" ]] && missing+=("OCI_REAL_MULTISOURCE_ARTIFACT_URI")
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing real multisource evidence inputs: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          for name in \
+            OCI_REAL_MULTISOURCE_RUN_ID \
+            OCI_REAL_MULTISOURCE_CONTEXTS \
+            OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON \
+            OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON \
+            OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV \
+            OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV \
+            OCI_REAL_MULTISOURCE_HOST_METRICS_TSV \
+            OCI_REAL_MULTISOURCE_HOST_METRICS_TIMELINE_TSV \
+            OCI_REAL_MULTISOURCE_ARTIFACT_URI \
+            OCI_REAL_MULTISOURCE_OUTPUT_DIR; do
+            value="${!name:-}"
+            if [[ -n "${value}" ]]; then
+              printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
+            fi
+          done
+
+      - name: Run real multisource public evidence gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools/test/run-oci-real-multisource-public-evidence.sh
+
+      - name: Upload real multisource evidence artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: transaction-read-real-multisource-public-evidence-${{ github.run_id }}
+          path: build/reports/k6/${{ env.OCI_REAL_MULTISOURCE_NAME }}/
+          if-no-files-found: ignore

--- a/tools/test/check-transaction-read-real-multisource-public-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-real-multisource-public-evidence-workflow.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/transaction-read-real-multisource-public-evidence.yml"
+
+echo "[transaction-read-real-multisource-public-evidence-workflow] workflow exists"
+test -f "${workflow}"
+
+echo "[transaction-read-real-multisource-public-evidence-workflow] yaml syntax"
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "ok"' "${workflow}" >/dev/null
+
+echo "[transaction-read-real-multisource-public-evidence-workflow] workflow contract"
+grep -F "name: Transaction Read Real Multi-Source Public Evidence" "${workflow}" >/dev/null
+grep -F "workflow_dispatch:" "${workflow}" >/dev/null
+grep -F "pull_request:" "${workflow}" >/dev/null
+grep -F "real_multisource_run_id:" "${workflow}" >/dev/null
+grep -F "real_multisource_contexts:" "${workflow}" >/dev/null
+grep -F "single_source_summary_json:" "${workflow}" >/dev/null
+grep -F "multi_source_summary_json:" "${workflow}" >/dev/null
+grep -F "nginx_status_tsv:" "${workflow}" >/dev/null
+grep -F "source_evidence_tsv:" "${workflow}" >/dev/null
+grep -F "host_metrics_tsv:" "${workflow}" >/dev/null
+grep -F "host_metrics_timeline_tsv:" "${workflow}" >/dev/null
+grep -F "artifact_uri:" "${workflow}" >/dev/null
+grep -F "real multi-source public evidence contract" "${workflow}" >/dev/null
+grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
+grep -F "bash tools/test/check-transaction-read-real-multisource-public-evidence-workflow.sh" "${workflow}" >/dev/null
+grep -F "bash tools/test/check-oci-real-multisource-public-evidence.sh" "${workflow}" >/dev/null
+grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
+grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
+grep -F "environment:" "${workflow}" >/dev/null
+grep -F "name: staging" "${workflow}" >/dev/null
+grep -F 'OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}' "${workflow}" >/dev/null
+grep -F 'REAL_MULTISOURCE_RUN_ID_INPUT: ${{ inputs.real_multisource_run_id }}' "${workflow}" >/dev/null
+grep -F 'REAL_MULTISOURCE_CONTEXTS_INPUT: ${{ inputs.real_multisource_contexts }}' "${workflow}" >/dev/null
+grep -F 'SINGLE_SOURCE_SUMMARY_JSON_INPUT: ${{ inputs.single_source_summary_json }}' "${workflow}" >/dev/null
+grep -F 'MULTI_SOURCE_SUMMARY_JSON_INPUT: ${{ inputs.multi_source_summary_json }}' "${workflow}" >/dev/null
+grep -F 'NGINX_STATUS_TSV_INPUT: ${{ inputs.nginx_status_tsv }}' "${workflow}" >/dev/null
+grep -F 'SOURCE_EVIDENCE_TSV_INPUT: ${{ inputs.source_evidence_tsv }}' "${workflow}" >/dev/null
+grep -F 'HOST_METRICS_TSV_INPUT: ${{ inputs.host_metrics_tsv }}' "${workflow}" >/dev/null
+grep -F 'HOST_METRICS_TIMELINE_TSV_INPUT: ${{ inputs.host_metrics_timeline_tsv }}' "${workflow}" >/dev/null
+grep -F 'ARTIFACT_URI_INPUT: ${{ inputs.artifact_uri }}' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_CONTEXTS_VAR: ${{ vars.OCI_REAL_MULTISOURCE_CONTEXTS }}' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_ARTIFACT_URI_VAR: ${{ vars.OCI_REAL_MULTISOURCE_ARTIFACT_URI }}' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_CONTEXTS="${REAL_MULTISOURCE_CONTEXTS_INPUT:-${OCI_REAL_MULTISOURCE_CONTEXTS_VAR:-}}"' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON="${SINGLE_SOURCE_SUMMARY_JSON_INPUT:-${OCI_REAL_MULTISOURCE_SINGLE_SOURCE_SUMMARY_JSON_VAR:-}}"' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON="${MULTI_SOURCE_SUMMARY_JSON_INPUT:-${OCI_REAL_MULTISOURCE_MULTI_SOURCE_SUMMARY_JSON_VAR:-}}"' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV="${NGINX_STATUS_TSV_INPUT:-${OCI_REAL_MULTISOURCE_NGINX_STATUS_TSV_VAR:-}}"' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV="${SOURCE_EVIDENCE_TSV_INPUT:-${OCI_REAL_MULTISOURCE_SOURCE_EVIDENCE_TSV_VAR:-}}"' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_HOST_METRICS_TSV="${HOST_METRICS_TSV_INPUT:-${OCI_REAL_MULTISOURCE_HOST_METRICS_TSV_VAR:-}}"' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_HOST_METRICS_TIMELINE_TSV="${HOST_METRICS_TIMELINE_TSV_INPUT:-${OCI_REAL_MULTISOURCE_HOST_METRICS_TIMELINE_TSV_VAR:-}}"' "${workflow}" >/dev/null
+grep -F 'OCI_REAL_MULTISOURCE_ARTIFACT_URI="${ARTIFACT_URI_INPUT:-${OCI_REAL_MULTISOURCE_ARTIFACT_URI_VAR:-}}"' "${workflow}" >/dev/null
+grep -F 'tools/test/run-oci-real-multisource-public-evidence.sh' "${workflow}" >/dev/null
+grep -F "Upload real multisource evidence artifact" "${workflow}" >/dev/null
+grep -F "transaction-read-real-multisource-public-evidence" "${workflow}" >/dev/null
+grep -F "build/reports/k6/\${{ env.OCI_REAL_MULTISOURCE_NAME }}/" "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #779
- refs #773

## 🌿 Base Branch
- `main`

## 📝 Summary
- real multi-source public evidence를 최신 main SHA에서 직접 실행할 수 있는 workflow_dispatch live gate로 연결합니다.
- 기존 `run-oci-real-multisource-public-evidence.sh` artifact contract를 PR contract job에도 묶어 workflow drift를 막습니다.

## 🛠 Changes
- `transaction-read-real-multisource-public-evidence.yml` workflow 추가
- workflow_dispatch 입력/vars fallback으로 run id, 2개 이상 Docker context, single/multi summary, Nginx real-IP status TSV, source evidence TSV, host metrics timeline, artifact URI를 검증
- PR contract checker `check-transaction-read-real-multisource-public-evidence-workflow.sh` 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-real-multisource-public-evidence-workflow.sh`
- `bash tools/test/check-oci-real-multisource-public-evidence.sh`
- `bash tools/test/check-oci-real-ip-multisource-capacity-replay.sh`
- `bash tools/test/check-k6-transaction-100m-multisource.sh`
- `bash tools/test/check-oci-offhost-host-metrics-timeline.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/transaction-read-real-multisource-public-evidence.yml"); puts "ok"'`
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 새 workflow 추가만 포함하며 runtime 거래/DB/Nginx 운영값 변경 없음. workflow_dispatch 입력/vars가 비어 있으면 live gate가 fail-fast 한다.
- 롤백 방법: 이 PR revert. 기존 runner contract는 그대로 남는다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A