### PR TITLE
[Perf] transaction read deploy drain 499 live gate

### DIFF
--- a/.github/workflows/transaction-read-deploy-drain-live-evidence.yml
+++ b/.github/workflows/transaction-read-deploy-drain-live-evidence.yml
@@ -1,0 +1,142 @@
+name: Transaction Read Deploy Drain Live Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      evidence_manifest_tsv:
+        description: "OCI deploy-drain evidence manifest TSV path on the self-hosted runner"
+        required: false
+        type: string
+      deploy_499_budget_count:
+        description: "Allowed Nginx 499 budget count during deploy/drain"
+        required: false
+        default: "0"
+        type: string
+      report_name:
+        description: "Optional deploy drain evidence report name"
+        required: false
+        type: string
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/transaction-read-deploy-drain-live-evidence.yml"
+      - "tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh"
+      - "tools/test/run-transaction-read-deploy-drain-under-load-gate.sh"
+      - "tools/test/check-transaction-read-deploy-drain-under-load-gate.sh"
+      - "tools/test/run-transaction-read-oci-evidence-execution-gate.sh"
+      - "tools/test/check-transaction-read-oci-evidence-execution-gate.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: transaction-read-deploy-drain-live-evidence-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: deploy drain live evidence contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Check deploy drain live evidence workflow
+        run: bash tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh
+
+      - name: Check deploy drain under-load contract
+        run: bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh
+
+      - name: Check OCI evidence execution gate contract
+        run: bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh
+
+  live-evidence:
+    name: Deploy Drain Live Evidence Gate
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, oci-a1-staging]
+    timeout-minutes: 15
+    environment:
+      name: staging
+    env:
+      OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}
+      DEPLOY_DRAIN_LIVE_NAME: ${{ inputs.report_name || format('transaction-read-deploy-drain-live-evidence-{0}', github.run_id) }}
+      DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_INPUT: ${{ inputs.evidence_manifest_tsv }}
+      DEPLOY_DRAIN_499_BUDGET_COUNT_INPUT: ${{ inputs.deploy_499_budget_count }}
+      DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_VAR: ${{ vars.OCI_DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV }}
+      DEPLOY_DRAIN_499_BUDGET_COUNT_VAR: ${{ vars.OCI_DEPLOY_DRAIN_499_BUDGET_COUNT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve deploy drain evidence manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${DEPLOY_DRAIN_LIVE_NAME}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::DEPLOY_DRAIN_LIVE_NAME must contain only letters, numbers, dot, underscore, or hyphen."
+            exit 1
+          fi
+
+          report_dir="build/reports/k6/${DEPLOY_DRAIN_LIVE_NAME}"
+          mkdir -p "${report_dir}"
+
+          if [[ -n "${OCI_A1_STAGING_ENV}" ]]; then
+            staging_env_path="${RUNNER_TEMP}/oci-deploy-drain-live-evidence.env"
+            printf '%s\n' "${OCI_A1_STAGING_ENV}" >"${staging_env_path}"
+            chmod 600 "${staging_env_path}"
+
+            set -a
+            # staging env는 runner-local manifest 경로만 공급하고 secret 값은 artifact에 남기지 않는다.
+            source "${staging_env_path}"
+            set +a
+          fi
+
+          DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_INPUT:-${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV:-${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_VAR:-}}}"
+          DEPLOY_DRAIN_499_BUDGET_COUNT="${DEPLOY_DRAIN_499_BUDGET_COUNT_INPUT:-${DEPLOY_DRAIN_499_BUDGET_COUNT:-${DEPLOY_DRAIN_499_BUDGET_COUNT_VAR:-0}}}"
+          if [[ -z "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" ]]; then
+            echo "::error::Missing deploy drain evidence manifest. Dispatch with evidence_manifest_tsv or configure OCI_DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV."
+            exit 1
+          fi
+          if [[ ! -s "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" ]]; then
+            echo "::error::Deploy drain evidence manifest must be a non-empty runner-local TSV: ${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}"
+            exit 1
+          fi
+          if ! [[ "${DEPLOY_DRAIN_499_BUDGET_COUNT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::DEPLOY_DRAIN_499_BUDGET_COUNT must be a non-negative integer: ${DEPLOY_DRAIN_499_BUDGET_COUNT}"
+            exit 1
+          fi
+
+          printf 'DEPLOY_DRAIN_LIVE_OUTPUT_DIR=%s\n' "${report_dir}" >>"${GITHUB_ENV}"
+          printf 'DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV=%s\n' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >>"${GITHUB_ENV}"
+          printf 'DEPLOY_DRAIN_499_BUDGET_COUNT=%s\n' "${DEPLOY_DRAIN_499_BUDGET_COUNT}" >>"${GITHUB_ENV}"
+
+      - name: Run deploy drain live evidence gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          gate_output="$(
+            DEPLOY_DRAIN_GATE_NAME="${DEPLOY_DRAIN_LIVE_NAME}" \
+            DEPLOY_DRAIN_GATE_INPUT_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" \
+            DEPLOY_DRAIN_GATE_OUTPUT_DIR="${DEPLOY_DRAIN_LIVE_OUTPUT_DIR}" \
+            DEPLOY_DRAIN_GATE_499_BUDGET_COUNT="${DEPLOY_DRAIN_499_BUDGET_COUNT}" \
+              tools/test/run-transaction-read-deploy-drain-under-load-gate.sh
+          )"
+          echo "${gate_output}"
+
+          report_md="$(tail -1 <<<"${gate_output}")"
+          {
+            echo "## Transaction Read Deploy Drain Live Evidence"
+            echo
+            cat "${report_md}"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload deploy drain live evidence artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: transaction-read-deploy-drain-live-evidence-${{ github.run_id }}
+          path: build/reports/k6/${{ env.DEPLOY_DRAIN_LIVE_NAME }}/
+          if-no-files-found: ignore

--- a/tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/transaction-read-deploy-drain-live-evidence.yml"
+
+echo "[transaction-read-deploy-drain-live-evidence-workflow] workflow exists"
+test -f "${workflow}"
+
+echo "[transaction-read-deploy-drain-live-evidence-workflow] yaml syntax"
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "ok"' "${workflow}" >/dev/null
+
+echo "[transaction-read-deploy-drain-live-evidence-workflow] workflow contract"
+grep -F "name: Transaction Read Deploy Drain Live Evidence" "${workflow}" >/dev/null
+grep -F "workflow_dispatch:" "${workflow}" >/dev/null
+grep -F "pull_request:" "${workflow}" >/dev/null
+grep -F "evidence_manifest_tsv:" "${workflow}" >/dev/null
+grep -F "deploy_499_budget_count:" "${workflow}" >/dev/null
+grep -F "report_name:" "${workflow}" >/dev/null
+grep -F "deploy drain live evidence contract" "${workflow}" >/dev/null
+grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
+grep -F "bash tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh" "${workflow}" >/dev/null
+grep -F "bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh" "${workflow}" >/dev/null
+grep -F "bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh" "${workflow}" >/dev/null
+grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
+grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
+grep -F "environment:" "${workflow}" >/dev/null
+grep -F "name: staging" "${workflow}" >/dev/null
+grep -F 'OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}' "${workflow}" >/dev/null
+grep -F 'DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_INPUT: ${{ inputs.evidence_manifest_tsv }}' "${workflow}" >/dev/null
+grep -F 'DEPLOY_DRAIN_499_BUDGET_COUNT_INPUT: ${{ inputs.deploy_499_budget_count }}' "${workflow}" >/dev/null
+grep -F 'DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_VAR: ${{ vars.OCI_DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV }}' "${workflow}" >/dev/null
+grep -F 'DEPLOY_DRAIN_499_BUDGET_COUNT_VAR: ${{ vars.OCI_DEPLOY_DRAIN_499_BUDGET_COUNT }}' "${workflow}" >/dev/null
+grep -F 'DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_INPUT:-${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV:-${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_VAR:-}}}"' "${workflow}" >/dev/null
+grep -F 'DEPLOY_DRAIN_499_BUDGET_COUNT="${DEPLOY_DRAIN_499_BUDGET_COUNT_INPUT:-${DEPLOY_DRAIN_499_BUDGET_COUNT:-${DEPLOY_DRAIN_499_BUDGET_COUNT_VAR:-0}}}"' "${workflow}" >/dev/null
+grep -F 'DEPLOY_DRAIN_GATE_INPUT_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}"' "${workflow}" >/dev/null
+grep -F 'DEPLOY_DRAIN_GATE_499_BUDGET_COUNT="${DEPLOY_DRAIN_499_BUDGET_COUNT}"' "${workflow}" >/dev/null
+grep -F "tools/test/run-transaction-read-deploy-drain-under-load-gate.sh" "${workflow}" >/dev/null
+grep -F "Upload deploy drain live evidence artifact" "${workflow}" >/dev/null
+grep -F "transaction-read-deploy-drain-live-evidence" "${workflow}" >/dev/null
+grep -F "if-no-files-found: ignore" "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #782
- refs #773

## 🌿 Base Branch
- `main`

## 📝 Summary
- 최신 main에서 deploy-drain evidence manifest를 self-hosted OCI A1 staging runner에서 검증하는 dedicated workflow를 추가한다.
- 기존 deploy-drain under-load gate를 재사용해 deploy event, 499 budget, retry/reconnect contract, 5xx/499/Hikari hard-zero evidence를 닫는다.

## 🛠 Changes
- `transaction-read-deploy-drain-live-evidence.yml` workflow_dispatch와 PR contract job 추가
- workflow contract test 추가
- 기존 deploy-drain under-load gate와 OCI execution gate contract를 PR check에 연결

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh`
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-ci-runtime-optimization-contract.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: workflow_dispatch는 runner-local `deploy-drain` evidence manifest 경로가 필요하므로, 운영자가 manifest 경로 또는 `OCI_DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV` 변수를 준비해야 한다.
- 롤백 방법: 이 PR의 workflow와 contract script commit을 revert한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
