### PR TITLE
[Fix] staging optional replay 실패 처리 수정

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -400,6 +400,7 @@ jobs:
       FRONTEND_IMAGE: ${{ needs.frontend-image.outputs.frontend_image }}
     outputs:
       transaction_replay_result: ${{ steps.resolve-transaction-replay-result.outputs.result }}
+      transaction_replay_required: ${{ steps.load-oci-a1-staging-env.outputs.transaction_replay_required }}
     steps:
       - name: Checkout deploy SHA
         uses: actions/checkout@v5
@@ -408,6 +409,7 @@ jobs:
           fetch-depth: 0
 
       - name: Load OCI A1 staging env
+        id: load-oci-a1-staging-env
         env:
           OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}
         shell: bash
@@ -460,6 +462,7 @@ jobs:
             true|false) ;;
             *) echo "::error::STAGING_REPLAY_REQUIRED must be true or false."; exit 1 ;;
           esac
+          printf 'transaction_replay_required=%s\n' "${STAGING_REPLAY_REQUIRED}" >>"${GITHUB_OUTPUT}"
 
           replay_missing=()
           [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && replay_missing+=("STAGING_REPLAY_TOKEN")
@@ -712,6 +715,7 @@ jobs:
       DEPLOYMENT_ID: ${{ needs.create-deployment.outputs.deployment_id }}
       DEPLOY_RESULT: ${{ needs.deploy-and-verify.result }}
       TRANSACTION_REPLAY_RESULT: ${{ needs.deploy-and-verify.outputs.transaction_replay_result }}
+      TRANSACTION_REPLAY_REQUIRED: ${{ needs.deploy-and-verify.outputs.transaction_replay_required }}
       BACKEND_IMAGE_RESULT: ${{ needs.backend-image.result }}
       FRONTEND_IMAGE_RESULT: ${{ needs.frontend-image.result }}
       LATEST_MAIN_RESULT: ${{ needs.validate-latest-before-deploy.result }}
@@ -811,7 +815,10 @@ jobs:
           always() &&
           needs.validate-latest-before-deploy.outputs.should_deploy == 'true' &&
           needs.deploy-and-verify.result == 'success' &&
-          needs.deploy-and-verify.outputs.transaction_replay_result != 'failure'
+          (
+            needs.deploy-and-verify.outputs.transaction_replay_result != 'failure' ||
+            needs.deploy-and-verify.outputs.transaction_replay_required != 'true'
+          )
         shell: bash
         run: |
           set -euo pipefail
@@ -854,7 +861,10 @@ jobs:
           (
             needs.backend-image.result != 'success' ||
             needs.frontend-image.result != 'success' ||
-            needs.deploy-and-verify.outputs.transaction_replay_result == 'failure' ||
+            (
+              needs.deploy-and-verify.outputs.transaction_replay_required == 'true' &&
+              needs.deploy-and-verify.outputs.transaction_replay_result == 'failure'
+            ) ||
             (
               needs.validate-latest-before-deploy.outputs.should_deploy == 'true' &&
               needs.deploy-and-verify.result != 'success'
@@ -863,7 +873,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "::error::Staging deployment failed. backend_image=${BACKEND_IMAGE_RESULT} frontend_image=${FRONTEND_IMAGE_RESULT} latest_main=${LATEST_MAIN_RESULT}/${LATEST_MAIN_SHOULD_DEPLOY} deploy=${DEPLOY_RESULT} replay=${TRANSACTION_REPLAY_RESULT}"
+          echo "::error::Staging deployment failed. backend_image=${BACKEND_IMAGE_RESULT} frontend_image=${FRONTEND_IMAGE_RESULT} latest_main=${LATEST_MAIN_RESULT}/${LATEST_MAIN_SHOULD_DEPLOY} deploy=${DEPLOY_RESULT} replay=${TRANSACTION_REPLAY_RESULT} replay_required=${TRANSACTION_REPLAY_REQUIRED}"
           payload="$(
             jq -n \
               --arg log_url "${DEPLOY_LOG_URL}" \

--- a/tools/test/run-staging-deploy-transaction-replay-gate.sh
+++ b/tools/test/run-staging-deploy-transaction-replay-gate.sh
@@ -72,6 +72,7 @@ abort('replay report upload must run after replay gate') unless replay_index < u
 
 deploy_outputs = deploy_job.fetch('outputs')
 abort('deploy job must expose transaction replay result') unless deploy_outputs.fetch('transaction_replay_result').include?('resolve-transaction-replay-result')
+abort('deploy job must expose transaction replay required flag') unless deploy_outputs.fetch('transaction_replay_required').include?('load-oci-a1-staging-env')
 
 finalize_needs = Array(finalize_job.fetch('needs'))
 abort('finalize job must depend on deploy-and-verify') unless finalize_needs.include?('deploy-and-verify')
@@ -80,18 +81,21 @@ finalize_step_names = finalize_steps.map { |step| step['name'] }
 record_replay_evidence_index = finalize_step_names.index(record_replay_evidence_name) or abort("missing step: #{record_replay_evidence_name}")
 success_step = finalize_steps.find { |step| step['name'] == 'Mark staging deployment success' } or abort('missing finalize success step')
 abort('success status must require deploy-and-verify success') unless success_step.fetch('if').include?("needs.deploy-and-verify.result == 'success'")
-abort('success status must not run when transaction replay failed') unless success_step.fetch('if').include?("needs.deploy-and-verify.outputs.transaction_replay_result != 'failure'")
+abort('success status must allow optional transaction replay failure') unless success_step.fetch('if').include?("needs.deploy-and-verify.outputs.transaction_replay_required != 'true'")
+abort('success status must block required transaction replay failure') unless success_step.fetch('if').include?("needs.deploy-and-verify.outputs.transaction_replay_result != 'failure'")
 record_replay_evidence_step = finalize_steps.fetch(record_replay_evidence_index)
 record_replay_evidence_run = record_replay_evidence_step.fetch('run')
 abort('replay evidence must use separate deployment environment') unless record_replay_evidence_run.include?('staging-100m-replay')
 abort('replay evidence must not fail staging CD on replay failure') if record_replay_evidence_run.include?('exit 1')
 failure_step = finalize_steps.find { |step| step['name'] == 'Mark staging deployment failure' } or abort('missing finalize failure step')
 failure_if = failure_step.fetch('if')
-abort('failure status must include transaction replay failure') unless failure_if.include?("needs.deploy-and-verify.outputs.transaction_replay_result == 'failure'")
+abort('failure status must include required transaction replay failure') unless failure_if.include?("needs.deploy-and-verify.outputs.transaction_replay_required == 'true'") && failure_if.include?("needs.deploy-and-verify.outputs.transaction_replay_result == 'failure'")
 failure_run = failure_step.fetch('run')
 abort('failure log must include transaction replay result') unless failure_run.include?('replay=${TRANSACTION_REPLAY_RESULT}')
+abort('failure log must include transaction replay required flag') unless failure_run.include?('replay_required=${TRANSACTION_REPLAY_REQUIRED}')
 
 load_env_step = steps.fetch(load_env_index)
+abort('load env step must have a stable id for deploy outputs') unless load_env_step.fetch('id') == 'load-oci-a1-staging-env'
 load_env = load_env_step.fetch('env')
 load_run = load_env_step.fetch('run')
 replay_step = steps.fetch(replay_index)
@@ -129,6 +133,7 @@ end
 abort('load step must read only the unified staging env secret') unless load_env.fetch('OCI_A1_STAGING_ENV').include?('secrets.OCI_A1_STAGING_ENV')
 abort('load step must source the staging env file') unless load_run.include?('source "${staging_env_path}"')
 abort('load step must default replay required to false') unless load_run.include?('STAGING_REPLAY_REQUIRED="${STAGING_REPLAY_REQUIRED:-false}"')
+abort('load step must write replay required flag to job output') unless load_run.include?('transaction_replay_required=%s')
 abort('load step must derive replay enabled from replay keys') unless load_run.include?('STAGING_REPLAY_ENABLED')
 abort('replay step should not scatter staging env mappings') if replay_step.key?('env')
 abort('replay step must be soft-fail for staging CD') unless replay_step['continue-on-error'] == true


### PR DESCRIPTION
## 🔗 Related Issue
close #788

## 🌿 Base Branch
- `main`

## 📝 Summary
- `Staging Deploy`에서 optional transaction replay 실패가 앱 staging deployment 전체를 failure로 마킹하던 조건을 수정했습니다.
- `STAGING_REPLAY_REQUIRED=false`이면 앱 배포 성공은 유지하고, replay 실패는 기존처럼 `staging-100m-replay` evidence에 별도 failure로 기록합니다.

## 🛠 Changes
- `deploy-and-verify` job이 `transaction_replay_required` output을 노출하도록 `Load OCI A1 staging env` step id/output을 추가했습니다.
- finalize success/failure 조건을 `transaction_replay_required` 기준으로 분리했습니다.
- workflow contract test가 optional replay failure 허용과 required replay failure 차단 조건을 검증하도록 확장했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/run-staging-deploy-transaction-replay-gate.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/staging-deploy.yml'); puts 'ok'"`
- `git diff --check HEAD~1..HEAD`
- `git rev-list --count main..HEAD` -> `1`

확인한 실패 근거:
- 실패 run: `Staging Deploy` `25391414850`
- 배포 job 결과: deploy/smoke/storage validation 성공
- finalize failure env: `DEPLOY_RESULT=success`, `TRANSACTION_REPLAY_RESULT=failure`
- replay artifact: `fixture_missing`, estimated rows `0`, expected rows `100000000`
- replay artifact `baseUrl`: 이전 IP `146.56.149.120`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: `STAGING_REPLAY_REQUIRED=false`에서는 100m fixture가 없는 상태여도 staging 앱 배포가 성공으로 기록됩니다. replay evidence deployment는 별도 failure로 남습니다.
- 예상 리스크: `OCI_A1_STAGING_ENV` 안의 staging public/base URL이 이전 IP를 가리키는 운영 설정은 이 PR 범위 밖입니다.
- 롤백 방법: 이 PR을 revert하면 기존처럼 replay failure가 staging deployment failure로 처리됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?