### PR TITLE
[Perf] 30m soak Hikari PostgreSQL evidence closure

### DIFF
--- a/.github/workflows/transaction-read-30m-soak-live-evidence.yml
+++ b/.github/workflows/transaction-read-30m-soak-live-evidence.yml
@@ -776,13 +776,18 @@ jobs:
         run: |
           set -euo pipefail
           summary_json="build/reports/k6/${K6_REPORT_NAME}-summary.json"
+          summary_md="build/reports/k6/${K6_REPORT_NAME}-summary.md"
+          summary_artifact_json="${SOAK_30M_REPORT_DIR}/${K6_REPORT_NAME}-summary.json"
+          summary_artifact_md="${SOAK_30M_REPORT_DIR}/${K6_REPORT_NAME}-summary.md"
+          cp "${summary_json}" "${summary_artifact_json}"
+          cp "${summary_md}" "${summary_artifact_md}"
           manifest_output="$(
             SOAK_30M_ARTIFACTS_NAME="${SOAK_30M_REPORT_NAME}" \
             SOAK_30M_ARTIFACTS_RUN_ID="${K6_RUN_ID}" \
             SOAK_30M_ARTIFACTS_EXECUTED_AT_UTC="${SOAK_30M_STARTED_AT_UTC}" \
             SOAK_30M_ARTIFACTS_DURATION_MIN="${SOAK_30M_DURATION_MIN}" \
             SOAK_30M_ARTIFACTS_OUTPUT_DIR="${SOAK_30M_REPORT_DIR}" \
-            SOAK_30M_ARTIFACTS_K6_SUMMARY_JSON="${summary_json}" \
+            SOAK_30M_ARTIFACTS_K6_SUMMARY_JSON="${summary_artifact_json}" \
             SOAK_30M_ARTIFACTS_NGINX_ACCESS_LOG="${K6_NGINX_ACCESS_LOG}" \
             SOAK_30M_ARTIFACTS_SPRING_METRICS_REF="${SOAK_30M_SPRING_METRICS_REF}" \
             SOAK_30M_ARTIFACTS_HIKARI_LOG="${SOAK_30M_HIKARI_LOG_REF}" \

--- a/.github/workflows/transaction-read-30m-soak-live-evidence.yml
+++ b/.github/workflows/transaction-read-30m-soak-live-evidence.yml
@@ -201,6 +201,8 @@ jobs:
           fi
           K6_REMOTE_BASE_URL="${CAPACITY_K6_REMOTE_BASE_URL:-${STAGING_BASE_URL:-}}"
           K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${CAPACITY_K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-http://172.17.0.2:9090/api/v1/write}"
+          # remote-write optional: 30m closure는 local timeline/summary artifact로 판정.
+          K6_REMOTE_PROMETHEUS_RW_REQUIRED="false"
           K6_REMOTE_WORKDIR="${CAPACITY_K6_REMOTE_WORKDIR:-${GITHUB_WORKSPACE}}"
           K6_REMOTE_PREFLIGHT="true"
           K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"
@@ -262,6 +264,7 @@ jobs:
             K6_DOCKER_CONTEXT_SOURCE
             K6_REMOTE_BASE_URL
             K6_REMOTE_PROMETHEUS_RW_SERVER_URL
+            K6_REMOTE_PROMETHEUS_RW_REQUIRED
             K6_REMOTE_WORKDIR
             K6_REMOTE_PREFLIGHT
             K6_AUTH_TOKEN_ENV_NAME

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-artifacts.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-artifacts.sh
@@ -137,6 +137,9 @@ grep -F $'p999-long-correlation\trun-soak-artifacts-001\t2026-05-05T00:00:00Z\t3
 grep -F "hikari_config_source=aquila-bank-backend" "${output_dir}/hikari-zero-warning-soak.md" >/dev/null
 grep -F "expected_hikari_max_lifetime_ms=45000" "${output_dir}/hikari-zero-warning-soak.md" >/dev/null
 grep -F "p95/p99/p99.9/max: 95/220/490/650" "${output_dir}/manifest/soak-artifacts-check-30m-soak-live-evidence-manifest.md" >/dev/null
+grep -F "Hikari warning/pending: 0/0" "${output_dir}/manifest/soak-artifacts-check-30m-soak-live-evidence-manifest.md" >/dev/null
+grep -F "429 hard-zero: backend=0 unknown=0 edge_rate=0" "${output_dir}/manifest/soak-artifacts-check-30m-soak-live-evidence-manifest.md" >/dev/null
+grep -F "Nginx 499/5xx: 0/0" "${output_dir}/manifest/soak-artifacts-check-30m-soak-live-evidence-manifest.md" >/dev/null
 grep -F "PostgreSQL checkpoint start/end/delta: 10/13/3" "${output_dir}/manifest/soak-artifacts-check-30m-soak-live-evidence-manifest.md" >/dev/null
 grep -F "PostgreSQL temp file start/end/delta: 20/20/0" "${output_dir}/manifest/soak-artifacts-check-30m-soak-live-evidence-manifest.md" >/dev/null
 grep -F "PostgreSQL temp file delta budget: <=0" "${output_dir}/manifest/soak-artifacts-check-30m-soak-live-evidence-manifest.md" >/dev/null

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh
@@ -66,6 +66,7 @@ grep -F "Hikari validation warnings: 0" "${report_md}" >/dev/null
 grep -F "PostgreSQL wait/checkpoint/temp file artifacts: verified" "${report_md}" >/dev/null
 grep -F "PostgreSQL temp file delta: 0 (budget <= 0)" "${report_md}" >/dev/null
 grep -F "Nginx upstream latency artifact: verified" "${report_md}" >/dev/null
+grep -F "429/5xx/499 hard-zero: backend=0 unknown=0 5xx=0 499=0" "${report_md}" >/dev/null
 grep -F "Hikari lifetime alignment: verified" "${report_md}" >/dev/null
 grep -F $'run-soak-live-001\tpass\tok\t30\t30\t95\t220\t490\t650\t0\t0' "${summary_tsv}" >/dev/null
 

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
@@ -100,7 +100,12 @@ grep -F 'OCI_A1_DB_IDLE_IN_TX_TIMEOUT_MS' "${workflow}" >/dev/null
 grep -F 'DB_IDLE_IN_TX_TIMEOUT_MS' "${workflow}" >/dev/null
 grep -F 'expected_hikari_max_lifetime_ms' "${workflow}" >/dev/null
 grep -F "Build 30m soak live evidence artifact pack" "${workflow}" >/dev/null
+grep -F 'summary_artifact_json="${SOAK_30M_REPORT_DIR}/${K6_REPORT_NAME}-summary.json"' "${workflow}" >/dev/null
+grep -F 'summary_artifact_md="${SOAK_30M_REPORT_DIR}/${K6_REPORT_NAME}-summary.md"' "${workflow}" >/dev/null
+grep -F 'cp "${summary_json}" "${summary_artifact_json}"' "${workflow}" >/dev/null
+grep -F 'cp "${summary_md}" "${summary_artifact_md}"' "${workflow}" >/dev/null
 grep -F 'SOAK_30M_ARTIFACTS_DURATION_MIN="${SOAK_30M_DURATION_MIN}"' "${workflow}" >/dev/null
+grep -F 'SOAK_30M_ARTIFACTS_K6_SUMMARY_JSON="${summary_artifact_json}"' "${workflow}" >/dev/null
 grep -F 'SOAK_30M_ARTIFACTS_POSTGRES_TEMP_FILE_DELTA_MAX="${SOAK_30M_POSTGRES_TEMP_FILE_DELTA_MAX:-0}"' "${workflow}" >/dev/null
 grep -F 'tools/test/run-transaction-read-30m-soak-live-evidence-artifacts.sh' "${workflow}" >/dev/null
 grep -F "Run 30m soak live evidence gate" "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
@@ -41,6 +41,12 @@ grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-manifest.sh" "
 grep -F "tools/test/run-transaction-read-30m-soak-live-evidence-artifacts.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-artifacts.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-oci-evidence-execution-gate.sh" "${workflow}" >/dev/null
+env_names_block="$(awk '
+  /env_names=\(/ { in_block = 1 }
+  in_block { print }
+  in_block && /^\s*\)/ { exit }
+' "${workflow}")"
+grep -F "K6_REMOTE_PROMETHEUS_RW_REQUIRED" <<<"${env_names_block}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
 grep -F "timeout-minutes: 50" "${workflow}" >/dev/null
@@ -54,6 +60,8 @@ grep -F "Prepare 30m soak evidence mode" "${workflow}" >/dev/null
 grep -F 'SOAK_30M_USE_EXISTING_MANIFEST=true' "${workflow}" >/dev/null
 grep -F "Load OCI A1 staging env" "${workflow}" >/dev/null
 grep -F 'K6_RUN_PURPOSE="capacity"' "${workflow}" >/dev/null
+grep -F 'K6_REMOTE_PROMETHEUS_RW_REQUIRED="false"' "${workflow}" >/dev/null
+grep -F 'remote-write optional' "${workflow}" >/dev/null
 grep -F 'K6_DOCKER_CONTEXT_SOURCE="input"' "${workflow}" >/dev/null
 grep -F 'K6_DOCKER_CONTEXT_SOURCE="env"' "${workflow}" >/dev/null
 grep -F 'K6_DOCKER_CONTEXT_SOURCE="default"' "${workflow}" >/dev/null

--- a/tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh
+++ b/tools/test/run-transaction-read-30m-soak-live-evidence-gate.sh
@@ -97,7 +97,7 @@ execution_report="$(tail -1 <<<"${gate_output}")"
 
 awk -F '\t' '
 BEGIN {
-  print "run_id\tstatus\treason\thikari_duration_min\tp999_duration_min\tp95_ms\tp99_ms\tp999_ms\tmax_ms\thikari_pending_max\thikari_validation_warnings\tpostgres_wait_ref\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref"
+  print "run_id\tstatus\treason\thikari_duration_min\tp999_duration_min\tp95_ms\tp99_ms\tp999_ms\tmax_ms\thikari_pending_max\thikari_validation_warnings\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\tpostgres_wait_ref\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref"
 }
 NR == 1 { next }
 $1 == "hikari-lifetime" {
@@ -106,6 +106,10 @@ $1 == "hikari-lifetime" {
   hikari_duration = $5
   hikari_pending = $22
   hikari_warnings = $21
+  hikari_backend_429 = $17
+  hikari_unknown_429 = $18
+  hikari_five_xx = $19
+  hikari_nginx_499 = $20
   hikari_postgres_wait_ref = $12
   hikari_config_ref = $30
   hikari_max_lifetime = $31
@@ -124,6 +128,10 @@ $1 == "p999-long-correlation" {
   max = $26
   p999_pending = $22
   p999_warnings = $21
+  p999_backend_429 = $17
+  p999_unknown_429 = $18
+  p999_five_xx = $19
+  p999_nginx_499 = $20
   p999_postgres_wait_ref = $12
   checkpoint_count = $27
   temp_file_count = $28
@@ -142,10 +150,18 @@ END {
   if (p999_pending > pending) pending = p999_pending
   warnings = hikari_warnings
   if (p999_warnings > warnings) warnings = p999_warnings
+  backend_429 = hikari_backend_429
+  if (p999_backend_429 > backend_429) backend_429 = p999_backend_429
+  unknown_429 = hikari_unknown_429
+  if (p999_unknown_429 > unknown_429) unknown_429 = p999_unknown_429
+  five_xx = hikari_five_xx
+  if (p999_five_xx > five_xx) five_xx = p999_five_xx
+  nginx_499 = hikari_nginx_499
+  if (p999_nginx_499 > nginx_499) nginx_499 = p999_nginx_499
   postgres_wait_ref = (hikari_postgres_wait_ref != "" ? hikari_postgres_wait_ref : p999_postgres_wait_ref)
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
     hikari_run_id, status, reason, hikari_duration, p999_duration, p95, p99, p999, max,
-    pending, warnings, postgres_wait_ref, checkpoint_count, temp_file_count, upstream_p95,
+    pending, warnings, backend_429, unknown_429, five_xx, nginx_499, postgres_wait_ref, checkpoint_count, temp_file_count, upstream_p95,
     hikari_config_ref, hikari_max_lifetime, hikari_keepalive, postgres_idle, oci_nat, hikari_zero_warning
   if (status == "fail") exit 2
 }
@@ -155,11 +171,15 @@ gate_status="$(awk -F '\t' 'NR == 2 { print $2 }' "${summary_tsv}")"
 run_id="$(awk -F '\t' 'NR == 2 { print $1 }' "${summary_tsv}")"
 hikari_pending="$(awk -F '\t' 'NR == 2 { print $10 }' "${summary_tsv}")"
 hikari_warnings="$(awk -F '\t' 'NR == 2 { print $11 }' "${summary_tsv}")"
-hikari_max_lifetime="$(awk -F '\t' 'NR == 2 { print $17 }' "${summary_tsv}")"
-hikari_keepalive="$(awk -F '\t' 'NR == 2 { print $18 }' "${summary_tsv}")"
-postgres_idle="$(awk -F '\t' 'NR == 2 { print $19 }' "${summary_tsv}")"
-oci_nat="$(awk -F '\t' 'NR == 2 { print $20 }' "${summary_tsv}")"
-postgres_temp_file_delta="$(awk -F '\t' 'NR == 2 { print $14 }' "${summary_tsv}")"
+backend_429_count="$(awk -F '\t' 'NR == 2 { print $12 }' "${summary_tsv}")"
+unknown_429_count="$(awk -F '\t' 'NR == 2 { print $13 }' "${summary_tsv}")"
+five_xx_count="$(awk -F '\t' 'NR == 2 { print $14 }' "${summary_tsv}")"
+nginx_499_count="$(awk -F '\t' 'NR == 2 { print $15 }' "${summary_tsv}")"
+hikari_max_lifetime="$(awk -F '\t' 'NR == 2 { print $21 }' "${summary_tsv}")"
+hikari_keepalive="$(awk -F '\t' 'NR == 2 { print $22 }' "${summary_tsv}")"
+postgres_idle="$(awk -F '\t' 'NR == 2 { print $23 }' "${summary_tsv}")"
+oci_nat="$(awk -F '\t' 'NR == 2 { print $24 }' "${summary_tsv}")"
+postgres_temp_file_delta="$(awk -F '\t' 'NR == 2 { print $18 }' "${summary_tsv}")"
 
 cat >"${report_md}" <<REPORT
 # Transaction Read 30m Soak Live Evidence Gate
@@ -175,6 +195,7 @@ cat >"${report_md}" <<REPORT
 - PostgreSQL wait/checkpoint/temp file artifacts: verified
 - PostgreSQL temp file delta: ${postgres_temp_file_delta} (budget <= ${max_postgres_temp_file_delta})
 - Nginx upstream latency artifact: verified
+- 429/5xx/499 hard-zero: backend=${backend_429_count} unknown=${unknown_429_count} 5xx=${five_xx_count} 499=${nginx_499_count}
 - Hikari lifetime alignment: verified
 - Hikari maxLifetime/keepaliveTime: ${hikari_max_lifetime}ms/${hikari_keepalive}ms
 - PostgreSQL/NAT idle basis: ${postgres_idle}ms/${oci_nat}ms

--- a/tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh
+++ b/tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh
@@ -250,6 +250,9 @@ cat >"${report_md}" <<REPORT
 - PostgreSQL temp file delta budget: <=${postgres_temp_file_delta_max}
 - Nginx upstream latency: ${nginx_upstream_latency_ref}
 - p95/p99/p99.9/max: ${p95_ms}/${p99_ms}/${p999_ms}/${max_ms}
+- Hikari warning/pending: ${hikari_validation_warnings}/${db_pool_pending_max}
+- 429 hard-zero: backend=${backend_429_count} unknown=${unknown_429_count} edge_rate=${edge_429_rate}
+- Nginx 499/5xx: ${nginx_499_count}/${five_xx_count}
 
 ## Artifacts
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #794

## 🌿 Base Branch
- `main`

## 📝 Summary
- 30m transaction-read soak에서 Prometheus remote-write preflight 장애가 k6 실행을 막지 않도록 remote-write를 optional observability로 전환했습니다.
- 기존 local summary/timeline/Hikari/PostgreSQL artifact pack은 유지하고, report에 429/5xx/499/Hikari/PG hard-zero 값을 명시했습니다.
- k6 summary JSON/MD를 업로드 artifact pack 안으로 복사해 PR/issue에서 재검증 가능한 증거로 남깁니다.

## 🛠 Changes
- `transaction-read-30m-soak-live-evidence` workflow에서 `K6_REMOTE_PROMETHEUS_RW_REQUIRED=false`를 export합니다.
- 30m live evidence manifest/report에 Hikari warning/pending, 429 hard-zero, Nginx 499/5xx closure 값을 추가했습니다.
- workflow/artifact/gate contract checks를 보강했습니다.
- 30m artifact upload에 k6 summary JSON/MD를 포함했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-30m-soak-live-evidence-artifacts.sh`
- `bash tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh`
- `bash tools/test/check-transaction-read-30m-soak-live-evidence-manifest.sh`
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-k6-transaction-100m-loadtest.sh`
- `git diff --check`
- `tools/test/with-resource-lock.sh backend-check ./back/gradlew -p back check`
- PR checks: 30m Soak Live Evidence Contract, CI Runtime Optimization Contract, Nginx Runtime Gate pass
- workflow_dispatch: run `25413485665` pass, 30m live evidence gate pass

### Live evidence highlights
- gate_status: `pass`
- observability downgrade: remote-write optional, summary-only
- accepted 200 count: `112441`
- http_req_failed rate: `0`
- checks rate: `1`
- Hikari validation warnings: `0`
- db pool pending max: `0`
- backend 429 / unknown 429 / 5xx / 499: `0 / 0 / 0 / 0`
- PostgreSQL checkpoint delta: `6`
- PostgreSQL temp file delta: `0`
- Nginx transaction read rows: `112461`
- p95/p99/p99.9/max: `6.787531999999999 / 9.192070569999998 / 12.686911932000072 / 49.81681`
- uploaded artifact includes k6 summary JSON/MD

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Prometheus remote-write가 비가용이면 30m live run은 summary-only로 계속 진행되므로 Prometheus 장기 시계열은 비어 있을 수 있습니다. 대신 remote-write failure artifact와 local summary/timeline/Hikari/PostgreSQL artifact가 남습니다.
- 롤백 방법: 이 PR의 workflow/check/script 변경 commit을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
