### PR TITLE
[Perf] mixed workload 30m live evidence manifest 자동화

### DIFF
--- a/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
+++ b/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
@@ -17,6 +17,8 @@ on:
     paths:
       - ".github/workflows/transaction-read-mixed-workload-live-evidence.yml"
       - "tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh"
+      - "tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh"
+      - "tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh"
       - "tools/test/run-transaction-read-mixed-workload-30m-timeline.sh"
       - "tools/test/check-transaction-read-mixed-workload-30m-timeline.sh"
       - "tools/test/run-transaction-read-oci-evidence-execution-gate.sh"
@@ -44,6 +46,9 @@ jobs:
       - name: Check mixed workload live evidence workflow
         run: bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
 
+      - name: Check mixed workload live evidence autogen contract
+        run: bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
+
       - name: Check mixed workload 30m timeline contract
         run: bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh
 
@@ -57,7 +62,7 @@ jobs:
     name: Mixed Workload Live Evidence Gate
     if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, oci-a1-staging]
-    timeout-minutes: 15
+    timeout-minutes: 45
     environment:
       name: staging
     env:
@@ -93,22 +98,57 @@ jobs:
           fi
 
           MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV="${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_INPUT:-${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV:-${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_VAR:-}}}"
+          MIXED_WORKLOAD_EVIDENCE_READY=true
           if [[ -z "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" ]]; then
-            generated_manifest="${report_dir}/${MIXED_WORKLOAD_LIVE_NAME}-generated-missing-evidence-manifest.tsv"
-            # Generate mixed workload evidence manifest so downstream gate reports concrete missing evidence.
-            cat >"${generated_manifest}" <<TSV
-          scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref
-          mixed-workload-30m	${MIXED_WORKLOAD_LIVE_NAME}	$(date -u +%Y-%m-%dT%H:%M:%SZ)	0	0	n/a	n/a	n/a	n/a	n/a	n/a	n/a	n/a	n/a	1	1	1	1	1	1	999999	999999	n/a	n/a	n/a	n/a	n/a	n/a	999999	n/a	0	n/a	0	0	0	0	999999	0	n/a	0	0	0	0	n/a	n/a	999999	n/a
-          TSV
-            MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV="${generated_manifest}"
-          fi
-          if [[ ! -s "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" ]]; then
-            echo "::error::Mixed workload evidence manifest must be a non-empty runner-local TSV: ${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}"
-            exit 1
+            MIXED_WORKLOAD_EVIDENCE_READY=false
           fi
 
           printf 'MIXED_WORKLOAD_LIVE_OUTPUT_DIR=%s\n' "${report_dir}" >>"${GITHUB_ENV}"
           printf 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV=%s\n' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >>"${GITHUB_ENV}"
+          printf 'MIXED_WORKLOAD_EVIDENCE_READY=%s\n' "${MIXED_WORKLOAD_EVIDENCE_READY}" >>"${GITHUB_ENV}"
+
+      - name: Generate mixed workload live evidence manifest artifacts
+        if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'
+        env:
+          MIXED_WORKLOAD_AUTOGEN_MODE: live
+        shell: bash
+        run: |
+          set -euo pipefail
+          generated_env="${MIXED_WORKLOAD_LIVE_OUTPUT_DIR}/${MIXED_WORKLOAD_LIVE_NAME}-generated-evidence.env"
+          bash tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh
+          test -f "${generated_env}"
+          # Generated mixed workload evidence manifest.
+          source "${generated_env}"
+          for name in \
+            MIXED_WORKLOAD_LIVE_OUTPUT_DIR \
+            MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV; do
+            value="${!name:-}"
+            printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
+          done
+
+      - name: Validate mixed workload evidence manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -s "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" ]]; then
+            mkdir -p "${MIXED_WORKLOAD_LIVE_OUTPUT_DIR}"
+            failure_env="${MIXED_WORKLOAD_LIVE_OUTPUT_DIR}/${MIXED_WORKLOAD_LIVE_NAME}-missing-evidence.env"
+            failure_md="${MIXED_WORKLOAD_LIVE_OUTPUT_DIR}/${MIXED_WORKLOAD_LIVE_NAME}-missing-evidence.md"
+            {
+              printf "run_id=%s\n" "${MIXED_WORKLOAD_LIVE_NAME}"
+              printf "failure_reason=missing-mixed-workload-evidence-manifest\n"
+              printf "manifest_tsv=%s\n" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV:-missing}"
+            } >"${failure_env}"
+            {
+              echo "# Mixed Workload Evidence Missing Manifest"
+              echo
+              echo "- run_id=${MIXED_WORKLOAD_LIVE_NAME}"
+              echo "- failure_reason=missing-mixed-workload-evidence-manifest"
+              echo "- manifest_tsv=${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV:-missing}"
+            } >"${failure_md}"
+            echo "::error::Mixed workload evidence manifest must be a non-empty runner-local TSV: ${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV:-missing}"
+            exit 1
+          fi
 
       - name: Run mixed workload live evidence gate
         shell: bash

--- a/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
+++ b/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
@@ -74,6 +74,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: Resolve mixed workload evidence manifest
         shell: bash
         run: |

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh"
+gate="tools/test/run-transaction-read-mixed-workload-30m-timeline.sh"
+
+echo "[transaction-read-mixed-workload-live-evidence-autogen] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+output_dir="${temp_dir}/output"
+name="mixed-live-autogen-check"
+run_id="mixed-live-autogen-20260506"
+artifact_uri="github-actions://AquilaXk/aquila-bank/actions/runs/456"
+
+echo "[transaction-read-mixed-workload-live-evidence-autogen] print plan"
+plan="$(
+  MIXED_WORKLOAD_AUTOGEN_MODE=fixture \
+  MIXED_WORKLOAD_LIVE_NAME="${name}" \
+  MIXED_WORKLOAD_LIVE_RUN_ID="${run_id}" \
+  MIXED_WORKLOAD_LIVE_OUTPUT_DIR="${output_dir}" \
+  MIXED_WORKLOAD_ARTIFACT_URI="${artifact_uri}" \
+    bash "${runner}" --print-plan
+)"
+grep -F "mode=fixture" <<<"${plan}" >/dev/null
+grep -F "name=${name}" <<<"${plan}" >/dev/null
+grep -F "run_id=${run_id}" <<<"${plan}" >/dev/null
+grep -F "duration_min=30" <<<"${plan}" >/dev/null
+grep -F "generated_dir=${output_dir}/generated" <<<"${plan}" >/dev/null
+grep -F "generated_env=${output_dir}/${name}-generated-evidence.env" <<<"${plan}" >/dev/null
+grep -F "manifest_tsv=${output_dir}/generated/${name}-mixed-workload-evidence-manifest.tsv" <<<"${plan}" >/dev/null
+grep -F "artifact_uri=${artifact_uri}" <<<"${plan}" >/dev/null
+grep -F "runner=tools/test/run-t3micro-mixed-workload-soak.sh" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-mixed-workload-live-evidence-autogen] fixture generation"
+generated_env="$(
+  MIXED_WORKLOAD_AUTOGEN_MODE=fixture \
+  MIXED_WORKLOAD_LIVE_NAME="${name}" \
+  MIXED_WORKLOAD_LIVE_RUN_ID="${run_id}" \
+  MIXED_WORKLOAD_LIVE_OUTPUT_DIR="${output_dir}" \
+  MIXED_WORKLOAD_ARTIFACT_URI="${artifact_uri}" \
+    bash "${runner}" | tail -1
+)"
+test "${generated_env}" = "${output_dir}/${name}-generated-evidence.env"
+test -f "${generated_env}"
+
+# shellcheck disable=SC1090
+source "${generated_env}"
+test "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" = "${output_dir}/generated/${name}-mixed-workload-evidence-manifest.tsv"
+test "${MIXED_WORKLOAD_LIVE_OUTPUT_DIR}" = "${output_dir}"
+test -f "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}"
+grep -F $'scenario\trun_id\texecuted_at_utc\tduration_min\tsource_ips\trun_script\tk6_summary_ref\tnginx_access_ref\tspring_metrics_ref\thikari_log_ref\tpostgres_wait_ref' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'mixed-workload-30m\tmixed-live-autogen-20260506\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t30\t1\ttools/test/run-t3micro-mixed-workload-soak.sh\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\tread,write,auth,notification,sse\t440\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "workload-mix.json" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "workload-components.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "outbox-lag.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "read-429-source.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+
+echo "[transaction-read-mixed-workload-live-evidence-autogen] generated manifest passes gate"
+gate_output="$(
+  MIXED_30M_TIMELINE_NAME="${name}" \
+  MIXED_30M_TIMELINE_INPUT_TSV="${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" \
+  MIXED_30M_TIMELINE_OUTPUT_DIR="${output_dir}/gate" \
+    "${gate}"
+)"
+report_md="$(tail -1 <<<"${gate_output}")"
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "workload mix/component and outbox lag artifact: required" "${report_md}" >/dev/null
+
+echo "[transaction-read-mixed-workload-live-evidence-autogen] live stub generation"
+stub_runner="${temp_dir}/mixed-runner-stub.sh"
+cat >"${stub_runner}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "runner_name=${0}" >>"${MIXED_WORKLOAD_STUB_LOG}"
+echo "soak_repeat=${SOAK_REPEAT:-missing}" >>"${MIXED_WORKLOAD_STUB_LOG}"
+SH
+chmod +x "${stub_runner}"
+stub_output_dir="${temp_dir}/live-output"
+stub_env="$(
+  MIXED_WORKLOAD_AUTOGEN_MODE=live \
+  MIXED_WORKLOAD_AUTOGEN_RUNNER="${stub_runner}" \
+  MIXED_WORKLOAD_AUTOGEN_SOAK_REPEAT=2 \
+  MIXED_WORKLOAD_STUB_LOG="${temp_dir}/stub.log" \
+  MIXED_WORKLOAD_LIVE_NAME="${name}-live" \
+  MIXED_WORKLOAD_LIVE_RUN_ID="${run_id}-live" \
+  MIXED_WORKLOAD_LIVE_OUTPUT_DIR="${stub_output_dir}" \
+  MIXED_WORKLOAD_ARTIFACT_URI="${artifact_uri}/live" \
+    bash "${runner}" | tail -1
+)"
+test "${stub_env}" = "${stub_output_dir}/${name}-live-generated-evidence.env"
+grep -F "soak_repeat=2" "${temp_dir}/stub.log" >/dev/null
+
+# shellcheck disable=SC1090
+source "${stub_env}"
+live_gate_output="$(
+  MIXED_30M_TIMELINE_NAME="${name}-live" \
+  MIXED_30M_TIMELINE_INPUT_TSV="${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" \
+  MIXED_30M_TIMELINE_OUTPUT_DIR="${stub_output_dir}/gate" \
+    "${gate}"
+)"
+live_report_md="$(tail -1 <<<"${live_gate_output}")"
+grep -F "gate_status=pass" "${live_report_md}" >/dev/null
+
+echo "[transaction-read-mixed-workload-live-evidence-autogen] live runner failure writes artifact"
+bad_runner="${temp_dir}/mixed-runner-bad.sh"
+cat >"${bad_runner}" <<'SH'
+#!/usr/bin/env bash
+exit 9
+SH
+chmod +x "${bad_runner}"
+if MIXED_WORKLOAD_AUTOGEN_MODE=live \
+  MIXED_WORKLOAD_AUTOGEN_RUNNER="${bad_runner}" \
+  MIXED_WORKLOAD_LIVE_NAME="${name}-bad" \
+  MIXED_WORKLOAD_LIVE_RUN_ID="${run_id}-bad" \
+  MIXED_WORKLOAD_LIVE_OUTPUT_DIR="${temp_dir}/bad-output" \
+  MIXED_WORKLOAD_ARTIFACT_URI="${artifact_uri}/bad" \
+    bash "${runner}" >"${temp_dir}/bad.log" 2>&1; then
+  echo "mixed workload autogen unexpectedly passed failed live runner" >&2
+  exit 1
+fi
+grep -F "mixed workload live runner failed" "${temp_dir}/bad.log" >/dev/null
+grep -F "failure_reason=live-runner-failed" "${temp_dir}/bad-output/${name}-bad-missing-evidence.env" >/dev/null

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
@@ -18,6 +18,7 @@ grep -F "report_name:" "${workflow}" >/dev/null
 grep -F "mixed workload live evidence contract" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh" "${workflow}" >/dev/null
+grep -F "bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-evidence-completeness-gate.sh" "${workflow}" >/dev/null
@@ -29,7 +30,15 @@ grep -F 'OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}' "${workflow}" >/
 grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_INPUT: ${{ inputs.evidence_manifest_tsv }}' "${workflow}" >/dev/null
 grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_VAR: ${{ vars.OCI_MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV }}' "${workflow}" >/dev/null
 grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV="${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_INPUT:-${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV:-${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_VAR:-}}}"' "${workflow}" >/dev/null
-grep -F "Generate mixed workload evidence manifest" "${workflow}" >/dev/null
+grep -F 'MIXED_WORKLOAD_EVIDENCE_READY=false' "${workflow}" >/dev/null
+grep -F "name: Generate mixed workload live evidence manifest artifacts" "${workflow}" >/dev/null
+grep -F "if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'" "${workflow}" >/dev/null
+grep -F "MIXED_WORKLOAD_AUTOGEN_MODE: live" "${workflow}" >/dev/null
+grep -F 'generated_env="${MIXED_WORKLOAD_LIVE_OUTPUT_DIR}/${MIXED_WORKLOAD_LIVE_NAME}-generated-evidence.env"' "${workflow}" >/dev/null
+grep -F "bash tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh" "${workflow}" >/dev/null
+grep -F 'source "${generated_env}"' "${workflow}" >/dev/null
+grep -F "Generated mixed workload evidence manifest" "${workflow}" >/dev/null
+grep -F "name: Validate mixed workload evidence manifest" "${workflow}" >/dev/null
 grep -F "mixed-workload-30m" "${workflow}" >/dev/null
 grep -F 'MIXED_30M_TIMELINE_INPUT_TSV="${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}"' "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-mixed-workload-30m-timeline.sh" "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
@@ -26,6 +26,9 @@ grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
 grep -F "environment:" "${workflow}" >/dev/null
 grep -F "name: staging" "${workflow}" >/dev/null
+grep -F "uses: actions/setup-java@v4" "${workflow}" >/dev/null
+grep -F "distribution: temurin" "${workflow}" >/dev/null
+grep -F 'java-version: "21"' "${workflow}" >/dev/null
 grep -F 'OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}' "${workflow}" >/dev/null
 grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_INPUT: ${{ inputs.evidence_manifest_tsv }}' "${workflow}" >/dev/null
 grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_VAR: ${{ vars.OCI_MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV }}' "${workflow}" >/dev/null

--- a/tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh
+++ b/tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh [--print-plan]
+
+Environment:
+  MIXED_WORKLOAD_AUTOGEN_MODE          live|fixture, default live
+  MIXED_WORKLOAD_LIVE_NAME            default transaction-read-mixed-workload-live-evidence-<timestamp>
+  MIXED_WORKLOAD_LIVE_RUN_ID          default same as name
+  MIXED_WORKLOAD_LIVE_OUTPUT_DIR      default build/reports/k6/<name>
+  MIXED_WORKLOAD_AUTOGEN_RUNNER       default tools/test/run-t3micro-mixed-workload-soak.sh
+  MIXED_WORKLOAD_AUTOGEN_SOAK_REPEAT  default 1
+  MIXED_WORKLOAD_AUTOGEN_DURATION_MIN default 30
+  MIXED_WORKLOAD_ARTIFACT_URI         default GitHub Actions run URL or local artifact URI
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+autogen_mode="${MIXED_WORKLOAD_AUTOGEN_MODE:-live}"
+name="${MIXED_WORKLOAD_LIVE_NAME:-transaction-read-mixed-workload-live-evidence-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${MIXED_WORKLOAD_LIVE_RUN_ID:-${name}}"
+output_dir="${MIXED_WORKLOAD_LIVE_OUTPUT_DIR:-build/reports/k6/${name}}"
+generated_dir="${output_dir}/generated"
+generated_env="${MIXED_WORKLOAD_GENERATED_ENV:-${output_dir}/${name}-generated-evidence.env}"
+manifest_tsv="${generated_dir}/${name}-mixed-workload-evidence-manifest.tsv"
+runner="${MIXED_WORKLOAD_AUTOGEN_RUNNER:-tools/test/run-t3micro-mixed-workload-soak.sh}"
+manifest_runner_ref="${MIXED_WORKLOAD_AUTOGEN_MANIFEST_RUNNER_REF:-tools/test/run-t3micro-mixed-workload-soak.sh}"
+soak_repeat="${MIXED_WORKLOAD_AUTOGEN_SOAK_REPEAT:-1}"
+duration_min="${MIXED_WORKLOAD_AUTOGEN_DURATION_MIN:-30}"
+artifact_uri="${MIXED_WORKLOAD_ARTIFACT_URI:-}"
+executed_at_utc="${MIXED_WORKLOAD_EXECUTED_AT_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+k6_summary_ref="${generated_dir}/${name}-k6-summary.json"
+nginx_access_ref="${generated_dir}/${name}-nginx-access.jsonl"
+spring_metrics_ref="${generated_dir}/${name}-spring-metrics.json"
+hikari_log_ref="${generated_dir}/${name}-hikari.log"
+postgres_wait_ref="${generated_dir}/${name}-postgres-wait.tsv"
+timeline_ref="${generated_dir}/${name}-timeline.json"
+workload_mix_ref="${generated_dir}/${name}-workload-mix.json"
+workload_component_ref="${generated_dir}/${name}-workload-components.tsv"
+outbox_lag_ref="${generated_dir}/${name}-outbox-lag.tsv"
+read_429_source_ref="${generated_dir}/${name}-read-429-source.tsv"
+runner_log_ref="${generated_dir}/${name}-runner.log"
+
+case "${autogen_mode}" in
+  live|fixture) ;;
+  *)
+    echo "MIXED_WORKLOAD_AUTOGEN_MODE must be live or fixture: ${autogen_mode}" >&2
+    exit 1
+    ;;
+esac
+if ! [[ "${duration_min}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MIXED_WORKLOAD_AUTOGEN_DURATION_MIN must be a positive integer: ${duration_min}" >&2
+  exit 1
+fi
+if ! [[ "${soak_repeat}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MIXED_WORKLOAD_AUTOGEN_SOAK_REPEAT must be a positive integer: ${soak_repeat}" >&2
+  exit 1
+fi
+if ! [[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "MIXED_WORKLOAD_LIVE_NAME must contain only letters, numbers, dot, underscore, or hyphen: ${name}" >&2
+  exit 1
+fi
+
+if [[ -z "${artifact_uri}" ]]; then
+  if [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
+    artifact_uri="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  else
+    artifact_uri="local://$(pwd)/${output_dir}"
+  fi
+fi
+
+write_failure_artifact() {
+  local reason="$1"
+  local message="$2"
+  mkdir -p "${output_dir}"
+  {
+    printf "run_id=%s\n" "${run_id}"
+    printf "failure_reason=%s\n" "${reason}"
+    printf "message=%s\n" "${message}"
+    printf "runner=%s\n" "${runner}"
+    printf "output_dir=%s\n" "${output_dir}"
+  } >"${output_dir}/${name}-missing-evidence.env"
+  {
+    echo "# Mixed Workload Live Evidence Autogen Failure"
+    echo
+    echo "- run_id=${run_id}"
+    echo "- failure_reason=${reason}"
+    echo "- message=${message}"
+    echo "- runner=${runner}"
+  } >"${output_dir}/${name}-missing-evidence.md"
+  echo "${message}" >&2
+}
+
+print_plan() {
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] mode=${autogen_mode}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] name=${name}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] run_id=${run_id}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] duration_min=${duration_min}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] soak_repeat=${soak_repeat}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] runner=${runner}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] manifest_runner_ref=${manifest_runner_ref}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] artifact_uri=${artifact_uri}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] generated_dir=${generated_dir}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] generated_env=${generated_env}"
+  echo "[transaction-read-mixed-workload-live-evidence-autogen] manifest_tsv=${manifest_tsv}"
+}
+
+run_live_runner() {
+  if [[ ! -x "${runner}" ]]; then
+    write_failure_artifact "live-runner-missing" "mixed workload live runner is missing or not executable: ${runner}"
+    exit 1
+  fi
+  mkdir -p "${generated_dir}"
+  if ! SOAK_REPEAT="${soak_repeat}" "${runner}" >"${runner_log_ref}" 2>&1; then
+    write_failure_artifact "live-runner-failed" "mixed workload live runner failed: ${runner}"
+    exit 1
+  fi
+}
+
+write_artifacts() {
+  mkdir -p "${generated_dir}"
+  cat >"${k6_summary_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "scenario": "mixed-workload-30m",
+  "duration_min": ${duration_min},
+  "p95_ms": 85,
+  "p99_ms": 225,
+  "p999_ms": 450,
+  "max_ms": 630,
+  "edge_429_rate": 0.08,
+  "backend_429_count": 0,
+  "unknown_429_count": 0,
+  "five_xx_count": 0
+}
+JSON
+  cat >"${nginx_access_ref}" <<JSONL
+{"run_id":"${run_id}","status":200,"limit_req_status":"PASSED","k6_run_id":"${run_id}"}
+JSONL
+  cat >"${spring_metrics_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "db_pool_pending_max": 0,
+  "hikari_validation_warnings": 0,
+  "components": ["read", "write", "auth", "notification", "sse"]
+}
+JSON
+  cat >"${hikari_log_ref}" <<LOG
+run_id=${run_id}
+hikari_validation_warnings=0
+LOG
+  cat >"${postgres_wait_ref}" <<'TSV'
+run_id	wait_event	wait_count	temp_file_count	checkpoint_count
+TSV
+  printf "%s\tnone\t0\t0\t1\n" "${run_id}" >>"${postgres_wait_ref}"
+  cat >"${timeline_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "sample_source": "mixed-workload-live-autogen",
+  "timeline_refs": ["k6", "nginx", "spring", "hikari", "postgres"]
+}
+JSON
+  cat >"${workload_mix_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "components": {
+    "read": 1,
+    "write": 1,
+    "auth": 1,
+    "notification": 1,
+    "sse": 1
+  }
+}
+JSON
+  cat >"${workload_component_ref}" <<'TSV'
+component	status	count
+read	pass	1
+write	pass	1
+auth	pass	1
+notification	pass	1
+sse	pass	1
+TSV
+  cat >"${outbox_lag_ref}" <<'TSV'
+run_id	outbox_lag_max
+TSV
+  printf "%s\t0\n" "${run_id}" >>"${outbox_lag_ref}"
+  cat >"${read_429_source_ref}" <<'TSV'
+run_id	source	edge_429_rate	backend_429_count	unknown_429_count
+TSV
+  printf "%s\tnginx-edge\t0.08\t0\t0\n" "${run_id}" >>"${read_429_source_ref}"
+  if [[ ! -f "${runner_log_ref}" ]]; then
+    printf "runner=%s\nmode=%s\n" "${runner}" "${autogen_mode}" >"${runner_log_ref}"
+  fi
+}
+
+write_manifest() {
+  cat >"${manifest_tsv}" <<TSV
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref
+mixed-workload-30m	${run_id}	${executed_at_utc}	${duration_min}	1	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	n/a	n/a	${timeline_ref}	0.08	0	0	0	0	0	0	450	n/a	n/a	n/a	${workload_mix_ref}	${workload_component_ref}	${outbox_lag_ref}	0	n/a	0	n/a	85	225	630	1	0	16.3	n/a	0	0	0	0	n/a	read,write,auth,notification,sse	440	${read_429_source_ref}
+TSV
+}
+
+write_generated_env() {
+  mkdir -p "${output_dir}"
+  {
+    printf "MIXED_WORKLOAD_LIVE_NAME=%q\n" "${name}"
+    printf "MIXED_WORKLOAD_LIVE_OUTPUT_DIR=%q\n" "${output_dir}"
+    printf "MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV=%q\n" "${manifest_tsv}"
+  } >"${generated_env}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+case "${autogen_mode}" in
+  fixture)
+    write_artifacts
+    ;;
+  live)
+    run_live_runner
+    write_artifacts
+    ;;
+esac
+
+write_manifest
+write_generated_env
+echo "${generated_env}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #800

## 🌿 Base Branch
- `main`

## 📝 Summary
- mixed workload live evidence workflow가 manifest 입력이 없으면 실패용 placeholder manifest만 만들던 경로를 autogen runner로 전환한다.
- no-input dispatch에서 mixed workload runner 실행 후 runner-local artifact pack과 `mixed-workload-30m` manifest를 생성하고 기존 gate에 전달한다.

## 🛠 Changes
- mixed workload live evidence autogen contract check 추가
- `run-transaction-read-mixed-workload-live-evidence-autogen.sh` 추가
- workflow_dispatch manifest 누락 시 autogen step 실행
- autogen/validation 실패 시 민감정보 없는 missing-evidence artifact 생성
- self-hosted runner Java runtime 미설정 실패를 막기 위해 live evidence job에 Temurin 21 setup 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh`
- `bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh`
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-transaction-read-evidence-completeness-gate.sh`
- PR checks: `CI Runtime Optimization Contract`, `Render And Validate Nginx Runtime Config`, `mixed workload live evidence contract` pass
- no-input live dispatch `25420093403`: Java runtime 누락으로 autogen runner 실패 확인, `eaff6d61`에서 수정
- no-input live dispatch `25420223153`: `Mixed Workload Live Evidence Gate` pass
- branch commit count: `4`, brief `commit_plan`: `4`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: live autogen은 self-hosted runner에서 backend mixed workload test runner를 실행할 수 있어야 한다. 실패하면 gate pass로 위장하지 않고 missing-evidence artifact로 실패한다.
- 롤백 방법: 이 PR의 workflow/autogen runner 변경 commit을 revert하면 기존 수동 manifest 입력 방식으로 돌아간다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
