### PR TITLE
[Perf] deploy drain under-load live evidence manifest 자동화

### DIFF
--- a/.github/workflows/transaction-read-deploy-drain-live-evidence.yml
+++ b/.github/workflows/transaction-read-deploy-drain-live-evidence.yml
@@ -22,6 +22,8 @@ on:
     paths:
       - ".github/workflows/transaction-read-deploy-drain-live-evidence.yml"
       - "tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh"
+      - "tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh"
+      - "tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh"
       - "tools/test/run-transaction-read-deploy-drain-under-load-gate.sh"
       - "tools/test/check-transaction-read-deploy-drain-under-load-gate.sh"
       - "tools/test/run-transaction-read-oci-evidence-execution-gate.sh"
@@ -49,6 +51,9 @@ jobs:
       - name: Check deploy drain live evidence workflow
         run: bash tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh
 
+      - name: Check deploy drain live evidence autogen
+        run: bash tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh
+
       - name: Check deploy drain under-load contract
         run: bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh
 
@@ -62,7 +67,7 @@ jobs:
     name: Deploy Drain Live Evidence Gate
     if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, oci-a1-staging]
-    timeout-minutes: 15
+    timeout-minutes: 30
     environment:
       name: staging
     env:
@@ -75,6 +80,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
 
       - name: Resolve deploy drain evidence manifest
         shell: bash
@@ -101,18 +112,9 @@ jobs:
 
           DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_INPUT:-${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV:-${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_VAR:-}}}"
           DEPLOY_DRAIN_499_BUDGET_COUNT="${DEPLOY_DRAIN_499_BUDGET_COUNT_INPUT:-${DEPLOY_DRAIN_499_BUDGET_COUNT:-${DEPLOY_DRAIN_499_BUDGET_COUNT_VAR:-0}}}"
+          DEPLOY_DRAIN_EVIDENCE_READY=true
           if [[ -z "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" ]]; then
-            generated_manifest="${report_dir}/${DEPLOY_DRAIN_LIVE_NAME}-generated-missing-evidence-manifest.tsv"
-            # Generate deploy drain evidence manifest so downstream gate reports concrete missing evidence.
-            cat >"${generated_manifest}" <<TSV
-          scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref	deploy_actions	deploy_499_budget_count	client_retry_success_count	deploy_reconnect_success_count
-          deploy-drain	${DEPLOY_DRAIN_LIVE_NAME}	$(date -u +%Y-%m-%dT%H:%M:%SZ)	0	0	n/a	n/a	n/a	n/a	n/a	n/a	n/a	n/a	n/a	1	1	1	1	1	1	999999	999999	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	0	0	0	0	999999	0	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	0	0	0
-          TSV
-            DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV="${generated_manifest}"
-          fi
-          if [[ ! -s "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" ]]; then
-            echo "::error::Deploy drain evidence manifest must be a non-empty runner-local TSV: ${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}"
-            exit 1
+            DEPLOY_DRAIN_EVIDENCE_READY=false
           fi
           if ! [[ "${DEPLOY_DRAIN_499_BUDGET_COUNT}" =~ ^[0-9]+$ ]]; then
             echo "::error::DEPLOY_DRAIN_499_BUDGET_COUNT must be a non-negative integer: ${DEPLOY_DRAIN_499_BUDGET_COUNT}"
@@ -122,6 +124,59 @@ jobs:
           printf 'DEPLOY_DRAIN_LIVE_OUTPUT_DIR=%s\n' "${report_dir}" >>"${GITHUB_ENV}"
           printf 'DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV=%s\n' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >>"${GITHUB_ENV}"
           printf 'DEPLOY_DRAIN_499_BUDGET_COUNT=%s\n' "${DEPLOY_DRAIN_499_BUDGET_COUNT}" >>"${GITHUB_ENV}"
+          printf 'DEPLOY_DRAIN_EVIDENCE_READY=%s\n' "${DEPLOY_DRAIN_EVIDENCE_READY}" >>"${GITHUB_ENV}"
+
+      - name: Generate deploy drain live evidence manifest artifacts
+        if: env.DEPLOY_DRAIN_EVIDENCE_READY != 'true'
+        shell: bash
+        env:
+          DEPLOY_DRAIN_AUTOGEN_MODE: live
+        run: |
+          set -euo pipefail
+          generated_env="${DEPLOY_DRAIN_LIVE_OUTPUT_DIR}/${DEPLOY_DRAIN_LIVE_NAME}-generated-evidence.env"
+          DEPLOY_DRAIN_GENERATED_ENV="${generated_env}" \
+            bash tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh
+
+          if [[ ! -s "${generated_env}" ]]; then
+            echo "::error::Generated deploy drain evidence env is missing: ${generated_env}"
+            exit 1
+          fi
+
+          # shellcheck disable=SC1090
+          source "${generated_env}"
+          if [[ ! -s "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" ]]; then
+            echo "::error::Generated deploy drain evidence manifest is missing: ${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}"
+            exit 1
+          fi
+
+          echo "::notice::Generated deploy drain evidence manifest: ${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}"
+          printf 'DEPLOY_DRAIN_LIVE_OUTPUT_DIR=%s\n' "${DEPLOY_DRAIN_LIVE_OUTPUT_DIR}" >>"${GITHUB_ENV}"
+          printf 'DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV=%s\n' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >>"${GITHUB_ENV}"
+          printf 'DEPLOY_DRAIN_499_BUDGET_COUNT=%s\n' "${DEPLOY_DRAIN_499_BUDGET_COUNT}" >>"${GITHUB_ENV}"
+
+      - name: Validate deploy drain evidence manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV:-}" && -s "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" ]]; then
+            exit 0
+          fi
+
+          {
+            printf "run_id=%s\n" "${DEPLOY_DRAIN_LIVE_NAME}"
+            printf "failure_reason=missing-deploy-drain-evidence-manifest\n"
+            printf "manifest=%s\n" "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV:-missing}"
+          } >"${DEPLOY_DRAIN_LIVE_OUTPUT_DIR}/${DEPLOY_DRAIN_LIVE_NAME}-missing-evidence.env"
+          {
+            echo "# Deploy Drain Live Evidence Missing Manifest"
+            echo
+            echo "- run_id=${DEPLOY_DRAIN_LIVE_NAME}"
+            echo "- failure_reason=missing-deploy-drain-evidence-manifest"
+            echo "- manifest=${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV:-missing}"
+          } >"${DEPLOY_DRAIN_LIVE_OUTPUT_DIR}/${DEPLOY_DRAIN_LIVE_NAME}-missing-evidence.md"
+
+          echo "::error::Deploy drain evidence manifest must be a non-empty runner-local TSV: ${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV:-missing}"
+          exit 1
 
       - name: Run deploy drain live evidence gate
         shell: bash

--- a/tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh
+++ b/tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh"
+gate="tools/test/run-transaction-read-deploy-drain-under-load-gate.sh"
+
+echo "[transaction-read-deploy-drain-live-evidence-autogen] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+output_dir="${temp_dir}/output"
+name="deploy-drain-live-autogen-check"
+run_id="deploy-drain-live-autogen-20260506"
+artifact_uri="github-actions://AquilaXk/aquila-bank/actions/runs/789"
+
+echo "[transaction-read-deploy-drain-live-evidence-autogen] print plan"
+plan="$(
+  DEPLOY_DRAIN_AUTOGEN_MODE=fixture \
+  DEPLOY_DRAIN_LIVE_NAME="${name}" \
+  DEPLOY_DRAIN_LIVE_RUN_ID="${run_id}" \
+  DEPLOY_DRAIN_LIVE_OUTPUT_DIR="${output_dir}" \
+  DEPLOY_DRAIN_ARTIFACT_URI="${artifact_uri}" \
+    bash "${runner}" --print-plan
+)"
+grep -F "mode=fixture" <<<"${plan}" >/dev/null
+grep -F "name=${name}" <<<"${plan}" >/dev/null
+grep -F "run_id=${run_id}" <<<"${plan}" >/dev/null
+grep -F "duration_min=5" <<<"${plan}" >/dev/null
+grep -F "499_budget_count=0" <<<"${plan}" >/dev/null
+grep -F "generated_dir=${output_dir}/generated" <<<"${plan}" >/dev/null
+grep -F "generated_env=${output_dir}/${name}-generated-evidence.env" <<<"${plan}" >/dev/null
+grep -F "manifest_tsv=${output_dir}/generated/${name}-deploy-drain-evidence-manifest.tsv" <<<"${plan}" >/dev/null
+grep -F "artifact_uri=${artifact_uri}" <<<"${plan}" >/dev/null
+grep -F "runner=tools/test/run-sse-multinode-drain-smoke.sh" <<<"${plan}" >/dev/null
+
+echo "[transaction-read-deploy-drain-live-evidence-autogen] fixture generation"
+generated_env="$(
+  DEPLOY_DRAIN_AUTOGEN_MODE=fixture \
+  DEPLOY_DRAIN_LIVE_NAME="${name}" \
+  DEPLOY_DRAIN_LIVE_RUN_ID="${run_id}" \
+  DEPLOY_DRAIN_LIVE_OUTPUT_DIR="${output_dir}" \
+  DEPLOY_DRAIN_ARTIFACT_URI="${artifact_uri}" \
+    bash "${runner}" | tail -1
+)"
+test "${generated_env}" = "${output_dir}/${name}-generated-evidence.env"
+test -f "${generated_env}"
+
+# shellcheck disable=SC1090
+source "${generated_env}"
+test "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" = "${output_dir}/generated/${name}-deploy-drain-evidence-manifest.tsv"
+test "${DEPLOY_DRAIN_LIVE_OUTPUT_DIR}" = "${output_dir}"
+test "${DEPLOY_DRAIN_499_BUDGET_COUNT}" = "0"
+test -f "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}"
+grep -F $'scenario\trun_id\texecuted_at_utc\tduration_min\tsource_ips\trun_script\tk6_summary_ref\tnginx_access_ref\tspring_metrics_ref\thikari_log_ref\tpostgres_wait_ref\tdeploy_event_ref' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'deploy-drain\tdeploy-drain-live-autogen-20260506\t' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t5\t1\ttools/test/run-sse-multinode-drain-smoke.sh\t' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\tbackend-restart,blue-green-drain\t0\t2\t2' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "deploy-event.json" "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "deploy-retry-contract.json" "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "deploy-499-budget.tsv" "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+
+echo "[transaction-read-deploy-drain-live-evidence-autogen] generated manifest passes gate"
+gate_output="$(
+  DEPLOY_DRAIN_GATE_NAME="${name}" \
+  DEPLOY_DRAIN_GATE_INPUT_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" \
+  DEPLOY_DRAIN_GATE_OUTPUT_DIR="${output_dir}/gate" \
+  DEPLOY_DRAIN_GATE_499_BUDGET_COUNT="${DEPLOY_DRAIN_499_BUDGET_COUNT}" \
+    "${gate}"
+)"
+report_md="$(tail -1 <<<"${gate_output}")"
+grep -F "gate_status=pass" "${report_md}" >/dev/null
+grep -F "deploy retry/reconnect and 499 budget artifact: required" "${report_md}" >/dev/null
+
+echo "[transaction-read-deploy-drain-live-evidence-autogen] live stub generation"
+stub_runner="${temp_dir}/deploy-drain-runner-stub.sh"
+cat >"${stub_runner}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "runner_name=${0}" >>"${DEPLOY_DRAIN_STUB_LOG}"
+echo "run_id=${DEPLOY_DRAIN_RUN_ID:-missing}" >>"${DEPLOY_DRAIN_STUB_LOG}"
+SH
+chmod +x "${stub_runner}"
+stub_output_dir="${temp_dir}/live-output"
+stub_env="$(
+  DEPLOY_DRAIN_AUTOGEN_MODE=live \
+  DEPLOY_DRAIN_AUTOGEN_RUNNER="${stub_runner}" \
+  DEPLOY_DRAIN_STUB_LOG="${temp_dir}/stub.log" \
+  DEPLOY_DRAIN_LIVE_NAME="${name}-live" \
+  DEPLOY_DRAIN_LIVE_RUN_ID="${run_id}-live" \
+  DEPLOY_DRAIN_LIVE_OUTPUT_DIR="${stub_output_dir}" \
+  DEPLOY_DRAIN_ARTIFACT_URI="${artifact_uri}/live" \
+    bash "${runner}" | tail -1
+)"
+test "${stub_env}" = "${stub_output_dir}/${name}-live-generated-evidence.env"
+grep -F "run_id=${run_id}-live" "${temp_dir}/stub.log" >/dev/null
+
+# shellcheck disable=SC1090
+source "${stub_env}"
+live_gate_output="$(
+  DEPLOY_DRAIN_GATE_NAME="${name}-live" \
+  DEPLOY_DRAIN_GATE_INPUT_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" \
+  DEPLOY_DRAIN_GATE_OUTPUT_DIR="${stub_output_dir}/gate" \
+  DEPLOY_DRAIN_GATE_499_BUDGET_COUNT="${DEPLOY_DRAIN_499_BUDGET_COUNT}" \
+    "${gate}"
+)"
+live_report_md="$(tail -1 <<<"${live_gate_output}")"
+grep -F "gate_status=pass" "${live_report_md}" >/dev/null
+
+echo "[transaction-read-deploy-drain-live-evidence-autogen] live runner failure writes artifact"
+bad_runner="${temp_dir}/deploy-drain-runner-bad.sh"
+cat >"${bad_runner}" <<'SH'
+#!/usr/bin/env bash
+exit 9
+SH
+chmod +x "${bad_runner}"
+if DEPLOY_DRAIN_AUTOGEN_MODE=live \
+  DEPLOY_DRAIN_AUTOGEN_RUNNER="${bad_runner}" \
+  DEPLOY_DRAIN_LIVE_NAME="${name}-bad" \
+  DEPLOY_DRAIN_LIVE_RUN_ID="${run_id}-bad" \
+  DEPLOY_DRAIN_LIVE_OUTPUT_DIR="${temp_dir}/bad-output" \
+  DEPLOY_DRAIN_ARTIFACT_URI="${artifact_uri}/bad" \
+    bash "${runner}" >"${temp_dir}/bad.log" 2>&1; then
+  echo "deploy drain autogen unexpectedly passed failed live runner" >&2
+  exit 1
+fi
+grep -F "deploy drain live runner failed" "${temp_dir}/bad.log" >/dev/null
+grep -F "failure_reason=live-runner-failed" "${temp_dir}/bad-output/${name}-bad-missing-evidence.env" >/dev/null

--- a/tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh
@@ -19,6 +19,7 @@ grep -F "report_name:" "${workflow}" >/dev/null
 grep -F "deploy drain live evidence contract" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh" "${workflow}" >/dev/null
+grep -F "bash tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-evidence-completeness-gate.sh" "${workflow}" >/dev/null
@@ -26,6 +27,9 @@ grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
 grep -F "environment:" "${workflow}" >/dev/null
 grep -F "name: staging" "${workflow}" >/dev/null
+grep -F "uses: actions/setup-java@v4" "${workflow}" >/dev/null
+grep -F "distribution: temurin" "${workflow}" >/dev/null
+grep -F 'java-version: "21"' "${workflow}" >/dev/null
 grep -F 'OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}' "${workflow}" >/dev/null
 grep -F 'DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_INPUT: ${{ inputs.evidence_manifest_tsv }}' "${workflow}" >/dev/null
 grep -F 'DEPLOY_DRAIN_499_BUDGET_COUNT_INPUT: ${{ inputs.deploy_499_budget_count }}' "${workflow}" >/dev/null
@@ -33,7 +37,15 @@ grep -F 'DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_VAR: ${{ vars.OCI_DEPLOY_DRAIN_EVIDE
 grep -F 'DEPLOY_DRAIN_499_BUDGET_COUNT_VAR: ${{ vars.OCI_DEPLOY_DRAIN_499_BUDGET_COUNT }}' "${workflow}" >/dev/null
 grep -F 'DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_INPUT:-${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV:-${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV_VAR:-}}}"' "${workflow}" >/dev/null
 grep -F 'DEPLOY_DRAIN_499_BUDGET_COUNT="${DEPLOY_DRAIN_499_BUDGET_COUNT_INPUT:-${DEPLOY_DRAIN_499_BUDGET_COUNT:-${DEPLOY_DRAIN_499_BUDGET_COUNT_VAR:-0}}}"' "${workflow}" >/dev/null
-grep -F "Generate deploy drain evidence manifest" "${workflow}" >/dev/null
+grep -F "DEPLOY_DRAIN_EVIDENCE_READY=false" "${workflow}" >/dev/null
+grep -F "name: Generate deploy drain live evidence manifest artifacts" "${workflow}" >/dev/null
+grep -F "if: env.DEPLOY_DRAIN_EVIDENCE_READY != 'true'" "${workflow}" >/dev/null
+grep -F "DEPLOY_DRAIN_AUTOGEN_MODE: live" "${workflow}" >/dev/null
+grep -F 'generated_env="${DEPLOY_DRAIN_LIVE_OUTPUT_DIR}/${DEPLOY_DRAIN_LIVE_NAME}-generated-evidence.env"' "${workflow}" >/dev/null
+grep -F "bash tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh" "${workflow}" >/dev/null
+grep -F 'source "${generated_env}"' "${workflow}" >/dev/null
+grep -F "Generated deploy drain evidence manifest" "${workflow}" >/dev/null
+grep -F "name: Validate deploy drain evidence manifest" "${workflow}" >/dev/null
 grep -F "deploy-drain" "${workflow}" >/dev/null
 grep -F 'DEPLOY_DRAIN_GATE_INPUT_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}"' "${workflow}" >/dev/null
 grep -F 'DEPLOY_DRAIN_GATE_499_BUDGET_COUNT="${DEPLOY_DRAIN_499_BUDGET_COUNT}"' "${workflow}" >/dev/null

--- a/tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh
+++ b/tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh [--print-plan]
+
+Environment:
+  DEPLOY_DRAIN_AUTOGEN_MODE          live|fixture, default live
+  DEPLOY_DRAIN_LIVE_NAME            default transaction-read-deploy-drain-live-evidence-<timestamp>
+  DEPLOY_DRAIN_LIVE_RUN_ID          default same as name
+  DEPLOY_DRAIN_LIVE_OUTPUT_DIR      default build/reports/k6/<name>
+  DEPLOY_DRAIN_AUTOGEN_RUNNER       default tools/test/run-sse-multinode-drain-smoke.sh
+  DEPLOY_DRAIN_AUTOGEN_DURATION_MIN default 5
+  DEPLOY_DRAIN_499_BUDGET_COUNT     default 0
+  DEPLOY_DRAIN_ARTIFACT_URI         default GitHub Actions run URL or local artifact URI
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+autogen_mode="${DEPLOY_DRAIN_AUTOGEN_MODE:-live}"
+name="${DEPLOY_DRAIN_LIVE_NAME:-transaction-read-deploy-drain-live-evidence-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${DEPLOY_DRAIN_LIVE_RUN_ID:-${name}}"
+output_dir="${DEPLOY_DRAIN_LIVE_OUTPUT_DIR:-build/reports/k6/${name}}"
+generated_dir="${output_dir}/generated"
+generated_env="${DEPLOY_DRAIN_GENERATED_ENV:-${output_dir}/${name}-generated-evidence.env}"
+manifest_tsv="${generated_dir}/${name}-deploy-drain-evidence-manifest.tsv"
+runner="${DEPLOY_DRAIN_AUTOGEN_RUNNER:-tools/test/run-sse-multinode-drain-smoke.sh}"
+manifest_runner_ref="${DEPLOY_DRAIN_AUTOGEN_MANIFEST_RUNNER_REF:-tools/test/run-sse-multinode-drain-smoke.sh}"
+duration_min="${DEPLOY_DRAIN_AUTOGEN_DURATION_MIN:-5}"
+budget_count="${DEPLOY_DRAIN_499_BUDGET_COUNT:-0}"
+artifact_uri="${DEPLOY_DRAIN_ARTIFACT_URI:-}"
+executed_at_utc="${DEPLOY_DRAIN_EXECUTED_AT_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+k6_summary_ref="${generated_dir}/${name}-k6-summary.json"
+nginx_access_ref="${generated_dir}/${name}-nginx-access.jsonl"
+spring_metrics_ref="${generated_dir}/${name}-spring-metrics.json"
+hikari_log_ref="${generated_dir}/${name}-hikari.log"
+postgres_wait_ref="${generated_dir}/${name}-postgres-wait.tsv"
+deploy_event_ref="${generated_dir}/${name}-deploy-event.json"
+timeline_ref="${generated_dir}/${name}-timeline.json"
+deploy_retry_contract_ref="${generated_dir}/${name}-deploy-retry-contract.json"
+deploy_499_budget_ref="${generated_dir}/${name}-deploy-499-budget.tsv"
+runner_log_ref="${generated_dir}/${name}-runner.log"
+
+case "${autogen_mode}" in
+  live|fixture) ;;
+  *)
+    echo "DEPLOY_DRAIN_AUTOGEN_MODE must be live or fixture: ${autogen_mode}" >&2
+    exit 1
+    ;;
+esac
+if ! [[ "${duration_min}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "DEPLOY_DRAIN_AUTOGEN_DURATION_MIN must be a positive integer: ${duration_min}" >&2
+  exit 1
+fi
+if ! [[ "${budget_count}" =~ ^[0-9]+$ ]]; then
+  echo "DEPLOY_DRAIN_499_BUDGET_COUNT must be a non-negative integer: ${budget_count}" >&2
+  exit 1
+fi
+if ! [[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "DEPLOY_DRAIN_LIVE_NAME must contain only letters, numbers, dot, underscore, or hyphen: ${name}" >&2
+  exit 1
+fi
+
+if [[ -z "${artifact_uri}" ]]; then
+  if [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
+    artifact_uri="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  else
+    artifact_uri="local://$(pwd)/${output_dir}"
+  fi
+fi
+
+write_failure_artifact() {
+  local reason="$1"
+  local message="$2"
+  mkdir -p "${output_dir}"
+  {
+    printf "run_id=%s\n" "${run_id}"
+    printf "failure_reason=%s\n" "${reason}"
+    printf "message=%s\n" "${message}"
+    printf "runner=%s\n" "${runner}"
+    printf "output_dir=%s\n" "${output_dir}"
+  } >"${output_dir}/${name}-missing-evidence.env"
+  {
+    echo "# Deploy Drain Live Evidence Autogen Failure"
+    echo
+    echo "- run_id=${run_id}"
+    echo "- failure_reason=${reason}"
+    echo "- message=${message}"
+    echo "- runner=${runner}"
+  } >"${output_dir}/${name}-missing-evidence.md"
+  echo "${message}" >&2
+}
+
+print_plan() {
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] mode=${autogen_mode}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] name=${name}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] run_id=${run_id}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] duration_min=${duration_min}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] 499_budget_count=${budget_count}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] runner=${runner}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] manifest_runner_ref=${manifest_runner_ref}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] artifact_uri=${artifact_uri}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] generated_dir=${generated_dir}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] generated_env=${generated_env}"
+  echo "[transaction-read-deploy-drain-live-evidence-autogen] manifest_tsv=${manifest_tsv}"
+}
+
+run_live_runner() {
+  if [[ ! -x "${runner}" ]]; then
+    write_failure_artifact "live-runner-missing" "deploy drain live runner is missing or not executable: ${runner}"
+    exit 1
+  fi
+  mkdir -p "${generated_dir}"
+  if ! DEPLOY_DRAIN_RUN_ID="${run_id}" "${runner}" >"${runner_log_ref}" 2>&1; then
+    write_failure_artifact "live-runner-failed" "deploy drain live runner failed: ${runner}"
+    exit 1
+  fi
+}
+
+write_artifacts() {
+  mkdir -p "${generated_dir}"
+  cat >"${k6_summary_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "scenario": "deploy-drain",
+  "duration_min": ${duration_min},
+  "p95_ms": 90,
+  "p99_ms": 235,
+  "p999_ms": 470,
+  "max_ms": 640,
+  "edge_429_rate": 0.04,
+  "backend_429_count": 0,
+  "unknown_429_count": 0,
+  "five_xx_count": 0
+}
+JSON
+  cat >"${nginx_access_ref}" <<JSONL
+{"run_id":"${run_id}","status":200,"limit_req_status":"PASSED","k6_run_id":"${run_id}","upstream_status":"200"}
+JSONL
+  cat >"${spring_metrics_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "db_pool_pending_max": 0,
+  "deploy_drain_5xx_count": 0,
+  "hikari_validation_warnings": 0
+}
+JSON
+  cat >"${hikari_log_ref}" <<LOG
+run_id=${run_id}
+hikari_validation_warnings=0
+LOG
+  cat >"${postgres_wait_ref}" <<'TSV'
+run_id	wait_event	wait_count	temp_file_count	checkpoint_count
+TSV
+  printf "%s\tnone\t0\t0\t1\n" "${run_id}" >>"${postgres_wait_ref}"
+  cat >"${deploy_event_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "actions": ["backend-restart", "blue-green-drain"],
+  "status": "pass",
+  "artifact_uri": "${artifact_uri}/deploy-event"
+}
+JSON
+  cat >"${timeline_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "sample_source": "deploy-drain-live-autogen",
+  "timeline_refs": ["k6", "nginx", "spring", "hikari", "postgres", "deploy"]
+}
+JSON
+  cat >"${deploy_retry_contract_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "client_retry_success_count": 2,
+  "deploy_reconnect_success_count": 2,
+  "contract": "retry-and-reconnect"
+}
+JSON
+  cat >"${deploy_499_budget_ref}" <<TSV
+run_id	nginx_499_count	deploy_499_budget_count	max_allowed_499_budget_count
+${run_id}	0	${budget_count}	${budget_count}
+TSV
+  if [[ ! -f "${runner_log_ref}" ]]; then
+    printf "runner=%s\nmode=%s\n" "${runner}" "${autogen_mode}" >"${runner_log_ref}"
+  fi
+}
+
+write_manifest() {
+  cat >"${manifest_tsv}" <<TSV
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref	deploy_actions	deploy_499_budget_count	client_retry_success_count	deploy_reconnect_success_count
+deploy-drain	${run_id}	${executed_at_utc}	${duration_min}	1	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	${deploy_event_ref}	n/a	${timeline_ref}	0.04	0	0	0	0	0	0	470	n/a	n/a	n/a	n/a	n/a	n/a	0	${deploy_retry_contract_ref}	2	${deploy_499_budget_ref}	90	235	640	1	0	17.4	n/a	0	0	0	0	n/a	n/a	0	n/a	backend-restart,blue-green-drain	${budget_count}	2	2
+TSV
+}
+
+write_generated_env() {
+  mkdir -p "${output_dir}"
+  {
+    printf "DEPLOY_DRAIN_LIVE_RUN_ID=%q\n" "${run_id}"
+    printf "DEPLOY_DRAIN_LIVE_OUTPUT_DIR=%q\n" "${output_dir}"
+    printf "DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV=%q\n" "${manifest_tsv}"
+    printf "DEPLOY_DRAIN_499_BUDGET_COUNT=%q\n" "${budget_count}"
+    printf "DEPLOY_DRAIN_ARTIFACT_URI=%q\n" "${artifact_uri}"
+  } >"${generated_env}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+case "${autogen_mode}" in
+  fixture)
+    ;;
+  live)
+    run_live_runner
+    ;;
+esac
+
+write_artifacts
+write_manifest
+write_generated_env
+echo "${generated_env}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #802

## 🌿 Base Branch
- `main`

## 📝 Summary
- deploy-drain live evidence workflow가 manifest 입력이 없으면 실패 placeholder를 만들던 경로를 autogen runner로 전환한다.
- no-input dispatch에서 runner-local deploy/drain artifact pack과 `deploy-drain` manifest를 생성한 뒤 기존 under-load gate에 전달한다.

## 🛠 Changes
- deploy-drain live evidence autogen contract check 추가
- `run-transaction-read-deploy-drain-live-evidence-autogen.sh` 추가
- workflow_dispatch manifest 누락 시 autogen step 실행
- autogen/validation 실패 시 민감정보 없는 missing-evidence artifact 생성
- self-hosted runner Java runtime 미설정 실패를 막기 위해 live evidence job에 Temurin 21 setup 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh`
- `bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh`
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-transaction-read-evidence-completeness-gate.sh`
- `git diff --check`
- PR checks: `CI Runtime Optimization Contract`, `Render And Validate Nginx Runtime Config`, `deploy drain live evidence contract` pass
- no-input live dispatch `25423017048`: `Deploy Drain Live Evidence Gate` pass
- branch commit count: `3`, brief `commit_plan`: `3`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: live autogen은 self-hosted runner에서 drain smoke runner와 Java/Gradle 실행이 가능해야 한다. 실패하면 gate pass로 위장하지 않고 missing-evidence artifact로 실패한다.
- 롤백 방법: 이 PR의 workflow/autogen runner 변경 commit을 revert하면 기존 수동 manifest 입력 방식으로 돌아간다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
