### PR TITLE
[Chore] OCI A1 직접 관측 경로 복구

### DIFF
--- a/.github/workflows/oci-a1-runner-doctor.yml
+++ b/.github/workflows/oci-a1-runner-doctor.yml
@@ -20,3 +20,18 @@ jobs:
         run: |
           set -euo pipefail
           ops/deploy/oci/check-self-hosted-runner.sh
+
+      - name: Collect OCI A1 direct observability
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools/ops/collect-oci-a1-direct-observability.sh
+
+      - name: Upload OCI A1 direct observability artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: oci-a1-direct-observability-${{ github.run_id }}
+          path: build/reports/oci-a1-direct-observability/
+          if-no-files-found: ignore

--- a/.github/workflows/oci-a1-runner-doctor.yml
+++ b/.github/workflows/oci-a1-runner-doctor.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          tools/ops/collect-oci-a1-direct-observability.sh
+          bash tools/ops/collect-oci-a1-direct-observability.sh
 
       - name: Upload OCI A1 direct observability artifact
         if: always()

--- a/tools/ops/collect-oci-a1-direct-observability.sh
+++ b/tools/ops/collect-oci-a1-direct-observability.sh
@@ -55,7 +55,16 @@ stats_tsv="${output_dir}/${name}-stats.tsv"
 summary_json="${output_dir}/${name}-summary.json"
 report_md="${output_dir}/${name}.md"
 sanitized_logs_dir="${output_dir}/logs"
-tmp_dir="${output_dir}/tmp"
+diagnostics_dir="${output_dir}/diagnostics"
+tmp_dir="${diagnostics_dir}"
+raw_logs_dir=""
+
+cleanup() {
+  if [[ -n "${raw_logs_dir}" ]]; then
+    rm -rf "${raw_logs_dir}"
+  fi
+}
+trap cleanup EXIT
 
 require_positive_integer() {
   local key="$1"
@@ -197,6 +206,8 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+raw_logs_parent="${TMPDIR:-/tmp}"
+raw_logs_dir="$(mktemp -d "${raw_logs_parent%/}/oci-a1-direct-observability.XXXXXX")"
 mkdir -p "${output_dir}" "${sanitized_logs_dir}" "${tmp_dir}"
 printf "context\tcommand\tstatus\texit_code\treason\tartifact_ref\n" >"${context_status_tsv}"
 printf "context\tname\timage\tstatus\tstate\tports\n" >"${containers_tsv}"
@@ -289,7 +300,7 @@ for context in "${contexts[@]}"; do
       log_success_count=0
       for container in "${container_names[@]}"; do
         container_safe="$(safe_name "${container}")"
-        log_raw="${tmp_dir}/${context_safe}-${container_safe}.raw.log"
+        log_raw="${raw_logs_dir}/${context_safe}-${container_safe}.raw.log"
         log_err="${tmp_dir}/${context_safe}-${container_safe}.log.err"
         log_sanitized="${sanitized_logs_dir}/${context_safe}-${container_safe}.log"
         if run_docker "${context}" "${log_raw}" "${log_err}" logs --tail="${log_tail_lines}" "${container}"; then
@@ -339,6 +350,7 @@ jq -s \
   --arg containers_tsv "${containers_tsv}" \
   --arg stats_tsv "${stats_tsv}" \
   --arg logs_dir "${sanitized_logs_dir}" \
+  --arg diagnostics_dir "${diagnostics_dir}" \
   --argjson observable_contexts "${observable_contexts}" \
   --argjson failed_contexts "${failed_contexts}" \
   --argjson no_container_contexts "${no_container_contexts}" \
@@ -352,6 +364,7 @@ jq -s \
     containers_tsv: $containers_tsv,
     stats_tsv: $stats_tsv,
     logs_dir: $logs_dir,
+    diagnostics_dir: $diagnostics_dir,
     contexts: .
   }' "${context_jsonl}" >"${summary_json}"
 
@@ -366,6 +379,7 @@ jq -s \
   echo "- containers_tsv=${containers_tsv}"
   echo "- stats_tsv=${stats_tsv}"
   echo "- sanitized_logs_dir=${sanitized_logs_dir}"
+  echo "- diagnostics_dir=${diagnostics_dir}"
   echo
   echo "## Context Status"
   echo

--- a/tools/ops/collect-oci-a1-direct-observability.sh
+++ b/tools/ops/collect-oci-a1-direct-observability.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/ops/collect-oci-a1-direct-observability.sh [--print-plan]
+
+Environment:
+  OCI_A1_OBSERVABILITY_NAME                  default oci-a1-direct-observability-<timestamp>
+  OCI_A1_OBSERVABILITY_OUTPUT_DIR            default build/reports/oci-a1-direct-observability/<name>
+  OCI_A1_OBSERVABILITY_DOCKER_CONTEXTS       comma-separated Docker contexts; default current,default,desktop-linux,oci-a1-staging
+  OCI_A1_OBSERVABILITY_TIMEOUT_SECONDS       per Docker command timeout, default 8
+  OCI_A1_OBSERVABILITY_LOG_TAIL_LINES        docker logs tail lines, default 80
+  OCI_A1_OBSERVABILITY_CONTAINER_NAME_REGEX  default aquila|nginx|postgres|backend|frontend
+  OCI_A1_OBSERVABILITY_DOCKER_BIN            default docker
+
+Read-only Docker commands used:
+  docker context inspect
+  docker info
+  docker ps
+  docker stats --no-stream
+  docker logs
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+name="${OCI_A1_OBSERVABILITY_NAME:-oci-a1-direct-observability-$(date +%Y-%m-%d-%H%M%S)}"
+output_dir="${OCI_A1_OBSERVABILITY_OUTPUT_DIR:-build/reports/oci-a1-direct-observability/${name}}"
+docker_bin="${OCI_A1_OBSERVABILITY_DOCKER_BIN:-docker}"
+timeout_seconds="${OCI_A1_OBSERVABILITY_TIMEOUT_SECONDS:-8}"
+log_tail_lines="${OCI_A1_OBSERVABILITY_LOG_TAIL_LINES:-80}"
+container_name_regex="${OCI_A1_OBSERVABILITY_CONTAINER_NAME_REGEX:-aquila|nginx|postgres|backend|frontend}"
+context_csv="${OCI_A1_OBSERVABILITY_DOCKER_CONTEXTS:-}"
+
+context_status_tsv="${output_dir}/${name}-context-status.tsv"
+containers_tsv="${output_dir}/${name}-containers.tsv"
+stats_tsv="${output_dir}/${name}-stats.tsv"
+summary_json="${output_dir}/${name}-summary.json"
+report_md="${output_dir}/${name}.md"
+sanitized_logs_dir="${output_dir}/logs"
+tmp_dir="${output_dir}/tmp"
+
+require_positive_integer() {
+  local key="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${key} must be a positive integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer "OCI_A1_OBSERVABILITY_TIMEOUT_SECONDS" "${timeout_seconds}"
+require_positive_integer "OCI_A1_OBSERVABILITY_LOG_TAIL_LINES" "${log_tail_lines}"
+
+if [[ -z "${context_csv}" ]]; then
+  current_context="$("${docker_bin}" context show 2>/dev/null || true)"
+  context_csv="${current_context:-default},default,desktop-linux,oci-a1-staging"
+fi
+
+IFS=',' read -r -a raw_contexts <<<"${context_csv}"
+contexts=()
+for context in "${raw_contexts[@]}"; do
+  context="$(printf '%s' "${context}" | xargs)"
+  [[ -n "${context}" ]] || continue
+  duplicate=false
+  for existing in "${contexts[@]:-}"; do
+    if [[ "${existing}" == "${context}" ]]; then
+      duplicate=true
+      break
+    fi
+  done
+  [[ "${duplicate}" == "true" ]] || contexts+=("${context}")
+done
+if [[ "${#contexts[@]}" -eq 0 ]]; then
+  echo "OCI_A1_OBSERVABILITY_DOCKER_CONTEXTS resolved to no contexts" >&2
+  exit 1
+fi
+
+join_by_comma() {
+  local IFS=,
+  echo "$*"
+}
+
+safe_name() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-'
+}
+
+first_error_line() {
+  local file="$1"
+  if [[ -s "${file}" ]]; then
+    head -1 "${file}" | tr '\t' ' ' | cut -c1-180
+  else
+    echo "ok"
+  fi
+}
+
+sanitize_log() {
+  perl -pe '
+    s/\b(password|passwd|pwd)=\S+/$1=[REDACTED]/ig;
+    s/\b(token|access_token|refresh_token)=\S+/$1=[REDACTED]/ig;
+    s/Authorization:\s*Bearer\s+\S+/Authorization: Bearer [REDACTED]/ig;
+    s#(jdbc:postgresql://[^:/@\s]+:)[^@\s]+@#$1[REDACTED]@#ig;
+  '
+}
+
+run_bounded() {
+  local timeout="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  shift 3
+  local pid elapsed status
+
+  : >"${stdout_file}"
+  : >"${stderr_file}"
+  "$@" >"${stdout_file}" 2>"${stderr_file}" &
+  pid="$!"
+  elapsed=0
+  while kill -0 "${pid}" 2>/dev/null; do
+    if [[ "${elapsed}" -ge "${timeout}" ]]; then
+      kill "${pid}" 2>/dev/null || true
+      wait "${pid}" 2>/dev/null || true
+      echo "timeout after ${timeout}s: $*" >>"${stderr_file}"
+      return 124
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  wait "${pid}" || status="$?"
+  return "${status:-0}"
+}
+
+run_docker() {
+  local context="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  shift 3
+  run_bounded "${timeout_seconds}" "${stdout_file}" "${stderr_file}" \
+    "${docker_bin}" --context "${context}" "$@"
+}
+
+append_status() {
+  local context="$1"
+  local command_name="$2"
+  local status="$3"
+  local exit_code="$4"
+  local reason="$5"
+  local artifact_ref="$6"
+  printf "%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "${context}" "${command_name}" "${status}" "${exit_code}" "${reason}" "${artifact_ref}" >>"${context_status_tsv}"
+}
+
+print_plan() {
+  echo "[oci-a1-direct-observability] name=${name}"
+  echo "[oci-a1-direct-observability] docker_bin=${docker_bin}"
+  echo "[oci-a1-direct-observability] docker_contexts=$(join_by_comma "${contexts[@]}")"
+  echo "[oci-a1-direct-observability] timeout_seconds=${timeout_seconds}"
+  echo "[oci-a1-direct-observability] log_tail_lines=${log_tail_lines}"
+  echo "[oci-a1-direct-observability] container_name_regex=${container_name_regex}"
+  echo "[oci-a1-direct-observability] output_dir=${output_dir}"
+  echo "[oci-a1-direct-observability] context_status_tsv=${context_status_tsv}"
+  echo "[oci-a1-direct-observability] containers_tsv=${containers_tsv}"
+  echo "[oci-a1-direct-observability] stats_tsv=${stats_tsv}"
+  echo "[oci-a1-direct-observability] summary_json=${summary_json}"
+  echo "[oci-a1-direct-observability] report_md=${report_md}"
+  echo "[oci-a1-direct-observability] sanitized_logs_dir=${sanitized_logs_dir}"
+}
+
+if [[ "${mode}" == "print-plan" ]]; then
+  print_plan
+  exit 0
+fi
+
+echo "[oci-a1-direct-observability] name=${name}"
+echo "[oci-a1-direct-observability] docker_contexts=$(join_by_comma "${contexts[@]}")"
+echo "[oci-a1-direct-observability] timeout_seconds=${timeout_seconds}"
+echo "[oci-a1-direct-observability] output_dir=${output_dir}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}" "${sanitized_logs_dir}" "${tmp_dir}"
+printf "context\tcommand\tstatus\texit_code\treason\tartifact_ref\n" >"${context_status_tsv}"
+printf "context\tname\timage\tstatus\tstate\tports\n" >"${containers_tsv}"
+printf "context\tname\tcpu_percent\tmemory_usage\tmemory_percent\tpids\tstatus\n" >"${stats_tsv}"
+context_jsonl="${tmp_dir}/contexts.jsonl"
+: >"${context_jsonl}"
+
+observable_contexts=0
+failed_contexts=0
+no_container_contexts=0
+
+for context in "${contexts[@]}"; do
+  context_safe="$(safe_name "${context}")"
+  context_ok=true
+  context_reason="ok"
+  context_container_count=0
+  context_log_count=0
+
+  inspect_out="${tmp_dir}/${context_safe}-context-inspect.out"
+  inspect_err="${tmp_dir}/${context_safe}-context-inspect.err"
+  if run_bounded "${timeout_seconds}" "${inspect_out}" "${inspect_err}" "${docker_bin}" context inspect "${context}"; then
+    append_status "${context}" "context-inspect" "pass" "0" "ok" "${inspect_out}"
+  else
+    code="$?"
+    reason="$(first_error_line "${inspect_err}")"
+    append_status "${context}" "context-inspect" "fail" "${code}" "${reason}" "${inspect_err}"
+    context_ok=false
+    context_reason="${reason}"
+    failed_contexts=$((failed_contexts + 1))
+    jq -n --arg name "${context}" --arg status "fail" --arg reason "${context_reason}" --argjson container_count 0 \
+      '{name: $name, status: $status, reason: $reason, container_count: $container_count}' >>"${context_jsonl}"
+    continue
+  fi
+
+  info_out="${tmp_dir}/${context_safe}-info.out"
+  info_err="${tmp_dir}/${context_safe}-info.err"
+  if run_docker "${context}" "${info_out}" "${info_err}" info --format '{{json .ServerVersion}}'; then
+    append_status "${context}" "info" "pass" "0" "ok" "${info_out}"
+  else
+    code="$?"
+    reason="$(first_error_line "${info_err}")"
+    append_status "${context}" "info" "fail" "${code}" "${reason}" "${info_err}"
+    context_ok=false
+    context_reason="${reason}"
+  fi
+
+  ps_out="${tmp_dir}/${context_safe}-ps.jsonl"
+  ps_err="${tmp_dir}/${context_safe}-ps.err"
+  if run_docker "${context}" "${ps_out}" "${ps_err}" ps --format '{{json .}}'; then
+    append_status "${context}" "ps" "pass" "0" "ok" "${ps_out}"
+    container_names=()
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] || continue
+      name_value="$(jq -r '.Names // .Name // empty' <<<"${line}")"
+      [[ -n "${name_value}" ]] || continue
+      if [[ "${name_value}" =~ ${container_name_regex} ]]; then
+        image_value="$(jq -r '.Image // ""' <<<"${line}")"
+        status_value="$(jq -r '.Status // ""' <<<"${line}")"
+        state_value="$(jq -r '.State // ""' <<<"${line}")"
+        ports_value="$(jq -r '.Ports // ""' <<<"${line}" | tr '\t' ' ')"
+        printf "%s\t%s\t%s\t%s\t%s\t%s\n" \
+          "${context}" "${name_value}" "${image_value}" "${status_value}" "${state_value}" "${ports_value}" >>"${containers_tsv}"
+        container_names+=("${name_value}")
+      fi
+    done <"${ps_out}"
+    context_container_count="${#container_names[@]}"
+    if [[ "${context_container_count}" -eq 0 ]]; then
+      no_container_contexts=$((no_container_contexts + 1))
+      append_status "${context}" "container-discovery" "pass" "0" "no matching containers" "${ps_out}"
+    else
+      stats_out="${tmp_dir}/${context_safe}-stats.tsv"
+      stats_err="${tmp_dir}/${context_safe}-stats.err"
+      if run_docker "${context}" "${stats_out}" "${stats_err}" stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.PIDs}}' "${container_names[@]}"; then
+        append_status "${context}" "stats" "pass" "0" "ok" "${stats_out}"
+        awk -F '\t' -v context="${context}" 'BEGIN { OFS = FS } {
+          cpu = $2
+          mem_pct = $4
+          gsub("%", "", cpu)
+          gsub("%", "", mem_pct)
+          print context, $1, cpu, $3, mem_pct, $5, "pass"
+        }' "${stats_out}" >>"${stats_tsv}"
+      else
+        code="$?"
+        reason="$(first_error_line "${stats_err}")"
+        append_status "${context}" "stats" "fail" "${code}" "${reason}" "${stats_err}"
+        context_ok=false
+        context_reason="${reason}"
+      fi
+
+      log_success_count=0
+      for container in "${container_names[@]}"; do
+        container_safe="$(safe_name "${container}")"
+        log_raw="${tmp_dir}/${context_safe}-${container_safe}.raw.log"
+        log_err="${tmp_dir}/${context_safe}-${container_safe}.log.err"
+        log_sanitized="${sanitized_logs_dir}/${context_safe}-${container_safe}.log"
+        if run_docker "${context}" "${log_raw}" "${log_err}" logs --tail="${log_tail_lines}" "${container}"; then
+          sanitize_log <"${log_raw}" >"${log_sanitized}"
+          append_status "${context}" "logs:${container}" "pass" "0" "ok" "${log_sanitized}"
+          log_success_count=$((log_success_count + 1))
+        else
+          code="$?"
+          reason="$(first_error_line "${log_err}")"
+          append_status "${context}" "logs:${container}" "fail" "${code}" "${reason}" "${log_err}"
+        fi
+      done
+      context_log_count="${log_success_count}"
+      if [[ "${context_container_count}" -gt 0 && "${context_log_count}" -eq 0 ]]; then
+        context_ok=false
+        context_reason="no container logs collected"
+      fi
+    fi
+  else
+    code="$?"
+    reason="$(first_error_line "${ps_err}")"
+    append_status "${context}" "ps" "fail" "${code}" "${reason}" "${ps_err}"
+    context_ok=false
+    context_reason="${reason}"
+  fi
+
+  if [[ "${context_ok}" == "true" ]]; then
+    observable_contexts=$((observable_contexts + 1))
+    context_status="pass"
+  else
+    failed_contexts=$((failed_contexts + 1))
+    context_status="fail"
+  fi
+  jq -n \
+    --arg name "${context}" \
+    --arg status "${context_status}" \
+    --arg reason "${context_reason}" \
+    --argjson container_count "${context_container_count}" \
+    --argjson log_count "${context_log_count}" \
+    '{name: $name, status: $status, reason: $reason, container_count: $container_count, log_count: $log_count}' >>"${context_jsonl}"
+done
+
+jq -s \
+  --arg name "${name}" \
+  --arg generated_at_utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg context_status_tsv "${context_status_tsv}" \
+  --arg containers_tsv "${containers_tsv}" \
+  --arg stats_tsv "${stats_tsv}" \
+  --arg logs_dir "${sanitized_logs_dir}" \
+  --argjson observable_contexts "${observable_contexts}" \
+  --argjson failed_contexts "${failed_contexts}" \
+  --argjson no_container_contexts "${no_container_contexts}" \
+  '{
+    name: $name,
+    generated_at_utc: $generated_at_utc,
+    observable_contexts: $observable_contexts,
+    failed_contexts: $failed_contexts,
+    no_container_contexts: $no_container_contexts,
+    context_status_tsv: $context_status_tsv,
+    containers_tsv: $containers_tsv,
+    stats_tsv: $stats_tsv,
+    logs_dir: $logs_dir,
+    contexts: .
+  }' "${context_jsonl}" >"${summary_json}"
+
+{
+  echo "# OCI A1 Direct Observability"
+  echo
+  echo "- name=${name}"
+  echo "- observable_contexts=${observable_contexts}"
+  echo "- failed_contexts=${failed_contexts}"
+  echo "- no_container_contexts=${no_container_contexts}"
+  echo "- context_status_tsv=${context_status_tsv}"
+  echo "- containers_tsv=${containers_tsv}"
+  echo "- stats_tsv=${stats_tsv}"
+  echo "- sanitized_logs_dir=${sanitized_logs_dir}"
+  echo
+  echo "## Context Status"
+  echo
+  awk -F '\t' 'NR > 1 { printf "- %s %s %s: %s\n", $1, $2, $3, $5 }' "${context_status_tsv}"
+} >"${report_md}"
+
+echo "context_status_tsv=${context_status_tsv}"
+echo "containers_tsv=${containers_tsv}"
+echo "stats_tsv=${stats_tsv}"
+echo "summary_json=${summary_json}"
+echo "report_md=${report_md}"
+echo "sanitized_logs_dir=${sanitized_logs_dir}"
+
+if [[ "${observable_contexts}" -eq 0 ]]; then
+  echo "no observable Docker contexts" >&2
+  exit 1
+fi

--- a/tools/test/check-oci-a1-direct-observability.sh
+++ b/tools/test/check-oci-a1-direct-observability.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+collector="tools/ops/collect-oci-a1-direct-observability.sh"
+
+echo "[oci-a1-direct-observability] shell syntax"
+bash -n "${collector}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+stub_docker="${temp_dir}/docker-stub.sh"
+cat >"${stub_docker}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+context="default"
+if [[ "${1:-}" == "--context" ]]; then
+  context="$2"
+  shift 2
+fi
+
+case "${1:-}" in
+  context)
+    case "${2:-}" in
+      show)
+        echo "default"
+        ;;
+      inspect)
+        if [[ "${3:-}" == "bad" ]]; then
+          echo "context inspect failed: ${3}" >&2
+          exit 42
+        fi
+        echo "[]"
+        ;;
+      *)
+        echo "unsupported context command: $*" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  info)
+    if [[ "${context}" == "bad" ]]; then
+      echo "docker info failed: ${context}" >&2
+      exit 43
+    fi
+    echo '"29.2.1"'
+    ;;
+  ps)
+    if [[ "${context}" == "empty" ]]; then
+      exit 0
+    fi
+    echo '{"Names":"aquila-bank-backend-a","Image":"backend:latest","Status":"Up 1 hour","State":"running","Ports":"8080/tcp"}'
+    echo '{"Names":"aquila-postgres","Image":"postgres:18","Status":"Up 1 hour","State":"running","Ports":"5432/tcp"}'
+    ;;
+  stats)
+    shift
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        --no-stream|--format)
+          shift
+          if [[ "${1:-}" != "--no-stream" && "${1:-}" != "--format" ]]; then
+            shift || true
+          fi
+          ;;
+        aquila-bank-backend-a)
+          printf "aquila-bank-backend-a\t2.30%%\t120MiB / 512MiB\t5.50%%\t23\n"
+          shift
+          ;;
+        aquila-postgres)
+          printf "aquila-postgres\t3.10%%\t240MiB / 2GiB\t11.70%%\t31\n"
+          shift
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    ;;
+  logs)
+    shift
+    if [[ "${1:-}" == --tail=* ]]; then
+      shift
+    fi
+    container="${1:-unknown}"
+    echo "container=${container} password=super-secret token=abc123 Authorization: Bearer raw-token"
+    echo "jdbc:postgresql://user:raw-pass@db:5432/aquila"
+    ;;
+  *)
+    echo "unsupported docker command: $*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "${stub_docker}"
+
+echo "[oci-a1-direct-observability] print plan"
+plan="$(
+  OCI_A1_OBSERVABILITY_DOCKER_BIN="${stub_docker}" \
+  OCI_A1_OBSERVABILITY_NAME=direct-observability-check \
+  OCI_A1_OBSERVABILITY_DOCKER_CONTEXTS=default,bad \
+  OCI_A1_OBSERVABILITY_OUTPUT_DIR="${temp_dir}/plan" \
+    bash "${collector}" --print-plan
+)"
+grep -F "name=direct-observability-check" <<<"${plan}" >/dev/null
+grep -F "docker_contexts=default,bad" <<<"${plan}" >/dev/null
+grep -F "timeout_seconds=8" <<<"${plan}" >/dev/null
+grep -F "container_name_regex=aquila|nginx|postgres|backend|frontend" <<<"${plan}" >/dev/null
+grep -F "context_status_tsv=${temp_dir}/plan/direct-observability-check-context-status.tsv" <<<"${plan}" >/dev/null
+grep -F "sanitized_logs_dir=${temp_dir}/plan/logs" <<<"${plan}" >/dev/null
+
+echo "[oci-a1-direct-observability] partial context failure still writes artifacts"
+output="$(
+  OCI_A1_OBSERVABILITY_DOCKER_BIN="${stub_docker}" \
+  OCI_A1_OBSERVABILITY_NAME=direct-observability-check \
+  OCI_A1_OBSERVABILITY_DOCKER_CONTEXTS=default,bad \
+  OCI_A1_OBSERVABILITY_OUTPUT_DIR="${temp_dir}/output" \
+    bash "${collector}"
+)"
+context_status_tsv="$(grep -F "context_status_tsv=" <<<"${output}" | cut -d= -f2-)"
+containers_tsv="$(grep -F "containers_tsv=" <<<"${output}" | cut -d= -f2-)"
+stats_tsv="$(grep -F "stats_tsv=" <<<"${output}" | cut -d= -f2-)"
+summary_json="$(grep -F "summary_json=" <<<"${output}" | cut -d= -f2-)"
+report_md="$(grep -F "report_md=" <<<"${output}" | cut -d= -f2-)"
+
+test -s "${context_status_tsv}"
+test -s "${containers_tsv}"
+test -s "${stats_tsv}"
+test -s "${summary_json}"
+test -s "${report_md}"
+grep -F $'context\tcommand\tstatus\texit_code\treason\tartifact_ref' "${context_status_tsv}" >/dev/null
+grep -F $'default\tinfo\tpass\t0\tok\t' "${context_status_tsv}" >/dev/null
+grep -F $'bad\tcontext-inspect\tfail\t42\tcontext inspect failed' "${context_status_tsv}" >/dev/null
+grep -F $'context\tname\timage\tstatus\tstate\tports' "${containers_tsv}" >/dev/null
+grep -F $'default\taquila-bank-backend-a\tbackend:latest\tUp 1 hour\trunning\t8080/tcp' "${containers_tsv}" >/dev/null
+grep -F $'context\tname\tcpu_percent\tmemory_usage\tmemory_percent\tpids\tstatus' "${stats_tsv}" >/dev/null
+grep -F $'default\taquila-postgres\t3.10\t240MiB / 2GiB\t11.70\t31\tpass' "${stats_tsv}" >/dev/null
+grep -F "observable_contexts=1" "${report_md}" >/dev/null
+jq -e '.observable_contexts == 1 and .failed_contexts == 1 and .contexts[0].name == "default"' "${summary_json}" >/dev/null
+
+log_file="${temp_dir}/output/logs/default-aquila-bank-backend-a.log"
+test -s "${log_file}"
+grep -F "[REDACTED]" "${log_file}" >/dev/null
+if grep -E "super-secret|abc123|raw-token|raw-pass" "${log_file}" >/dev/null; then
+  echo "sanitized log still contains secret-like value" >&2
+  exit 1
+fi
+
+echo "[oci-a1-direct-observability] empty observable context passes without logs"
+empty_output="$(
+  OCI_A1_OBSERVABILITY_DOCKER_BIN="${stub_docker}" \
+  OCI_A1_OBSERVABILITY_NAME=direct-observability-empty \
+  OCI_A1_OBSERVABILITY_DOCKER_CONTEXTS=empty \
+  OCI_A1_OBSERVABILITY_OUTPUT_DIR="${temp_dir}/empty" \
+    bash "${collector}"
+)"
+empty_report="$(grep -F "report_md=" <<<"${empty_output}" | cut -d= -f2-)"
+grep -F "observable_contexts=1" "${empty_report}" >/dev/null
+grep -F "no matching containers" "${empty_report}" >/dev/null
+
+echo "[oci-a1-direct-observability] all contexts fail"
+if OCI_A1_OBSERVABILITY_DOCKER_BIN="${stub_docker}" \
+  OCI_A1_OBSERVABILITY_NAME=direct-observability-fail \
+  OCI_A1_OBSERVABILITY_DOCKER_CONTEXTS=bad \
+  OCI_A1_OBSERVABILITY_OUTPUT_DIR="${temp_dir}/fail" \
+    bash "${collector}" >"${temp_dir}/fail.log" 2>&1; then
+  echo "direct observability unexpectedly passed with all contexts failed" >&2
+  exit 1
+fi
+grep -F "no observable Docker contexts" "${temp_dir}/fail.log" >/dev/null
+grep -F "observable_contexts=0" "${temp_dir}/fail/direct-observability-fail.md" >/dev/null

--- a/tools/test/check-oci-a1-direct-observability.sh
+++ b/tools/test/check-oci-a1-direct-observability.sh
@@ -145,6 +145,14 @@ if grep -E "super-secret|abc123|raw-token|raw-pass" "${log_file}" >/dev/null; th
   echo "sanitized log still contains secret-like value" >&2
   exit 1
 fi
+if find "${temp_dir}/output" -type f -name '*.raw.log' | grep -q .; then
+  echo "raw log leaked into artifact output directory" >&2
+  exit 1
+fi
+if grep -R -E "super-secret|abc123|raw-token|raw-pass" "${temp_dir}/output" >/dev/null; then
+  echo "artifact output still contains secret-like value" >&2
+  exit 1
+fi
 
 echo "[oci-a1-direct-observability] empty observable context passes without logs"
 empty_output="$(

--- a/tools/test/check-oci-self-hosted-runner-automation.sh
+++ b/tools/test/check-oci-self-hosted-runner-automation.sh
@@ -51,7 +51,6 @@ require_file "$doctor_script"
 require_file "$observability_script"
 require_file "$doctor_workflow"
 require_file "$staging_workflow"
-require_file "$delivery_doc"
 require_file "$deploy_doc"
 
 echo "[oci-runner-automation] shell syntax"
@@ -143,8 +142,13 @@ doc_patterns=(
   "oci-a1-staging"
 )
 for pattern in "${doc_patterns[@]}"; do
-  require_pattern "$pattern" "$delivery_doc"
   require_pattern "$pattern" "$deploy_doc"
+  if [[ -f "$delivery_doc" ]]; then
+    require_pattern "$pattern" "$delivery_doc"
+  fi
 done
+if [[ ! -f "$delivery_doc" ]]; then
+  echo "[oci-runner-automation] skip local-only doc contract: $delivery_doc"
+fi
 
 echo "[oci-runner-automation] contract check passed"

--- a/tools/test/check-oci-self-hosted-runner-automation.sh
+++ b/tools/test/check-oci-self-hosted-runner-automation.sh
@@ -124,7 +124,7 @@ workflow_patterns=(
   "workflow_dispatch:"
   "runs-on: [self-hosted, oci-a1-staging]"
   "ops/deploy/oci/check-self-hosted-runner.sh"
-  "tools/ops/collect-oci-a1-direct-observability.sh"
+  "bash tools/ops/collect-oci-a1-direct-observability.sh"
   "Upload OCI A1 direct observability artifact"
   "build/reports/oci-a1-direct-observability/"
 )

--- a/tools/test/check-oci-self-hosted-runner-automation.sh
+++ b/tools/test/check-oci-self-hosted-runner-automation.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 bootstrap_script="ops/deploy/oci/bootstrap-self-hosted-runner.sh"
 doctor_script="ops/deploy/oci/check-self-hosted-runner.sh"
+observability_script="tools/ops/collect-oci-a1-direct-observability.sh"
 doctor_workflow=".github/workflows/oci-a1-runner-doctor.yml"
 staging_workflow=".github/workflows/staging-deploy.yml"
 delivery_doc="docs/delivery-flow.md"
@@ -47,6 +48,7 @@ reject_pattern() {
 echo "[oci-runner-automation] required files"
 require_file "$bootstrap_script"
 require_file "$doctor_script"
+require_file "$observability_script"
 require_file "$doctor_workflow"
 require_file "$staging_workflow"
 require_file "$delivery_doc"
@@ -55,6 +57,7 @@ require_file "$deploy_doc"
 echo "[oci-runner-automation] shell syntax"
 bash -n "$bootstrap_script"
 bash -n "$doctor_script"
+bash -n "$observability_script"
 bash -n "$0"
 
 echo "[oci-runner-automation] yaml syntax"
@@ -96,6 +99,22 @@ for pattern in "${doctor_patterns[@]}"; do
   require_pattern "$pattern" "$doctor_script"
 done
 
+echo "[oci-runner-automation] direct observability contract"
+observability_patterns=(
+  "OCI_A1_OBSERVABILITY_DOCKER_CONTEXTS"
+  "OCI_A1_OBSERVABILITY_TIMEOUT_SECONDS"
+  "OCI_A1_OBSERVABILITY_LOG_TAIL_LINES"
+  "docker context inspect"
+  "docker ps"
+  "docker stats --no-stream"
+  "docker logs"
+  "sanitize_log"
+  "no observable Docker contexts"
+)
+for pattern in "${observability_patterns[@]}"; do
+  require_pattern "$pattern" "$observability_script"
+done
+
 OCI_A1_RUNNER_CHECK_NETWORK=false \
 OCI_A1_RUNNER_CHECK_GHCR=false \
   "$doctor_script" --dry-run >/dev/null
@@ -106,6 +125,9 @@ workflow_patterns=(
   "workflow_dispatch:"
   "runs-on: [self-hosted, oci-a1-staging]"
   "ops/deploy/oci/check-self-hosted-runner.sh"
+  "tools/ops/collect-oci-a1-direct-observability.sh"
+  "Upload OCI A1 direct observability artifact"
+  "build/reports/oci-a1-direct-observability/"
 )
 for pattern in "${workflow_patterns[@]}"; do
   require_pattern "$pattern" "$doctor_workflow"


### PR DESCRIPTION
## 🔗 Related Issue
- close #804

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI A1 runner doctor가 Docker context별 직접 관측 결과를 artifact로 남기도록 연결합니다.
- `docker context inspect/info/ps/stats/logs`를 bounded timeout으로 실행하고, 민감정보를 마스킹한 로그만 업로드 대상으로 저장합니다.

## 🛠 Changes
- OCI A1 direct observability collector 추가
- stub Docker 기반 collector 계약 테스트 추가
- runner doctor workflow에 collector 실행과 artifact upload 연결
- 로컬 전용 `docs/delivery-flow.md`가 없을 때 runner automation 계약 테스트가 skip하도록 조정

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-a1-direct-observability.sh`
- `bash tools/test/check-oci-self-hosted-runner-automation.sh`
- `bash tools/test/check-oci-offhost-host-metrics-snapshot.sh`
- `git diff --check`
- `git rev-list --count origin/main..HEAD`
- `gh workflow run oci-a1-runner-doctor.yml --ref chore/oci-a1-direct-observability`
- `gh run watch 25430401476 --exit-status --interval 15`
- `gh run download 25430401476 --dir /private/tmp/oci-a1-doctor-25430401476`
- `find /private/tmp/oci-a1-doctor-25430401476 -type f -name '*.raw.log'`
- `grep -R -E "password=|token=|Authorization: Bearer|raw-pass" /private/tmp/oci-a1-doctor-25430401476`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: self-hosted runner의 Docker socket 또는 SSH context 접근이 전부 실패하면 doctor workflow가 실패한다. 실패 시 context-status TSV와 summary JSON으로 실패 원인을 확인한다.
- 롤백 방법: 이 PR의 workflow/collector/test 변경 commit을 revert한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
