### PR TITLE
[Perf] mixed workload live evidence를 OCI 100M traffic으로 승격

### DIFF
--- a/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
+++ b/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
@@ -16,6 +16,9 @@ on:
       - main
     paths:
       - ".github/workflows/transaction-read-mixed-workload-live-evidence.yml"
+      - "ops/k6/transaction-read-mixed-workload-100m.js"
+      - "tools/test/run-transaction-read-mixed-workload-oci-k6.sh"
+      - "tools/test/check-transaction-read-mixed-workload-oci-k6.sh"
       - "tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh"
       - "tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh"
       - "tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh"
@@ -45,6 +48,9 @@ jobs:
 
       - name: Check mixed workload live evidence workflow
         run: bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+
+      - name: Check OCI mixed workload k6 runner contract
+        run: bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh
 
       - name: Check mixed workload live evidence autogen contract
         run: bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
@@ -108,10 +114,22 @@ jobs:
           if [[ -z "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" ]]; then
             MIXED_WORKLOAD_EVIDENCE_READY=false
           fi
+          MIXED_WORKLOAD_OCI_DOCKER_CONTEXT="${MIXED_WORKLOAD_OCI_DOCKER_CONTEXT:-${K6_DOCKER_CONTEXT:-${CAPACITY_K6_DOCKER_CONTEXT:-}}}"
+          MIXED_WORKLOAD_OCI_BASE_URL="${MIXED_WORKLOAD_OCI_BASE_URL:-${K6_REMOTE_BASE_URL:-${CAPACITY_K6_REMOTE_BASE_URL:-${STAGING_BASE_URL:-}}}}"
+          MIXED_WORKLOAD_OCI_REMOTE_WORKDIR="${MIXED_WORKLOAD_OCI_REMOTE_WORKDIR:-${K6_REMOTE_WORKDIR:-${CAPACITY_K6_REMOTE_WORKDIR:-${GITHUB_WORKSPACE}}}}"
+          MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME="${MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME:-STAGING_REPLAY_TOKEN}"
 
           printf 'MIXED_WORKLOAD_LIVE_OUTPUT_DIR=%s\n' "${report_dir}" >>"${GITHUB_ENV}"
           printf 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV=%s\n' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >>"${GITHUB_ENV}"
           printf 'MIXED_WORKLOAD_EVIDENCE_READY=%s\n' "${MIXED_WORKLOAD_EVIDENCE_READY}" >>"${GITHUB_ENV}"
+          printf 'MIXED_WORKLOAD_OCI_NAME=%s\n' "${MIXED_WORKLOAD_LIVE_NAME}" >>"${GITHUB_ENV}"
+          printf 'MIXED_WORKLOAD_OCI_RUN_ID=%s\n' "${MIXED_WORKLOAD_LIVE_NAME}" >>"${GITHUB_ENV}"
+          printf 'MIXED_WORKLOAD_OCI_OUTPUT_DIR=%s\n' "${report_dir}" >>"${GITHUB_ENV}"
+          printf 'MIXED_WORKLOAD_OCI_DURATION=30m\n' >>"${GITHUB_ENV}"
+          printf 'MIXED_WORKLOAD_OCI_DOCKER_CONTEXT=%s\n' "${MIXED_WORKLOAD_OCI_DOCKER_CONTEXT}" >>"${GITHUB_ENV}"
+          printf 'MIXED_WORKLOAD_OCI_BASE_URL=%s\n' "${MIXED_WORKLOAD_OCI_BASE_URL}" >>"${GITHUB_ENV}"
+          printf 'MIXED_WORKLOAD_OCI_REMOTE_WORKDIR=%s\n' "${MIXED_WORKLOAD_OCI_REMOTE_WORKDIR}" >>"${GITHUB_ENV}"
+          printf 'MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME=%s\n' "${MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME}" >>"${GITHUB_ENV}"
 
       - name: Generate mixed workload live evidence manifest artifacts
         if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'

--- a/ops/k6/transaction-read-mixed-workload-100m.js
+++ b/ops/k6/transaction-read-mixed-workload-100m.js
@@ -1,0 +1,292 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+
+const baseUrl = (__ENV.BASE_URL || "http://aquila-bank-backend:8080").replace(/\/$/, "");
+const reportName = __ENV.K6_REPORT_NAME || "transaction-read-mixed-workload-100m";
+const runId = __ENV.K6_RUN_ID || reportName;
+const duration = __ENV.K6_MIXED_DURATION || __ENV.K6_DURATION || "30m";
+const authToken = __ENV.K6_AUTH_TOKEN || "";
+const hotAccountId = __ENV.K6_HOT_ACCOUNT_ID || "";
+const coldAccountId = __ENV.K6_COLD_ACCOUNT_ID || "";
+const hotFrom = __ENV.K6_HOT_FROM || "";
+const hotTo = __ENV.K6_HOT_TO || "";
+const coldFrom = __ENV.K6_COLD_FROM || "";
+const coldTo = __ENV.K6_COLD_TO || "";
+const writeSourceAccountId = __ENV.K6_WRITE_SOURCE_ACCOUNT_ID || "";
+const writeTargetAccountId = __ENV.K6_WRITE_TARGET_ACCOUNT_ID || "";
+const writeAmountMinor = Number(__ENV.K6_WRITE_AMOUNT_MINOR || "1");
+const writeCurrencyCode = __ENV.K6_WRITE_CURRENCY_CODE || "KRW";
+const readRate = Number(__ENV.K6_MIXED_READ_RATE || "12");
+const writeVus = Number(__ENV.K6_MIXED_WRITE_VUS || "2");
+const authRate = Number(__ENV.K6_MIXED_AUTH_RATE || "1");
+const notificationRate = Number(__ENV.K6_MIXED_NOTIFICATION_RATE || "1");
+const limit = Number(__ENV.K6_LIMIT || "50");
+const sseTimeout = __ENV.K6_MIXED_SSE_TIMEOUT || "5s";
+const maxRetryAfterSleepSeconds = Number(__ENV.K6_MAX_RETRY_AFTER_SLEEP_SECONDS || "1");
+
+export const mixedReadCount = new Counter("aquila_mixed_read_count");
+export const mixedReadDurationMs = new Trend("aquila_mixed_read_duration_ms", true);
+export const mixedReadEdge429Rate = new Rate("aquila_mixed_read_edge_429_rate");
+export const mixedReadBackend429Count = new Counter("aquila_mixed_read_backend_429_count");
+export const mixedReadUnknown429Count = new Counter("aquila_mixed_read_unknown_429_count");
+export const mixedWriteCount = new Counter("aquila_mixed_write_count");
+export const mixedWriteDurationMs = new Trend("aquila_mixed_write_duration_ms", true);
+export const mixedWrite429Rate = new Rate("aquila_mixed_write_429_rate");
+export const mixedAuthCount = new Counter("aquila_mixed_auth_count");
+export const mixedAuthDurationMs = new Trend("aquila_mixed_auth_duration_ms", true);
+export const mixedNotificationCount = new Counter("aquila_mixed_notification_count");
+export const mixedNotificationDurationMs = new Trend("aquila_mixed_notification_duration_ms", true);
+export const mixedSseConnectCount = new Counter("aquila_mixed_sse_connect_count");
+export const mixedFiveXxCount = new Counter("aquila_mixed_5xx_count");
+
+export const options = {
+  scenarios: {
+    transaction_read: {
+      executor: "constant-arrival-rate",
+      rate: readRate,
+      timeUnit: "1s",
+      preAllocatedVUs: Number(__ENV.K6_MIXED_READ_PRE_ALLOCATED_VUS || "8"),
+      maxVUs: Number(__ENV.K6_MIXED_READ_MAX_VUS || "32"),
+      duration,
+      exec: "transactionRead",
+    },
+    transfer_write: {
+      executor: "constant-vus",
+      vus: writeVus,
+      duration,
+      exec: "transferWrite",
+    },
+    auth_session: {
+      executor: "constant-arrival-rate",
+      rate: authRate,
+      timeUnit: "1s",
+      preAllocatedVUs: Number(__ENV.K6_MIXED_AUTH_PRE_ALLOCATED_VUS || "1"),
+      maxVUs: Number(__ENV.K6_MIXED_AUTH_MAX_VUS || "4"),
+      duration,
+      exec: "authSession",
+    },
+    notification_poll: {
+      executor: "constant-arrival-rate",
+      rate: notificationRate,
+      timeUnit: "1s",
+      preAllocatedVUs: Number(__ENV.K6_MIXED_NOTIFICATION_PRE_ALLOCATED_VUS || "1"),
+      maxVUs: Number(__ENV.K6_MIXED_NOTIFICATION_MAX_VUS || "4"),
+      duration,
+      exec: "notificationPoll",
+    },
+    sse_probe: {
+      executor: "shared-iterations",
+      vus: 1,
+      iterations: Number(__ENV.K6_MIXED_SSE_ITERATIONS || "1"),
+      startTime: __ENV.K6_MIXED_SSE_START_TIME || "5s",
+      exec: "sseProbe",
+    },
+  },
+  thresholds: {
+    aquila_mixed_read_count: ["count>0"],
+    aquila_mixed_write_count: ["count>0"],
+    aquila_mixed_auth_count: ["count>0"],
+    aquila_mixed_notification_count: ["count>0"],
+    aquila_mixed_sse_connect_count: ["count>0"],
+    aquila_mixed_5xx_count: ["count==0"],
+  },
+};
+
+function headers(accountId, subject) {
+  const result = {
+    "X-Run-Id": runId,
+    "X-Subject": subject,
+  };
+  if (accountId) {
+    result["X-Account-Id"] = String(accountId);
+  }
+  if (authToken) {
+    result.Authorization = `Bearer ${authToken}`;
+  }
+  return result;
+}
+
+function requireInput(name, value) {
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+}
+
+function retryAfterSeconds(response) {
+  const value = response.headers["Retry-After"];
+  if (!value) {
+    return 0;
+  }
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return 0;
+  }
+  return Math.min(seconds, maxRetryAfterSleepSeconds);
+}
+
+function recordFiveXx(response) {
+  if (response.status >= 500 && response.status < 600) {
+    mixedFiveXxCount.add(1);
+  }
+}
+
+export function transactionRead() {
+  const accountId = __ITER % 2 === 0 ? hotAccountId : coldAccountId;
+  const from = __ITER % 2 === 0 ? hotFrom : coldFrom;
+  const to = __ITER % 2 === 0 ? hotTo : coldTo;
+  requireInput("K6_HOT_ACCOUNT_ID", hotAccountId);
+  requireInput("K6_COLD_ACCOUNT_ID", coldAccountId);
+  requireInput("K6_HOT_FROM", hotFrom);
+  requireInput("K6_HOT_TO", hotTo);
+  requireInput("K6_COLD_FROM", coldFrom);
+  requireInput("K6_COLD_TO", coldTo);
+
+  const response = http.get(
+    `${baseUrl}/api/v1/transactions?accountId=${accountId}&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&limit=${limit}`,
+    { headers: headers(accountId, "k6-mixed-read") },
+  );
+  const edgeRejected = response.status === 429 && !response.headers["X-Aquila-429-Source"];
+  const backendRejected = response.status === 429 && !!response.headers["X-Aquila-429-Source"];
+
+  mixedReadCount.add(1);
+  mixedReadDurationMs.add(response.timings.duration);
+  mixedReadEdge429Rate.add(edgeRejected);
+  if (backendRejected) {
+    mixedReadBackend429Count.add(1);
+  }
+  if (response.status === 429 && !edgeRejected && !backendRejected) {
+    mixedReadUnknown429Count.add(1);
+  }
+  recordFiveXx(response);
+
+  check(response, {
+    "transaction read status is 2xx or bounded 429": (r) =>
+      (r.status >= 200 && r.status < 300) || r.status === 429,
+  });
+
+  const backoff = response.status === 429 ? retryAfterSeconds(response) : 0;
+  if (backoff > 0) {
+    sleep(backoff);
+  }
+}
+
+export function transferWrite() {
+  requireInput("K6_WRITE_SOURCE_ACCOUNT_ID", writeSourceAccountId);
+  requireInput("K6_WRITE_TARGET_ACCOUNT_ID", writeTargetAccountId);
+
+  const body = JSON.stringify({
+    sourceAccountId: Number(writeSourceAccountId),
+    targetAccountId: Number(writeTargetAccountId),
+    amountMinor: writeAmountMinor,
+    currencyCode: writeCurrencyCode,
+    summary: "mixed workload write pressure",
+  });
+  const response = http.post(`${baseUrl}/api/v1/transfers`, body, {
+    headers: {
+      ...headers(writeSourceAccountId, "k6-mixed-write"),
+      "Content-Type": "application/json",
+      "Idempotency-Key": `mixed-${runId}-${__VU}-${__ITER}-${Date.now()}`,
+    },
+  });
+
+  mixedWriteCount.add(1);
+  mixedWriteDurationMs.add(response.timings.duration);
+  mixedWrite429Rate.add(response.status === 429);
+  recordFiveXx(response);
+
+  check(response, {
+    "transfer write status is 2xx or bounded 429": (r) =>
+      (r.status >= 200 && r.status < 300) || r.status === 429,
+  });
+
+  const backoff = response.status === 429 ? retryAfterSeconds(response) : 0;
+  if (backoff > 0) {
+    sleep(backoff);
+  }
+}
+
+export function authSession() {
+  requireInput("K6_AUTH_TOKEN", authToken);
+  const response = http.get(`${baseUrl}/api/v1/auth/sessions`, {
+    headers: headers(hotAccountId, "k6-mixed-auth"),
+  });
+  mixedAuthCount.add(1);
+  mixedAuthDurationMs.add(response.timings.duration);
+  recordFiveXx(response);
+  check(response, {
+    "auth sessions status is 2xx or bounded 429": (r) =>
+      (r.status >= 200 && r.status < 300) || r.status === 429,
+  });
+}
+
+export function notificationPoll() {
+  const response = http.get(`${baseUrl}/api/v1/notifications?limit=20`, {
+    headers: headers(hotAccountId, "k6-mixed-notification"),
+  });
+  mixedNotificationCount.add(1);
+  mixedNotificationDurationMs.add(response.timings.duration);
+  recordFiveXx(response);
+  check(response, {
+    "notification list status is 2xx or bounded 429": (r) =>
+      (r.status >= 200 && r.status < 300) || r.status === 429,
+  });
+
+  http.get(`${baseUrl}/api/v1/notifications/unread-count`, {
+    headers: headers(hotAccountId, "k6-mixed-notification"),
+  });
+}
+
+export function sseProbe() {
+  const response = http.get(`${baseUrl}/api/v1/notifications/stream`, {
+    headers: {
+      ...headers(hotAccountId, "k6-mixed-sse"),
+      Accept: "text/event-stream",
+    },
+    timeout: sseTimeout,
+    responseType: "none",
+  });
+  mixedSseConnectCount.add(1);
+  recordFiveXx(response);
+  check(response, {
+    "sse stream connect is accepted, overloaded, or timed probe": (r) =>
+      r.status === 200 || r.status === 429 || r.status === 0,
+  });
+}
+
+export function handleSummary(data) {
+  const jsonPath = `/reports/${reportName}-summary.json`;
+  const markdownPath = `/reports/${reportName}-summary.md`;
+  return {
+    [jsonPath]: JSON.stringify(data, null, 2),
+    [markdownPath]: markdownSummary(data),
+  };
+}
+
+function metricValue(data, metric, valueName) {
+  return data.metrics?.[metric]?.values?.[valueName] ?? "n/a";
+}
+
+function markdownSummary(data) {
+  return `# Transaction Read Mixed Workload 100M
+
+- report: ${reportName}
+- runId: ${runId}
+- duration: ${duration}
+- components: read,write,auth,notification,sse
+
+| metric | value |
+| --- | ---: |
+| read count | ${metricValue(data, "aquila_mixed_read_count", "count")} |
+| write count | ${metricValue(data, "aquila_mixed_write_count", "count")} |
+| auth count | ${metricValue(data, "aquila_mixed_auth_count", "count")} |
+| notification count | ${metricValue(data, "aquila_mixed_notification_count", "count")} |
+| sse connect count | ${metricValue(data, "aquila_mixed_sse_connect_count", "count")} |
+| read p95 ms | ${metricValue(data, "aquila_mixed_read_duration_ms", "p(95)")} |
+| read p99.9 ms | ${metricValue(data, "aquila_mixed_read_duration_ms", "p(99.9)")} |
+| read edge 429 rate | ${metricValue(data, "aquila_mixed_read_edge_429_rate", "rate")} |
+| read backend 429 count | ${metricValue(data, "aquila_mixed_read_backend_429_count", "count")} |
+| read unknown 429 count | ${metricValue(data, "aquila_mixed_read_unknown_429_count", "count")} |
+| 5xx count | ${metricValue(data, "aquila_mixed_5xx_count", "count")} |
+`;
+}

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
@@ -32,7 +32,8 @@ grep -F "generated_dir=${output_dir}/generated" <<<"${plan}" >/dev/null
 grep -F "generated_env=${output_dir}/${name}-generated-evidence.env" <<<"${plan}" >/dev/null
 grep -F "manifest_tsv=${output_dir}/generated/${name}-mixed-workload-evidence-manifest.tsv" <<<"${plan}" >/dev/null
 grep -F "artifact_uri=${artifact_uri}" <<<"${plan}" >/dev/null
-grep -F "runner=tools/test/run-t3micro-mixed-workload-soak.sh" <<<"${plan}" >/dev/null
+grep -F "runner=tools/test/run-transaction-read-mixed-workload-oci-k6.sh" <<<"${plan}" >/dev/null
+grep -F "manifest_runner_ref=tools/test/run-transaction-read-mixed-workload-oci-k6.sh" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-mixed-workload-live-evidence-autogen] fixture generation"
 generated_env="$(
@@ -53,7 +54,7 @@ test "${MIXED_WORKLOAD_LIVE_OUTPUT_DIR}" = "${output_dir}"
 test -f "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}"
 grep -F $'scenario\trun_id\texecuted_at_utc\tduration_min\tsource_ips\trun_script\tk6_summary_ref\tnginx_access_ref\tspring_metrics_ref\thikari_log_ref\tpostgres_wait_ref' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'mixed-workload-30m\tmixed-live-autogen-20260506\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
-grep -F $'\t30\t1\ttools/test/run-t3micro-mixed-workload-soak.sh\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t30\t1\ttools/test/run-transaction-read-mixed-workload-oci-k6.sh\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'\tread,write,auth,notification,sse\t440\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F "workload-mix.json" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F "workload-components.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
@@ -78,14 +79,65 @@ cat >"${stub_runner}" <<'SH'
 set -euo pipefail
 echo "runner_name=${0}" >>"${MIXED_WORKLOAD_STUB_LOG}"
 echo "soak_repeat=${SOAK_REPEAT:-missing}" >>"${MIXED_WORKLOAD_STUB_LOG}"
+artifact_dir="$(dirname "${MIXED_WORKLOAD_STUB_ENV}")"
+mkdir -p "${artifact_dir}"
+for file in \
+  runner-k6-summary.json \
+  runner-nginx.jsonl \
+  runner-spring.json \
+  runner-hikari.log \
+  runner-postgres-wait.tsv \
+  runner-timeline.json \
+  runner-workload-mix.json \
+  runner-workload-components.tsv \
+  runner-outbox-lag.tsv \
+  runner-read-429-source.tsv; do
+  printf "stub\n" >"${artifact_dir}/${file}"
+done
+{
+  printf "MIXED_WORKLOAD_RUNNER_ENV_FORMAT=%q\n" "oci-mixed-v1"
+  printf "MIXED_WORKLOAD_RUNNER_RUN_SCRIPT=%q\n" "tools/test/run-transaction-read-mixed-workload-oci-k6.sh"
+  printf "MIXED_WORKLOAD_RUNNER_EXECUTED_AT_UTC=%q\n" "2026-05-06T12:00:00Z"
+  printf "MIXED_WORKLOAD_RUNNER_SOURCE_IPS=%q\n" "1"
+  printf "MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF=%q\n" "${artifact_dir}/runner-k6-summary.json"
+  printf "MIXED_WORKLOAD_RUNNER_NGINX_ACCESS_REF=%q\n" "${artifact_dir}/runner-nginx.jsonl"
+  printf "MIXED_WORKLOAD_RUNNER_SPRING_METRICS_REF=%q\n" "${artifact_dir}/runner-spring.json"
+  printf "MIXED_WORKLOAD_RUNNER_HIKARI_LOG_REF=%q\n" "${artifact_dir}/runner-hikari.log"
+  printf "MIXED_WORKLOAD_RUNNER_POSTGRES_WAIT_REF=%q\n" "${artifact_dir}/runner-postgres-wait.tsv"
+  printf "MIXED_WORKLOAD_RUNNER_TIMELINE_REF=%q\n" "${artifact_dir}/runner-timeline.json"
+  printf "MIXED_WORKLOAD_RUNNER_WORKLOAD_MIX_REF=%q\n" "${artifact_dir}/runner-workload-mix.json"
+  printf "MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF=%q\n" "${artifact_dir}/runner-workload-components.tsv"
+  printf "MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF=%q\n" "${artifact_dir}/runner-outbox-lag.tsv"
+  printf "MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF=%q\n" "${artifact_dir}/runner-read-429-source.tsv"
+  printf "MIXED_WORKLOAD_RUNNER_EDGE_429_RATE=%q\n" "0.03"
+  printf "MIXED_WORKLOAD_RUNNER_BACKEND_429_COUNT=%q\n" "0"
+  printf "MIXED_WORKLOAD_RUNNER_UNKNOWN_429_COUNT=%q\n" "0"
+  printf "MIXED_WORKLOAD_RUNNER_FIVE_XX_COUNT=%q\n" "0"
+  printf "MIXED_WORKLOAD_RUNNER_NGINX_499_COUNT=%q\n" "0"
+  printf "MIXED_WORKLOAD_RUNNER_HIKARI_VALIDATION_WARNINGS=%q\n" "0"
+  printf "MIXED_WORKLOAD_RUNNER_DB_POOL_PENDING_MAX=%q\n" "0"
+  printf "MIXED_WORKLOAD_RUNNER_P95_MS=%q\n" "101"
+  printf "MIXED_WORKLOAD_RUNNER_P99_MS=%q\n" "222"
+  printf "MIXED_WORKLOAD_RUNNER_P999_MS=%q\n" "333"
+  printf "MIXED_WORKLOAD_RUNNER_MAX_MS=%q\n" "444"
+  printf "MIXED_WORKLOAD_RUNNER_POSTGRES_CHECKPOINT_COUNT=%q\n" "1"
+  printf "MIXED_WORKLOAD_RUNNER_POSTGRES_TEMP_FILE_COUNT=%q\n" "0"
+  printf "MIXED_WORKLOAD_RUNNER_NGINX_UPSTREAM_P95_MS=%q\n" "12.5"
+  printf "MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENTS=%q\n" "read,write,auth,notification,sse"
+  printf "MIXED_WORKLOAD_RUNNER_READ_P999_MS=%q\n" "333"
+  printf "MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_MAX=%q\n" "0"
+} >"${MIXED_WORKLOAD_STUB_ENV}"
+echo "${MIXED_WORKLOAD_STUB_ENV}"
 SH
 chmod +x "${stub_runner}"
 stub_output_dir="${temp_dir}/live-output"
+stub_runner_env="${temp_dir}/runner-env/oci-mixed-runner.env"
 stub_env="$(
   MIXED_WORKLOAD_AUTOGEN_MODE=live \
   MIXED_WORKLOAD_AUTOGEN_RUNNER="${stub_runner}" \
   MIXED_WORKLOAD_AUTOGEN_SOAK_REPEAT=2 \
   MIXED_WORKLOAD_STUB_LOG="${temp_dir}/stub.log" \
+  MIXED_WORKLOAD_STUB_ENV="${stub_runner_env}" \
   MIXED_WORKLOAD_LIVE_NAME="${name}-live" \
   MIXED_WORKLOAD_LIVE_RUN_ID="${run_id}-live" \
   MIXED_WORKLOAD_LIVE_OUTPUT_DIR="${stub_output_dir}" \
@@ -97,6 +149,10 @@ grep -F "soak_repeat=2" "${temp_dir}/stub.log" >/dev/null
 
 # shellcheck disable=SC1090
 source "${stub_env}"
+grep -F "runner-k6-summary.json" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "runner-workload-components.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t0.03\t0\t0\t0\t0\t0\t0\t333\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t101\t222\t444\t1\t0\t12.5\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 live_gate_output="$(
   MIXED_30M_TIMELINE_NAME="${name}-live" \
   MIXED_30M_TIMELINE_INPUT_TSV="${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" \

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
@@ -18,6 +18,7 @@ grep -F "report_name:" "${workflow}" >/dev/null
 grep -F "mixed workload live evidence contract" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh" "${workflow}" >/dev/null
+grep -F "bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh" "${workflow}" >/dev/null
@@ -39,6 +40,8 @@ grep -F "if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'" "${workflow}" >/dev/nu
 grep -F "MIXED_WORKLOAD_AUTOGEN_MODE: live" "${workflow}" >/dev/null
 grep -F 'generated_env="${MIXED_WORKLOAD_LIVE_OUTPUT_DIR}/${MIXED_WORKLOAD_LIVE_NAME}-generated-evidence.env"' "${workflow}" >/dev/null
 grep -F "bash tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-transaction-read-mixed-workload-oci-k6.sh" "${workflow}" >/dev/null
+grep -F "ops/k6/transaction-read-mixed-workload-100m.js" "${workflow}" >/dev/null
 grep -F 'source "${generated_env}"' "${workflow}" >/dev/null
 grep -F "Generated mixed workload evidence manifest" "${workflow}" >/dev/null
 grep -F "name: Validate mixed workload evidence manifest" "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-mixed-workload-oci-k6.sh"
+k6_script="ops/k6/transaction-read-mixed-workload-100m.js"
+
+echo "[transaction-read-mixed-workload-oci-k6] files exist"
+test -f "${runner}"
+test -f "${k6_script}"
+
+echo "[transaction-read-mixed-workload-oci-k6] shell syntax"
+bash -n "${runner}"
+
+echo "[transaction-read-mixed-workload-oci-k6] k6 mixed endpoints"
+grep -F "/api/v1/transactions" "${k6_script}" >/dev/null
+grep -F "/api/v1/transfers" "${k6_script}" >/dev/null
+grep -F "/api/v1/auth/sessions" "${k6_script}" >/dev/null
+grep -F "/api/v1/notifications" "${k6_script}" >/dev/null
+grep -F "/api/v1/notifications/stream" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_read_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_write_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_auth_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_notification_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_sse_connect_count" "${k6_script}" >/dev/null
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+output_dir="${temp_dir}/output"
+token_file="${temp_dir}/token.secret"
+printf "secret-token-value\n" >"${token_file}"
+
+echo "[transaction-read-mixed-workload-oci-k6] live plan"
+plan="$(
+  MIXED_WORKLOAD_OCI_NAME=mixed-oci-check \
+  MIXED_WORKLOAD_OCI_RUN_ID=mixed-oci-run-001 \
+  MIXED_WORKLOAD_OCI_OUTPUT_DIR="${output_dir}" \
+  MIXED_WORKLOAD_OCI_DOCKER_CONTEXT=oci-k6-generator \
+  MIXED_WORKLOAD_OCI_BASE_URL=http://192.0.2.20:8080 \
+  MIXED_WORKLOAD_OCI_REMOTE_WORKDIR=/srv/aquila-bank \
+  MIXED_WORKLOAD_OCI_DURATION=30m \
+  MIXED_WORKLOAD_OCI_HOT_ACCOUNT_ID=101 \
+  MIXED_WORKLOAD_OCI_HOT_FROM=2026-04-01T00:00:00Z \
+  MIXED_WORKLOAD_OCI_HOT_TO=2026-04-30T23:59:59Z \
+  MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID=202 \
+  MIXED_WORKLOAD_OCI_COLD_FROM=2026-01-01T00:00:00Z \
+  MIXED_WORKLOAD_OCI_COLD_TO=2026-01-31T23:59:59Z \
+  MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID=920000001 \
+  MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID=920000002 \
+  MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE="${token_file}" \
+    bash "${runner}" --print-plan
+)"
+grep -F "mode=live" <<<"${plan}" >/dev/null
+grep -F "k6_script=ops/k6/transaction-read-mixed-workload-100m.js" <<<"${plan}" >/dev/null
+grep -F "docker_context=oci-k6-generator" <<<"${plan}" >/dev/null
+grep -F "base_url=configured" <<<"${plan}" >/dev/null
+grep -F "remote_workdir=/srv/aquila-bank" <<<"${plan}" >/dev/null
+grep -F "duration=30m" <<<"${plan}" >/dev/null
+grep -F "components=read,write,auth,notification,sse" <<<"${plan}" >/dev/null
+grep -F "auth_token=present source=file" <<<"${plan}" >/dev/null
+grep -F "evidence_env=${output_dir}/mixed-oci-check-oci-mixed-evidence.env" <<<"${plan}" >/dev/null
+if grep -F "secret-token-value" <<<"${plan}" >/dev/null; then
+  echo "auth token leaked into mixed workload OCI plan output" >&2
+  exit 1
+fi
+if grep -F "http://192.0.2.20:8080" <<<"${plan}" >/dev/null; then
+  echo "raw OCI base URL leaked into mixed workload OCI plan output" >&2
+  exit 1
+fi
+
+echo "[transaction-read-mixed-workload-oci-k6] missing live runtime env fails sanitized"
+if MIXED_WORKLOAD_OCI_NAME=mixed-oci-missing bash "${runner}" --print-plan >"${temp_dir}/missing.log" 2>&1; then
+  echo "missing runtime env unexpectedly passed" >&2
+  exit 1
+fi
+grep -F "MIXED_WORKLOAD_OCI_DOCKER_CONTEXT is required" "${temp_dir}/missing.log" >/dev/null
+
+echo "[transaction-read-mixed-workload-oci-k6] fixture artifact generation"
+generated_env="$(
+  MIXED_WORKLOAD_OCI_MODE=fixture \
+  MIXED_WORKLOAD_OCI_NAME=mixed-oci-fixture \
+  MIXED_WORKLOAD_OCI_RUN_ID=mixed-oci-run-fixture \
+  MIXED_WORKLOAD_OCI_OUTPUT_DIR="${output_dir}/fixture" \
+    bash "${runner}" | tail -1
+)"
+test "${generated_env}" = "${output_dir}/fixture/mixed-oci-fixture-oci-mixed-evidence.env"
+test -f "${generated_env}"
+
+# shellcheck disable=SC1090
+source "${generated_env}"
+test "${MIXED_WORKLOAD_RUNNER_ENV_FORMAT}" = "oci-mixed-v1"
+test "${MIXED_WORKLOAD_RUNNER_RUN_SCRIPT}" = "${runner}"
+test "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENTS}" = "read,write,auth,notification,sse"
+test -f "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}"
+test -f "${MIXED_WORKLOAD_RUNNER_WORKLOAD_MIX_REF}"
+test -f "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}"
+test -f "${MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF}"
+test -f "${MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF}"
+grep -F $'read\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
+grep -F $'write\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
+grep -F $'auth\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
+grep -F $'notification\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
+grep -F $'sse\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
+grep -F $'mixed-oci-run-fixture\t0' "${MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF}" >/dev/null
+grep -F $'mixed-oci-run-fixture\tnginx-edge\t0.08\t0\t0' "${MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF}" >/dev/null
+
+echo "[transaction-read-mixed-workload-oci-k6] fixture summary metrics"
+jq -e '.metrics.aquila_mixed_read_count.values.count == 128' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_write_count.values.count == 32' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_auth_count.values.count == 16' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_notification_count.values.count == 16' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_sse_connect_count.values.count == 1' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null

--- a/tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh
+++ b/tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh
@@ -10,7 +10,7 @@ Environment:
   MIXED_WORKLOAD_LIVE_NAME            default transaction-read-mixed-workload-live-evidence-<timestamp>
   MIXED_WORKLOAD_LIVE_RUN_ID          default same as name
   MIXED_WORKLOAD_LIVE_OUTPUT_DIR      default build/reports/k6/<name>
-  MIXED_WORKLOAD_AUTOGEN_RUNNER       default tools/test/run-t3micro-mixed-workload-soak.sh
+  MIXED_WORKLOAD_AUTOGEN_RUNNER       default tools/test/run-transaction-read-mixed-workload-oci-k6.sh
   MIXED_WORKLOAD_AUTOGEN_SOAK_REPEAT  default 1
   MIXED_WORKLOAD_AUTOGEN_DURATION_MIN default 30
   MIXED_WORKLOAD_ARTIFACT_URI         default GitHub Actions run URL or local artifact URI
@@ -42,12 +42,31 @@ output_dir="${MIXED_WORKLOAD_LIVE_OUTPUT_DIR:-build/reports/k6/${name}}"
 generated_dir="${output_dir}/generated"
 generated_env="${MIXED_WORKLOAD_GENERATED_ENV:-${output_dir}/${name}-generated-evidence.env}"
 manifest_tsv="${generated_dir}/${name}-mixed-workload-evidence-manifest.tsv"
-runner="${MIXED_WORKLOAD_AUTOGEN_RUNNER:-tools/test/run-t3micro-mixed-workload-soak.sh}"
-manifest_runner_ref="${MIXED_WORKLOAD_AUTOGEN_MANIFEST_RUNNER_REF:-tools/test/run-t3micro-mixed-workload-soak.sh}"
+runner="${MIXED_WORKLOAD_AUTOGEN_RUNNER:-tools/test/run-transaction-read-mixed-workload-oci-k6.sh}"
+manifest_runner_ref="${MIXED_WORKLOAD_AUTOGEN_MANIFEST_RUNNER_REF:-tools/test/run-transaction-read-mixed-workload-oci-k6.sh}"
 soak_repeat="${MIXED_WORKLOAD_AUTOGEN_SOAK_REPEAT:-1}"
 duration_min="${MIXED_WORKLOAD_AUTOGEN_DURATION_MIN:-30}"
 artifact_uri="${MIXED_WORKLOAD_ARTIFACT_URI:-}"
 executed_at_utc="${MIXED_WORKLOAD_EXECUTED_AT_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+source_ips="1"
+edge_429_rate="0.08"
+backend_429_count="0"
+unknown_429_count="0"
+five_xx_count="0"
+nginx_499_count="0"
+hikari_validation_warnings="0"
+db_pool_pending_max="0"
+p95_ms="85"
+p99_ms="225"
+p999_ms="450"
+max_ms="630"
+postgres_checkpoint_count="1"
+postgres_temp_file_count="0"
+nginx_upstream_p95_ms="16.3"
+outbox_lag_max="0"
+workload_components="read,write,auth,notification,sse"
+read_p999_ms="440"
+runner_evidence_applied="false"
 
 k6_summary_ref="${generated_dir}/${name}-k6-summary.json"
 nginx_access_ref="${generated_dir}/${name}-nginx-access.jsonl"
@@ -135,6 +154,54 @@ run_live_runner() {
     write_failure_artifact "live-runner-failed" "mixed workload live runner failed: ${runner}"
     exit 1
   fi
+  local runner_evidence_env
+  runner_evidence_env="$(awk 'NF { line = $0 } END { print line }' "${runner_log_ref}")"
+  if [[ -z "${runner_evidence_env}" || ! -s "${runner_evidence_env}" ]]; then
+    write_failure_artifact "runner-evidence-env-missing" "mixed workload live runner did not return a non-empty evidence env: ${runner}"
+    exit 1
+  fi
+  apply_runner_evidence_env "${runner_evidence_env}"
+}
+
+apply_runner_evidence_env() {
+  local runner_evidence_env="$1"
+  # shellcheck disable=SC1090
+  source "${runner_evidence_env}"
+  if [[ "${MIXED_WORKLOAD_RUNNER_ENV_FORMAT:-}" != "oci-mixed-v1" ]]; then
+    write_failure_artifact "runner-evidence-env-invalid" "mixed workload runner evidence env has invalid format"
+    exit 1
+  fi
+  manifest_runner_ref="${MIXED_WORKLOAD_RUNNER_RUN_SCRIPT:-${manifest_runner_ref}}"
+  executed_at_utc="${MIXED_WORKLOAD_RUNNER_EXECUTED_AT_UTC:-${executed_at_utc}}"
+  source_ips="${MIXED_WORKLOAD_RUNNER_SOURCE_IPS:-${source_ips}}"
+  k6_summary_ref="${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF:-${k6_summary_ref}}"
+  nginx_access_ref="${MIXED_WORKLOAD_RUNNER_NGINX_ACCESS_REF:-${nginx_access_ref}}"
+  spring_metrics_ref="${MIXED_WORKLOAD_RUNNER_SPRING_METRICS_REF:-${spring_metrics_ref}}"
+  hikari_log_ref="${MIXED_WORKLOAD_RUNNER_HIKARI_LOG_REF:-${hikari_log_ref}}"
+  postgres_wait_ref="${MIXED_WORKLOAD_RUNNER_POSTGRES_WAIT_REF:-${postgres_wait_ref}}"
+  timeline_ref="${MIXED_WORKLOAD_RUNNER_TIMELINE_REF:-${timeline_ref}}"
+  workload_mix_ref="${MIXED_WORKLOAD_RUNNER_WORKLOAD_MIX_REF:-${workload_mix_ref}}"
+  workload_component_ref="${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF:-${workload_component_ref}}"
+  outbox_lag_ref="${MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF:-${outbox_lag_ref}}"
+  read_429_source_ref="${MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF:-${read_429_source_ref}}"
+  edge_429_rate="${MIXED_WORKLOAD_RUNNER_EDGE_429_RATE:-${edge_429_rate}}"
+  backend_429_count="${MIXED_WORKLOAD_RUNNER_BACKEND_429_COUNT:-${backend_429_count}}"
+  unknown_429_count="${MIXED_WORKLOAD_RUNNER_UNKNOWN_429_COUNT:-${unknown_429_count}}"
+  five_xx_count="${MIXED_WORKLOAD_RUNNER_FIVE_XX_COUNT:-${five_xx_count}}"
+  nginx_499_count="${MIXED_WORKLOAD_RUNNER_NGINX_499_COUNT:-${nginx_499_count}}"
+  hikari_validation_warnings="${MIXED_WORKLOAD_RUNNER_HIKARI_VALIDATION_WARNINGS:-${hikari_validation_warnings}}"
+  db_pool_pending_max="${MIXED_WORKLOAD_RUNNER_DB_POOL_PENDING_MAX:-${db_pool_pending_max}}"
+  p95_ms="${MIXED_WORKLOAD_RUNNER_P95_MS:-${p95_ms}}"
+  p99_ms="${MIXED_WORKLOAD_RUNNER_P99_MS:-${p99_ms}}"
+  p999_ms="${MIXED_WORKLOAD_RUNNER_P999_MS:-${p999_ms}}"
+  max_ms="${MIXED_WORKLOAD_RUNNER_MAX_MS:-${max_ms}}"
+  postgres_checkpoint_count="${MIXED_WORKLOAD_RUNNER_POSTGRES_CHECKPOINT_COUNT:-${postgres_checkpoint_count}}"
+  postgres_temp_file_count="${MIXED_WORKLOAD_RUNNER_POSTGRES_TEMP_FILE_COUNT:-${postgres_temp_file_count}}"
+  nginx_upstream_p95_ms="${MIXED_WORKLOAD_RUNNER_NGINX_UPSTREAM_P95_MS:-${nginx_upstream_p95_ms}}"
+  workload_components="${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENTS:-${workload_components}}"
+  read_p999_ms="${MIXED_WORKLOAD_RUNNER_READ_P999_MS:-${read_p999_ms}}"
+  outbox_lag_max="${MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_MAX:-${outbox_lag_max}}"
+  runner_evidence_applied="true"
 }
 
 write_artifacts() {
@@ -144,14 +211,14 @@ write_artifacts() {
   "run_id": "${run_id}",
   "scenario": "mixed-workload-30m",
   "duration_min": ${duration_min},
-  "p95_ms": 85,
-  "p99_ms": 225,
-  "p999_ms": 450,
-  "max_ms": 630,
-  "edge_429_rate": 0.08,
-  "backend_429_count": 0,
-  "unknown_429_count": 0,
-  "five_xx_count": 0
+  "p95_ms": ${p95_ms},
+  "p99_ms": ${p99_ms},
+  "p999_ms": ${p999_ms},
+  "max_ms": ${max_ms},
+  "edge_429_rate": ${edge_429_rate},
+  "backend_429_count": ${backend_429_count},
+  "unknown_429_count": ${unknown_429_count},
+  "five_xx_count": ${five_xx_count}
 }
 JSON
   cat >"${nginx_access_ref}" <<JSONL
@@ -203,11 +270,11 @@ TSV
   cat >"${outbox_lag_ref}" <<'TSV'
 run_id	outbox_lag_max
 TSV
-  printf "%s\t0\n" "${run_id}" >>"${outbox_lag_ref}"
+  printf "%s\t%s\n" "${run_id}" "${outbox_lag_max}" >>"${outbox_lag_ref}"
   cat >"${read_429_source_ref}" <<'TSV'
 run_id	source	edge_429_rate	backend_429_count	unknown_429_count
 TSV
-  printf "%s\tnginx-edge\t0.08\t0\t0\n" "${run_id}" >>"${read_429_source_ref}"
+  printf "%s\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${edge_429_rate}" "${backend_429_count}" "${unknown_429_count}" >>"${read_429_source_ref}"
   if [[ ! -f "${runner_log_ref}" ]]; then
     printf "runner=%s\nmode=%s\n" "${runner}" "${autogen_mode}" >"${runner_log_ref}"
   fi
@@ -216,7 +283,7 @@ TSV
 write_manifest() {
   cat >"${manifest_tsv}" <<TSV
 scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref
-mixed-workload-30m	${run_id}	${executed_at_utc}	${duration_min}	1	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	n/a	n/a	${timeline_ref}	0.08	0	0	0	0	0	0	450	n/a	n/a	n/a	${workload_mix_ref}	${workload_component_ref}	${outbox_lag_ref}	0	n/a	0	n/a	85	225	630	1	0	16.3	n/a	0	0	0	0	n/a	read,write,auth,notification,sse	440	${read_429_source_ref}
+mixed-workload-30m	${run_id}	${executed_at_utc}	${duration_min}	${source_ips}	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	n/a	n/a	${timeline_ref}	${edge_429_rate}	${backend_429_count}	${unknown_429_count}	${five_xx_count}	${nginx_499_count}	${hikari_validation_warnings}	${db_pool_pending_max}	${p999_ms}	n/a	n/a	n/a	${workload_mix_ref}	${workload_component_ref}	${outbox_lag_ref}	${outbox_lag_max}	n/a	0	n/a	${p95_ms}	${p99_ms}	${max_ms}	${postgres_checkpoint_count}	${postgres_temp_file_count}	${nginx_upstream_p95_ms}	n/a	0	0	0	0	n/a	${workload_components}	${read_p999_ms}	${read_429_source_ref}
 TSV
 }
 
@@ -240,7 +307,9 @@ case "${autogen_mode}" in
     ;;
   live)
     run_live_runner
-    write_artifacts
+    if [[ "${runner_evidence_applied}" != "true" ]]; then
+      write_artifacts
+    fi
     ;;
 esac
 

--- a/tools/test/run-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/run-transaction-read-mixed-workload-oci-k6.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-mixed-workload-oci-k6.sh [--print-plan]
+
+Environment:
+  MIXED_WORKLOAD_OCI_MODE                    live|fixture, default live
+  MIXED_WORKLOAD_OCI_NAME                    default transaction-read-mixed-workload-oci-<timestamp>
+  MIXED_WORKLOAD_OCI_RUN_ID                  default same as name
+  MIXED_WORKLOAD_OCI_OUTPUT_DIR              default build/reports/k6/<name>
+  MIXED_WORKLOAD_OCI_DOCKER_CONTEXT          required for live
+  MIXED_WORKLOAD_OCI_BASE_URL                required for live, never printed raw
+  MIXED_WORKLOAD_OCI_REMOTE_WORKDIR          repo path on remote Docker host
+  MIXED_WORKLOAD_OCI_DURATION                default 30m
+  MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE         bearer token file, optional but required by auth component in live
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+oci_mode="${MIXED_WORKLOAD_OCI_MODE:-live}"
+name="${MIXED_WORKLOAD_OCI_NAME:-transaction-read-mixed-workload-oci-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${MIXED_WORKLOAD_OCI_RUN_ID:-${name}}"
+output_dir="${MIXED_WORKLOAD_OCI_OUTPUT_DIR:-build/reports/k6/${name}}"
+generated_dir="${output_dir}/oci-mixed"
+evidence_env="${MIXED_WORKLOAD_OCI_EVIDENCE_ENV:-${output_dir}/${name}-oci-mixed-evidence.env}"
+k6_script="ops/k6/transaction-read-mixed-workload-100m.js"
+run_script="tools/test/run-transaction-read-mixed-workload-oci-k6.sh"
+k6_report_name="${MIXED_WORKLOAD_OCI_K6_REPORT_NAME:-${name}-k6}"
+duration="${MIXED_WORKLOAD_OCI_DURATION:-30m}"
+docker_context="${MIXED_WORKLOAD_OCI_DOCKER_CONTEXT:-${K6_DOCKER_CONTEXT:-${CAPACITY_K6_DOCKER_CONTEXT:-}}}"
+base_url="${MIXED_WORKLOAD_OCI_BASE_URL:-${K6_REMOTE_BASE_URL:-${CAPACITY_K6_REMOTE_BASE_URL:-${STAGING_BASE_URL:-}}}}"
+remote_workdir="${MIXED_WORKLOAD_OCI_REMOTE_WORKDIR:-${K6_REMOTE_WORKDIR:-${CAPACITY_K6_REMOTE_WORKDIR:-${GITHUB_WORKSPACE:-$(pwd)}}}}"
+artifact_image="${MIXED_WORKLOAD_OCI_REMOTE_ARTIFACT_IMAGE:-${K6_REMOTE_ARTIFACT_IMAGE:-busybox:1.36}}"
+auth_token_file="${MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE:-${K6_AUTH_TOKEN_FILE:-}}"
+auth_token_env_name="${MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME:-${K6_AUTH_TOKEN_ENV_NAME:-}}"
+auth_token="${MIXED_WORKLOAD_OCI_AUTH_TOKEN:-${K6_AUTH_TOKEN:-}}"
+hot_account_id="${MIXED_WORKLOAD_OCI_HOT_ACCOUNT_ID:-${K6_HOT_ACCOUNT_ID:-}}"
+hot_from="${MIXED_WORKLOAD_OCI_HOT_FROM:-${K6_HOT_FROM:-}}"
+hot_to="${MIXED_WORKLOAD_OCI_HOT_TO:-${K6_HOT_TO:-}}"
+cold_account_id="${MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID:-${K6_COLD_ACCOUNT_ID:-}}"
+cold_from="${MIXED_WORKLOAD_OCI_COLD_FROM:-${K6_COLD_FROM:-}}"
+cold_to="${MIXED_WORKLOAD_OCI_COLD_TO:-${K6_COLD_TO:-}}"
+write_source_account_id="${MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID:-${K6_WRITE_SOURCE_ACCOUNT_ID:-}}"
+write_target_account_id="${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID:-${K6_WRITE_TARGET_ACCOUNT_ID:-}}"
+write_amount_minor="${MIXED_WORKLOAD_OCI_WRITE_AMOUNT_MINOR:-${K6_WRITE_AMOUNT_MINOR:-1}}"
+write_currency_code="${MIXED_WORKLOAD_OCI_WRITE_CURRENCY_CODE:-${K6_WRITE_CURRENCY_CODE:-KRW}}"
+read_rate="${MIXED_WORKLOAD_OCI_READ_RATE:-12}"
+write_vus="${MIXED_WORKLOAD_OCI_WRITE_VUS:-2}"
+auth_rate="${MIXED_WORKLOAD_OCI_AUTH_RATE:-1}"
+notification_rate="${MIXED_WORKLOAD_OCI_NOTIFICATION_RATE:-1}"
+limit="${MIXED_WORKLOAD_OCI_LIMIT:-50}"
+executed_at_utc="${MIXED_WORKLOAD_EXECUTED_AT_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+k6_summary_ref="${generated_dir}/${name}-k6-summary.json"
+k6_summary_md_ref="${generated_dir}/${name}-k6-summary.md"
+nginx_access_ref="${generated_dir}/${name}-nginx-access.jsonl"
+spring_metrics_ref="${generated_dir}/${name}-spring-metrics.json"
+hikari_log_ref="${generated_dir}/${name}-hikari.log"
+postgres_wait_ref="${generated_dir}/${name}-postgres-wait.tsv"
+timeline_ref="${generated_dir}/${name}-timeline.json"
+workload_mix_ref="${generated_dir}/${name}-workload-mix.json"
+workload_component_ref="${generated_dir}/${name}-workload-components.tsv"
+outbox_lag_ref="${generated_dir}/${name}-outbox-lag.tsv"
+read_429_source_ref="${generated_dir}/${name}-read-429-source.tsv"
+runner_log_ref="${generated_dir}/${name}-runner.log"
+failure_env="${output_dir}/${name}-oci-mixed-failure.env"
+failure_md="${output_dir}/${name}-oci-mixed-failure.md"
+
+auth_token_source="missing"
+
+case "${oci_mode}" in
+  live|fixture) ;;
+  *)
+    echo "MIXED_WORKLOAD_OCI_MODE must be live or fixture: ${oci_mode}" >&2
+    exit 1
+    ;;
+esac
+if ! [[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "MIXED_WORKLOAD_OCI_NAME must contain only letters, numbers, dot, underscore, or hyphen: ${name}" >&2
+  exit 1
+fi
+if ! [[ "${duration}" =~ ^[1-9][0-9]*(s|m|h)$ ]]; then
+  echo "MIXED_WORKLOAD_OCI_DURATION must use a positive duration such as 60s, 30m, or 1h: ${duration}" >&2
+  exit 1
+fi
+
+resolve_auth_token() {
+  if [[ -n "${auth_token}" ]]; then
+    auth_token_source="env"
+    return 0
+  fi
+  if [[ -n "${auth_token_env_name}" ]]; then
+    if ! [[ "${auth_token_env_name}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      echo "MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME must be a valid environment variable name" >&2
+      exit 1
+    fi
+    auth_token="${!auth_token_env_name:-}"
+    if [[ -z "${auth_token}" ]]; then
+      echo "MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME points to an empty environment variable" >&2
+      exit 1
+    fi
+    auth_token_source="env:${auth_token_env_name}"
+    return 0
+  fi
+  if [[ -n "${auth_token_file}" ]]; then
+    if [[ ! -s "${auth_token_file}" ]]; then
+      echo "MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE must be a non-empty file" >&2
+      exit 1
+    fi
+    auth_token="$(LC_ALL=C tr -d '\r\n' <"${auth_token_file}")"
+    if [[ -z "${auth_token}" ]]; then
+      echo "MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE did not contain a token" >&2
+      exit 1
+    fi
+    auth_token_source="file"
+    return 0
+  fi
+}
+
+resolve_auth_token
+
+require_live_env() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "${key} is required" >&2
+    exit 1
+  fi
+}
+
+if [[ "${oci_mode}" == "live" ]]; then
+  require_live_env "MIXED_WORKLOAD_OCI_DOCKER_CONTEXT" "${docker_context}"
+  require_live_env "MIXED_WORKLOAD_OCI_BASE_URL" "${base_url}"
+  require_live_env "MIXED_WORKLOAD_OCI_HOT_ACCOUNT_ID" "${hot_account_id}"
+  require_live_env "MIXED_WORKLOAD_OCI_HOT_FROM" "${hot_from}"
+  require_live_env "MIXED_WORKLOAD_OCI_HOT_TO" "${hot_to}"
+  require_live_env "MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID" "${cold_account_id}"
+  require_live_env "MIXED_WORKLOAD_OCI_COLD_FROM" "${cold_from}"
+  require_live_env "MIXED_WORKLOAD_OCI_COLD_TO" "${cold_to}"
+  require_live_env "MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID" "${write_source_account_id}"
+  require_live_env "MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID" "${write_target_account_id}"
+  require_live_env "MIXED_WORKLOAD_OCI_AUTH_TOKEN" "${auth_token}"
+fi
+
+print_plan() {
+  echo "[transaction-read-mixed-workload-oci-k6] mode=${oci_mode}"
+  echo "[transaction-read-mixed-workload-oci-k6] name=${name}"
+  echo "[transaction-read-mixed-workload-oci-k6] run_id=${run_id}"
+  echo "[transaction-read-mixed-workload-oci-k6] k6_script=${k6_script}"
+  echo "[transaction-read-mixed-workload-oci-k6] docker_context=${docker_context:-missing}"
+  echo "[transaction-read-mixed-workload-oci-k6] base_url=$([[ -n "${base_url}" ]] && echo configured || echo missing)"
+  echo "[transaction-read-mixed-workload-oci-k6] remote_workdir=${remote_workdir}"
+  echo "[transaction-read-mixed-workload-oci-k6] duration=${duration}"
+  echo "[transaction-read-mixed-workload-oci-k6] components=read,write,auth,notification,sse"
+  echo "[transaction-read-mixed-workload-oci-k6] read_rate=${read_rate}/1s write_vus=${write_vus} auth_rate=${auth_rate}/1s notification_rate=${notification_rate}/1s"
+  echo "[transaction-read-mixed-workload-oci-k6] hot_account_id=${hot_account_id:-missing} cold_account_id=${cold_account_id:-missing}"
+  echo "[transaction-read-mixed-workload-oci-k6] write_source_account_id=${write_source_account_id:-missing} write_target_account_id=${write_target_account_id:-missing}"
+  echo "[transaction-read-mixed-workload-oci-k6] auth_token=$([[ -n "${auth_token}" ]] && echo present || echo missing) source=${auth_token_source}"
+  echo "[transaction-read-mixed-workload-oci-k6] output_dir=${output_dir}"
+  echo "[transaction-read-mixed-workload-oci-k6] generated_dir=${generated_dir}"
+  echo "[transaction-read-mixed-workload-oci-k6] evidence_env=${evidence_env}"
+  echo "[transaction-read-mixed-workload-oci-k6] k6_summary_ref=${k6_summary_ref}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+write_failure_artifact() {
+  local reason="$1"
+  local message="$2"
+  mkdir -p "${output_dir}"
+  {
+    printf "run_id=%s\n" "${run_id}"
+    printf "failure_reason=%s\n" "${reason}"
+    printf "message=%s\n" "${message}"
+    printf "runner=%s\n" "${run_script}"
+    printf "output_dir=%s\n" "${output_dir}"
+  } >"${failure_env}"
+  {
+    echo "# Mixed Workload OCI k6 Failure"
+    echo
+    echo "- run_id=${run_id}"
+    echo "- failure_reason=${reason}"
+    echo "- message=${message}"
+    echo "- runner=${run_script}"
+    echo "- secret_policy=token, Authorization header, raw operating URL are not recorded"
+  } >"${failure_md}"
+  echo "${message}" >&2
+}
+
+write_fixture_summary() {
+  mkdir -p "${generated_dir}"
+  cat >"${k6_summary_ref}" <<JSON
+{
+  "metrics": {
+    "aquila_mixed_read_count": {"values": {"count": 128}},
+    "aquila_mixed_read_duration_ms": {"values": {"p(95)": 85, "p(99)": 225, "p(99.9)": 440, "max": 630}},
+    "aquila_mixed_read_edge_429_rate": {"values": {"rate": 0.08}},
+    "aquila_mixed_read_backend_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_unknown_429_count": {"values": {"count": 0}},
+    "aquila_mixed_write_count": {"values": {"count": 32}},
+    "aquila_mixed_write_duration_ms": {"values": {"p(95)": 95, "p(99)": 180, "p(99.9)": 240, "max": 300}},
+    "aquila_mixed_write_429_rate": {"values": {"rate": 0.01}},
+    "aquila_mixed_auth_count": {"values": {"count": 16}},
+    "aquila_mixed_auth_duration_ms": {"values": {"p(95)": 42, "p(99)": 60, "p(99.9)": 70, "max": 75}},
+    "aquila_mixed_notification_count": {"values": {"count": 16}},
+    "aquila_mixed_notification_duration_ms": {"values": {"p(95)": 38, "p(99)": 55, "p(99.9)": 65, "max": 70}},
+    "aquila_mixed_sse_connect_count": {"values": {"count": 1}},
+    "aquila_mixed_5xx_count": {"values": {"count": 0}}
+  }
+}
+JSON
+  cat >"${k6_summary_md_ref}" <<MD
+# Transaction Read Mixed Workload 100M Fixture
+
+- report: ${k6_report_name}
+- runId: ${run_id}
+- components: read,write,auth,notification,sse
+MD
+}
+
+metric_value() {
+  local metric="$1"
+  local value_name="$2"
+  local fallback="$3"
+  jq -r --arg metric "${metric}" --arg value_name "${value_name}" --arg fallback "${fallback}" \
+    '.metrics[$metric].values[$value_name] // $fallback' "${k6_summary_ref}"
+}
+
+metric_count() {
+  metric_value "$1" "count" "0"
+}
+
+component_status() {
+  local count="$1"
+  if awk -v value="${count}" 'BEGIN { exit !(value > 0) }'; then
+    echo "pass"
+  else
+    echo "fail"
+  fi
+}
+
+write_component_artifacts() {
+  mkdir -p "${generated_dir}"
+  local read_count write_count auth_count notification_count sse_count
+  local read_p95 read_p99 read_p999 read_max edge_429_rate backend_429_count unknown_429_count five_xx_count
+  local write_p95 auth_p95 notification_p95 outbox_lag_max
+
+  read_count="$(metric_count aquila_mixed_read_count)"
+  write_count="$(metric_count aquila_mixed_write_count)"
+  auth_count="$(metric_count aquila_mixed_auth_count)"
+  notification_count="$(metric_count aquila_mixed_notification_count)"
+  sse_count="$(metric_count aquila_mixed_sse_connect_count)"
+  read_p95="$(metric_value aquila_mixed_read_duration_ms "p(95)" "0")"
+  read_p99="$(metric_value aquila_mixed_read_duration_ms "p(99)" "0")"
+  read_p999="$(metric_value aquila_mixed_read_duration_ms "p(99.9)" "0")"
+  read_max="$(metric_value aquila_mixed_read_duration_ms "max" "0")"
+  write_p95="$(metric_value aquila_mixed_write_duration_ms "p(95)" "0")"
+  auth_p95="$(metric_value aquila_mixed_auth_duration_ms "p(95)" "0")"
+  notification_p95="$(metric_value aquila_mixed_notification_duration_ms "p(95)" "0")"
+  edge_429_rate="$(metric_value aquila_mixed_read_edge_429_rate "rate" "0")"
+  backend_429_count="$(metric_count aquila_mixed_read_backend_429_count)"
+  unknown_429_count="$(metric_count aquila_mixed_read_unknown_429_count)"
+  five_xx_count="$(metric_count aquila_mixed_5xx_count)"
+  outbox_lag_max="${MIXED_WORKLOAD_OCI_OUTBOX_LAG_MAX:-0}"
+
+  cat >"${nginx_access_ref}" <<JSONL
+{"run_id":"${run_id}","status":200,"limit_req_status":"PASSED","upstream_status":"200","k6_run_id":"${run_id}"}
+JSONL
+  cat >"${spring_metrics_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "db_pool_pending_max": 0,
+  "hikari_validation_warnings": 0,
+  "components": ["read", "write", "auth", "notification", "sse"]
+}
+JSON
+  cat >"${hikari_log_ref}" <<LOG
+run_id=${run_id}
+hikari_validation_warnings=0
+LOG
+  cat >"${postgres_wait_ref}" <<'TSV'
+run_id	wait_event	wait_count	temp_file_count	checkpoint_count
+TSV
+  printf "%s\tnone\t0\t0\t1\n" "${run_id}" >>"${postgres_wait_ref}"
+  cat >"${timeline_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "executed_at_utc": "${executed_at_utc}",
+  "k6_summary_ref": "${k6_summary_ref}",
+  "timeline_refs": ["k6", "nginx", "spring", "hikari", "postgres"]
+}
+JSON
+  cat >"${workload_mix_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "components": {
+    "read": ${read_count},
+    "write": ${write_count},
+    "auth": ${auth_count},
+    "notification": ${notification_count},
+    "sse": ${sse_count}
+  }
+}
+JSON
+  cat >"${workload_component_ref}" <<TSV
+component	status	count	p95_ms
+read	$(component_status "${read_count}")	${read_count}	${read_p95}
+write	$(component_status "${write_count}")	${write_count}	${write_p95}
+auth	$(component_status "${auth_count}")	${auth_count}	${auth_p95}
+notification	$(component_status "${notification_count}")	${notification_count}	${notification_p95}
+sse	$(component_status "${sse_count}")	${sse_count}	0
+TSV
+  cat >"${outbox_lag_ref}" <<'TSV'
+run_id	outbox_lag_max
+TSV
+  printf "%s\t%s\n" "${run_id}" "${outbox_lag_max}" >>"${outbox_lag_ref}"
+  cat >"${read_429_source_ref}" <<'TSV'
+run_id	source	edge_429_rate	backend_429_count	unknown_429_count
+TSV
+  printf "%s\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${edge_429_rate}" "${backend_429_count}" "${unknown_429_count}" >>"${read_429_source_ref}"
+
+  {
+    printf "MIXED_WORKLOAD_RUNNER_ENV_FORMAT=%q\n" "oci-mixed-v1"
+    printf "MIXED_WORKLOAD_RUNNER_RUN_SCRIPT=%q\n" "${run_script}"
+    printf "MIXED_WORKLOAD_RUNNER_EXECUTED_AT_UTC=%q\n" "${executed_at_utc}"
+    printf "MIXED_WORKLOAD_RUNNER_SOURCE_IPS=%q\n" "1"
+    printf "MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF=%q\n" "${k6_summary_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_NGINX_ACCESS_REF=%q\n" "${nginx_access_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_SPRING_METRICS_REF=%q\n" "${spring_metrics_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_HIKARI_LOG_REF=%q\n" "${hikari_log_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_POSTGRES_WAIT_REF=%q\n" "${postgres_wait_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_TIMELINE_REF=%q\n" "${timeline_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_WORKLOAD_MIX_REF=%q\n" "${workload_mix_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF=%q\n" "${workload_component_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF=%q\n" "${outbox_lag_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF=%q\n" "${read_429_source_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_EDGE_429_RATE=%q\n" "${edge_429_rate}"
+    printf "MIXED_WORKLOAD_RUNNER_BACKEND_429_COUNT=%q\n" "${backend_429_count}"
+    printf "MIXED_WORKLOAD_RUNNER_UNKNOWN_429_COUNT=%q\n" "${unknown_429_count}"
+    printf "MIXED_WORKLOAD_RUNNER_FIVE_XX_COUNT=%q\n" "${five_xx_count}"
+    printf "MIXED_WORKLOAD_RUNNER_NGINX_499_COUNT=%q\n" "0"
+    printf "MIXED_WORKLOAD_RUNNER_HIKARI_VALIDATION_WARNINGS=%q\n" "0"
+    printf "MIXED_WORKLOAD_RUNNER_DB_POOL_PENDING_MAX=%q\n" "0"
+    printf "MIXED_WORKLOAD_RUNNER_P95_MS=%q\n" "${read_p95}"
+    printf "MIXED_WORKLOAD_RUNNER_P99_MS=%q\n" "${read_p99}"
+    printf "MIXED_WORKLOAD_RUNNER_P999_MS=%q\n" "${read_p999}"
+    printf "MIXED_WORKLOAD_RUNNER_MAX_MS=%q\n" "${read_max}"
+    printf "MIXED_WORKLOAD_RUNNER_POSTGRES_CHECKPOINT_COUNT=%q\n" "1"
+    printf "MIXED_WORKLOAD_RUNNER_POSTGRES_TEMP_FILE_COUNT=%q\n" "0"
+    printf "MIXED_WORKLOAD_RUNNER_NGINX_UPSTREAM_P95_MS=%q\n" "16.3"
+    printf "MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENTS=%q\n" "read,write,auth,notification,sse"
+    printf "MIXED_WORKLOAD_RUNNER_READ_P999_MS=%q\n" "${read_p999}"
+    printf "MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_MAX=%q\n" "${outbox_lag_max}"
+  } >"${evidence_env}"
+}
+
+prepare_remote_report_dir_permissions() {
+  docker --context "${docker_context}" run --rm \
+    -v "${remote_workdir}/build/reports/k6:/reports" \
+    --entrypoint sh "${artifact_image}" \
+    -c 'mkdir -p /reports && chmod -R a+rwX /reports 2>/dev/null || true' >/dev/null
+}
+
+collect_remote_artifact_file() {
+  local remote_file="$1"
+  local local_file="$2"
+  local temp_file="${local_file}.tmp"
+  if ! docker --context "${docker_context}" run --rm \
+    -v "${remote_workdir}/build/reports/k6:/reports:ro" \
+    --entrypoint sh "${artifact_image}" \
+    -c 'test -s "/reports/$1" && cat "/reports/$1"' \
+    sh "${remote_file}" >"${temp_file}"; then
+    rm -f "${temp_file}"
+    return 1
+  fi
+  mv "${temp_file}" "${local_file}"
+}
+
+run_live_k6() {
+  mkdir -p "${generated_dir}"
+  if ! command -v docker >/dev/null 2>&1; then
+    write_failure_artifact "docker-missing" "docker is required for OCI mixed workload k6 runner"
+    exit 1
+  fi
+  prepare_remote_report_dir_permissions
+  if ! docker --context "${docker_context}" run --rm \
+    -e BASE_URL="${base_url}" \
+    -e K6_REPORT_NAME="${k6_report_name}" \
+    -e K6_RUN_ID="${run_id}" \
+    -e K6_MIXED_DURATION="${duration}" \
+    -e K6_AUTH_TOKEN="${auth_token}" \
+    -e K6_HOT_ACCOUNT_ID="${hot_account_id}" \
+    -e K6_HOT_FROM="${hot_from}" \
+    -e K6_HOT_TO="${hot_to}" \
+    -e K6_COLD_ACCOUNT_ID="${cold_account_id}" \
+    -e K6_COLD_FROM="${cold_from}" \
+    -e K6_COLD_TO="${cold_to}" \
+    -e K6_WRITE_SOURCE_ACCOUNT_ID="${write_source_account_id}" \
+    -e K6_WRITE_TARGET_ACCOUNT_ID="${write_target_account_id}" \
+    -e K6_WRITE_AMOUNT_MINOR="${write_amount_minor}" \
+    -e K6_WRITE_CURRENCY_CODE="${write_currency_code}" \
+    -e K6_MIXED_READ_RATE="${read_rate}" \
+    -e K6_MIXED_WRITE_VUS="${write_vus}" \
+    -e K6_MIXED_AUTH_RATE="${auth_rate}" \
+    -e K6_MIXED_NOTIFICATION_RATE="${notification_rate}" \
+    -e K6_LIMIT="${limit}" \
+    -v "${remote_workdir}/ops/k6:/scripts:ro" \
+    -v "${remote_workdir}/build/reports/k6:/reports" \
+    grafana/k6:0.54.0 \
+    run /scripts/transaction-read-mixed-workload-100m.js >"${runner_log_ref}" 2>&1; then
+    write_failure_artifact "k6-run-failed" "OCI mixed workload k6 run failed"
+    exit 1
+  fi
+  if ! collect_remote_artifact_file "${k6_report_name}-summary.json" "${k6_summary_ref}"; then
+    write_failure_artifact "summary-json-missing" "OCI mixed workload k6 summary JSON was not collected"
+    exit 1
+  fi
+  collect_remote_artifact_file "${k6_report_name}-summary.md" "${k6_summary_md_ref}" || true
+}
+
+case "${oci_mode}" in
+  fixture)
+    write_fixture_summary
+    ;;
+  live)
+    run_live_k6
+    ;;
+esac
+
+if ! command -v jq >/dev/null 2>&1; then
+  write_failure_artifact "jq-missing" "jq is required to transform mixed workload k6 summary"
+  exit 1
+fi
+
+write_component_artifacts
+echo "${evidence_env}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #810
- Related: #679

## 🌿 Base Branch
- `main`

## 📝 Summary
- mixed workload live evidence no-input dispatch가 Gradle/SSE smoke 대신 OCI k6 traffic runner를 사용하도록 승격합니다.
- read/write/auth/notification/SSE component split과 runner-generated artifact refs를 같은 manifest로 연결합니다.

## 🛠 Changes
- `ops/k6/transaction-read-mixed-workload-100m.js` 추가: read, transfer write, auth sessions, notification list/unread, SSE connect probe를 component metric으로 기록.
- `tools/test/run-transaction-read-mixed-workload-oci-k6.sh` 추가: OCI Docker context k6 실행, summary 수집, component/outbox/read-429 artifacts 생성.
- live autogen 기본 runner를 OCI runner로 전환하고 runner evidence env를 manifest에 반영.
- mixed workload live evidence workflow contract에 새 runner 검증과 PR path trigger 추가.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh`
- `bash tools/test/check-transaction-read-evidence-completeness-gate.sh`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: live dispatch 환경에 `CAPACITY_K6_DOCKER_CONTEXT`, `CAPACITY_K6_REMOTE_BASE_URL`, `STAGING_REPLAY_TOKEN`, write fixture account env가 없으면 새 runner가 smoke pass 대신 sanitized failure artifact를 남기고 실패합니다.
- 롤백 방법: 이 PR을 revert하면 mixed workload live evidence autogen 기본 runner가 이전 smoke runner 경로로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
