### PR TITLE
[Perf] 100M replay planner stats maintenance 병목 완화

### DIFF
--- a/tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
+++ b/tools/ops/transaction-read-model-planner-stats-freshness-guard.sh
@@ -16,6 +16,9 @@ Environment:
 Threshold overrides:
   STATS_MAX_AGE_HOURS        default 24
   STATS_MAX_MODIFIED_RATIO   default 0.05
+
+Artifacts:
+  STATS_REPORT_PATH          optional CSV copy path for workflow/replay recovery
 USAGE
 }
 
@@ -208,6 +211,11 @@ else
 fi
 
 cat "${result_file}"
+
+if [[ -n "${STATS_REPORT_PATH:-}" ]]; then
+  mkdir -p "$(dirname "${STATS_REPORT_PATH}")"
+  cp "${result_file}" "${STATS_REPORT_PATH}"
+fi
 
 failure_count="$(
   awk -F, 'NR > 1 && $2 != "ok" { count += 1 } END { print count + 0 }' "${result_file}"

--- a/tools/ops/transaction-read-model-staging-replay.sh
+++ b/tools/ops/transaction-read-model-staging-replay.sh
@@ -28,6 +28,11 @@ PLANNER_STATS_MAX_AGE_HOURS="${PLANNER_STATS_MAX_AGE_HOURS:-24}"
 PLANNER_STATS_MAX_MODIFIED_RATIO="${PLANNER_STATS_MAX_MODIFIED_RATIO:-0.05}"
 PLANNER_STATS_AUTO_ANALYZE="${PLANNER_STATS_AUTO_ANALYZE:-true}"
 PLANNER_STATS_ANALYZE_SCRIPT="${PLANNER_STATS_ANALYZE_SCRIPT:-tools/ops/transaction-read-model-chunk-lifecycle.sh}"
+PLANNER_STATS_REPORT_PATH="${PLANNER_STATS_REPORT_PATH:-${REPORT_DIR}/planner-stats.csv}"
+PLANNER_STATS_ANALYZE_LOCK_TIMEOUT_MS="${PLANNER_STATS_ANALYZE_LOCK_TIMEOUT_MS:-1000}"
+PLANNER_STATS_ANALYZE_STATEMENT_TIMEOUT_MS="${PLANNER_STATS_ANALYZE_STATEMENT_TIMEOUT_MS:-300000}"
+PLANNER_STATS_ANALYZE_HOT_STATEMENT_TIMEOUT_MS="${PLANNER_STATS_ANALYZE_HOT_STATEMENT_TIMEOUT_MS:-${PLANNER_STATS_ANALYZE_STATEMENT_TIMEOUT_MS}}"
+PLANNER_STATS_ANALYZE_ARCHIVE_STATEMENT_TIMEOUT_MS="${PLANNER_STATS_ANALYZE_ARCHIVE_STATEMENT_TIMEOUT_MS:-${PLANNER_STATS_ANALYZE_STATEMENT_TIMEOUT_MS}}"
 
 fail() {
   echo "::error::$*" >&2
@@ -202,6 +207,9 @@ validate_inputs() {
   require_positive_integer PLANNER_STATS_MAX_AGE_HOURS
   require_ratio_between_zero_and_one PLANNER_STATS_MAX_MODIFIED_RATIO
   require_bool PLANNER_STATS_AUTO_ANALYZE
+  require_positive_integer PLANNER_STATS_ANALYZE_LOCK_TIMEOUT_MS
+  require_positive_integer PLANNER_STATS_ANALYZE_HOT_STATEMENT_TIMEOUT_MS
+  require_positive_integer PLANNER_STATS_ANALYZE_ARCHIVE_STATEMENT_TIMEOUT_MS
 
   if [ "$PAGE_LIMIT" -gt 100 ]; then
     fail "PAGE_LIMIT must be 100 or less"
@@ -218,28 +226,85 @@ validate_inputs() {
   STAGING_BASE_URL="${STAGING_BASE_URL%/}"
 }
 
-run_planner_stats_analyze() {
-  notice "Planner stats freshness guard failed; running ANALYZE before replay."
-  # stats refresh는 replay evidence 정확도 목적이며, chunk lifecycle script의 lock/statement timeout을 사용합니다.
+planner_stats_analyze_targets() {
+  local table_name status rest seen_hot seen_archive
+  seen_hot=false
+  seen_archive=false
+  while IFS=, read -r table_name status rest; do
+    [ "$table_name" != "table_name" ] || continue
+    [ "$status" != "ok" ] || continue
+    case "$table_name" in
+      transaction_read_model)
+        if [ "$seen_hot" = "false" ]; then
+          printf '%s\n' hot
+          seen_hot=true
+        fi
+        ;;
+      transaction_read_model_archive)
+        if [ "$seen_archive" = "false" ]; then
+          printf '%s\n' archive
+          seen_archive=true
+        fi
+        ;;
+    esac
+  done <"$PLANNER_STATS_REPORT_PATH"
+}
+
+planner_stats_statement_timeout_ms() {
+  local target="$1"
+  case "$target" in
+    hot)
+      printf '%s\n' "$PLANNER_STATS_ANALYZE_HOT_STATEMENT_TIMEOUT_MS"
+      ;;
+    archive)
+      printf '%s\n' "$PLANNER_STATS_ANALYZE_ARCHIVE_STATEMENT_TIMEOUT_MS"
+      ;;
+    *)
+      fail "Unknown planner stats analyze target: ${target}"
+      ;;
+  esac
+}
+
+run_planner_stats_guard_once() {
+  mkdir -p "$(dirname "$PLANNER_STATS_REPORT_PATH")"
   DATABASE_URL="$STAGING_DATABASE_URL" \
-    "$PLANNER_STATS_ANALYZE_SCRIPT" --action analyze --target both
+    STATS_MAX_AGE_HOURS="$PLANNER_STATS_MAX_AGE_HOURS" \
+    STATS_MAX_MODIFIED_RATIO="$PLANNER_STATS_MAX_MODIFIED_RATIO" \
+    STATS_REPORT_PATH="$PLANNER_STATS_REPORT_PATH" \
+    "$PLANNER_STATS_GUARD_SCRIPT"
+}
+
+run_planner_stats_analyze() {
+  local target target_count statement_timeout_ms
+  notice "Planner stats freshness guard failed; running target ANALYZE before replay."
+  [ -s "$PLANNER_STATS_REPORT_PATH" ] || fail "Planner stats report is missing: ${PLANNER_STATS_REPORT_PATH}"
+
+  target_count=0
+  while IFS= read -r target; do
+    [ -n "$target" ] || continue
+    target_count=$((target_count + 1))
+    statement_timeout_ms="$(planner_stats_statement_timeout_ms "$target")"
+    # replay 요청 timeout과 DB maintenance timeout을 분리해 50M급 partition ANALYZE를 허용합니다.
+    DATABASE_URL="$STAGING_DATABASE_URL" \
+      "$PLANNER_STATS_ANALYZE_SCRIPT" \
+        --action analyze \
+        --target "$target" \
+        --lock-timeout-ms "$PLANNER_STATS_ANALYZE_LOCK_TIMEOUT_MS" \
+        --statement-timeout-ms "$statement_timeout_ms"
+  done < <(planner_stats_analyze_targets)
+
+  [ "$target_count" -gt 0 ] || fail "Planner stats report has no stale analyze target: ${PLANNER_STATS_REPORT_PATH}"
 }
 
 run_planner_stats_guard() {
   # `reltuples` estimate는 stale stats에 취약해서 replay 전에 ANALYZE 필요 여부를 먼저 차단합니다.
-  if DATABASE_URL="$STAGING_DATABASE_URL" \
-    STATS_MAX_AGE_HOURS="$PLANNER_STATS_MAX_AGE_HOURS" \
-    STATS_MAX_MODIFIED_RATIO="$PLANNER_STATS_MAX_MODIFIED_RATIO" \
-    "$PLANNER_STATS_GUARD_SCRIPT"; then
+  if run_planner_stats_guard_once; then
     return 0
   fi
 
   if [ "$PLANNER_STATS_AUTO_ANALYZE" = "true" ]; then
     run_planner_stats_analyze
-    if DATABASE_URL="$STAGING_DATABASE_URL" \
-      STATS_MAX_AGE_HOURS="$PLANNER_STATS_MAX_AGE_HOURS" \
-      STATS_MAX_MODIFIED_RATIO="$PLANNER_STATS_MAX_MODIFIED_RATIO" \
-      "$PLANNER_STATS_GUARD_SCRIPT"; then
+    if run_planner_stats_guard_once; then
       return 0
     fi
   fi

--- a/tools/test/run-transaction-read-model-staging-replay-guard.sh
+++ b/tools/test/run-transaction-read-model-staging-replay-guard.sh
@@ -29,6 +29,41 @@ EOF
   chmod +x "${bin_dir}/${command_name}"
 done
 
+freshness_guard_script="tools/ops/transaction-read-model-planner-stats-freshness-guard.sh"
+echo "[transaction-staging-replay-guard] planner stats guard writes report artifact"
+bash -n "${freshness_guard_script}"
+
+cat >"${bin_dir}/psql" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'CSV'
+table_name,status,row_estimate,live_tuple_count,modified_tuple_count,modified_ratio,last_analyze_at,analyze_age_hours,analyze_count,autoanalyze_count,analyze_command
+transaction_read_model,stale_analyze_age,50000000,50000002,0,0.0000,2026-05-06 04:49:06.97483+09,29.1,28,10,tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target hot
+transaction_read_model_archive,ok,50000028,50000028,0,0.0000,2026-05-07 09:46:07.782577+09,0.2,68,9,tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target archive
+CSV
+EOF
+chmod +x "${bin_dir}/psql"
+
+planner_report_path="${temp_dir}/planner-stats.csv"
+set +e
+planner_guard_output="$(
+  PATH="${bin_dir}:${PATH}" \
+  DATABASE_URL="postgres://user:pass@localhost:5432/db" \
+  STATS_REPORT_PATH="${planner_report_path}" \
+  "${freshness_guard_script}" 2>&1
+)"
+planner_guard_status=$?
+set -e
+
+if [ "${planner_guard_status}" -eq 0 ]; then
+  echo "planner stats guard unexpectedly succeeded" >&2
+  exit 1
+fi
+
+grep -F "Planner stats freshness guard detected stale stats" <<<"${planner_guard_output}" >/dev/null
+grep -F "transaction_read_model,stale_analyze_age" "${planner_report_path}" >/dev/null
+grep -F "transaction_read_model_archive,ok" "${planner_report_path}" >/dev/null
+
 guard_script="${temp_dir}/planner-guard.sh"
 cat >"${guard_script}" <<'EOF'
 #!/usr/bin/env bash
@@ -94,6 +129,10 @@ guard_retry_script="${temp_dir}/planner-guard-retry.sh"
 cat >"${guard_retry_script}" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+[ -n "${STATS_REPORT_PATH:-}" ] || {
+  echo "STATS_REPORT_PATH missing" >&2
+  exit 42
+}
 count_file="${GUARD_RETRY_COUNT_PATH}"
 count=0
 if [ -f "${count_file}" ]; then
@@ -102,6 +141,12 @@ fi
 count=$((count + 1))
 echo "${count}" >"${count_file}"
 if [ "${count}" -eq 1 ]; then
+  mkdir -p "$(dirname "${STATS_REPORT_PATH}")"
+  cat >"${STATS_REPORT_PATH}" <<'CSV'
+table_name,status,row_estimate,live_tuple_count,modified_tuple_count,modified_ratio,last_analyze_at,analyze_age_hours,analyze_count,autoanalyze_count,analyze_command
+transaction_read_model,stale_analyze_age,50000000,50000002,0,0.0000,2026-05-06 04:49:06.97483+09,29.1,28,10,tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target hot
+transaction_read_model_archive,ok,50000028,50000028,0,0.0000,2026-05-07 09:46:07.782577+09,0.2,68,9,tools/ops/transaction-read-model-chunk-lifecycle.sh --action analyze --target archive
+CSV
   exit 19
 fi
 exit 0
@@ -116,7 +161,7 @@ if [ "${DATABASE_URL:-}" != "postgres://user:pass@localhost:5432/db" ]; then
   echo "analyze DATABASE_URL mismatch: ${DATABASE_URL:-}" >&2
   exit 1
 fi
-if [ "$*" != "--action analyze --target both" ]; then
+if [ "$*" != "--action analyze --target hot --lock-timeout-ms 1500 --statement-timeout-ms 420000" ]; then
   echo "unexpected analyze args: $*" >&2
   exit 1
 fi
@@ -140,6 +185,8 @@ auto_output="$(
   ANALYZE_MARKER_PATH="${temp_dir}/analyze-called" \
   PLANNER_STATS_GUARD_SCRIPT="${guard_retry_script}" \
   PLANNER_STATS_ANALYZE_SCRIPT="${analyze_script}" \
+  PLANNER_STATS_ANALYZE_LOCK_TIMEOUT_MS="1500" \
+  PLANNER_STATS_ANALYZE_HOT_STATEMENT_TIMEOUT_MS="420000" \
   STAGING_BASE_URL="https://staging.example.com" \
   STAGING_REPLAY_TOKEN="token" \
   STAGING_RDS_DATABASE_URL="postgres://user:pass@localhost:5432/db" \
@@ -161,7 +208,7 @@ if [ "${auto_status}" -eq 0 ]; then
   exit 1
 fi
 
-grep -F "Planner stats freshness guard failed; running ANALYZE before replay." <<<"${auto_output}" >/dev/null
+grep -F "Planner stats freshness guard failed; running target ANALYZE before replay." <<<"${auto_output}" >/dev/null
 grep -F "fixture_missing" <<<"${auto_output}" >/dev/null
 grep -Fx "2" "${temp_dir}/guard-retry-count" >/dev/null
 grep -F "analyze-called" "${temp_dir}/analyze-called" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #816

## 🌿 Base Branch
- `main`

## 📝 Summary
- 100M staging replay가 stale planner stats와 30s ANALYZE timeout 때문에 실제 hot/cold latency 측정 전에 막히던 병목을 줄입니다.
- planner stats guard 결과를 CSV artifact로 남기고, replay 자동 복구는 stale target만 분석합니다.
- replay request timeout과 DB maintenance ANALYZE timeout을 분리해 50M급 partition 분석을 허용합니다.

## 🛠 Changes
- `transaction-read-model-planner-stats-freshness-guard.sh`가 `STATS_REPORT_PATH`로 CSV 결과를 남길 수 있게 했습니다.
- `transaction-read-model-staging-replay.sh`가 guard report에서 stale target을 읽어 `hot`/`archive` 중 실패한 대상만 `ANALYZE`합니다.
- `PLANNER_STATS_ANALYZE_HOT_STATEMENT_TIMEOUT_MS`, `PLANNER_STATS_ANALYZE_ARCHIVE_STATEMENT_TIMEOUT_MS`, `PLANNER_STATS_ANALYZE_LOCK_TIMEOUT_MS`로 운영 maintenance timeout을 분리했습니다.
- staging replay guard contract test에 run `25469738409` 형태의 stale hot stats + timeout 병목 회귀 케이스를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/run-transaction-read-model-staging-replay-guard.sh`
- `bash tools/test/run-transaction-read-model-chunk-lifecycle.sh`
- `bash tools/test/run-transaction-read-model-planner-stats-freshness-guard.sh`
- `bash -n tools/ops/transaction-read-model-planner-stats-freshness-guard.sh`
- `bash -n tools/ops/transaction-read-model-staging-replay.sh`
- `git diff --check origin/main...HEAD`
- `tools/test/with-resource-lock.sh planner-stats-pr-check ./back/gradlew -p back check`
- `git rev-list --count origin/main..HEAD` = `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: stale target 판정 CSV가 손상되면 auto-analyze가 실패하고 기존처럼 replay가 fail-fast합니다. 기본 ANALYZE timeout이 300s로 늘어 DB maintenance 시간이 길어질 수 있습니다.
- 롤백 방법: 이 PR을 revert하면 replay auto-analyze는 기존 `--target both` / 기본 timeout 경로로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
