### PR TITLE
[Fix] mixed workload live runner 인증값 전달 복구

### DIFF
--- a/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
+++ b/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
@@ -117,7 +117,14 @@ jobs:
           MIXED_WORKLOAD_OCI_DOCKER_CONTEXT="${MIXED_WORKLOAD_OCI_DOCKER_CONTEXT:-${K6_DOCKER_CONTEXT:-${CAPACITY_K6_DOCKER_CONTEXT:-}}}"
           MIXED_WORKLOAD_OCI_BASE_URL="${MIXED_WORKLOAD_OCI_BASE_URL:-${K6_REMOTE_BASE_URL:-${CAPACITY_K6_REMOTE_BASE_URL:-${STAGING_BASE_URL:-}}}}"
           MIXED_WORKLOAD_OCI_REMOTE_WORKDIR="${MIXED_WORKLOAD_OCI_REMOTE_WORKDIR:-${K6_REMOTE_WORKDIR:-${CAPACITY_K6_REMOTE_WORKDIR:-${GITHUB_WORKSPACE}}}}"
-          MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME="${MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME:-STAGING_REPLAY_TOKEN}"
+
+          if [[ -n "${STAGING_REPLAY_TOKEN:-}" ]]; then
+            mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"
+            printf '::add-mask::%s\n' "${STAGING_REPLAY_TOKEN}"
+            printf '%s' "${STAGING_REPLAY_TOKEN}" >"${mixed_workload_auth_token_file}"
+            chmod 600 "${mixed_workload_auth_token_file}"
+            printf 'MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE=%s\n' "${mixed_workload_auth_token_file}" >>"${GITHUB_ENV}"
+          fi
 
           printf 'MIXED_WORKLOAD_LIVE_OUTPUT_DIR=%s\n' "${report_dir}" >>"${GITHUB_ENV}"
           printf 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV=%s\n' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >>"${GITHUB_ENV}"
@@ -129,7 +136,6 @@ jobs:
           printf 'MIXED_WORKLOAD_OCI_DOCKER_CONTEXT=%s\n' "${MIXED_WORKLOAD_OCI_DOCKER_CONTEXT}" >>"${GITHUB_ENV}"
           printf 'MIXED_WORKLOAD_OCI_BASE_URL=%s\n' "${MIXED_WORKLOAD_OCI_BASE_URL}" >>"${GITHUB_ENV}"
           printf 'MIXED_WORKLOAD_OCI_REMOTE_WORKDIR=%s\n' "${MIXED_WORKLOAD_OCI_REMOTE_WORKDIR}" >>"${GITHUB_ENV}"
-          printf 'MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME=%s\n' "${MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME}" >>"${GITHUB_ENV}"
 
       - name: Generate mixed workload live evidence manifest artifacts
         if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
@@ -35,6 +35,15 @@ grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_INPUT: ${{ inputs.evidence_manifes
 grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_VAR: ${{ vars.OCI_MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV }}' "${workflow}" >/dev/null
 grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV="${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_INPUT:-${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV:-${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_VAR:-}}}"' "${workflow}" >/dev/null
 grep -F 'MIXED_WORKLOAD_EVIDENCE_READY=false' "${workflow}" >/dev/null
+grep -F 'mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"' "${workflow}" >/dev/null
+grep -F 'printf '\''::add-mask::%s\n'\'' "${STAGING_REPLAY_TOKEN}"' "${workflow}" >/dev/null
+grep -F 'printf '\''%s'\'' "${STAGING_REPLAY_TOKEN}" >"${mixed_workload_auth_token_file}"' "${workflow}" >/dev/null
+grep -F 'chmod 600 "${mixed_workload_auth_token_file}"' "${workflow}" >/dev/null
+grep -F 'printf '\''MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE=%s\n'\'' "${mixed_workload_auth_token_file}" >>"${GITHUB_ENV}"' "${workflow}" >/dev/null
+if grep -F 'MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME=%s' "${workflow}" >/dev/null; then
+  echo "mixed workload workflow must use token file propagation instead of env-name handoff" >&2
+  exit 1
+fi
 grep -F "name: Generate mixed workload live evidence manifest artifacts" "${workflow}" >/dev/null
 grep -F "if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'" "${workflow}" >/dev/null
 grep -F "MIXED_WORKLOAD_AUTOGEN_MODE: live" "${workflow}" >/dev/null


### PR DESCRIPTION
## 🔗 Related Issue
- close #818

## 🌿 Base Branch
- `main`

## 📝 Summary
- Mixed workload live workflow가 staging env에서 읽은 `STAGING_REPLAY_TOKEN`을 다음 step으로 전달하지 못해 OCI k6 runner가 부하 전 실패하던 문제를 고쳤습니다.
- raw token/env-name handoff 대신 runner temp token file을 만들고 `MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE`만 전달합니다.

## 🛠 Changes
- `transaction-read-mixed-workload-live-evidence.yml` resolve step에서 token을 `RUNNER_TEMP` 파일로 저장하고 GitHub mask를 등록합니다.
- `MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME` export를 제거해 empty env-name이 token file fallback을 막지 않게 했습니다.
- workflow contract test에 token file propagation 및 env-name handoff 금지 조건을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- run 25471359516 artifact `runner.log`: empty `MIXED_WORKLOAD_OCI_AUTH_TOKEN_ENV_NAME` failure 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: staging env에 `STAGING_REPLAY_TOKEN`이 없으면 기존처럼 live runner는 인증값 누락으로 실패하지만, 실패 원인은 env-name empty가 아니라 token missing으로 좁혀집니다.
- 롤백 방법: 이 PR revert 후 기존 env-name handoff로 복구합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?