### PR TITLE
[Chore] Runner Doctor expected context degraded policy 복구

### DIFF
--- a/.github/workflows/oci-a1-runner-doctor.yml
+++ b/.github/workflows/oci-a1-runner-doctor.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         env:
           OCI_A1_OBSERVABILITY_EXPECTED_CONTEXTS: ${{ vars.OCI_A1_OBSERVABILITY_EXPECTED_CONTEXTS || 'desktop-linux,oci-a1-staging' }}
-          OCI_A1_OBSERVABILITY_EXPECTED_CONTEXT_POLICY: fail
+          OCI_A1_OBSERVABILITY_EXPECTED_CONTEXT_POLICY: report
         run: |
           set -euo pipefail
           bash tools/ops/collect-oci-a1-direct-observability.sh

--- a/tools/test/check-oci-self-hosted-runner-automation.sh
+++ b/tools/test/check-oci-self-hosted-runner-automation.sh
@@ -129,7 +129,7 @@ workflow_patterns=(
   "runs-on: [self-hosted, oci-a1-staging]"
   "ops/deploy/oci/check-self-hosted-runner.sh"
   "OCI_A1_OBSERVABILITY_EXPECTED_CONTEXTS"
-  "OCI_A1_OBSERVABILITY_EXPECTED_CONTEXT_POLICY: fail"
+  "OCI_A1_OBSERVABILITY_EXPECTED_CONTEXT_POLICY: report"
   "bash tools/ops/collect-oci-a1-direct-observability.sh"
   "Upload OCI A1 direct observability artifact"
   "build/reports/oci-a1-direct-observability/"
@@ -137,6 +137,7 @@ workflow_patterns=(
 for pattern in "${workflow_patterns[@]}"; do
   require_pattern "$pattern" "$doctor_workflow"
 done
+reject_pattern "OCI_A1_OBSERVABILITY_EXPECTED_CONTEXT_POLICY: fail" "$doctor_workflow"
 require_pattern "ops/deploy/oci/check-self-hosted-runner.sh" "$staging_workflow"
 reject_pattern "for command_name in base64 curl jq psql" "$staging_workflow"
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #820

## 🌿 Base Branch
- `main`

## 📝 Summary
- Runner Doctor가 기본 Docker context를 관측해도 expected named context 2개 실패 때문에 workflow 전체를 실패 처리하던 정책을 `report`로 전환했습니다.
- 모든 context가 실패하는 hard failure는 collector에 그대로 남기고, expected context 실패는 `summary_status=degraded` artifact로 남기는 운영 정책입니다.

## 🛠 Changes
- `oci-a1-runner-doctor.yml`의 `OCI_A1_OBSERVABILITY_EXPECTED_CONTEXT_POLICY`를 `fail`에서 `report`로 변경했습니다.
- self-hosted runner automation contract test가 `report` 정책을 요구하고 `fail` 정책 회귀를 금지하도록 갱신했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-oci-self-hosted-runner-automation.sh`
- `bash tools/test/check-oci-a1-direct-observability.sh`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- run 25471548410 log: expected Docker contexts failed 2 / exit code 2 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: named context 누락이 workflow 실패로 즉시 보이지 않고 degraded artifact로 확인해야 합니다. 단, 모든 Docker context가 관측 불가하면 기존처럼 실패합니다.
- 롤백 방법: 이 PR revert 후 Runner Doctor policy를 `fail`로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?