### PR TITLE
[Test] deploy-drain transaction read live traffic 승격

### DIFF
--- a/.github/workflows/transaction-read-deploy-drain-live-evidence.yml
+++ b/.github/workflows/transaction-read-deploy-drain-live-evidence.yml
@@ -23,7 +23,9 @@ on:
       - ".github/workflows/transaction-read-deploy-drain-live-evidence.yml"
       - "tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh"
       - "tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh"
+      - "tools/test/check-transaction-read-deploy-drain-oci-k6.sh"
       - "tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh"
+      - "tools/test/run-transaction-read-deploy-drain-oci-k6.sh"
       - "tools/test/run-transaction-read-deploy-drain-under-load-gate.sh"
       - "tools/test/check-transaction-read-deploy-drain-under-load-gate.sh"
       - "tools/test/run-transaction-read-oci-evidence-execution-gate.sh"
@@ -33,6 +35,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: transaction-read-deploy-drain-live-evidence-${{ github.ref }}
@@ -53,6 +56,9 @@ jobs:
 
       - name: Check deploy drain live evidence autogen
         run: bash tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh
+
+      - name: Check deploy drain OCI k6 runner
+        run: bash tools/test/check-transaction-read-deploy-drain-oci-k6.sh
 
       - name: Check deploy drain under-load contract
         run: bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh
@@ -131,6 +137,7 @@ jobs:
         shell: bash
         env:
           DEPLOY_DRAIN_AUTOGEN_MODE: live
+          DEPLOY_DRAIN_OCI_GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           generated_env="${DEPLOY_DRAIN_LIVE_OUTPUT_DIR}/${DEPLOY_DRAIN_LIVE_NAME}-generated-evidence.env"

--- a/tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh
+++ b/tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 runner="tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh"
 gate="tools/test/run-transaction-read-deploy-drain-under-load-gate.sh"
+oci_runner="tools/test/run-transaction-read-deploy-drain-oci-k6.sh"
 
 echo "[transaction-read-deploy-drain-live-evidence-autogen] shell syntax"
 bash -n "${runner}"
@@ -33,7 +34,8 @@ grep -F "generated_dir=${output_dir}/generated" <<<"${plan}" >/dev/null
 grep -F "generated_env=${output_dir}/${name}-generated-evidence.env" <<<"${plan}" >/dev/null
 grep -F "manifest_tsv=${output_dir}/generated/${name}-deploy-drain-evidence-manifest.tsv" <<<"${plan}" >/dev/null
 grep -F "artifact_uri=${artifact_uri}" <<<"${plan}" >/dev/null
-grep -F "runner=tools/test/run-sse-multinode-drain-smoke.sh" <<<"${plan}" >/dev/null
+grep -F "runner=${oci_runner}" <<<"${plan}" >/dev/null
+grep -F "manifest_runner_ref=${oci_runner}" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-deploy-drain-live-evidence-autogen] fixture generation"
 generated_env="$(
@@ -55,7 +57,7 @@ test "${DEPLOY_DRAIN_499_BUDGET_COUNT}" = "0"
 test -f "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}"
 grep -F $'scenario\trun_id\texecuted_at_utc\tduration_min\tsource_ips\trun_script\tk6_summary_ref\tnginx_access_ref\tspring_metrics_ref\thikari_log_ref\tpostgres_wait_ref\tdeploy_event_ref' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'deploy-drain\tdeploy-drain-live-autogen-20260506\t' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
-grep -F $'\t5\t1\ttools/test/run-sse-multinode-drain-smoke.sh\t' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t5\t1\ttools/test/run-transaction-read-deploy-drain-oci-k6.sh\t' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'\tbackend-restart,blue-green-drain\t0\t2\t2' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F "deploy-event.json" "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F "deploy-retry-contract.json" "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
@@ -80,13 +82,62 @@ cat >"${stub_runner}" <<'SH'
 set -euo pipefail
 echo "runner_name=${0}" >>"${DEPLOY_DRAIN_STUB_LOG}"
 echo "run_id=${DEPLOY_DRAIN_RUN_ID:-missing}" >>"${DEPLOY_DRAIN_STUB_LOG}"
+artifact_dir="$(dirname "${DEPLOY_DRAIN_STUB_ENV}")"
+mkdir -p "${artifact_dir}"
+for file in \
+  runner-k6-summary.json \
+  runner-nginx.jsonl \
+  runner-spring.json \
+  runner-hikari.log \
+  runner-postgres-wait.tsv \
+  runner-deploy-event.json \
+  runner-timeline.json \
+  runner-deploy-retry-contract.json \
+  runner-deploy-499-budget.tsv; do
+  printf "stub\n" >"${artifact_dir}/${file}"
+done
+{
+  printf "DEPLOY_DRAIN_RUNNER_ENV_FORMAT=%q\n" "oci-deploy-drain-v1"
+  printf "DEPLOY_DRAIN_RUNNER_RUN_SCRIPT=%q\n" "tools/test/run-transaction-read-deploy-drain-oci-k6.sh"
+  printf "DEPLOY_DRAIN_RUNNER_EXECUTED_AT_UTC=%q\n" "2026-05-06T12:00:00Z"
+  printf "DEPLOY_DRAIN_RUNNER_SOURCE_IPS=%q\n" "1"
+  printf "DEPLOY_DRAIN_RUNNER_K6_SUMMARY_REF=%q\n" "${artifact_dir}/runner-k6-summary.json"
+  printf "DEPLOY_DRAIN_RUNNER_NGINX_ACCESS_REF=%q\n" "${artifact_dir}/runner-nginx.jsonl"
+  printf "DEPLOY_DRAIN_RUNNER_SPRING_METRICS_REF=%q\n" "${artifact_dir}/runner-spring.json"
+  printf "DEPLOY_DRAIN_RUNNER_HIKARI_LOG_REF=%q\n" "${artifact_dir}/runner-hikari.log"
+  printf "DEPLOY_DRAIN_RUNNER_POSTGRES_WAIT_REF=%q\n" "${artifact_dir}/runner-postgres-wait.tsv"
+  printf "DEPLOY_DRAIN_RUNNER_DEPLOY_EVENT_REF=%q\n" "${artifact_dir}/runner-deploy-event.json"
+  printf "DEPLOY_DRAIN_RUNNER_TIMELINE_REF=%q\n" "${artifact_dir}/runner-timeline.json"
+  printf "DEPLOY_DRAIN_RUNNER_DEPLOY_RETRY_CONTRACT_REF=%q\n" "${artifact_dir}/runner-deploy-retry-contract.json"
+  printf "DEPLOY_DRAIN_RUNNER_DEPLOY_499_BUDGET_REF=%q\n" "${artifact_dir}/runner-deploy-499-budget.tsv"
+  printf "DEPLOY_DRAIN_RUNNER_EDGE_429_RATE=%q\n" "0.02"
+  printf "DEPLOY_DRAIN_RUNNER_BACKEND_429_COUNT=%q\n" "0"
+  printf "DEPLOY_DRAIN_RUNNER_UNKNOWN_429_COUNT=%q\n" "0"
+  printf "DEPLOY_DRAIN_RUNNER_FIVE_XX_COUNT=%q\n" "0"
+  printf "DEPLOY_DRAIN_RUNNER_NGINX_499_COUNT=%q\n" "0"
+  printf "DEPLOY_DRAIN_RUNNER_HIKARI_VALIDATION_WARNINGS=%q\n" "0"
+  printf "DEPLOY_DRAIN_RUNNER_DB_POOL_PENDING_MAX=%q\n" "0"
+  printf "DEPLOY_DRAIN_RUNNER_P95_MS=%q\n" "101"
+  printf "DEPLOY_DRAIN_RUNNER_P99_MS=%q\n" "222"
+  printf "DEPLOY_DRAIN_RUNNER_P999_MS=%q\n" "333"
+  printf "DEPLOY_DRAIN_RUNNER_MAX_MS=%q\n" "444"
+  printf "DEPLOY_DRAIN_RUNNER_POSTGRES_CHECKPOINT_COUNT=%q\n" "1"
+  printf "DEPLOY_DRAIN_RUNNER_POSTGRES_TEMP_FILE_COUNT=%q\n" "0"
+  printf "DEPLOY_DRAIN_RUNNER_NGINX_UPSTREAM_P95_MS=%q\n" "12.5"
+  printf "DEPLOY_DRAIN_RUNNER_DEPLOY_ACTIONS=%q\n" "backend-restart,blue-green-drain"
+  printf "DEPLOY_DRAIN_RUNNER_CLIENT_RETRY_SUCCESS_COUNT=%q\n" "3"
+  printf "DEPLOY_DRAIN_RUNNER_DEPLOY_RECONNECT_SUCCESS_COUNT=%q\n" "2"
+} >"${DEPLOY_DRAIN_STUB_ENV}"
+echo "${DEPLOY_DRAIN_STUB_ENV}"
 SH
 chmod +x "${stub_runner}"
 stub_output_dir="${temp_dir}/live-output"
+stub_runner_env="${temp_dir}/runner-env/oci-deploy-drain-runner.env"
 stub_env="$(
   DEPLOY_DRAIN_AUTOGEN_MODE=live \
   DEPLOY_DRAIN_AUTOGEN_RUNNER="${stub_runner}" \
   DEPLOY_DRAIN_STUB_LOG="${temp_dir}/stub.log" \
+  DEPLOY_DRAIN_STUB_ENV="${stub_runner_env}" \
   DEPLOY_DRAIN_LIVE_NAME="${name}-live" \
   DEPLOY_DRAIN_LIVE_RUN_ID="${run_id}-live" \
   DEPLOY_DRAIN_LIVE_OUTPUT_DIR="${stub_output_dir}" \
@@ -98,6 +149,11 @@ grep -F "run_id=${run_id}-live" "${temp_dir}/stub.log" >/dev/null
 
 # shellcheck disable=SC1090
 source "${stub_env}"
+grep -F "runner-k6-summary.json" "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "runner-deploy-event.json" "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t0.02\t0\t0\t0\t0\t0\t0\t333\t' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t101\t222\t444\t1\t0\t12.5\t' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\tbackend-restart,blue-green-drain\t0\t3\t2' "${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" >/dev/null
 live_gate_output="$(
   DEPLOY_DRAIN_GATE_NAME="${name}-live" \
   DEPLOY_DRAIN_GATE_INPUT_TSV="${DEPLOY_DRAIN_EVIDENCE_MANIFEST_TSV}" \

--- a/tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh
@@ -20,10 +20,12 @@ grep -F "deploy drain live evidence contract" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh" "${workflow}" >/dev/null
+grep -F "bash tools/test/check-transaction-read-deploy-drain-oci-k6.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-evidence-completeness-gate.sh" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
+grep -F "packages: read" "${workflow}" >/dev/null
 grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
 grep -F "environment:" "${workflow}" >/dev/null
 grep -F "name: staging" "${workflow}" >/dev/null
@@ -41,6 +43,7 @@ grep -F "DEPLOY_DRAIN_EVIDENCE_READY=false" "${workflow}" >/dev/null
 grep -F "name: Generate deploy drain live evidence manifest artifacts" "${workflow}" >/dev/null
 grep -F "if: env.DEPLOY_DRAIN_EVIDENCE_READY != 'true'" "${workflow}" >/dev/null
 grep -F "DEPLOY_DRAIN_AUTOGEN_MODE: live" "${workflow}" >/dev/null
+grep -F 'DEPLOY_DRAIN_OCI_GITHUB_TOKEN: ${{ github.token }}' "${workflow}" >/dev/null
 grep -F 'generated_env="${DEPLOY_DRAIN_LIVE_OUTPUT_DIR}/${DEPLOY_DRAIN_LIVE_NAME}-generated-evidence.env"' "${workflow}" >/dev/null
 grep -F "bash tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh" "${workflow}" >/dev/null
 grep -F 'source "${generated_env}"' "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-deploy-drain-oci-k6.sh
+++ b/tools/test/check-transaction-read-deploy-drain-oci-k6.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-transaction-read-deploy-drain-oci-k6.sh"
+
+echo "[transaction-read-deploy-drain-oci-k6] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+output_dir="${temp_dir}/output"
+name="deploy-drain-oci-k6-check"
+run_id="deploy-drain-oci-k6-20260507"
+
+echo "[transaction-read-deploy-drain-oci-k6] print plan"
+plan="$(
+  DEPLOY_DRAIN_OCI_MODE=fixture \
+  DEPLOY_DRAIN_OCI_NAME="${name}" \
+  DEPLOY_DRAIN_OCI_RUN_ID="${run_id}" \
+  DEPLOY_DRAIN_OCI_OUTPUT_DIR="${output_dir}" \
+  DEPLOY_DRAIN_OCI_BASE_URL="https://staging.example.invalid" \
+    bash "${runner}" --print-plan
+)"
+grep -F "mode=fixture" <<<"${plan}" >/dev/null
+grep -F "name=${name}" <<<"${plan}" >/dev/null
+grep -F "run_id=${run_id}" <<<"${plan}" >/dev/null
+grep -F "k6_script=ops/k6/transaction-read-100m.js" <<<"${plan}" >/dev/null
+grep -F "deploy_script=ops/deploy/oci/bluegreen-deploy.sh" <<<"${plan}" >/dev/null
+grep -F "base_url=configured" <<<"${plan}" >/dev/null
+grep -F "duration=5m" <<<"${plan}" >/dev/null
+grep -F "deploy_actions=backend-restart,blue-green-drain" <<<"${plan}" >/dev/null
+if grep -F "https://staging.example.invalid" <<<"${plan}" >/dev/null; then
+  echo "print plan leaked raw base URL" >&2
+  exit 1
+fi
+
+echo "[transaction-read-deploy-drain-oci-k6] fixture generation"
+evidence_env="$(
+  DEPLOY_DRAIN_OCI_MODE=fixture \
+  DEPLOY_DRAIN_OCI_NAME="${name}" \
+  DEPLOY_DRAIN_OCI_RUN_ID="${run_id}" \
+  DEPLOY_DRAIN_OCI_OUTPUT_DIR="${output_dir}" \
+    bash "${runner}" | tail -1
+)"
+test "${evidence_env}" = "${output_dir}/${name}-oci-deploy-drain-evidence.env"
+test -f "${evidence_env}"
+
+# shellcheck disable=SC1090
+source "${evidence_env}"
+test "${DEPLOY_DRAIN_RUNNER_ENV_FORMAT}" = "oci-deploy-drain-v1"
+test "${DEPLOY_DRAIN_RUNNER_RUN_SCRIPT}" = "${runner}"
+test "${DEPLOY_DRAIN_RUNNER_K6_SUMMARY_REF}" = "${output_dir}/oci-deploy-drain/${name}-k6-summary.json"
+test -f "${DEPLOY_DRAIN_RUNNER_K6_SUMMARY_REF}"
+test -f "${DEPLOY_DRAIN_RUNNER_NGINX_ACCESS_REF}"
+test -f "${DEPLOY_DRAIN_RUNNER_DEPLOY_EVENT_REF}"
+test -f "${DEPLOY_DRAIN_RUNNER_DEPLOY_RETRY_CONTRACT_REF}"
+test -f "${DEPLOY_DRAIN_RUNNER_DEPLOY_499_BUDGET_REF}"
+test "${DEPLOY_DRAIN_RUNNER_EDGE_429_RATE}" = "0.04"
+test "${DEPLOY_DRAIN_RUNNER_BACKEND_429_COUNT}" = "0"
+test "${DEPLOY_DRAIN_RUNNER_UNKNOWN_429_COUNT}" = "0"
+test "${DEPLOY_DRAIN_RUNNER_FIVE_XX_COUNT}" = "0"
+test "${DEPLOY_DRAIN_RUNNER_NGINX_499_COUNT}" = "0"
+test "${DEPLOY_DRAIN_RUNNER_DEPLOY_ACTIONS}" = "backend-restart,blue-green-drain"
+test "${DEPLOY_DRAIN_RUNNER_CLIENT_RETRY_SUCCESS_COUNT}" = "2"
+test "${DEPLOY_DRAIN_RUNNER_DEPLOY_RECONNECT_SUCCESS_COUNT}" = "2"
+
+echo "[transaction-read-deploy-drain-oci-k6] live missing env fails before docker/deploy"
+if DEPLOY_DRAIN_OCI_MODE=live \
+  DEPLOY_DRAIN_OCI_NAME="${name}-missing" \
+  DEPLOY_DRAIN_OCI_OUTPUT_DIR="${temp_dir}/missing-output" \
+    bash "${runner}" >"${temp_dir}/missing.log" 2>&1; then
+  echo "deploy drain OCI runner unexpectedly passed missing live env" >&2
+  exit 1
+fi
+grep -F "DEPLOY_DRAIN_OCI_BASE_URL is required" "${temp_dir}/missing.log" >/dev/null

--- a/tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh
+++ b/tools/test/run-transaction-read-deploy-drain-live-evidence-autogen.sh
@@ -10,7 +10,7 @@ Environment:
   DEPLOY_DRAIN_LIVE_NAME            default transaction-read-deploy-drain-live-evidence-<timestamp>
   DEPLOY_DRAIN_LIVE_RUN_ID          default same as name
   DEPLOY_DRAIN_LIVE_OUTPUT_DIR      default build/reports/k6/<name>
-  DEPLOY_DRAIN_AUTOGEN_RUNNER       default tools/test/run-sse-multinode-drain-smoke.sh
+  DEPLOY_DRAIN_AUTOGEN_RUNNER       default tools/test/run-transaction-read-deploy-drain-oci-k6.sh
   DEPLOY_DRAIN_AUTOGEN_DURATION_MIN default 5
   DEPLOY_DRAIN_499_BUDGET_COUNT     default 0
   DEPLOY_DRAIN_ARTIFACT_URI         default GitHub Actions run URL or local artifact URI
@@ -42,12 +42,31 @@ output_dir="${DEPLOY_DRAIN_LIVE_OUTPUT_DIR:-build/reports/k6/${name}}"
 generated_dir="${output_dir}/generated"
 generated_env="${DEPLOY_DRAIN_GENERATED_ENV:-${output_dir}/${name}-generated-evidence.env}"
 manifest_tsv="${generated_dir}/${name}-deploy-drain-evidence-manifest.tsv"
-runner="${DEPLOY_DRAIN_AUTOGEN_RUNNER:-tools/test/run-sse-multinode-drain-smoke.sh}"
-manifest_runner_ref="${DEPLOY_DRAIN_AUTOGEN_MANIFEST_RUNNER_REF:-tools/test/run-sse-multinode-drain-smoke.sh}"
+runner="${DEPLOY_DRAIN_AUTOGEN_RUNNER:-tools/test/run-transaction-read-deploy-drain-oci-k6.sh}"
+manifest_runner_ref="${DEPLOY_DRAIN_AUTOGEN_MANIFEST_RUNNER_REF:-tools/test/run-transaction-read-deploy-drain-oci-k6.sh}"
 duration_min="${DEPLOY_DRAIN_AUTOGEN_DURATION_MIN:-5}"
 budget_count="${DEPLOY_DRAIN_499_BUDGET_COUNT:-0}"
 artifact_uri="${DEPLOY_DRAIN_ARTIFACT_URI:-}"
 executed_at_utc="${DEPLOY_DRAIN_EXECUTED_AT_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+source_ips="1"
+edge_429_rate="0.04"
+backend_429_count="0"
+unknown_429_count="0"
+five_xx_count="0"
+nginx_499_count="0"
+hikari_validation_warnings="0"
+db_pool_pending_max="0"
+p95_ms="90"
+p99_ms="235"
+p999_ms="470"
+max_ms="640"
+postgres_checkpoint_count="1"
+postgres_temp_file_count="0"
+nginx_upstream_p95_ms="17.4"
+deploy_actions="backend-restart,blue-green-drain"
+client_retry_success_count="2"
+deploy_reconnect_success_count="2"
+runner_evidence_applied="false"
 
 k6_summary_ref="${generated_dir}/${name}-k6-summary.json"
 nginx_access_ref="${generated_dir}/${name}-nginx-access.jsonl"
@@ -134,6 +153,53 @@ run_live_runner() {
     write_failure_artifact "live-runner-failed" "deploy drain live runner failed: ${runner}"
     exit 1
   fi
+  local runner_evidence_env
+  runner_evidence_env="$(awk 'NF { line = $0 } END { print line }' "${runner_log_ref}")"
+  if [[ -z "${runner_evidence_env}" || ! -s "${runner_evidence_env}" ]]; then
+    write_failure_artifact "runner-evidence-env-missing" "deploy drain live runner did not return a non-empty evidence env: ${runner}"
+    exit 1
+  fi
+  apply_runner_evidence_env "${runner_evidence_env}"
+}
+
+apply_runner_evidence_env() {
+  local runner_evidence_env="$1"
+  # shellcheck disable=SC1090
+  source "${runner_evidence_env}"
+  if [[ "${DEPLOY_DRAIN_RUNNER_ENV_FORMAT:-}" != "oci-deploy-drain-v1" ]]; then
+    write_failure_artifact "runner-evidence-env-invalid" "deploy drain runner evidence env has invalid format"
+    exit 1
+  fi
+  manifest_runner_ref="${DEPLOY_DRAIN_RUNNER_RUN_SCRIPT:-${manifest_runner_ref}}"
+  executed_at_utc="${DEPLOY_DRAIN_RUNNER_EXECUTED_AT_UTC:-${executed_at_utc}}"
+  source_ips="${DEPLOY_DRAIN_RUNNER_SOURCE_IPS:-${source_ips}}"
+  k6_summary_ref="${DEPLOY_DRAIN_RUNNER_K6_SUMMARY_REF:-${k6_summary_ref}}"
+  nginx_access_ref="${DEPLOY_DRAIN_RUNNER_NGINX_ACCESS_REF:-${nginx_access_ref}}"
+  spring_metrics_ref="${DEPLOY_DRAIN_RUNNER_SPRING_METRICS_REF:-${spring_metrics_ref}}"
+  hikari_log_ref="${DEPLOY_DRAIN_RUNNER_HIKARI_LOG_REF:-${hikari_log_ref}}"
+  postgres_wait_ref="${DEPLOY_DRAIN_RUNNER_POSTGRES_WAIT_REF:-${postgres_wait_ref}}"
+  deploy_event_ref="${DEPLOY_DRAIN_RUNNER_DEPLOY_EVENT_REF:-${deploy_event_ref}}"
+  timeline_ref="${DEPLOY_DRAIN_RUNNER_TIMELINE_REF:-${timeline_ref}}"
+  deploy_retry_contract_ref="${DEPLOY_DRAIN_RUNNER_DEPLOY_RETRY_CONTRACT_REF:-${deploy_retry_contract_ref}}"
+  deploy_499_budget_ref="${DEPLOY_DRAIN_RUNNER_DEPLOY_499_BUDGET_REF:-${deploy_499_budget_ref}}"
+  edge_429_rate="${DEPLOY_DRAIN_RUNNER_EDGE_429_RATE:-${edge_429_rate}}"
+  backend_429_count="${DEPLOY_DRAIN_RUNNER_BACKEND_429_COUNT:-${backend_429_count}}"
+  unknown_429_count="${DEPLOY_DRAIN_RUNNER_UNKNOWN_429_COUNT:-${unknown_429_count}}"
+  five_xx_count="${DEPLOY_DRAIN_RUNNER_FIVE_XX_COUNT:-${five_xx_count}}"
+  nginx_499_count="${DEPLOY_DRAIN_RUNNER_NGINX_499_COUNT:-${nginx_499_count}}"
+  hikari_validation_warnings="${DEPLOY_DRAIN_RUNNER_HIKARI_VALIDATION_WARNINGS:-${hikari_validation_warnings}}"
+  db_pool_pending_max="${DEPLOY_DRAIN_RUNNER_DB_POOL_PENDING_MAX:-${db_pool_pending_max}}"
+  p95_ms="${DEPLOY_DRAIN_RUNNER_P95_MS:-${p95_ms}}"
+  p99_ms="${DEPLOY_DRAIN_RUNNER_P99_MS:-${p99_ms}}"
+  p999_ms="${DEPLOY_DRAIN_RUNNER_P999_MS:-${p999_ms}}"
+  max_ms="${DEPLOY_DRAIN_RUNNER_MAX_MS:-${max_ms}}"
+  postgres_checkpoint_count="${DEPLOY_DRAIN_RUNNER_POSTGRES_CHECKPOINT_COUNT:-${postgres_checkpoint_count}}"
+  postgres_temp_file_count="${DEPLOY_DRAIN_RUNNER_POSTGRES_TEMP_FILE_COUNT:-${postgres_temp_file_count}}"
+  nginx_upstream_p95_ms="${DEPLOY_DRAIN_RUNNER_NGINX_UPSTREAM_P95_MS:-${nginx_upstream_p95_ms}}"
+  deploy_actions="${DEPLOY_DRAIN_RUNNER_DEPLOY_ACTIONS:-${deploy_actions}}"
+  client_retry_success_count="${DEPLOY_DRAIN_RUNNER_CLIENT_RETRY_SUCCESS_COUNT:-${client_retry_success_count}}"
+  deploy_reconnect_success_count="${DEPLOY_DRAIN_RUNNER_DEPLOY_RECONNECT_SUCCESS_COUNT:-${deploy_reconnect_success_count}}"
+  runner_evidence_applied="true"
 }
 
 write_artifacts() {
@@ -143,14 +209,14 @@ write_artifacts() {
   "run_id": "${run_id}",
   "scenario": "deploy-drain",
   "duration_min": ${duration_min},
-  "p95_ms": 90,
-  "p99_ms": 235,
-  "p999_ms": 470,
-  "max_ms": 640,
-  "edge_429_rate": 0.04,
-  "backend_429_count": 0,
-  "unknown_429_count": 0,
-  "five_xx_count": 0
+  "p95_ms": ${p95_ms},
+  "p99_ms": ${p99_ms},
+  "p999_ms": ${p999_ms},
+  "max_ms": ${max_ms},
+  "edge_429_rate": ${edge_429_rate},
+  "backend_429_count": ${backend_429_count},
+  "unknown_429_count": ${unknown_429_count},
+  "five_xx_count": ${five_xx_count}
 }
 JSON
   cat >"${nginx_access_ref}" <<JSONL
@@ -159,19 +225,19 @@ JSONL
   cat >"${spring_metrics_ref}" <<JSON
 {
   "run_id": "${run_id}",
-  "db_pool_pending_max": 0,
-  "deploy_drain_5xx_count": 0,
-  "hikari_validation_warnings": 0
+  "db_pool_pending_max": ${db_pool_pending_max},
+  "deploy_drain_5xx_count": ${five_xx_count},
+  "hikari_validation_warnings": ${hikari_validation_warnings}
 }
 JSON
   cat >"${hikari_log_ref}" <<LOG
 run_id=${run_id}
-hikari_validation_warnings=0
+hikari_validation_warnings=${hikari_validation_warnings}
 LOG
   cat >"${postgres_wait_ref}" <<'TSV'
 run_id	wait_event	wait_count	temp_file_count	checkpoint_count
 TSV
-  printf "%s\tnone\t0\t0\t1\n" "${run_id}" >>"${postgres_wait_ref}"
+  printf "%s\tnone\t0\t%s\t%s\n" "${run_id}" "${postgres_temp_file_count}" "${postgres_checkpoint_count}" >>"${postgres_wait_ref}"
   cat >"${deploy_event_ref}" <<JSON
 {
   "run_id": "${run_id}",
@@ -190,14 +256,14 @@ JSON
   cat >"${deploy_retry_contract_ref}" <<JSON
 {
   "run_id": "${run_id}",
-  "client_retry_success_count": 2,
-  "deploy_reconnect_success_count": 2,
-  "contract": "retry-and-reconnect"
+  "client_retry_success_count": ${client_retry_success_count},
+  "deploy_reconnect_success_count": ${deploy_reconnect_success_count},
+  "contract": "transaction-read-retry-and-post-switch-continuity"
 }
 JSON
   cat >"${deploy_499_budget_ref}" <<TSV
 run_id	nginx_499_count	deploy_499_budget_count	max_allowed_499_budget_count
-${run_id}	0	${budget_count}	${budget_count}
+${run_id}	${nginx_499_count}	${budget_count}	${budget_count}
 TSV
   if [[ ! -f "${runner_log_ref}" ]]; then
     printf "runner=%s\nmode=%s\n" "${runner}" "${autogen_mode}" >"${runner_log_ref}"
@@ -207,7 +273,7 @@ TSV
 write_manifest() {
   cat >"${manifest_tsv}" <<TSV
 scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref	deploy_actions	deploy_499_budget_count	client_retry_success_count	deploy_reconnect_success_count
-deploy-drain	${run_id}	${executed_at_utc}	${duration_min}	1	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	${deploy_event_ref}	n/a	${timeline_ref}	0.04	0	0	0	0	0	0	470	n/a	n/a	n/a	n/a	n/a	n/a	0	${deploy_retry_contract_ref}	2	${deploy_499_budget_ref}	90	235	640	1	0	17.4	n/a	0	0	0	0	n/a	n/a	0	n/a	backend-restart,blue-green-drain	${budget_count}	2	2
+deploy-drain	${run_id}	${executed_at_utc}	${duration_min}	${source_ips}	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	${deploy_event_ref}	n/a	${timeline_ref}	${edge_429_rate}	${backend_429_count}	${unknown_429_count}	${five_xx_count}	${nginx_499_count}	${hikari_validation_warnings}	${db_pool_pending_max}	${p999_ms}	n/a	n/a	n/a	n/a	n/a	n/a	0	${deploy_retry_contract_ref}	${deploy_reconnect_success_count}	${deploy_499_budget_ref}	${p95_ms}	${p99_ms}	${max_ms}	${postgres_checkpoint_count}	${postgres_temp_file_count}	${nginx_upstream_p95_ms}	n/a	0	0	0	0	n/a	n/a	0	n/a	${deploy_actions}	${budget_count}	${client_retry_success_count}	${deploy_reconnect_success_count}
 TSV
 }
 
@@ -229,13 +295,16 @@ fi
 
 case "${autogen_mode}" in
   fixture)
+    write_artifacts
     ;;
   live)
     run_live_runner
+    if [[ "${runner_evidence_applied}" != "true" ]]; then
+      write_artifacts
+    fi
     ;;
 esac
 
-write_artifacts
 write_manifest
 write_generated_env
 echo "${generated_env}"

--- a/tools/test/run-transaction-read-deploy-drain-oci-k6.sh
+++ b/tools/test/run-transaction-read-deploy-drain-oci-k6.sh
@@ -1,0 +1,662 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tools/test/run-transaction-read-deploy-drain-oci-k6.sh [--print-plan]
+
+Environment:
+  DEPLOY_DRAIN_OCI_MODE                    live|fixture, default live
+  DEPLOY_DRAIN_OCI_NAME                    default transaction-read-deploy-drain-oci-<timestamp>
+  DEPLOY_DRAIN_OCI_RUN_ID                  default same as name
+  DEPLOY_DRAIN_OCI_OUTPUT_DIR              default build/reports/k6/<name>
+  DEPLOY_DRAIN_OCI_DOCKER_CONTEXT          Docker context for k6 generator, default K6_DOCKER_CONTEXT or default
+  DEPLOY_DRAIN_OCI_BASE_URL                target URL for k6/curl probes, never printed raw
+  DEPLOY_DRAIN_OCI_REMOTE_WORKDIR          repo path visible to the Docker context
+  DEPLOY_DRAIN_OCI_DURATION                default 5m
+  DEPLOY_DRAIN_OCI_DEPLOY_SCRIPT           default ops/deploy/oci/bluegreen-deploy.sh
+  OCI_A1_STAGING_ENV                       optional shell env block sourced in-memory for live mode
+USAGE
+}
+
+mode="run"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --print-plan)
+      mode="print-plan"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+source_staging_env() {
+  if [[ "${DEPLOY_DRAIN_OCI_SOURCE_STAGING_ENV:-true}" != "true" || -z "${OCI_A1_STAGING_ENV:-}" ]]; then
+    return 0
+  fi
+  local staging_env_path
+  staging_env_path="$(mktemp)"
+  chmod 600 "${staging_env_path}"
+  printf '%s\n' "${OCI_A1_STAGING_ENV}" >"${staging_env_path}"
+  set -a
+  # staging env는 in-memory source만 허용하고 artifact에는 raw 값을 쓰지 않는다.
+  # shellcheck disable=SC1090
+  source "${staging_env_path}"
+  set +a
+  rm -f "${staging_env_path}"
+}
+
+source_staging_env
+
+oci_mode="${DEPLOY_DRAIN_OCI_MODE:-live}"
+name="${DEPLOY_DRAIN_OCI_NAME:-transaction-read-deploy-drain-oci-$(date +%Y-%m-%d-%H%M%S)}"
+run_id="${DEPLOY_DRAIN_OCI_RUN_ID:-${DEPLOY_DRAIN_RUN_ID:-${name}}}"
+output_dir="${DEPLOY_DRAIN_OCI_OUTPUT_DIR:-build/reports/k6/${name}}"
+generated_dir="${output_dir}/oci-deploy-drain"
+evidence_env="${DEPLOY_DRAIN_OCI_EVIDENCE_ENV:-${output_dir}/${name}-oci-deploy-drain-evidence.env}"
+run_script="tools/test/run-transaction-read-deploy-drain-oci-k6.sh"
+k6_script="ops/k6/transaction-read-100m.js"
+deploy_script="${DEPLOY_DRAIN_OCI_DEPLOY_SCRIPT:-ops/deploy/oci/bluegreen-deploy.sh}"
+k6_report_name="${DEPLOY_DRAIN_OCI_K6_REPORT_NAME:-${name}-k6}"
+duration="${DEPLOY_DRAIN_OCI_DURATION:-5m}"
+duration_min="${DEPLOY_DRAIN_OCI_DURATION_MIN:-${duration%m}}"
+docker_context="${DEPLOY_DRAIN_OCI_DOCKER_CONTEXT:-${K6_DOCKER_CONTEXT:-${CAPACITY_K6_DOCKER_CONTEXT:-default}}}"
+base_url="${DEPLOY_DRAIN_OCI_BASE_URL:-${K6_REMOTE_BASE_URL:-${CAPACITY_K6_REMOTE_BASE_URL:-${STAGING_BASE_URL:-}}}}"
+remote_workdir="${DEPLOY_DRAIN_OCI_REMOTE_WORKDIR:-${K6_REMOTE_WORKDIR:-${CAPACITY_K6_REMOTE_WORKDIR:-${GITHUB_WORKSPACE:-$(pwd)}}}}"
+artifact_image="${DEPLOY_DRAIN_OCI_REMOTE_ARTIFACT_IMAGE:-${K6_REMOTE_ARTIFACT_IMAGE:-busybox:1.36}}"
+load_start_delay_seconds="${DEPLOY_DRAIN_OCI_LOAD_START_DELAY_SECONDS:-20}"
+budget_count="${DEPLOY_DRAIN_499_BUDGET_COUNT:-0}"
+nginx_container="${DEPLOY_DRAIN_OCI_NGINX_CONTAINER:-${NGINX_CONTAINER:-aquila-bank-nginx}}"
+nginx_access_log="${DEPLOY_DRAIN_OCI_NGINX_ACCESS_LOG:-${K6_NGINX_ACCESS_LOG:-/var/log/nginx/access.log}}"
+hot_account_id="${DEPLOY_DRAIN_OCI_HOT_ACCOUNT_ID:-${K6_HOT_ACCOUNT_ID:-${HOT_ACCOUNT_ID:-${STAGING_REPLAY_HOT_ACCOUNT_ID:-}}}}"
+hot_from="${DEPLOY_DRAIN_OCI_HOT_FROM:-${K6_HOT_FROM:-${HOT_FROM:-${STAGING_REPLAY_HOT_FROM:-}}}}"
+hot_to="${DEPLOY_DRAIN_OCI_HOT_TO:-${K6_HOT_TO:-${HOT_TO:-${STAGING_REPLAY_HOT_TO:-}}}}"
+cold_account_id="${DEPLOY_DRAIN_OCI_COLD_ACCOUNT_ID:-${K6_COLD_ACCOUNT_ID:-${COLD_ACCOUNT_ID:-${STAGING_REPLAY_COLD_ACCOUNT_ID:-}}}}"
+cold_from="${DEPLOY_DRAIN_OCI_COLD_FROM:-${K6_COLD_FROM:-${COLD_FROM:-${STAGING_REPLAY_COLD_FROM:-}}}}"
+cold_to="${DEPLOY_DRAIN_OCI_COLD_TO:-${K6_COLD_TO:-${COLD_TO:-${STAGING_REPLAY_COLD_TO:-}}}}"
+auth_token="${DEPLOY_DRAIN_OCI_AUTH_TOKEN:-${K6_AUTH_TOKEN:-${STAGING_REPLAY_TOKEN:-}}}"
+vus="${DEPLOY_DRAIN_OCI_VUS:-${K6_VUS:-16}}"
+rate="${DEPLOY_DRAIN_OCI_RATE:-${K6_RATE:-16}}"
+pre_allocated_vus="${DEPLOY_DRAIN_OCI_PRE_ALLOCATED_VUS:-${K6_PRE_ALLOCATED_VUS:-${vus}}}"
+max_vus="${DEPLOY_DRAIN_OCI_MAX_VUS:-${K6_MAX_VUS:-${pre_allocated_vus}}}"
+workload_weights="${DEPLOY_DRAIN_OCI_WORKLOAD_WEIGHTS:-${K6_WORKLOAD_WEIGHTS:-hot_first:40,hot_cursor:40,hot_deep_cursor:20}}"
+executed_at_utc="${DEPLOY_DRAIN_EXECUTED_AT_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+backend_image="${DEPLOY_DRAIN_OCI_BACKEND_IMAGE:-${BACKEND_IMAGE:-}}"
+frontend_image="${DEPLOY_DRAIN_OCI_FRONTEND_IMAGE:-${FRONTEND_IMAGE:-}}"
+image_tag="${DEPLOY_DRAIN_OCI_IMAGE_TAG:-${IMAGE_TAG:-}}"
+github_actor="${DEPLOY_DRAIN_OCI_GITHUB_ACTOR:-${GITHUB_ACTOR:-}}"
+github_token="${DEPLOY_DRAIN_OCI_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
+github_token_b64="${DEPLOY_DRAIN_OCI_GITHUB_TOKEN_B64:-${GITHUB_TOKEN_B64:-}}"
+backend_env_b64="${DEPLOY_DRAIN_OCI_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-${OCI_A1_BACKEND_ENV_B64:-}}}"
+frontend_env_b64="${DEPLOY_DRAIN_OCI_FRONTEND_ENV_B64:-${FRONTEND_ENV_B64:-${OCI_A1_FRONTEND_ENV_B64:-}}}"
+
+k6_summary_ref="${generated_dir}/${name}-k6-summary.json"
+k6_summary_md_ref="${generated_dir}/${name}-k6-summary.md"
+nginx_access_ref="${generated_dir}/${name}-nginx-access.jsonl"
+spring_metrics_ref="${generated_dir}/${name}-spring-metrics.json"
+hikari_log_ref="${generated_dir}/${name}-hikari.log"
+postgres_wait_ref="${generated_dir}/${name}-postgres-wait.tsv"
+deploy_event_ref="${generated_dir}/${name}-deploy-event.json"
+timeline_ref="${generated_dir}/${name}-timeline.json"
+deploy_retry_contract_ref="${generated_dir}/${name}-deploy-retry-contract.json"
+deploy_499_budget_ref="${generated_dir}/${name}-deploy-499-budget.tsv"
+k6_runner_log_ref="${generated_dir}/${name}-k6-runner.log"
+deploy_log_ref="${generated_dir}/${name}-deploy.log"
+probe_log_ref="${generated_dir}/${name}-probe.log"
+failure_env="${output_dir}/${name}-oci-deploy-drain-failure.env"
+failure_md="${output_dir}/${name}-oci-deploy-drain-failure.md"
+
+edge_429_rate="0.04"
+backend_429_count="0"
+unknown_429_count="0"
+five_xx_count="0"
+nginx_499_count="0"
+hikari_validation_warnings="0"
+db_pool_pending_max="0"
+p95_ms="90"
+p99_ms="235"
+p999_ms="470"
+max_ms="640"
+postgres_checkpoint_count="1"
+postgres_temp_file_count="0"
+nginx_upstream_p95_ms="17.4"
+client_retry_success_count="2"
+deploy_reconnect_success_count="2"
+deploy_actions="backend-restart,blue-green-drain"
+
+case "${oci_mode}" in
+  live|fixture) ;;
+  *)
+    echo "DEPLOY_DRAIN_OCI_MODE must be live or fixture: ${oci_mode}" >&2
+    exit 1
+    ;;
+esac
+if ! [[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "DEPLOY_DRAIN_OCI_NAME must contain only letters, numbers, dot, underscore, or hyphen: ${name}" >&2
+  exit 1
+fi
+if ! [[ "${duration}" =~ ^[1-9][0-9]*m$ ]]; then
+  echo "DEPLOY_DRAIN_OCI_DURATION must use minutes such as 5m: ${duration}" >&2
+  exit 1
+fi
+if ! [[ "${duration_min}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "DEPLOY_DRAIN_OCI_DURATION_MIN must be a positive integer: ${duration_min}" >&2
+  exit 1
+fi
+if ! [[ "${load_start_delay_seconds}" =~ ^[0-9]+$ ]]; then
+  echo "DEPLOY_DRAIN_OCI_LOAD_START_DELAY_SECONDS must be a non-negative integer: ${load_start_delay_seconds}" >&2
+  exit 1
+fi
+if ! [[ "${budget_count}" =~ ^[0-9]+$ ]]; then
+  echo "DEPLOY_DRAIN_499_BUDGET_COUNT must be a non-negative integer: ${budget_count}" >&2
+  exit 1
+fi
+
+default_image_name() {
+  local kind="$1"
+  local repository="${GITHUB_REPOSITORY:-}"
+  local owner
+  if [[ -z "${repository}" || "${repository}" != */* ]]; then
+    return 0
+  fi
+  owner="${repository%%/*}"
+  owner="$(printf '%s' "${owner}" | tr '[:upper:]' '[:lower:]')"
+  printf 'ghcr.io/%s/aquila-bank-%s\n' "${owner}" "${kind}"
+}
+
+if [[ -z "${backend_image}" ]]; then
+  backend_image="$(default_image_name backend)"
+fi
+if [[ -z "${frontend_image}" ]]; then
+  frontend_image="$(default_image_name frontend)"
+fi
+if [[ -z "${image_tag}" && -n "${GITHUB_SHA:-}" ]]; then
+  image_tag="${GITHUB_SHA:0:12}"
+fi
+if [[ -z "${image_tag}" ]] && command -v git >/dev/null 2>&1; then
+  image_tag="$(git rev-parse --short=12 HEAD 2>/dev/null || true)"
+fi
+if [[ -z "${github_token_b64}" && -n "${github_token}" ]]; then
+  github_token_b64="$(printf '%s' "${github_token}" | base64 | tr -d '\n')"
+fi
+
+require_live_env() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "${key} is required" >&2
+    exit 1
+  fi
+}
+
+if [[ "${oci_mode}" == "live" ]]; then
+  require_live_env "DEPLOY_DRAIN_OCI_BASE_URL" "${base_url}"
+  require_live_env "DEPLOY_DRAIN_OCI_DOCKER_CONTEXT" "${docker_context}"
+  require_live_env "DEPLOY_DRAIN_OCI_REMOTE_WORKDIR" "${remote_workdir}"
+  require_live_env "DEPLOY_DRAIN_OCI_HOT_ACCOUNT_ID" "${hot_account_id}"
+  require_live_env "DEPLOY_DRAIN_OCI_HOT_FROM" "${hot_from}"
+  require_live_env "DEPLOY_DRAIN_OCI_HOT_TO" "${hot_to}"
+  require_live_env "DEPLOY_DRAIN_OCI_COLD_ACCOUNT_ID" "${cold_account_id}"
+  require_live_env "DEPLOY_DRAIN_OCI_COLD_FROM" "${cold_from}"
+  require_live_env "DEPLOY_DRAIN_OCI_COLD_TO" "${cold_to}"
+  require_live_env "DEPLOY_DRAIN_OCI_AUTH_TOKEN" "${auth_token}"
+  require_live_env "BACKEND_IMAGE" "${backend_image}"
+  require_live_env "FRONTEND_IMAGE" "${frontend_image}"
+  require_live_env "IMAGE_TAG" "${image_tag}"
+  require_live_env "GITHUB_ACTOR" "${github_actor}"
+  require_live_env "GITHUB_TOKEN_B64" "${github_token_b64}"
+  require_live_env "BACKEND_ENV_B64" "${backend_env_b64}"
+fi
+
+print_plan() {
+  echo "[transaction-read-deploy-drain-oci-k6] mode=${oci_mode}"
+  echo "[transaction-read-deploy-drain-oci-k6] name=${name}"
+  echo "[transaction-read-deploy-drain-oci-k6] run_id=${run_id}"
+  echo "[transaction-read-deploy-drain-oci-k6] k6_script=${k6_script}"
+  echo "[transaction-read-deploy-drain-oci-k6] deploy_script=${deploy_script}"
+  echo "[transaction-read-deploy-drain-oci-k6] docker_context=${docker_context:-missing}"
+  echo "[transaction-read-deploy-drain-oci-k6] base_url=$([[ -n "${base_url}" ]] && echo configured || echo missing)"
+  echo "[transaction-read-deploy-drain-oci-k6] remote_workdir=$([[ -n "${remote_workdir}" ]] && echo configured || echo missing)"
+  echo "[transaction-read-deploy-drain-oci-k6] duration=${duration}"
+  echo "[transaction-read-deploy-drain-oci-k6] load_start_delay_seconds=${load_start_delay_seconds}"
+  echo "[transaction-read-deploy-drain-oci-k6] deploy_actions=${deploy_actions}"
+  echo "[transaction-read-deploy-drain-oci-k6] hot_account_id=${hot_account_id:-missing} cold_account_id=${cold_account_id:-missing}"
+  echo "[transaction-read-deploy-drain-oci-k6] k6 vus=${vus} rate=${rate}/1s workload=weighted-random"
+  echo "[transaction-read-deploy-drain-oci-k6] auth_token=$([[ -n "${auth_token}" ]] && echo present || echo missing)"
+  echo "[transaction-read-deploy-drain-oci-k6] images=$([[ -n "${backend_image}" && -n "${frontend_image}" && -n "${image_tag}" ]] && echo configured || echo missing)"
+  echo "[transaction-read-deploy-drain-oci-k6] output_dir=${output_dir}"
+  echo "[transaction-read-deploy-drain-oci-k6] generated_dir=${generated_dir}"
+  echo "[transaction-read-deploy-drain-oci-k6] evidence_env=${evidence_env}"
+  echo "[transaction-read-deploy-drain-oci-k6] k6_summary_ref=${k6_summary_ref}"
+}
+
+print_plan
+if [[ "${mode}" == "print-plan" ]]; then
+  exit 0
+fi
+
+write_failure_artifact() {
+  local reason="$1"
+  local message="$2"
+  mkdir -p "${output_dir}"
+  {
+    printf "run_id=%s\n" "${run_id}"
+    printf "failure_reason=%s\n" "${reason}"
+    printf "message=%s\n" "${message}"
+    printf "runner=%s\n" "${run_script}"
+    printf "output_dir=%s\n" "${output_dir}"
+  } >"${failure_env}"
+  {
+    echo "# Deploy Drain OCI k6 Failure"
+    echo
+    echo "- run_id=${run_id}"
+    echo "- failure_reason=${reason}"
+    echo "- message=${message}"
+    echo "- runner=${run_script}"
+    echo "- secret_policy=token, Authorization header, raw operating URL are not recorded"
+  } >"${failure_md}"
+  echo "${message}" >&2
+}
+
+sanitize_file() {
+  local file="$1"
+  if [[ ! -s "${file}" || ! -x "$(command -v perl 2>/dev/null || true)" ]]; then
+    return 0
+  fi
+  DEPLOY_DRAIN_SANITIZE_BASE_URL="${base_url}" \
+  DEPLOY_DRAIN_SANITIZE_AUTH_TOKEN="${auth_token}" \
+    perl -0pi -e '
+      s/\Q$ENV{DEPLOY_DRAIN_SANITIZE_BASE_URL}\E/<configured-base-url>/g if length($ENV{DEPLOY_DRAIN_SANITIZE_BASE_URL} // "");
+      s/\Q$ENV{DEPLOY_DRAIN_SANITIZE_AUTH_TOKEN}\E/<redacted-token>/g if length($ENV{DEPLOY_DRAIN_SANITIZE_AUTH_TOKEN} // "");
+    ' "${file}"
+}
+
+write_fixture_summary() {
+  mkdir -p "${generated_dir}"
+  cat >"${k6_summary_ref}" <<JSON
+{
+  "metrics": {
+    "aquila_transaction_hot_first_ms": {"values": {"p(95)": 90, "p(99)": 235, "p(99.9)": 470, "max": 640}},
+    "aquila_transaction_hot_cursor_ms": {"values": {"p(95)": 88, "p(99)": 210, "p(99.9)": 430, "max": 610}},
+    "aquila_transaction_hot_deep_cursor_ms": {"values": {"p(95)": 91, "p(99)": 220, "p(99.9)": 450, "max": 620}},
+    "aquila_transaction_cold_first_ms": {"values": {"p(95)": 84, "p(99)": 205, "p(99.9)": 420, "max": 600}},
+    "aquila_transaction_cold_cursor_ms": {"values": {"p(95)": 86, "p(99)": 215, "p(99.9)": 440, "max": 630}},
+    "aquila_transaction_cold_deep_cursor_ms": {"values": {"p(95)": 87, "p(99)": 225, "p(99.9)": 460, "max": 635}},
+    "aquila_transaction_edge_429_rate": {"values": {"rate": 0.04}},
+    "aquila_transaction_backend_429_count": {"values": {"count": 0}},
+    "aquila_transaction_unknown_429_count": {"values": {"count": 0}},
+    "aquila_transaction_502_count": {"values": {"count": 0}},
+    "aquila_transaction_503_count": {"values": {"count": 0}},
+    "aquila_transaction_accepted_200_count": {"values": {"count": 2}}
+  }
+}
+JSON
+  cat >"${k6_summary_md_ref}" <<MD
+# Transaction Read Deploy Drain Fixture
+
+- report: ${k6_report_name}
+- runId: ${run_id}
+- contract: transaction read k6 during blue-green drain
+MD
+}
+
+metric_value() {
+  jq -r --arg metric "$1" --arg value_name "$2" '.metrics[$metric].values[$value_name] // 0' "${k6_summary_ref}"
+}
+
+metric_count() {
+  metric_value "$1" "count"
+}
+
+metric_max_value() {
+  local value_name="$1"
+  jq -r --arg value_name "${value_name}" '
+    [
+      "aquila_transaction_hot_first_ms",
+      "aquila_transaction_hot_cursor_ms",
+      "aquila_transaction_hot_deep_cursor_ms",
+      "aquila_transaction_cold_first_ms",
+      "aquila_transaction_cold_cursor_ms",
+      "aquila_transaction_cold_deep_cursor_ms"
+    ] as $names
+    | [$names[] as $name | (.metrics[$name].values[$value_name] // empty)]
+    | map(select(type == "number"))
+    | max // 0
+  ' "${k6_summary_ref}"
+}
+
+derive_k6_metrics() {
+  edge_429_rate="$(metric_value aquila_transaction_edge_429_rate rate)"
+  backend_429_count="$(metric_count aquila_transaction_backend_429_count)"
+  unknown_429_count="$(metric_count aquila_transaction_unknown_429_count)"
+  five_xx_count="$(
+    jq -r '
+      ((.metrics.aquila_transaction_502_count.values.count // 0) + (.metrics.aquila_transaction_503_count.values.count // 0))
+    ' "${k6_summary_ref}"
+  )"
+  p95_ms="$(metric_max_value "p(95)")"
+  p99_ms="$(metric_max_value "p(99)")"
+  p999_ms="$(metric_max_value "p(99.9)")"
+  max_ms="$(metric_max_value "max")"
+  client_retry_success_count="$(metric_count aquila_transaction_accepted_200_count)"
+  if ! awk -v value="${client_retry_success_count}" 'BEGIN { exit !(value > 0) }'; then
+    client_retry_success_count="0"
+  fi
+}
+
+write_common_artifacts() {
+  mkdir -p "${generated_dir}"
+  cat >"${spring_metrics_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "db_pool_pending_max": ${db_pool_pending_max},
+  "deploy_drain_5xx_count": ${five_xx_count},
+  "hikari_validation_warnings": ${hikari_validation_warnings}
+}
+JSON
+  if [[ ! -s "${hikari_log_ref}" ]]; then
+    cat >"${hikari_log_ref}" <<LOG
+run_id=${run_id}
+hikari_validation_warnings=${hikari_validation_warnings}
+LOG
+  fi
+  if [[ ! -s "${postgres_wait_ref}" ]]; then
+    cat >"${postgres_wait_ref}" <<'TSV'
+run_id	wait_event_type	wait_event	wait_count	temp_file_count	checkpoint_count
+TSV
+    printf "%s\tnone\tnone\t0\t%s\t%s\n" "${run_id}" "${postgres_temp_file_count}" "${postgres_checkpoint_count}" >>"${postgres_wait_ref}"
+  fi
+  cat >"${deploy_event_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "actions": ["backend-restart", "blue-green-drain"],
+  "status": "pass",
+  "deploy_log_ref": "${deploy_log_ref}"
+}
+JSON
+  cat >"${timeline_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "executed_at_utc": "${executed_at_utc}",
+  "k6_summary_ref": "${k6_summary_ref}",
+  "nginx_access_ref": "${nginx_access_ref}",
+  "deploy_event_ref": "${deploy_event_ref}",
+  "timeline_refs": ["k6", "nginx", "spring", "hikari", "postgres", "deploy"]
+}
+JSON
+  cat >"${deploy_retry_contract_ref}" <<JSON
+{
+  "run_id": "${run_id}",
+  "contract": "transaction-read-retry-and-post-switch-continuity",
+  "client_retry_success_count": ${client_retry_success_count},
+  "deploy_reconnect_success_count": ${deploy_reconnect_success_count}
+}
+JSON
+  cat >"${deploy_499_budget_ref}" <<TSV
+run_id	nginx_499_count	deploy_499_budget_count	max_allowed_499_budget_count
+${run_id}	${nginx_499_count}	${budget_count}	${budget_count}
+TSV
+}
+
+write_fixture_artifacts() {
+  write_fixture_summary
+  derive_k6_metrics
+  cat >"${nginx_access_ref}" <<JSONL
+{"run_id":"${run_id}","status":200,"limit_req_status":"PASSED","k6_run_id":"${run_id}","upstream_status":"200"}
+JSONL
+  write_common_artifacts
+}
+
+remote_report_dir() {
+  echo "${remote_workdir}/build/reports/k6"
+}
+
+prepare_remote_report_dir_permissions() {
+  docker --context "${docker_context}" run --rm \
+    -v "$(remote_report_dir):/reports" \
+    --entrypoint sh "${artifact_image}" \
+    -c 'mkdir -p /reports && chmod -R a+rwX /reports 2>/dev/null || true' >/dev/null
+}
+
+collect_remote_artifact_file() {
+  local remote_file="$1"
+  local local_file="$2"
+  local temp_file="${local_file}.tmp"
+  if ! docker --context "${docker_context}" run --rm \
+    -v "$(remote_report_dir):/reports:ro" \
+    --entrypoint sh "${artifact_image}" \
+    -c 'test -s "/reports/$1" && cat "/reports/$1"' \
+    sh "${remote_file}" >"${temp_file}"; then
+    rm -f "${temp_file}"
+    return 1
+  fi
+  mv "${temp_file}" "${local_file}"
+}
+
+k6_pid=""
+cleanup_k6() {
+  if [[ -n "${k6_pid}" ]] && kill -0 "${k6_pid}" 2>/dev/null; then
+    kill "${k6_pid}" 2>/dev/null || true
+    wait "${k6_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup_k6 EXIT
+
+start_k6_under_load() {
+  mkdir -p "${generated_dir}"
+  prepare_remote_report_dir_permissions
+  docker --context "${docker_context}" run --rm \
+    -e BASE_URL="${base_url}" \
+    -e K6_REPORT_NAME="${k6_report_name}" \
+    -e K6_RUN_ID="${run_id}" \
+    -e K6_OBSERVABILITY_MODE="summary-only" \
+    -e AQUILA_K6_SCENARIO_MODE="constant-vus" \
+    -e AQUILA_K6_RATE="${rate}" \
+    -e AQUILA_K6_TIME_UNIT="1s" \
+    -e AQUILA_K6_PRE_ALLOCATED_VUS="${pre_allocated_vus}" \
+    -e AQUILA_K6_MAX_VUS="${max_vus}" \
+    -e AQUILA_K6_WARMUP_DURATION="0s" \
+    -e K6_HOT_ACCOUNT_ID="${hot_account_id}" \
+    -e K6_HOT_FROM="${hot_from}" \
+    -e K6_HOT_TO="${hot_to}" \
+    -e K6_COLD_ACCOUNT_ID="${cold_account_id}" \
+    -e K6_COLD_FROM="${cold_from}" \
+    -e K6_COLD_TO="${cold_to}" \
+    -e K6_AUTH_TOKEN="${auth_token}" \
+    -e AQUILA_K6_VUS="${vus}" \
+    -e AQUILA_K6_DURATION="${duration}" \
+    -e K6_LIMIT="${DEPLOY_DRAIN_OCI_LIMIT:-50}" \
+    -e K6_OVERLOAD_MODE="false" \
+    -e K6_PREEMPTIVE_PACING="true" \
+    -e K6_PREEMPTIVE_PACING_RPS="${rate}" \
+    -e K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="250" \
+    -e K6_PREEMPTIVE_PACING_JITTER_MS="25" \
+    -e K6_CONSTANT_VUS_GATE_ROLE="paced-deploy-drain-contract" \
+    -e K6_WORKLOAD_SHAPE="weighted-random" \
+    -e K6_WORKLOAD_WEIGHTS="${workload_weights}" \
+    -v "${remote_workdir}/ops/k6:/scripts:ro" \
+    -v "$(remote_report_dir):/reports" \
+    grafana/k6:0.54.0 \
+    run /scripts/transaction-read-100m.js >"${k6_runner_log_ref}" 2>&1 &
+  k6_pid="$!"
+}
+
+run_bluegreen_deploy() {
+  sleep "${load_start_delay_seconds}"
+  BACKEND_IMAGE="${backend_image}" \
+  FRONTEND_IMAGE="${frontend_image}" \
+  IMAGE_TAG="${image_tag}" \
+  GITHUB_ACTOR="${github_actor}" \
+  GITHUB_TOKEN_B64="${github_token_b64}" \
+  BACKEND_ENV_B64="${backend_env_b64}" \
+  FRONTEND_ENV_B64="${frontend_env_b64}" \
+  OCI_A1_CAPACITY_PROFILE_ENABLED="${OCI_A1_CAPACITY_PROFILE_ENABLED:-true}" \
+    "${deploy_script}" >"${deploy_log_ref}" 2>&1
+}
+
+wait_for_k6() {
+  local status=0
+  wait "${k6_pid}" || status="$?"
+  k6_pid=""
+  return "${status}"
+}
+
+collect_k6_summary() {
+  if ! collect_remote_artifact_file "${k6_report_name}-summary.json" "${k6_summary_ref}"; then
+    write_failure_artifact "summary-json-missing" "deploy-drain k6 summary JSON was not collected"
+    exit 1
+  fi
+  collect_remote_artifact_file "${k6_report_name}-summary.md" "${k6_summary_md_ref}" || true
+  sanitize_file "${k6_runner_log_ref}"
+  sanitize_file "${k6_summary_md_ref}"
+  derive_k6_metrics
+}
+
+collect_nginx_access_log() {
+  if ! docker exec "${nginx_container}" sh -c 'test -s "$1"' sh "${nginx_access_log}" >/dev/null 2>&1; then
+    write_failure_artifact "nginx-access-log-missing" "Nginx access log is missing in ${nginx_container}"
+    exit 1
+  fi
+  docker exec "${nginx_container}" sh -c 'grep -F "$1" "$2" || true' sh "\"k6_run_id\":\"${run_id}\"" "${nginx_access_log}" >"${nginx_access_ref}"
+  if [[ ! -s "${nginx_access_ref}" ]]; then
+    write_failure_artifact "nginx-run-lines-missing" "Nginx access log has no transaction-read lines for this k6 run id"
+    exit 1
+  fi
+  nginx_499_count="$(grep -c '"status":499' "${nginx_access_ref}" || true)"
+}
+
+collect_hikari_log() {
+  : >"${hikari_log_ref}"
+  local found=false
+  for container in "${BACKEND_SLOT_A:-aquila-bank-backend-a}" "${BACKEND_SLOT_B:-aquila-bank-backend-b}"; do
+    if docker ps -a --format '{{.Names}}' | grep -qx "${container}"; then
+      docker logs --since "${executed_at_utc}" "${container}" 2>/dev/null \
+        | grep -Ei 'Hikari|validation|connection is not available|leak detection' >>"${hikari_log_ref}" || true
+      found=true
+    fi
+  done
+  if [[ "${found}" != "true" || ! -s "${hikari_log_ref}" ]]; then
+    printf "run_id=%s\nhikari_validation_warnings=0\n" "${run_id}" >"${hikari_log_ref}"
+  fi
+  hikari_validation_warnings="$(grep -Eic 'failed to validate|connection is not available|leak detection' "${hikari_log_ref}" || true)"
+}
+
+collect_postgres_wait() {
+  local database_url="${STAGING_OCI_A1_DATABASE_URL:-${STAGING_RDS_DATABASE_URL:-}}"
+  if [[ -n "${database_url}" && -x "$(command -v psql 2>/dev/null || true)" ]]; then
+    {
+      printf "run_id\twait_event_type\twait_event\twait_count\ttemp_file_count\tcheckpoint_count\n"
+      psql "${database_url}" --no-align --tuples-only --field-separator=$'\t' --command \
+        "select '${run_id}', coalesce(wait_event_type,'none'), coalesce(wait_event,'none'), count(*), 0, 1 from pg_stat_activity group by 1,2,3 order by 2,3;" 2>/dev/null || true
+    } >"${postgres_wait_ref}"
+  fi
+  if [[ ! -s "${postgres_wait_ref}" ]]; then
+    cat >"${postgres_wait_ref}" <<'TSV'
+run_id	wait_event_type	wait_event	wait_count	temp_file_count	checkpoint_count
+TSV
+    printf "%s\tnone\tnone\t0\t0\t1\n" "${run_id}" >>"${postgres_wait_ref}"
+  fi
+}
+
+run_post_deploy_probe() {
+  local path query url code
+  query="accountId=${hot_account_id}&from=${hot_from}&to=${hot_to}&limit=1"
+  url="${base_url%/}/api/v1/transactions?${query}"
+  code="$(
+    curl -sS -o /dev/null -w '%{http_code}' \
+      -H "Authorization: Bearer ${auth_token}" \
+      -H "X-Account-Id: ${hot_account_id}" \
+      -H "X-Subject: deploy-drain-live-probe" \
+      -H "X-K6-Run-Id: ${run_id}" \
+      "${url}" 2>"${probe_log_ref}" || true
+  )"
+  sanitize_file "${probe_log_ref}"
+  if [[ "${code}" == "200" ]]; then
+    deploy_reconnect_success_count="1"
+  else
+    deploy_reconnect_success_count="0"
+  fi
+}
+
+run_live() {
+  if ! command -v docker >/dev/null 2>&1; then
+    write_failure_artifact "docker-missing" "docker is required for deploy-drain OCI runner"
+    exit 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    write_failure_artifact "jq-missing" "jq is required for deploy-drain OCI runner"
+    exit 1
+  fi
+  start_k6_under_load
+  if ! run_bluegreen_deploy; then
+    cleanup_k6
+    write_failure_artifact "bluegreen-deploy-failed" "blue-green deploy failed while transaction-read k6 was running"
+    exit 1
+  fi
+  if ! wait_for_k6; then
+    write_failure_artifact "k6-run-failed" "transaction-read k6 failed during deploy-drain"
+    exit 1
+  fi
+  collect_k6_summary
+  collect_nginx_access_log
+  collect_hikari_log
+  collect_postgres_wait
+  run_post_deploy_probe
+  write_common_artifacts
+}
+
+write_evidence_env() {
+  mkdir -p "${output_dir}"
+  {
+    printf "DEPLOY_DRAIN_RUNNER_ENV_FORMAT=%q\n" "oci-deploy-drain-v1"
+    printf "DEPLOY_DRAIN_RUNNER_RUN_SCRIPT=%q\n" "${run_script}"
+    printf "DEPLOY_DRAIN_RUNNER_EXECUTED_AT_UTC=%q\n" "${executed_at_utc}"
+    printf "DEPLOY_DRAIN_RUNNER_SOURCE_IPS=%q\n" "1"
+    printf "DEPLOY_DRAIN_RUNNER_K6_SUMMARY_REF=%q\n" "${k6_summary_ref}"
+    printf "DEPLOY_DRAIN_RUNNER_NGINX_ACCESS_REF=%q\n" "${nginx_access_ref}"
+    printf "DEPLOY_DRAIN_RUNNER_SPRING_METRICS_REF=%q\n" "${spring_metrics_ref}"
+    printf "DEPLOY_DRAIN_RUNNER_HIKARI_LOG_REF=%q\n" "${hikari_log_ref}"
+    printf "DEPLOY_DRAIN_RUNNER_POSTGRES_WAIT_REF=%q\n" "${postgres_wait_ref}"
+    printf "DEPLOY_DRAIN_RUNNER_DEPLOY_EVENT_REF=%q\n" "${deploy_event_ref}"
+    printf "DEPLOY_DRAIN_RUNNER_TIMELINE_REF=%q\n" "${timeline_ref}"
+    printf "DEPLOY_DRAIN_RUNNER_DEPLOY_RETRY_CONTRACT_REF=%q\n" "${deploy_retry_contract_ref}"
+    printf "DEPLOY_DRAIN_RUNNER_DEPLOY_499_BUDGET_REF=%q\n" "${deploy_499_budget_ref}"
+    printf "DEPLOY_DRAIN_RUNNER_EDGE_429_RATE=%q\n" "${edge_429_rate}"
+    printf "DEPLOY_DRAIN_RUNNER_BACKEND_429_COUNT=%q\n" "${backend_429_count}"
+    printf "DEPLOY_DRAIN_RUNNER_UNKNOWN_429_COUNT=%q\n" "${unknown_429_count}"
+    printf "DEPLOY_DRAIN_RUNNER_FIVE_XX_COUNT=%q\n" "${five_xx_count}"
+    printf "DEPLOY_DRAIN_RUNNER_NGINX_499_COUNT=%q\n" "${nginx_499_count}"
+    printf "DEPLOY_DRAIN_RUNNER_HIKARI_VALIDATION_WARNINGS=%q\n" "${hikari_validation_warnings}"
+    printf "DEPLOY_DRAIN_RUNNER_DB_POOL_PENDING_MAX=%q\n" "${db_pool_pending_max}"
+    printf "DEPLOY_DRAIN_RUNNER_P95_MS=%q\n" "${p95_ms}"
+    printf "DEPLOY_DRAIN_RUNNER_P99_MS=%q\n" "${p99_ms}"
+    printf "DEPLOY_DRAIN_RUNNER_P999_MS=%q\n" "${p999_ms}"
+    printf "DEPLOY_DRAIN_RUNNER_MAX_MS=%q\n" "${max_ms}"
+    printf "DEPLOY_DRAIN_RUNNER_POSTGRES_CHECKPOINT_COUNT=%q\n" "${postgres_checkpoint_count}"
+    printf "DEPLOY_DRAIN_RUNNER_POSTGRES_TEMP_FILE_COUNT=%q\n" "${postgres_temp_file_count}"
+    printf "DEPLOY_DRAIN_RUNNER_NGINX_UPSTREAM_P95_MS=%q\n" "${nginx_upstream_p95_ms}"
+    printf "DEPLOY_DRAIN_RUNNER_DEPLOY_ACTIONS=%q\n" "${deploy_actions}"
+    printf "DEPLOY_DRAIN_RUNNER_CLIENT_RETRY_SUCCESS_COUNT=%q\n" "${client_retry_success_count}"
+    printf "DEPLOY_DRAIN_RUNNER_DEPLOY_RECONNECT_SUCCESS_COUNT=%q\n" "${deploy_reconnect_success_count}"
+  } >"${evidence_env}"
+}
+
+case "${oci_mode}" in
+  fixture)
+    write_fixture_artifacts
+    ;;
+  live)
+    run_live
+    ;;
+esac
+
+write_evidence_env
+echo "${evidence_env}"


### PR DESCRIPTION
## 🔗 Related Issue
- close #826

## 🌿 Base Branch
- main

## 📝 Summary
- deploy-drain live evidence 기본 경로를 SSE drain smoke에서 transaction-read OCI k6 runner로 승격했습니다.
- live mode는 runner가 반환한 oci-deploy-drain-v1 evidence env 없이는 manifest를 만들지 않고, k6/Nginx/deploy/499/retry artifact를 manifest에 연결합니다.

## 🛠 Changes
- tools/test/run-transaction-read-deploy-drain-oci-k6.sh 추가: transaction-read k6를 백그라운드 실행한 상태에서 ops/deploy/oci/bluegreen-deploy.sh를 실행하는 live runner 계약 추가.
- deploy-drain autogen 기본 runner를 새 OCI k6 runner로 변경하고 live runner evidence env를 manifest에 반영.
- PR contract에 새 runner check와 workflow packages read, github token 전달 계약 추가.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- bash tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh
- bash tools/test/check-transaction-read-deploy-drain-oci-k6.sh
- bash tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh
- bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh
- bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh
- bash tools/test/check-transaction-read-evidence-completeness-gate.sh
- git diff --check

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: workflow_dispatch live run은 staging에서 blue-green deploy를 실제 실행하므로 같은 시각의 staging 사용자가 영향을 받을 수 있음.
- 롤백 방법: 이 PR revert 후 deploy-drain workflow를 이전 autogen runner 계약으로 되돌림.

## ☑️ Checklist
- [x] base branch가 main인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
