### PR TITLE
[Fix] deploy-drain live Nginx 로그 해석 복구

### DIFF
--- a/tools/test/check-transaction-read-deploy-drain-oci-k6.sh
+++ b/tools/test/check-transaction-read-deploy-drain-oci-k6.sh
@@ -35,6 +35,12 @@ if grep -F "https://staging.example.invalid" <<<"${plan}" >/dev/null; then
   exit 1
 fi
 
+echo "[transaction-read-deploy-drain-oci-k6] nginx current-run log fallback contract"
+grep -F 'docker exec "${container}" sh -c' "${runner}" >/dev/null
+grep -F 'docker logs --since "${nginx_log_since}" "${container}"' "${runner}" >/dev/null
+grep -F '"k6_run_id":"${run_id}"' "${runner}" >/dev/null
+grep -F 'nginx-run-lines-missing' "${runner}" >/dev/null
+
 echo "[transaction-read-deploy-drain-oci-k6] fixture generation"
 evidence_env="$(
   DEPLOY_DRAIN_OCI_MODE=fixture \

--- a/tools/test/run-transaction-read-deploy-drain-oci-k6.sh
+++ b/tools/test/run-transaction-read-deploy-drain-oci-k6.sh
@@ -88,6 +88,7 @@ pre_allocated_vus="${DEPLOY_DRAIN_OCI_PRE_ALLOCATED_VUS:-${K6_PRE_ALLOCATED_VUS:
 max_vus="${DEPLOY_DRAIN_OCI_MAX_VUS:-${K6_MAX_VUS:-${pre_allocated_vus}}}"
 workload_weights="${DEPLOY_DRAIN_OCI_WORKLOAD_WEIGHTS:-${K6_WORKLOAD_WEIGHTS:-hot_first:40,hot_cursor:40,hot_deep_cursor:20}}"
 executed_at_utc="${DEPLOY_DRAIN_EXECUTED_AT_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+nginx_log_since="${DEPLOY_DRAIN_OCI_NGINX_LOG_SINCE:-${K6_NGINX_LOG_SINCE:-${executed_at_utc}}}"
 
 backend_image="${DEPLOY_DRAIN_OCI_BACKEND_IMAGE:-${BACKEND_IMAGE:-}}"
 frontend_image="${DEPLOY_DRAIN_OCI_FRONTEND_IMAGE:-${FRONTEND_IMAGE:-}}"
@@ -521,13 +522,57 @@ collect_k6_summary() {
 }
 
 collect_nginx_access_log() {
-  if ! docker exec "${nginx_container}" sh -c 'test -s "$1"' sh "${nginx_access_log}" >/dev/null 2>&1; then
-    write_failure_artifact "nginx-access-log-missing" "Nginx access log is missing in ${nginx_container}"
-    exit 1
+  local container
+  local found_source=false
+  local pattern="\"k6_run_id\":\"${run_id}\""
+  local temp_log="${nginx_access_ref}.tmp"
+  local container_candidates=(
+    "${nginx_container}"
+    "${K6_NGINX_CONTAINER:-}"
+    "${NGINX_CONTAINER:-}"
+    "aquila-bank-nginx"
+    "aquila-nginx"
+    "nginx"
+  )
+
+  if command -v docker >/dev/null 2>&1; then
+    while IFS= read -r container; do
+      container_candidates+=("${container}")
+    done < <(docker ps --format '{{.Names}}' 2>/dev/null | grep -E 'nginx|proxy' || true)
   fi
-  docker exec "${nginx_container}" sh -c 'grep -F "$1" "$2" || true' sh "\"k6_run_id\":\"${run_id}\"" "${nginx_access_log}" >"${nginx_access_ref}"
+
+  : >"${nginx_access_ref}"
+  for container in "${container_candidates[@]}"; do
+    [[ -z "${container}" ]] && continue
+
+    # 운영 Nginx는 access_log 파일 대신 stdout으로 보낼 수 있어 두 경로를 모두 확인한다.
+    if docker exec "${container}" sh -c 'test -s "$1"' sh "${nginx_access_log}" >/dev/null 2>&1; then
+      found_source=true
+      docker exec "${container}" sh -c 'grep -F "$1" "$2" || true' sh "${pattern}" "${nginx_access_log}" >"${nginx_access_ref}"
+      if [[ -s "${nginx_access_ref}" ]]; then
+        break
+      fi
+    fi
+
+    if docker logs --since "${nginx_log_since}" "${container}" >"${temp_log}" 2>/dev/null; then
+      if [[ -s "${temp_log}" ]]; then
+        found_source=true
+      fi
+      grep -F "${pattern}" "${temp_log}" >"${nginx_access_ref}" || true
+      rm -f "${temp_log}"
+      if [[ -s "${nginx_access_ref}" ]]; then
+        break
+      fi
+    fi
+    rm -f "${temp_log}"
+  done
+
   if [[ ! -s "${nginx_access_ref}" ]]; then
-    write_failure_artifact "nginx-run-lines-missing" "Nginx access log has no transaction-read lines for this k6 run id"
+    if [[ "${found_source}" == "true" ]]; then
+      write_failure_artifact "nginx-run-lines-missing" "Nginx access log has no transaction-read lines for this k6 run id"
+    else
+      write_failure_artifact "nginx-access-log-missing" "Nginx access log is missing in ${nginx_container}"
+    fi
     exit 1
   fi
   nginx_499_count="$(grep -c '"status":499' "${nginx_access_ref}" || true)"


### PR DESCRIPTION
## 🔗 Related Issue
- close #828

## 🌿 Base Branch
- `main`

## 📝 Summary
- deploy-drain live runner가 Nginx access log를 파일 경로에서만 찾던 문제를 수정합니다.
- 최신 staging Nginx처럼 access log가 stdout으로 흘러가는 경우에도 `docker logs --since`에서 current-run `k6_run_id` row를 찾아 manifest 생성을 계속합니다.

## 🛠 Changes
- `tools/test/run-transaction-read-deploy-drain-oci-k6.sh`에서 Nginx container 후보를 순회하며 파일 로그와 Docker stdout 로그를 모두 확인하도록 변경
- current-run 로그 row가 없을 때 `nginx-run-lines-missing`, 로그 source 자체가 없을 때 `nginx-access-log-missing`으로 failure artifact 사유 분리
- deploy-drain OCI runner contract check에 stdout fallback 요구 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-deploy-drain-oci-k6.sh`
- `bash tools/test/check-transaction-read-deploy-drain-live-evidence-autogen.sh`
- `bash tools/test/check-transaction-read-deploy-drain-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-deploy-drain-under-load-gate.sh`
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-transaction-read-evidence-completeness-gate.sh`
- `git diff --check`
- 실패 재현 확인: `Transaction Read Deploy Drain Live Evidence` run `25479302655`, failure reason `Nginx access log is missing in aquila-bank-nginx`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: Docker stdout 로그가 과거 로그를 포함할 수 있으나 `k6_run_id`로 current-run row만 필터링한다.
- 롤백 방법: 이 PR 커밋 revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
