### PR TITLE
[Perf] deploy-drain backend admission headroom 완화

### DIFF
--- a/back/src/main/resources/application-oci-a1.yml
+++ b/back/src/main/resources/application-oci-a1.yml
@@ -38,8 +38,8 @@ transaction:
 oci-a1:
   transaction-read:
     admission:
-      # paced-weighted-vu16에서 Hikari pending이 낮아 admission 회복 여지를 둔다.
-      max: ${OCI_A1_TRANSACTION_READ_ADMISSION_MAX:8}
+      # deploy-drain live에서 DB pending 없이 backend 429가 먼저 떠서 기본 headroom만 소폭 올린다.
+      max: ${OCI_A1_TRANSACTION_READ_ADMISSION_MAX:10}
       retry-after-seconds: ${OCI_A1_TRANSACTION_READ_ADMISSION_RETRY_AFTER_SECONDS:0}
       min: ${OCI_A1_TRANSACTION_READ_ADMISSION_MIN:6}
       adaptive-max: ${OCI_A1_TRANSACTION_READ_ADMISSION_ADAPTIVE_MAX:12}

--- a/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/OciA1CapacityProfileTest.java
@@ -71,7 +71,7 @@ class OciA1CapacityProfileTest {
           assertThat(
                   environment.getProperty(
                       "ops.api-admission-control.endpoints[0].max-concurrency", Integer.class))
-              .isEqualTo(8);
+              .isEqualTo(10);
           assertThat(
                   environment.getProperty(
                       "ops.api-admission-control.endpoints[0].retry-after-seconds", Integer.class))
@@ -128,7 +128,7 @@ class OciA1CapacityProfileTest {
           assertThat(
                   environment.getProperty(
                       "ops.api-admission-control.endpoints[1].max-concurrency", Integer.class))
-              .isEqualTo(8);
+              .isEqualTo(10);
         });
   }
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #830

## 🌿 Base Branch
- `main`

## 📝 Summary
- deploy-drain live evidence run 25480435540에서 확인된 `backend429>0` 병목을 OCI A1 transaction-read admission 설정으로 완화한다.
- DB pending/Hikari warning/5xx/499 없이 backend admission이 먼저 거절한 케이스라 pool/thread 확대 없이 기본 admission headroom만 소폭 조정한다.

## 🛠 Changes
- OCI A1 transaction-read admission 기본 max를 `8 -> 10`으로 상향했다.
- archive/hot transaction-read endpoint가 새 기본 max를 바인딩하는지 capacity profile 테스트를 갱신했다.
- adaptive max `12`, min `6`, Hikari/read replica pool/thread 설정은 유지했다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh backend-gradle ./back/gradlew -p back test --tests com.aquilabank.global.config.OciA1CapacityProfileTest`
- `tools/test/with-resource-lock.sh backend-gradle ./back/gradlew -p back test --tests com.aquilabank.global.config.ApiAdmissionControlConfigurationTest --tests com.aquilabank.global.ops.ApiAdmissionControlTest`
- `tools/test/with-resource-lock.sh backend-gradle ./back/gradlew -p back check`
- `git diff --check`
- TDD RED: 설정 변경 전 `OciA1CapacityProfileTest`가 expected max `10`에서 실패하는 것 확인

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: admission 기본 동시성 증가로 deploy-drain 중 backend/DB 순간 부하가 소폭 증가할 수 있다. adaptive max와 DB/thread pool은 그대로 유지해 상한 확대를 제한했다.
- 롤백 방법: `OCI_A1_TRANSACTION_READ_ADMISSION_MAX=8` 환경 변수로 즉시 되돌리거나 이 PR을 revert한다.
- 후속 검증: main merge 후 staging deploy 성공 SHA에서 `Transaction Read Deploy Drain Live Evidence` workflow를 재실행해 `backend_429_count=0`, `5xx=0`, `499=0`, `db_pool_pending_max=0`, `p99.9<=500ms`를 확인한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A