### PR TITLE
[Fix] mixed workload live gate check 실패 반영

### DIFF
--- a/ops/k6/transaction-read-mixed-workload-100m.js
+++ b/ops/k6/transaction-read-mixed-workload-100m.js
@@ -89,6 +89,7 @@ export const options = {
     aquila_mixed_auth_count: ["count>0"],
     aquila_mixed_notification_count: ["count>0"],
     aquila_mixed_sse_connect_count: ["count>0"],
+    checks: ["rate==1"],
     aquila_mixed_5xx_count: ["count==0"],
   },
 };

--- a/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
@@ -22,6 +22,7 @@ grep -F "aquila_mixed_write_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_auth_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_notification_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_sse_connect_count" "${k6_script}" >/dev/null
+grep -F 'checks: ["rate==1"]' "${k6_script}" >/dev/null
 
 temp_dir="$(mktemp -d)"
 trap 'rm -rf "${temp_dir}"' EXIT


### PR DESCRIPTION
## 🔗 Related Issue
- close #844

## 🌿 Base Branch
- `main`

## 📝 Summary
- mixed workload live evidence가 k6 check 실패를 숨기지 않도록 `checks` metric을 hard threshold로 승격한다.
- run `25499695289`에서 `checks.values.fails=5405`인데도 gate가 pass한 false-positive를 막는다.

## 🛠 Changes
- `ops/k6/transaction-read-mixed-workload-100m.js`에 `checks: ["rate==1"]` threshold 추가
- `tools/test/check-transaction-read-mixed-workload-oci-k6.sh`가 check threshold 누락을 잡도록 보강

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh`
- `git diff --check`
- `git rev-list --count main..HEAD`
- run `25499695289` artifact 확인: `checks.values.fails=5405`, `aquila_mixed_write_429_rate.values.rate=0.3985757204851452`, execution gate `pass`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 mixed workload live run이 숨기던 component check 실패를 실제 실패로 드러내 CI/evidence가 red로 바뀔 수 있다.
- 롤백 방법: 이 PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
