### PR TITLE
[Fix] mixed workload k6 실패 summary 수집 복구

### DIFF
--- a/ops/k6/transaction-read-mixed-workload-100m.js
+++ b/ops/k6/transaction-read-mixed-workload-100m.js
@@ -32,6 +32,9 @@ export const mixedReadBackend429Count = new Counter("aquila_mixed_read_backend_4
 export const mixedReadUnknown429Count = new Counter("aquila_mixed_read_unknown_429_count");
 export const mixedWriteCount = new Counter("aquila_mixed_write_count");
 export const mixedWriteDurationMs = new Trend("aquila_mixed_write_duration_ms", true);
+export const mixedWrite2xxCount = new Counter("aquila_mixed_write_2xx_count");
+export const mixedWrite429Count = new Counter("aquila_mixed_write_429_count");
+export const mixedWriteUnexpectedStatusCount = new Counter("aquila_mixed_write_unexpected_status_count");
 export const mixedWrite429Rate = new Rate("aquila_mixed_write_429_rate");
 export const mixedAuthCount = new Counter("aquila_mixed_auth_count");
 export const mixedAuthDurationMs = new Trend("aquila_mixed_auth_duration_ms", true);
@@ -191,9 +194,20 @@ export function transferWrite() {
     },
   });
 
+  const accepted = response.status >= 200 && response.status < 300;
+  const boundedRejected = response.status === 429;
   mixedWriteCount.add(1);
   mixedWriteDurationMs.add(response.timings.duration);
-  mixedWrite429Rate.add(response.status === 429);
+  if (accepted) {
+    mixedWrite2xxCount.add(1);
+  }
+  if (boundedRejected) {
+    mixedWrite429Count.add(1);
+  }
+  if (!accepted && !boundedRejected) {
+    mixedWriteUnexpectedStatusCount.add(1);
+  }
+  mixedWrite429Rate.add(boundedRejected);
   recordFiveXx(response);
 
   check(response, {
@@ -288,6 +302,9 @@ function markdownSummary(data) {
 | read edge 429 rate | ${metricValue(data, "aquila_mixed_read_edge_429_rate", "rate")} |
 | read backend 429 count | ${metricValue(data, "aquila_mixed_read_backend_429_count", "count")} |
 | read unknown 429 count | ${metricValue(data, "aquila_mixed_read_unknown_429_count", "count")} |
+| write 2xx count | ${metricValue(data, "aquila_mixed_write_2xx_count", "count")} |
+| write 429 count | ${metricValue(data, "aquila_mixed_write_429_count", "count")} |
+| write unexpected status count | ${metricValue(data, "aquila_mixed_write_unexpected_status_count", "count")} |
 | 5xx count | ${metricValue(data, "aquila_mixed_5xx_count", "count")} |
 `;
 }

--- a/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
@@ -19,6 +19,9 @@ grep -F "/api/v1/notifications" "${k6_script}" >/dev/null
 grep -F "/api/v1/notifications/stream" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_read_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_write_2xx_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_write_429_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_write_unexpected_status_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_auth_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_notification_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_sse_connect_count" "${k6_script}" >/dev/null
@@ -30,6 +33,63 @@ trap 'rm -rf "${temp_dir}"' EXIT
 output_dir="${temp_dir}/output"
 token_file="${temp_dir}/token.secret"
 printf "secret-token-value\n" >"${token_file}"
+
+fake_bin="${temp_dir}/bin"
+fake_remote_reports="${temp_dir}/remote-reports"
+fake_docker_log="${temp_dir}/fake-docker.log"
+mkdir -p "${fake_bin}" "${fake_remote_reports}"
+cat >"${fake_bin}/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf "%s\n" "$*" >>"${FAKE_DOCKER_LOG}"
+
+last_arg="${!#}"
+if [[ "${last_arg}" == *"-summary.json" ]]; then
+  cat "${FAKE_REMOTE_REPORTS}/${last_arg}"
+  exit 0
+fi
+if [[ "${last_arg}" == *"-summary.md" ]]; then
+  cat "${FAKE_REMOTE_REPORTS}/${last_arg}"
+  exit 0
+fi
+
+if [[ "$*" == *"grafana/k6:0.54.0 run /scripts/transaction-read-mixed-workload-100m.js"* ]]; then
+  mkdir -p "${FAKE_REMOTE_REPORTS}"
+  cat >"${FAKE_REMOTE_REPORTS}/${FAKE_K6_REPORT_NAME}-summary.json" <<JSON
+{
+  "metrics": {
+    "aquila_mixed_read_count": {"values": {"count": 12}},
+    "aquila_mixed_read_duration_ms": {"values": {"p(95)": 80, "p(99)": 120, "p(99.9)": 180, "max": 240}},
+    "aquila_mixed_read_edge_429_rate": {"values": {"rate": 0.01}},
+    "aquila_mixed_read_backend_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_unknown_429_count": {"values": {"count": 0}},
+    "aquila_mixed_write_count": {"values": {"count": 9}},
+    "aquila_mixed_write_duration_ms": {"values": {"p(95)": 95, "p(99)": 140, "p(99.9)": 170, "max": 210}},
+    "aquila_mixed_write_2xx_count": {"values": {"count": 4}},
+    "aquila_mixed_write_429_count": {"values": {"count": 2}},
+    "aquila_mixed_write_unexpected_status_count": {"values": {"count": 3}},
+    "aquila_mixed_write_429_rate": {"values": {"rate": 0.2222222222}},
+    "aquila_mixed_auth_count": {"values": {"count": 3}},
+    "aquila_mixed_auth_duration_ms": {"values": {"p(95)": 42}},
+    "aquila_mixed_notification_count": {"values": {"count": 3}},
+    "aquila_mixed_notification_duration_ms": {"values": {"p(95)": 38}},
+    "aquila_mixed_sse_connect_count": {"values": {"count": 1}},
+    "aquila_mixed_5xx_count": {"values": {"count": 0}},
+    "checks": {"values": {"rate": 0.9, "passes": 18, "fails": 2}}
+  }
+}
+JSON
+  cat >"${FAKE_REMOTE_REPORTS}/${FAKE_K6_REPORT_NAME}-summary.md" <<MD
+# Fake k6 summary
+MD
+  echo "thresholds on metrics 'checks' have been crossed" >&2
+  exit 99
+fi
+
+exit 0
+SH
+chmod +x "${fake_bin}/docker"
 
 echo "[transaction-read-mixed-workload-oci-k6] live plan"
 plan="$(
@@ -108,6 +168,66 @@ grep -F $'mixed-oci-run-fixture\tnginx-edge\t0.08\t0\t0' "${MIXED_WORKLOAD_RUNNE
 echo "[transaction-read-mixed-workload-oci-k6] fixture summary metrics"
 jq -e '.metrics.aquila_mixed_read_count.values.count == 128' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_write_count.values.count == 32' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_write_2xx_count.values.count == 28' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_write_429_count.values.count == 1' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_write_unexpected_status_count.values.count == 3' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_auth_count.values.count == 16' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_notification_count.values.count == 16' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_sse_connect_count.values.count == 1' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+
+test "${MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT}" = "28"
+test "${MIXED_WORKLOAD_RUNNER_WRITE_429_COUNT}" = "1"
+test "${MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT}" = "3"
+grep -F $'write\tpass\t32\t95\t28\t1\t3' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
+
+echo "[transaction-read-mixed-workload-oci-k6] failed k6 still collects summary"
+live_output_dir="${output_dir}/live-threshold-failure"
+set +e
+PATH="${fake_bin}:${PATH}" \
+FAKE_DOCKER_LOG="${fake_docker_log}" \
+FAKE_REMOTE_REPORTS="${fake_remote_reports}" \
+FAKE_K6_REPORT_NAME="mixed-oci-live-failed-k6" \
+MIXED_WORKLOAD_OCI_NAME=mixed-oci-live-failed \
+MIXED_WORKLOAD_OCI_RUN_ID=mixed-oci-run-live-failed \
+MIXED_WORKLOAD_OCI_OUTPUT_DIR="${live_output_dir}" \
+MIXED_WORKLOAD_OCI_K6_REPORT_NAME=mixed-oci-live-failed-k6 \
+MIXED_WORKLOAD_OCI_DOCKER_CONTEXT=oci-k6-generator \
+MIXED_WORKLOAD_OCI_BASE_URL=http://192.0.2.20:8080 \
+MIXED_WORKLOAD_OCI_REMOTE_WORKDIR=/srv/aquila-bank \
+MIXED_WORKLOAD_OCI_DURATION=30m \
+MIXED_WORKLOAD_OCI_HOT_ACCOUNT_ID=101 \
+MIXED_WORKLOAD_OCI_HOT_FROM=2026-04-01T00:00:00Z \
+MIXED_WORKLOAD_OCI_HOT_TO=2026-04-30T23:59:59Z \
+MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID=202 \
+MIXED_WORKLOAD_OCI_COLD_FROM=2026-01-01T00:00:00Z \
+MIXED_WORKLOAD_OCI_COLD_TO=2026-01-31T23:59:59Z \
+MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID=920000001 \
+MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID=920000002 \
+MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE="${token_file}" \
+  bash "${runner}" >"${temp_dir}/live-failed.log" 2>"${temp_dir}/live-failed.err"
+live_failed_status="$?"
+set -e
+test "${live_failed_status}" = "99"
+live_generated_env="$(awk 'NF { line = $0 } END { print line }' "${temp_dir}/live-failed.log")"
+test -f "${live_generated_env}"
+
+# shellcheck disable=SC1090
+source "${live_generated_env}"
+test -f "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}"
+test -f "${live_output_dir}/mixed-oci-live-failed-oci-mixed-failure.md"
+jq -e '.metrics.aquila_mixed_write_2xx_count.values.count == 4' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_write_429_count.values.count == 2' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_write_unexpected_status_count.values.count == 3' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+test "${MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT}" = "4"
+test "${MIXED_WORKLOAD_RUNNER_WRITE_429_COUNT}" = "2"
+test "${MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT}" = "3"
+grep -F $'write\tpass\t9\t95\t4\t2\t3' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
+grep -F "OCI mixed workload k6 run failed" "${temp_dir}/live-failed.err" >/dev/null
+if grep -F "secret-token-value" "${temp_dir}/live-failed.log" "${temp_dir}/live-failed.err" >/dev/null; then
+  echo "auth token leaked into failed live mixed workload output" >&2
+  exit 1
+fi
+if grep -F "http://192.0.2.20:8080" "${temp_dir}/live-failed.log" "${temp_dir}/live-failed.err" >/dev/null; then
+  echo "raw OCI base URL leaked into failed live mixed workload output" >&2
+  exit 1
+fi

--- a/tools/test/run-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/run-transaction-read-mixed-workload-oci-k6.sh
@@ -84,6 +84,7 @@ read_429_source_ref="${generated_dir}/${name}-read-429-source.tsv"
 runner_log_ref="${generated_dir}/${name}-runner.log"
 failure_env="${output_dir}/${name}-oci-mixed-failure.env"
 failure_md="${output_dir}/${name}-oci-mixed-failure.md"
+k6_exit_status=0
 
 auth_token_source="missing"
 
@@ -221,6 +222,9 @@ write_fixture_summary() {
     "aquila_mixed_read_unknown_429_count": {"values": {"count": 0}},
     "aquila_mixed_write_count": {"values": {"count": 32}},
     "aquila_mixed_write_duration_ms": {"values": {"p(95)": 95, "p(99)": 180, "p(99.9)": 240, "max": 300}},
+    "aquila_mixed_write_2xx_count": {"values": {"count": 28}},
+    "aquila_mixed_write_429_count": {"values": {"count": 1}},
+    "aquila_mixed_write_unexpected_status_count": {"values": {"count": 3}},
     "aquila_mixed_write_429_rate": {"values": {"rate": 0.01}},
     "aquila_mixed_auth_count": {"values": {"count": 16}},
     "aquila_mixed_auth_duration_ms": {"values": {"p(95)": 42, "p(99)": 60, "p(99.9)": 70, "max": 75}},
@@ -265,7 +269,7 @@ write_component_artifacts() {
   mkdir -p "${generated_dir}"
   local read_count write_count auth_count notification_count sse_count
   local read_p95 read_p99 read_p999 read_max edge_429_rate backend_429_count unknown_429_count five_xx_count
-  local write_p95 auth_p95 notification_p95 outbox_lag_max
+  local write_p95 write_2xx_count write_429_count write_unexpected_status_count auth_p95 notification_p95 outbox_lag_max
 
   read_count="$(metric_count aquila_mixed_read_count)"
   write_count="$(metric_count aquila_mixed_write_count)"
@@ -277,6 +281,9 @@ write_component_artifacts() {
   read_p999="$(metric_value aquila_mixed_read_duration_ms "p(99.9)" "0")"
   read_max="$(metric_value aquila_mixed_read_duration_ms "max" "0")"
   write_p95="$(metric_value aquila_mixed_write_duration_ms "p(95)" "0")"
+  write_2xx_count="$(metric_count aquila_mixed_write_2xx_count)"
+  write_429_count="$(metric_count aquila_mixed_write_429_count)"
+  write_unexpected_status_count="$(metric_count aquila_mixed_write_unexpected_status_count)"
   auth_p95="$(metric_value aquila_mixed_auth_duration_ms "p(95)" "0")"
   notification_p95="$(metric_value aquila_mixed_notification_duration_ms "p(95)" "0")"
   edge_429_rate="$(metric_value aquila_mixed_read_edge_429_rate "rate" "0")"
@@ -325,12 +332,12 @@ JSON
 }
 JSON
   cat >"${workload_component_ref}" <<TSV
-component	status	count	p95_ms
-read	$(component_status "${read_count}")	${read_count}	${read_p95}
-write	$(component_status "${write_count}")	${write_count}	${write_p95}
-auth	$(component_status "${auth_count}")	${auth_count}	${auth_p95}
-notification	$(component_status "${notification_count}")	${notification_count}	${notification_p95}
-sse	$(component_status "${sse_count}")	${sse_count}	0
+component	status	count	p95_ms	write_2xx_count	write_429_count	write_unexpected_status_count
+read	$(component_status "${read_count}")	${read_count}	${read_p95}	0	0	0
+write	$(component_status "${write_count}")	${write_count}	${write_p95}	${write_2xx_count}	${write_429_count}	${write_unexpected_status_count}
+auth	$(component_status "${auth_count}")	${auth_count}	${auth_p95}	0	0	0
+notification	$(component_status "${notification_count}")	${notification_count}	${notification_p95}	0	0	0
+sse	$(component_status "${sse_count}")	${sse_count}	0	0	0	0
 TSV
   cat >"${outbox_lag_ref}" <<'TSV'
 run_id	outbox_lag_max
@@ -359,6 +366,9 @@ TSV
     printf "MIXED_WORKLOAD_RUNNER_EDGE_429_RATE=%q\n" "${edge_429_rate}"
     printf "MIXED_WORKLOAD_RUNNER_BACKEND_429_COUNT=%q\n" "${backend_429_count}"
     printf "MIXED_WORKLOAD_RUNNER_UNKNOWN_429_COUNT=%q\n" "${unknown_429_count}"
+    printf "MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT=%q\n" "${write_2xx_count}"
+    printf "MIXED_WORKLOAD_RUNNER_WRITE_429_COUNT=%q\n" "${write_429_count}"
+    printf "MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT=%q\n" "${write_unexpected_status_count}"
     printf "MIXED_WORKLOAD_RUNNER_FIVE_XX_COUNT=%q\n" "${five_xx_count}"
     printf "MIXED_WORKLOAD_RUNNER_NGINX_499_COUNT=%q\n" "0"
     printf "MIXED_WORKLOAD_RUNNER_HIKARI_VALIDATION_WARNINGS=%q\n" "0"
@@ -405,7 +415,8 @@ run_live_k6() {
     exit 1
   fi
   prepare_remote_report_dir_permissions
-  if ! docker --context "${docker_context}" run --rm \
+  set +e
+  docker --context "${docker_context}" run --rm \
     -e BASE_URL="${base_url}" \
     -e K6_REPORT_NAME="${k6_report_name}" \
     -e K6_RUN_ID="${run_id}" \
@@ -429,9 +440,11 @@ run_live_k6() {
     -v "${remote_workdir}/ops/k6:/scripts:ro" \
     -v "${remote_workdir}/build/reports/k6:/reports" \
     grafana/k6:0.54.0 \
-    run /scripts/transaction-read-mixed-workload-100m.js >"${runner_log_ref}" 2>&1; then
+    run /scripts/transaction-read-mixed-workload-100m.js >"${runner_log_ref}" 2>&1
+  k6_exit_status="$?"
+  set -e
+  if [[ "${k6_exit_status}" -ne 0 ]]; then
     write_failure_artifact "k6-run-failed" "OCI mixed workload k6 run failed"
-    exit 1
   fi
   if ! collect_remote_artifact_file "${k6_report_name}-summary.json" "${k6_summary_ref}"; then
     write_failure_artifact "summary-json-missing" "OCI mixed workload k6 summary JSON was not collected"
@@ -456,3 +469,6 @@ fi
 
 write_component_artifacts
 echo "${evidence_env}"
+if [[ "${k6_exit_status}" -ne 0 ]]; then
+  exit "${k6_exit_status}"
+fi


### PR DESCRIPTION
## 🔗 Related Issue
- close #848

## 🌿 Base Branch
- `main`

## 📝 Summary
- mixed workload live k6가 `checks` threshold 실패로 non-zero 종료해도 summary JSON/markdown을 먼저 수집하도록 runner 흐름을 바꿉니다.
- transfer write 응답을 2xx, 429, unexpected 상태 카운트로 분리해 다음 live artifact에서 실제 실패 원인을 확인할 수 있게 합니다.

## 🛠 Changes
- `ops/k6/transaction-read-mixed-workload-100m.js`: transfer write 상태 카운터와 markdown summary 항목 추가
- `tools/test/run-transaction-read-mixed-workload-oci-k6.sh`: k6 실패 exit code 유지, summary 수집 및 evidence env 출력 보장
- `tools/test/check-transaction-read-mixed-workload-oci-k6.sh`: fake docker 기반 threshold 실패 계약 테스트 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh`
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-transaction-read-evidence-completeness-gate.sh`
- `git diff --check main..HEAD`
- `git rev-list --count main..HEAD` -> `1`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: failed k6 run에서도 summary artifact가 추가로 남아 artifact 구성이 늘어난다. threshold 실패 exit code는 유지되므로 gate 의미는 바뀌지 않는다.
- 롤백 방법: PR revert. k6/live runner 계약만 되돌리며 거래/원장 도메인 영향은 없다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
