### PR TITLE
[Test] mixed workload live fixture coverage closure

### DIFF
--- a/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
+++ b/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
@@ -17,6 +17,9 @@ on:
     paths:
       - ".github/workflows/transaction-read-mixed-workload-live-evidence.yml"
       - "ops/k6/transaction-read-mixed-workload-100m.js"
+      - "tools/ops/staging-fixture-principal-bootstrap.sh"
+      - "tools/ops/resolve-oci-a1-staging-database-url.sh"
+      - "tools/test/run-staging-fixture-principal-bootstrap-contract.sh"
       - "tools/test/run-transaction-read-mixed-workload-oci-k6.sh"
       - "tools/test/check-transaction-read-mixed-workload-oci-k6.sh"
       - "tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh"
@@ -48,6 +51,9 @@ jobs:
 
       - name: Check mixed workload live evidence workflow
         run: bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+
+      - name: Check staging fixture principal contract
+        run: bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh
 
       - name: Check OCI mixed workload k6 runner contract
         run: bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh
@@ -152,6 +158,29 @@ jobs:
           printf 'MIXED_WORKLOAD_OCI_COLD_TO=%s\n' "${MIXED_WORKLOAD_OCI_COLD_TO}" >>"${GITHUB_ENV}"
           printf 'MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID=%s\n' "${MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID}" >>"${GITHUB_ENV}"
           printf 'MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID=%s\n' "${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID}" >>"${GITHUB_ENV}"
+
+      - name: Resolve mixed workload staging database URL
+        if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"; then
+            echo "::error::Failed to resolve mixed workload staging database URL."
+            exit 1
+          fi
+          echo "::add-mask::${resolved_database_url}"
+          printf 'STAGING_OCI_A1_DATABASE_URL=%s\n' "${resolved_database_url}" >>"${GITHUB_ENV}"
+
+      - name: Ensure mixed workload fixture principal
+        if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          HOT_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_HOT_ACCOUNT_ID}" \
+          COLD_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID}" \
+          STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID}" \
+          STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID}" \
+            tools/ops/staging-fixture-principal-bootstrap.sh
 
       - name: Generate mixed workload live evidence manifest artifacts
         if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'

--- a/ops/k6/transaction-read-mixed-workload-100m.js
+++ b/ops/k6/transaction-read-mixed-workload-100m.js
@@ -9,10 +9,13 @@ const duration = __ENV.K6_MIXED_DURATION || __ENV.K6_DURATION || "30m";
 const authToken = __ENV.K6_AUTH_TOKEN || "";
 const hotAccountId = __ENV.K6_HOT_ACCOUNT_ID || "";
 const coldAccountId = __ENV.K6_COLD_ACCOUNT_ID || "";
+const archiveAccountId = __ENV.K6_ARCHIVE_ACCOUNT_ID || coldAccountId;
 const hotFrom = __ENV.K6_HOT_FROM || "";
 const hotTo = __ENV.K6_HOT_TO || "";
 const coldFrom = __ENV.K6_COLD_FROM || "";
 const coldTo = __ENV.K6_COLD_TO || "";
+const archiveFrom = __ENV.K6_ARCHIVE_FROM || coldFrom;
+const archiveTo = __ENV.K6_ARCHIVE_TO || coldTo;
 const writeSourceAccountId = __ENV.K6_WRITE_SOURCE_ACCOUNT_ID || "";
 const writeTargetAccountId = __ENV.K6_WRITE_TARGET_ACCOUNT_ID || "";
 const writeAmountMinor = Number(__ENV.K6_WRITE_AMOUNT_MINOR || "1");
@@ -30,11 +33,31 @@ export const mixedReadDurationMs = new Trend("aquila_mixed_read_duration_ms", tr
 export const mixedReadEdge429Rate = new Rate("aquila_mixed_read_edge_429_rate");
 export const mixedReadBackend429Count = new Counter("aquila_mixed_read_backend_429_count");
 export const mixedReadUnknown429Count = new Counter("aquila_mixed_read_unknown_429_count");
+export const mixedReadHotCount = new Counter("aquila_mixed_read_hot_count");
+export const mixedReadHotDurationMs = new Trend("aquila_mixed_read_hot_duration_ms", true);
+export const mixedReadHotEdge429Rate = new Rate("aquila_mixed_read_hot_edge_429_rate");
+export const mixedReadHotBackend429Count = new Counter("aquila_mixed_read_hot_backend_429_count");
+export const mixedReadHotUnknown429Count = new Counter("aquila_mixed_read_hot_unknown_429_count");
+export const mixedReadColdCount = new Counter("aquila_mixed_read_cold_count");
+export const mixedReadColdDurationMs = new Trend("aquila_mixed_read_cold_duration_ms", true);
+export const mixedReadColdEdge429Rate = new Rate("aquila_mixed_read_cold_edge_429_rate");
+export const mixedReadColdBackend429Count = new Counter("aquila_mixed_read_cold_backend_429_count");
+export const mixedReadColdUnknown429Count = new Counter("aquila_mixed_read_cold_unknown_429_count");
+export const mixedReadArchiveCount = new Counter("aquila_mixed_read_archive_count");
+export const mixedReadArchiveDurationMs = new Trend("aquila_mixed_read_archive_duration_ms", true);
+export const mixedReadArchiveEdge429Rate = new Rate("aquila_mixed_read_archive_edge_429_rate");
+export const mixedReadArchiveBackend429Count = new Counter("aquila_mixed_read_archive_backend_429_count");
+export const mixedReadArchiveUnknown429Count = new Counter("aquila_mixed_read_archive_unknown_429_count");
 export const mixedWriteCount = new Counter("aquila_mixed_write_count");
 export const mixedWriteDurationMs = new Trend("aquila_mixed_write_duration_ms", true);
 export const mixedWrite2xxCount = new Counter("aquila_mixed_write_2xx_count");
 export const mixedWrite429Count = new Counter("aquila_mixed_write_429_count");
 export const mixedWriteUnexpectedStatusCount = new Counter("aquila_mixed_write_unexpected_status_count");
+export const mixedWrite401Count = new Counter("aquila_mixed_write_401_count");
+export const mixedWrite403Count = new Counter("aquila_mixed_write_403_count");
+export const mixedWrite409Count = new Counter("aquila_mixed_write_409_count");
+export const mixedWrite422Count = new Counter("aquila_mixed_write_422_count");
+export const mixedWriteOtherUnexpectedCount = new Counter("aquila_mixed_write_other_unexpected_count");
 export const mixedWrite429Rate = new Rate("aquila_mixed_write_429_rate");
 export const mixedAuthCount = new Counter("aquila_mixed_auth_count");
 export const mixedAuthDurationMs = new Trend("aquila_mixed_auth_duration_ms", true);
@@ -88,6 +111,9 @@ export const options = {
   },
   thresholds: {
     aquila_mixed_read_count: ["count>0"],
+    aquila_mixed_read_hot_count: ["count>0"],
+    aquila_mixed_read_cold_count: ["count>0"],
+    aquila_mixed_read_archive_count: ["count>0"],
     aquila_mixed_write_count: ["count>0"],
     aquila_mixed_auth_count: ["count>0"],
     aquila_mixed_notification_count: ["count>0"],
@@ -135,20 +161,87 @@ function recordFiveXx(response) {
   }
 }
 
+function readTarget(iteration) {
+  const bucketIndex = iteration % 3;
+  if (bucketIndex === 0) {
+    return {
+      bucket: "hot",
+      accountId: hotAccountId,
+      from: hotFrom,
+      to: hotTo,
+      path: "/api/v1/transactions",
+    };
+  }
+  if (bucketIndex === 1) {
+    return {
+      bucket: "cold",
+      accountId: coldAccountId,
+      from: coldFrom,
+      to: coldTo,
+      path: "/api/v1/transactions",
+    };
+  }
+  return {
+    bucket: "archive",
+    accountId: archiveAccountId,
+    from: archiveFrom,
+    to: archiveTo,
+    path: "/api/v1/transactions/archive",
+  };
+}
+
+function recordBucketRead(bucket, response, edgeRejected, backendRejected) {
+  const unknownRejected = response.status === 429 && !edgeRejected && !backendRejected;
+  if (bucket === "hot") {
+    mixedReadHotCount.add(1);
+    mixedReadHotDurationMs.add(response.timings.duration);
+    mixedReadHotEdge429Rate.add(edgeRejected);
+    if (backendRejected) {
+      mixedReadHotBackend429Count.add(1);
+    }
+    if (unknownRejected) {
+      mixedReadHotUnknown429Count.add(1);
+    }
+    return;
+  }
+  if (bucket === "cold") {
+    mixedReadColdCount.add(1);
+    mixedReadColdDurationMs.add(response.timings.duration);
+    mixedReadColdEdge429Rate.add(edgeRejected);
+    if (backendRejected) {
+      mixedReadColdBackend429Count.add(1);
+    }
+    if (unknownRejected) {
+      mixedReadColdUnknown429Count.add(1);
+    }
+    return;
+  }
+  mixedReadArchiveCount.add(1);
+  mixedReadArchiveDurationMs.add(response.timings.duration);
+  mixedReadArchiveEdge429Rate.add(edgeRejected);
+  if (backendRejected) {
+    mixedReadArchiveBackend429Count.add(1);
+  }
+  if (unknownRejected) {
+    mixedReadArchiveUnknown429Count.add(1);
+  }
+}
+
 export function transactionRead() {
-  const accountId = __ITER % 2 === 0 ? hotAccountId : coldAccountId;
-  const from = __ITER % 2 === 0 ? hotFrom : coldFrom;
-  const to = __ITER % 2 === 0 ? hotTo : coldTo;
+  const target = readTarget(__ITER);
   requireInput("K6_HOT_ACCOUNT_ID", hotAccountId);
   requireInput("K6_COLD_ACCOUNT_ID", coldAccountId);
+  requireInput("K6_ARCHIVE_ACCOUNT_ID", archiveAccountId);
   requireInput("K6_HOT_FROM", hotFrom);
   requireInput("K6_HOT_TO", hotTo);
   requireInput("K6_COLD_FROM", coldFrom);
   requireInput("K6_COLD_TO", coldTo);
+  requireInput("K6_ARCHIVE_FROM", archiveFrom);
+  requireInput("K6_ARCHIVE_TO", archiveTo);
 
   const response = http.get(
-    `${baseUrl}/api/v1/transactions?accountId=${accountId}&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&limit=${limit}`,
-    { headers: headers(accountId, "k6-mixed-read") },
+    `${baseUrl}${target.path}?accountId=${target.accountId}&from=${encodeURIComponent(target.from)}&to=${encodeURIComponent(target.to)}&limit=${limit}`,
+    { headers: headers(target.accountId, `k6-mixed-read-${target.bucket}`) },
   );
   const edgeRejected = response.status === 429 && !response.headers["X-Aquila-429-Source"];
   const backendRejected = response.status === 429 && !!response.headers["X-Aquila-429-Source"];
@@ -156,6 +249,7 @@ export function transactionRead() {
   mixedReadCount.add(1);
   mixedReadDurationMs.add(response.timings.duration);
   mixedReadEdge429Rate.add(edgeRejected);
+  recordBucketRead(target.bucket, response, edgeRejected, backendRejected);
   if (backendRejected) {
     mixedReadBackend429Count.add(1);
   }
@@ -206,6 +300,17 @@ export function transferWrite() {
   }
   if (!accepted && !boundedRejected) {
     mixedWriteUnexpectedStatusCount.add(1);
+    if (response.status === 401) {
+      mixedWrite401Count.add(1);
+    } else if (response.status === 403) {
+      mixedWrite403Count.add(1);
+    } else if (response.status === 409) {
+      mixedWrite409Count.add(1);
+    } else if (response.status === 422) {
+      mixedWrite422Count.add(1);
+    } else {
+      mixedWriteOtherUnexpectedCount.add(1);
+    }
   }
   mixedWrite429Rate.add(boundedRejected);
   recordFiveXx(response);
@@ -302,9 +407,17 @@ function markdownSummary(data) {
 | read edge 429 rate | ${metricValue(data, "aquila_mixed_read_edge_429_rate", "rate")} |
 | read backend 429 count | ${metricValue(data, "aquila_mixed_read_backend_429_count", "count")} |
 | read unknown 429 count | ${metricValue(data, "aquila_mixed_read_unknown_429_count", "count")} |
+| hot read p95 ms | ${metricValue(data, "aquila_mixed_read_hot_duration_ms", "p(95)")} |
+| cold read p95 ms | ${metricValue(data, "aquila_mixed_read_cold_duration_ms", "p(95)")} |
+| archive read p95 ms | ${metricValue(data, "aquila_mixed_read_archive_duration_ms", "p(95)")} |
 | write 2xx count | ${metricValue(data, "aquila_mixed_write_2xx_count", "count")} |
 | write 429 count | ${metricValue(data, "aquila_mixed_write_429_count", "count")} |
 | write unexpected status count | ${metricValue(data, "aquila_mixed_write_unexpected_status_count", "count")} |
+| write 401 count | ${metricValue(data, "aquila_mixed_write_401_count", "count")} |
+| write 403 count | ${metricValue(data, "aquila_mixed_write_403_count", "count")} |
+| write 409 count | ${metricValue(data, "aquila_mixed_write_409_count", "count")} |
+| write 422 count | ${metricValue(data, "aquila_mixed_write_422_count", "count")} |
+| write other unexpected count | ${metricValue(data, "aquila_mixed_write_other_unexpected_count", "count")} |
 | 5xx count | ${metricValue(data, "aquila_mixed_5xx_count", "count")} |
 `;
 }

--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -14,6 +14,12 @@ HOT_ACCOUNT_IDS="${HOT_ACCOUNT_IDS:-${STAGING_REPLAY_HOT_ACCOUNT_IDS:-${HOT_ACCO
 COLD_ACCOUNT_IDS="${COLD_ACCOUNT_IDS:-${STAGING_REPLAY_COLD_ACCOUNT_IDS:-${COLD_ACCOUNT_ID}}}"
 STAGING_REPLAY_HOT_ACCOUNT_NUMBER="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER:-}"
 STAGING_REPLAY_COLD_ACCOUNT_NUMBER="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER:-}"
+STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID="${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID:-${MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID:-${K6_WRITE_SOURCE_ACCOUNT_ID:-}}}"
+STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID="${STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID:-${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID:-${K6_WRITE_TARGET_ACCOUNT_ID:-}}}"
+STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_NUMBER="${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_NUMBER:-}"
+STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_NUMBER="${STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_NUMBER:-}"
+STAGING_MIXED_WORKLOAD_WRITE_SOURCE_BALANCE_MINOR="${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_BALANCE_MINOR:-50000000}"
+STAGING_MIXED_WORKLOAD_WRITE_TARGET_BALANCE_MINOR="${STAGING_MIXED_WORKLOAD_WRITE_TARGET_BALANCE_MINOR:-0}"
 STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS="${STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS:-3}"
 STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS="${STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS:-5}"
 
@@ -98,6 +104,29 @@ require_account_number_lengths() {
   done
 }
 
+validate_optional_write_accounts() {
+  local has_source=false
+  local has_target=false
+  [[ -n "${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID}" ]] && has_source=true
+  [[ -n "${STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID}" ]] && has_target=true
+  if [[ "${has_source}" == "false" && "${has_target}" == "false" ]]; then
+    return
+  fi
+  [[ "${has_source}" == "true" ]] || fail "STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID is required when write target is set"
+  [[ "${has_target}" == "true" ]] || fail "STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID is required when write source is set"
+  require_positive_integer STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID
+  require_positive_integer STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID
+  if [[ "${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID}" == "${STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID}" ]]; then
+    fail "STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID and STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID must differ"
+  fi
+  require_positive_integer STAGING_MIXED_WORKLOAD_WRITE_SOURCE_BALANCE_MINOR
+  require_non_negative_integer STAGING_MIXED_WORKLOAD_WRITE_TARGET_BALANCE_MINOR
+  STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_NUMBER="${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_NUMBER:-STG-WR-SRC-${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID}}"
+  STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_NUMBER="${STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_NUMBER:-STG-WR-TGT-${STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID}}"
+  require_max_length STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_NUMBER 20
+  require_max_length STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_NUMBER 20
+}
+
 validate_inputs() {
   require_command psql
   require_env STAGING_DATABASE_URL
@@ -120,6 +149,7 @@ validate_inputs() {
   require_max_length STAGING_REPLAY_COLD_ACCOUNT_NUMBER 20
   require_account_number_lengths "HOT_ACCOUNT_IDS" "${HOT_ACCOUNT_IDS}" "${STAGING_REPLAY_HOT_ACCOUNT_NUMBER}" "STG-HOT-"
   require_account_number_lengths "COLD_ACCOUNT_IDS" "${COLD_ACCOUNT_IDS}" "${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" "STG-COLD-"
+  validate_optional_write_accounts
   require_positive_integer STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS
   require_non_negative_integer STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS
 }
@@ -139,7 +169,13 @@ ensure_fixture_principal() {
     -v hot_account_ids="${HOT_ACCOUNT_IDS}" \
     -v cold_account_ids="${COLD_ACCOUNT_IDS}" \
     -v hot_account_number="${STAGING_REPLAY_HOT_ACCOUNT_NUMBER}" \
-    -v cold_account_number="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" <<'SQL'
+    -v cold_account_number="${STAGING_REPLAY_COLD_ACCOUNT_NUMBER}" \
+    -v write_source_account_id="${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID}" \
+    -v write_target_account_id="${STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID}" \
+    -v write_source_account_number="${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_NUMBER}" \
+    -v write_target_account_number="${STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_NUMBER}" \
+    -v write_source_balance_minor="${STAGING_MIXED_WORKLOAD_WRITE_SOURCE_BALANCE_MINOR}" \
+    -v write_target_balance_minor="${STAGING_MIXED_WORKLOAD_WRITE_TARGET_BALANCE_MINOR}" <<'SQL'
       -- psql 변수(:name)는 -c 경로에서 치환되지 않아 stdin으로 전달한다.
       BEGIN;
 
@@ -149,28 +185,64 @@ ensure_fixture_principal() {
               'hot' AS account_group,
               0 AS group_rank,
               hot.ordinal,
-              hot.account_id_text::bigint AS account_id
+              hot.account_id_text::bigint AS account_id,
+              CASE
+                  WHEN hot.ordinal = 1 THEN :'hot_account_number'
+                  ELSE concat('STG-HOT-', hot.account_id_text)
+              END AS account_number,
+              'Staging hot fixture account' AS display_name,
+              0::bigint AS desired_available_balance_minor
           FROM regexp_split_to_table(:'hot_account_ids', ',') WITH ORDINALITY AS hot(account_id_text, ordinal)
           UNION ALL
           SELECT
               'cold' AS account_group,
               1 AS group_rank,
               cold.ordinal,
-              cold.account_id_text::bigint AS account_id
+              cold.account_id_text::bigint AS account_id,
+              CASE
+                  WHEN cold.ordinal = 1 THEN :'cold_account_number'
+                  ELSE concat('STG-COLD-', cold.account_id_text)
+              END AS account_number,
+              'Staging cold fixture account' AS display_name,
+              0::bigint AS desired_available_balance_minor
           FROM regexp_split_to_table(:'cold_account_ids', ',') WITH ORDINALITY AS cold(account_id_text, ordinal)
+          UNION ALL
+          SELECT
+              'write_source' AS account_group,
+              2 AS group_rank,
+              1 AS ordinal,
+              NULLIF(:'write_source_account_id', '')::bigint AS account_id,
+              :'write_source_account_number' AS account_number,
+              'Staging mixed workload write source account' AS display_name,
+              :'write_source_balance_minor'::bigint AS desired_available_balance_minor
+          WHERE NULLIF(:'write_source_account_id', '') IS NOT NULL
+          UNION ALL
+          SELECT
+              'write_target' AS account_group,
+              3 AS group_rank,
+              1 AS ordinal,
+              NULLIF(:'write_target_account_id', '')::bigint AS account_id,
+              :'write_target_account_number' AS account_number,
+              'Staging mixed workload write target account' AS display_name,
+              :'write_target_balance_minor'::bigint AS desired_available_balance_minor
+          WHERE NULLIF(:'write_target_account_id', '') IS NOT NULL
+      ),
+      fixture_accounts AS (
+          SELECT
+              account_id,
+              account_number,
+              display_name,
+              max(desired_available_balance_minor) OVER (PARTITION BY account_id) AS desired_available_balance_minor,
+              group_rank,
+              ordinal
+          FROM raw_fixture_accounts
       )
       SELECT DISTINCT ON (account_id)
           account_id,
-          CASE
-              WHEN account_group = 'hot' AND ordinal = 1 THEN :'hot_account_number'
-              WHEN account_group = 'cold' AND ordinal = 1 THEN :'cold_account_number'
-              ELSE concat('STG-', upper(account_group), '-', account_id::text)
-          END AS account_number,
-          CASE
-              WHEN account_group = 'hot' THEN 'Staging hot fixture account'
-              ELSE 'Staging cold fixture account'
-          END AS display_name
-      FROM raw_fixture_accounts
+          account_number,
+          display_name,
+          desired_available_balance_minor
+      FROM fixture_accounts
       ORDER BY account_id, group_rank, ordinal;
 
       INSERT INTO bank_account (
@@ -208,14 +280,15 @@ ensure_fixture_principal() {
       SELECT
           account_id,
           0,
-          0,
+          desired_available_balance_minor,
           0,
           'KRW',
           CURRENT_TIMESTAMP
       FROM staging_fixture_accounts
       ON CONFLICT (account_id)
       DO UPDATE
-      SET currency_code = EXCLUDED.currency_code,
+      SET available_balance_minor = GREATEST(account_balance_snapshot.available_balance_minor, EXCLUDED.available_balance_minor),
+          currency_code = EXCLUDED.currency_code,
           updated_at = CURRENT_TIMESTAMP;
 
       INSERT INTO bank_user (

--- a/tools/test/check-transaction-read-mixed-workload-30m-timeline.sh
+++ b/tools/test/check-transaction-read-mixed-workload-30m-timeline.sh
@@ -16,11 +16,11 @@ mkdir -p "${artifact_dir}"
 touch "${artifact_dir}/k6.json" "${artifact_dir}/nginx.jsonl" "${artifact_dir}/spring.json" \
   "${artifact_dir}/hikari.log" "${artifact_dir}/postgres.tsv" "${artifact_dir}/timeline.json" \
   "${artifact_dir}/workload-mix.json" "${artifact_dir}/workload-components.tsv" "${artifact_dir}/outbox-lag.tsv" \
-  "${artifact_dir}/read-429-source.tsv"
+  "${artifact_dir}/read-429-source.tsv" "${artifact_dir}/read-buckets.tsv" "${artifact_dir}/write-status.tsv"
 
 cat >"${input_tsv}" <<TSV
-scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	workload_components	read_p999_ms	read_429_source_ref
-mixed-workload-30m	run-mixed-001	2026-05-02T02:00:00Z	30	1	tools/test/run-t3micro-mixed-workload-soak.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.08	0	0	0	0	0	0	450	${artifact_dir}/workload-mix.json	${artifact_dir}/workload-components.tsv	${artifact_dir}/outbox-lag.tsv	0	read,write,auth,notification,sse	440	${artifact_dir}/read-429-source.tsv
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	workload_components	read_p999_ms	read_429_source_ref	read_buckets	read_bucket_ref	write_2xx_count	write_unexpected_status_count	write_status_ref
+mixed-workload-30m	run-mixed-001	2026-05-02T02:00:00Z	30	1	tools/test/run-t3micro-mixed-workload-soak.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.08	0	0	0	0	0	0	450	${artifact_dir}/workload-mix.json	${artifact_dir}/workload-components.tsv	${artifact_dir}/outbox-lag.tsv	0	read,write,auth,notification,sse	440	${artifact_dir}/read-429-source.tsv	hot,cold,archive	${artifact_dir}/read-buckets.tsv	4	0	${artifact_dir}/write-status.tsv
 TSV
 
 echo "[transaction-read-mixed-30m-timeline] print plan"
@@ -50,6 +50,8 @@ grep -F "Prometheus/Grafana long timeline artifact: required" "${report_md}" >/d
 grep -F "p95/p99.9, 429 source, 499/5xx, Hikari pending/warning hard gate" "${report_md}" >/dev/null
 grep -F "read/write/auth/notification/SSE components: required" "${report_md}" >/dev/null
 grep -F "read p99.9 and 429 source artifact: required" "${report_md}" >/dev/null
+grep -F "hot/cold/archive read bucket artifact: required" "${report_md}" >/dev/null
+grep -F "write 2xx and status classification artifact: required" "${report_md}" >/dev/null
 grep -F "workload mix/component and outbox lag artifact: required" "${report_md}" >/dev/null
 
 echo "[transaction-read-mixed-30m-timeline] unknown 429 fails"
@@ -79,5 +81,25 @@ if MIXED_30M_TIMELINE_NAME=mixed-30m-component \
   MIXED_30M_TIMELINE_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "mixed 30m timeline unexpectedly passed missing auth component" >&2
+  exit 1
+fi
+
+echo "[transaction-read-mixed-30m-timeline] read bucket fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $30 = "hot,cold"; print }' "${input_tsv}" >"${input_tsv}.bucket"
+if MIXED_30M_TIMELINE_NAME=mixed-30m-bucket \
+  MIXED_30M_TIMELINE_INPUT_TSV="${input_tsv}.bucket" \
+  MIXED_30M_TIMELINE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "mixed 30m timeline unexpectedly passed missing archive bucket" >&2
+  exit 1
+fi
+
+echo "[transaction-read-mixed-30m-timeline] write 2xx fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $32 = 0; print }' "${input_tsv}" >"${input_tsv}.write"
+if MIXED_30M_TIMELINE_NAME=mixed-30m-write \
+  MIXED_30M_TIMELINE_INPUT_TSV="${input_tsv}.write" \
+  MIXED_30M_TIMELINE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "mixed 30m timeline unexpectedly passed write 2xx missing" >&2
   exit 1
 fi

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
@@ -60,6 +60,10 @@ grep -F "workload-mix.json" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F "workload-components.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F "outbox-lag.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F "read-429-source.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "read-buckets.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "write-status.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\thot,cold,archive\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t1\t0\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 
 echo "[transaction-read-mixed-workload-live-evidence-autogen] generated manifest passes gate"
 gate_output="$(
@@ -91,7 +95,9 @@ for file in \
   runner-workload-mix.json \
   runner-workload-components.tsv \
   runner-outbox-lag.tsv \
-  runner-read-429-source.tsv; do
+  runner-read-429-source.tsv \
+  runner-read-buckets.tsv \
+  runner-write-status.tsv; do
   printf "stub\n" >"${artifact_dir}/${file}"
 done
 {
@@ -109,6 +115,8 @@ done
   printf "MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF=%q\n" "${artifact_dir}/runner-workload-components.tsv"
   printf "MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF=%q\n" "${artifact_dir}/runner-outbox-lag.tsv"
   printf "MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF=%q\n" "${artifact_dir}/runner-read-429-source.tsv"
+  printf "MIXED_WORKLOAD_RUNNER_READ_BUCKET_REF=%q\n" "${artifact_dir}/runner-read-buckets.tsv"
+  printf "MIXED_WORKLOAD_RUNNER_WRITE_STATUS_REF=%q\n" "${artifact_dir}/runner-write-status.tsv"
   printf "MIXED_WORKLOAD_RUNNER_EDGE_429_RATE=%q\n" "0.03"
   printf "MIXED_WORKLOAD_RUNNER_BACKEND_429_COUNT=%q\n" "0"
   printf "MIXED_WORKLOAD_RUNNER_UNKNOWN_429_COUNT=%q\n" "0"
@@ -125,6 +133,9 @@ done
   printf "MIXED_WORKLOAD_RUNNER_NGINX_UPSTREAM_P95_MS=%q\n" "12.5"
   printf "MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENTS=%q\n" "read,write,auth,notification,sse"
   printf "MIXED_WORKLOAD_RUNNER_READ_P999_MS=%q\n" "333"
+  printf "MIXED_WORKLOAD_RUNNER_READ_BUCKETS=%q\n" "hot,cold,archive"
+  printf "MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT=%q\n" "7"
+  printf "MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT=%q\n" "2"
   printf "MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_MAX=%q\n" "0"
 } >"${MIXED_WORKLOAD_STUB_ENV}"
 echo "${MIXED_WORKLOAD_STUB_ENV}"
@@ -151,8 +162,12 @@ grep -F "soak_repeat=2" "${temp_dir}/stub.log" >/dev/null
 source "${stub_env}"
 grep -F "runner-k6-summary.json" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F "runner-workload-components.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "runner-read-buckets.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F "runner-write-status.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'\t0.03\t0\t0\t0\t0\t0\t0\t333\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'\t101\t222\t444\t1\t0\t12.5\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\thot,cold,archive\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t7\t2\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 live_gate_output="$(
   MIXED_30M_TIMELINE_NAME="${name}-live" \
   MIXED_30M_TIMELINE_INPUT_TSV="${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" \

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
@@ -18,6 +18,7 @@ grep -F "report_name:" "${workflow}" >/dev/null
 grep -F "mixed workload live evidence contract" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh" "${workflow}" >/dev/null
+grep -F "bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh" "${workflow}" >/dev/null
@@ -44,6 +45,12 @@ grep -F 'printf '\''MIXED_WORKLOAD_OCI_HOT_ACCOUNT_ID=%s\n'\'' "${MIXED_WORKLOAD
 grep -F 'printf '\''MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID=%s\n'\'' "${MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID}" >>"${GITHUB_ENV}"' "${workflow}" >/dev/null
 grep -F 'printf '\''MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID=%s\n'\'' "${MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID}" >>"${GITHUB_ENV}"' "${workflow}" >/dev/null
 grep -F 'printf '\''MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID=%s\n'\'' "${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID}" >>"${GITHUB_ENV}"' "${workflow}" >/dev/null
+grep -F "name: Resolve mixed workload staging database URL" "${workflow}" >/dev/null
+grep -F "tools/ops/resolve-oci-a1-staging-database-url.sh" "${workflow}" >/dev/null
+grep -F "name: Ensure mixed workload fixture principal" "${workflow}" >/dev/null
+grep -F 'STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID}"' "${workflow}" >/dev/null
+grep -F 'STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID}"' "${workflow}" >/dev/null
+grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
 grep -F 'mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"' "${workflow}" >/dev/null
 grep -F 'printf '\''::add-mask::%s\n'\'' "${STAGING_REPLAY_TOKEN}"' "${workflow}" >/dev/null
 grep -F 'printf '\''%s'\'' "${STAGING_REPLAY_TOKEN}" >"${mixed_workload_auth_token_file}"' "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
@@ -18,14 +18,22 @@ grep -F "/api/v1/auth/sessions" "${k6_script}" >/dev/null
 grep -F "/api/v1/notifications" "${k6_script}" >/dev/null
 grep -F "/api/v1/notifications/stream" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_read_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_read_hot_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_read_cold_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_read_archive_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_2xx_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_429_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_unexpected_status_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_write_401_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_write_403_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_write_409_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_write_422_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_auth_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_notification_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_sse_connect_count" "${k6_script}" >/dev/null
 grep -F 'checks: ["rate==1"]' "${k6_script}" >/dev/null
+grep -F 'path: "/api/v1/transactions/archive"' "${k6_script}" >/dev/null
 
 temp_dir="$(mktemp -d)"
 trap 'rm -rf "${temp_dir}"' EXIT
@@ -64,11 +72,31 @@ if [[ "$*" == *"grafana/k6:0.54.0 run /scripts/transaction-read-mixed-workload-1
     "aquila_mixed_read_edge_429_rate": {"values": {"rate": 0.01}},
     "aquila_mixed_read_backend_429_count": {"values": {"count": 0}},
     "aquila_mixed_read_unknown_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_hot_count": {"values": {"count": 4}},
+    "aquila_mixed_read_hot_duration_ms": {"values": {"p(95)": 70, "p(99.9)": 130}},
+    "aquila_mixed_read_hot_edge_429_rate": {"values": {"rate": 0.01}},
+    "aquila_mixed_read_hot_backend_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_hot_unknown_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_cold_count": {"values": {"count": 4}},
+    "aquila_mixed_read_cold_duration_ms": {"values": {"p(95)": 82, "p(99.9)": 150}},
+    "aquila_mixed_read_cold_edge_429_rate": {"values": {"rate": 0.02}},
+    "aquila_mixed_read_cold_backend_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_cold_unknown_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_archive_count": {"values": {"count": 4}},
+    "aquila_mixed_read_archive_duration_ms": {"values": {"p(95)": 88, "p(99.9)": 180}},
+    "aquila_mixed_read_archive_edge_429_rate": {"values": {"rate": 0.03}},
+    "aquila_mixed_read_archive_backend_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_archive_unknown_429_count": {"values": {"count": 0}},
     "aquila_mixed_write_count": {"values": {"count": 9}},
     "aquila_mixed_write_duration_ms": {"values": {"p(95)": 95, "p(99)": 140, "p(99.9)": 170, "max": 210}},
     "aquila_mixed_write_2xx_count": {"values": {"count": 4}},
     "aquila_mixed_write_429_count": {"values": {"count": 2}},
     "aquila_mixed_write_unexpected_status_count": {"values": {"count": 3}},
+    "aquila_mixed_write_401_count": {"values": {"count": 1}},
+    "aquila_mixed_write_403_count": {"values": {"count": 1}},
+    "aquila_mixed_write_409_count": {"values": {"count": 1}},
+    "aquila_mixed_write_422_count": {"values": {"count": 0}},
+    "aquila_mixed_write_other_unexpected_count": {"values": {"count": 0}},
     "aquila_mixed_write_429_rate": {"values": {"rate": 0.2222222222}},
     "aquila_mixed_auth_count": {"values": {"count": 3}},
     "aquila_mixed_auth_duration_ms": {"values": {"p(95)": 42}},
@@ -106,6 +134,9 @@ plan="$(
   MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID=202 \
   MIXED_WORKLOAD_OCI_COLD_FROM=2026-01-01T00:00:00Z \
   MIXED_WORKLOAD_OCI_COLD_TO=2026-01-31T23:59:59Z \
+  MIXED_WORKLOAD_OCI_ARCHIVE_ACCOUNT_ID=303 \
+  MIXED_WORKLOAD_OCI_ARCHIVE_FROM=2026-01-01T00:00:00Z \
+  MIXED_WORKLOAD_OCI_ARCHIVE_TO=2026-01-31T23:59:59Z \
   MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID=920000001 \
   MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID=920000002 \
   MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE="${token_file}" \
@@ -157,16 +188,30 @@ test -f "${MIXED_WORKLOAD_RUNNER_WORKLOAD_MIX_REF}"
 test -f "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}"
 test -f "${MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF}"
 test -f "${MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF}"
+test -f "${MIXED_WORKLOAD_RUNNER_READ_BUCKET_REF}"
+test -f "${MIXED_WORKLOAD_RUNNER_WRITE_STATUS_REF}"
 grep -F $'read\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
 grep -F $'write\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
 grep -F $'auth\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
 grep -F $'notification\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
 grep -F $'sse\tpass\t' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
 grep -F $'mixed-oci-run-fixture\t0' "${MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF}" >/dev/null
-grep -F $'mixed-oci-run-fixture\tnginx-edge\t0.08\t0\t0' "${MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF}" >/dev/null
+grep -F $'mixed-oci-run-fixture\thot\tnginx-edge\t0.03\t0\t0' "${MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF}" >/dev/null
+grep -F $'mixed-oci-run-fixture\tcold\tnginx-edge\t0.05\t0\t0' "${MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF}" >/dev/null
+grep -F $'mixed-oci-run-fixture\tarchive\tnginx-edge\t0.08\t0\t0' "${MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF}" >/dev/null
+grep -F $'hot\t44\t72\t350\t0.03\t0\t0' "${MIXED_WORKLOAD_RUNNER_READ_BUCKET_REF}" >/dev/null
+grep -F $'cold\t42\t88\t410\t0.05\t0\t0' "${MIXED_WORKLOAD_RUNNER_READ_BUCKET_REF}" >/dev/null
+grep -F $'archive\t42\t96\t440\t0.08\t0\t0' "${MIXED_WORKLOAD_RUNNER_READ_BUCKET_REF}" >/dev/null
+grep -F $'2xx\t28' "${MIXED_WORKLOAD_RUNNER_WRITE_STATUS_REF}" >/dev/null
+grep -F $'401\t1' "${MIXED_WORKLOAD_RUNNER_WRITE_STATUS_REF}" >/dev/null
+grep -F $'403\t1' "${MIXED_WORKLOAD_RUNNER_WRITE_STATUS_REF}" >/dev/null
+grep -F $'409\t1' "${MIXED_WORKLOAD_RUNNER_WRITE_STATUS_REF}" >/dev/null
 
 echo "[transaction-read-mixed-workload-oci-k6] fixture summary metrics"
 jq -e '.metrics.aquila_mixed_read_count.values.count == 128' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_read_hot_count.values.count == 44' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_read_cold_count.values.count == 42' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_read_archive_count.values.count == 42' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_write_count.values.count == 32' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_write_2xx_count.values.count == 28' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_write_429_count.values.count == 1' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
@@ -178,6 +223,10 @@ jq -e '.metrics.aquila_mixed_sse_connect_count.values.count == 1' "${MIXED_WORKL
 test "${MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT}" = "28"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_429_COUNT}" = "1"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT}" = "3"
+test "${MIXED_WORKLOAD_RUNNER_READ_BUCKETS}" = "hot,cold,archive"
+test "${MIXED_WORKLOAD_RUNNER_READ_HOT_P999_MS}" = "350"
+test "${MIXED_WORKLOAD_RUNNER_READ_COLD_P999_MS}" = "410"
+test "${MIXED_WORKLOAD_RUNNER_READ_ARCHIVE_P999_MS}" = "440"
 grep -F $'write\tpass\t32\t95\t28\t1\t3' "${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF}" >/dev/null
 
 echo "[transaction-read-mixed-workload-oci-k6] failed k6 still collects summary"
@@ -201,6 +250,9 @@ MIXED_WORKLOAD_OCI_HOT_TO=2026-04-30T23:59:59Z \
 MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID=202 \
 MIXED_WORKLOAD_OCI_COLD_FROM=2026-01-01T00:00:00Z \
 MIXED_WORKLOAD_OCI_COLD_TO=2026-01-31T23:59:59Z \
+MIXED_WORKLOAD_OCI_ARCHIVE_ACCOUNT_ID=303 \
+MIXED_WORKLOAD_OCI_ARCHIVE_FROM=2026-01-01T00:00:00Z \
+MIXED_WORKLOAD_OCI_ARCHIVE_TO=2026-01-31T23:59:59Z \
 MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID=920000001 \
 MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID=920000002 \
 MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE="${token_file}" \

--- a/tools/test/check-transaction-read-oci-evidence-execution-gate.sh
+++ b/tools/test/check-transaction-read-oci-evidence-execution-gate.sh
@@ -30,16 +30,18 @@ touch \
   "${artifact_dir}/workload-components.tsv" \
   "${artifact_dir}/outbox-lag.tsv" \
   "${artifact_dir}/read-429-source.tsv" \
+  "${artifact_dir}/read-buckets.tsv" \
+  "${artifact_dir}/write-status.tsv" \
   "${artifact_dir}/deploy-retry.json" \
   "${artifact_dir}/deploy-499.tsv"
 
 cat >"${input_tsv}" <<TSV
-scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref
-hikari-lifetime	run-hikari-001	2026-05-02T01:00:00Z	30	1	tools/test/run-transaction-read-weighted-10m-soak-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.01	0	0	0	0	0	0	420	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	80	210	610	0	0	14.1	${artifact_dir}/hikari-config.tsv	45000	30000	300000	350000	${artifact_dir}/hikari-zero-warning.md	n/a	0	n/a
-mixed-workload-30m	run-mixed-001	2026-05-02T02:00:00Z	30	1	tools/test/run-t3micro-mixed-workload-soak.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.08	0	0	0	0	0	0	450	n/a	n/a	n/a	${artifact_dir}/workload-mix.json	${artifact_dir}/workload-components.tsv	${artifact_dir}/outbox-lag.tsv	0	n/a	0	n/a	85	225	630	1	0	16.3	n/a	0	0	0	0	n/a	read,write,auth,notification,sse	440	${artifact_dir}/read-429-source.tsv
-cold-warm-cache	run-cache-001	2026-05-02T02:40:00Z	3	1	tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	${artifact_dir}/cache.json	${artifact_dir}/timeline.json	0.02	0	0	0	0	0	0	410	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	78	205	600	0	0	13.8	n/a	0	0	0	0	n/a	n/a	0	n/a
-deploy-drain	run-drain-001	2026-05-02T03:00:00Z	5	1	tools/test/run-staging-deploy-transaction-replay-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	${artifact_dir}/deploy.json	n/a	${artifact_dir}/timeline.json	0.04	0	0	0	0	0	0	470	n/a	n/a	n/a	n/a	n/a	n/a	0	${artifact_dir}/deploy-retry.json	2	${artifact_dir}/deploy-499.tsv	90	235	640	1	0	17.4	n/a	0	0	0	0	n/a	n/a	0	n/a
-p999-long-correlation	run-p999-001	2026-05-02T03:20:00Z	30	1	tools/test/run-transaction-read-p999-spike-attribution.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.06	0	0	0	0	0	0	490	${artifact_dir}/checkpoint.tsv	${artifact_dir}/temp-files.tsv	${artifact_dir}/nginx-upstream.tsv	n/a	n/a	n/a	0	n/a	0	n/a	95	220	650	3	0	18.5	n/a	0	0	0	0	n/a	n/a	0	n/a
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref	read_buckets	read_bucket_ref	write_2xx_count	write_unexpected_status_count	write_status_ref
+hikari-lifetime	run-hikari-001	2026-05-02T01:00:00Z	30	1	tools/test/run-transaction-read-weighted-10m-soak-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.01	0	0	0	0	0	0	420	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	80	210	610	0	0	14.1	${artifact_dir}/hikari-config.tsv	45000	30000	300000	350000	${artifact_dir}/hikari-zero-warning.md	n/a	0	n/a	n/a	n/a	0	0	n/a
+mixed-workload-30m	run-mixed-001	2026-05-02T02:00:00Z	30	1	tools/test/run-t3micro-mixed-workload-soak.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.08	0	0	0	0	0	0	450	n/a	n/a	n/a	${artifact_dir}/workload-mix.json	${artifact_dir}/workload-components.tsv	${artifact_dir}/outbox-lag.tsv	0	n/a	0	n/a	85	225	630	1	0	16.3	n/a	0	0	0	0	n/a	read,write,auth,notification,sse	440	${artifact_dir}/read-429-source.tsv	hot,cold,archive	${artifact_dir}/read-buckets.tsv	4	3	${artifact_dir}/write-status.tsv
+cold-warm-cache	run-cache-001	2026-05-02T02:40:00Z	3	1	tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	${artifact_dir}/cache.json	${artifact_dir}/timeline.json	0.02	0	0	0	0	0	0	410	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	78	205	600	0	0	13.8	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	n/a	0	0	n/a
+deploy-drain	run-drain-001	2026-05-02T03:00:00Z	5	1	tools/test/run-staging-deploy-transaction-replay-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	${artifact_dir}/deploy.json	n/a	${artifact_dir}/timeline.json	0.04	0	0	0	0	0	0	470	n/a	n/a	n/a	n/a	n/a	n/a	0	${artifact_dir}/deploy-retry.json	2	${artifact_dir}/deploy-499.tsv	90	235	640	1	0	17.4	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	n/a	0	0	n/a
+p999-long-correlation	run-p999-001	2026-05-02T03:20:00Z	30	1	tools/test/run-transaction-read-p999-spike-attribution.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.06	0	0	0	0	0	0	490	${artifact_dir}/checkpoint.tsv	${artifact_dir}/temp-files.tsv	${artifact_dir}/nginx-upstream.tsv	n/a	n/a	n/a	0	n/a	0	n/a	95	220	650	3	0	18.5	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	n/a	0	0	n/a
 TSV
 
 echo "[transaction-read-oci-evidence-execution] print plan"
@@ -77,14 +79,18 @@ grep -F "Hikari lifetime alignment artifacts: config ref, zero-warning soak ref,
 grep -F "mixed workload closure artifacts: workload mix, component split, outbox lag" "${report_md}" >/dev/null
 grep -F "mixed workload required components: read,write,auth,notification,sse" "${report_md}" >/dev/null
 grep -F "mixed workload read p99.9 and 429 source artifact: required" "${report_md}" >/dev/null
+grep -F "mixed workload hot/cold/archive read bucket artifact: required" "${report_md}" >/dev/null
+grep -F "mixed workload write 2xx and status classification artifact: required" "${report_md}" >/dev/null
 grep -F "deploy drain closure artifacts: 499 budget, retry contract, reconnect success" "${report_md}" >/dev/null
 grep -F $'\tp95_ms\tp99_ms\tmax_ms\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms' "${summary_tsv}" >/dev/null
 grep -F $'\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref' "${summary_tsv}" >/dev/null
 grep -F $'\tworkload_components\tread_p999_ms\tread_429_source_ref' "${summary_tsv}" >/dev/null
+grep -F $'\tread_buckets\tread_bucket_ref\twrite_2xx_count\twrite_unexpected_status_count\twrite_status_ref' "${summary_tsv}" >/dev/null
 grep -F $'mixed-workload-30m\tpass\tok\trun-mixed-001\t30\t1\ttools/test/run-t3micro-mixed-workload-soak.sh' "${summary_tsv}" >/dev/null
 awk -F '\t' '$1 == "p999-long-correlation" && $23 == 490 && $24 == 95 && $25 == 220 && $26 == 650 && $27 == 3 && $28 == 0 && $29 == 18.5 { found = 1 } END { exit !found }' "${summary_tsv}"
 awk -F '\t' '$1 == "hikari-lifetime" && $5 == 30 && $30 ~ /hikari-config[.]tsv$/ && $31 == 45000 && $32 == 30000 && $33 == 300000 && $34 == 350000 && $35 ~ /hikari-zero-warning[.]md$/ { found = 1 } END { exit !found }' "${summary_tsv}"
 awk -F '\t' '$1 == "mixed-workload-30m" && $36 == "read,write,auth,notification,sse" && $37 == 440 && $38 ~ /read-429-source[.]tsv$/ { found = 1 } END { exit !found }' "${summary_tsv}"
+awk -F '\t' '$1 == "mixed-workload-30m" && $39 == "hot,cold,archive" && $40 ~ /read-buckets[.]tsv$/ && $41 == 4 && $42 == 3 && $43 ~ /write-status[.]tsv$/ { found = 1 } END { exit !found }' "${summary_tsv}"
 
 echo "[transaction-read-oci-evidence-execution] failure report"
 awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload-30m" { $14 = "n/a"; $17 = 1; $18 = 1; $19 = 1; $20 = 2; $21 = 2; $22 = 560 } { print }' \
@@ -188,6 +194,28 @@ if OCI_EVIDENCE_EXECUTION_NAME=oci-exec-mixed-component-fail \
   OCI_EVIDENCE_EXECUTION_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "OCI execution gate unexpectedly passed mixed workload without auth component" >&2
+  exit 1
+fi
+
+echo "[transaction-read-oci-evidence-execution] mixed read bucket closure fail"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload-30m" { $48 = "hot,cold"; $49 = "n/a" } { print }' \
+  "${input_tsv}" >"${input_tsv}.mixed-read-bucket-fail"
+if OCI_EVIDENCE_EXECUTION_NAME=oci-exec-mixed-read-bucket-fail \
+  OCI_EVIDENCE_EXECUTION_INPUT_TSV="${input_tsv}.mixed-read-bucket-fail" \
+  OCI_EVIDENCE_EXECUTION_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "OCI execution gate unexpectedly passed missing mixed read bucket artifact" >&2
+  exit 1
+fi
+
+echo "[transaction-read-oci-evidence-execution] mixed write 2xx closure fail"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload-30m" { $50 = 0 } { print }' \
+  "${input_tsv}" >"${input_tsv}.mixed-write-2xx-fail"
+if OCI_EVIDENCE_EXECUTION_NAME=oci-exec-mixed-write-2xx-fail \
+  OCI_EVIDENCE_EXECUTION_INPUT_TSV="${input_tsv}.mixed-write-2xx-fail" \
+  OCI_EVIDENCE_EXECUTION_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "OCI execution gate unexpectedly passed mixed workload without write 2xx" >&2
   exit 1
 fi
 

--- a/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+++ b/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
@@ -66,6 +66,24 @@ run_bootstrap_with_csv_accounts() {
     "${script}"
 }
 
+run_bootstrap_with_write_accounts() {
+  env \
+    PATH="${tmp_dir}:${PATH}" \
+    PSQL_STUB_LOG="${psql_log}" \
+    PSQL_STDIN_LOG="${psql_stdin_log}" \
+    STAGING_OCI_A1_DATABASE_URL="postgresql://fixture-db/aquila" \
+    STAGING_REPLAY_USER_ID="55" \
+    STAGING_REPLAY_LOGIN_ID="staging-fixture-user" \
+    STAGING_REPLAY_USER_PASSWORD_HASH="fixturePasswordHashWithLetters" \
+    STAGING_REPLAY_USER_DISPLAY_NAME="Staging Fixture User" \
+    HOT_ACCOUNT_ID="1001" \
+    COLD_ACCOUNT_ID="1002" \
+    STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID="920000001" \
+    STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID="920000002" \
+    STAGING_MIXED_WORKLOAD_WRITE_SOURCE_BALANCE_MINOR="50000000" \
+    "${script}"
+}
+
 assert_valid_secret_like_values_do_not_enter_arithmetic() {
   run_bootstrap >/dev/null
   grep -q -- "fixture_password_hash=fixturePasswordHashWithLetters" "${psql_log}"
@@ -81,6 +99,22 @@ assert_csv_account_ids_feed_fixture_sql() {
   grep -q -- "cold_account_ids=1002,1004" "${psql_log}"
   grep -q -- "regexp_split_to_table(:'hot_account_ids', ',')" "${psql_stdin_log}"
   grep -q -- "regexp_split_to_table(:'cold_account_ids', ',')" "${psql_stdin_log}"
+  grep -q -- "INSERT INTO user_account_membership" "${psql_stdin_log}"
+}
+
+assert_write_accounts_are_funded_and_authorized() {
+  : >"${psql_log}"
+  : >"${psql_stdin_log}"
+
+  run_bootstrap_with_write_accounts >/dev/null
+
+  grep -q -- "write_source_account_id=920000001" "${psql_log}"
+  grep -q -- "write_target_account_id=920000002" "${psql_log}"
+  grep -q -- "write_source_balance_minor=50000000" "${psql_log}"
+  grep -q -- "'write_source' AS account_group" "${psql_stdin_log}"
+  grep -q -- "'write_target' AS account_group" "${psql_stdin_log}"
+  grep -q -- "desired_available_balance_minor" "${psql_stdin_log}"
+  grep -q -- "GREATEST(account_balance_snapshot.available_balance_minor, EXCLUDED.available_balance_minor)" "${psql_stdin_log}"
   grep -q -- "INSERT INTO user_account_membership" "${psql_stdin_log}"
 }
 
@@ -144,6 +178,7 @@ assert_too_long_password_hash_fails_before_psql() {
 
 assert_valid_secret_like_values_do_not_enter_arithmetic
 assert_csv_account_ids_feed_fixture_sql
+assert_write_accounts_are_funded_and_authorized
 assert_transient_psql_timeout_retries_fixture_sql
 assert_too_long_password_hash_fails_before_psql
 

--- a/tools/test/run-transaction-read-mixed-workload-30m-timeline.sh
+++ b/tools/test/run-transaction-read-mixed-workload-30m-timeline.sh
@@ -85,6 +85,8 @@ cat >"${report_md}" <<REPORT
 - p95/p99.9, 429 source, 499/5xx, Hikari pending/warning hard gate
 - read/write/auth/notification/SSE components: required
 - read p99.9 and 429 source artifact: required
+- hot/cold/archive read bucket artifact: required
+- write 2xx and status classification artifact: required
 - workload mix/component and outbox lag artifact: required
 - execution gate report: ${execution_report}
 
@@ -92,6 +94,7 @@ cat >"${report_md}" <<REPORT
 
 - read-only capacity와 운영 혼합 부하는 분리해서 본다.
 - mixed workload는 read/write/auth/notification/SSE component가 모두 있어야 운영 간섭 증거로 인정한다.
+- mixed workload는 hot/cold/archive read bucket과 write status classification을 같이 남겨야 한다.
 - unknown 429, 499, 5xx, Hikari warning, Hikari pending은 execution gate에서 hard-zero로 검증한다.
 - outbox lag는 혼합 부하에서 write/notification 간섭을 닫는 hard-zero evidence로 본다.
 - timeline ref는 k6, Nginx upstream, Spring metric, Hikari, PostgreSQL wait를 같은 run id로 묶는 기준이다.

--- a/tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh
+++ b/tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh
@@ -66,6 +66,9 @@ nginx_upstream_p95_ms="16.3"
 outbox_lag_max="0"
 workload_components="read,write,auth,notification,sse"
 read_p999_ms="440"
+read_buckets="hot,cold,archive"
+write_2xx_count="1"
+write_unexpected_status_count="0"
 runner_evidence_applied="false"
 
 k6_summary_ref="${generated_dir}/${name}-k6-summary.json"
@@ -78,6 +81,8 @@ workload_mix_ref="${generated_dir}/${name}-workload-mix.json"
 workload_component_ref="${generated_dir}/${name}-workload-components.tsv"
 outbox_lag_ref="${generated_dir}/${name}-outbox-lag.tsv"
 read_429_source_ref="${generated_dir}/${name}-read-429-source.tsv"
+read_bucket_ref="${generated_dir}/${name}-read-buckets.tsv"
+write_status_ref="${generated_dir}/${name}-write-status.tsv"
 runner_log_ref="${generated_dir}/${name}-runner.log"
 
 case "${autogen_mode}" in
@@ -184,6 +189,8 @@ apply_runner_evidence_env() {
   workload_component_ref="${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF:-${workload_component_ref}}"
   outbox_lag_ref="${MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF:-${outbox_lag_ref}}"
   read_429_source_ref="${MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF:-${read_429_source_ref}}"
+  read_bucket_ref="${MIXED_WORKLOAD_RUNNER_READ_BUCKET_REF:-${read_bucket_ref}}"
+  write_status_ref="${MIXED_WORKLOAD_RUNNER_WRITE_STATUS_REF:-${write_status_ref}}"
   edge_429_rate="${MIXED_WORKLOAD_RUNNER_EDGE_429_RATE:-${edge_429_rate}}"
   backend_429_count="${MIXED_WORKLOAD_RUNNER_BACKEND_429_COUNT:-${backend_429_count}}"
   unknown_429_count="${MIXED_WORKLOAD_RUNNER_UNKNOWN_429_COUNT:-${unknown_429_count}}"
@@ -200,6 +207,9 @@ apply_runner_evidence_env() {
   nginx_upstream_p95_ms="${MIXED_WORKLOAD_RUNNER_NGINX_UPSTREAM_P95_MS:-${nginx_upstream_p95_ms}}"
   workload_components="${MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENTS:-${workload_components}}"
   read_p999_ms="${MIXED_WORKLOAD_RUNNER_READ_P999_MS:-${read_p999_ms}}"
+  read_buckets="${MIXED_WORKLOAD_RUNNER_READ_BUCKETS:-${read_buckets}}"
+  write_2xx_count="${MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT:-${write_2xx_count}}"
+  write_unexpected_status_count="${MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT:-${write_unexpected_status_count}}"
   outbox_lag_max="${MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_MAX:-${outbox_lag_max}}"
   runner_evidence_applied="true"
 }
@@ -272,9 +282,27 @@ run_id	outbox_lag_max
 TSV
   printf "%s\t%s\n" "${run_id}" "${outbox_lag_max}" >>"${outbox_lag_ref}"
   cat >"${read_429_source_ref}" <<'TSV'
-run_id	source	edge_429_rate	backend_429_count	unknown_429_count
+run_id	bucket	source	edge_429_rate	backend_429_count	unknown_429_count
 TSV
-  printf "%s\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${edge_429_rate}" "${backend_429_count}" "${unknown_429_count}" >>"${read_429_source_ref}"
+  printf "%s\thot\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${edge_429_rate}" "${backend_429_count}" "${unknown_429_count}" >>"${read_429_source_ref}"
+  printf "%s\tcold\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${edge_429_rate}" "${backend_429_count}" "${unknown_429_count}" >>"${read_429_source_ref}"
+  printf "%s\tarchive\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${edge_429_rate}" "${backend_429_count}" "${unknown_429_count}" >>"${read_429_source_ref}"
+  cat >"${read_bucket_ref}" <<'TSV'
+bucket	count	p95_ms	p999_ms	edge_429_rate	backend_429_count	unknown_429_count
+hot	1	80	420	0.08	0	0
+cold	1	85	430	0.08	0	0
+archive	1	90	440	0.08	0	0
+TSV
+  cat >"${write_status_ref}" <<'TSV'
+status	count
+2xx	1
+429	0
+401	0
+403	0
+409	0
+422	0
+other_unexpected	0
+TSV
   if [[ ! -f "${runner_log_ref}" ]]; then
     printf "runner=%s\nmode=%s\n" "${runner}" "${autogen_mode}" >"${runner_log_ref}"
   fi
@@ -282,8 +310,8 @@ TSV
 
 write_manifest() {
   cat >"${manifest_tsv}" <<TSV
-scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref
-mixed-workload-30m	${run_id}	${executed_at_utc}	${duration_min}	${source_ips}	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	n/a	n/a	${timeline_ref}	${edge_429_rate}	${backend_429_count}	${unknown_429_count}	${five_xx_count}	${nginx_499_count}	${hikari_validation_warnings}	${db_pool_pending_max}	${p999_ms}	n/a	n/a	n/a	${workload_mix_ref}	${workload_component_ref}	${outbox_lag_ref}	${outbox_lag_max}	n/a	0	n/a	${p95_ms}	${p99_ms}	${max_ms}	${postgres_checkpoint_count}	${postgres_temp_file_count}	${nginx_upstream_p95_ms}	n/a	0	0	0	0	n/a	${workload_components}	${read_p999_ms}	${read_429_source_ref}
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref	read_buckets	read_bucket_ref	write_2xx_count	write_unexpected_status_count	write_status_ref
+mixed-workload-30m	${run_id}	${executed_at_utc}	${duration_min}	${source_ips}	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	n/a	n/a	${timeline_ref}	${edge_429_rate}	${backend_429_count}	${unknown_429_count}	${five_xx_count}	${nginx_499_count}	${hikari_validation_warnings}	${db_pool_pending_max}	${p999_ms}	n/a	n/a	n/a	${workload_mix_ref}	${workload_component_ref}	${outbox_lag_ref}	${outbox_lag_max}	n/a	0	n/a	${p95_ms}	${p99_ms}	${max_ms}	${postgres_checkpoint_count}	${postgres_temp_file_count}	${nginx_upstream_p95_ms}	n/a	0	0	0	0	n/a	${workload_components}	${read_p999_ms}	${read_429_source_ref}	${read_buckets}	${read_bucket_ref}	${write_2xx_count}	${write_unexpected_status_count}	${write_status_ref}
 TSV
 }
 

--- a/tools/test/run-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/run-transaction-read-mixed-workload-oci-k6.sh
@@ -59,6 +59,9 @@ hot_to="${MIXED_WORKLOAD_OCI_HOT_TO:-${K6_HOT_TO:-}}"
 cold_account_id="${MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID:-${K6_COLD_ACCOUNT_ID:-}}"
 cold_from="${MIXED_WORKLOAD_OCI_COLD_FROM:-${K6_COLD_FROM:-}}"
 cold_to="${MIXED_WORKLOAD_OCI_COLD_TO:-${K6_COLD_TO:-}}"
+archive_account_id="${MIXED_WORKLOAD_OCI_ARCHIVE_ACCOUNT_ID:-${K6_ARCHIVE_ACCOUNT_ID:-${cold_account_id}}}"
+archive_from="${MIXED_WORKLOAD_OCI_ARCHIVE_FROM:-${K6_ARCHIVE_FROM:-${cold_from}}}"
+archive_to="${MIXED_WORKLOAD_OCI_ARCHIVE_TO:-${K6_ARCHIVE_TO:-${cold_to}}}"
 write_source_account_id="${MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID:-${K6_WRITE_SOURCE_ACCOUNT_ID:-}}"
 write_target_account_id="${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID:-${K6_WRITE_TARGET_ACCOUNT_ID:-}}"
 write_amount_minor="${MIXED_WORKLOAD_OCI_WRITE_AMOUNT_MINOR:-${K6_WRITE_AMOUNT_MINOR:-1}}"
@@ -81,6 +84,8 @@ workload_mix_ref="${generated_dir}/${name}-workload-mix.json"
 workload_component_ref="${generated_dir}/${name}-workload-components.tsv"
 outbox_lag_ref="${generated_dir}/${name}-outbox-lag.tsv"
 read_429_source_ref="${generated_dir}/${name}-read-429-source.tsv"
+read_bucket_ref="${generated_dir}/${name}-read-buckets.tsv"
+write_status_ref="${generated_dir}/${name}-write-status.tsv"
 runner_log_ref="${generated_dir}/${name}-runner.log"
 failure_env="${output_dir}/${name}-oci-mixed-failure.env"
 failure_md="${output_dir}/${name}-oci-mixed-failure.md"
@@ -157,6 +162,9 @@ if [[ "${oci_mode}" == "live" ]]; then
   require_live_env "MIXED_WORKLOAD_OCI_COLD_ACCOUNT_ID" "${cold_account_id}"
   require_live_env "MIXED_WORKLOAD_OCI_COLD_FROM" "${cold_from}"
   require_live_env "MIXED_WORKLOAD_OCI_COLD_TO" "${cold_to}"
+  require_live_env "MIXED_WORKLOAD_OCI_ARCHIVE_ACCOUNT_ID" "${archive_account_id}"
+  require_live_env "MIXED_WORKLOAD_OCI_ARCHIVE_FROM" "${archive_from}"
+  require_live_env "MIXED_WORKLOAD_OCI_ARCHIVE_TO" "${archive_to}"
   require_live_env "MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID" "${write_source_account_id}"
   require_live_env "MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID" "${write_target_account_id}"
   require_live_env "MIXED_WORKLOAD_OCI_AUTH_TOKEN" "${auth_token}"
@@ -174,6 +182,7 @@ print_plan() {
   echo "[transaction-read-mixed-workload-oci-k6] components=read,write,auth,notification,sse"
   echo "[transaction-read-mixed-workload-oci-k6] read_rate=${read_rate}/1s write_vus=${write_vus} auth_rate=${auth_rate}/1s notification_rate=${notification_rate}/1s"
   echo "[transaction-read-mixed-workload-oci-k6] hot_account_id=${hot_account_id:-missing} cold_account_id=${cold_account_id:-missing}"
+  echo "[transaction-read-mixed-workload-oci-k6] archive_account_id=${archive_account_id:-missing}"
   echo "[transaction-read-mixed-workload-oci-k6] write_source_account_id=${write_source_account_id:-missing} write_target_account_id=${write_target_account_id:-missing}"
   echo "[transaction-read-mixed-workload-oci-k6] auth_token=$([[ -n "${auth_token}" ]] && echo present || echo missing) source=${auth_token_source}"
   echo "[transaction-read-mixed-workload-oci-k6] output_dir=${output_dir}"
@@ -220,11 +229,31 @@ write_fixture_summary() {
     "aquila_mixed_read_edge_429_rate": {"values": {"rate": 0.08}},
     "aquila_mixed_read_backend_429_count": {"values": {"count": 0}},
     "aquila_mixed_read_unknown_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_hot_count": {"values": {"count": 44}},
+    "aquila_mixed_read_hot_duration_ms": {"values": {"p(95)": 72, "p(99)": 180, "p(99.9)": 350, "max": 520}},
+    "aquila_mixed_read_hot_edge_429_rate": {"values": {"rate": 0.03}},
+    "aquila_mixed_read_hot_backend_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_hot_unknown_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_cold_count": {"values": {"count": 42}},
+    "aquila_mixed_read_cold_duration_ms": {"values": {"p(95)": 88, "p(99)": 205, "p(99.9)": 410, "max": 590}},
+    "aquila_mixed_read_cold_edge_429_rate": {"values": {"rate": 0.05}},
+    "aquila_mixed_read_cold_backend_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_cold_unknown_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_archive_count": {"values": {"count": 42}},
+    "aquila_mixed_read_archive_duration_ms": {"values": {"p(95)": 96, "p(99)": 225, "p(99.9)": 440, "max": 630}},
+    "aquila_mixed_read_archive_edge_429_rate": {"values": {"rate": 0.08}},
+    "aquila_mixed_read_archive_backend_429_count": {"values": {"count": 0}},
+    "aquila_mixed_read_archive_unknown_429_count": {"values": {"count": 0}},
     "aquila_mixed_write_count": {"values": {"count": 32}},
     "aquila_mixed_write_duration_ms": {"values": {"p(95)": 95, "p(99)": 180, "p(99.9)": 240, "max": 300}},
     "aquila_mixed_write_2xx_count": {"values": {"count": 28}},
     "aquila_mixed_write_429_count": {"values": {"count": 1}},
     "aquila_mixed_write_unexpected_status_count": {"values": {"count": 3}},
+    "aquila_mixed_write_401_count": {"values": {"count": 1}},
+    "aquila_mixed_write_403_count": {"values": {"count": 1}},
+    "aquila_mixed_write_409_count": {"values": {"count": 1}},
+    "aquila_mixed_write_422_count": {"values": {"count": 0}},
+    "aquila_mixed_write_other_unexpected_count": {"values": {"count": 0}},
     "aquila_mixed_write_429_rate": {"values": {"rate": 0.01}},
     "aquila_mixed_auth_count": {"values": {"count": 16}},
     "aquila_mixed_auth_duration_ms": {"values": {"p(95)": 42, "p(99)": 60, "p(99.9)": 70, "max": 75}},
@@ -269,7 +298,12 @@ write_component_artifacts() {
   mkdir -p "${generated_dir}"
   local read_count write_count auth_count notification_count sse_count
   local read_p95 read_p99 read_p999 read_max edge_429_rate backend_429_count unknown_429_count five_xx_count
-  local write_p95 write_2xx_count write_429_count write_unexpected_status_count auth_p95 notification_p95 outbox_lag_max
+  local hot_count hot_p95 hot_p999 hot_edge_429_rate hot_backend_429_count hot_unknown_429_count
+  local cold_count cold_p95 cold_p999 cold_edge_429_rate cold_backend_429_count cold_unknown_429_count
+  local archive_count archive_p95 archive_p999 archive_edge_429_rate archive_backend_429_count archive_unknown_429_count
+  local write_p95 write_2xx_count write_429_count write_unexpected_status_count
+  local write_401_count write_403_count write_409_count write_422_count write_other_unexpected_count
+  local auth_p95 notification_p95 outbox_lag_max
 
   read_count="$(metric_count aquila_mixed_read_count)"
   write_count="$(metric_count aquila_mixed_write_count)"
@@ -280,10 +314,33 @@ write_component_artifacts() {
   read_p99="$(metric_value aquila_mixed_read_duration_ms "p(99)" "0")"
   read_p999="$(metric_value aquila_mixed_read_duration_ms "p(99.9)" "0")"
   read_max="$(metric_value aquila_mixed_read_duration_ms "max" "0")"
+  hot_count="$(metric_count aquila_mixed_read_hot_count)"
+  hot_p95="$(metric_value aquila_mixed_read_hot_duration_ms "p(95)" "0")"
+  hot_p999="$(metric_value aquila_mixed_read_hot_duration_ms "p(99.9)" "0")"
+  hot_edge_429_rate="$(metric_value aquila_mixed_read_hot_edge_429_rate "rate" "0")"
+  hot_backend_429_count="$(metric_count aquila_mixed_read_hot_backend_429_count)"
+  hot_unknown_429_count="$(metric_count aquila_mixed_read_hot_unknown_429_count)"
+  cold_count="$(metric_count aquila_mixed_read_cold_count)"
+  cold_p95="$(metric_value aquila_mixed_read_cold_duration_ms "p(95)" "0")"
+  cold_p999="$(metric_value aquila_mixed_read_cold_duration_ms "p(99.9)" "0")"
+  cold_edge_429_rate="$(metric_value aquila_mixed_read_cold_edge_429_rate "rate" "0")"
+  cold_backend_429_count="$(metric_count aquila_mixed_read_cold_backend_429_count)"
+  cold_unknown_429_count="$(metric_count aquila_mixed_read_cold_unknown_429_count)"
+  archive_count="$(metric_count aquila_mixed_read_archive_count)"
+  archive_p95="$(metric_value aquila_mixed_read_archive_duration_ms "p(95)" "0")"
+  archive_p999="$(metric_value aquila_mixed_read_archive_duration_ms "p(99.9)" "0")"
+  archive_edge_429_rate="$(metric_value aquila_mixed_read_archive_edge_429_rate "rate" "0")"
+  archive_backend_429_count="$(metric_count aquila_mixed_read_archive_backend_429_count)"
+  archive_unknown_429_count="$(metric_count aquila_mixed_read_archive_unknown_429_count)"
   write_p95="$(metric_value aquila_mixed_write_duration_ms "p(95)" "0")"
   write_2xx_count="$(metric_count aquila_mixed_write_2xx_count)"
   write_429_count="$(metric_count aquila_mixed_write_429_count)"
   write_unexpected_status_count="$(metric_count aquila_mixed_write_unexpected_status_count)"
+  write_401_count="$(metric_count aquila_mixed_write_401_count)"
+  write_403_count="$(metric_count aquila_mixed_write_403_count)"
+  write_409_count="$(metric_count aquila_mixed_write_409_count)"
+  write_422_count="$(metric_count aquila_mixed_write_422_count)"
+  write_other_unexpected_count="$(metric_count aquila_mixed_write_other_unexpected_count)"
   auth_p95="$(metric_value aquila_mixed_auth_duration_ms "p(95)" "0")"
   notification_p95="$(metric_value aquila_mixed_notification_duration_ms "p(95)" "0")"
   edge_429_rate="$(metric_value aquila_mixed_read_edge_429_rate "rate" "0")"
@@ -324,6 +381,9 @@ JSON
   "run_id": "${run_id}",
   "components": {
     "read": ${read_count},
+    "read_hot": ${hot_count},
+    "read_cold": ${cold_count},
+    "read_archive": ${archive_count},
     "write": ${write_count},
     "auth": ${auth_count},
     "notification": ${notification_count},
@@ -344,9 +404,27 @@ run_id	outbox_lag_max
 TSV
   printf "%s\t%s\n" "${run_id}" "${outbox_lag_max}" >>"${outbox_lag_ref}"
   cat >"${read_429_source_ref}" <<'TSV'
-run_id	source	edge_429_rate	backend_429_count	unknown_429_count
+run_id	bucket	source	edge_429_rate	backend_429_count	unknown_429_count
 TSV
-  printf "%s\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${edge_429_rate}" "${backend_429_count}" "${unknown_429_count}" >>"${read_429_source_ref}"
+  printf "%s\thot\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${hot_edge_429_rate}" "${hot_backend_429_count}" "${hot_unknown_429_count}" >>"${read_429_source_ref}"
+  printf "%s\tcold\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${cold_edge_429_rate}" "${cold_backend_429_count}" "${cold_unknown_429_count}" >>"${read_429_source_ref}"
+  printf "%s\tarchive\tnginx-edge\t%s\t%s\t%s\n" "${run_id}" "${archive_edge_429_rate}" "${archive_backend_429_count}" "${archive_unknown_429_count}" >>"${read_429_source_ref}"
+  cat >"${read_bucket_ref}" <<'TSV'
+bucket	count	p95_ms	p999_ms	edge_429_rate	backend_429_count	unknown_429_count
+TSV
+  printf "hot\t%s\t%s\t%s\t%s\t%s\t%s\n" "${hot_count}" "${hot_p95}" "${hot_p999}" "${hot_edge_429_rate}" "${hot_backend_429_count}" "${hot_unknown_429_count}" >>"${read_bucket_ref}"
+  printf "cold\t%s\t%s\t%s\t%s\t%s\t%s\n" "${cold_count}" "${cold_p95}" "${cold_p999}" "${cold_edge_429_rate}" "${cold_backend_429_count}" "${cold_unknown_429_count}" >>"${read_bucket_ref}"
+  printf "archive\t%s\t%s\t%s\t%s\t%s\t%s\n" "${archive_count}" "${archive_p95}" "${archive_p999}" "${archive_edge_429_rate}" "${archive_backend_429_count}" "${archive_unknown_429_count}" >>"${read_bucket_ref}"
+  cat >"${write_status_ref}" <<'TSV'
+status	count
+TSV
+  printf "2xx\t%s\n" "${write_2xx_count}" >>"${write_status_ref}"
+  printf "429\t%s\n" "${write_429_count}" >>"${write_status_ref}"
+  printf "401\t%s\n" "${write_401_count}" >>"${write_status_ref}"
+  printf "403\t%s\n" "${write_403_count}" >>"${write_status_ref}"
+  printf "409\t%s\n" "${write_409_count}" >>"${write_status_ref}"
+  printf "422\t%s\n" "${write_422_count}" >>"${write_status_ref}"
+  printf "other_unexpected\t%s\n" "${write_other_unexpected_count}" >>"${write_status_ref}"
 
   {
     printf "MIXED_WORKLOAD_RUNNER_ENV_FORMAT=%q\n" "oci-mixed-v1"
@@ -363,12 +441,18 @@ TSV
     printf "MIXED_WORKLOAD_RUNNER_WORKLOAD_COMPONENT_REF=%q\n" "${workload_component_ref}"
     printf "MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_REF=%q\n" "${outbox_lag_ref}"
     printf "MIXED_WORKLOAD_RUNNER_READ_429_SOURCE_REF=%q\n" "${read_429_source_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_READ_BUCKET_REF=%q\n" "${read_bucket_ref}"
+    printf "MIXED_WORKLOAD_RUNNER_WRITE_STATUS_REF=%q\n" "${write_status_ref}"
     printf "MIXED_WORKLOAD_RUNNER_EDGE_429_RATE=%q\n" "${edge_429_rate}"
     printf "MIXED_WORKLOAD_RUNNER_BACKEND_429_COUNT=%q\n" "${backend_429_count}"
     printf "MIXED_WORKLOAD_RUNNER_UNKNOWN_429_COUNT=%q\n" "${unknown_429_count}"
     printf "MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT=%q\n" "${write_2xx_count}"
     printf "MIXED_WORKLOAD_RUNNER_WRITE_429_COUNT=%q\n" "${write_429_count}"
     printf "MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT=%q\n" "${write_unexpected_status_count}"
+    printf "MIXED_WORKLOAD_RUNNER_READ_BUCKETS=%q\n" "hot,cold,archive"
+    printf "MIXED_WORKLOAD_RUNNER_READ_HOT_P999_MS=%q\n" "${hot_p999}"
+    printf "MIXED_WORKLOAD_RUNNER_READ_COLD_P999_MS=%q\n" "${cold_p999}"
+    printf "MIXED_WORKLOAD_RUNNER_READ_ARCHIVE_P999_MS=%q\n" "${archive_p999}"
     printf "MIXED_WORKLOAD_RUNNER_FIVE_XX_COUNT=%q\n" "${five_xx_count}"
     printf "MIXED_WORKLOAD_RUNNER_NGINX_499_COUNT=%q\n" "0"
     printf "MIXED_WORKLOAD_RUNNER_HIKARI_VALIDATION_WARNINGS=%q\n" "0"
@@ -428,6 +512,9 @@ run_live_k6() {
     -e K6_COLD_ACCOUNT_ID="${cold_account_id}" \
     -e K6_COLD_FROM="${cold_from}" \
     -e K6_COLD_TO="${cold_to}" \
+    -e K6_ARCHIVE_ACCOUNT_ID="${archive_account_id}" \
+    -e K6_ARCHIVE_FROM="${archive_from}" \
+    -e K6_ARCHIVE_TO="${archive_to}" \
     -e K6_WRITE_SOURCE_ACCOUNT_ID="${write_source_account_id}" \
     -e K6_WRITE_TARGET_ACCOUNT_ID="${write_target_account_id}" \
     -e K6_WRITE_AMOUNT_MINOR="${write_amount_minor}" \

--- a/tools/test/run-transaction-read-oci-evidence-execution-gate.sh
+++ b/tools/test/run-transaction-read-oci-evidence-execution-gate.sh
@@ -194,7 +194,7 @@ BEGIN {
   for (i in required_items) {
     required[required_items[i]] = 1
   }
-  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\trun_script\tk6_summary_ref\tnginx_access_ref\tspring_metrics_ref\thikari_log_ref\tpostgres_wait_ref\tdeploy_event_ref\tcache_state_ref\ttimeline_ref\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tp999_ms\tp95_ms\tp99_ms\tmax_ms\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref\tworkload_components\tread_p999_ms\tread_429_source_ref"
+  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\trun_script\tk6_summary_ref\tnginx_access_ref\tspring_metrics_ref\thikari_log_ref\tpostgres_wait_ref\tdeploy_event_ref\tcache_state_ref\ttimeline_ref\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tp999_ms\tp95_ms\tp99_ms\tmax_ms\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref\tworkload_components\tread_p999_ms\tread_429_source_ref\tread_buckets\tread_bucket_ref\twrite_2xx_count\twrite_unexpected_status_count\twrite_status_ref"
 }
 NR == 1 {
   for (i = 1; i <= NF; i++) {
@@ -232,6 +232,11 @@ NR == 1 {
   workload_components = value("workload_components", "")
   read_p999_ms = value("read_p999_ms", "")
   read_429_source_ref = value("read_429_source_ref", "")
+  read_buckets = value("read_buckets", "")
+  read_bucket_ref = value("read_bucket_ref", "")
+  write_2xx_count = value("write_2xx_count", "")
+  write_unexpected_status_count = value("write_unexpected_status_count", "")
+  write_status_ref = value("write_status_ref", "")
   status = "pass"
   reason = "ok"
   seen[scenario] = 1
@@ -259,10 +264,18 @@ NR == 1 {
     require_ref("workload_component_ref", "workload-component-missing")
     require_ref("outbox_lag_ref", "outbox-lag-missing")
     require_ref("read_429_source_ref", "read-429-source-missing")
+    require_ref("read_bucket_ref", "read-bucket-missing")
+    require_ref("write_status_ref", "write-status-missing")
     read_p999_ms = require_number("read_p999_ms", "read-p999-missing")
+    write_2xx_count = require_number("write_2xx_count", "write-2xx-missing")
+    write_unexpected_status_count = require_number("write_unexpected_status_count", "write-unexpected-status-missing")
     if (read_p999_ms > max_p999_ms) add_reason("read-p999>" max_p999_ms)
+    if (write_2xx_count <= 0) add_reason("write-2xx-missing")
     if (!has_component(workload_components, "read") || !has_component(workload_components, "write") || !has_component(workload_components, "auth") || !has_component(workload_components, "notification") || !has_component(workload_components, "sse")) {
       add_reason("workload-components-missing")
+    }
+    if (!has_component(read_buckets, "hot") || !has_component(read_buckets, "cold") || !has_component(read_buckets, "archive")) {
+      add_reason("read-buckets-missing")
     }
     if (value("outbox_lag_max", "1") + 0 > 0) add_reason("outbox-lag>0")
   }
@@ -303,7 +316,7 @@ NR == 1 {
   if (p999_ms > max_p999_ms) add_reason("p999>" max_p999_ms)
 
   if (status == "fail") fail_count++
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
     scenario, status, reason, run_id, duration_min, source_ips, run_script,
     value("k6_summary_ref", ""), value("nginx_access_ref", ""), value("spring_metrics_ref", ""),
     value("hikari_log_ref", ""), value("postgres_wait_ref", ""), value("deploy_event_ref", ""),
@@ -312,7 +325,8 @@ NR == 1 {
     value("hikari_validation_warnings", "0"), value("db_pool_pending_max", "0"), value("p999_ms", "0"),
     p95_ms, p99_ms, max_ms, postgres_checkpoint_count, postgres_temp_file_count, nginx_upstream_p95_ms,
     hikari_config_ref, hikari_max_lifetime_ms, hikari_keepalive_time_ms, postgres_idle_timeout_ms, oci_nat_idle_timeout_ms, hikari_zero_warning_soak_ref,
-    workload_components, read_p999_ms, read_429_source_ref
+    workload_components, read_p999_ms, read_429_source_ref,
+    read_buckets, read_bucket_ref, write_2xx_count, write_unexpected_status_count, write_status_ref
 }
 END {
   missing = ""
@@ -374,6 +388,8 @@ cat >"${report_md}" <<REPORT
 - mixed workload closure artifacts: workload mix, component split, outbox lag
 - mixed workload required components: read,write,auth,notification,sse
 - mixed workload read p99.9 and 429 source artifact: required
+- mixed workload hot/cold/archive read bucket artifact: required
+- mixed workload write 2xx and status classification artifact: required
 - deploy drain closure artifacts: 499 budget, retry contract, reconnect success
 
 ## Result Table


### PR DESCRIPTION
## 🔗 Related Issue
- close #860

## 🌿 Base Branch
- `main`

## 📝 Summary
- mixed workload live evidence가 실제 write 2xx를 만들 수 있도록 staging fixture principal/account membership bootstrap을 보강했습니다.
- 30m mixed workload read evidence가 hot/cold/archive bucket별 p95/p99.9 및 429 source를 남기도록 k6/runner/gate 계약을 확장했습니다.
- 성능 개선 주장은 하지 않습니다. live artifact를 열기 위한 `[Test]` 범위이며 Transfer 비용 절감, Burst96 retune, multi-source infra는 제외했습니다.

## 🛠 Changes
- staging fixture bootstrap에 mixed workload write source/target 계정 생성, membership, balance snapshot 검증을 추가했습니다.
- live evidence workflow가 manifest 자동 생성 경로에서 staging DB resolver와 fixture bootstrap을 먼저 실행하도록 연결했습니다.
- mixed workload k6가 hot/cold/archive read bucket metric과 write unexpected status 분류 metric을 생성하도록 보강했습니다.
- runner/autogen/gate/report 계약에 `read-buckets.tsv`, `write-status.tsv`, write 2xx 필수 조건, hot/cold/archive coverage 검증을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh`
- `bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh`
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh`
- `tools/test/with-resource-lock.sh back-transfer-api ./back/gradlew -p back integrationTest --tests "*TransferCommandApiIntegrationTest"`
- `git diff --check origin/main...HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: mixed workload live workflow의 artifact 계약이 확장되어, 실제 OCI 실행에서 누락된 env/artifact가 있으면 gate가 더 명확히 실패할 수 있습니다.
- 롤백 방법: 이 PR revert. DB schema 변경은 없고, fixture bootstrap은 명시 계정 ID가 있을 때만 write fixture 계정을 추가합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?