### PR TITLE
[Fix] mixed workload live ephemeral replay token

### DIFF
--- a/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
+++ b/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
@@ -18,7 +18,9 @@ on:
       - ".github/workflows/transaction-read-mixed-workload-live-evidence.yml"
       - "ops/k6/transaction-read-mixed-workload-100m.js"
       - "tools/ops/staging-fixture-principal-bootstrap.sh"
+      - "tools/ops/issue-staging-replay-token.py"
       - "tools/ops/resolve-oci-a1-staging-database-url.sh"
+      - "tools/test/check-issue-staging-replay-token.py"
       - "tools/test/run-staging-fixture-principal-bootstrap-contract.sh"
       - "tools/test/run-transaction-read-mixed-workload-oci-k6.sh"
       - "tools/test/check-transaction-read-mixed-workload-oci-k6.sh"
@@ -54,6 +56,9 @@ jobs:
 
       - name: Check staging fixture principal contract
         run: bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+
+      - name: Check staging replay token issuer contract
+        run: python3 tools/test/check-issue-staging-replay-token.py
 
       - name: Check OCI mixed workload k6 runner contract
         run: bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh
@@ -151,8 +156,15 @@ jobs:
           MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID:-${K6_WRITE_SOURCE_ACCOUNT_ID:-920000001}}"
           MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID:-${K6_WRITE_TARGET_ACCOUNT_ID:-920000002}}"
 
-          if [[ -n "${STAGING_REPLAY_TOKEN:-}" ]]; then
-            mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"
+          mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"
+          if [[ -n "${OCI_A1_BACKEND_ENV_B64:-}" ]]; then
+            STAGING_REPLAY_TOKEN_OUTPUT_FILE="${mixed_workload_auth_token_file}" \
+            STAGING_REPLAY_TOKEN_TTL_SECONDS="${MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS:-7200}" \
+              python3 tools/ops/issue-staging-replay-token.py
+            mixed_workload_auth_token="$(<"${mixed_workload_auth_token_file}")"
+            printf '::add-mask::%s\n' "${mixed_workload_auth_token}"
+            printf 'MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE=%s\n' "${mixed_workload_auth_token_file}" >>"${GITHUB_ENV}"
+          elif [[ -n "${STAGING_REPLAY_TOKEN:-}" ]]; then
             printf '::add-mask::%s\n' "${STAGING_REPLAY_TOKEN}"
             printf '%s' "${STAGING_REPLAY_TOKEN}" >"${mixed_workload_auth_token_file}"
             chmod 600 "${mixed_workload_auth_token_file}"

--- a/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
+++ b/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
@@ -157,15 +157,7 @@ jobs:
           MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID:-${K6_WRITE_TARGET_ACCOUNT_ID:-920000002}}"
 
           mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"
-          if [[ -n "${OCI_A1_BACKEND_ENV_B64:-}" ]]; then
-            STAGING_REPLAY_SESSION_ID="" \
-            STAGING_REPLAY_TOKEN_OUTPUT_FILE="${mixed_workload_auth_token_file}" \
-            STAGING_REPLAY_TOKEN_TTL_SECONDS="${MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS:-7200}" \
-              python3 tools/ops/issue-staging-replay-token.py
-            mixed_workload_auth_token="$(<"${mixed_workload_auth_token_file}")"
-            printf '::add-mask::%s\n' "${mixed_workload_auth_token}"
-            printf 'MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE=%s\n' "${mixed_workload_auth_token_file}" >>"${GITHUB_ENV}"
-          elif [[ -n "${STAGING_REPLAY_TOKEN:-}" ]]; then
+          if [[ -z "${OCI_A1_BACKEND_ENV_B64:-}" && -n "${STAGING_REPLAY_TOKEN:-}" ]]; then
             printf '::add-mask::%s\n' "${STAGING_REPLAY_TOKEN}"
             printf '%s' "${STAGING_REPLAY_TOKEN}" >"${mixed_workload_auth_token_file}"
             chmod 600 "${mixed_workload_auth_token_file}"
@@ -202,6 +194,25 @@ jobs:
           fi
           echo "::add-mask::${resolved_database_url}"
           printf 'STAGING_OCI_A1_DATABASE_URL=%s\n' "${resolved_database_url}" >>"${GITHUB_ENV}"
+
+      - name: Issue mixed workload replay token
+        if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${OCI_A1_BACKEND_ENV_B64:-}" ]]; then
+            exit 0
+          fi
+
+          mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"
+          STAGING_REPLAY_SESSION_ID="" \
+          STAGING_REPLAY_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-}" \
+          STAGING_REPLAY_TOKEN_OUTPUT_FILE="${mixed_workload_auth_token_file}" \
+          STAGING_REPLAY_TOKEN_TTL_SECONDS="${MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS:-7200}" \
+            python3 tools/ops/issue-staging-replay-token.py
+          mixed_workload_auth_token="$(<"${mixed_workload_auth_token_file}")"
+          printf '::add-mask::%s\n' "${mixed_workload_auth_token}"
+          printf 'MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE=%s\n' "${mixed_workload_auth_token_file}" >>"${GITHUB_ENV}"
 
       - name: Ensure mixed workload fixture principal
         if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'

--- a/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
+++ b/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
@@ -213,6 +213,7 @@ jobs:
           mixed_workload_auth_token="$(<"${mixed_workload_auth_token_file}")"
           printf '::add-mask::%s\n' "${mixed_workload_auth_token}"
           printf 'MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE=%s\n' "${mixed_workload_auth_token_file}" >>"${GITHUB_ENV}"
+          printf 'STAGING_REPLAY_ALLOW_SESSION_REASSIGN=true\n' >>"${GITHUB_ENV}"
 
       - name: Ensure mixed workload fixture principal
         if: env.MIXED_WORKLOAD_EVIDENCE_READY != 'true'

--- a/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
+++ b/.github/workflows/transaction-read-mixed-workload-live-evidence.yml
@@ -158,6 +158,7 @@ jobs:
 
           mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"
           if [[ -n "${OCI_A1_BACKEND_ENV_B64:-}" ]]; then
+            STAGING_REPLAY_SESSION_ID="" \
             STAGING_REPLAY_TOKEN_OUTPUT_FILE="${mixed_workload_auth_token_file}" \
             STAGING_REPLAY_TOKEN_TTL_SECONDS="${MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS:-7200}" \
               python3 tools/ops/issue-staging-replay-token.py

--- a/tools/ops/issue-staging-replay-token.py
+++ b/tools/ops/issue-staging-replay-token.py
@@ -11,6 +11,7 @@ import time
 
 
 MAX_BIGINT = 9_223_372_036_854_775_807
+MIN_RUN_LOCAL_SESSION_ID = 9_000_000_000_000_000_000
 DEFAULT_USER_ID = 55
 DEFAULT_LOGIN_ID = "staging-fixture-user"
 DEFAULT_TTL_SECONDS = 7200
@@ -83,8 +84,25 @@ def require_backend_value(values: dict[str, str], name: str) -> str:
 
 
 def random_session_id() -> int:
-    # sequence 기반 운영 session과 충돌하지 않도록 63-bit 양수 범위에서 run-local id를 뽑는다.
-    return secrets.randbelow(MAX_BIGINT - 1) + 1
+    # sequence 기반 운영 session과 충돌하지 않도록 run-local 전용 high range를 사용한다.
+    return MIN_RUN_LOCAL_SESSION_ID + secrets.randbelow(MAX_BIGINT - MIN_RUN_LOCAL_SESSION_ID)
+
+
+def resolve_ttl_seconds() -> int:
+    raw = os.environ.get("STAGING_REPLAY_TOKEN_TTL_SECONDS")
+    if raw:
+        return positive_int("STAGING_REPLAY_TOKEN_TTL_SECONDS")
+    raw = os.environ.get("MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS")
+    if raw:
+        return positive_int("MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS")
+    return DEFAULT_TTL_SECONDS
+
+
+def resolve_session_id() -> tuple[int, str]:
+    raw = os.environ.get("STAGING_REPLAY_SESSION_ID")
+    if raw:
+        return positive_int("STAGING_REPLAY_SESSION_ID"), "env"
+    return random_session_id(), "generated"
 
 
 def issue_token(secret: str, issuer: str, user_id: int, subject: str, session_id: int, ttl_seconds: int) -> str:
@@ -132,17 +150,15 @@ def main() -> None:
     if not subject:
         fail("STAGING_REPLAY_LOGIN_ID must not be blank")
 
-    ttl_seconds = positive_int(
-        "STAGING_REPLAY_TOKEN_TTL_SECONDS",
-        positive_int("MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS", DEFAULT_TTL_SECONDS),
-    )
-    session_id = positive_int("STAGING_REPLAY_SESSION_ID", random_session_id())
+    ttl_seconds = resolve_ttl_seconds()
+    session_id, session_id_source = resolve_session_id()
 
     token = issue_token(secret, issuer, user_id, subject, session_id, ttl_seconds)
     write_token(output_path, token)
     print(
         "[issue-staging-replay-token] wrote "
-        f"token_file={output_path} user_id={user_id} session_id=present ttl_seconds={ttl_seconds}"
+        f"token_file={output_path} user_id={user_id} "
+        f"session_id_source={session_id_source} ttl_seconds={ttl_seconds}"
     )
 
 

--- a/tools/ops/issue-staging-replay-token.py
+++ b/tools/ops/issue-staging-replay-token.py
@@ -6,6 +6,7 @@ import json
 import os
 import pathlib
 import secrets
+import subprocess
 import sys
 import time
 
@@ -102,7 +103,42 @@ def resolve_session_id() -> tuple[int, str]:
     raw = os.environ.get("STAGING_REPLAY_SESSION_ID")
     if raw:
         return positive_int("STAGING_REPLAY_SESSION_ID"), "env"
+    database_url = os.environ.get("STAGING_REPLAY_DATABASE_URL") or os.environ.get("STAGING_DATABASE_URL")
+    if database_url:
+        return reserve_database_session_id(database_url), "database_sequence"
     return random_session_id(), "generated"
+
+
+def reserve_database_session_id(database_url: str) -> int:
+    query = """
+WITH candidate AS (
+    SELECT nextval(pg_get_serial_sequence('auth_refresh_token_session', 'id'))::bigint AS id
+)
+SELECT id
+FROM candidate
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM auth_refresh_token_session existing
+    WHERE existing.id = candidate.id
+);
+"""
+    for _ in range(5):
+        result = subprocess.run(
+            ["psql", database_url, "-AtX", "-v", "ON_ERROR_STOP=1", "-c", query],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode != 0:
+            fail("Failed to reserve auth_refresh_token_session sequence id")
+        value = result.stdout.strip()
+        if not value:
+            continue
+        if not value.isdigit() or int(value) <= 0:
+            fail("auth_refresh_token_session sequence returned an invalid id")
+        return int(value)
+    fail("Failed to reserve unused auth_refresh_token_session id")
 
 
 def issue_token(secret: str, issuer: str, user_id: int, subject: str, session_id: int, ttl_seconds: int) -> str:

--- a/tools/ops/issue-staging-replay-token.py
+++ b/tools/ops/issue-staging-replay-token.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+import base64
+import hashlib
+import hmac
+import json
+import os
+import pathlib
+import secrets
+import sys
+import time
+
+
+MAX_BIGINT = 9_223_372_036_854_775_807
+DEFAULT_USER_ID = 55
+DEFAULT_LOGIN_ID = "staging-fixture-user"
+DEFAULT_TTL_SECONDS = 7200
+
+
+def fail(message: str) -> None:
+    print(f"::error::{message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def positive_int(name: str, default: int | None = None) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        if default is None:
+            fail(f"{name} is required")
+        return default
+    if not raw.isdigit() or int(raw) <= 0:
+        fail(f"{name} must be a positive integer")
+    return int(raw)
+
+
+def base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def decode_backend_env() -> str:
+    encoded = os.environ.get("OCI_A1_BACKEND_ENV_B64") or os.environ.get("BACKEND_ENV_B64")
+    if not encoded:
+        fail("OCI_A1_BACKEND_ENV_B64 is required")
+
+    cleaned = "".join(encoded.split())
+    padded = cleaned + ("=" * (-len(cleaned) % 4))
+    for decoder in (
+        lambda value: base64.b64decode(value, validate=True),
+        base64.urlsafe_b64decode,
+    ):
+        try:
+            return decoder(padded).decode("utf-8")
+        except Exception:
+            continue
+    fail("Failed to decode OCI_A1_BACKEND_ENV_B64")
+
+
+def parse_backend_env(text: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        name = name.strip()
+        value = value.strip()
+        if not name:
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        result[name] = value
+    return result
+
+
+def require_backend_value(values: dict[str, str], name: str) -> str:
+    value = values.get(name, "")
+    if not value:
+        fail(f"{name} is required in OCI_A1_BACKEND_ENV_B64")
+    return value
+
+
+def random_session_id() -> int:
+    # sequence 기반 운영 session과 충돌하지 않도록 63-bit 양수 범위에서 run-local id를 뽑는다.
+    return secrets.randbelow(MAX_BIGINT - 1) + 1
+
+
+def issue_token(secret: str, issuer: str, user_id: int, subject: str, session_id: int, ttl_seconds: int) -> str:
+    now = int(time.time())
+    payload: dict[str, int | str] = {
+        "sub": subject,
+        "iat": now,
+        "exp": now + ttl_seconds,
+        "user_id": user_id,
+        "session_id": session_id,
+    }
+    if issuer:
+        payload["iss"] = issuer
+
+    header = {"alg": "HS256", "typ": "JWT"}
+    header_segment = base64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    payload_segment = base64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{header_segment}.{payload_segment}".encode("ascii")
+    signature = hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    return f"{header_segment}.{payload_segment}.{base64url(signature)}"
+
+
+def write_token(path: pathlib.Path, token: str) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as output:
+            output.write(token)
+    finally:
+        os.chmod(path, 0o600)
+
+
+def main() -> None:
+    output_path_raw = os.environ.get("STAGING_REPLAY_TOKEN_OUTPUT_FILE", "")
+    if not output_path_raw:
+        fail("STAGING_REPLAY_TOKEN_OUTPUT_FILE is required")
+    output_path = pathlib.Path(output_path_raw)
+    if not output_path.parent.is_dir():
+        fail("STAGING_REPLAY_TOKEN_OUTPUT_FILE parent directory must exist")
+
+    backend_values = parse_backend_env(decode_backend_env())
+    secret = require_backend_value(backend_values, "SECURITY_JWT_SECRET")
+    issuer = backend_values.get("SECURITY_JWT_ISSUER", "")
+    user_id = positive_int("STAGING_REPLAY_USER_ID", DEFAULT_USER_ID)
+    subject = os.environ.get("STAGING_REPLAY_LOGIN_ID", DEFAULT_LOGIN_ID)
+    if not subject:
+        fail("STAGING_REPLAY_LOGIN_ID must not be blank")
+
+    ttl_seconds = positive_int(
+        "STAGING_REPLAY_TOKEN_TTL_SECONDS",
+        positive_int("MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS", DEFAULT_TTL_SECONDS),
+    )
+    session_id = positive_int("STAGING_REPLAY_SESSION_ID", random_session_id())
+
+    token = issue_token(secret, issuer, user_id, subject, session_id, ttl_seconds)
+    write_token(output_path, token)
+    print(
+        "[issue-staging-replay-token] wrote "
+        f"token_file={output_path} user_id={user_id} session_id=present ttl_seconds={ttl_seconds}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -412,7 +412,7 @@ ensure_fixture_principal() {
                 AND session_status = 'ACTIVE'
                 AND expires_at > CURRENT_TIMESTAMP
           )
-          AND :'replay_allow_session_reassign' <> 'true'
+          AND (:replay_allow_session_reassign)::boolean IS NOT TRUE
           THEN CAST('replay session id belongs to another user' AS integer)
           ELSE 1
       END
@@ -446,7 +446,7 @@ ensure_fixture_principal() {
       ON CONFLICT (id)
       DO UPDATE
       SET user_id = CASE
-              WHEN :'replay_allow_session_reassign' = 'true' THEN EXCLUDED.user_id
+              WHEN (:replay_allow_session_reassign)::boolean IS TRUE THEN EXCLUDED.user_id
               ELSE auth_refresh_token_session.user_id
           END,
           token_hash = EXCLUDED.token_hash,
@@ -456,7 +456,7 @@ ensure_fixture_principal() {
           session_status = 'ACTIVE',
           expires_at = GREATEST(auth_refresh_token_session.expires_at, EXCLUDED.expires_at),
           updated_at = CURRENT_TIMESTAMP
-      WHERE :'replay_allow_session_reassign' = 'true'
+      WHERE (:replay_allow_session_reassign)::boolean IS TRUE
          OR auth_refresh_token_session.user_id = EXCLUDED.user_id
          OR auth_refresh_token_session.session_status <> 'ACTIVE'
          OR auth_refresh_token_session.expires_at <= CURRENT_TIMESTAMP;

--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -234,11 +234,34 @@ validate_inputs() {
   resolve_replay_token_session
 }
 
+check_replay_session_ownership() {
+  [[ -n "${STAGING_REPLAY_SESSION_ID}" ]] || return 0
+  [[ "${STAGING_REPLAY_ALLOW_SESSION_REASSIGN}" == "true" ]] && return 0
+
+  psql "${STAGING_DATABASE_URL}" \
+    -v ON_ERROR_STOP=1 \
+    -v fixture_user_id="${STAGING_REPLAY_USER_ID}" \
+    -v replay_session_id="${STAGING_REPLAY_SESSION_ID}" <<'SQL'
+      SELECT CASE
+          WHEN EXISTS (
+              SELECT 1
+              FROM auth_refresh_token_session
+              WHERE id = NULLIF(:'replay_session_id', '')::bigint
+                AND user_id <> :fixture_user_id
+                AND session_status = 'ACTIVE'
+                AND expires_at > CURRENT_TIMESTAMP
+          )
+          THEN CAST('replay session id belongs to another user' AS integer)
+          ELSE 1
+      END;
+SQL
+}
+
 ensure_fixture_principal() {
   # replay JWT는 user_id claim을 고정하므로, smoke/replay 전에 권한 row도 같은 id로 고정합니다.
   local attempt=1
   while true; do
-    if psql "${STAGING_DATABASE_URL}" \
+    if check_replay_session_ownership && psql "${STAGING_DATABASE_URL}" \
     -v ON_ERROR_STOP=1 \
     -v fixture_user_id="${STAGING_REPLAY_USER_ID}" \
     -v fixture_login_id="${STAGING_REPLAY_LOGIN_ID}" \
@@ -403,21 +426,6 @@ ensure_fixture_principal() {
           updated_at = CURRENT_TIMESTAMP;
 
       -- mixed workload write는 current session active gate를 통과해야 하므로 replay JWT의 session row를 맞춘다.
-      SELECT CASE
-          WHEN EXISTS (
-              SELECT 1
-              FROM auth_refresh_token_session
-              WHERE id = NULLIF(:'replay_session_id', '')::bigint
-                AND user_id <> :fixture_user_id
-                AND session_status = 'ACTIVE'
-                AND expires_at > CURRENT_TIMESTAMP
-          )
-          AND (:replay_allow_session_reassign)::boolean IS NOT TRUE
-          THEN CAST('replay session id belongs to another user' AS integer)
-          ELSE 1
-      END
-      WHERE NULLIF(:'replay_session_id', '') IS NOT NULL;
-
       INSERT INTO auth_refresh_token_session (
           id,
           user_id,
@@ -445,21 +453,14 @@ ensure_fixture_principal() {
       WHERE NULLIF(:'replay_session_id', '') IS NOT NULL
       ON CONFLICT (id)
       DO UPDATE
-      SET user_id = CASE
-              WHEN (:replay_allow_session_reassign)::boolean IS TRUE THEN EXCLUDED.user_id
-              ELSE auth_refresh_token_session.user_id
-          END,
+      SET user_id = EXCLUDED.user_id,
           token_hash = EXCLUDED.token_hash,
           device_binding_hash = EXCLUDED.device_binding_hash,
           device_name = EXCLUDED.device_name,
           ip_address = EXCLUDED.ip_address,
           session_status = 'ACTIVE',
           expires_at = GREATEST(auth_refresh_token_session.expires_at, EXCLUDED.expires_at),
-          updated_at = CURRENT_TIMESTAMP
-      WHERE (:replay_allow_session_reassign)::boolean IS TRUE
-         OR auth_refresh_token_session.user_id = EXCLUDED.user_id
-         OR auth_refresh_token_session.session_status <> 'ACTIVE'
-         OR auth_refresh_token_session.expires_at <= CURRENT_TIMESTAMP;
+          updated_at = CURRENT_TIMESTAMP;
 
       INSERT INTO user_account_membership (
           user_id,

--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -23,6 +23,7 @@ STAGING_MIXED_WORKLOAD_WRITE_TARGET_BALANCE_MINOR="${STAGING_MIXED_WORKLOAD_WRIT
 STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS="${STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS:-3}"
 STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS="${STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS:-5}"
 STAGING_REPLAY_TOKEN_FILE="${STAGING_REPLAY_TOKEN_FILE:-}"
+STAGING_REPLAY_ALLOW_SESSION_REASSIGN="${STAGING_REPLAY_ALLOW_SESSION_REASSIGN:-false}"
 STAGING_REPLAY_SESSION_ID=""
 STAGING_REPLAY_SESSION_EXPIRES_EPOCH=""
 STAGING_REPLAY_SESSION_TOKEN_HASH=""
@@ -53,6 +54,12 @@ require_non_negative_integer() {
   local name="$1"
   local value="${!name:-}"
   [[ "$value" =~ ^[0-9]+$ ]] || fail "${name} must be a non-negative integer"
+}
+
+require_boolean() {
+  local name="$1"
+  local value="${!name:-}"
+  [[ "${value}" == "true" || "${value}" == "false" ]] || fail "${name} must be true or false"
 }
 
 normalize_account_ids() {
@@ -223,6 +230,7 @@ validate_inputs() {
   validate_optional_write_accounts
   require_positive_integer STAGING_FIXTURE_PRINCIPAL_DB_ATTEMPTS
   require_non_negative_integer STAGING_FIXTURE_PRINCIPAL_DB_RETRY_SLEEP_SECONDS
+  require_boolean STAGING_REPLAY_ALLOW_SESSION_REASSIGN
   resolve_replay_token_session
 }
 
@@ -251,7 +259,8 @@ ensure_fixture_principal() {
     -v replay_session_id="${STAGING_REPLAY_SESSION_ID}" \
     -v replay_session_expires_epoch="${STAGING_REPLAY_SESSION_EXPIRES_EPOCH}" \
     -v replay_session_token_hash="${STAGING_REPLAY_SESSION_TOKEN_HASH}" \
-    -v replay_session_device_binding_hash="${STAGING_REPLAY_SESSION_DEVICE_BINDING_HASH}" <<'SQL'
+    -v replay_session_device_binding_hash="${STAGING_REPLAY_SESSION_DEVICE_BINDING_HASH}" \
+    -v replay_allow_session_reassign="${STAGING_REPLAY_ALLOW_SESSION_REASSIGN}" <<'SQL'
       -- psql 변수(:name)는 -c 경로에서 치환되지 않아 stdin으로 전달한다.
       BEGIN;
 
@@ -403,6 +412,7 @@ ensure_fixture_principal() {
                 AND session_status = 'ACTIVE'
                 AND expires_at > CURRENT_TIMESTAMP
           )
+          AND :'replay_allow_session_reassign' <> 'true'
           THEN CAST('replay session id belongs to another user' AS integer)
           ELSE 1
       END
@@ -435,14 +445,19 @@ ensure_fixture_principal() {
       WHERE NULLIF(:'replay_session_id', '') IS NOT NULL
       ON CONFLICT (id)
       DO UPDATE
-      SET token_hash = EXCLUDED.token_hash,
+      SET user_id = CASE
+              WHEN :'replay_allow_session_reassign' = 'true' THEN EXCLUDED.user_id
+              ELSE auth_refresh_token_session.user_id
+          END,
+          token_hash = EXCLUDED.token_hash,
           device_binding_hash = EXCLUDED.device_binding_hash,
           device_name = EXCLUDED.device_name,
           ip_address = EXCLUDED.ip_address,
           session_status = 'ACTIVE',
           expires_at = GREATEST(auth_refresh_token_session.expires_at, EXCLUDED.expires_at),
           updated_at = CURRENT_TIMESTAMP
-      WHERE auth_refresh_token_session.user_id = EXCLUDED.user_id
+      WHERE :'replay_allow_session_reassign' = 'true'
+         OR auth_refresh_token_session.user_id = EXCLUDED.user_id
          OR auth_refresh_token_session.session_status <> 'ACTIVE'
          OR auth_refresh_token_session.expires_at <= CURRENT_TIMESTAMP;
 

--- a/tools/test/check-issue-staging-replay-token.py
+++ b/tools/test/check-issue-staging-replay-token.py
@@ -14,6 +14,7 @@ import time
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "tools" / "ops" / "issue-staging-replay-token.py"
+MIN_RUN_LOCAL_SESSION_ID = 9_000_000_000_000_000_000
 
 
 def fail(message: str) -> None:
@@ -82,6 +83,8 @@ def assert_ephemeral_token_is_signed() -> None:
             fail("issuer should write token only to the output file")
         if secret in result.stdout or secret in result.stderr:
             fail("issuer output must not leak JWT secret")
+        if "session_id_source=env" not in result.stdout:
+            fail(f"issuer should mark explicit session id source: {result.stdout!r}")
 
         mode = stat.S_IMODE(output_file.stat().st_mode)
         if mode != 0o600:
@@ -118,6 +121,31 @@ def assert_ephemeral_token_is_signed() -> None:
             fail(f"iat claim should be current run time: {payload!r}")
 
 
+def assert_empty_session_id_uses_reserved_generated_range() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_file = pathlib.Path(temp_dir) / "generated-session.jwt"
+        secret = "contract-secret-with-enough-entropy"
+        env_b64 = encode_env(f"SECURITY_JWT_SECRET={secret}\n")
+        result = run_issuer(
+            {
+                "OCI_A1_BACKEND_ENV_B64": env_b64,
+                "STAGING_REPLAY_TOKEN_OUTPUT_FILE": str(output_file),
+                "STAGING_REPLAY_SESSION_ID": "",
+            }
+        )
+
+        if result.returncode != 0:
+            fail(f"issuer should generate session id, stderr={result.stderr!r}, stdout={result.stdout!r}")
+        if "session_id_source=generated" not in result.stdout:
+            fail(f"issuer should mark generated session id source: {result.stdout!r}")
+
+        token = output_file.read_text(encoding="utf-8").strip()
+        payload = decode_segment(token.split(".")[1])
+        session_id = payload.get("session_id")
+        if not isinstance(session_id, int) or session_id < MIN_RUN_LOCAL_SESSION_ID:
+            fail(f"generated session id should use reserved high range: {payload!r}")
+
+
 def assert_missing_secret_fails_without_token() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         output_file = pathlib.Path(temp_dir) / "missing-secret.jwt"
@@ -140,6 +168,8 @@ def assert_missing_secret_fails_without_token() -> None:
 def main() -> None:
     print("[issue-staging-replay-token] signed token contract")
     assert_ephemeral_token_is_signed()
+    print("[issue-staging-replay-token] generated session contract")
+    assert_empty_session_id_uses_reserved_generated_range()
     print("[issue-staging-replay-token] missing secret contract")
     assert_missing_secret_fails_without_token()
     print("ok")

--- a/tools/test/check-issue-staging-replay-token.py
+++ b/tools/test/check-issue-staging-replay-token.py
@@ -30,9 +30,13 @@ def decode_segment(value: str) -> dict:
     return json.loads(base64.urlsafe_b64decode(padded.encode("ascii")))
 
 
-def run_issuer(extra_env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def run_issuer(
+    extra_env: dict[str, str], path_prefix: pathlib.Path | None = None
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.update(extra_env)
+    if path_prefix is not None:
+        env["PATH"] = f"{path_prefix}{os.pathsep}{env.get('PATH', '')}"
     return subprocess.run(
         [sys.executable, str(SCRIPT)],
         cwd=REPO_ROOT,
@@ -146,6 +150,57 @@ def assert_empty_session_id_uses_reserved_generated_range() -> None:
             fail(f"generated session id should use reserved high range: {payload!r}")
 
 
+def assert_database_sequence_session_id_is_used_when_available() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = pathlib.Path(temp_dir)
+        fake_bin = temp_path / "bin"
+        fake_bin.mkdir()
+        psql_log = temp_path / "psql-args.log"
+        psql = fake_bin / "psql"
+        psql.write_text(
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import pathlib",
+                    "import sys",
+                    f"pathlib.Path({str(psql_log)!r}).write_text(' '.join(sys.argv), encoding='utf-8')",
+                    "print('345678901')",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        psql.chmod(0o700)
+
+        output_file = temp_path / "database-sequence.jwt"
+        secret = "contract-secret-with-enough-entropy"
+        env_b64 = encode_env(f"SECURITY_JWT_SECRET={secret}\n")
+        result = run_issuer(
+            {
+                "OCI_A1_BACKEND_ENV_B64": env_b64,
+                "STAGING_REPLAY_TOKEN_OUTPUT_FILE": str(output_file),
+                "STAGING_REPLAY_DATABASE_URL": "postgresql://fixture:secret@127.0.0.1/aquila",
+                "STAGING_REPLAY_SESSION_ID": "",
+            },
+            path_prefix=fake_bin,
+        )
+
+        if result.returncode != 0:
+            fail(f"issuer should use database sequence, stderr={result.stderr!r}, stdout={result.stdout!r}")
+        if "session_id_source=database_sequence" not in result.stdout:
+            fail(f"issuer should mark database sequence source: {result.stdout!r}")
+
+        token = output_file.read_text(encoding="utf-8").strip()
+        payload = decode_segment(token.split(".")[1])
+        if payload.get("session_id") != 345678901:
+            fail(f"issuer should use psql sequence result: {payload!r}")
+        psql_args = psql_log.read_text(encoding="utf-8")
+        if "postgresql://fixture:secret@127.0.0.1/aquila" in result.stdout + result.stderr:
+            fail("issuer output must not leak database URL")
+        if "pg_get_serial_sequence" not in psql_args:
+            fail(f"issuer should query auth_refresh_token_session sequence: {psql_args!r}")
+
+
 def assert_missing_secret_fails_without_token() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         output_file = pathlib.Path(temp_dir) / "missing-secret.jwt"
@@ -170,6 +225,8 @@ def main() -> None:
     assert_ephemeral_token_is_signed()
     print("[issue-staging-replay-token] generated session contract")
     assert_empty_session_id_uses_reserved_generated_range()
+    print("[issue-staging-replay-token] database sequence contract")
+    assert_database_sequence_session_id_is_used_when_available()
     print("[issue-staging-replay-token] missing secret contract")
     assert_missing_secret_fails_without_token()
     print("ok")

--- a/tools/test/check-issue-staging-replay-token.py
+++ b/tools/test/check-issue-staging-replay-token.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+import base64
+import hashlib
+import hmac
+import json
+import os
+import pathlib
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools" / "ops" / "issue-staging-replay-token.py"
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def encode_env(value: str) -> str:
+    return base64.b64encode(value.encode("utf-8")).decode("ascii")
+
+
+def decode_segment(value: str) -> dict:
+    padded = value + ("=" * (-len(value) % 4))
+    return json.loads(base64.urlsafe_b64decode(padded.encode("ascii")))
+
+
+def run_issuer(extra_env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def assert_ephemeral_token_is_signed() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_file = pathlib.Path(temp_dir) / "replay-token.jwt"
+        secret = "contract-secret-with-enough-entropy"
+        issuer = "https://staging.example.test"
+        env_b64 = encode_env(
+            "\n".join(
+                [
+                    "SPRING_DATASOURCE_URL=jdbc:postgresql://postgres/aquila",
+                    f"SECURITY_JWT_SECRET={secret}",
+                    f"SECURITY_JWT_ISSUER={issuer}",
+                    "",
+                ]
+            )
+        )
+
+        before = int(time.time())
+        result = run_issuer(
+            {
+                "OCI_A1_BACKEND_ENV_B64": env_b64,
+                "STAGING_REPLAY_TOKEN_OUTPUT_FILE": str(output_file),
+                "STAGING_REPLAY_USER_ID": "55",
+                "STAGING_REPLAY_LOGIN_ID": "staging-fixture-user",
+                "STAGING_REPLAY_SESSION_ID": "123456789",
+                "STAGING_REPLAY_TOKEN_TTL_SECONDS": "7200",
+            }
+        )
+        after = int(time.time())
+
+        if result.returncode != 0:
+            fail(f"issuer should succeed, stderr={result.stderr!r}, stdout={result.stdout!r}")
+        if not output_file.is_file():
+            fail("issuer should create token output file")
+
+        token = output_file.read_text(encoding="utf-8").strip()
+        if not token or token in result.stdout or token in result.stderr:
+            fail("issuer should write token only to the output file")
+        if secret in result.stdout or secret in result.stderr:
+            fail("issuer output must not leak JWT secret")
+
+        mode = stat.S_IMODE(output_file.stat().st_mode)
+        if mode != 0o600:
+            fail(f"token file mode should be 0600, got {oct(mode)}")
+
+        parts = token.split(".")
+        if len(parts) != 3:
+            fail("issuer should write a compact JWT")
+
+        header = decode_segment(parts[0])
+        payload = decode_segment(parts[1])
+        expected_signature = hmac.new(
+            secret.encode("utf-8"),
+            f"{parts[0]}.{parts[1]}".encode("ascii"),
+            hashlib.sha256,
+        ).digest()
+        actual_signature = base64.urlsafe_b64decode(parts[2] + ("=" * (-len(parts[2]) % 4)))
+
+        if not hmac.compare_digest(actual_signature, expected_signature):
+            fail("JWT signature should be HS256 over the backend JWT secret")
+        if header != {"alg": "HS256", "typ": "JWT"}:
+            fail(f"unexpected JWT header: {header!r}")
+        if payload.get("iss") != issuer:
+            fail(f"issuer claim mismatch: {payload!r}")
+        if payload.get("sub") != "staging-fixture-user":
+            fail(f"subject claim mismatch: {payload!r}")
+        if payload.get("user_id") != 55:
+            fail(f"user_id claim mismatch: {payload!r}")
+        if payload.get("session_id") != 123456789:
+            fail(f"session_id claim mismatch: {payload!r}")
+        if payload.get("exp") - payload.get("iat") != 7200:
+            fail(f"ttl claim mismatch: {payload!r}")
+        if not (before <= payload.get("iat") <= after):
+            fail(f"iat claim should be current run time: {payload!r}")
+
+
+def assert_missing_secret_fails_without_token() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_file = pathlib.Path(temp_dir) / "missing-secret.jwt"
+        env_b64 = encode_env("SECURITY_JWT_ISSUER=https://staging.example.test\n")
+        result = run_issuer(
+            {
+                "OCI_A1_BACKEND_ENV_B64": env_b64,
+                "STAGING_REPLAY_TOKEN_OUTPUT_FILE": str(output_file),
+            }
+        )
+
+        if result.returncode == 0:
+            fail("issuer should fail when SECURITY_JWT_SECRET is absent")
+        if output_file.exists():
+            fail("issuer should not create a token without signing secret")
+        if "SECURITY_JWT_SECRET" not in result.stderr:
+            fail(f"failure should identify missing secret without leaking values: {result.stderr!r}")
+
+
+def main() -> None:
+    print("[issue-staging-replay-token] signed token contract")
+    assert_ephemeral_token_is_signed()
+    print("[issue-staging-replay-token] missing secret contract")
+    assert_missing_secret_fails_without_token()
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
@@ -73,6 +73,7 @@ grep -F 'python3 tools/ops/issue-staging-replay-token.py' "${workflow}" >/dev/nu
 grep -F 'mixed_workload_auth_token="$(<"${mixed_workload_auth_token_file}")"' "${workflow}" >/dev/null
 grep -F 'printf '\''::add-mask::%s\n'\'' "${mixed_workload_auth_token}"' "${workflow}" >/dev/null
 grep -F 'if [[ -z "${OCI_A1_BACKEND_ENV_B64:-}" && -n "${STAGING_REPLAY_TOKEN:-}" ]]; then' "${workflow}" >/dev/null
+grep -F 'printf '\''STAGING_REPLAY_ALLOW_SESSION_REASSIGN=true\n'\'' >>"${GITHUB_ENV}"' "${workflow}" >/dev/null
 grep -F 'printf '\''::add-mask::%s\n'\'' "${STAGING_REPLAY_TOKEN}"' "${workflow}" >/dev/null
 grep -F 'printf '\''%s'\'' "${STAGING_REPLAY_TOKEN}" >"${mixed_workload_auth_token_file}"' "${workflow}" >/dev/null
 grep -F 'chmod 600 "${mixed_workload_auth_token_file}"' "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
@@ -64,6 +64,7 @@ grep -F 'STAGING_REPLAY_TOKEN_FILE="${MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE:-}"' "$
 grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
 grep -F 'mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"' "${workflow}" >/dev/null
 grep -F 'if [[ -n "${OCI_A1_BACKEND_ENV_B64:-}" ]]; then' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_SESSION_ID="" \' "${workflow}" >/dev/null
 grep -F 'STAGING_REPLAY_TOKEN_OUTPUT_FILE="${mixed_workload_auth_token_file}" \' "${workflow}" >/dev/null
 grep -F 'STAGING_REPLAY_TOKEN_TTL_SECONDS="${MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS:-7200}" \' "${workflow}" >/dev/null
 grep -F 'python3 tools/ops/issue-staging-replay-token.py' "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
@@ -57,20 +57,22 @@ grep -F 'printf '\''MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID=%s\n'\'' "${MIXED
 grep -F 'printf '\''MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID=%s\n'\'' "${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID}" >>"${GITHUB_ENV}"' "${workflow}" >/dev/null
 grep -F "name: Resolve mixed workload staging database URL" "${workflow}" >/dev/null
 grep -F "tools/ops/resolve-oci-a1-staging-database-url.sh" "${workflow}" >/dev/null
+grep -F "name: Issue mixed workload replay token" "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-}" \' "${workflow}" >/dev/null
 grep -F "name: Ensure mixed workload fixture principal" "${workflow}" >/dev/null
 grep -F 'STAGING_MIXED_WORKLOAD_WRITE_SOURCE_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WRITE_SOURCE_ACCOUNT_ID}"' "${workflow}" >/dev/null
 grep -F 'STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WRITE_TARGET_ACCOUNT_ID}"' "${workflow}" >/dev/null
 grep -F 'STAGING_REPLAY_TOKEN_FILE="${MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE:-}"' "${workflow}" >/dev/null
 grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
 grep -F 'mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"' "${workflow}" >/dev/null
-grep -F 'if [[ -n "${OCI_A1_BACKEND_ENV_B64:-}" ]]; then' "${workflow}" >/dev/null
+grep -F 'if [[ -z "${OCI_A1_BACKEND_ENV_B64:-}" ]]; then' "${workflow}" >/dev/null
 grep -F 'STAGING_REPLAY_SESSION_ID="" \' "${workflow}" >/dev/null
 grep -F 'STAGING_REPLAY_TOKEN_OUTPUT_FILE="${mixed_workload_auth_token_file}" \' "${workflow}" >/dev/null
 grep -F 'STAGING_REPLAY_TOKEN_TTL_SECONDS="${MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS:-7200}" \' "${workflow}" >/dev/null
 grep -F 'python3 tools/ops/issue-staging-replay-token.py' "${workflow}" >/dev/null
 grep -F 'mixed_workload_auth_token="$(<"${mixed_workload_auth_token_file}")"' "${workflow}" >/dev/null
 grep -F 'printf '\''::add-mask::%s\n'\'' "${mixed_workload_auth_token}"' "${workflow}" >/dev/null
-grep -F 'elif [[ -n "${STAGING_REPLAY_TOKEN:-}" ]]; then' "${workflow}" >/dev/null
+grep -F 'if [[ -z "${OCI_A1_BACKEND_ENV_B64:-}" && -n "${STAGING_REPLAY_TOKEN:-}" ]]; then' "${workflow}" >/dev/null
 grep -F 'printf '\''::add-mask::%s\n'\'' "${STAGING_REPLAY_TOKEN}"' "${workflow}" >/dev/null
 grep -F 'printf '\''%s'\'' "${STAGING_REPLAY_TOKEN}" >"${mixed_workload_auth_token_file}"' "${workflow}" >/dev/null
 grep -F 'chmod 600 "${mixed_workload_auth_token_file}"' "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh
@@ -19,6 +19,7 @@ grep -F "mixed workload live evidence contract" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh" "${workflow}" >/dev/null
+grep -F "python3 tools/test/check-issue-staging-replay-token.py" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh" "${workflow}" >/dev/null
 grep -F "bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh" "${workflow}" >/dev/null
@@ -36,6 +37,8 @@ grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_INPUT: ${{ inputs.evidence_manifes
 grep -F 'MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV_VAR: ${{ vars.OCI_MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV }}' "${workflow}" >/dev/null
 grep -F 'staging_db_env_names=(' "${workflow}" >/dev/null
 grep -F 'OCI_A1_BACKEND_ENV_B64' "${workflow}" >/dev/null
+grep -F 'tools/ops/issue-staging-replay-token.py' "${workflow}" >/dev/null
+grep -F 'tools/test/check-issue-staging-replay-token.py' "${workflow}" >/dev/null
 grep -F 'STAGING_OCI_A1_DATABASE_URL' "${workflow}" >/dev/null
 grep -F 'POSTGRES_CONTAINER_NAME' "${workflow}" >/dev/null
 grep -F 'POSTGRES_NETWORK_ALIAS' "${workflow}" >/dev/null
@@ -60,6 +63,13 @@ grep -F 'STAGING_MIXED_WORKLOAD_WRITE_TARGET_ACCOUNT_ID="${MIXED_WORKLOAD_OCI_WR
 grep -F 'STAGING_REPLAY_TOKEN_FILE="${MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE:-}"' "${workflow}" >/dev/null
 grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
 grep -F 'mixed_workload_auth_token_file="${RUNNER_TEMP}/mixed-workload-live-auth-token"' "${workflow}" >/dev/null
+grep -F 'if [[ -n "${OCI_A1_BACKEND_ENV_B64:-}" ]]; then' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_OUTPUT_FILE="${mixed_workload_auth_token_file}" \' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_TTL_SECONDS="${MIXED_WORKLOAD_REPLAY_TOKEN_TTL_SECONDS:-7200}" \' "${workflow}" >/dev/null
+grep -F 'python3 tools/ops/issue-staging-replay-token.py' "${workflow}" >/dev/null
+grep -F 'mixed_workload_auth_token="$(<"${mixed_workload_auth_token_file}")"' "${workflow}" >/dev/null
+grep -F 'printf '\''::add-mask::%s\n'\'' "${mixed_workload_auth_token}"' "${workflow}" >/dev/null
+grep -F 'elif [[ -n "${STAGING_REPLAY_TOKEN:-}" ]]; then' "${workflow}" >/dev/null
 grep -F 'printf '\''::add-mask::%s\n'\'' "${STAGING_REPLAY_TOKEN}"' "${workflow}" >/dev/null
 grep -F 'printf '\''%s'\'' "${STAGING_REPLAY_TOKEN}" >"${mixed_workload_auth_token_file}"' "${workflow}" >/dev/null
 grep -F 'chmod 600 "${mixed_workload_auth_token_file}"' "${workflow}" >/dev/null

--- a/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+++ b/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
@@ -215,9 +215,9 @@ assert_replay_token_session_reassign_is_explicit() {
   run_bootstrap_with_replay_token_file_reassign >/dev/null
 
   grep -q -- "replay_allow_session_reassign=true" "${psql_log}"
-  grep -q -- ":'replay_allow_session_reassign' <> 'true'" "${psql_stdin_log}"
+  grep -q -- "(:replay_allow_session_reassign)::boolean IS NOT TRUE" "${psql_stdin_log}"
   grep -q -- "user_id = CASE" "${psql_stdin_log}"
-  grep -q -- ":'replay_allow_session_reassign' = 'true'" "${psql_stdin_log}"
+  grep -q -- "(:replay_allow_session_reassign)::boolean IS TRUE" "${psql_stdin_log}"
 }
 
 assert_replay_token_user_mismatch_fails_before_psql() {

--- a/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+++ b/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
@@ -106,6 +106,29 @@ run_bootstrap_with_replay_token_file() {
     "${script}"
 }
 
+run_bootstrap_with_replay_token_file_reassign() {
+  local token_file="${tmp_dir}/staging-replay-token-reassign.jwt"
+  printf '%s' \
+    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdGFnaW5nLWZpeHR1cmUtdXNlciIsInVzZXJfaWQiOjU1LCJzZXNzaW9uX2lkIjoxMjM0NSwiZXhwIjoxODkzNDU2MDAwfQ.sig' \
+    >"${token_file}"
+  chmod 600 "${token_file}"
+
+  env \
+    PATH="${tmp_dir}:${PATH}" \
+    PSQL_STUB_LOG="${psql_log}" \
+    PSQL_STDIN_LOG="${psql_stdin_log}" \
+    STAGING_OCI_A1_DATABASE_URL="postgresql://fixture-db/aquila" \
+    STAGING_REPLAY_USER_ID="55" \
+    STAGING_REPLAY_LOGIN_ID="staging-fixture-user" \
+    STAGING_REPLAY_USER_PASSWORD_HASH="fixturePasswordHashWithLetters" \
+    STAGING_REPLAY_USER_DISPLAY_NAME="Staging Fixture User" \
+    STAGING_REPLAY_TOKEN_FILE="${token_file}" \
+    STAGING_REPLAY_ALLOW_SESSION_REASSIGN="true" \
+    HOT_ACCOUNT_ID="1001" \
+    COLD_ACCOUNT_ID="1002" \
+    "${script}"
+}
+
 run_bootstrap_with_mismatched_replay_token_file() {
   local token_file="${tmp_dir}/staging-replay-token-mismatch.jwt"
   printf '%s' \
@@ -170,6 +193,7 @@ assert_replay_token_session_is_bootstrapped_without_token_leak() {
 
   grep -q -- "replay_session_id=12345" "${psql_log}"
   grep -q -- "replay_session_expires_epoch=1893456000" "${psql_log}"
+  grep -q -- "replay_allow_session_reassign=false" "${psql_log}"
   grep -q -- "INSERT INTO auth_refresh_token_session" "${psql_stdin_log}"
   grep -q -- "OVERRIDING SYSTEM VALUE" "${psql_stdin_log}"
   grep -q -- "pg_get_serial_sequence('auth_refresh_token_session', 'id')" "${psql_stdin_log}"
@@ -177,10 +201,23 @@ assert_replay_token_session_is_bootstrapped_without_token_leak() {
   grep -q -- "expires_at > CURRENT_TIMESTAMP" "${psql_stdin_log}"
   grep -q -- "auth_refresh_token_session.session_status <> 'ACTIVE'" "${psql_stdin_log}"
   grep -q -- "auth_refresh_token_session.expires_at <= CURRENT_TIMESTAMP" "${psql_stdin_log}"
+  grep -q -- "replay_allow_session_reassign" "${psql_stdin_log}"
   if grep -F "eyJhbGciOiJIUzI1NiJ9" "${psql_log}" "${psql_stdin_log}" >/dev/null; then
     echo "replay bearer token must not be printed or passed to psql" >&2
     exit 1
   fi
+}
+
+assert_replay_token_session_reassign_is_explicit() {
+  : >"${psql_log}"
+  : >"${psql_stdin_log}"
+
+  run_bootstrap_with_replay_token_file_reassign >/dev/null
+
+  grep -q -- "replay_allow_session_reassign=true" "${psql_log}"
+  grep -q -- ":'replay_allow_session_reassign' <> 'true'" "${psql_stdin_log}"
+  grep -q -- "user_id = CASE" "${psql_stdin_log}"
+  grep -q -- ":'replay_allow_session_reassign' = 'true'" "${psql_stdin_log}"
 }
 
 assert_replay_token_user_mismatch_fails_before_psql() {
@@ -262,6 +299,7 @@ assert_valid_secret_like_values_do_not_enter_arithmetic
 assert_csv_account_ids_feed_fixture_sql
 assert_write_accounts_are_funded_and_authorized
 assert_replay_token_session_is_bootstrapped_without_token_leak
+assert_replay_token_session_reassign_is_explicit
 assert_replay_token_user_mismatch_fails_before_psql
 assert_transient_psql_timeout_retries_fixture_sql
 assert_too_long_password_hash_fails_before_psql

--- a/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+++ b/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
@@ -199,9 +199,7 @@ assert_replay_token_session_is_bootstrapped_without_token_leak() {
   grep -q -- "pg_get_serial_sequence('auth_refresh_token_session', 'id')" "${psql_stdin_log}"
   grep -q -- "session_status = 'ACTIVE'" "${psql_stdin_log}"
   grep -q -- "expires_at > CURRENT_TIMESTAMP" "${psql_stdin_log}"
-  grep -q -- "auth_refresh_token_session.session_status <> 'ACTIVE'" "${psql_stdin_log}"
-  grep -q -- "auth_refresh_token_session.expires_at <= CURRENT_TIMESTAMP" "${psql_stdin_log}"
-  grep -q -- "replay_allow_session_reassign" "${psql_stdin_log}"
+  grep -q -- "user_id = EXCLUDED.user_id" "${psql_stdin_log}"
   if grep -F "eyJhbGciOiJIUzI1NiJ9" "${psql_log}" "${psql_stdin_log}" >/dev/null; then
     echo "replay bearer token must not be printed or passed to psql" >&2
     exit 1
@@ -215,9 +213,11 @@ assert_replay_token_session_reassign_is_explicit() {
   run_bootstrap_with_replay_token_file_reassign >/dev/null
 
   grep -q -- "replay_allow_session_reassign=true" "${psql_log}"
-  grep -q -- "(:replay_allow_session_reassign)::boolean IS NOT TRUE" "${psql_stdin_log}"
-  grep -q -- "user_id = CASE" "${psql_stdin_log}"
-  grep -q -- "(:replay_allow_session_reassign)::boolean IS TRUE" "${psql_stdin_log}"
+  grep -q -- "user_id = EXCLUDED.user_id" "${psql_stdin_log}"
+  if grep -F "replay session id belongs to another user" "${psql_stdin_log}" >/dev/null; then
+    echo "reassign mode must skip replay session collision preflight" >&2
+    exit 1
+  fi
 }
 
 assert_replay_token_user_mismatch_fails_before_psql() {


### PR DESCRIPTION
## 🔗 Related Issue
- close #866

## 🌿 Base Branch
- `main`

## 📝 Summary
- mixed workload live evidence가 고정 `STAGING_REPLAY_TOKEN`의 `session_id` 충돌로 부하 단계 전에 실패하던 문제를 해결합니다.
- OCI backend env 경로는 DB URL resolve 이후 replay JWT를 발급하고, fixture bootstrap이 같은 session row를 준비하도록 연결합니다.
- 반복 live run에서 collision guard가 계속 차단되어, 최종적으로 allow=false static token은 별도 preflight로 보호하고 workflow-generated token은 명시적으로 fixture session을 회수하는 경로로 분리했습니다.

## 🛠 Changes
- `tools/ops/issue-staging-replay-token.py` 추가: backend env를 source하지 않고 JWT secret/issuer만 파싱해 HS256 replay JWT를 발급합니다.
- DB URL이 있으면 `psql`로 `auth_refresh_token_session` sequence 후보를 받아 미사용 session id를 JWT claim에 사용합니다.
- mixed workload live workflow에서 static `STAGING_REPLAY_TOKEN`은 backend env가 없을 때 fallback으로만 유지합니다.
- `STAGING_REPLAY_ALLOW_SESSION_REASSIGN` 기본값은 false이고, workflow-generated token에서만 true로 전달합니다.
- allow=false collision preflight와 allow=true fixture session 회수 upsert를 분리했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `python3 tools/test/check-issue-staging-replay-token.py`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh`
- `bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh`
- `bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh`
- `bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh`
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-transaction-read-evidence-completeness-gate.sh`
- `git diff --check origin/main...HEAD`
- `git rev-list --count origin/main..HEAD` → `8`
- live dispatch 25531006133, 25531120411, 25531255730, 25531433947, 25531574295, 25531668511로 root cause를 순차 분리했고 최신 head 재실행 예정

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: backend env secret 파싱 또는 DB sequence 예약 실패 시 mixed workload live workflow가 fail-fast합니다. secret 값과 token 값은 출력하지 않습니다. session reassign은 `STAGING_REPLAY_ALLOW_SESSION_REASSIGN=true`가 명시된 workflow-generated token 경로에만 적용됩니다.
- 롤백 방법: PR revert 또는 workflow에서 static `STAGING_REPLAY_TOKEN` fallback만 사용하도록 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?