### PR TITLE
[Fix] staging fixture replay session collision preflight

### DIFF
--- a/tools/ops/staging-fixture-principal-bootstrap.sh
+++ b/tools/ops/staging-fixture-principal-bootstrap.sh
@@ -242,6 +242,7 @@ check_replay_session_ownership() {
     -v ON_ERROR_STOP=1 \
     -v fixture_user_id="${STAGING_REPLAY_USER_ID}" \
     -v replay_session_id="${STAGING_REPLAY_SESSION_ID}" <<'SQL'
+      -- token session 탈취 방지: 충돌은 타입 오류가 아닌 고정 메시지로 종료한다.
       SELECT CASE
           WHEN EXISTS (
               SELECT 1
@@ -251,9 +252,14 @@ check_replay_session_ownership() {
                 AND session_status = 'ACTIVE'
                 AND expires_at > CURRENT_TIMESTAMP
           )
-          THEN CAST('replay session id belongs to another user' AS integer)
-          ELSE 1
-      END;
+          THEN 'true'
+          ELSE 'false'
+      END AS replay_session_owner_conflict
+      \gset
+      \if :replay_session_owner_conflict
+        \echo 'replay_session_owner_conflict'
+        \quit 1
+      \endif
 SQL
 }
 

--- a/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+++ b/tools/test/run-staging-fixture-principal-bootstrap-contract.sh
@@ -220,6 +220,19 @@ assert_replay_token_session_reassign_is_explicit() {
   fi
 }
 
+assert_replay_token_session_collision_uses_sanitized_exception() {
+  : >"${psql_log}"
+  : >"${psql_stdin_log}"
+
+  run_bootstrap_with_replay_token_file >/dev/null
+
+  grep -q -- "replay_session_owner_conflict" "${psql_stdin_log}"
+  if grep -F "CAST('replay session id belongs to another user' AS integer)" "${psql_stdin_log}" >/dev/null; then
+    echo "replay session collision preflight must not rely on integer cast failure" >&2
+    exit 1
+  fi
+}
+
 assert_replay_token_user_mismatch_fails_before_psql() {
   local log="${tmp_dir}/replay-token-mismatch.log"
   : >"${psql_log}"
@@ -300,6 +313,7 @@ assert_csv_account_ids_feed_fixture_sql
 assert_write_accounts_are_funded_and_authorized
 assert_replay_token_session_is_bootstrapped_without_token_leak
 assert_replay_token_session_reassign_is_explicit
+assert_replay_token_session_collision_uses_sanitized_exception
 assert_replay_token_user_mismatch_fails_before_psql
 assert_transient_psql_timeout_retries_fixture_sql
 assert_too_long_password_hash_fails_before_psql


### PR DESCRIPTION
## 🔗 Related Issue
- close #868

## 🌿 Base Branch
- main

## 📝 Summary
- staging fixture principal replay session 충돌 preflight가 PostgreSQL 타입 변환 오류로 실패하던 경로를 정리한다.
- 성능 개선 PR이 아니라 staging deploy/live evidence 차단 버그를 푸는 최소 Fix다.

## 🛠 Changes
- replay session owner 충돌 검증을 integer cast 실패 대신 psql conditional과 sanitized replay_session_owner_conflict 종료로 변경.
- contract에 CAST 기반 실패 금지 회귀 검증 추가.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh
- bash -n tools/ops/staging-fixture-principal-bootstrap.sh tools/test/run-staging-fixture-principal-bootstrap-contract.sh
- git diff --check
- GitHub Actions 확인: main run 25532074764는 Backend Check 진행 중, mixed workload live run 25531775769는 Generate mixed workload live evidence manifest artifacts 진행 중

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: psql conditional 지원이 없는 매우 오래된 psql이면 preflight가 실패할 수 있으나, 현재 PostgreSQL 18 운영 기준에서는 지원 범위다.
- 롤백 방법: 이 PR revert 후 staging deploy를 재실행한다.

## ☑️ Checklist
- [x] base branch가 main인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?