### PR TITLE
[Fix] mixed workload write idempotency key length

### DIFF
--- a/ops/k6/transaction-read-mixed-workload-100m.js
+++ b/ops/k6/transaction-read-mixed-workload-100m.js
@@ -27,6 +27,7 @@ const notificationRate = Number(__ENV.K6_MIXED_NOTIFICATION_RATE || "1");
 const limit = Number(__ENV.K6_LIMIT || "50");
 const sseTimeout = __ENV.K6_MIXED_SSE_TIMEOUT || "5s";
 const maxRetryAfterSleepSeconds = Number(__ENV.K6_MAX_RETRY_AFTER_SLEEP_SECONDS || "1");
+const IDEMPOTENCY_KEY_MAX_LENGTH = 80;
 
 export const mixedReadCount = new Counter("aquila_mixed_read_count");
 export const mixedReadDurationMs = new Trend("aquila_mixed_read_duration_ms", true);
@@ -141,6 +142,37 @@ function requireInput(name, value) {
   if (!value) {
     throw new Error(`${name} is required`);
   }
+}
+
+// API의 idempotency key 80자 계약을 넘기면 write 2xx가 0으로 왜곡됩니다.
+function stableHashSegment(value) {
+  let hash = 2166136261;
+  const source = String(value || "");
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function idempotencySegment(value) {
+  const segment = String(value || "run").replace(/[^A-Za-z0-9_-]/g, "-");
+  return segment || "run";
+}
+
+function mixedWriteIdempotencyKey(vu, iteration) {
+  const suffix = [
+    stableHashSegment(runId),
+    Number(vu || 0).toString(36),
+    Number(iteration || 0).toString(36),
+    Date.now().toString(36),
+  ].join("-");
+  const prefixBudget = Math.max(1, IDEMPOTENCY_KEY_MAX_LENGTH - "mixed--".length - suffix.length);
+  const prefix = idempotencySegment(runId).slice(0, prefixBudget);
+  const key = `mixed-${prefix}-${suffix}`;
+  return key.length <= IDEMPOTENCY_KEY_MAX_LENGTH
+    ? key
+    : key.slice(0, IDEMPOTENCY_KEY_MAX_LENGTH);
 }
 
 function retryAfterSeconds(response) {
@@ -284,7 +316,7 @@ export function transferWrite() {
     headers: {
       ...headers(writeSourceAccountId, "k6-mixed-write"),
       "Content-Type": "application/json",
-      "Idempotency-Key": `mixed-${runId}-${__VU}-${__ITER}-${Date.now()}`,
+      "Idempotency-Key": mixedWriteIdempotencyKey(__VU, __ITER),
     },
   });
 

--- a/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
@@ -34,6 +34,14 @@ grep -F "aquila_mixed_notification_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_sse_connect_count" "${k6_script}" >/dev/null
 grep -F 'checks: ["rate==1"]' "${k6_script}" >/dev/null
 grep -F 'path: "/api/v1/transactions/archive"' "${k6_script}" >/dev/null
+grep -F "function mixedWriteIdempotencyKey(" "${k6_script}" >/dev/null
+grep -F "const IDEMPOTENCY_KEY_MAX_LENGTH = 80" "${k6_script}" >/dev/null
+grep -F "stableHashSegment(runId)" "${k6_script}" >/dev/null
+grep -F '"Idempotency-Key": mixedWriteIdempotencyKey(__VU, __ITER)' "${k6_script}" >/dev/null
+if grep -F '"Idempotency-Key": `mixed-${runId}-${__VU}-${__ITER}-${Date.now()}`' "${k6_script}" >/dev/null; then
+  echo "mixed workload write idempotency key must stay within the API 80 character contract" >&2
+  exit 1
+fi
 
 temp_dir="$(mktemp -d)"
 trap 'rm -rf "${temp_dir}"' EXIT


### PR DESCRIPTION
## 🔗 Related Issue
- close #870

## 🌿 Base Branch
- main

## 📝 Summary
- mixed workload live run 25531775769에서 transfer write 2xx가 0으로 나온 원인을 workload idempotency key 길이 계약 위반으로 좁혔다.
- 긴 run id에서도 API의 80자 Idempotency-Key 계약을 넘지 않도록 bounded key를 생성한다.

## 🛠 Changes
- mixed workload k6 transfer write Idempotency-Key를 run id prefix + stable hash + VU/iteration/time suffix 구조로 제한.
- mixed workload OCI k6 contract에 긴 run id key 회귀 검증 추가.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh
- bash -n tools/test/run-transaction-read-mixed-workload-oci-k6.sh tools/test/check-transaction-read-mixed-workload-oci-k6.sh
- live artifact triage: run 25531775769, write count 8980, write 2xx 0, write 429 3576, write unexpected 5404, transfer write check fails 5404
- 최신 main staging deploy 25532317797 success

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: k6 write idempotency key 형식이 바뀌므로 기존 run id 전체 문자열로 DB idempotency row를 검색하는 임시 운영 쿼리가 있으면 prefix만으로는 찾기 어렵다. run id hash와 X-Run-Id는 유지된다.
- 롤백 방법: 이 PR revert 후 mixed workload live workflow를 재실행한다.

## ☑️ Checklist
- [x] base branch가 main인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?