### PR TITLE
[Test] mixed workload evidence guardrail 보강

### DIFF
--- a/.github/workflows/transaction-read-30m-soak-live-evidence.yml
+++ b/.github/workflows/transaction-read-30m-soak-live-evidence.yml
@@ -60,9 +60,9 @@ on:
         required: false
         type: string
       workload_weights:
-        description: "Weighted-random k6 workload weights; default uses fixture-backed hot read paths"
+        description: "Weighted-random k6 workload weights; default includes archive-backed cold read paths"
         required: false
-        default: "hot_first:40,hot_cursor:40,hot_deep_cursor:20"
+        default: "hot_first:30,hot_cursor:20,hot_deep_cursor:10,cold_first:20,cold_cursor:10,cold_deep_cursor:10"
         type: string
   pull_request:
     branches:
@@ -224,7 +224,7 @@ jobs:
           K6_OVERLOAD_MODE="false"
           K6_BURST_RATE="${K6_VUS}"
           K6_WORKLOAD_SHAPE="weighted-random"
-          K6_WORKLOAD_WEIGHTS="${SOAK_30M_WORKLOAD_WEIGHTS_INPUT:-hot_first:40,hot_cursor:40,hot_deep_cursor:20}"
+          K6_WORKLOAD_WEIGHTS="${SOAK_30M_WORKLOAD_WEIGHTS_INPUT:-hot_first:30,hot_cursor:20,hot_deep_cursor:10,cold_first:20,cold_cursor:10,cold_deep_cursor:10}"
           K6_PREEMPTIVE_PACING="true"
           K6_PREEMPTIVE_PACING_RPS="${K6_VUS}"
           K6_PREEMPTIVE_PACING_MAX_SLEEP_MS="250"

--- a/ops/k6/transaction-read-mixed-workload-100m.js
+++ b/ops/k6/transaction-read-mixed-workload-100m.js
@@ -27,6 +27,7 @@ const notificationRate = Number(__ENV.K6_MIXED_NOTIFICATION_RATE || "1");
 const limit = Number(__ENV.K6_LIMIT || "50");
 const sseTimeout = __ENV.K6_MIXED_SSE_TIMEOUT || "5s";
 const maxRetryAfterSleepSeconds = Number(__ENV.K6_MAX_RETRY_AFTER_SLEEP_SECONDS || "1");
+const writeAcceptedRatioThreshold = __ENV.K6_MIXED_WRITE_ACCEPTED_RATIO_THRESHOLD || "0.80";
 const IDEMPOTENCY_KEY_MAX_LENGTH = 80;
 
 export const mixedReadCount = new Counter("aquila_mixed_read_count");
@@ -63,6 +64,7 @@ export const mixedWrite409Count = new Counter("aquila_mixed_write_409_count");
 export const mixedWrite422Count = new Counter("aquila_mixed_write_422_count");
 export const mixedWriteOtherUnexpectedCount = new Counter("aquila_mixed_write_other_unexpected_count");
 export const mixedWrite429Rate = new Rate("aquila_mixed_write_429_rate");
+export const mixedWriteAcceptedRatio = new Rate("aquila_mixed_write_accepted_ratio");
 export const mixedAuthCount = new Counter("aquila_mixed_auth_count");
 export const mixedAuthDurationMs = new Trend("aquila_mixed_auth_duration_ms", true);
 export const mixedNotificationCount = new Counter("aquila_mixed_notification_count");
@@ -124,6 +126,7 @@ export const options = {
     aquila_mixed_sse_connect_count: ["count>0"],
     checks: ["rate==1"],
     aquila_mixed_5xx_count: ["count==0"],
+    aquila_mixed_write_accepted_ratio: [`rate>=${writeAcceptedRatioThreshold}`],
   },
 };
 
@@ -347,6 +350,7 @@ export function transferWrite() {
   const source = rejectedSource(response);
   mixedWriteCount.add(1);
   mixedWriteDurationMs.add(response.timings.duration);
+  mixedWriteAcceptedRatio.add(accepted);
   if (accepted) {
     mixedWrite2xxCount.add(1);
   }
@@ -456,6 +460,7 @@ function markdownSummary(data) {
 - runId: ${runId}
 - duration: ${duration}
 - components: read,write,auth,notification,sse
+- write accepted ratio threshold: ${writeAcceptedRatioThreshold}
 
 | metric | value |
 | --- | ---: |
@@ -474,6 +479,7 @@ function markdownSummary(data) {
 | archive read p95 ms | ${metricValue(data, "aquila_mixed_read_archive_duration_ms", "p(95)")} |
 | write 2xx count | ${metricValue(data, "aquila_mixed_write_2xx_count", "count")} |
 | write 429 count | ${metricValue(data, "aquila_mixed_write_429_count", "count")} |
+| write accepted ratio | ${metricValue(data, "aquila_mixed_write_accepted_ratio", "rate")} |
 | write edge 429 count | ${metricValue(data, "aquila_mixed_write_edge_429_count", "count")} |
 | write backend 429 count | ${metricValue(data, "aquila_mixed_write_backend_429_count", "count")} |
 | write unknown 429 count | ${metricValue(data, "aquila_mixed_write_unknown_429_count", "count")} |

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
@@ -32,6 +32,8 @@ grep -F 'description: "Cold-labeled range end for k6; default matches the fixtur
 grep -F "docker_context:" "${workflow}" >/dev/null
 grep -F 'SOAK_30M_DOCKER_CONTEXT_INPUT: ${{ inputs.docker_context }}' "${workflow}" >/dev/null
 grep -F "workload_weights:" "${workflow}" >/dev/null
+grep -F 'description: "Weighted-random k6 workload weights; default includes archive-backed cold read paths"' "${workflow}" >/dev/null
+grep -F 'default: "hot_first:30,hot_cursor:20,hot_deep_cursor:10,cold_first:20,cold_cursor:10,cold_deep_cursor:10"' "${workflow}" >/dev/null
 grep -F 'SOAK_30M_WORKLOAD_WEIGHTS_INPUT: ${{ inputs.workload_weights }}' "${workflow}" >/dev/null
 grep -F "30m Soak Live Evidence Contract" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh" "${workflow}" >/dev/null
@@ -66,7 +68,7 @@ grep -F 'K6_DOCKER_CONTEXT_SOURCE="input"' "${workflow}" >/dev/null
 grep -F 'K6_DOCKER_CONTEXT_SOURCE="env"' "${workflow}" >/dev/null
 grep -F 'K6_DOCKER_CONTEXT_SOURCE="default"' "${workflow}" >/dev/null
 grep -F 'K6_WORKLOAD_SHAPE="weighted-random"' "${workflow}" >/dev/null
-grep -F 'K6_WORKLOAD_WEIGHTS="${SOAK_30M_WORKLOAD_WEIGHTS_INPUT:-hot_first:40,hot_cursor:40,hot_deep_cursor:20}"' "${workflow}" >/dev/null
+grep -F 'K6_WORKLOAD_WEIGHTS="${SOAK_30M_WORKLOAD_WEIGHTS_INPUT:-hot_first:30,hot_cursor:20,hot_deep_cursor:10,cold_first:20,cold_cursor:10,cold_deep_cursor:10}"' "${workflow}" >/dev/null
 if grep -F 'K6_RUN_PURPOSE="30m-soak-live-evidence"' "${workflow}" >/dev/null; then
   echo "30m live k6 runner must use an accepted K6_RUN_PURPOSE" >&2
   exit 1

--- a/tools/test/check-transaction-read-mixed-workload-30m-timeline.sh
+++ b/tools/test/check-transaction-read-mixed-workload-30m-timeline.sh
@@ -19,8 +19,8 @@ touch "${artifact_dir}/k6.json" "${artifact_dir}/nginx.jsonl" "${artifact_dir}/s
   "${artifact_dir}/read-429-source.tsv" "${artifact_dir}/read-buckets.tsv" "${artifact_dir}/write-status.tsv"
 
 cat >"${input_tsv}" <<TSV
-scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	workload_components	read_p999_ms	read_429_source_ref	read_buckets	read_bucket_ref	write_2xx_count	write_unexpected_status_count	write_status_ref
-mixed-workload-30m	run-mixed-001	2026-05-02T02:00:00Z	30	1	tools/test/run-t3micro-mixed-workload-soak.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.08	0	0	0	0	0	0	450	${artifact_dir}/workload-mix.json	${artifact_dir}/workload-components.tsv	${artifact_dir}/outbox-lag.tsv	0	read,write,auth,notification,sse	440	${artifact_dir}/read-429-source.tsv	hot,cold,archive	${artifact_dir}/read-buckets.tsv	4	0	${artifact_dir}/write-status.tsv
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	workload_components	read_p999_ms	read_429_source_ref	read_buckets	read_bucket_ref	write_2xx_count	write_unexpected_status_count	write_status_ref	write_accepted_ratio	min_write_accepted_ratio
+mixed-workload-30m	run-mixed-001	2026-05-02T02:00:00Z	30	1	tools/test/run-t3micro-mixed-workload-soak.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.08	0	0	0	0	0	0	450	${artifact_dir}/workload-mix.json	${artifact_dir}/workload-components.tsv	${artifact_dir}/outbox-lag.tsv	0	read,write,auth,notification,sse	440	${artifact_dir}/read-429-source.tsv	hot,cold,archive	${artifact_dir}/read-buckets.tsv	4	0	${artifact_dir}/write-status.tsv	0.806	0.80
 TSV
 
 echo "[transaction-read-mixed-30m-timeline] print plan"
@@ -52,6 +52,7 @@ grep -F "read/write/auth/notification/SSE components: required" "${report_md}" >
 grep -F "read p99.9 and 429 source artifact: required" "${report_md}" >/dev/null
 grep -F "hot/cold/archive read bucket artifact: required" "${report_md}" >/dev/null
 grep -F "write 2xx and status classification artifact: required" "${report_md}" >/dev/null
+grep -F "write accepted ratio guardrail: required" "${report_md}" >/dev/null
 grep -F "workload mix/component and outbox lag artifact: required" "${report_md}" >/dev/null
 
 echo "[transaction-read-mixed-30m-timeline] unknown 429 fails"
@@ -101,5 +102,15 @@ if MIXED_30M_TIMELINE_NAME=mixed-30m-write \
   MIXED_30M_TIMELINE_OUTPUT_DIR="${output_dir}" \
     "${runner}" >/dev/null 2>&1; then
   echo "mixed 30m timeline unexpectedly passed write 2xx missing" >&2
+  exit 1
+fi
+
+echo "[transaction-read-mixed-30m-timeline] write accepted ratio fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } { $35 = 0.799; print }' "${input_tsv}" >"${input_tsv}.write-ratio"
+if MIXED_30M_TIMELINE_NAME=mixed-30m-write-ratio \
+  MIXED_30M_TIMELINE_INPUT_TSV="${input_tsv}.write-ratio" \
+  MIXED_30M_TIMELINE_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "mixed 30m timeline unexpectedly passed low write accepted ratio" >&2
   exit 1
 fi

--- a/tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
+++ b/tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh
@@ -64,6 +64,8 @@ grep -F "read-buckets.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F "write-status.tsv" "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'\thot,cold,archive\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'\t1\t0\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\twrite_accepted_ratio\tmin_write_accepted_ratio' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t1\t0.80' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 
 echo "[transaction-read-mixed-workload-live-evidence-autogen] generated manifest passes gate"
 gate_output="$(
@@ -136,6 +138,8 @@ done
   printf "MIXED_WORKLOAD_RUNNER_READ_BUCKETS=%q\n" "hot,cold,archive"
   printf "MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT=%q\n" "7"
   printf "MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT=%q\n" "2"
+  printf "MIXED_WORKLOAD_RUNNER_WRITE_ACCEPTED_RATIO=%q\n" "0.875"
+  printf "MIXED_WORKLOAD_RUNNER_MIN_WRITE_ACCEPTED_RATIO=%q\n" "0.80"
   printf "MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_MAX=%q\n" "0"
 } >"${MIXED_WORKLOAD_STUB_ENV}"
 echo "${MIXED_WORKLOAD_STUB_ENV}"
@@ -168,6 +172,7 @@ grep -F $'\t0.03\t0\t0\t0\t0\t0\t0\t333\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_T
 grep -F $'\t101\t222\t444\t1\t0\t12.5\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'\thot,cold,archive\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 grep -F $'\t7\t2\t' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
+grep -F $'\t0.875\t0.80' "${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" >/dev/null
 live_gate_output="$(
   MIXED_30M_TIMELINE_NAME="${name}-live" \
   MIXED_30M_TIMELINE_INPUT_TSV="${MIXED_WORKLOAD_EVIDENCE_MANIFEST_TSV}" \

--- a/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/check-transaction-read-mixed-workload-oci-k6.sh
@@ -28,6 +28,8 @@ grep -F "aquila_mixed_write_edge_429_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_backend_429_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_unknown_429_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_unexpected_status_count" "${k6_script}" >/dev/null
+grep -F "aquila_mixed_write_accepted_ratio" "${k6_script}" >/dev/null
+grep -F "K6_MIXED_WRITE_ACCEPTED_RATIO_THRESHOLD" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_401_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_403_count" "${k6_script}" >/dev/null
 grep -F "aquila_mixed_write_409_count" "${k6_script}" >/dev/null
@@ -113,6 +115,7 @@ if [[ "$*" == *"grafana/k6:0.54.0 run /scripts/transaction-read-mixed-workload-1
     "aquila_mixed_write_422_count": {"values": {"count": 0}},
     "aquila_mixed_write_other_unexpected_count": {"values": {"count": 0}},
     "aquila_mixed_write_429_rate": {"values": {"rate": 0.2222222222}},
+    "aquila_mixed_write_accepted_ratio": {"values": {"rate": 0.4444444444}},
     "aquila_mixed_auth_count": {"values": {"count": 3}},
     "aquila_mixed_auth_duration_ms": {"values": {"p(95)": 42}},
     "aquila_mixed_notification_count": {"values": {"count": 3}},
@@ -164,6 +167,7 @@ grep -F "base_url=configured" <<<"${plan}" >/dev/null
 grep -F "remote_workdir=/srv/aquila-bank" <<<"${plan}" >/dev/null
 grep -F "duration=30m" <<<"${plan}" >/dev/null
 grep -F "components=read,write,auth,notification,sse" <<<"${plan}" >/dev/null
+grep -F "write_accepted_ratio_threshold=0.80" <<<"${plan}" >/dev/null
 grep -F "auth_token=present source=file" <<<"${plan}" >/dev/null
 grep -F "evidence_env=${output_dir}/mixed-oci-check-oci-mixed-evidence.env" <<<"${plan}" >/dev/null
 if grep -F "secret-token-value" <<<"${plan}" >/dev/null; then
@@ -238,6 +242,7 @@ jq -e '.metrics.aquila_mixed_write_edge_429_count.values.count == 1' "${MIXED_WO
 jq -e '.metrics.aquila_mixed_write_backend_429_count.values.count == 0' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_write_unknown_429_count.values.count == 0' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_write_unexpected_status_count.values.count == 3' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_write_accepted_ratio.values.rate == 0.875' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_auth_count.values.count == 16' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_notification_count.values.count == 16' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_sse_connect_count.values.count == 1' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
@@ -248,6 +253,8 @@ test "${MIXED_WORKLOAD_RUNNER_WRITE_EDGE_429_COUNT}" = "1"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_BACKEND_429_COUNT}" = "0"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_UNKNOWN_429_COUNT}" = "0"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT}" = "3"
+test "${MIXED_WORKLOAD_RUNNER_WRITE_ACCEPTED_RATIO}" = "0.875"
+test "${MIXED_WORKLOAD_RUNNER_MIN_WRITE_ACCEPTED_RATIO}" = "0.80"
 test "${MIXED_WORKLOAD_RUNNER_READ_BUCKETS}" = "hot,cold,archive"
 test "${MIXED_WORKLOAD_RUNNER_READ_HOT_P999_MS}" = "350"
 test "${MIXED_WORKLOAD_RUNNER_READ_COLD_P999_MS}" = "410"
@@ -298,12 +305,15 @@ jq -e '.metrics.aquila_mixed_write_edge_429_count.values.count == 1' "${MIXED_WO
 jq -e '.metrics.aquila_mixed_write_backend_429_count.values.count == 1' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_write_unknown_429_count.values.count == 0' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 jq -e '.metrics.aquila_mixed_write_unexpected_status_count.values.count == 3' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
+jq -e '.metrics.aquila_mixed_write_accepted_ratio.values.rate == 0.4444444444' "${MIXED_WORKLOAD_RUNNER_K6_SUMMARY_REF}" >/dev/null
 test "${MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT}" = "4"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_429_COUNT}" = "2"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_EDGE_429_COUNT}" = "1"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_BACKEND_429_COUNT}" = "1"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_UNKNOWN_429_COUNT}" = "0"
 test "${MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT}" = "3"
+test "${MIXED_WORKLOAD_RUNNER_WRITE_ACCEPTED_RATIO}" = "0.4444444444"
+test "${MIXED_WORKLOAD_RUNNER_MIN_WRITE_ACCEPTED_RATIO}" = "0.80"
 test -f "${MIXED_WORKLOAD_RUNNER_WRITE_429_SOURCE_REF}"
 grep -F $'mixed-oci-run-live-failed\tedge\t1' "${MIXED_WORKLOAD_RUNNER_WRITE_429_SOURCE_REF}" >/dev/null
 grep -F $'mixed-oci-run-live-failed\tbackend\t1' "${MIXED_WORKLOAD_RUNNER_WRITE_429_SOURCE_REF}" >/dev/null

--- a/tools/test/check-transaction-read-oci-evidence-execution-gate.sh
+++ b/tools/test/check-transaction-read-oci-evidence-execution-gate.sh
@@ -36,12 +36,12 @@ touch \
   "${artifact_dir}/deploy-499.tsv"
 
 cat >"${input_tsv}" <<TSV
-scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref	read_buckets	read_bucket_ref	write_2xx_count	write_unexpected_status_count	write_status_ref
-hikari-lifetime	run-hikari-001	2026-05-02T01:00:00Z	30	1	tools/test/run-transaction-read-weighted-10m-soak-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.01	0	0	0	0	0	0	420	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	80	210	610	0	0	14.1	${artifact_dir}/hikari-config.tsv	45000	30000	300000	350000	${artifact_dir}/hikari-zero-warning.md	n/a	0	n/a	n/a	n/a	0	0	n/a
-mixed-workload-30m	run-mixed-001	2026-05-02T02:00:00Z	30	1	tools/test/run-t3micro-mixed-workload-soak.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.08	0	0	0	0	0	0	450	n/a	n/a	n/a	${artifact_dir}/workload-mix.json	${artifact_dir}/workload-components.tsv	${artifact_dir}/outbox-lag.tsv	0	n/a	0	n/a	85	225	630	1	0	16.3	n/a	0	0	0	0	n/a	read,write,auth,notification,sse	440	${artifact_dir}/read-429-source.tsv	hot,cold,archive	${artifact_dir}/read-buckets.tsv	4	3	${artifact_dir}/write-status.tsv
-cold-warm-cache	run-cache-001	2026-05-02T02:40:00Z	3	1	tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	${artifact_dir}/cache.json	${artifact_dir}/timeline.json	0.02	0	0	0	0	0	0	410	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	78	205	600	0	0	13.8	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	n/a	0	0	n/a
-deploy-drain	run-drain-001	2026-05-02T03:00:00Z	5	1	tools/test/run-staging-deploy-transaction-replay-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	${artifact_dir}/deploy.json	n/a	${artifact_dir}/timeline.json	0.04	0	0	0	0	0	0	470	n/a	n/a	n/a	n/a	n/a	n/a	0	${artifact_dir}/deploy-retry.json	2	${artifact_dir}/deploy-499.tsv	90	235	640	1	0	17.4	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	n/a	0	0	n/a
-p999-long-correlation	run-p999-001	2026-05-02T03:20:00Z	30	1	tools/test/run-transaction-read-p999-spike-attribution.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.06	0	0	0	0	0	0	490	${artifact_dir}/checkpoint.tsv	${artifact_dir}/temp-files.tsv	${artifact_dir}/nginx-upstream.tsv	n/a	n/a	n/a	0	n/a	0	n/a	95	220	650	3	0	18.5	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	n/a	0	0	n/a
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref	read_buckets	read_bucket_ref	write_2xx_count	write_unexpected_status_count	write_status_ref	write_accepted_ratio	min_write_accepted_ratio
+hikari-lifetime	run-hikari-001	2026-05-02T01:00:00Z	30	1	tools/test/run-transaction-read-weighted-10m-soak-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.01	0	0	0	0	0	0	420	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	80	210	610	0	0	14.1	${artifact_dir}/hikari-config.tsv	45000	30000	300000	350000	${artifact_dir}/hikari-zero-warning.md	n/a	0	n/a	n/a	n/a	0	0	n/a	n/a	n/a
+mixed-workload-30m	run-mixed-001	2026-05-02T02:00:00Z	30	1	tools/test/run-t3micro-mixed-workload-soak.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.08	0	0	0	0	0	0	450	n/a	n/a	n/a	${artifact_dir}/workload-mix.json	${artifact_dir}/workload-components.tsv	${artifact_dir}/outbox-lag.tsv	0	n/a	0	n/a	85	225	630	1	0	16.3	n/a	0	0	0	0	n/a	read,write,auth,notification,sse	440	${artifact_dir}/read-429-source.tsv	hot,cold,archive	${artifact_dir}/read-buckets.tsv	4	3	${artifact_dir}/write-status.tsv	0.806	0.80
+cold-warm-cache	run-cache-001	2026-05-02T02:40:00Z	3	1	tools/test/run-transaction-100m-cold-start-cache-warm-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	${artifact_dir}/cache.json	${artifact_dir}/timeline.json	0.02	0	0	0	0	0	0	410	n/a	n/a	n/a	n/a	n/a	n/a	0	n/a	0	n/a	78	205	600	0	0	13.8	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	n/a	0	0	n/a	n/a	n/a
+deploy-drain	run-drain-001	2026-05-02T03:00:00Z	5	1	tools/test/run-staging-deploy-transaction-replay-gate.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	${artifact_dir}/deploy.json	n/a	${artifact_dir}/timeline.json	0.04	0	0	0	0	0	0	470	n/a	n/a	n/a	n/a	n/a	n/a	0	${artifact_dir}/deploy-retry.json	2	${artifact_dir}/deploy-499.tsv	90	235	640	1	0	17.4	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	n/a	0	0	n/a	n/a	n/a
+p999-long-correlation	run-p999-001	2026-05-02T03:20:00Z	30	1	tools/test/run-transaction-read-p999-spike-attribution.sh	${artifact_dir}/k6.json	${artifact_dir}/nginx.jsonl	${artifact_dir}/spring.json	${artifact_dir}/hikari.log	${artifact_dir}/postgres.tsv	n/a	n/a	${artifact_dir}/timeline.json	0.06	0	0	0	0	0	0	490	${artifact_dir}/checkpoint.tsv	${artifact_dir}/temp-files.tsv	${artifact_dir}/nginx-upstream.tsv	n/a	n/a	n/a	0	n/a	0	n/a	95	220	650	3	0	18.5	n/a	0	0	0	0	n/a	n/a	0	n/a	n/a	n/a	0	0	n/a	n/a	n/a
 TSV
 
 echo "[transaction-read-oci-evidence-execution] print plan"
@@ -57,6 +57,8 @@ grep -F "mixed_min_duration_min=30" <<<"${plan}" >/dev/null
 grep -F "p999_min_duration_min=30" <<<"${plan}" >/dev/null
 grep -F "hikari_min_duration_min=30" <<<"${plan}" >/dev/null
 grep -F "max_postgres_temp_file_delta=0" <<<"${plan}" >/dev/null
+grep -F "min_source_ips=1" <<<"${plan}" >/dev/null
+grep -F "min_mixed_write_accepted_ratio=0.80" <<<"${plan}" >/dev/null
 
 echo "[transaction-read-oci-evidence-execution] pass report"
 output="$(
@@ -81,16 +83,21 @@ grep -F "mixed workload required components: read,write,auth,notification,sse" "
 grep -F "mixed workload read p99.9 and 429 source artifact: required" "${report_md}" >/dev/null
 grep -F "mixed workload hot/cold/archive read bucket artifact: required" "${report_md}" >/dev/null
 grep -F "mixed workload write 2xx and status classification artifact: required" "${report_md}" >/dev/null
+grep -F "mixed workload write accepted ratio min: 0.80" "${report_md}" >/dev/null
+grep -F "source IPs min: 1" "${report_md}" >/dev/null
+grep -F "mixed workload write accepted ratio: required" "${report_md}" >/dev/null
 grep -F "deploy drain closure artifacts: 499 budget, retry contract, reconnect success" "${report_md}" >/dev/null
 grep -F $'\tp95_ms\tp99_ms\tmax_ms\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms' "${summary_tsv}" >/dev/null
 grep -F $'\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref' "${summary_tsv}" >/dev/null
 grep -F $'\tworkload_components\tread_p999_ms\tread_429_source_ref' "${summary_tsv}" >/dev/null
 grep -F $'\tread_buckets\tread_bucket_ref\twrite_2xx_count\twrite_unexpected_status_count\twrite_status_ref' "${summary_tsv}" >/dev/null
+grep -F $'\twrite_accepted_ratio\tmin_write_accepted_ratio' "${summary_tsv}" >/dev/null
 grep -F $'mixed-workload-30m\tpass\tok\trun-mixed-001\t30\t1\ttools/test/run-t3micro-mixed-workload-soak.sh' "${summary_tsv}" >/dev/null
 awk -F '\t' '$1 == "p999-long-correlation" && $23 == 490 && $24 == 95 && $25 == 220 && $26 == 650 && $27 == 3 && $28 == 0 && $29 == 18.5 { found = 1 } END { exit !found }' "${summary_tsv}"
 awk -F '\t' '$1 == "hikari-lifetime" && $5 == 30 && $30 ~ /hikari-config[.]tsv$/ && $31 == 45000 && $32 == 30000 && $33 == 300000 && $34 == 350000 && $35 ~ /hikari-zero-warning[.]md$/ { found = 1 } END { exit !found }' "${summary_tsv}"
 awk -F '\t' '$1 == "mixed-workload-30m" && $36 == "read,write,auth,notification,sse" && $37 == 440 && $38 ~ /read-429-source[.]tsv$/ { found = 1 } END { exit !found }' "${summary_tsv}"
 awk -F '\t' '$1 == "mixed-workload-30m" && $39 == "hot,cold,archive" && $40 ~ /read-buckets[.]tsv$/ && $41 == 4 && $42 == 3 && $43 ~ /write-status[.]tsv$/ { found = 1 } END { exit !found }' "${summary_tsv}"
+awk -F '\t' '$1 == "mixed-workload-30m" && $44 == 0.806 && $45 == 0.80 { found = 1 } END { exit !found }' "${summary_tsv}"
 
 echo "[transaction-read-oci-evidence-execution] failure report"
 awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload-30m" { $14 = "n/a"; $17 = 1; $18 = 1; $19 = 1; $20 = 2; $21 = 2; $22 = 560 } { print }' \
@@ -141,6 +148,38 @@ if OCI_EVIDENCE_EXECUTION_NAME=oci-exec-missing \
   echo "OCI execution gate unexpectedly passed missing deploy-drain scenario" >&2
   exit 1
 fi
+
+echo "[transaction-read-oci-evidence-execution] source IP minimum fails"
+if OCI_EVIDENCE_EXECUTION_NAME=oci-exec-source-fail \
+  OCI_EVIDENCE_EXECUTION_INPUT_TSV="${input_tsv}" \
+  OCI_EVIDENCE_EXECUTION_OUTPUT_DIR="${output_dir}" \
+  OCI_EVIDENCE_EXECUTION_MIN_SOURCE_IPS=2 \
+    "${runner}" >/dev/null 2>&1; then
+  echo "OCI execution gate unexpectedly passed source IP minimum violation" >&2
+  exit 1
+fi
+OCI_EVIDENCE_EXECUTION_NAME=oci-exec-source-fail \
+OCI_EVIDENCE_EXECUTION_INPUT_TSV="${input_tsv}" \
+OCI_EVIDENCE_EXECUTION_OUTPUT_DIR="${output_dir}" \
+OCI_EVIDENCE_EXECUTION_MIN_SOURCE_IPS=2 \
+  "${runner}" >/dev/null 2>&1 || true
+grep -F "source-ips<2" "${output_dir}/oci-exec-source-fail-oci-evidence-execution.tsv" >/dev/null
+
+echo "[transaction-read-oci-evidence-execution] mixed write accepted ratio fails"
+awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "mixed-workload-30m" { $53 = 0.799 } { print }' \
+  "${input_tsv}" >"${input_tsv}.mixed-write-ratio-fail"
+if OCI_EVIDENCE_EXECUTION_NAME=oci-exec-mixed-write-ratio-fail \
+  OCI_EVIDENCE_EXECUTION_INPUT_TSV="${input_tsv}.mixed-write-ratio-fail" \
+  OCI_EVIDENCE_EXECUTION_OUTPUT_DIR="${output_dir}" \
+    "${runner}" >/dev/null 2>&1; then
+  echo "OCI execution gate unexpectedly passed mixed write accepted ratio violation" >&2
+  exit 1
+fi
+OCI_EVIDENCE_EXECUTION_NAME=oci-exec-mixed-write-ratio-fail \
+OCI_EVIDENCE_EXECUTION_INPUT_TSV="${input_tsv}.mixed-write-ratio-fail" \
+OCI_EVIDENCE_EXECUTION_OUTPUT_DIR="${output_dir}" \
+  "${runner}" >/dev/null 2>&1 || true
+grep -F "write-accepted-ratio<0.8" "${output_dir}/oci-exec-mixed-write-ratio-fail-oci-evidence-execution.tsv" >/dev/null
 
 echo "[transaction-read-oci-evidence-execution] p999 closure artifact fail"
 awk -F '\t' 'BEGIN { OFS = FS } NR == 1 { print; next } $1 == "p999-long-correlation" { $24 = "n/a" } { print }' \

--- a/tools/test/run-transaction-read-mixed-workload-30m-timeline.sh
+++ b/tools/test/run-transaction-read-mixed-workload-30m-timeline.sh
@@ -87,6 +87,7 @@ cat >"${report_md}" <<REPORT
 - read p99.9 and 429 source artifact: required
 - hot/cold/archive read bucket artifact: required
 - write 2xx and status classification artifact: required
+- write accepted ratio guardrail: required
 - workload mix/component and outbox lag artifact: required
 - execution gate report: ${execution_report}
 

--- a/tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh
+++ b/tools/test/run-transaction-read-mixed-workload-live-evidence-autogen.sh
@@ -69,6 +69,8 @@ read_p999_ms="440"
 read_buckets="hot,cold,archive"
 write_2xx_count="1"
 write_unexpected_status_count="0"
+write_accepted_ratio="1"
+min_write_accepted_ratio="0.80"
 runner_evidence_applied="false"
 
 k6_summary_ref="${generated_dir}/${name}-k6-summary.json"
@@ -210,6 +212,8 @@ apply_runner_evidence_env() {
   read_buckets="${MIXED_WORKLOAD_RUNNER_READ_BUCKETS:-${read_buckets}}"
   write_2xx_count="${MIXED_WORKLOAD_RUNNER_WRITE_2XX_COUNT:-${write_2xx_count}}"
   write_unexpected_status_count="${MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT:-${write_unexpected_status_count}}"
+  write_accepted_ratio="${MIXED_WORKLOAD_RUNNER_WRITE_ACCEPTED_RATIO:-${write_accepted_ratio}}"
+  min_write_accepted_ratio="${MIXED_WORKLOAD_RUNNER_MIN_WRITE_ACCEPTED_RATIO:-${min_write_accepted_ratio}}"
   outbox_lag_max="${MIXED_WORKLOAD_RUNNER_OUTBOX_LAG_MAX:-${outbox_lag_max}}"
   runner_evidence_applied="true"
 }
@@ -310,8 +314,8 @@ TSV
 
 write_manifest() {
   cat >"${manifest_tsv}" <<TSV
-scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref	read_buckets	read_bucket_ref	write_2xx_count	write_unexpected_status_count	write_status_ref
-mixed-workload-30m	${run_id}	${executed_at_utc}	${duration_min}	${source_ips}	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	n/a	n/a	${timeline_ref}	${edge_429_rate}	${backend_429_count}	${unknown_429_count}	${five_xx_count}	${nginx_499_count}	${hikari_validation_warnings}	${db_pool_pending_max}	${p999_ms}	n/a	n/a	n/a	${workload_mix_ref}	${workload_component_ref}	${outbox_lag_ref}	${outbox_lag_max}	n/a	0	n/a	${p95_ms}	${p99_ms}	${max_ms}	${postgres_checkpoint_count}	${postgres_temp_file_count}	${nginx_upstream_p95_ms}	n/a	0	0	0	0	n/a	${workload_components}	${read_p999_ms}	${read_429_source_ref}	${read_buckets}	${read_bucket_ref}	${write_2xx_count}	${write_unexpected_status_count}	${write_status_ref}
+scenario	run_id	executed_at_utc	duration_min	source_ips	run_script	k6_summary_ref	nginx_access_ref	spring_metrics_ref	hikari_log_ref	postgres_wait_ref	deploy_event_ref	cache_state_ref	timeline_ref	edge_429_rate	backend_429_count	unknown_429_count	five_xx_count	nginx_499_count	hikari_validation_warnings	db_pool_pending_max	p999_ms	postgres_checkpoint_ref	postgres_temp_file_ref	nginx_upstream_latency_ref	workload_mix_ref	workload_component_ref	outbox_lag_ref	outbox_lag_max	deploy_retry_contract_ref	deploy_reconnect_success_count	deploy_499_budget_ref	p95_ms	p99_ms	max_ms	postgres_checkpoint_count	postgres_temp_file_count	nginx_upstream_p95_ms	hikari_config_ref	hikari_max_lifetime_ms	hikari_keepalive_time_ms	postgres_idle_timeout_ms	oci_nat_idle_timeout_ms	hikari_zero_warning_soak_ref	workload_components	read_p999_ms	read_429_source_ref	read_buckets	read_bucket_ref	write_2xx_count	write_unexpected_status_count	write_status_ref	write_accepted_ratio	min_write_accepted_ratio
+mixed-workload-30m	${run_id}	${executed_at_utc}	${duration_min}	${source_ips}	${manifest_runner_ref}	${k6_summary_ref}	${nginx_access_ref}	${spring_metrics_ref}	${hikari_log_ref}	${postgres_wait_ref}	n/a	n/a	${timeline_ref}	${edge_429_rate}	${backend_429_count}	${unknown_429_count}	${five_xx_count}	${nginx_499_count}	${hikari_validation_warnings}	${db_pool_pending_max}	${p999_ms}	n/a	n/a	n/a	${workload_mix_ref}	${workload_component_ref}	${outbox_lag_ref}	${outbox_lag_max}	n/a	0	n/a	${p95_ms}	${p99_ms}	${max_ms}	${postgres_checkpoint_count}	${postgres_temp_file_count}	${nginx_upstream_p95_ms}	n/a	0	0	0	0	n/a	${workload_components}	${read_p999_ms}	${read_429_source_ref}	${read_buckets}	${read_bucket_ref}	${write_2xx_count}	${write_unexpected_status_count}	${write_status_ref}	${write_accepted_ratio}	${min_write_accepted_ratio}
 TSV
 }
 

--- a/tools/test/run-transaction-read-mixed-workload-oci-k6.sh
+++ b/tools/test/run-transaction-read-mixed-workload-oci-k6.sh
@@ -15,6 +15,7 @@ Environment:
   MIXED_WORKLOAD_OCI_REMOTE_WORKDIR          repo path on remote Docker host
   MIXED_WORKLOAD_OCI_DURATION                default 30m
   MIXED_WORKLOAD_OCI_AUTH_TOKEN_FILE         bearer token file, optional but required by auth component in live
+  MIXED_WORKLOAD_OCI_WRITE_ACCEPTED_RATIO_THRESHOLD default 0.80
 USAGE
 }
 
@@ -71,6 +72,7 @@ write_vus="${MIXED_WORKLOAD_OCI_WRITE_VUS:-2}"
 auth_rate="${MIXED_WORKLOAD_OCI_AUTH_RATE:-1}"
 notification_rate="${MIXED_WORKLOAD_OCI_NOTIFICATION_RATE:-1}"
 limit="${MIXED_WORKLOAD_OCI_LIMIT:-50}"
+write_accepted_ratio_threshold="${MIXED_WORKLOAD_OCI_WRITE_ACCEPTED_RATIO_THRESHOLD:-${K6_MIXED_WRITE_ACCEPTED_RATIO_THRESHOLD:-0.80}}"
 executed_at_utc="${MIXED_WORKLOAD_EXECUTED_AT_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
 k6_summary_ref="${generated_dir}/${name}-k6-summary.json"
@@ -107,6 +109,14 @@ if ! [[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]]; then
 fi
 if ! [[ "${duration}" =~ ^[1-9][0-9]*(s|m|h)$ ]]; then
   echo "MIXED_WORKLOAD_OCI_DURATION must use a positive duration such as 60s, 30m, or 1h: ${duration}" >&2
+  exit 1
+fi
+if ! [[ "${write_accepted_ratio_threshold}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  echo "MIXED_WORKLOAD_OCI_WRITE_ACCEPTED_RATIO_THRESHOLD must be a non-negative decimal: ${write_accepted_ratio_threshold}" >&2
+  exit 1
+fi
+if ! awk -v value="${write_accepted_ratio_threshold}" 'BEGIN { exit !(value >= 0 && value <= 1) }'; then
+  echo "MIXED_WORKLOAD_OCI_WRITE_ACCEPTED_RATIO_THRESHOLD must be between 0 and 1: ${write_accepted_ratio_threshold}" >&2
   exit 1
 fi
 
@@ -182,6 +192,7 @@ print_plan() {
   echo "[transaction-read-mixed-workload-oci-k6] duration=${duration}"
   echo "[transaction-read-mixed-workload-oci-k6] components=read,write,auth,notification,sse"
   echo "[transaction-read-mixed-workload-oci-k6] read_rate=${read_rate}/1s write_vus=${write_vus} auth_rate=${auth_rate}/1s notification_rate=${notification_rate}/1s"
+  echo "[transaction-read-mixed-workload-oci-k6] write_accepted_ratio_threshold=${write_accepted_ratio_threshold}"
   echo "[transaction-read-mixed-workload-oci-k6] hot_account_id=${hot_account_id:-missing} cold_account_id=${cold_account_id:-missing}"
   echo "[transaction-read-mixed-workload-oci-k6] archive_account_id=${archive_account_id:-missing}"
   echo "[transaction-read-mixed-workload-oci-k6] write_source_account_id=${write_source_account_id:-missing} write_target_account_id=${write_target_account_id:-missing}"
@@ -259,6 +270,7 @@ write_fixture_summary() {
     "aquila_mixed_write_422_count": {"values": {"count": 0}},
     "aquila_mixed_write_other_unexpected_count": {"values": {"count": 0}},
     "aquila_mixed_write_429_rate": {"values": {"rate": 0.01}},
+    "aquila_mixed_write_accepted_ratio": {"values": {"rate": 0.875}},
     "aquila_mixed_auth_count": {"values": {"count": 16}},
     "aquila_mixed_auth_duration_ms": {"values": {"p(95)": 42, "p(99)": 60, "p(99.9)": 70, "max": 75}},
     "aquila_mixed_notification_count": {"values": {"count": 16}},
@@ -306,6 +318,7 @@ write_component_artifacts() {
   local cold_count cold_p95 cold_p999 cold_edge_429_rate cold_backend_429_count cold_unknown_429_count
   local archive_count archive_p95 archive_p999 archive_edge_429_rate archive_backend_429_count archive_unknown_429_count
   local write_p95 write_2xx_count write_429_count write_edge_429_count write_backend_429_count write_unknown_429_count write_unexpected_status_count
+  local write_accepted_ratio
   local write_401_count write_403_count write_409_count write_422_count write_other_unexpected_count
   local auth_p95 notification_p95 outbox_lag_max
 
@@ -343,6 +356,10 @@ write_component_artifacts() {
   write_backend_429_count="$(metric_count aquila_mixed_write_backend_429_count)"
   write_unknown_429_count="$(metric_count aquila_mixed_write_unknown_429_count)"
   write_unexpected_status_count="$(metric_count aquila_mixed_write_unexpected_status_count)"
+  write_accepted_ratio="$(metric_value aquila_mixed_write_accepted_ratio "rate" "n/a")"
+  if [[ "${write_accepted_ratio}" == "n/a" || -z "${write_accepted_ratio}" ]]; then
+    write_accepted_ratio="$(awk -v accepted="${write_2xx_count}" -v total="${write_count}" 'BEGIN { if (total > 0) printf "%.6f", accepted / total; else print "0" }')"
+  fi
   write_401_count="$(metric_count aquila_mixed_write_401_count)"
   write_403_count="$(metric_count aquila_mixed_write_403_count)"
   write_409_count="$(metric_count aquila_mixed_write_409_count)"
@@ -466,6 +483,8 @@ TSV
     printf "MIXED_WORKLOAD_RUNNER_WRITE_BACKEND_429_COUNT=%q\n" "${write_backend_429_count}"
     printf "MIXED_WORKLOAD_RUNNER_WRITE_UNKNOWN_429_COUNT=%q\n" "${write_unknown_429_count}"
     printf "MIXED_WORKLOAD_RUNNER_WRITE_UNEXPECTED_STATUS_COUNT=%q\n" "${write_unexpected_status_count}"
+    printf "MIXED_WORKLOAD_RUNNER_WRITE_ACCEPTED_RATIO=%q\n" "${write_accepted_ratio}"
+    printf "MIXED_WORKLOAD_RUNNER_MIN_WRITE_ACCEPTED_RATIO=%q\n" "${write_accepted_ratio_threshold}"
     printf "MIXED_WORKLOAD_RUNNER_READ_BUCKETS=%q\n" "hot,cold,archive"
     printf "MIXED_WORKLOAD_RUNNER_READ_HOT_P999_MS=%q\n" "${hot_p999}"
     printf "MIXED_WORKLOAD_RUNNER_READ_COLD_P999_MS=%q\n" "${cold_p999}"
@@ -540,6 +559,7 @@ run_live_k6() {
     -e K6_MIXED_WRITE_VUS="${write_vus}" \
     -e K6_MIXED_AUTH_RATE="${auth_rate}" \
     -e K6_MIXED_NOTIFICATION_RATE="${notification_rate}" \
+    -e K6_MIXED_WRITE_ACCEPTED_RATIO_THRESHOLD="${write_accepted_ratio_threshold}" \
     -e K6_LIMIT="${limit}" \
     -v "${remote_workdir}/ops/k6:/scripts:ro" \
     -v "${remote_workdir}/build/reports/k6:/reports" \

--- a/tools/test/run-transaction-read-oci-evidence-execution-gate.sh
+++ b/tools/test/run-transaction-read-oci-evidence-execution-gate.sh
@@ -14,6 +14,8 @@ Environment:
   OCI_EVIDENCE_EXECUTION_MAX_P999_MS             default 500
   OCI_EVIDENCE_EXECUTION_MAX_POOL_PENDING        default 0
   OCI_EVIDENCE_EXECUTION_MAX_POSTGRES_TEMP_FILE_DELTA default 0
+  OCI_EVIDENCE_EXECUTION_MIN_SOURCE_IPS          default 1
+  OCI_EVIDENCE_EXECUTION_MIN_MIXED_WRITE_ACCEPTED_RATIO default 0.80
   OCI_EVIDENCE_EXECUTION_MIXED_MIN_DURATION_MIN  default 30
   OCI_EVIDENCE_EXECUTION_P999_MIN_DURATION_MIN   default 30
   OCI_EVIDENCE_EXECUTION_HIKARI_MIN_DURATION_MIN default 30
@@ -47,6 +49,8 @@ max_edge_429_rate="${OCI_EVIDENCE_EXECUTION_MAX_EDGE_429_RATE:-0.10}"
 max_p999_ms="${OCI_EVIDENCE_EXECUTION_MAX_P999_MS:-500}"
 max_pool_pending="${OCI_EVIDENCE_EXECUTION_MAX_POOL_PENDING:-0}"
 max_postgres_temp_file_delta="${OCI_EVIDENCE_EXECUTION_MAX_POSTGRES_TEMP_FILE_DELTA:-0}"
+min_source_ips="${OCI_EVIDENCE_EXECUTION_MIN_SOURCE_IPS:-1}"
+min_mixed_write_accepted_ratio="${OCI_EVIDENCE_EXECUTION_MIN_MIXED_WRITE_ACCEPTED_RATIO:-0.80}"
 mixed_min_duration_min="${OCI_EVIDENCE_EXECUTION_MIXED_MIN_DURATION_MIN:-30}"
 p999_min_duration_min="${OCI_EVIDENCE_EXECUTION_P999_MIN_DURATION_MIN:-30}"
 hikari_min_duration_min="${OCI_EVIDENCE_EXECUTION_HIKARI_MIN_DURATION_MIN:-30}"
@@ -124,6 +128,8 @@ print_plan() {
   echo "[transaction-read-oci-evidence-execution] max_p999_ms=${max_p999_ms}"
   echo "[transaction-read-oci-evidence-execution] max_pool_pending=${max_pool_pending}"
   echo "[transaction-read-oci-evidence-execution] max_postgres_temp_file_delta=${max_postgres_temp_file_delta}"
+  echo "[transaction-read-oci-evidence-execution] min_source_ips=${min_source_ips}"
+  echo "[transaction-read-oci-evidence-execution] min_mixed_write_accepted_ratio=${min_mixed_write_accepted_ratio}"
   echo "[transaction-read-oci-evidence-execution] mixed_min_duration_min=${mixed_min_duration_min}"
   echo "[transaction-read-oci-evidence-execution] p999_min_duration_min=${p999_min_duration_min}"
   echo "[transaction-read-oci-evidence-execution] hikari_min_duration_min=${hikari_min_duration_min}"
@@ -136,6 +142,8 @@ require_rate "OCI_EVIDENCE_EXECUTION_MAX_EDGE_429_RATE" "${max_edge_429_rate}"
 require_non_negative_number "OCI_EVIDENCE_EXECUTION_MAX_P999_MS" "${max_p999_ms}"
 require_non_negative_integer "OCI_EVIDENCE_EXECUTION_MAX_POOL_PENDING" "${max_pool_pending}"
 require_non_negative_integer "OCI_EVIDENCE_EXECUTION_MAX_POSTGRES_TEMP_FILE_DELTA" "${max_postgres_temp_file_delta}"
+require_non_negative_integer "OCI_EVIDENCE_EXECUTION_MIN_SOURCE_IPS" "${min_source_ips}"
+require_rate "OCI_EVIDENCE_EXECUTION_MIN_MIXED_WRITE_ACCEPTED_RATIO" "${min_mixed_write_accepted_ratio}"
 require_non_negative_integer "OCI_EVIDENCE_EXECUTION_MIXED_MIN_DURATION_MIN" "${mixed_min_duration_min}"
 require_non_negative_integer "OCI_EVIDENCE_EXECUTION_P999_MIN_DURATION_MIN" "${p999_min_duration_min}"
 require_non_negative_integer "OCI_EVIDENCE_EXECUTION_HIKARI_MIN_DURATION_MIN" "${hikari_min_duration_min}"
@@ -156,6 +164,8 @@ awk -F '\t' \
   -v max_p999_ms="${max_p999_ms}" \
   -v max_pool_pending="${max_pool_pending}" \
   -v max_postgres_temp_file_delta="${max_postgres_temp_file_delta}" \
+  -v min_source_ips="${min_source_ips}" \
+  -v min_mixed_write_accepted_ratio="${min_mixed_write_accepted_ratio}" \
   -v mixed_min_duration_min="${mixed_min_duration_min}" \
   -v p999_min_duration_min="${p999_min_duration_min}" \
   -v hikari_min_duration_min="${hikari_min_duration_min}" \
@@ -194,7 +204,7 @@ BEGIN {
   for (i in required_items) {
     required[required_items[i]] = 1
   }
-  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\trun_script\tk6_summary_ref\tnginx_access_ref\tspring_metrics_ref\thikari_log_ref\tpostgres_wait_ref\tdeploy_event_ref\tcache_state_ref\ttimeline_ref\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tp999_ms\tp95_ms\tp99_ms\tmax_ms\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref\tworkload_components\tread_p999_ms\tread_429_source_ref\tread_buckets\tread_bucket_ref\twrite_2xx_count\twrite_unexpected_status_count\twrite_status_ref"
+  print "scenario\tstatus\treason\trun_id\tduration_min\tsource_ips\trun_script\tk6_summary_ref\tnginx_access_ref\tspring_metrics_ref\thikari_log_ref\tpostgres_wait_ref\tdeploy_event_ref\tcache_state_ref\ttimeline_ref\tedge_429_rate\tbackend_429_count\tunknown_429_count\tfive_xx_count\tnginx_499_count\thikari_validation_warnings\tdb_pool_pending_max\tp999_ms\tp95_ms\tp99_ms\tmax_ms\tpostgres_checkpoint_count\tpostgres_temp_file_count\tnginx_upstream_p95_ms\thikari_config_ref\thikari_max_lifetime_ms\thikari_keepalive_time_ms\tpostgres_idle_timeout_ms\toci_nat_idle_timeout_ms\thikari_zero_warning_soak_ref\tworkload_components\tread_p999_ms\tread_429_source_ref\tread_buckets\tread_bucket_ref\twrite_2xx_count\twrite_unexpected_status_count\twrite_status_ref\twrite_accepted_ratio\tmin_write_accepted_ratio"
 }
 NR == 1 {
   for (i = 1; i <= NF; i++) {
@@ -237,6 +247,8 @@ NR == 1 {
   write_2xx_count = value("write_2xx_count", "")
   write_unexpected_status_count = value("write_unexpected_status_count", "")
   write_status_ref = value("write_status_ref", "")
+  write_accepted_ratio = value("write_accepted_ratio", "")
+  row_min_write_accepted_ratio = value("min_write_accepted_ratio", "")
   status = "pass"
   reason = "ok"
   seen[scenario] = 1
@@ -244,6 +256,7 @@ NR == 1 {
   if (run_id == "") add_reason("run-id-missing")
   if (executed_at == "") add_reason("executed-at-missing")
   if (run_script !~ /^tools\/test\/run-.*[.]sh$/) add_reason("run-script-invalid")
+  if (source_ips < min_source_ips) add_reason("source-ips<" min_source_ips)
   require_ref("k6_summary_ref", "k6-summary-missing")
   require_ref("nginx_access_ref", "nginx-access-missing")
   require_ref("spring_metrics_ref", "spring-metrics-missing")
@@ -269,8 +282,15 @@ NR == 1 {
     read_p999_ms = require_number("read_p999_ms", "read-p999-missing")
     write_2xx_count = require_number("write_2xx_count", "write-2xx-missing")
     write_unexpected_status_count = require_number("write_unexpected_status_count", "write-unexpected-status-missing")
+    write_accepted_ratio = require_number("write_accepted_ratio", "write-accepted-ratio-missing")
+    if (row_min_write_accepted_ratio == "" || row_min_write_accepted_ratio == "n/a") {
+      row_min_write_accepted_ratio = min_mixed_write_accepted_ratio
+    } else {
+      row_min_write_accepted_ratio = require_number("min_write_accepted_ratio", "min-write-accepted-ratio-invalid")
+    }
     if (read_p999_ms > max_p999_ms) add_reason("read-p999>" max_p999_ms)
     if (write_2xx_count <= 0) add_reason("write-2xx-missing")
+    if (write_accepted_ratio < row_min_write_accepted_ratio) add_reason("write-accepted-ratio<" row_min_write_accepted_ratio)
     if (!has_component(workload_components, "read") || !has_component(workload_components, "write") || !has_component(workload_components, "auth") || !has_component(workload_components, "notification") || !has_component(workload_components, "sse")) {
       add_reason("workload-components-missing")
     }
@@ -316,7 +336,7 @@ NR == 1 {
   if (p999_ms > max_p999_ms) add_reason("p999>" max_p999_ms)
 
   if (status == "fail") fail_count++
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
     scenario, status, reason, run_id, duration_min, source_ips, run_script,
     value("k6_summary_ref", ""), value("nginx_access_ref", ""), value("spring_metrics_ref", ""),
     value("hikari_log_ref", ""), value("postgres_wait_ref", ""), value("deploy_event_ref", ""),
@@ -326,7 +346,7 @@ NR == 1 {
     p95_ms, p99_ms, max_ms, postgres_checkpoint_count, postgres_temp_file_count, nginx_upstream_p95_ms,
     hikari_config_ref, hikari_max_lifetime_ms, hikari_keepalive_time_ms, postgres_idle_timeout_ms, oci_nat_idle_timeout_ms, hikari_zero_warning_soak_ref,
     workload_components, read_p999_ms, read_429_source_ref,
-    read_buckets, read_bucket_ref, write_2xx_count, write_unexpected_status_count, write_status_ref
+    read_buckets, read_bucket_ref, write_2xx_count, write_unexpected_status_count, write_status_ref, write_accepted_ratio, row_min_write_accepted_ratio
 }
 END {
   missing = ""
@@ -379,6 +399,8 @@ cat >"${report_md}" <<REPORT
 - edge 429 max rate: ${max_edge_429_rate}
 - p99.9 max: ${max_p999_ms}ms
 - PostgreSQL temp file delta max: ${max_postgres_temp_file_delta}
+- source IPs min: ${min_source_ips}
+- mixed workload write accepted ratio min: ${min_mixed_write_accepted_ratio}
 - backend 429/unknown 429/499/5xx/Hikari warning/pool pending target: 0
 - unknown 429 hard-zero
 - p99.9 closure artifacts: PostgreSQL checkpoint, temp file, Nginx upstream latency
@@ -390,6 +412,7 @@ cat >"${report_md}" <<REPORT
 - mixed workload read p99.9 and 429 source artifact: required
 - mixed workload hot/cold/archive read bucket artifact: required
 - mixed workload write 2xx and status classification artifact: required
+- mixed workload write accepted ratio: required
 - deploy drain closure artifacts: 499 budget, retry contract, reconnect success
 
 ## Result Table


### PR DESCRIPTION
## 🔗 Related Issue
- close #876

## 🌿 Base Branch
- `main`

## 📝 Summary
- `[Perf]`가 아닌 `[Test]` 범위로 mixed workload evidence guardrail을 보강했습니다.
- write accepted ratio와 source IP 최소값은 evidence gate에서 검증하고, 30m soak 기본 workload는 hot-only가 아니라 cold/archive path를 포함합니다.

## 🛠 Changes
- mixed workload k6에 `aquila_mixed_write_accepted_ratio` metric과 configurable threshold를 추가했습니다.
- OCI evidence execution gate가 mixed write accepted ratio와 `OCI_EVIDENCE_EXECUTION_MIN_SOURCE_IPS`를 검증합니다.
- mixed workload runner/autogen/timeline manifest가 accepted ratio 값을 전달합니다.
- 30m soak workflow 기본 workload weight에 cold/archive read path를 포함했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-transaction-read-oci-evidence-execution-gate.sh`
- `bash tools/test/check-transaction-read-mixed-workload-30m-timeline.sh`
- `bash tools/test/check-transaction-read-mixed-workload-oci-k6.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-autogen.sh`
- `bash tools/test/check-transaction-read-mixed-workload-live-evidence-workflow.sh`
- `bash tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh`
- `git diff --check HEAD`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: accepted ratio threshold가 낮은 live run을 PR gate에서 실패시킬 수 있습니다.
- 예상 리스크: 30m soak 기본값이 archive-backed cold path를 포함해 기존 hot-only run보다 입력 fixture 민감도가 커집니다.
- 롤백 방법: 이 PR의 두 커밋을 revert하면 기존 evidence gate와 hot-only default로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?