### PR TITLE
[Feat] 고객 웹뱅킹 MVP 구현

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -447,6 +447,39 @@ label span {
   font-weight: 800;
 }
 
+.status-badge.unread {
+  border-color: #f7c580;
+  background: #fff7ed;
+  color: #9a3412;
+}
+
+.notification-status {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.notification-status div {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface-muted);
+  padding: 12px;
+}
+
+.notification-status span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.notification-status strong {
+  overflow-wrap: anywhere;
+  color: var(--primary-dark);
+}
+
 .two-column {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -488,6 +521,16 @@ label span {
 
 .filter-grid {
   grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.notification-filter {
+  margin-top: 12px;
+}
+
+.inline-toolbar {
+  margin: -14px -14px 0;
+  border: 0;
+  border-bottom: 1px solid var(--line);
 }
 
 .inline-control {
@@ -664,6 +707,48 @@ label span {
   color: var(--muted);
 }
 
+.table-message {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.preference-actions {
+  margin-top: 12px;
+}
+
+.preference-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.preference-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface-muted);
+  padding: 10px;
+}
+
+.preference-row input {
+  width: auto;
+  height: auto;
+}
+
+.preference-row span {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+}
+
+.preference-row small {
+  color: var(--muted);
+}
+
 .tab-switch {
   display: inline-flex;
   overflow: hidden;
@@ -766,15 +851,12 @@ label span {
     grid-column: 1 / -1;
   }
 
-  .right-rail {
-    grid-row: 2;
-  }
-
   .summary-grid,
   .account-grid,
   .split-work,
   .form-grid,
   .filter-grid,
+  .notification-status,
   .two-column {
     grid-template-columns: 1fr;
   }

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -383,6 +383,70 @@ label span {
   width: 100%;
 }
 
+.account-grid,
+.split-work {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.detail-panel,
+.result-panel {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  padding: 14px;
+}
+
+.balance-card {
+  display: grid;
+  gap: 4px;
+  margin: 12px 0;
+  border: 1px solid #bcd3ef;
+  border-radius: 6px;
+  background: var(--primary-soft);
+  padding: 16px;
+}
+
+.balance-card span,
+.balance-card small {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.balance-card strong {
+  color: var(--primary-dark);
+  font-size: 26px;
+}
+
+.amount-cell,
+.amount {
+  text-align: right;
+  font-weight: 800;
+}
+
+.amount.debit {
+  color: var(--primary-dark);
+}
+
+.amount.credit {
+  color: var(--success);
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border: 1px solid #bfd3ea;
+  border-radius: 4px;
+  background: var(--primary-soft);
+  color: var(--primary-dark);
+  padding: 0 8px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
 .two-column {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -406,6 +470,35 @@ label span {
 .bank-form > button {
   background: var(--primary);
   color: #fff;
+}
+
+.filter-form {
+  margin-top: 12px;
+}
+
+.form-grid,
+.filter-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.form-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.filter-grid {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.inline-control {
+  display: grid;
+  grid-template-columns: auto 90px;
+  align-items: center;
+  gap: 8px;
+}
+
+.inline-control span {
+  margin: 0;
 }
 
 .form-heading {
@@ -490,6 +583,10 @@ label span {
   overflow: hidden;
 }
 
+.table-panel.embedded {
+  margin-top: 0;
+}
+
 .panel-toolbar {
   padding: 12px 14px;
   border-bottom: 1px solid var(--line);
@@ -565,6 +662,28 @@ label span {
 
 .empty-business span {
   color: var(--muted);
+}
+
+.tab-switch {
+  display: inline-flex;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+}
+
+.tab-switch button {
+  min-width: 90px;
+  border: 0;
+  border-radius: 0;
+}
+
+.tab-switch button + button {
+  border-left: 1px solid var(--line-strong);
+}
+
+.tab-switch button.active {
+  background: var(--primary);
+  color: #fff;
 }
 
 .right-rail {
@@ -652,6 +771,10 @@ label span {
   }
 
   .summary-grid,
+  .account-grid,
+  .split-work,
+  .form-grid,
+  .filter-grid,
   .two-column {
     grid-template-columns: 1fr;
   }

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,13 +1,22 @@
 :root {
-  /* bootstrap 랜딩 화면 공통 디자인 토큰 */
   color-scheme: light;
-  --bg: #f4efe7;
-  --ink: #14213d;
-  --muted: #5e6472;
-  --line: rgba(20, 33, 61, 0.12);
-  --panel: rgba(255, 255, 255, 0.72);
-  --accent: #0f766e;
-  --accent-soft: rgba(15, 118, 110, 0.12);
+  --page: #eef2f7;
+  --surface: #ffffff;
+  --surface-muted: #f6f8fb;
+  --line: #d8e0eb;
+  --line-strong: #aebbd0;
+  --text: #1d2733;
+  --muted: #66758a;
+  --primary: #1157a6;
+  --primary-dark: #073f83;
+  --primary-soft: #e7f0fb;
+  --accent: #0a7d8f;
+  --danger: #b42318;
+  --danger-soft: #fff1f0;
+  --success: #087443;
+  --success-soft: #ecfdf3;
+  --warning-soft: #fff8e1;
+  --shadow: 0 8px 24px rgba(29, 39, 51, 0.08);
 }
 
 * {
@@ -16,219 +25,640 @@
 
 html,
 body {
+  min-height: 100%;
   margin: 0;
   padding: 0;
-  min-height: 100%;
 }
 
 body {
-  /* 여러 gradient를 겹쳐 초기 화면이 빈 scaffold처럼 보이지 않게 합니다. */
-  background:
-    radial-gradient(circle at top left, rgba(15, 118, 110, 0.18), transparent 28%),
-    radial-gradient(circle at top right, rgba(20, 33, 61, 0.14), transparent 24%),
-    linear-gradient(180deg, #f8f3ed 0%, var(--bg) 100%);
-  color: var(--ink);
-  font-family: "Avenir Next", "Segoe UI", system-ui, sans-serif;
+  background: var(--page);
+  color: var(--text);
+  font-family:
+    "Noto Sans KR",
+    "Malgun Gothic",
+    "Apple SD Gothic Neo",
+    Arial,
+    sans-serif;
+  font-size: 14px;
 }
 
-.shell {
-  width: min(1120px, calc(100% - 40px));
-  margin: 0 auto;
-  padding: 64px 0 96px;
+button,
+input,
+select {
+  font: inherit;
 }
 
-.hero,
-.panel {
-  /* 두 surface 모두 같은 glass panel 톤을 써서 화면 일관성을 맞춥니다. */
-  position: relative;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  background: var(--panel);
-  backdrop-filter: blur(16px);
-  box-shadow: 0 24px 80px rgba(20, 33, 61, 0.08);
-}
-
-.hero {
-  padding: 48px;
-  border-radius: 32px;
-}
-
-.hero::after {
-  content: "";
-  position: absolute;
-  inset: auto -120px -120px auto;
-  width: 320px;
-  height: 320px;
-  border-radius: 50%;
-  background: var(--accent-soft);
-  filter: blur(8px);
-}
-
-.eyebrow {
-  margin: 0 0 12px;
-  color: var(--accent);
-  font-size: 0.82rem;
+button {
+  min-height: 34px;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
   font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
 }
 
-h1,
-h2,
-h3,
-strong {
-  font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+button:hover:not(:disabled) {
+  border-color: var(--primary);
+  color: var(--primary);
 }
 
-h1 {
-  max-width: 11ch;
-  margin: 0;
-  font-size: clamp(2.8rem, 6vw, 5rem);
-  line-height: 0.95;
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
 }
 
-.lead {
-  max-width: 780px;
-  margin: 24px 0 0;
-  color: var(--muted);
-  font-size: 1.05rem;
-  line-height: 1.8;
+input,
+select {
+  width: 100%;
+  height: 36px;
+  border: 1px solid var(--line-strong);
+  border-radius: 3px;
+  background: #fff;
+  color: var(--text);
+  padding: 0 10px;
 }
 
-.lead.compact {
-  max-width: 720px;
-}
-
-.hero-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
-  margin-top: 36px;
-}
-
-.metric,
-.card {
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.78);
-}
-
-.metric {
-  border-radius: 20px;
-  padding: 20px 22px;
-}
-
-.metric-label {
+label span {
   display: block;
-  color: var(--muted);
-  font-size: 0.85rem;
+  margin-bottom: 6px;
+  color: #344054;
+  font-size: 13px;
+  font-weight: 700;
 }
 
-.metric strong {
-  display: block;
-  margin-top: 8px;
-  font-size: 1.6rem;
+.bank-shell {
+  min-width: 1180px;
 }
 
-.panel {
-  margin-top: 28px;
-  border-radius: 28px;
-  padding: 36px;
+.bank-header {
+  border-bottom: 1px solid #c9d5e4;
+  background: var(--surface);
+  box-shadow: var(--shadow);
 }
 
-.panel-header h2 {
-  margin: 0;
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
+.utility-bar,
+.brand-row,
+.bank-layout {
+  width: min(1440px, calc(100% - 48px));
+  margin: 0 auto;
 }
 
-.cards {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
-  margin-top: 24px;
-}
-
-.card {
-  border-radius: 22px;
-  padding: 24px;
-}
-
-.card h3 {
-  margin: 0 0 12px;
-  font-size: 1.35rem;
-}
-
-.card p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.7;
-}
-
-.feature-flag-panel {
-  margin-top: 28px;
-}
-
-.flag-list {
+.utility-bar {
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 24px;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 38px;
+  border-bottom: 1px solid var(--line);
 }
 
-.flag-chip {
+.utility-left,
+.utility-right,
+.primary-nav,
+.button-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.utility-link {
+  min-height: 28px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.utility-link.active {
+  color: var(--primary);
+}
+
+.search-field {
+  display: grid;
+  grid-template-columns: auto 220px;
+  align-items: center;
+  gap: 8px;
+}
+
+.search-field span {
+  margin: 0;
+}
+
+.brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 78px;
+}
+
+.brand-mark {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-symbol {
   display: inline-flex;
   align-items: center;
-  border-radius: 999px;
-  border: 1px solid rgba(15, 118, 110, 0.18);
-  background: rgba(15, 118, 110, 0.1);
-  color: var(--accent);
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 6px;
+  background: var(--primary);
+  color: #fff;
+  font-size: 22px;
+  font-weight: 900;
+}
+
+.brand-mark strong {
+  display: block;
+  font-size: 22px;
+  letter-spacing: 0;
+}
+
+.brand-mark small {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.primary-nav {
+  gap: 2px;
+}
+
+.nav-tab {
+  min-width: 104px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.nav-tab.active {
+  border-bottom: 3px solid var(--primary);
+  color: var(--primary);
+}
+
+.bank-layout {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 280px;
+  gap: 16px;
+  padding: 18px 0 48px;
+}
+
+.side-menu,
+.right-rail,
+.work-area {
+  min-width: 0;
+}
+
+.side-menu {
+  border: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.side-title {
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--primary);
+  color: #fff;
+  font-size: 17px;
+  font-weight: 800;
+}
+
+.side-item {
+  display: grid;
+  width: 100%;
+  min-height: 58px;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  background: #fff;
   padding: 10px 14px;
-  font-size: 0.9rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  text-align: left;
 }
 
-.flag-empty {
-  margin: 24px 0 0;
+.side-item span {
   color: var(--muted);
-  line-height: 1.7;
+  font-size: 12px;
 }
 
-.preview-card {
-  margin-top: 24px;
-  border: 1px solid rgba(15, 118, 110, 0.14);
-  border-radius: 24px;
-  background:
-    linear-gradient(135deg, rgba(15, 118, 110, 0.12), rgba(20, 33, 61, 0.04)),
-    rgba(255, 255, 255, 0.82);
-  padding: 24px;
+.side-item strong {
+  font-size: 15px;
 }
 
-.preview-card h3 {
-  margin: 0 0 12px;
-  font-size: 1.4rem;
+.side-item.active {
+  border-left: 4px solid var(--primary);
+  background: var(--primary-soft);
 }
 
-.preview-card p:last-child {
+.work-area {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.task-section,
+.rail-panel,
+.table-panel {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+}
+
+.task-section {
+  padding: 18px;
+}
+
+.section-title,
+.panel-toolbar,
+.rail-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.section-title {
+  padding-bottom: 14px;
+  border-bottom: 2px solid #263b56;
+}
+
+.section-title p {
+  margin: 0 0 4px;
+  color: var(--primary);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.section-title h1 {
   margin: 0;
+  font-size: 24px;
+  letter-spacing: 0;
+}
+
+.button-row {
+  flex-wrap: wrap;
+}
+
+.button-row button {
+  padding: 0 12px;
+}
+
+.button-row.compact {
+  gap: 6px;
+}
+
+.button-row.compact button {
+  min-height: 30px;
+  padding: 0 9px;
+  font-size: 12px;
+}
+
+.alert {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  min-height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--warning-soft);
+  padding: 10px 12px;
+}
+
+.alert strong {
+  color: var(--primary-dark);
+}
+
+.alert.success {
+  border-color: #b7e4ca;
+  background: var(--success-soft);
+}
+
+.alert.error {
+  border-color: #f3b6ae;
+  background: var(--danger-soft);
+}
+
+.alert.error strong {
+  color: var(--danger);
+}
+
+.busy-strip {
+  border: 1px solid #9dc7ff;
+  border-radius: 4px;
+  background: #eef6ff;
+  color: var(--primary-dark);
+  padding: 9px 12px;
+  font-weight: 800;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.summary-box {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface-muted);
+  padding: 14px;
+}
+
+.summary-box span {
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.summary-box strong {
+  display: block;
+  margin: 8px 0 14px;
+  font-size: 17px;
+}
+
+.summary-box button {
+  width: 100%;
+}
+
+.two-column {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.bank-form {
+  display: grid;
+  gap: 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface-muted);
+  padding: 14px;
+}
+
+.bank-form.passive {
+  background: #fff;
+}
+
+.bank-form > button {
+  background: var(--primary);
+  color: #fff;
+}
+
+.form-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--line);
+}
+
+.form-heading strong {
+  font-size: 16px;
+}
+
+.form-heading span,
+.field-note {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.checkbox-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkbox-line input {
+  width: auto;
+  height: auto;
+}
+
+.checkbox-line span {
+  margin: 0;
+}
+
+.detail-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.detail-list div,
+.session-summary div {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr);
+  gap: 8px;
+}
+
+.detail-list dt,
+.session-summary dt {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.detail-list dd,
+.session-summary dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.compact-list div {
+  grid-template-columns: 70px minmax(0, 1fr);
+}
+
+.code-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.code-list code {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: #fff;
+  padding: 5px 7px;
+}
+
+.table-panel {
+  margin-top: 12px;
+  overflow: hidden;
+}
+
+.panel-toolbar {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+  background: #f8fafc;
+}
+
+.panel-toolbar strong {
+  display: block;
+}
+
+.panel-toolbar span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.bank-table-wrap {
+  margin-top: 14px;
+  overflow-x: auto;
+  border: 1px solid var(--line);
+}
+
+.table-panel .bank-table-wrap {
+  margin-top: 0;
+  border: 0;
+}
+
+.bank-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+}
+
+.bank-table caption {
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.bank-table th,
+.bank-table td {
+  border-bottom: 1px solid var(--line);
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.bank-table th {
+  background: #f0f4f9;
+  color: #263b56;
+  font-size: 13px;
+}
+
+.bank-table td {
+  font-size: 13px;
+}
+
+.empty-business {
+  display: grid;
+  gap: 6px;
+  margin-top: 14px;
+  border: 1px dashed var(--line-strong);
+  border-radius: 6px;
+  background: var(--surface-muted);
+  padding: 28px;
+  text-align: center;
+}
+
+.empty-business strong {
+  font-size: 18px;
+}
+
+.empty-business span {
+  color: var(--muted);
+}
+
+.right-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rail-panel {
+  padding: 14px;
+}
+
+.rail-heading {
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.rail-heading span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.rail-heading strong {
+  color: var(--primary);
+}
+
+.rail-copy {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.session-summary {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0;
+  font-size: 12px;
+}
+
+.quick-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.quick-grid button {
+  min-height: 38px;
+  font-size: 12px;
+}
+
+.notice-list ul {
+  margin: 12px 0 0;
+  padding-left: 18px;
   color: var(--muted);
   line-height: 1.7;
 }
 
-@media (max-width: 900px) {
-  /* 모바일에서는 metric/card grid를 한 컬럼으로 접어 가독성을 유지합니다. */
-  .shell {
-    width: min(100% - 24px, 1120px);
-    padding: 24px 0 56px;
+@media (max-width: 1180px) {
+  .bank-shell {
+    min-width: 0;
   }
 
-  .hero,
-  .panel {
-    padding: 24px;
-    border-radius: 24px;
+  .utility-bar,
+  .brand-row,
+  .bank-layout {
+    width: min(100% - 24px, 960px);
   }
 
-  .hero-grid,
-  .cards {
+  .bank-layout {
     grid-template-columns: 1fr;
+  }
+
+  .side-menu {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .side-title {
+    grid-column: 1 / -1;
+  }
+
+  .right-rail {
+    grid-row: 2;
+  }
+
+  .summary-grid,
+  .two-column {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-row,
+  .utility-bar,
+  .primary-nav {
+    flex-wrap: wrap;
   }
 }

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FormEvent } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ApiClientError,
   ApiConfigurationError,
@@ -20,6 +20,9 @@ import type {
   BackupCodeIssueResponse,
   CustomerSession,
   LoginResponse,
+  NotificationItem,
+  NotificationPreferenceItem,
+  NotificationQueryResponse,
   PasswordRecoveryRequestResult,
   TransactionDetailResponse,
   TransactionItem,
@@ -190,6 +193,31 @@ export default function HomePage() {
   const [transactions, setTransactions] = useState<TransactionItem[]>([]);
   const [transactionDetail, setTransactionDetail] =
     useState<TransactionDetailResponse | null>(null);
+  const [notificationMode, setNotificationMode] = useState<"inbox" | "search">(
+    "inbox",
+  );
+  const [notificationFilters, setNotificationFilters] = useState({
+    limit: "20",
+    cursor: "",
+    readStatus: "ALL",
+    eventType: "",
+    from: toLocalInputValue(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)),
+    to: toLocalInputValue(new Date()),
+  });
+  const [notificationSlice, setNotificationSlice] =
+    useState<NotificationQueryResponse | null>(null);
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [selectedNotificationIds, setSelectedNotificationIds] = useState<number[]>(
+    [],
+  );
+  const [unreadCount, setUnreadCount] = useState<number | null>(null);
+  const [preferences, setPreferences] = useState<NotificationPreferenceItem[]>([]);
+  const [sseStatus, setSseStatus] = useState({
+    state: "disconnected",
+    lastEventAt: "",
+    lastEventId: "",
+  });
+  const eventSourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
     const storedSession = loadCustomerSession();
@@ -200,6 +228,12 @@ export default function HomePage() {
         text: "저장된 세션을 불러왔습니다.",
       });
     }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      eventSourceRef.current?.close();
+    };
   }, []);
 
   function applyLoginResult(result: LoginResponse): void {
@@ -607,6 +641,167 @@ export default function HomePage() {
     });
   }
 
+  async function handleLoadNotifications(
+    mode = notificationMode,
+    cursor = "",
+    append = false,
+  ) {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("알림 조회", async () => {
+      const commonParams = {
+        limit: Number(notificationFilters.limit || 20),
+        cursor,
+      };
+      const result =
+        mode === "search"
+          ? await api.searchNotifications(
+              {
+                ...commonParams,
+                readStatus: notificationFilters.readStatus,
+                eventType: notificationFilters.eventType || undefined,
+                from: toIsoDateTime(notificationFilters.from),
+                to: toIsoDateTime(notificationFilters.to),
+              },
+              currentSession.accessToken,
+            )
+          : await api.getNotifications(commonParams, currentSession.accessToken);
+      setNotificationMode(mode);
+      setNotificationSlice(result);
+      setNotifications((items) => (append ? [...items, ...result.items] : result.items));
+      setNotificationFilters((form) => ({
+        ...form,
+        cursor: result.nextCursor ?? "",
+      }));
+      setSelectedNotificationIds([]);
+      setAlert({ type: "success", text: "알림을 불러왔습니다." });
+    });
+  }
+
+  async function handleLoadUnreadCount() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("미확인 알림 조회", async () => {
+      const result = await api.getUnreadCount(currentSession.accessToken);
+      setUnreadCount(result.unreadCount);
+      setAlert({ type: "success", text: "미확인 알림 수를 불러왔습니다." });
+    });
+  }
+
+  async function handleLoadPreferences() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("알림 설정 조회", async () => {
+      const result = await api.getNotificationPreferences(currentSession.accessToken);
+      setPreferences(result.items);
+      setAlert({ type: "success", text: "알림 설정을 불러왔습니다." });
+    });
+  }
+
+  async function handleUpdatePreferences() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("알림 설정 저장", async () => {
+      await api.updateNotificationPreferences({ items: preferences }, currentSession.accessToken);
+      setAlert({ type: "success", text: "알림 설정을 저장했습니다." });
+    });
+  }
+
+  function toggleNotificationId(notificationId: number): void {
+    setSelectedNotificationIds((items) =>
+      items.includes(notificationId)
+        ? items.filter((item) => item !== notificationId)
+        : [...items, notificationId],
+    );
+  }
+
+  async function handleNotificationBulkAction(
+    action: "read" | "archive" | "delete",
+    notificationId?: number,
+  ) {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    const notificationIds =
+      notificationId === undefined ? selectedNotificationIds : [notificationId];
+    if (notificationIds.length === 0) {
+      setAlert({ type: "error", text: "선택된 알림이 없습니다." });
+      return;
+    }
+    await runAction("알림 처리", async () => {
+      if (action === "read" && notificationId !== undefined) {
+        await api.markNotificationAsRead(notificationId, currentSession.accessToken);
+      } else if (action === "read") {
+        await api.markNotificationsAsRead({ notificationIds }, currentSession.accessToken);
+      } else if (action === "archive") {
+        await api.archiveNotifications({ notificationIds }, currentSession.accessToken);
+      } else {
+        await api.deleteNotifications({ notificationIds }, currentSession.accessToken);
+      }
+      setNotifications((items) =>
+        action === "delete" || action === "archive"
+          ? items.filter((item) => !notificationIds.includes(item.notificationId))
+          : items.map((item) =>
+              notificationIds.includes(item.notificationId)
+                ? { ...item, read: true, readAt: new Date().toISOString() }
+                : item,
+            ),
+      );
+      setSelectedNotificationIds([]);
+      setAlert({ type: "success", text: "알림 처리가 완료되었습니다." });
+    });
+  }
+
+  function handleConnectNotifications() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    try {
+      eventSourceRef.current?.close();
+      const eventSource = new EventSource(
+        api.streamUrl("/api/v1/notifications/stream", currentSession.accessToken),
+      );
+      eventSourceRef.current = eventSource;
+      setSseStatus({
+        state: "connecting",
+        lastEventAt: "",
+        lastEventId: "",
+      });
+      eventSource.onopen = () => {
+        setSseStatus((status) => ({ ...status, state: "connected" }));
+        setAlert({ type: "success", text: "알림 스트림에 연결되었습니다." });
+      };
+      eventSource.onmessage = (event) => {
+        setSseStatus({
+          state: "connected",
+          lastEventAt: new Date().toISOString(),
+          lastEventId: event.lastEventId || "",
+        });
+      };
+      eventSource.onerror = () => {
+        setSseStatus((status) => ({ ...status, state: "error" }));
+      };
+    } catch (error) {
+      setAlert({ type: "error", text: toErrorMessage(error) });
+    }
+  }
+
+  function handleDisconnectNotifications() {
+    eventSourceRef.current?.close();
+    eventSourceRef.current = null;
+    setSseStatus((status) => ({ ...status, state: "disconnected" }));
+  }
+
   const isBusy = busyLabel !== null;
 
   return (
@@ -759,6 +954,7 @@ export default function HomePage() {
               totpCode={totpCode}
               totpEnrollment={totpEnrollment}
               onBackupChallengeChange={setBackupChallengeForm}
+              onBackupChallenge={handleBackupChallenge}
               onDisableTotp={handleDisableTotp}
               onIssueBackupCodes={handleIssueBackupCodes}
               onLoadSessions={handleLoadSessions}
@@ -781,7 +977,40 @@ export default function HomePage() {
             />
           ) : null}
           {activeSection === "notifications" ? (
-            <BusinessPlaceholder section={activeSection} onMove={setActiveSection} />
+            <NotificationsSection
+              filters={notificationFilters}
+              isBusy={isBusy}
+              mode={notificationMode}
+              notifications={notifications}
+              preferences={preferences}
+              selectedIds={selectedNotificationIds}
+              slice={notificationSlice}
+              sseStatus={sseStatus}
+              unreadCount={unreadCount}
+              onBulkAction={handleNotificationBulkAction}
+              onConnect={handleConnectNotifications}
+              onDisconnect={handleDisconnectNotifications}
+              onFilterChange={setNotificationFilters}
+              onLoadPreferences={handleLoadPreferences}
+              onLoadUnreadCount={handleLoadUnreadCount}
+              onModeChange={setNotificationMode}
+              onNext={() =>
+                notificationSlice?.nextCursor
+                  ? handleLoadNotifications(
+                      notificationMode,
+                      notificationSlice.nextCursor,
+                      true,
+                    )
+                  : undefined
+              }
+              onPreferenceChange={setPreferences}
+              onSearch={(event) => {
+                event.preventDefault();
+                handleLoadNotifications(notificationMode);
+              }}
+              onToggleId={toggleNotificationId}
+              onUpdatePreferences={handleUpdatePreferences}
+            />
           ) : null}
         </section>
 
@@ -1734,60 +1963,340 @@ function ResultPanel({ title, rows }: { title: string; rows: string[][] }) {
   );
 }
 
-function BusinessPlaceholder({
-  section,
-  onMove,
+function NotificationsSection({
+  filters,
+  isBusy,
+  mode,
+  notifications,
+  preferences,
+  selectedIds,
+  slice,
+  sseStatus,
+  unreadCount,
+  onBulkAction,
+  onConnect,
+  onDisconnect,
+  onFilterChange,
+  onLoadPreferences,
+  onLoadUnreadCount,
+  onModeChange,
+  onNext,
+  onPreferenceChange,
+  onSearch,
+  onToggleId,
+  onUpdatePreferences,
 }: {
-  section: MenuSection;
-  onMove: (section: MenuSection) => void;
+  filters: {
+    limit: string;
+    cursor: string;
+    readStatus: string;
+    eventType: string;
+    from: string;
+    to: string;
+  };
+  isBusy: boolean;
+  mode: "inbox" | "search";
+  notifications: NotificationItem[];
+  preferences: NotificationPreferenceItem[];
+  selectedIds: number[];
+  slice: NotificationQueryResponse | null;
+  sseStatus: {
+    state: string;
+    lastEventAt: string;
+    lastEventId: string;
+  };
+  unreadCount: number | null;
+  onBulkAction: (
+    action: "read" | "archive" | "delete",
+    notificationId?: number,
+  ) => void;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  onFilterChange: (value: {
+    limit: string;
+    cursor: string;
+    readStatus: string;
+    eventType: string;
+    from: string;
+    to: string;
+  }) => void;
+  onLoadPreferences: () => void;
+  onLoadUnreadCount: () => void;
+  onModeChange: (mode: "inbox" | "search") => void;
+  onNext: () => void;
+  onPreferenceChange: (value: NotificationPreferenceItem[]) => void;
+  onSearch: (event: FormEvent<HTMLFormElement>) => void;
+  onToggleId: (notificationId: number) => void;
+  onUpdatePreferences: () => void;
 }) {
-  if (section === "accounts" || section === "transfer" || section === "transactions") {
-    return (
-      <section className="task-section">
-        <div className="section-title">
-          <div>
-            <p>{section === "transfer" ? "이체" : "조회"}</p>
-            <h1>
-              {section === "accounts"
-                ? "계좌조회"
-                : section === "transfer"
-                  ? "이체"
-                  : "거래내역 조회"}
-            </h1>
-          </div>
-          <button onClick={() => onMove("security")} type="button">
-            로그인 확인
+  return (
+    <section className="task-section">
+      <div className="section-title">
+        <div>
+          <p>고객센터</p>
+          <h1>알림</h1>
+        </div>
+        <div className="button-row">
+          <button disabled={isBusy} onClick={onLoadUnreadCount} type="button">
+            미확인 조회
+          </button>
+          <button disabled={isBusy} onClick={onConnect} type="button">
+            SSE 연결
+          </button>
+          <button onClick={onDisconnect} type="button">
+            연결 해제
           </button>
         </div>
-        <div className="empty-business">
-          <strong>업무 화면 연결 대기</strong>
-          <span>다음 구현 단위에서 백엔드 공개 API와 연결됩니다.</span>
-        </div>
-      </section>
-    );
-  }
+      </div>
 
-  if (section === "notifications") {
-    return (
-      <section className="task-section">
-        <div className="section-title">
-          <div>
-            <p>고객센터</p>
-            <h1>알림</h1>
+      <div className="notification-status">
+        <div>
+          <span>SSE</span>
+          <strong>{sseStatus.state}</strong>
+        </div>
+        <div>
+          <span>Unread</span>
+          <strong>{unreadCount ?? "-"}</strong>
+        </div>
+        <div>
+          <span>Last Event</span>
+          <strong>{sseStatus.lastEventId || "-"}</strong>
+        </div>
+        <div>
+          <span>수신시각</span>
+          <strong>{formatDateTime(sseStatus.lastEventAt)}</strong>
+        </div>
+      </div>
+
+      <form className="bank-form filter-form" onSubmit={onSearch}>
+        <div className="panel-toolbar inline-toolbar">
+          <div className="tab-switch" role="tablist" aria-label="알림 조회 구분">
+            <button
+              aria-selected={mode === "inbox"}
+              className={mode === "inbox" ? "active" : ""}
+              onClick={() => onModeChange("inbox")}
+              role="tab"
+              type="button"
+            >
+              Inbox
+            </button>
+            <button
+              aria-selected={mode === "search"}
+              className={mode === "search" ? "active" : ""}
+              onClick={() => onModeChange("search")}
+              role="tab"
+              type="button"
+            >
+              Search
+            </button>
           </div>
-          <button onClick={() => onMove("security")} type="button">
-            로그인 확인
-          </button>
+          <div className="button-row compact">
+            <button disabled={isBusy} type="submit">
+              조회
+            </button>
+            <button disabled={!slice?.nextCursor || isBusy} onClick={onNext} type="button">
+              다음
+            </button>
+          </div>
         </div>
-        <div className="empty-business">
-          <strong>알림 화면 연결 대기</strong>
-          <span>다음 구현 단위에서 inbox, 검색, SSE 상태가 연결됩니다.</span>
+        <div className="filter-grid notification-filter">
+          <label>
+            <span>건수</span>
+            <select
+              onChange={(event) =>
+                onFilterChange({ ...filters, limit: event.target.value })
+              }
+              value={filters.limit}
+            >
+              <option value="20">20</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
+          </label>
+          <label>
+            <span>읽음상태</span>
+            <select
+              disabled={mode === "inbox"}
+              onChange={(event) =>
+                onFilterChange({ ...filters, readStatus: event.target.value })
+              }
+              value={filters.readStatus}
+            >
+              <option value="ALL">ALL</option>
+              <option value="READ">READ</option>
+              <option value="UNREAD">UNREAD</option>
+            </select>
+          </label>
+          <label>
+            <span>이벤트 유형</span>
+            <input
+              disabled={mode === "inbox"}
+              onChange={(event) =>
+                onFilterChange({ ...filters, eventType: event.target.value })
+              }
+              value={filters.eventType}
+            />
+          </label>
+          <label>
+            <span>시작일시</span>
+            <input
+              disabled={mode === "inbox"}
+              onChange={(event) =>
+                onFilterChange({ ...filters, from: event.target.value })
+              }
+              type="datetime-local"
+              value={filters.from}
+            />
+          </label>
+          <label>
+            <span>종료일시</span>
+            <input
+              disabled={mode === "inbox"}
+              onChange={(event) =>
+                onFilterChange({ ...filters, to: event.target.value })
+              }
+              type="datetime-local"
+              value={filters.to}
+            />
+          </label>
         </div>
-      </section>
-    );
-  }
+      </form>
 
-  return null;
+      <div className="split-work">
+        <section className="table-panel embedded">
+          <div className="panel-toolbar">
+            <div>
+              <strong>알림함</strong>
+              <span>
+                {slice
+                  ? `${notifications.length}건 표시 / next ${slice.hasNext ? "있음" : "없음"}`
+                  : "조회 전"}
+              </span>
+            </div>
+            <div className="button-row compact">
+              <button
+                disabled={selectedIds.length === 0 || isBusy}
+                onClick={() => onBulkAction("read")}
+                type="button"
+              >
+                읽음
+              </button>
+              <button
+                disabled={selectedIds.length === 0 || isBusy}
+                onClick={() => onBulkAction("archive")}
+                type="button"
+              >
+                보관
+              </button>
+              <button
+                disabled={selectedIds.length === 0 || isBusy}
+                onClick={() => onBulkAction("delete")}
+                type="button"
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+          <div className="bank-table-wrap">
+            <table className="bank-table">
+              <caption>알림 목록</caption>
+              <thead>
+                <tr>
+                  <th>선택</th>
+                  <th>상태</th>
+                  <th>유형</th>
+                  <th>제목</th>
+                  <th>수신시각</th>
+                  <th>관리</th>
+                </tr>
+              </thead>
+              <tbody>
+                {notifications.length === 0 ? (
+                  <tr>
+                    <td colSpan={6}>조회된 알림이 없습니다.</td>
+                  </tr>
+                ) : (
+                  notifications.map((item) => (
+                    <tr key={item.notificationId}>
+                      <td>
+                        <input
+                          aria-label={`${item.notificationId} 선택`}
+                          checked={selectedIds.includes(item.notificationId)}
+                          onChange={() => onToggleId(item.notificationId)}
+                          type="checkbox"
+                        />
+                      </td>
+                      <td>
+                        <span className={item.read ? "status-badge" : "status-badge unread"}>
+                          {item.read ? "READ" : "UNREAD"}
+                        </span>
+                      </td>
+                      <td>{item.eventType}</td>
+                      <td>
+                        <strong>{item.title}</strong>
+                        <p className="table-message">{item.message}</p>
+                      </td>
+                      <td>{formatDateTime(item.createdAt)}</td>
+                      <td>
+                        <button
+                          disabled={item.read || isBusy}
+                          onClick={() => onBulkAction("read", item.notificationId)}
+                          type="button"
+                        >
+                          읽음
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <aside className="detail-panel">
+          <div className="form-heading">
+            <strong>알림 수신 설정</strong>
+            <span>{preferences.length}건</span>
+          </div>
+          <div className="button-row compact preference-actions">
+            <button disabled={isBusy} onClick={onLoadPreferences} type="button">
+              설정 조회
+            </button>
+            <button disabled={preferences.length === 0 || isBusy} onClick={onUpdatePreferences} type="button">
+              저장
+            </button>
+          </div>
+          {preferences.length === 0 ? (
+            <p className="rail-copy">알림 설정을 조회하세요.</p>
+          ) : (
+            <div className="preference-list">
+              {preferences.map((item, index) => (
+                <label className="preference-row" key={`${item.category}-${item.channel}`}>
+                  <input
+                    checked={item.enabled}
+                    onChange={(event) => {
+                      const nextItems = [...preferences];
+                      nextItems[index] = {
+                        ...item,
+                        enabled: event.target.checked,
+                      };
+                      onPreferenceChange(nextItems);
+                    }}
+                    type="checkbox"
+                  />
+                  <span>
+                    <strong>{item.category}</strong>
+                    <small>{item.channel}</small>
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+        </aside>
+      </div>
+    </section>
+  );
 }
 
 function SecuritySection(props: {
@@ -1824,6 +2333,7 @@ function SecuritySection(props: {
     backupCode: string;
     rememberDevice: boolean;
   }) => void;
+  onBackupChallenge: (event: FormEvent<HTMLFormElement>) => void;
   onDisableTotp: () => void;
   onIssueBackupCodes: () => void;
   onLoadSessions: () => void;

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -1,107 +1,1171 @@
-import {
-  featureFlagKeys,
-  getEnabledFeatureFlags,
-  isFeatureFlagEnabled,
-} from "../lib/feature-flags";
+"use client";
 
-// 카드 내용을 데이터로 분리해 초기 랜딩 화면을 나중에 쉽게 교체하거나 확장할 수 있게 합니다.
-const highlights = [
-  {
-    title: "Real-time Alerts",
-    text: "이벤트 기반 알림 흐름을 기준으로 중복 발행 방지와 재시도 전략을 프런트 UX와 함께 검증합니다.",
-  },
-  {
-    title: "Bounded Transaction Query",
-    text: "1억 건 저장 규모에서도 accountId, 기간, keyset pagination으로 조회 범위를 작게 유지합니다.",
-  },
-  {
-    title: "Operational Readiness",
-    text: "권한, 감사, 장애 대응, 성능 계측을 서비스 화면과 운영 화면 모두에서 확인할 수 있게 확장합니다.",
-  },
+import type { FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  ApiClientError,
+  ApiConfigurationError,
+  AquilaBankApiClient,
+} from "@/lib/api/client";
+import {
+  clearCustomerSession,
+  loadCustomerSession,
+  saveCustomerSession,
+  toCustomerSession,
+} from "@/lib/api/session";
+import type {
+  AuthSessionItem,
+  BackupCodeIssueResponse,
+  CustomerSession,
+  LoginResponse,
+  PasswordRecoveryRequestResult,
+  TotpEnrollmentStartResponse,
+} from "@/lib/api/types";
+
+type MenuSection =
+  | "dashboard"
+  | "accounts"
+  | "transfer"
+  | "transactions"
+  | "notifications"
+  | "security";
+
+type AlertMessage = {
+  type: "info" | "success" | "error";
+  text: string;
+};
+
+const mainMenus: Array<{ id: MenuSection; label: string; group: string }> = [
+  { id: "dashboard", label: "뱅킹홈", group: "개인뱅킹" },
+  { id: "accounts", label: "조회", group: "계좌" },
+  { id: "transfer", label: "이체", group: "이체" },
+  { id: "transactions", label: "거래내역 조회", group: "조회" },
+  { id: "notifications", label: "알림", group: "고객센터" },
+  { id: "security", label: "인증/세션 관리", group: "뱅킹관리" },
 ];
 
+const quickMenus = ["계좌조회", "즉시이체", "거래내역", "인증센터", "알림함"];
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof ApiConfigurationError) {
+    return "백엔드 API 주소가 설정되지 않았습니다. NEXT_PUBLIC_API_BASE_URL을 확인하세요.";
+  }
+  if (error instanceof ApiClientError) {
+    return `[${error.status}] ${error.message}`;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "요청 처리 중 오류가 발생했습니다.";
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) {
+    return "-";
+  }
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function maskToken(value: string): string {
+  if (value.length <= 16) {
+    return value;
+  }
+  return `${value.slice(0, 10)}...${value.slice(-6)}`;
+}
+
 export default function HomePage() {
-  const enabledFeatureFlags = getEnabledFeatureFlags();
-  const showOpsConsolePreview = isFeatureFlagEnabled(
-    featureFlagKeys.opsConsolePreview,
+  const api = useMemo(() => new AquilaBankApiClient(), []);
+  const [activeSection, setActiveSection] = useState<MenuSection>("dashboard");
+  const [session, setSession] = useState<CustomerSession | null>(null);
+  const [alert, setAlert] = useState<AlertMessage>({
+    type: "info",
+    text: "안전한 웹뱅킹 이용을 위해 로그인 후 업무를 진행하세요.",
+  });
+  const [busyLabel, setBusyLabel] = useState<string | null>(null);
+  const [loginForm, setLoginForm] = useState({ loginId: "", password: "" });
+  const [challenge, setChallenge] = useState<LoginResponse | null>(null);
+  const [totpChallengeForm, setTotpChallengeForm] = useState({
+    totpCode: "",
+    rememberDevice: false,
+  });
+  const [backupChallengeForm, setBackupChallengeForm] = useState({
+    backupCode: "",
+    rememberDevice: false,
+  });
+  const [passwordRecoveryForm, setPasswordRecoveryForm] = useState({
+    loginId: "",
+    recoveryToken: "",
+    newPassword: "",
+  });
+  const [passwordResetForm, setPasswordResetForm] = useState({
+    currentPassword: "",
+    newPassword: "",
+  });
+  const [totpCode, setTotpCode] = useState("");
+  const [sessions, setSessions] = useState<AuthSessionItem[]>([]);
+  const [totpEnrollment, setTotpEnrollment] =
+    useState<TotpEnrollmentStartResponse | null>(null);
+  const [backupCodes, setBackupCodes] = useState<BackupCodeIssueResponse | null>(
+    null,
   );
+  const [passwordRecoveryResult, setPasswordRecoveryResult] =
+    useState<PasswordRecoveryRequestResult | null>(null);
+
+  useEffect(() => {
+    const storedSession = loadCustomerSession();
+    if (storedSession) {
+      setSession(storedSession);
+      setAlert({
+        type: "success",
+        text: "저장된 세션을 불러왔습니다.",
+      });
+    }
+  }, []);
+
+  function applyLoginResult(result: LoginResponse): void {
+    if (result.status === "MFA_REQUIRED") {
+      setChallenge(result);
+      setAlert({
+        type: "info",
+        text: "추가 인증이 필요합니다. TOTP 또는 backup code를 입력하세요.",
+      });
+      return;
+    }
+
+    const nextSession = toCustomerSession(result);
+    if (!nextSession) {
+      setAlert({
+        type: "error",
+        text: "로그인 응답에 accessToken 또는 refreshToken이 없습니다.",
+      });
+      return;
+    }
+
+    saveCustomerSession(nextSession);
+    setSession(nextSession);
+    setChallenge(null);
+    setAlert({
+      type: "success",
+      text: "로그인되었습니다.",
+    });
+  }
+
+  async function runAction(label: string, action: () => Promise<void>): Promise<void> {
+    setBusyLabel(label);
+    try {
+      await action();
+    } catch (error) {
+      setAlert({ type: "error", text: toErrorMessage(error) });
+    } finally {
+      setBusyLabel(null);
+    }
+  }
+
+  function requireSession(): CustomerSession | null {
+    if (!session) {
+      setAlert({ type: "error", text: "로그인이 필요한 업무입니다." });
+      return null;
+    }
+    return session;
+  }
+
+  async function handleLogin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await runAction("로그인", async () => {
+      const result = await api.login(loginForm);
+      applyLoginResult(result);
+    });
+  }
+
+  async function handleTotpChallenge(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!challenge?.challengeId) {
+      setAlert({ type: "error", text: "인증 challenge가 없습니다." });
+      return;
+    }
+    await runAction("TOTP 인증", async () => {
+      const result = await api.verifyTotpChallenge({
+        challengeId: challenge.challengeId as string,
+        totpCode: totpChallengeForm.totpCode,
+        rememberDevice: totpChallengeForm.rememberDevice,
+      });
+      applyLoginResult(result);
+    });
+  }
+
+  async function handleBackupChallenge(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!challenge?.challengeId) {
+      setAlert({ type: "error", text: "인증 challenge가 없습니다." });
+      return;
+    }
+    await runAction("Backup code 인증", async () => {
+      const result = await api.verifyBackupCodeChallenge({
+        challengeId: challenge.challengeId as string,
+        backupCode: backupChallengeForm.backupCode,
+        rememberDevice: backupChallengeForm.rememberDevice,
+      });
+      applyLoginResult(result);
+    });
+  }
+
+  async function handleRefresh() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("토큰 재발급", async () => {
+      const result = await api.refresh({ refreshToken: currentSession.refreshToken });
+      applyLoginResult(result);
+    });
+  }
+
+  async function handleLogout() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("로그아웃", async () => {
+      await api.logout(
+        { refreshToken: currentSession.refreshToken },
+        currentSession.accessToken,
+      );
+      clearCustomerSession();
+      setSession(null);
+      setSessions([]);
+      setAlert({ type: "success", text: "로그아웃되었습니다." });
+    });
+  }
+
+  async function handlePasswordRecoveryRequest(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await runAction("비밀번호 찾기 요청", async () => {
+      const result = await api.requestPasswordRecovery({
+        loginId: passwordRecoveryForm.loginId,
+      });
+      setPasswordRecoveryResult(result);
+      setAlert({
+        type: "success",
+        text: "비밀번호 복구 요청이 접수되었습니다.",
+      });
+    });
+  }
+
+  async function handlePasswordRecoveryConfirm(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await runAction("비밀번호 복구 확정", async () => {
+      await api.confirmPasswordRecovery({
+        recoveryToken: passwordRecoveryForm.recoveryToken,
+        newPassword: passwordRecoveryForm.newPassword,
+      });
+      setAlert({ type: "success", text: "비밀번호가 변경되었습니다." });
+    });
+  }
+
+  async function handlePasswordReset(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("비밀번호 변경", async () => {
+      await api.resetPassword(passwordResetForm, currentSession.accessToken);
+      clearCustomerSession();
+      setSession(null);
+      setAlert({
+        type: "success",
+        text: "비밀번호가 변경되었습니다. 다시 로그인하세요.",
+      });
+    });
+  }
+
+  async function handleLoadSessions() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("세션 조회", async () => {
+      const result = await api.getSessions(currentSession.accessToken);
+      setSessions(result.items);
+      setAlert({ type: "success", text: "세션 목록을 불러왔습니다." });
+    });
+  }
+
+  async function handleRevokeSession(sessionId: number) {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("세션 해지", async () => {
+      await api.revokeSession(sessionId, currentSession.accessToken);
+      setSessions((items) => items.filter((item) => item.sessionId !== sessionId));
+      setAlert({ type: "success", text: "선택한 세션을 해지했습니다." });
+    });
+  }
+
+  async function handleRevokeAllSessions() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("전체 세션 해지", async () => {
+      await api.revokeAllSessions(currentSession.accessToken);
+      clearCustomerSession();
+      setSession(null);
+      setSessions([]);
+      setAlert({ type: "success", text: "전체 세션을 해지했습니다." });
+    });
+  }
+
+  async function handleStartTotpEnrollment() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("TOTP 등록 시작", async () => {
+      const result = await api.startTotpEnrollment(currentSession.accessToken);
+      setTotpEnrollment(result);
+      setAlert({ type: "success", text: "TOTP 등록 정보가 발급되었습니다." });
+    });
+  }
+
+  async function handleVerifyTotpEnrollment() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("TOTP 등록 확인", async () => {
+      const result = await api.verifyTotpEnrollment(
+        { totpCode },
+        currentSession.accessToken,
+      );
+      setAlert({ type: "success", text: `TOTP 상태: ${result.status}` });
+    });
+  }
+
+  async function handleDisableTotp() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("TOTP 해지", async () => {
+      await api.disableTotp({ totpCode }, currentSession.accessToken);
+      clearCustomerSession();
+      setSession(null);
+      setAlert({ type: "success", text: "TOTP가 해지되었습니다." });
+    });
+  }
+
+  async function handleIssueBackupCodes() {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("Backup code 발급", async () => {
+      const result = await api.issueBackupCodes(
+        { totpCode },
+        currentSession.accessToken,
+      );
+      setBackupCodes(result);
+      setAlert({ type: "success", text: "Backup code가 발급되었습니다." });
+    });
+  }
+
+  const isBusy = busyLabel !== null;
 
   return (
-    <main className="shell">
-      <section className="hero">
-        {/* hero 영역에서 왜 repo를 처음부터 front/back으로 나눴는지 설명합니다. */}
-        <p className="eyebrow">Aquila Bank Workspace</p>
-        <h1>고신뢰 웹뱅킹을 위한 front/back 분리 워크스페이스</h1>
-        <p className="lead">
-          실시간 알림과 방어형 거래 조회를 함께 다루는 구조를 기준으로 프런트와
-          백엔드를 분리했습니다. 이제 고객 채널, 운영 콘솔, API, 비동기 처리
-          경계를 작은 인프라 예산 안에서 독립적으로 제한할 수 있습니다.
-        </p>
-        <div className="hero-grid">
-          <div className="metric">
-            <span className="metric-label">Data Scale</span>
-            <strong>100M rows</strong>
+    <main className="bank-shell">
+      <header className="bank-header">
+        <div className="utility-bar" aria-label="상단 유틸리티">
+          <div className="utility-left">
+            <button className="utility-link active" type="button">
+              개인
+            </button>
+            <button className="utility-link" type="button">
+              기업
+            </button>
+            <button className="utility-link" type="button">
+              인증센터
+            </button>
+            <button className="utility-link" type="button">
+              고객센터
+            </button>
           </div>
-          <div className="metric">
-            <span className="metric-label">Notification Mode</span>
-            <strong>Real-time</strong>
-          </div>
-          <div className="metric">
-            <span className="metric-label">Architecture</span>
-            <strong>front / back</strong>
+          <div className="utility-right">
+            <label className="search-field">
+              <span>검색</span>
+              <input aria-label="통합 검색" placeholder="업무명 또는 메뉴 검색" />
+            </label>
           </div>
         </div>
-      </section>
-
-      <section className="panel">
-        <div className="panel-header">
-          <p className="eyebrow">Initial Direction</p>
-          <h2>초기 프런트 골격</h2>
-        </div>
-        <div className="cards">
-          {/* 이 카드들은 현재 워크스페이스가 맞추려는 세 가지 delivery 축을 보여줍니다. */}
-          {highlights.map((item) => (
-            <article className="card" key={item.title}>
-              <h3>{item.title}</h3>
-              <p>{item.text}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="panel feature-flag-panel">
-        <div className="panel-header">
-          <p className="eyebrow">Feature Flags</p>
-          <h2>미완성 기능은 기본 비노출</h2>
-        </div>
-        <p className="lead compact">
-          장기 `develop` 브랜치 대신 `NEXT_PUBLIC_FEATURE_FLAGS`로 preview 기능을
-          노출합니다. flag가 없으면 merge된 코드도 사용자 화면에서는 숨겨집니다.
-        </p>
-        {enabledFeatureFlags.length > 0 ? (
-          <div className="flag-list" aria-label="enabled feature flags">
-            {enabledFeatureFlags.map((flag) => (
-              <span className="flag-chip" key={flag}>
-                {flag}
-              </span>
+        <div className="brand-row">
+          <div className="brand-mark" aria-label="Aquila Bank">
+            <span className="brand-symbol">A</span>
+            <div>
+              <strong>Aquila Bank</strong>
+              <small>Personal Internet Banking</small>
+            </div>
+          </div>
+          <nav className="primary-nav" aria-label="주요 메뉴">
+            {mainMenus.map((item) => (
+              <button
+                className={activeSection === item.id ? "nav-tab active" : "nav-tab"}
+                key={item.id}
+                onClick={() => setActiveSection(item.id)}
+                type="button"
+              >
+                {item.label}
+              </button>
             ))}
+          </nav>
+        </div>
+      </header>
+
+      <div className="bank-layout">
+        <aside className="side-menu" aria-label="개인뱅킹 메뉴">
+          <div className="side-title">개인뱅킹</div>
+          {mainMenus.map((item) => (
+            <button
+              className={activeSection === item.id ? "side-item active" : "side-item"}
+              key={item.id}
+              onClick={() => setActiveSection(item.id)}
+              type="button"
+            >
+              <span>{item.group}</span>
+              <strong>{item.label}</strong>
+            </button>
+          ))}
+        </aside>
+
+        <section className="work-area" aria-live="polite">
+          <div className={`alert ${alert.type}`}>
+            <strong>{alert.type === "error" ? "확인 필요" : "안내"}</strong>
+            <span>{alert.text}</span>
           </div>
-        ) : (
-          <p className="flag-empty">
-            현재 활성화된 preview flag가 없어 미완성 기능은 노출되지 않습니다.
-          </p>
-        )}
-        {showOpsConsolePreview ? (
-          <article className="preview-card">
-            <p className="eyebrow">Preview Enabled</p>
-            <h3>Operations Console Preview</h3>
-            <p>
-              `main` merge 후 CI 결과와 운영 체크리스트를 노출하는 preview UI를
-              여기서 이어서 붙일 수 있습니다.
-            </p>
-          </article>
-        ) : null}
-      </section>
+          {busyLabel ? (
+            <div className="busy-strip" role="status">
+              {busyLabel} 처리 중
+            </div>
+          ) : null}
+          {activeSection === "dashboard" ? (
+            <DashboardSection
+              hasSession={Boolean(session)}
+              onMove={setActiveSection}
+              onRefresh={handleRefresh}
+              isBusy={isBusy}
+            />
+          ) : null}
+          {activeSection === "security" ? (
+            <SecuritySection
+              backupChallengeForm={backupChallengeForm}
+              backupCodes={backupCodes}
+              challenge={challenge}
+              isBusy={isBusy}
+              loginForm={loginForm}
+              passwordRecoveryForm={passwordRecoveryForm}
+              passwordRecoveryResult={passwordRecoveryResult}
+              passwordResetForm={passwordResetForm}
+              session={session}
+              sessions={sessions}
+              totpChallengeForm={totpChallengeForm}
+              totpCode={totpCode}
+              totpEnrollment={totpEnrollment}
+              onBackupChallengeChange={setBackupChallengeForm}
+              onDisableTotp={handleDisableTotp}
+              onIssueBackupCodes={handleIssueBackupCodes}
+              onLoadSessions={handleLoadSessions}
+              onLogin={handleLogin}
+              onLoginChange={setLoginForm}
+              onLogout={handleLogout}
+              onPasswordRecoveryChange={setPasswordRecoveryForm}
+              onPasswordRecoveryConfirm={handlePasswordRecoveryConfirm}
+              onPasswordRecoveryRequest={handlePasswordRecoveryRequest}
+              onPasswordReset={handlePasswordReset}
+              onPasswordResetChange={setPasswordResetForm}
+              onRefresh={handleRefresh}
+              onRevokeAllSessions={handleRevokeAllSessions}
+              onRevokeSession={handleRevokeSession}
+              onStartTotpEnrollment={handleStartTotpEnrollment}
+              onTotpChallenge={handleTotpChallenge}
+              onTotpChallengeChange={setTotpChallengeForm}
+              onTotpCodeChange={setTotpCode}
+              onVerifyTotpEnrollment={handleVerifyTotpEnrollment}
+            />
+          ) : (
+            <BusinessPlaceholder section={activeSection} onMove={setActiveSection} />
+          )}
+        </section>
+
+        <aside className="right-rail" aria-label="빠른 업무">
+          <section className="rail-panel login-panel">
+            <div className="rail-heading">
+              <span>로그인 상태</span>
+              <strong>{session ? "정상" : "미로그인"}</strong>
+            </div>
+            {session ? (
+              <dl className="session-summary">
+                <div>
+                  <dt>User ID</dt>
+                  <dd>{session.userId ?? "-"}</dd>
+                </div>
+                <div>
+                  <dt>Access Token</dt>
+                  <dd>{maskToken(session.accessToken)}</dd>
+                </div>
+                <div>
+                  <dt>만료</dt>
+                  <dd>{formatDateTime(session.expiresAt)}</dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="rail-copy">인증 후 조회, 이체, 거래내역 업무를 이용할 수 있습니다.</p>
+            )}
+            <div className="button-row compact">
+              <button onClick={() => setActiveSection("security")} type="button">
+                인증센터
+              </button>
+              <button disabled={!session || isBusy} onClick={handleRefresh} type="button">
+                재발급
+              </button>
+            </div>
+          </section>
+
+          <section className="rail-panel">
+            <div className="rail-heading">
+              <span>빠른메뉴</span>
+            </div>
+            <div className="quick-grid">
+              {quickMenus.map((item) => (
+                <button key={item} type="button">
+                  {item}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="rail-panel notice-list">
+            <div className="rail-heading">
+              <span>보안안내</span>
+            </div>
+            <ul>
+              <li>OTP 전체 번호 요구 시 즉시 거래를 중단하세요.</li>
+              <li>타 계좌 거래 조회는 권한 확인 후 차단됩니다.</li>
+              <li>대량 거래 조회는 기간과 계좌 기준으로 제한됩니다.</li>
+            </ul>
+          </section>
+        </aside>
+      </div>
     </main>
+  );
+}
+
+function DashboardSection({
+  hasSession,
+  isBusy,
+  onMove,
+  onRefresh,
+}: {
+  hasSession: boolean;
+  isBusy: boolean;
+  onMove: (section: MenuSection) => void;
+  onRefresh: () => void;
+}) {
+  return (
+    <section className="task-section">
+      <div className="section-title">
+        <div>
+          <p>개인뱅킹</p>
+          <h1>뱅킹 업무</h1>
+        </div>
+        <div className="button-row">
+          <button onClick={() => onMove("accounts")} type="button">
+            계좌조회
+          </button>
+          <button onClick={() => onMove("transfer")} type="button">
+            이체
+          </button>
+          <button disabled={!hasSession || isBusy} onClick={onRefresh} type="button">
+            토큰 재발급
+          </button>
+        </div>
+      </div>
+      <div className="summary-grid">
+        <article className="summary-box">
+          <span>조회</span>
+          <strong>계좌 목록/잔액</strong>
+          <button onClick={() => onMove("accounts")} type="button">
+            바로가기
+          </button>
+        </article>
+        <article className="summary-box">
+          <span>이체</span>
+          <strong>즉시이체/취소</strong>
+          <button onClick={() => onMove("transfer")} type="button">
+            바로가기
+          </button>
+        </article>
+        <article className="summary-box">
+          <span>조회</span>
+          <strong>거래내역</strong>
+          <button onClick={() => onMove("transactions")} type="button">
+            바로가기
+          </button>
+        </article>
+        <article className="summary-box">
+          <span>알림</span>
+          <strong>알림함/설정</strong>
+          <button onClick={() => onMove("notifications")} type="button">
+            바로가기
+          </button>
+        </article>
+      </div>
+      <div className="bank-table-wrap">
+        <table className="bank-table">
+          <caption>업무별 처리 기준</caption>
+          <thead>
+            <tr>
+              <th>업무</th>
+              <th>기준</th>
+              <th>상태</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>거래내역 조회</td>
+              <td>계좌, 기간, limit, cursor 기반</td>
+              <td>bounded query</td>
+            </tr>
+            <tr>
+              <td>이체</td>
+              <td>요청 단위 Idempotency-Key 발급</td>
+              <td>중복 방지</td>
+            </tr>
+            <tr>
+              <td>알림</td>
+              <td>SSE 연결 상태와 inbox 동시 제공</td>
+              <td>실시간</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function BusinessPlaceholder({
+  section,
+  onMove,
+}: {
+  section: MenuSection;
+  onMove: (section: MenuSection) => void;
+}) {
+  if (section === "accounts" || section === "transfer" || section === "transactions") {
+    return (
+      <section className="task-section">
+        <div className="section-title">
+          <div>
+            <p>{section === "transfer" ? "이체" : "조회"}</p>
+            <h1>
+              {section === "accounts"
+                ? "계좌조회"
+                : section === "transfer"
+                  ? "이체"
+                  : "거래내역 조회"}
+            </h1>
+          </div>
+          <button onClick={() => onMove("security")} type="button">
+            로그인 확인
+          </button>
+        </div>
+        <div className="empty-business">
+          <strong>업무 화면 연결 대기</strong>
+          <span>다음 구현 단위에서 백엔드 공개 API와 연결됩니다.</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (section === "notifications") {
+    return (
+      <section className="task-section">
+        <div className="section-title">
+          <div>
+            <p>고객센터</p>
+            <h1>알림</h1>
+          </div>
+          <button onClick={() => onMove("security")} type="button">
+            로그인 확인
+          </button>
+        </div>
+        <div className="empty-business">
+          <strong>알림 화면 연결 대기</strong>
+          <span>다음 구현 단위에서 inbox, 검색, SSE 상태가 연결됩니다.</span>
+        </div>
+      </section>
+    );
+  }
+
+  return null;
+}
+
+function SecuritySection(props: {
+  backupChallengeForm: {
+    backupCode: string;
+    rememberDevice: boolean;
+  };
+  backupCodes: BackupCodeIssueResponse | null;
+  challenge: LoginResponse | null;
+  isBusy: boolean;
+  loginForm: {
+    loginId: string;
+    password: string;
+  };
+  passwordRecoveryForm: {
+    loginId: string;
+    recoveryToken: string;
+    newPassword: string;
+  };
+  passwordRecoveryResult: PasswordRecoveryRequestResult | null;
+  passwordResetForm: {
+    currentPassword: string;
+    newPassword: string;
+  };
+  session: CustomerSession | null;
+  sessions: AuthSessionItem[];
+  totpChallengeForm: {
+    totpCode: string;
+    rememberDevice: boolean;
+  };
+  totpCode: string;
+  totpEnrollment: TotpEnrollmentStartResponse | null;
+  onBackupChallengeChange: (value: {
+    backupCode: string;
+    rememberDevice: boolean;
+  }) => void;
+  onDisableTotp: () => void;
+  onIssueBackupCodes: () => void;
+  onLoadSessions: () => void;
+  onLogin: (event: FormEvent<HTMLFormElement>) => void;
+  onLoginChange: (value: { loginId: string; password: string }) => void;
+  onLogout: () => void;
+  onPasswordRecoveryChange: (value: {
+    loginId: string;
+    recoveryToken: string;
+    newPassword: string;
+  }) => void;
+  onPasswordRecoveryConfirm: (event: FormEvent<HTMLFormElement>) => void;
+  onPasswordRecoveryRequest: (event: FormEvent<HTMLFormElement>) => void;
+  onPasswordReset: (event: FormEvent<HTMLFormElement>) => void;
+  onPasswordResetChange: (value: {
+    currentPassword: string;
+    newPassword: string;
+  }) => void;
+  onRefresh: () => void;
+  onRevokeAllSessions: () => void;
+  onRevokeSession: (sessionId: number) => void;
+  onStartTotpEnrollment: () => void;
+  onTotpChallenge: (event: FormEvent<HTMLFormElement>) => void;
+  onTotpChallengeChange: (value: { totpCode: string; rememberDevice: boolean }) => void;
+  onTotpCodeChange: (value: string) => void;
+  onVerifyTotpEnrollment: () => void;
+}) {
+  return (
+    <section className="task-section security-section">
+      <div className="section-title">
+        <div>
+          <p>인증센터</p>
+          <h1>로그인 및 보안관리</h1>
+        </div>
+        <div className="button-row">
+          <button disabled={!props.session || props.isBusy} onClick={props.onRefresh} type="button">
+            토큰 재발급
+          </button>
+          <button disabled={!props.session || props.isBusy} onClick={props.onLogout} type="button">
+            로그아웃
+          </button>
+        </div>
+      </div>
+
+      <div className="two-column">
+        <form className="bank-form" onSubmit={props.onLogin}>
+          <div className="form-heading">
+            <strong>로그인</strong>
+            <span>아이디와 비밀번호</span>
+          </div>
+          <label>
+            <span>이용자 ID</span>
+            <input
+              autoComplete="username"
+              onChange={(event) =>
+                props.onLoginChange({
+                  ...props.loginForm,
+                  loginId: event.target.value,
+                })
+              }
+              required
+              value={props.loginForm.loginId}
+            />
+          </label>
+          <label>
+            <span>비밀번호</span>
+            <input
+              autoComplete="current-password"
+              onChange={(event) =>
+                props.onLoginChange({
+                  ...props.loginForm,
+                  password: event.target.value,
+                })
+              }
+              required
+              type="password"
+              value={props.loginForm.password}
+            />
+          </label>
+          <button disabled={props.isBusy} type="submit">
+            로그인
+          </button>
+        </form>
+
+        <div className="bank-form passive">
+          <div className="form-heading">
+            <strong>현재 세션</strong>
+            <span>{props.session ? "로그인됨" : "로그인 필요"}</span>
+          </div>
+          <dl className="detail-list">
+            <div>
+              <dt>User ID</dt>
+              <dd>{props.session?.userId ?? "-"}</dd>
+            </div>
+            <div>
+              <dt>Access Token</dt>
+              <dd>{props.session ? maskToken(props.session.accessToken) : "-"}</dd>
+            </div>
+            <div>
+              <dt>Refresh 만료</dt>
+              <dd>{formatDateTime(props.session?.refreshExpiresAt)}</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+
+      {props.challenge ? (
+        <div className="two-column">
+          <form className="bank-form" onSubmit={props.onTotpChallenge}>
+            <div className="form-heading">
+              <strong>TOTP 추가 인증</strong>
+              <span>{props.challenge.challengeType ?? "TOTP"}</span>
+            </div>
+            <label>
+              <span>인증번호 6자리</span>
+              <input
+                inputMode="numeric"
+                maxLength={6}
+                onChange={(event) =>
+                  props.onTotpChallengeChange({
+                    ...props.totpChallengeForm,
+                    totpCode: event.target.value,
+                  })
+                }
+                required
+                value={props.totpChallengeForm.totpCode}
+              />
+            </label>
+            <label className="checkbox-line">
+              <input
+                checked={props.totpChallengeForm.rememberDevice}
+                onChange={(event) =>
+                  props.onTotpChallengeChange({
+                    ...props.totpChallengeForm,
+                    rememberDevice: event.target.checked,
+                  })
+                }
+                type="checkbox"
+              />
+              <span>이 기기 기억</span>
+            </label>
+            <button disabled={props.isBusy} type="submit">
+              인증
+            </button>
+          </form>
+
+          <form className="bank-form" onSubmit={props.onBackupChallenge}>
+            <div className="form-heading">
+              <strong>Backup Code 인증</strong>
+              <span>대체 인증수단</span>
+            </div>
+            <label>
+              <span>Backup Code</span>
+              <input
+                onChange={(event) =>
+                  props.onBackupChallengeChange({
+                    ...props.backupChallengeForm,
+                    backupCode: event.target.value,
+                  })
+                }
+                required
+                value={props.backupChallengeForm.backupCode}
+              />
+            </label>
+            <label className="checkbox-line">
+              <input
+                checked={props.backupChallengeForm.rememberDevice}
+                onChange={(event) =>
+                  props.onBackupChallengeChange({
+                    ...props.backupChallengeForm,
+                    rememberDevice: event.target.checked,
+                  })
+                }
+                type="checkbox"
+              />
+              <span>이 기기 기억</span>
+            </label>
+            <button disabled={props.isBusy} type="submit">
+              인증
+            </button>
+          </form>
+        </div>
+      ) : null}
+
+      <div className="two-column">
+        <form className="bank-form" onSubmit={props.onPasswordRecoveryRequest}>
+          <div className="form-heading">
+            <strong>비밀번호 찾기</strong>
+            <span>복구 요청</span>
+          </div>
+          <label>
+            <span>이용자 ID</span>
+            <input
+              onChange={(event) =>
+                props.onPasswordRecoveryChange({
+                  ...props.passwordRecoveryForm,
+                  loginId: event.target.value,
+                })
+              }
+              required
+              value={props.passwordRecoveryForm.loginId}
+            />
+          </label>
+          <button disabled={props.isBusy} type="submit">
+            복구 요청
+          </button>
+          {props.passwordRecoveryResult?.handoffRequestId ? (
+            <p className="field-note">
+              Request ID: {props.passwordRecoveryResult.handoffRequestId}
+            </p>
+          ) : null}
+        </form>
+
+        <form className="bank-form" onSubmit={props.onPasswordRecoveryConfirm}>
+          <div className="form-heading">
+            <strong>복구 확정</strong>
+            <span>토큰 기반 변경</span>
+          </div>
+          <label>
+            <span>복구 토큰</span>
+            <input
+              onChange={(event) =>
+                props.onPasswordRecoveryChange({
+                  ...props.passwordRecoveryForm,
+                  recoveryToken: event.target.value,
+                })
+              }
+              required
+              value={props.passwordRecoveryForm.recoveryToken}
+            />
+          </label>
+          <label>
+            <span>새 비밀번호</span>
+            <input
+              onChange={(event) =>
+                props.onPasswordRecoveryChange({
+                  ...props.passwordRecoveryForm,
+                  newPassword: event.target.value,
+                })
+              }
+              required
+              type="password"
+              value={props.passwordRecoveryForm.newPassword}
+            />
+          </label>
+          <button disabled={props.isBusy} type="submit">
+            변경
+          </button>
+        </form>
+      </div>
+
+      <div className="two-column">
+        <form className="bank-form" onSubmit={props.onPasswordReset}>
+          <div className="form-heading">
+            <strong>비밀번호 변경</strong>
+            <span>로그인 세션 필요</span>
+          </div>
+          <label>
+            <span>현재 비밀번호</span>
+            <input
+              onChange={(event) =>
+                props.onPasswordResetChange({
+                  ...props.passwordResetForm,
+                  currentPassword: event.target.value,
+                })
+              }
+              required
+              type="password"
+              value={props.passwordResetForm.currentPassword}
+            />
+          </label>
+          <label>
+            <span>새 비밀번호</span>
+            <input
+              onChange={(event) =>
+                props.onPasswordResetChange({
+                  ...props.passwordResetForm,
+                  newPassword: event.target.value,
+                })
+              }
+              required
+              type="password"
+              value={props.passwordResetForm.newPassword}
+            />
+          </label>
+          <button disabled={!props.session || props.isBusy} type="submit">
+            변경
+          </button>
+        </form>
+
+        <div className="bank-form passive">
+          <div className="form-heading">
+            <strong>MFA 관리</strong>
+            <span>TOTP / Backup Code</span>
+          </div>
+          <label>
+            <span>TOTP 인증번호</span>
+            <input
+              inputMode="numeric"
+              maxLength={6}
+              onChange={(event) => props.onTotpCodeChange(event.target.value)}
+              value={props.totpCode}
+            />
+          </label>
+          <div className="button-row compact">
+            <button
+              disabled={!props.session || props.isBusy}
+              onClick={props.onStartTotpEnrollment}
+              type="button"
+            >
+              등록 시작
+            </button>
+            <button
+              disabled={!props.session || props.isBusy}
+              onClick={props.onVerifyTotpEnrollment}
+              type="button"
+            >
+              등록 확인
+            </button>
+            <button
+              disabled={!props.session || props.isBusy}
+              onClick={props.onIssueBackupCodes}
+              type="button"
+            >
+              코드 발급
+            </button>
+            <button
+              disabled={!props.session || props.isBusy}
+              onClick={props.onDisableTotp}
+              type="button"
+            >
+              해지
+            </button>
+          </div>
+          {props.totpEnrollment ? (
+            <dl className="detail-list compact-list">
+              <div>
+                <dt>Secret</dt>
+                <dd>{props.totpEnrollment.secretKey}</dd>
+              </div>
+              <div>
+                <dt>만료</dt>
+                <dd>{formatDateTime(props.totpEnrollment.expiresAt)}</dd>
+              </div>
+            </dl>
+          ) : null}
+          {props.backupCodes ? (
+            <div className="code-list">
+              {props.backupCodes.backupCodes.map((code) => (
+                <code key={code}>{code}</code>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <section className="table-panel">
+        <div className="panel-toolbar">
+          <div>
+            <strong>접속 세션</strong>
+            <span>현재 사용자 refresh token session</span>
+          </div>
+          <div className="button-row compact">
+            <button
+              disabled={!props.session || props.isBusy}
+              onClick={props.onLoadSessions}
+              type="button"
+            >
+              조회
+            </button>
+            <button
+              disabled={!props.session || props.isBusy}
+              onClick={props.onRevokeAllSessions}
+              type="button"
+            >
+              전체 해지
+            </button>
+          </div>
+        </div>
+        <div className="bank-table-wrap">
+          <table className="bank-table">
+            <caption>인증 세션 목록</caption>
+            <thead>
+              <tr>
+                <th>Session ID</th>
+                <th>상태</th>
+                <th>기기</th>
+                <th>IP</th>
+                <th>최종 사용</th>
+                <th>관리</th>
+              </tr>
+            </thead>
+            <tbody>
+              {props.sessions.length === 0 ? (
+                <tr>
+                  <td colSpan={6}>조회된 세션이 없습니다.</td>
+                </tr>
+              ) : (
+                props.sessions.map((item) => (
+                  <tr key={item.sessionId}>
+                    <td>{item.sessionId}</td>
+                    <td>{item.currentSession ? "현재 세션" : item.sessionStatus}</td>
+                    <td>{item.deviceName ?? "-"}</td>
+                    <td>{item.ipAddress ?? "-"}</td>
+                    <td>{formatDateTime(item.lastUsedAt)}</td>
+                    <td>
+                      <button
+                        disabled={props.isBusy}
+                        onClick={() => props.onRevokeSession(item.sessionId)}
+                        type="button"
+                      >
+                        해지
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </section>
   );
 }

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -14,12 +14,19 @@ import {
   toCustomerSession,
 } from "@/lib/api/session";
 import type {
+  AccountItem,
+  AccountSummaryResponse,
   AuthSessionItem,
   BackupCodeIssueResponse,
   CustomerSession,
   LoginResponse,
   PasswordRecoveryRequestResult,
+  TransactionDetailResponse,
+  TransactionItem,
+  TransactionQueryResponse,
   TotpEnrollmentStartResponse,
+  TransferResponse,
+  TransferReversalResponse,
 } from "@/lib/api/types";
 
 type MenuSection =
@@ -45,6 +52,31 @@ const mainMenus: Array<{ id: MenuSection; label: string; group: string }> = [
 ];
 
 const quickMenus = ["계좌조회", "즉시이체", "거래내역", "인증센터", "알림함"];
+
+function toLocalInputValue(date: Date): string {
+  const offset = date.getTimezoneOffset();
+  const localDate = new Date(date.getTime() - offset * 60_000);
+  return localDate.toISOString().slice(0, 16);
+}
+
+function toIsoDateTime(value: string): string {
+  return new Date(value).toISOString();
+}
+
+function toOptionalNumber(value: string): number | undefined {
+  if (!value.trim()) {
+    return undefined;
+  }
+  return Number(value);
+}
+
+function formatMinorAmount(value: number, currencyCode = "KRW"): string {
+  return new Intl.NumberFormat("ko-KR", {
+    style: "currency",
+    currency: currencyCode,
+    maximumFractionDigits: 0,
+  }).format(value / 100);
+}
 
 function toErrorMessage(error: unknown): string {
   if (error instanceof ApiConfigurationError) {
@@ -113,6 +145,51 @@ export default function HomePage() {
   );
   const [passwordRecoveryResult, setPasswordRecoveryResult] =
     useState<PasswordRecoveryRequestResult | null>(null);
+  const [accounts, setAccounts] = useState<AccountItem[]>([]);
+  const [accountCursor, setAccountCursor] = useState("");
+  const [accountLimit, setAccountLimit] = useState(20);
+  const [selectedAccount, setSelectedAccount] =
+    useState<AccountSummaryResponse | null>(null);
+  const [transferForm, setTransferForm] = useState({
+    sourceAccountId: "",
+    targetAccountId: "",
+    amountMinor: "",
+    currencyCode: "KRW",
+    summary: "",
+  });
+  const [transferResult, setTransferResult] = useState<TransferResponse | null>(
+    null,
+  );
+  const [reversalForm, setReversalForm] = useState({
+    transactionReference: "",
+    sourceAccountId: "",
+    amountMinor: "",
+    reversalReason: "CUSTOMER_REQUEST",
+    summary: "",
+  });
+  const [reversalResult, setReversalResult] =
+    useState<TransferReversalResponse | null>(null);
+  const [transactionMode, setTransactionMode] = useState<"active" | "archive">(
+    "active",
+  );
+  const [transactionFilters, setTransactionFilters] = useState({
+    accountId: "",
+    from: toLocalInputValue(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)),
+    to: toLocalInputValue(new Date()),
+    limit: "50",
+    cursor: "",
+    status: "",
+    direction: "",
+    minAmountMinor: "",
+    maxAmountMinor: "",
+    transactionReference: "",
+    responseShape: "full" as "full" | "slim",
+  });
+  const [transactionSlice, setTransactionSlice] =
+    useState<TransactionQueryResponse | null>(null);
+  const [transactions, setTransactions] = useState<TransactionItem[]>([]);
+  const [transactionDetail, setTransactionDetail] =
+    useState<TransactionDetailResponse | null>(null);
 
   useEffect(() => {
     const storedSession = loadCustomerSession();
@@ -374,6 +451,162 @@ export default function HomePage() {
     });
   }
 
+  async function handleLoadAccounts(cursor = "", append = false) {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("계좌 조회", async () => {
+      const result = await api.getAccounts(currentSession.accessToken, {
+        limit: accountLimit,
+        cursor,
+      });
+      setAccounts((items) => (append ? [...items, ...result.items] : result.items));
+      setAccountCursor(result.nextCursor ?? "");
+      if (result.items[0] && !selectedAccount) {
+        setSelectedAccount(result.items[0]);
+        setTransferForm((form) => ({
+          ...form,
+          sourceAccountId: String(result.items[0].accountId),
+        }));
+        setTransactionFilters((form) => ({
+          ...form,
+          accountId: String(result.items[0].accountId),
+        }));
+      }
+      setAlert({ type: "success", text: "계좌 목록을 불러왔습니다." });
+    });
+  }
+
+  async function handleLoadAccountDetail(accountId: number) {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("계좌 상세 조회", async () => {
+      const result = await api.getAccount(accountId, currentSession.accessToken);
+      setSelectedAccount(result);
+      setTransferForm((form) => ({
+        ...form,
+        sourceAccountId: String(result.accountId),
+      }));
+      setTransactionFilters((form) => ({
+        ...form,
+        accountId: String(result.accountId),
+      }));
+      setAlert({ type: "success", text: "계좌 상세를 불러왔습니다." });
+    });
+  }
+
+  async function handleTransfer(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("이체", async () => {
+      const result = await api.transfer(
+        {
+          sourceAccountId: Number(transferForm.sourceAccountId),
+          targetAccountId: Number(transferForm.targetAccountId),
+          amountMinor: Number(transferForm.amountMinor),
+          currencyCode: transferForm.currencyCode,
+          summary: transferForm.summary,
+        },
+        currentSession.accessToken,
+      );
+      setTransferResult(result);
+      setAlert({
+        type: "success",
+        text: `이체가 접수되었습니다. 거래번호 ${result.transactionReference}`,
+      });
+    });
+  }
+
+  async function handleReversal(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("이체 취소", async () => {
+      const result = await api.reverseTransfer(
+        reversalForm.transactionReference,
+        {
+          sourceAccountId: Number(reversalForm.sourceAccountId),
+          amountMinor: Number(reversalForm.amountMinor),
+          reversalReason: reversalForm.reversalReason,
+          summary: reversalForm.summary,
+        },
+        currentSession.accessToken,
+      );
+      setReversalResult(result);
+      setAlert({
+        type: "success",
+        text: `취소 거래가 접수되었습니다. 거래번호 ${result.reversalTransactionReference}`,
+      });
+    });
+  }
+
+  async function handleSearchTransactions(
+    mode = transactionMode,
+    cursor = "",
+    append = false,
+  ) {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    await runAction("거래내역 조회", async () => {
+      const params = {
+        accountId: Number(transactionFilters.accountId),
+        from: toIsoDateTime(transactionFilters.from),
+        to: toIsoDateTime(transactionFilters.to),
+        limit: Number(transactionFilters.limit || 50),
+        cursor,
+        status: transactionFilters.status || undefined,
+        direction: transactionFilters.direction || undefined,
+        minAmountMinor: toOptionalNumber(transactionFilters.minAmountMinor),
+        maxAmountMinor: toOptionalNumber(transactionFilters.maxAmountMinor),
+        transactionReference: transactionFilters.transactionReference || undefined,
+        responseShape: transactionFilters.responseShape,
+      };
+      const result =
+        mode === "archive"
+          ? await api.getArchivedTransactions(params, currentSession.accessToken)
+          : await api.getTransactions(params, currentSession.accessToken);
+      setTransactionMode(mode);
+      setTransactionSlice(result);
+      setTransactions((items) => (append ? [...items, ...result.items] : result.items));
+      setTransactionFilters((form) => ({
+        ...form,
+        cursor: result.nextCursor ?? "",
+      }));
+      setAlert({ type: "success", text: "거래내역을 불러왔습니다." });
+    });
+  }
+
+  async function handleLoadTransactionDetail(transactionReference: string) {
+    const currentSession = requireSession();
+    if (!currentSession) {
+      return;
+    }
+    const accountId = Number(transactionFilters.accountId || selectedAccount?.accountId);
+    if (!accountId) {
+      setAlert({ type: "error", text: "거래 상세 조회 계좌를 선택하세요." });
+      return;
+    }
+    await runAction("거래 상세 조회", async () => {
+      const result = await api.getTransactionDetail(
+        transactionReference,
+        accountId,
+        currentSession.accessToken,
+      );
+      setTransactionDetail(result);
+      setAlert({ type: "success", text: "거래 상세를 불러왔습니다." });
+    });
+  }
+
   const isBusy = busyLabel !== null;
 
   return (
@@ -458,6 +691,58 @@ export default function HomePage() {
               isBusy={isBusy}
             />
           ) : null}
+          {activeSection === "accounts" ? (
+            <AccountsSection
+              accountCursor={accountCursor}
+              accountLimit={accountLimit}
+              accounts={accounts}
+              isBusy={isBusy}
+              selectedAccount={selectedAccount}
+              onAccountLimitChange={setAccountLimit}
+              onLoadAccountDetail={handleLoadAccountDetail}
+              onLoadAccounts={() => handleLoadAccounts()}
+              onLoadNextAccounts={() => handleLoadAccounts(accountCursor, true)}
+            />
+          ) : null}
+          {activeSection === "transfer" ? (
+            <TransferSection
+              isBusy={isBusy}
+              reversalForm={reversalForm}
+              reversalResult={reversalResult}
+              transferForm={transferForm}
+              transferResult={transferResult}
+              onReversal={handleReversal}
+              onReversalChange={setReversalForm}
+              onTransfer={handleTransfer}
+              onTransferChange={setTransferForm}
+            />
+          ) : null}
+          {activeSection === "transactions" ? (
+            <TransactionsSection
+              filters={transactionFilters}
+              isBusy={isBusy}
+              mode={transactionMode}
+              slice={transactionSlice}
+              transactionDetail={transactionDetail}
+              transactions={transactions}
+              onDetail={handleLoadTransactionDetail}
+              onFilterChange={setTransactionFilters}
+              onModeChange={setTransactionMode}
+              onNext={() =>
+                transactionSlice?.nextCursor
+                  ? handleSearchTransactions(
+                      transactionMode,
+                      transactionSlice.nextCursor,
+                      true,
+                    )
+                  : undefined
+              }
+              onSearch={(event) => {
+                event.preventDefault();
+                handleSearchTransactions(transactionMode);
+              }}
+            />
+          ) : null}
           {activeSection === "security" ? (
             <SecuritySection
               backupChallengeForm={backupChallengeForm}
@@ -494,9 +779,10 @@ export default function HomePage() {
               onTotpCodeChange={setTotpCode}
               onVerifyTotpEnrollment={handleVerifyTotpEnrollment}
             />
-          ) : (
+          ) : null}
+          {activeSection === "notifications" ? (
             <BusinessPlaceholder section={activeSection} onMove={setActiveSection} />
-          )}
+          ) : null}
         </section>
 
         <aside className="right-rail" aria-label="빠른 업무">
@@ -652,6 +938,799 @@ function DashboardSection({
         </table>
       </div>
     </section>
+  );
+}
+
+function AccountsSection({
+  accountCursor,
+  accountLimit,
+  accounts,
+  isBusy,
+  selectedAccount,
+  onAccountLimitChange,
+  onLoadAccountDetail,
+  onLoadAccounts,
+  onLoadNextAccounts,
+}: {
+  accountCursor: string;
+  accountLimit: number;
+  accounts: AccountItem[];
+  isBusy: boolean;
+  selectedAccount: AccountSummaryResponse | null;
+  onAccountLimitChange: (value: number) => void;
+  onLoadAccountDetail: (accountId: number) => void;
+  onLoadAccounts: () => void;
+  onLoadNextAccounts: () => void;
+}) {
+  return (
+    <section className="task-section">
+      <div className="section-title">
+        <div>
+          <p>조회</p>
+          <h1>계좌조회</h1>
+        </div>
+        <div className="button-row">
+          <label className="inline-control">
+            <span>건수</span>
+            <select
+              onChange={(event) => onAccountLimitChange(Number(event.target.value))}
+              value={accountLimit}
+            >
+              <option value={10}>10</option>
+              <option value={20}>20</option>
+              <option value={50}>50</option>
+            </select>
+          </label>
+          <button disabled={isBusy} onClick={onLoadAccounts} type="button">
+            조회
+          </button>
+          <button disabled={!accountCursor || isBusy} onClick={onLoadNextAccounts} type="button">
+            다음
+          </button>
+        </div>
+      </div>
+
+      <div className="account-grid">
+        <section className="table-panel embedded">
+          <div className="panel-toolbar">
+            <div>
+              <strong>보유계좌</strong>
+              <span>계좌별 잔액과 상태</span>
+            </div>
+          </div>
+          <div className="bank-table-wrap">
+            <table className="bank-table">
+              <caption>계좌 목록</caption>
+              <thead>
+                <tr>
+                  <th>계좌번호</th>
+                  <th>계좌명</th>
+                  <th>상태</th>
+                  <th>출금가능액</th>
+                  <th>관리</th>
+                </tr>
+              </thead>
+              <tbody>
+                {accounts.length === 0 ? (
+                  <tr>
+                    <td colSpan={5}>조회된 계좌가 없습니다.</td>
+                  </tr>
+                ) : (
+                  accounts.map((account) => (
+                    <tr key={account.accountId}>
+                      <td>{account.accountNumber}</td>
+                      <td>{account.displayName}</td>
+                      <td>
+                        <span className="status-badge">{account.accountStatus}</span>
+                      </td>
+                      <td className="amount-cell">
+                        {formatMinorAmount(
+                          account.availableBalanceMinor,
+                          account.currencyCode,
+                        )}
+                      </td>
+                      <td>
+                        <button
+                          disabled={isBusy}
+                          onClick={() => onLoadAccountDetail(account.accountId)}
+                          type="button"
+                        >
+                          상세
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <aside className="detail-panel">
+          <div className="form-heading">
+            <strong>계좌상세</strong>
+            <span>{selectedAccount ? selectedAccount.accountStatus : "미선택"}</span>
+          </div>
+          {selectedAccount ? (
+            <>
+              <div className="balance-card">
+                <span>{selectedAccount.displayName}</span>
+                <strong>
+                  {formatMinorAmount(
+                    selectedAccount.availableBalanceMinor,
+                    selectedAccount.currencyCode,
+                  )}
+                </strong>
+                <small>출금가능금액</small>
+              </div>
+              <dl className="detail-list">
+                <div>
+                  <dt>Account ID</dt>
+                  <dd>{selectedAccount.accountId}</dd>
+                </div>
+                <div>
+                  <dt>계좌번호</dt>
+                  <dd>{selectedAccount.accountNumber}</dd>
+                </div>
+                <div>
+                  <dt>보류금액</dt>
+                  <dd>
+                    {formatMinorAmount(
+                      selectedAccount.pendingBalanceMinor,
+                      selectedAccount.currencyCode,
+                    )}
+                  </dd>
+                </div>
+                <div>
+                  <dt>잔액 갱신</dt>
+                  <dd>{formatDateTime(selectedAccount.balanceUpdatedAt)}</dd>
+                </div>
+              </dl>
+            </>
+          ) : (
+            <p className="rail-copy">계좌 목록에서 상세 버튼을 선택하세요.</p>
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function TransferSection({
+  isBusy,
+  reversalForm,
+  reversalResult,
+  transferForm,
+  transferResult,
+  onReversal,
+  onReversalChange,
+  onTransfer,
+  onTransferChange,
+}: {
+  isBusy: boolean;
+  reversalForm: {
+    transactionReference: string;
+    sourceAccountId: string;
+    amountMinor: string;
+    reversalReason: string;
+    summary: string;
+  };
+  reversalResult: TransferReversalResponse | null;
+  transferForm: {
+    sourceAccountId: string;
+    targetAccountId: string;
+    amountMinor: string;
+    currencyCode: string;
+    summary: string;
+  };
+  transferResult: TransferResponse | null;
+  onReversal: (event: FormEvent<HTMLFormElement>) => void;
+  onReversalChange: (value: {
+    transactionReference: string;
+    sourceAccountId: string;
+    amountMinor: string;
+    reversalReason: string;
+    summary: string;
+  }) => void;
+  onTransfer: (event: FormEvent<HTMLFormElement>) => void;
+  onTransferChange: (value: {
+    sourceAccountId: string;
+    targetAccountId: string;
+    amountMinor: string;
+    currencyCode: string;
+    summary: string;
+  }) => void;
+}) {
+  return (
+    <section className="task-section">
+      <div className="section-title">
+        <div>
+          <p>이체</p>
+          <h1>즉시이체</h1>
+        </div>
+      </div>
+
+      <div className="two-column">
+        <form className="bank-form" onSubmit={onTransfer}>
+          <div className="form-heading">
+            <strong>이체정보 입력</strong>
+            <span>요청 단위 중복 방지</span>
+          </div>
+          <div className="form-grid">
+            <label>
+              <span>출금계좌 ID</span>
+              <input
+                inputMode="numeric"
+                onChange={(event) =>
+                  onTransferChange({
+                    ...transferForm,
+                    sourceAccountId: event.target.value,
+                  })
+                }
+                required
+                value={transferForm.sourceAccountId}
+              />
+            </label>
+            <label>
+              <span>입금계좌 ID</span>
+              <input
+                inputMode="numeric"
+                onChange={(event) =>
+                  onTransferChange({
+                    ...transferForm,
+                    targetAccountId: event.target.value,
+                  })
+                }
+                required
+                value={transferForm.targetAccountId}
+              />
+            </label>
+            <label>
+              <span>금액 minor</span>
+              <input
+                inputMode="numeric"
+                onChange={(event) =>
+                  onTransferChange({
+                    ...transferForm,
+                    amountMinor: event.target.value,
+                  })
+                }
+                required
+                value={transferForm.amountMinor}
+              />
+            </label>
+            <label>
+              <span>통화</span>
+              <input
+                maxLength={3}
+                onChange={(event) =>
+                  onTransferChange({
+                    ...transferForm,
+                    currencyCode: event.target.value.toUpperCase(),
+                  })
+                }
+                required
+                value={transferForm.currencyCode}
+              />
+            </label>
+          </div>
+          <label>
+            <span>받는 분 통장 표시</span>
+            <input
+              maxLength={120}
+              onChange={(event) =>
+                onTransferChange({ ...transferForm, summary: event.target.value })
+              }
+              required
+              value={transferForm.summary}
+            />
+          </label>
+          <button disabled={isBusy} type="submit">
+            이체 실행
+          </button>
+        </form>
+
+        <ResultPanel
+          title="이체 결과"
+          rows={
+            transferResult
+              ? [
+                  ["거래번호", transferResult.transactionReference],
+                  ["상태", transferResult.status],
+                  [
+                    "이체금액",
+                    formatMinorAmount(
+                      transferResult.amountMinor,
+                      transferResult.currencyCode,
+                    ),
+                  ],
+                  [
+                    "이체 후 잔액",
+                    formatMinorAmount(
+                      transferResult.availableBalanceAfterMinor,
+                      transferResult.currencyCode,
+                    ),
+                  ],
+                  ["기장시각", formatDateTime(transferResult.bookedAt)],
+                ]
+              : []
+          }
+        />
+      </div>
+
+      <div className="two-column">
+        <form className="bank-form" onSubmit={onReversal}>
+          <div className="form-heading">
+            <strong>이체 취소</strong>
+            <span>원거래 reference 기준</span>
+          </div>
+          <label>
+            <span>원거래번호</span>
+            <input
+              onChange={(event) =>
+                onReversalChange({
+                  ...reversalForm,
+                  transactionReference: event.target.value,
+                })
+              }
+              required
+              value={reversalForm.transactionReference}
+            />
+          </label>
+          <div className="form-grid">
+            <label>
+              <span>출금계좌 ID</span>
+              <input
+                inputMode="numeric"
+                onChange={(event) =>
+                  onReversalChange({
+                    ...reversalForm,
+                    sourceAccountId: event.target.value,
+                  })
+                }
+                required
+                value={reversalForm.sourceAccountId}
+              />
+            </label>
+            <label>
+              <span>취소금액 minor</span>
+              <input
+                inputMode="numeric"
+                onChange={(event) =>
+                  onReversalChange({
+                    ...reversalForm,
+                    amountMinor: event.target.value,
+                  })
+                }
+                required
+                value={reversalForm.amountMinor}
+              />
+            </label>
+          </div>
+          <label>
+            <span>취소사유</span>
+            <select
+              onChange={(event) =>
+                onReversalChange({
+                  ...reversalForm,
+                  reversalReason: event.target.value,
+                })
+              }
+              value={reversalForm.reversalReason}
+            >
+              <option value="CUSTOMER_REQUEST">CUSTOMER_REQUEST</option>
+              <option value="DUPLICATE">DUPLICATE</option>
+              <option value="WRONG_AMOUNT">WRONG_AMOUNT</option>
+              <option value="WRONG_TARGET">WRONG_TARGET</option>
+              <option value="FRAUD_REPORTED">FRAUD_REPORTED</option>
+            </select>
+          </label>
+          <label>
+            <span>적요</span>
+            <input
+              maxLength={120}
+              onChange={(event) =>
+                onReversalChange({ ...reversalForm, summary: event.target.value })
+              }
+              required
+              value={reversalForm.summary}
+            />
+          </label>
+          <button disabled={isBusy} type="submit">
+            취소 실행
+          </button>
+        </form>
+
+        <ResultPanel
+          title="취소 결과"
+          rows={
+            reversalResult
+              ? [
+                  ["원거래", reversalResult.originalTransactionReference],
+                  ["취소거래", reversalResult.reversalTransactionReference],
+                  ["상태", reversalResult.status],
+                  [
+                    "취소금액",
+                    formatMinorAmount(
+                      reversalResult.amountMinor,
+                      reversalResult.currencyCode,
+                    ),
+                  ],
+                  ["기장시각", formatDateTime(reversalResult.bookedAt)],
+                ]
+              : []
+          }
+        />
+      </div>
+    </section>
+  );
+}
+
+function TransactionsSection({
+  filters,
+  isBusy,
+  mode,
+  slice,
+  transactionDetail,
+  transactions,
+  onDetail,
+  onFilterChange,
+  onModeChange,
+  onNext,
+  onSearch,
+}: {
+  filters: {
+    accountId: string;
+    from: string;
+    to: string;
+    limit: string;
+    cursor: string;
+    status: string;
+    direction: string;
+    minAmountMinor: string;
+    maxAmountMinor: string;
+    transactionReference: string;
+    responseShape: "full" | "slim";
+  };
+  isBusy: boolean;
+  mode: "active" | "archive";
+  slice: TransactionQueryResponse | null;
+  transactionDetail: TransactionDetailResponse | null;
+  transactions: TransactionItem[];
+  onDetail: (transactionReference: string) => void;
+  onFilterChange: (value: {
+    accountId: string;
+    from: string;
+    to: string;
+    limit: string;
+    cursor: string;
+    status: string;
+    direction: string;
+    minAmountMinor: string;
+    maxAmountMinor: string;
+    transactionReference: string;
+    responseShape: "full" | "slim";
+  }) => void;
+  onModeChange: (mode: "active" | "archive") => void;
+  onNext: () => void;
+  onSearch: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  return (
+    <section className="task-section">
+      <div className="section-title">
+        <div>
+          <p>조회</p>
+          <h1>거래내역 조회</h1>
+        </div>
+        <div className="tab-switch" role="tablist" aria-label="거래 조회 구분">
+          <button
+            aria-selected={mode === "active"}
+            className={mode === "active" ? "active" : ""}
+            onClick={() => onModeChange("active")}
+            role="tab"
+            type="button"
+          >
+            일반
+          </button>
+          <button
+            aria-selected={mode === "archive"}
+            className={mode === "archive" ? "active" : ""}
+            onClick={() => onModeChange("archive")}
+            role="tab"
+            type="button"
+          >
+            아카이브
+          </button>
+        </div>
+      </div>
+
+      <form className="bank-form filter-form" onSubmit={onSearch}>
+        <div className="filter-grid">
+          <label>
+            <span>계좌 ID</span>
+            <input
+              inputMode="numeric"
+              onChange={(event) =>
+                onFilterChange({ ...filters, accountId: event.target.value })
+              }
+              required
+              value={filters.accountId}
+            />
+          </label>
+          <label>
+            <span>시작일시</span>
+            <input
+              onChange={(event) =>
+                onFilterChange({ ...filters, from: event.target.value })
+              }
+              required
+              type="datetime-local"
+              value={filters.from}
+            />
+          </label>
+          <label>
+            <span>종료일시</span>
+            <input
+              onChange={(event) =>
+                onFilterChange({ ...filters, to: event.target.value })
+              }
+              required
+              type="datetime-local"
+              value={filters.to}
+            />
+          </label>
+          <label>
+            <span>건수</span>
+            <select
+              onChange={(event) =>
+                onFilterChange({ ...filters, limit: event.target.value })
+              }
+              value={filters.limit}
+            >
+              <option value="20">20</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
+          </label>
+          <label>
+            <span>상태</span>
+            <select
+              onChange={(event) =>
+                onFilterChange({ ...filters, status: event.target.value })
+              }
+              value={filters.status}
+            >
+              <option value="">전체</option>
+              <option value="PENDING">PENDING</option>
+              <option value="BOOKED">BOOKED</option>
+              <option value="REVERSED">REVERSED</option>
+              <option value="FAILED">FAILED</option>
+            </select>
+          </label>
+          <label>
+            <span>입출금</span>
+            <select
+              onChange={(event) =>
+                onFilterChange({ ...filters, direction: event.target.value })
+              }
+              value={filters.direction}
+            >
+              <option value="">전체</option>
+              <option value="DEBIT">출금</option>
+              <option value="CREDIT">입금</option>
+            </select>
+          </label>
+          <label>
+            <span>최소금액 minor</span>
+            <input
+              inputMode="numeric"
+              onChange={(event) =>
+                onFilterChange({
+                  ...filters,
+                  minAmountMinor: event.target.value,
+                })
+              }
+              value={filters.minAmountMinor}
+            />
+          </label>
+          <label>
+            <span>최대금액 minor</span>
+            <input
+              inputMode="numeric"
+              onChange={(event) =>
+                onFilterChange({
+                  ...filters,
+                  maxAmountMinor: event.target.value,
+                })
+              }
+              value={filters.maxAmountMinor}
+            />
+          </label>
+          <label>
+            <span>거래번호</span>
+            <input
+              onChange={(event) =>
+                onFilterChange({
+                  ...filters,
+                  transactionReference: event.target.value,
+                })
+              }
+              value={filters.transactionReference}
+            />
+          </label>
+          <label>
+            <span>응답형태</span>
+            <select
+              onChange={(event) =>
+                onFilterChange({
+                  ...filters,
+                  responseShape: event.target.value as "full" | "slim",
+                })
+              }
+              value={filters.responseShape}
+            >
+              <option value="full">full</option>
+              <option value="slim">slim</option>
+            </select>
+          </label>
+        </div>
+        <div className="button-row">
+          <button disabled={isBusy} type="submit">
+            조회
+          </button>
+          <button disabled={!slice?.nextCursor || isBusy} onClick={onNext} type="button">
+            다음 거래
+          </button>
+        </div>
+      </form>
+
+      <div className="split-work">
+        <section className="table-panel embedded">
+          <div className="panel-toolbar">
+            <div>
+              <strong>거래내역</strong>
+              <span>
+                {slice
+                  ? `${transactions.length}건 표시 / next ${slice.hasNext ? "있음" : "없음"}`
+                  : "조회 전"}
+              </span>
+            </div>
+          </div>
+          <div className="bank-table-wrap">
+            <table className="bank-table">
+              <caption>거래내역 목록</caption>
+              <thead>
+                <tr>
+                  <th>기장일시</th>
+                  <th>거래번호</th>
+                  <th>입출금</th>
+                  <th>상태</th>
+                  <th>금액</th>
+                  <th>잔액</th>
+                  <th>상세</th>
+                </tr>
+              </thead>
+              <tbody>
+                {transactions.length === 0 ? (
+                  <tr>
+                    <td colSpan={7}>조회된 거래가 없습니다.</td>
+                  </tr>
+                ) : (
+                  transactions.map((item) => (
+                    <tr key={`${item.id}-${item.transactionReference}`}>
+                      <td>{formatDateTime(item.bookedAt)}</td>
+                      <td>{item.transactionReference}</td>
+                      <td>{item.direction}</td>
+                      <td>
+                        <span className="status-badge">{item.status}</span>
+                      </td>
+                      <td className={item.direction === "DEBIT" ? "amount debit" : "amount credit"}>
+                        {formatMinorAmount(item.amountMinor, item.currencyCode)}
+                      </td>
+                      <td>
+                        {item.balanceAfterMinor == null
+                          ? "-"
+                          : formatMinorAmount(
+                              item.balanceAfterMinor,
+                              item.currencyCode,
+                            )}
+                      </td>
+                      <td>
+                        <button
+                          disabled={isBusy}
+                          onClick={() => onDetail(item.transactionReference)}
+                          type="button"
+                        >
+                          상세
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <aside className="detail-panel">
+          <div className="form-heading">
+            <strong>거래상세</strong>
+            <span>{transactionDetail?.transactionStatus ?? "미선택"}</span>
+          </div>
+          {transactionDetail ? (
+            <dl className="detail-list">
+              <div>
+                <dt>거래번호</dt>
+                <dd>{transactionDetail.transactionReference}</dd>
+              </div>
+              <div>
+                <dt>입출금</dt>
+                <dd>{transactionDetail.direction}</dd>
+              </div>
+              <div>
+                <dt>금액</dt>
+                <dd>
+                  {formatMinorAmount(
+                    transactionDetail.amountMinor,
+                    transactionDetail.currencyCode,
+                  )}
+                </dd>
+              </div>
+              <div>
+                <dt>잔액</dt>
+                <dd>
+                  {formatMinorAmount(
+                    transactionDetail.balanceAfterMinor,
+                    transactionDetail.currencyCode,
+                  )}
+                </dd>
+              </div>
+              <div>
+                <dt>상대방</dt>
+                <dd>{transactionDetail.counterpartyMaskedName ?? "-"}</dd>
+              </div>
+              <div>
+                <dt>Ledger</dt>
+                <dd>{transactionDetail.entryReference}</dd>
+              </div>
+              <div>
+                <dt>발생시각</dt>
+                <dd>{formatDateTime(transactionDetail.occurredAt)}</dd>
+              </div>
+              <div>
+                <dt>설명</dt>
+                <dd>{transactionDetail.description ?? "-"}</dd>
+              </div>
+            </dl>
+          ) : (
+            <p className="rail-copy">거래내역에서 상세 버튼을 선택하세요.</p>
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function ResultPanel({ title, rows }: { title: string; rows: string[][] }) {
+  return (
+    <div className="result-panel">
+      <div className="form-heading">
+        <strong>{title}</strong>
+        <span>{rows.length > 0 ? "완료" : "대기"}</span>
+      </div>
+      {rows.length === 0 ? (
+        <p className="rail-copy">처리 결과가 여기에 표시됩니다.</p>
+      ) : (
+        <dl className="detail-list">
+          {rows.map(([key, value]) => (
+            <div key={key}>
+              <dt>{key}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
   );
 }
 

--- a/front/src/lib/api/client.ts
+++ b/front/src/lib/api/client.ts
@@ -1,0 +1,439 @@
+import type {
+  AccountListResponse,
+  AccountSummaryResponse,
+  AuthSessionListResponse,
+  BackupCodeChallengeVerifyRequest,
+  BackupCodeIssueResponse,
+  LoginRequest,
+  LoginResponse,
+  LogoutRequest,
+  NotificationBulkActionRequest,
+  NotificationPreferenceResponse,
+  NotificationPreferenceUpdateRequest,
+  NotificationQueryParams,
+  NotificationQueryResponse,
+  NotificationSearchParams,
+  NotificationSearchResponse,
+  NotificationUnreadCountResponse,
+  PasswordRecoveryConfirmRequest,
+  PasswordRecoveryRequest,
+  PasswordRecoveryRequestResult,
+  PasswordResetRequest,
+  RefreshRequest,
+  TotpChallengeVerifyRequest,
+  TotpCodeRequest,
+  TotpEnrollmentStartResponse,
+  TotpEnrollmentVerifyResponse,
+  TransactionDetailResponse,
+  TransactionQueryParams,
+  TransactionQueryResponse,
+  TransferRequest,
+  TransferResponse,
+  TransferReversalRequest,
+  TransferReversalResponse,
+} from "./types";
+
+type RequestOptions = {
+  method?: "GET" | "POST" | "DELETE";
+  body?: unknown;
+  accessToken?: string;
+  headers?: Record<string, string>;
+};
+
+type ResponseWithHeaders<T> = {
+  data: T;
+  headers: Headers;
+};
+
+export class ApiClientError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: unknown,
+  ) {
+    super(message);
+    this.name = "ApiClientError";
+  }
+}
+
+export class ApiConfigurationError extends Error {
+  constructor() {
+    super("NEXT_PUBLIC_API_BASE_URL is not configured.");
+    this.name = "ApiConfigurationError";
+  }
+}
+
+export function resolveApiBaseUrl(): string {
+  return (process.env.NEXT_PUBLIC_API_BASE_URL ?? "").replace(/\/+$/, "");
+}
+
+function appendSearchParams(path: string, params: Record<string, unknown>): string {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") {
+      return;
+    }
+    searchParams.set(key, String(value));
+  });
+
+  const query = searchParams.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+function defaultHeaders(options: RequestOptions): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    ...options.headers,
+  };
+
+  if (options.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  if (options.accessToken) {
+    headers.Authorization = `Bearer ${options.accessToken}`;
+  }
+
+  return headers;
+}
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (response.status === 204) {
+    return undefined;
+  }
+  if (contentType.includes("application/json")) {
+    return response.json();
+  }
+  return response.text();
+}
+
+export function createIdempotencyKey(prefix = "web"): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export class AquilaBankApiClient {
+  constructor(private readonly baseUrl = resolveApiBaseUrl()) {}
+
+  streamUrl(path: string, accessToken?: string): string {
+    if (!this.baseUrl) {
+      throw new ApiConfigurationError();
+    }
+
+    const url = new URL(`${this.baseUrl}${path}`);
+    if (accessToken) {
+      // EventSource는 custom header를 지원하지 않아 MVP에서는 query fallback으로 제한합니다.
+      url.searchParams.set("accessToken", accessToken);
+    }
+    return url.toString();
+  }
+
+  private async requestWithHeaders<T>(
+    path: string,
+    options: RequestOptions = {},
+  ): Promise<ResponseWithHeaders<T>> {
+    if (!this.baseUrl) {
+      throw new ApiConfigurationError();
+    }
+
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method: options.method ?? "GET",
+      headers: defaultHeaders(options),
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      credentials: "include",
+    });
+    const body = await parseResponseBody(response);
+
+    if (!response.ok) {
+      const message =
+        typeof body === "object" && body !== null && "message" in body
+          ? String((body as { message?: unknown }).message)
+          : response.statusText;
+      throw new ApiClientError(message, response.status, body);
+    }
+
+    return {
+      data: body as T,
+      headers: response.headers,
+    };
+  }
+
+  private async request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+    const response = await this.requestWithHeaders<T>(path, options);
+    return response.data;
+  }
+
+  login(request: LoginRequest): Promise<LoginResponse> {
+    return this.request("/api/v1/auth/login", { method: "POST", body: request });
+  }
+
+  verifyTotpChallenge(request: TotpChallengeVerifyRequest): Promise<LoginResponse> {
+    return this.request("/api/v1/auth/mfa/totp/challenge/verify", {
+      method: "POST",
+      body: request,
+    });
+  }
+
+  verifyBackupCodeChallenge(
+    request: BackupCodeChallengeVerifyRequest,
+  ): Promise<LoginResponse> {
+    return this.request("/api/v1/auth/mfa/backup-codes/challenge/verify", {
+      method: "POST",
+      body: request,
+    });
+  }
+
+  startTotpEnrollment(accessToken: string): Promise<TotpEnrollmentStartResponse> {
+    return this.request("/api/v1/auth/mfa/totp/enroll", {
+      method: "POST",
+      accessToken,
+    });
+  }
+
+  verifyTotpEnrollment(
+    request: TotpCodeRequest,
+    accessToken: string,
+  ): Promise<TotpEnrollmentVerifyResponse> {
+    return this.request("/api/v1/auth/mfa/totp/enroll/verify", {
+      method: "POST",
+      body: request,
+      accessToken,
+    });
+  }
+
+  disableTotp(request: TotpCodeRequest, accessToken: string): Promise<void> {
+    return this.request("/api/v1/auth/mfa/totp/disable", {
+      method: "POST",
+      body: request,
+      accessToken,
+    });
+  }
+
+  issueBackupCodes(
+    request: TotpCodeRequest,
+    accessToken: string,
+  ): Promise<BackupCodeIssueResponse> {
+    return this.request("/api/v1/auth/mfa/backup-codes", {
+      method: "POST",
+      body: request,
+      accessToken,
+    });
+  }
+
+  getSessions(accessToken: string, size = 20): Promise<AuthSessionListResponse> {
+    return this.request(appendSearchParams("/api/v1/auth/sessions", { size }), {
+      accessToken,
+    });
+  }
+
+  revokeSession(sessionId: number, accessToken: string): Promise<void> {
+    return this.request(`/api/v1/auth/sessions/${sessionId}`, {
+      method: "DELETE",
+      accessToken,
+    });
+  }
+
+  revokeAllSessions(accessToken: string): Promise<void> {
+    return this.request("/api/v1/auth/sessions", {
+      method: "DELETE",
+      accessToken,
+    });
+  }
+
+  refresh(request: RefreshRequest): Promise<LoginResponse> {
+    return this.request("/api/v1/auth/refresh", {
+      method: "POST",
+      body: request,
+    });
+  }
+
+  logout(request: LogoutRequest, accessToken: string): Promise<void> {
+    return this.request("/api/v1/auth/logout", {
+      method: "POST",
+      body: request,
+      accessToken,
+    });
+  }
+
+  resetPassword(request: PasswordResetRequest, accessToken: string): Promise<void> {
+    return this.request("/api/v1/auth/password-reset", {
+      method: "POST",
+      body: request,
+      accessToken,
+    });
+  }
+
+  async requestPasswordRecovery(
+    request: PasswordRecoveryRequest,
+  ): Promise<PasswordRecoveryRequestResult> {
+    const response = await this.requestWithHeaders<void>(
+      "/api/v1/auth/password-recovery/request",
+      {
+        method: "POST",
+        body: request,
+      },
+    );
+    return {
+      handoffRequestId: response.headers.get("X-Password-Recovery-Request-Id"),
+    };
+  }
+
+  confirmPasswordRecovery(request: PasswordRecoveryConfirmRequest): Promise<void> {
+    return this.request("/api/v1/auth/password-recovery/confirm", {
+      method: "POST",
+      body: request,
+    });
+  }
+
+  getAccounts(
+    accessToken: string,
+    params: { limit?: number; cursor?: string } = {},
+  ): Promise<AccountListResponse> {
+    return this.request(appendSearchParams("/api/v1/accounts", params), {
+      accessToken,
+    });
+  }
+
+  getAccount(accountId: number, accessToken: string): Promise<AccountSummaryResponse> {
+    return this.request(`/api/v1/accounts/${accountId}`, { accessToken });
+  }
+
+  transfer(
+    request: TransferRequest,
+    accessToken: string,
+    idempotencyKey = createIdempotencyKey("transfer"),
+  ): Promise<TransferResponse> {
+    return this.request("/api/v1/transfers", {
+      method: "POST",
+      body: request,
+      accessToken,
+      headers: { "Idempotency-Key": idempotencyKey },
+    });
+  }
+
+  reverseTransfer(
+    transactionReference: string,
+    request: TransferReversalRequest,
+    accessToken: string,
+    idempotencyKey = createIdempotencyKey("reversal"),
+  ): Promise<TransferReversalResponse> {
+    return this.request(`/api/v1/transfers/${transactionReference}/reversal`, {
+      method: "POST",
+      body: request,
+      accessToken,
+      headers: { "Idempotency-Key": idempotencyKey },
+    });
+  }
+
+  getTransactions(
+    params: TransactionQueryParams,
+    accessToken: string,
+  ): Promise<TransactionQueryResponse> {
+    return this.request(appendSearchParams("/api/v1/transactions", params), {
+      accessToken,
+    });
+  }
+
+  getArchivedTransactions(
+    params: TransactionQueryParams,
+    accessToken: string,
+  ): Promise<TransactionQueryResponse> {
+    return this.request(appendSearchParams("/api/v1/transactions/archive", params), {
+      accessToken,
+    });
+  }
+
+  getTransactionDetail(
+    transactionReference: string,
+    accountId: number,
+    accessToken: string,
+  ): Promise<TransactionDetailResponse> {
+    return this.request(
+      appendSearchParams(`/api/v1/transactions/${transactionReference}`, { accountId }),
+      { accessToken },
+    );
+  }
+
+  getNotifications(
+    params: NotificationQueryParams,
+    accessToken: string,
+  ): Promise<NotificationQueryResponse> {
+    return this.request(appendSearchParams("/api/v1/notifications", params), {
+      accessToken,
+    });
+  }
+
+  searchNotifications(
+    params: NotificationSearchParams,
+    accessToken: string,
+  ): Promise<NotificationSearchResponse> {
+    return this.request(appendSearchParams("/api/v1/notifications/search", params), {
+      accessToken,
+    });
+  }
+
+  getUnreadCount(accessToken: string): Promise<NotificationUnreadCountResponse> {
+    return this.request("/api/v1/notifications/unread-count", { accessToken });
+  }
+
+  getNotificationPreferences(
+    accessToken: string,
+  ): Promise<NotificationPreferenceResponse> {
+    return this.request("/api/v1/notifications/preferences", { accessToken });
+  }
+
+  updateNotificationPreferences(
+    request: NotificationPreferenceUpdateRequest,
+    accessToken: string,
+  ): Promise<void> {
+    return this.request("/api/v1/notifications/preferences", {
+      method: "POST",
+      body: request,
+      accessToken,
+    });
+  }
+
+  markNotificationAsRead(notificationId: number, accessToken: string): Promise<void> {
+    return this.request(`/api/v1/notifications/${notificationId}/read`, {
+      method: "POST",
+      accessToken,
+    });
+  }
+
+  markNotificationsAsRead(
+    request: NotificationBulkActionRequest,
+    accessToken: string,
+  ): Promise<void> {
+    return this.request("/api/v1/notifications/read", {
+      method: "POST",
+      body: request,
+      accessToken,
+    });
+  }
+
+  archiveNotifications(
+    request: NotificationBulkActionRequest,
+    accessToken: string,
+  ): Promise<void> {
+    return this.request("/api/v1/notifications/archive", {
+      method: "POST",
+      body: request,
+      accessToken,
+    });
+  }
+
+  deleteNotifications(
+    request: NotificationBulkActionRequest,
+    accessToken: string,
+  ): Promise<void> {
+    return this.request("/api/v1/notifications/delete", {
+      method: "POST",
+      body: request,
+      accessToken,
+    });
+  }
+}

--- a/front/src/lib/api/session.ts
+++ b/front/src/lib/api/session.ts
@@ -1,0 +1,56 @@
+import type { CustomerSession, LoginResponse } from "./types";
+
+const STORAGE_KEY = "aquila-bank.customer-session";
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function toCustomerSession(result: LoginResponse): CustomerSession | null {
+  if (!result.accessToken || !result.refreshToken) {
+    return null;
+  }
+
+  return {
+    accessToken: result.accessToken,
+    refreshToken: result.refreshToken,
+    tokenType: result.tokenType ?? "Bearer",
+    userId: result.userId,
+    expiresAt: result.expiresAt,
+    refreshExpiresAt: result.refreshExpiresAt,
+  };
+}
+
+export function loadCustomerSession(): CustomerSession | null {
+  if (!canUseStorage()) {
+    return null;
+  }
+
+  const rawValue = window.localStorage.getItem(STORAGE_KEY);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(rawValue) as CustomerSession;
+  } catch {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+}
+
+export function saveCustomerSession(session: CustomerSession): void {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+}
+
+export function clearCustomerSession(): void {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  window.localStorage.removeItem(STORAGE_KEY);
+}

--- a/front/src/lib/api/types.ts
+++ b/front/src/lib/api/types.ts
@@ -251,13 +251,13 @@ export type NotificationSearchParams = NotificationQueryParams & {
 
 export type NotificationItem = {
   notificationId: number;
-  eventId: number;
+  accountId: number;
   eventType: string;
   title: string;
   message: string;
-  readAt: Nullable<string>;
-  archivedAt: Nullable<string>;
+  read: boolean;
   createdAt: string;
+  readAt: Nullable<string>;
 };
 
 export type NotificationQueryResponse = {
@@ -281,10 +281,9 @@ export type NotificationBulkActionRequest = {
 };
 
 export type NotificationPreferenceItem = {
-  eventType: string;
-  channelType: string;
+  category: string;
+  channel: string;
   enabled: boolean;
-  updatedAt?: Nullable<string>;
 };
 
 export type NotificationPreferenceResponse = {
@@ -293,8 +292,8 @@ export type NotificationPreferenceResponse = {
 
 export type NotificationPreferenceUpdateRequest = {
   items: Array<{
-    eventType: string;
-    channelType: string;
+    category: string;
+    channel: string;
     enabled: boolean;
   }>;
 };

--- a/front/src/lib/api/types.ts
+++ b/front/src/lib/api/types.ts
@@ -1,0 +1,309 @@
+export type Nullable<T> = T | null;
+
+export type ApiValidationDetail = {
+  field?: string;
+  message?: string;
+};
+
+export type ApiErrorBody = {
+  timestamp?: string;
+  status?: number;
+  error?: string;
+  message?: string;
+  path?: string;
+  requestId?: string;
+  details?: ApiValidationDetail[];
+};
+
+export type LoginStatus = "SUCCESS" | "MFA_REQUIRED";
+
+export type LoginResponse = {
+  status: LoginStatus | string;
+  accessToken: Nullable<string>;
+  refreshToken: Nullable<string>;
+  tokenType: Nullable<string>;
+  expiresAt: Nullable<string>;
+  refreshExpiresAt: Nullable<string>;
+  userId: Nullable<number>;
+  challengeId: Nullable<string>;
+  challengeType: Nullable<string>;
+  challengeExpiresAt: Nullable<string>;
+};
+
+export type LoginRequest = {
+  loginId: string;
+  password: string;
+};
+
+export type TotpChallengeVerifyRequest = {
+  challengeId: string;
+  totpCode: string;
+  rememberDevice?: boolean;
+};
+
+export type BackupCodeChallengeVerifyRequest = {
+  challengeId: string;
+  backupCode: string;
+  rememberDevice?: boolean;
+};
+
+export type TotpCodeRequest = {
+  totpCode: string;
+};
+
+export type TotpEnrollmentStartResponse = {
+  status: string;
+  secretKey: string;
+  otpauthUri: string;
+  expiresAt: string;
+};
+
+export type TotpEnrollmentVerifyResponse = {
+  status: string;
+  verifiedAt: string;
+};
+
+export type BackupCodeIssueResponse = {
+  codeCount: number;
+  backupCodes: string[];
+};
+
+export type AuthSessionItem = {
+  sessionId: number;
+  sessionStatus: string;
+  expiresAt: string;
+  lastUsedAt: Nullable<string>;
+  createdAt: string;
+  deviceName: Nullable<string>;
+  ipAddress: Nullable<string>;
+  currentSession: boolean;
+};
+
+export type AuthSessionListResponse = {
+  items: AuthSessionItem[];
+};
+
+export type RefreshRequest = {
+  refreshToken: string;
+};
+
+export type LogoutRequest = {
+  refreshToken: string;
+};
+
+export type PasswordResetRequest = {
+  currentPassword: string;
+  newPassword: string;
+};
+
+export type PasswordRecoveryRequest = {
+  loginId: string;
+};
+
+export type PasswordRecoveryConfirmRequest = {
+  recoveryToken: string;
+  newPassword: string;
+};
+
+export type PasswordRecoveryRequestResult = {
+  handoffRequestId: Nullable<string>;
+};
+
+export type AccountItem = {
+  accountId: number;
+  accountNumber: string;
+  displayName: string;
+  accountStatus: string;
+  currencyCode: string;
+  availableBalanceMinor: number;
+  pendingBalanceMinor: number;
+  createdAt: string;
+  balanceUpdatedAt: string;
+};
+
+export type AccountListResponse = {
+  items: AccountItem[];
+  nextCursor: Nullable<string>;
+};
+
+export type AccountSummaryResponse = AccountItem;
+
+export type TransferRequest = {
+  sourceAccountId: number;
+  targetAccountId: number;
+  amountMinor: number;
+  currencyCode: string;
+  summary: string;
+};
+
+export type TransferResponse = {
+  transactionReference: string;
+  sourceAccountId: number;
+  targetAccountId: number;
+  amountMinor: number;
+  currencyCode: string;
+  availableBalanceAfterMinor: number;
+  bookedAt: string;
+  status: string;
+};
+
+export type TransferReversalReason =
+  | "CUSTOMER_REQUEST"
+  | "DUPLICATE"
+  | "WRONG_AMOUNT"
+  | "WRONG_TARGET"
+  | "FRAUD_REPORTED"
+  | string;
+
+export type TransferReversalRequest = {
+  sourceAccountId: number;
+  amountMinor: number;
+  reversalReason: TransferReversalReason;
+  summary: string;
+};
+
+export type TransferReversalResponse = {
+  originalTransactionReference: string;
+  reversalTransactionReference: string;
+  sourceAccountId: number;
+  targetAccountId: number;
+  amountMinor: number;
+  currencyCode: string;
+  availableBalanceAfterMinor: number;
+  bookedAt: string;
+  status: string;
+};
+
+export type TransactionStatus =
+  | "PENDING"
+  | "BOOKED"
+  | "REVERSED"
+  | "FAILED"
+  | string;
+
+export type TransactionDirection = "DEBIT" | "CREDIT" | string;
+
+export type TransactionQueryParams = {
+  accountId: number;
+  from: string;
+  to: string;
+  limit?: number;
+  cursor?: string;
+  status?: string;
+  direction?: string;
+  minAmountMinor?: number;
+  maxAmountMinor?: number;
+  transactionReference?: string;
+  responseShape?: "full" | "slim";
+};
+
+export type TransactionItem = {
+  id: number;
+  accountId: number;
+  transactionReference: string;
+  direction: TransactionDirection;
+  status: TransactionStatus;
+  amountMinor: number;
+  balanceAfterMinor?: Nullable<number>;
+  currencyCode: string;
+  summary?: Nullable<string>;
+  counterpartyMaskedName?: Nullable<string>;
+  bookedAt: string;
+};
+
+export type TransactionQueryResponse = {
+  items: TransactionItem[];
+  nextCursor: Nullable<string>;
+  hasNext: boolean;
+  limit: number;
+};
+
+export type TransactionDetailResponse = {
+  accountId: number;
+  transactionReference: string;
+  direction: TransactionDirection;
+  transactionStatus: string;
+  amountMinor: number;
+  balanceAfterMinor: number;
+  currencyCode: string;
+  summary: string;
+  counterpartyMaskedName: Nullable<string>;
+  bookedAt: string;
+  entryReference: string;
+  entryStatus: string;
+  occurredAt: string;
+  description: Nullable<string>;
+};
+
+export type NotificationReadStatusFilter = "ALL" | "READ" | "UNREAD" | string;
+
+export type NotificationQueryParams = {
+  limit?: number;
+  cursor?: string;
+};
+
+export type NotificationSearchParams = NotificationQueryParams & {
+  readStatus?: NotificationReadStatusFilter;
+  eventType?: string;
+  from?: string;
+  to?: string;
+};
+
+export type NotificationItem = {
+  notificationId: number;
+  eventId: number;
+  eventType: string;
+  title: string;
+  message: string;
+  readAt: Nullable<string>;
+  archivedAt: Nullable<string>;
+  createdAt: string;
+};
+
+export type NotificationQueryResponse = {
+  items: NotificationItem[];
+  nextCursor: Nullable<string>;
+  hasNext: boolean;
+  limit: number;
+};
+
+export type NotificationSearchResponse = NotificationQueryResponse & {
+  appliedFrom?: string;
+  appliedTo?: string;
+};
+
+export type NotificationUnreadCountResponse = {
+  unreadCount: number;
+};
+
+export type NotificationBulkActionRequest = {
+  notificationIds: number[];
+};
+
+export type NotificationPreferenceItem = {
+  eventType: string;
+  channelType: string;
+  enabled: boolean;
+  updatedAt?: Nullable<string>;
+};
+
+export type NotificationPreferenceResponse = {
+  items: NotificationPreferenceItem[];
+};
+
+export type NotificationPreferenceUpdateRequest = {
+  items: Array<{
+    eventType: string;
+    channelType: string;
+    enabled: boolean;
+  }>;
+};
+
+export type CustomerSession = {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+  userId: Nullable<number>;
+  expiresAt: Nullable<string>;
+  refreshExpiresAt: Nullable<string>;
+};


### PR DESCRIPTION
## 🔗 Related Issue
- close #878

## 🌿 Base Branch
- `main`

## 📝 Summary
- 백엔드 공개 고객 API를 사용하는 고객 웹뱅킹 MVP 화면을 구현했습니다.
- 신한/우리/KB 같은 대형 은행 인터넷뱅킹의 공통 구조를 기준으로 상단/좌측/중앙/우측 업무형 UI를 적용했습니다.
- 내부 운영 API는 제외하고 로그인/MFA, 계좌, 이체/취소, 거래조회/상세, 알림/SSE/preferences만 연결했습니다.

## 🛠 Changes
- `front/src/lib/api/**`에 API DTO, API client, browser session persistence 추가
- `front/src/app/page.tsx`를 client banking workspace로 교체
- 인증/세션/TOTP/backup code/password recovery UI 구현
- 계좌 목록/상세, 이체, reversal, 거래내역 active/archive, 거래 상세 UI 구현
- 알림 inbox/search/unread/preferences/SSE 상태 UI 구현
- 국내 대형 은행형 고밀도 레이아웃과 responsive 순서 보정

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front lint`
- `yarn --cwd front build`
- `http://localhost:3000` 브라우저 확인
- 상단 메뉴 `조회`, `이체`, `거래내역 조회`, `알림`, `인증/세션 관리` 전환 확인
- 알림 화면 responsive 순서 확인

## 📸 Screenshot / API Example
- UI 변경: 브라우저에서 고객 웹뱅킹 홈과 알림 화면 수동 확인
- API 예시: `NEXT_PUBLIC_API_BASE_URL` 기반 client wrapper로 백엔드 공개 고객 API 호출

## ⚠️ Risk & Rollback
- 예상 리스크: MVP는 browser storage 기반 token 보관이므로 후속 httpOnly cookie/BFF 보강이 필요합니다.
- 예상 리스크: `EventSource`는 custom Authorization header를 지원하지 않아 SSE는 query fallback 형태로만 상태를 연결했습니다.
- 롤백 방법: 이 PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [ ] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [ ] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
