### PR TITLE
[Fix] 고객 웹뱅킹 인증 및 SSE 세션 보안 보강

### DIFF
--- a/back/src/main/java/com/aquilabank/global/security/CookieBearerTokenResolver.java
+++ b/back/src/main/java/com/aquilabank/global/security/CookieBearerTokenResolver.java
@@ -1,0 +1,43 @@
+package com.aquilabank.global.security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+
+/** Authorization header 우선, 웹 httpOnly access cookie fallback 순서로 bearer token을 찾습니다. */
+public final class CookieBearerTokenResolver implements BearerTokenResolver {
+
+  private final DefaultBearerTokenResolver delegate = new DefaultBearerTokenResolver();
+  private final String accessTokenCookieName;
+
+  public CookieBearerTokenResolver(String accessTokenCookieName) {
+    if (accessTokenCookieName == null || accessTokenCookieName.isBlank()) {
+      throw new IllegalArgumentException("accessTokenCookieName is required");
+    }
+    this.accessTokenCookieName = accessTokenCookieName;
+  }
+
+  @Override
+  public String resolve(HttpServletRequest request) {
+    String headerToken = delegate.resolve(request);
+    if (headerToken != null && !headerToken.isBlank()) {
+      return headerToken;
+    }
+    return resolveCookieToken(request);
+  }
+
+  private String resolveCookieToken(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return null;
+    }
+    for (Cookie cookie : cookies) {
+      if (accessTokenCookieName.equals(cookie.getName())) {
+        String value = cookie.getValue();
+        return value == null || value.isBlank() ? null : value;
+      }
+    }
+    return null;
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/SecurityAuthCookieProperties.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityAuthCookieProperties.java
@@ -1,0 +1,20 @@
+package com.aquilabank.global.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** 웹 세션 cookie 이름과 전송 보안 기준입니다. */
+@ConfigurationProperties(prefix = "security.auth-cookie")
+public record SecurityAuthCookieProperties(
+    String accessTokenCookieName, String refreshTokenCookieName, boolean secure) {
+
+  public SecurityAuthCookieProperties {
+    if (accessTokenCookieName == null || accessTokenCookieName.isBlank()) {
+      throw new IllegalArgumentException(
+          "security.auth-cookie.access-token-cookie-name is required");
+    }
+    if (refreshTokenCookieName == null || refreshTokenCookieName.isBlank()) {
+      throw new IllegalArgumentException(
+          "security.auth-cookie.refresh-token-cookie-name is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -33,7 +33,6 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
-import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
@@ -42,6 +41,7 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 @Configuration
 @EnableConfigurationProperties({
   SecurityJwtProperties.class,
+  SecurityAuthCookieProperties.class,
   SecurityTotpProperties.class,
   SecurityRememberDeviceProperties.class,
   LoginProtectionProperties.class,
@@ -187,8 +187,10 @@ public class SecurityConfiguration {
   }
 
   @Bean
-  BearerTokenResolver publicApiBearerTokenResolver() {
-    DefaultBearerTokenResolver delegate = new DefaultBearerTokenResolver();
+  BearerTokenResolver publicApiBearerTokenResolver(
+      SecurityAuthCookieProperties securityAuthCookieProperties) {
+    CookieBearerTokenResolver delegate =
+        new CookieBearerTokenResolver(securityAuthCookieProperties.accessTokenCookieName());
     return request -> isInternalApiRequest(request) ? null : delegate.resolve(request);
   }
 

--- a/back/src/main/java/com/aquilabank/global/web/auth/AuthSessionCookieManager.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/AuthSessionCookieManager.java
@@ -1,0 +1,97 @@
+package com.aquilabank.global.web.auth;
+
+import com.aquilabank.domain.auth.model.LoginResult;
+import com.aquilabank.global.security.SecurityAuthCookieProperties;
+import com.aquilabank.global.security.SecurityJwtProperties;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Duration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+/** public 웹 세션용 access/refresh token을 JS가 읽지 못하는 cookie로만 전달합니다. */
+@Component
+public class AuthSessionCookieManager {
+
+  private static final String SAME_SITE_LAX = "Lax";
+  private static final String ACCESS_COOKIE_PATH = "/";
+  private static final String REFRESH_COOKIE_PATH = "/api/v1/auth";
+
+  private final SecurityJwtProperties securityJwtProperties;
+  private final SecurityAuthCookieProperties securityAuthCookieProperties;
+
+  public AuthSessionCookieManager(
+      SecurityJwtProperties securityJwtProperties,
+      SecurityAuthCookieProperties securityAuthCookieProperties) {
+    this.securityJwtProperties = securityJwtProperties;
+    this.securityAuthCookieProperties = securityAuthCookieProperties;
+  }
+
+  public String resolveRefreshToken(HttpServletRequest request) {
+    return resolveCookie(request, securityAuthCookieProperties.refreshTokenCookieName());
+  }
+
+  public void addSessionCookies(HttpHeaders headers, LoginResult result) {
+    if (result.accessToken() != null && !result.accessToken().isBlank()) {
+      headers.add(HttpHeaders.SET_COOKIE, accessCookie(result.accessToken()).toString());
+    }
+    if (result.refreshToken() != null && !result.refreshToken().isBlank()) {
+      headers.add(HttpHeaders.SET_COOKIE, refreshCookie(result.refreshToken()).toString());
+    }
+  }
+
+  public void addClearCookies(HttpHeaders headers) {
+    headers.add(HttpHeaders.SET_COOKIE, clearAccessCookie().toString());
+    headers.add(HttpHeaders.SET_COOKIE, clearRefreshCookie().toString());
+  }
+
+  private String resolveCookie(HttpServletRequest request, String cookieName) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return null;
+    }
+    for (Cookie cookie : cookies) {
+      if (cookieName.equals(cookie.getName())) {
+        String value = cookie.getValue();
+        return value == null || value.isBlank() ? null : value;
+      }
+    }
+    return null;
+  }
+
+  private ResponseCookie accessCookie(String accessToken) {
+    return baseCookie(securityAuthCookieProperties.accessTokenCookieName(), accessToken)
+        .path(ACCESS_COOKIE_PATH)
+        .maxAge(Duration.ofSeconds(securityJwtProperties.accessTokenTtlSeconds()))
+        .build();
+  }
+
+  private ResponseCookie refreshCookie(String refreshToken) {
+    return baseCookie(securityAuthCookieProperties.refreshTokenCookieName(), refreshToken)
+        .path(REFRESH_COOKIE_PATH)
+        .maxAge(Duration.ofSeconds(securityJwtProperties.refreshTokenTtlSeconds()))
+        .build();
+  }
+
+  private ResponseCookie clearAccessCookie() {
+    return baseCookie(securityAuthCookieProperties.accessTokenCookieName(), "")
+        .path(ACCESS_COOKIE_PATH)
+        .maxAge(Duration.ZERO)
+        .build();
+  }
+
+  private ResponseCookie clearRefreshCookie() {
+    return baseCookie(securityAuthCookieProperties.refreshTokenCookieName(), "")
+        .path(REFRESH_COOKIE_PATH)
+        .maxAge(Duration.ZERO)
+        .build();
+  }
+
+  private ResponseCookie.ResponseCookieBuilder baseCookie(String cookieName, String value) {
+    return ResponseCookie.from(cookieName, value)
+        .httpOnly(true)
+        .secure(securityAuthCookieProperties.secure())
+        .sameSite(SAME_SITE_LAX);
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/LoginController.java
@@ -92,6 +92,7 @@ public class LoginController {
   private final LoginThrottleGuard loginThrottleGuard;
   private final RememberDeviceCookieManager rememberDeviceCookieManager;
   private final RefreshDeviceBindingCookieManager refreshDeviceBindingCookieManager;
+  private final AuthSessionCookieManager authSessionCookieManager;
 
   public LoginController(
       LoginUseCase loginUseCase,
@@ -111,7 +112,8 @@ public class LoginController {
       AuthSessionMetadataResolver authSessionMetadataResolver,
       LoginThrottleGuard loginThrottleGuard,
       RememberDeviceCookieManager rememberDeviceCookieManager,
-      RefreshDeviceBindingCookieManager refreshDeviceBindingCookieManager) {
+      RefreshDeviceBindingCookieManager refreshDeviceBindingCookieManager,
+      AuthSessionCookieManager authSessionCookieManager) {
     this.loginUseCase = loginUseCase;
     this.authSessionListUseCase = authSessionListUseCase;
     this.authSessionRevokeUseCase = authSessionRevokeUseCase;
@@ -130,6 +132,7 @@ public class LoginController {
     this.loginThrottleGuard = loginThrottleGuard;
     this.rememberDeviceCookieManager = rememberDeviceCookieManager;
     this.refreshDeviceBindingCookieManager = refreshDeviceBindingCookieManager;
+    this.authSessionCookieManager = authSessionCookieManager;
   }
 
   @PostMapping("/login")
@@ -242,10 +245,11 @@ public class LoginController {
   @PostMapping("/refresh")
   public ResponseEntity<LoginResponse> refresh(
       HttpServletRequest httpServletRequest, @Valid @RequestBody RefreshRequest request) {
+    String refreshToken = resolveRefreshToken(request.refreshToken(), httpServletRequest);
     LoginResult result =
         refreshTokenUseCase.refresh(
             new RefreshTokenCommand(
-                request.refreshToken(),
+                refreshToken,
                 refreshDeviceBindingCookieManager.resolve(httpServletRequest),
                 authSessionMetadataResolver.resolve(httpServletRequest),
                 RequestTraceContext.currentRequestId().orElse("-")));
@@ -257,10 +261,11 @@ public class LoginController {
       @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
       HttpServletRequest httpServletRequest,
       @Valid @RequestBody LogoutRequest request) {
+    String refreshToken = resolveRefreshToken(request.refreshToken(), httpServletRequest);
     logoutUseCase.logout(
         new LogoutCommand(
             resolveUserId(principal),
-            request.refreshToken(),
+            refreshToken,
             rememberDeviceCookieManager.resolve(httpServletRequest)));
     return noContentResponseClearingAuthCookies();
   }
@@ -304,11 +309,11 @@ public class LoginController {
 
   /** refresh token 재발급 요청 body */
   public record RefreshRequest(
-      @NotBlank(message = "refreshToken is required") @Size(max = 160, message = "refreshToken must be 160 characters or less") String refreshToken) {}
+      @Size(max = 160, message = "refreshToken must be 160 characters or less") String refreshToken) {}
 
   /** logout 요청 body */
   public record LogoutRequest(
-      @NotBlank(message = "refreshToken is required") @Size(max = 160, message = "refreshToken must be 160 characters or less") String refreshToken) {}
+      @Size(max = 160, message = "refreshToken must be 160 characters or less") String refreshToken) {}
 
   /** password reset 요청 body */
   public record PasswordResetRequest(
@@ -437,6 +442,7 @@ public class LoginController {
   private ResponseEntity<LoginResponse> loginResponse(
       LoginResult result, boolean clearRememberDeviceCookie) {
     HttpHeaders headers = new HttpHeaders();
+    authSessionCookieManager.addSessionCookies(headers, result);
     if (result.refreshDeviceBindingToken() != null) {
       refreshDeviceBindingCookieManager.addBindingCookie(
           headers, result.refreshDeviceBindingToken());
@@ -451,9 +457,21 @@ public class LoginController {
 
   private ResponseEntity<Void> noContentResponseClearingAuthCookies() {
     HttpHeaders headers = new HttpHeaders();
+    authSessionCookieManager.addClearCookies(headers);
     rememberDeviceCookieManager.addClearCookie(headers);
     refreshDeviceBindingCookieManager.addClearCookie(headers);
     return ResponseEntity.noContent().headers(headers).build();
+  }
+
+  private String resolveRefreshToken(String requestRefreshToken, HttpServletRequest request) {
+    if (requestRefreshToken != null && !requestRefreshToken.isBlank()) {
+      return requestRefreshToken;
+    }
+    String cookieRefreshToken = authSessionCookieManager.resolveRefreshToken(request);
+    if (cookieRefreshToken != null && !cookieRefreshToken.isBlank()) {
+      return cookieRefreshToken;
+    }
+    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "refreshToken is required");
   }
 
   private AuthenticatedUserPrincipal requireUserPrincipal(AuthenticatedRequestPrincipal principal) {

--- a/back/src/main/java/com/aquilabank/global/web/auth/OidcLoginAuthenticationSuccessHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/auth/OidcLoginAuthenticationSuccessHandler.java
@@ -25,16 +25,19 @@ public class OidcLoginAuthenticationSuccessHandler implements AuthenticationSucc
   private final ExternalOidcLoginUseCase externalOidcLoginUseCase;
   private final AuthSessionMetadataResolver authSessionMetadataResolver;
   private final RefreshDeviceBindingCookieManager refreshDeviceBindingCookieManager;
+  private final AuthSessionCookieManager authSessionCookieManager;
   private final ObjectMapper objectMapper;
 
   public OidcLoginAuthenticationSuccessHandler(
       ExternalOidcLoginUseCase externalOidcLoginUseCase,
       AuthSessionMetadataResolver authSessionMetadataResolver,
       RefreshDeviceBindingCookieManager refreshDeviceBindingCookieManager,
+      AuthSessionCookieManager authSessionCookieManager,
       ObjectMapper objectMapper) {
     this.externalOidcLoginUseCase = externalOidcLoginUseCase;
     this.authSessionMetadataResolver = authSessionMetadataResolver;
     this.refreshDeviceBindingCookieManager = refreshDeviceBindingCookieManager;
+    this.authSessionCookieManager = authSessionCookieManager;
     this.objectMapper = objectMapper;
   }
 
@@ -69,6 +72,7 @@ public class OidcLoginAuthenticationSuccessHandler implements AuthenticationSucc
 
   private void writeSuccess(HttpServletResponse response, LoginResult result) throws IOException {
     HttpHeaders headers = new HttpHeaders();
+    authSessionCookieManager.addSessionCookies(headers, result);
     if (result.refreshDeviceBindingToken() != null) {
       refreshDeviceBindingCookieManager.addBindingCookie(
           headers, result.refreshDeviceBindingToken());

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -392,6 +392,11 @@ security:
     access-token-ttl-seconds: ${SECURITY_JWT_ACCESS_TOKEN_TTL_SECONDS:900}
     refresh-token-ttl-seconds: ${SECURITY_JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
     refresh-device-cookie-name: ${SECURITY_JWT_REFRESH_DEVICE_COOKIE_NAME:ab_refresh_device}
+  auth-cookie:
+    access-token-cookie-name: ${SECURITY_AUTH_COOKIE_ACCESS_TOKEN_NAME:ab_access_token}
+    refresh-token-cookie-name: ${SECURITY_AUTH_COOKIE_REFRESH_TOKEN_NAME:ab_refresh_token}
+    # TLS 종단 환경은 true를 유지하고, direct HTTP staging smoke만 env에서 false로 낮춥니다.
+    secure: ${SECURITY_AUTH_COOKIE_SECURE:true}
   totp:
     issuer: ${SECURITY_TOTP_ISSUER:Aquila Bank}
     secret-encryption-key: ${SECURITY_TOTP_SECRET_ENCRYPTION_KEY:${SECURITY_JWT_SECRET:}}

--- a/back/src/test/java/com/aquilabank/global/security/CookieBearerTokenResolverTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/CookieBearerTokenResolverTest.java
@@ -1,0 +1,46 @@
+package com.aquilabank.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class CookieBearerTokenResolverTest {
+
+  private final CookieBearerTokenResolver resolver =
+      new CookieBearerTokenResolver("ab_access_token");
+
+  @Test
+  void rejectsBlankAccessTokenCookieName() {
+    assertThatThrownBy(() -> new CookieBearerTokenResolver(" "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("accessTokenCookieName is required");
+  }
+
+  @Test
+  void resolvesAuthorizationHeaderFirst() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer header-token");
+    request.setCookies(new Cookie("ab_access_token", "cookie-token"));
+
+    assertThat(resolver.resolve(request)).isEqualTo("header-token");
+  }
+
+  @Test
+  void resolvesAccessTokenCookieWhenAuthorizationHeaderIsMissing() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(new Cookie("ab_access_token", "cookie-token"));
+
+    assertThat(resolver.resolve(request)).isEqualTo("cookie-token");
+  }
+
+  @Test
+  void rejectsAccessTokenQueryParameter() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setParameter("accessToken", "query-token");
+
+    assertThat(resolver.resolve(request)).isNull();
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/AuthSessionCookieManagerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/AuthSessionCookieManagerTest.java
@@ -1,0 +1,32 @@
+package com.aquilabank.global.web.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.global.security.SecurityAuthCookieProperties;
+import com.aquilabank.global.security.SecurityJwtProperties;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class AuthSessionCookieManagerTest {
+
+  private final AuthSessionCookieManager manager =
+      new AuthSessionCookieManager(
+          new SecurityJwtProperties("secret", "issuer", 900L, 1_209_600L, "ab_refresh_device"),
+          new SecurityAuthCookieProperties("ab_access_token", "ab_refresh_token", false));
+
+  @Test
+  void returnsNullWhenRefreshCookieJarIsMissing() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+
+    assertThat(manager.resolveRefreshToken(request)).isNull();
+  }
+
+  @Test
+  void returnsNullWhenRefreshCookieIsMissing() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(new Cookie("other_cookie", "refresh-token"));
+
+    assertThat(manager.resolveRefreshToken(request)).isNull();
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerBackupCodeChallengeTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerBackupCodeChallengeTest.java
@@ -24,6 +24,7 @@ import com.aquilabank.domain.auth.usecase.TotpChallengeVerifyUseCase;
 import com.aquilabank.domain.auth.usecase.TotpDisableUseCase;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
 import com.aquilabank.global.security.LoginThrottleGuard;
+import com.aquilabank.global.security.SecurityAuthCookieProperties;
 import com.aquilabank.global.security.SecurityJwtProperties;
 import com.aquilabank.global.security.SecurityRememberDeviceProperties;
 import com.aquilabank.global.web.ApiExceptionHandler;
@@ -65,7 +66,12 @@ class LoginControllerBackupCodeChallengeTest {
                         new SecurityRememberDeviceProperties("ab_mfa_remember_device", 2_592_000L)),
                     new RefreshDeviceBindingCookieManager(
                         new SecurityJwtProperties(
-                            "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device"))))
+                            "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device")),
+                    new AuthSessionCookieManager(
+                        new SecurityJwtProperties(
+                            "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device"),
+                        new SecurityAuthCookieProperties(
+                            "ab_access_token", "ab_refresh_token", false))))
             .setControllerAdvice(new ApiExceptionHandler())
             .build();
   }

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerBackupCodeTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerBackupCodeTest.java
@@ -25,6 +25,7 @@ import com.aquilabank.domain.auth.usecase.TotpDisableUseCase;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.security.LoginThrottleGuard;
+import com.aquilabank.global.security.SecurityAuthCookieProperties;
 import com.aquilabank.global.security.SecurityJwtProperties;
 import com.aquilabank.global.security.SecurityRememberDeviceProperties;
 import com.aquilabank.global.web.ApiExceptionHandler;
@@ -70,7 +71,12 @@ class LoginControllerBackupCodeTest {
                         new SecurityRememberDeviceProperties("ab_mfa_remember_device", 2_592_000L)),
                     new RefreshDeviceBindingCookieManager(
                         new SecurityJwtProperties(
-                            "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device"))))
+                            "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device")),
+                    new AuthSessionCookieManager(
+                        new SecurityJwtProperties(
+                            "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device"),
+                        new SecurityAuthCookieProperties(
+                            "ab_access_token", "ab_refresh_token", false))))
             .setControllerAdvice(new ApiExceptionHandler())
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .build();

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerRefreshDeviceBindingTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerRefreshDeviceBindingTest.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.web.auth;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -31,6 +32,7 @@ import com.aquilabank.domain.auth.usecase.TotpDisableUseCase;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.security.LoginThrottleGuard;
+import com.aquilabank.global.security.SecurityAuthCookieProperties;
 import com.aquilabank.global.security.SecurityJwtProperties;
 import com.aquilabank.global.security.SecurityRememberDeviceProperties;
 import com.aquilabank.global.web.ApiExceptionHandler;
@@ -50,6 +52,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class LoginControllerRefreshDeviceBindingTest {
 
   private static final String COOKIE_NAME = "ab_refresh_device";
+  private static final String ACCESS_COOKIE_NAME = "ab_access_token";
+  private static final String REFRESH_COOKIE_NAME = "ab_refresh_token";
 
   private LoginUseCase loginUseCase;
   private RefreshTokenUseCase refreshTokenUseCase;
@@ -97,7 +101,12 @@ class LoginControllerRefreshDeviceBindingTest {
                         new SecurityRememberDeviceProperties("ab_mfa_remember_device", 2_592_000L)),
                     new RefreshDeviceBindingCookieManager(
                         new SecurityJwtProperties(
-                            "secret", "issuer", 900L, 1_209_600L, COOKIE_NAME))))
+                            "secret", "issuer", 900L, 1_209_600L, COOKIE_NAME)),
+                    new AuthSessionCookieManager(
+                        new SecurityJwtProperties(
+                            "secret", "issuer", 900L, 1_209_600L, COOKIE_NAME),
+                        new SecurityAuthCookieProperties(
+                            ACCESS_COOKIE_NAME, REFRESH_COOKIE_NAME, false))))
             .setControllerAdvice(new ApiExceptionHandler())
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .build();
@@ -141,9 +150,18 @@ class LoginControllerRefreshDeviceBindingTest {
         .andExpect(jsonPath("$.status").value("SUCCESS"))
         .andExpect(
             header()
-                .string(
+                .stringValues(
                     "Set-Cookie",
-                    org.hamcrest.Matchers.containsString(COOKIE_NAME + "=binding-token")));
+                    org.hamcrest.Matchers.hasItems(
+                        org.hamcrest.Matchers.containsString(COOKIE_NAME + "=binding-token"),
+                        org.hamcrest.Matchers.allOf(
+                            org.hamcrest.Matchers.containsString(
+                                ACCESS_COOKIE_NAME + "=access-token"),
+                            org.hamcrest.Matchers.containsString("HttpOnly")),
+                        org.hamcrest.Matchers.allOf(
+                            org.hamcrest.Matchers.containsString(
+                                REFRESH_COOKIE_NAME + "=refresh-token"),
+                            org.hamcrest.Matchers.containsString("HttpOnly")))));
   }
 
   @Test
@@ -179,9 +197,13 @@ class LoginControllerRefreshDeviceBindingTest {
         .andExpect(jsonPath("$.status").value("SUCCESS"))
         .andExpect(
             header()
-                .string(
+                .stringValues(
                     "Set-Cookie",
-                    org.hamcrest.Matchers.containsString(COOKIE_NAME + "=binding-token")));
+                    org.hamcrest.Matchers.hasItems(
+                        org.hamcrest.Matchers.containsString(COOKIE_NAME + "=binding-token"),
+                        org.hamcrest.Matchers.containsString(ACCESS_COOKIE_NAME + "=access-token"),
+                        org.hamcrest.Matchers.containsString(
+                            REFRESH_COOKIE_NAME + "=refresh-token"))));
   }
 
   @Test
@@ -217,9 +239,42 @@ class LoginControllerRefreshDeviceBindingTest {
         .andExpect(jsonPath("$.status").value("SUCCESS"))
         .andExpect(
             header()
-                .string(
+                .stringValues(
                     "Set-Cookie",
-                    org.hamcrest.Matchers.containsString(COOKIE_NAME + "=next-binding-token")));
+                    org.hamcrest.Matchers.hasItems(
+                        org.hamcrest.Matchers.containsString(COOKIE_NAME + "=next-binding-token"),
+                        org.hamcrest.Matchers.containsString(ACCESS_COOKIE_NAME + "=access-token"),
+                        org.hamcrest.Matchers.containsString(
+                            REFRESH_COOKIE_NAME + "=next-refresh-token"))));
+  }
+
+  @Test
+  void refreshReadsRefreshTokenCookieWhenBodyOmitsRefreshToken() throws Exception {
+    when(refreshTokenUseCase.refresh(
+            argThat(
+                (RefreshTokenCommand command) ->
+                    "refresh-token".equals(command.refreshToken())
+                        && "binding-token".equals(command.refreshDeviceBindingToken()))))
+        .thenReturn(
+            LoginResult.success(
+                "access-token",
+                "next-refresh-token",
+                "Bearer",
+                Instant.parse("2026-04-20T12:00:00Z"),
+                Instant.parse("2026-05-04T11:45:00Z"),
+                7L,
+                "next-binding-token",
+                null));
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/refresh")
+                .cookie(new Cookie(COOKIE_NAME, "binding-token"))
+                .cookie(new Cookie(REFRESH_COOKIE_NAME, "refresh-token"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"));
   }
 
   @Test
@@ -229,22 +284,30 @@ class LoginControllerRefreshDeviceBindingTest {
     mockMvc
         .perform(
             post("/api/v1/auth/logout")
+                .cookie(new Cookie(REFRESH_COOKIE_NAME, "refresh-token"))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    """
-                    {
-                      "refreshToken": "refresh-token"
-                    }
-                    """))
+                .content("{}"))
         .andExpect(status().isNoContent())
         .andExpect(
             header()
                 .stringValues(
                     "Set-Cookie",
-                    org.hamcrest.Matchers.hasItem(
+                    org.hamcrest.Matchers.hasItems(
                         org.hamcrest.Matchers.allOf(
                             org.hamcrest.Matchers.containsString(COOKIE_NAME + "="),
+                            org.hamcrest.Matchers.containsString("Max-Age=0")),
+                        org.hamcrest.Matchers.allOf(
+                            org.hamcrest.Matchers.containsString(ACCESS_COOKIE_NAME + "="),
+                            org.hamcrest.Matchers.containsString("Max-Age=0")),
+                        org.hamcrest.Matchers.allOf(
+                            org.hamcrest.Matchers.containsString(REFRESH_COOKIE_NAME + "="),
                             org.hamcrest.Matchers.containsString("Max-Age=0")))));
+
+    verify(logoutUseCase)
+        .logout(
+            argThat(
+                command ->
+                    command.userId() == 7L && "refresh-token".equals(command.refreshToken())));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerRememberDeviceTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginControllerRememberDeviceTest.java
@@ -29,6 +29,7 @@ import com.aquilabank.domain.auth.usecase.TotpChallengeVerifyUseCase;
 import com.aquilabank.domain.auth.usecase.TotpDisableUseCase;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
 import com.aquilabank.global.security.LoginThrottleGuard;
+import com.aquilabank.global.security.SecurityAuthCookieProperties;
 import com.aquilabank.global.security.SecurityJwtProperties;
 import com.aquilabank.global.security.SecurityRememberDeviceProperties;
 import com.aquilabank.global.web.ApiExceptionHandler;
@@ -78,7 +79,12 @@ class LoginControllerRememberDeviceTest {
                         new SecurityRememberDeviceProperties("ab_mfa_remember_device", 2_592_000L)),
                     new RefreshDeviceBindingCookieManager(
                         new SecurityJwtProperties(
-                            "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device"))))
+                            "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device")),
+                    new AuthSessionCookieManager(
+                        new SecurityJwtProperties(
+                            "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device"),
+                        new SecurityAuthCookieProperties(
+                            "ab_access_token", "ab_refresh_token", false))))
             .setControllerAdvice(new ApiExceptionHandler())
             .build();
   }
@@ -118,10 +124,11 @@ class LoginControllerRememberDeviceTest {
         .andExpect(jsonPath("$.status").value("SUCCESS"))
         .andExpect(
             header()
-                .string(
+                .stringValues(
                     "Set-Cookie",
-                    org.hamcrest.Matchers.containsString(
-                        "ab_mfa_remember_device=next-remember-device-token")));
+                    org.hamcrest.Matchers.hasItem(
+                        org.hamcrest.Matchers.containsString(
+                            "ab_mfa_remember_device=next-remember-device-token"))));
   }
 
   @Test
@@ -184,9 +191,10 @@ class LoginControllerRememberDeviceTest {
         .andExpect(jsonPath("$.status").value("SUCCESS"))
         .andExpect(
             header()
-                .string(
+                .stringValues(
                     "Set-Cookie",
-                    org.hamcrest.Matchers.containsString(
-                        "ab_mfa_remember_device=remember-device-token")));
+                    org.hamcrest.Matchers.hasItem(
+                        org.hamcrest.Matchers.containsString(
+                            "ab_mfa_remember_device=remember-device-token"))));
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/auth/OidcLoginAuthenticationSuccessHandlerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/OidcLoginAuthenticationSuccessHandlerTest.java
@@ -10,6 +10,7 @@ import com.aquilabank.domain.auth.model.AuthSessionClientMetadata;
 import com.aquilabank.domain.auth.model.ExternalOidcLoginCommand;
 import com.aquilabank.domain.auth.model.LoginResult;
 import com.aquilabank.domain.auth.usecase.ExternalOidcLoginUseCase;
+import com.aquilabank.global.security.SecurityAuthCookieProperties;
 import com.aquilabank.global.security.SecurityJwtProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,6 +43,10 @@ class OidcLoginAuthenticationSuccessHandlerTest {
             externalOidcLoginUseCase,
             authSessionMetadataResolver,
             refreshDeviceBindingCookieManager,
+            new AuthSessionCookieManager(
+                new SecurityJwtProperties(
+                    "secret", "issuer", 900L, 1_209_600L, "ab_refresh_device"),
+                new SecurityAuthCookieProperties("ab_access_token", "ab_refresh_token", false)),
             OBJECT_MAPPER);
     AuthSessionClientMetadata metadata =
         new AuthSessionClientMetadata("macOS / Safari", "203.0.113.20");
@@ -75,7 +80,10 @@ class OidcLoginAuthenticationSuccessHandlerTest {
     assertThat(body.get("status").asText()).isEqualTo("SUCCESS");
     assertThat(body.get("accessToken").asText()).isEqualTo("access-token");
     assertThat(body.get("refreshToken").asText()).isEqualTo("refresh-token");
-    assertThat(response.getHeader("Set-Cookie")).contains("ab_refresh_device=binding-token");
+    assertThat(response.getHeaders("Set-Cookie"))
+        .anySatisfy(cookie -> assertThat(cookie).contains("ab_access_token=access-token"))
+        .anySatisfy(cookie -> assertThat(cookie).contains("ab_refresh_token=refresh-token"))
+        .anySatisfy(cookie -> assertThat(cookie).contains("ab_refresh_device=binding-token"));
     verify(externalOidcLoginUseCase)
         .login(
             argThat(

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -8,7 +8,7 @@ import { TransactionsSection } from "@/components/customer-banking/sections/tran
 import { TransferSection } from "@/components/customer-banking/sections/transfer-section";
 import { useCustomerBanking } from "@/hooks/use-customer-banking";
 import { mainMenus, quickMenus } from "@/lib/customer-banking/constants";
-import { formatDateTime, maskToken } from "@/lib/customer-banking/format";
+import { formatDateTime } from "@/lib/customer-banking/format";
 
 export default function HomePage() {
   const {
@@ -318,8 +318,8 @@ export default function HomePage() {
                   <dd>{session.userId ?? "-"}</dd>
                 </div>
                 <div>
-                  <dt>Access Token</dt>
-                  <dd>{maskToken(session.accessToken)}</dd>
+                  <dt>세션 방식</dt>
+                  <dd>{session.tokenType}</dd>
                 </div>
                 <div>
                   <dt>만료</dt>

--- a/front/src/components/customer-banking/sections/security-section.tsx
+++ b/front/src/components/customer-banking/sections/security-section.tsx
@@ -1,6 +1,6 @@
 import type { FormEvent } from 'react';
 import type { AuthSessionItem, BackupCodeIssueResponse, CustomerSession, LoginResponse, PasswordRecoveryRequestResult, TotpEnrollmentStartResponse } from '@/lib/api/types';
-import { formatDateTime, maskToken } from '@/lib/customer-banking/format';
+import { formatDateTime } from '@/lib/customer-banking/format';
 
 export function SecuritySection(props: {
   backupChallengeForm: {
@@ -132,8 +132,8 @@ export function SecuritySection(props: {
               <dd>{props.session?.userId ?? "-"}</dd>
             </div>
             <div>
-              <dt>Access Token</dt>
-              <dd>{props.session ? maskToken(props.session.accessToken) : "-"}</dd>
+              <dt>세션 방식</dt>
+              <dd>{props.session?.tokenType ?? "-"}</dd>
             </div>
             <div>
               <dt>Refresh 만료</dt>

--- a/front/src/hooks/use-customer-banking.ts
+++ b/front/src/hooks/use-customer-banking.ts
@@ -1,7 +1,7 @@
 import type { FormEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AquilaBankApiClient } from '@/lib/api/client';
-import { clearCustomerSession, loadCustomerSession, saveCustomerSession, toCustomerSession } from '@/lib/api/session';
+import { clearCustomerSession, toCustomerSession } from '@/lib/api/session';
 import type { AccountItem, AccountSummaryResponse, AuthSessionItem, BackupCodeIssueResponse, CustomerSession, LoginResponse, NotificationItem, NotificationPreferenceItem, NotificationQueryResponse, PasswordRecoveryRequestResult, TransactionDetailResponse, TransactionItem, TransactionQueryResponse, TotpEnrollmentStartResponse, TransferResponse, TransferReversalResponse } from '@/lib/api/types';
 import { formatMinorAmount, toErrorMessage, toIsoDateTime, toLocalInputValue, toOptionalNumber } from '@/lib/customer-banking/format';
 import type { AlertMessage, MenuSection } from '@/lib/customer-banking/types';
@@ -115,17 +115,6 @@ export function useCustomerBanking() {
   const eventSourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
-    const storedSession = loadCustomerSession();
-    if (storedSession) {
-      setSession(storedSession);
-      setAlert({
-        type: "success",
-        text: "저장된 세션을 불러왔습니다.",
-      });
-    }
-  }, []);
-
-  useEffect(() => {
     return () => {
       eventSourceRef.current?.close();
     };
@@ -145,12 +134,11 @@ export function useCustomerBanking() {
     if (!nextSession) {
       setAlert({
         type: "error",
-        text: "로그인 응답에 accessToken 또는 refreshToken이 없습니다.",
+        text: "로그인 세션을 생성하지 못했습니다.",
       });
       return;
     }
 
-    saveCustomerSession(nextSession);
     setSession(nextSession);
     setChallenge(null);
     setAlert({
@@ -219,26 +207,21 @@ export function useCustomerBanking() {
   }
 
   async function handleRefresh() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("토큰 재발급", async () => {
-      const result = await api.refresh({ refreshToken: currentSession.refreshToken });
+      const result = await api.refresh();
       applyLoginResult(result);
     });
   }
 
   async function handleLogout() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("로그아웃", async () => {
-      await api.logout(
-        { refreshToken: currentSession.refreshToken },
-        currentSession.accessToken,
-      );
+      await api.logout();
       clearCustomerSession();
       setSession(null);
       setSessions([]);
@@ -273,12 +256,11 @@ export function useCustomerBanking() {
 
   async function handlePasswordReset(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("비밀번호 변경", async () => {
-      await api.resetPassword(passwordResetForm, currentSession.accessToken);
+      await api.resetPassword(passwordResetForm);
       clearCustomerSession();
       setSession(null);
       setAlert({
@@ -289,36 +271,33 @@ export function useCustomerBanking() {
   }
 
   async function handleLoadSessions() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("세션 조회", async () => {
-      const result = await api.getSessions(currentSession.accessToken);
+      const result = await api.getSessions();
       setSessions(result.items);
       setAlert({ type: "success", text: "세션 목록을 불러왔습니다." });
     });
   }
 
   async function handleRevokeSession(sessionId: number) {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("세션 해지", async () => {
-      await api.revokeSession(sessionId, currentSession.accessToken);
+      await api.revokeSession(sessionId);
       setSessions((items) => items.filter((item) => item.sessionId !== sessionId));
       setAlert({ type: "success", text: "선택한 세션을 해지했습니다." });
     });
   }
 
   async function handleRevokeAllSessions() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("전체 세션 해지", async () => {
-      await api.revokeAllSessions(currentSession.accessToken);
+      await api.revokeAllSessions();
       clearCustomerSession();
       setSession(null);
       setSessions([]);
@@ -327,38 +306,32 @@ export function useCustomerBanking() {
   }
 
   async function handleStartTotpEnrollment() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("TOTP 등록 시작", async () => {
-      const result = await api.startTotpEnrollment(currentSession.accessToken);
+      const result = await api.startTotpEnrollment();
       setTotpEnrollment(result);
       setAlert({ type: "success", text: "TOTP 등록 정보가 발급되었습니다." });
     });
   }
 
   async function handleVerifyTotpEnrollment() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("TOTP 등록 확인", async () => {
-      const result = await api.verifyTotpEnrollment(
-        { totpCode },
-        currentSession.accessToken,
-      );
+      const result = await api.verifyTotpEnrollment({ totpCode });
       setAlert({ type: "success", text: `TOTP 상태: ${result.status}` });
     });
   }
 
   async function handleDisableTotp() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("TOTP 해지", async () => {
-      await api.disableTotp({ totpCode }, currentSession.accessToken);
+      await api.disableTotp({ totpCode });
       clearCustomerSession();
       setSession(null);
       setAlert({ type: "success", text: "TOTP가 해지되었습니다." });
@@ -366,27 +339,22 @@ export function useCustomerBanking() {
   }
 
   async function handleIssueBackupCodes() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("Backup code 발급", async () => {
-      const result = await api.issueBackupCodes(
-        { totpCode },
-        currentSession.accessToken,
-      );
+      const result = await api.issueBackupCodes({ totpCode });
       setBackupCodes(result);
       setAlert({ type: "success", text: "Backup code가 발급되었습니다." });
     });
   }
 
   async function handleLoadAccounts(cursor = "", append = false) {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("계좌 조회", async () => {
-      const result = await api.getAccounts(currentSession.accessToken, {
+      const result = await api.getAccounts({
         limit: accountLimit,
         cursor,
       });
@@ -408,12 +376,11 @@ export function useCustomerBanking() {
   }
 
   async function handleLoadAccountDetail(accountId: number) {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("계좌 상세 조회", async () => {
-      const result = await api.getAccount(accountId, currentSession.accessToken);
+      const result = await api.getAccount(accountId);
       setSelectedAccount(result);
       setTransferForm((form) => ({
         ...form,
@@ -429,8 +396,7 @@ export function useCustomerBanking() {
 
   async function handleTransfer(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("이체", async () => {
@@ -442,7 +408,6 @@ export function useCustomerBanking() {
           currencyCode: transferForm.currencyCode,
           summary: transferForm.summary,
         },
-        currentSession.accessToken,
       );
       setTransferResult(result);
       setAlert({
@@ -454,8 +419,7 @@ export function useCustomerBanking() {
 
   async function handleReversal(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("이체 취소", async () => {
@@ -467,7 +431,6 @@ export function useCustomerBanking() {
           reversalReason: reversalForm.reversalReason,
           summary: reversalForm.summary,
         },
-        currentSession.accessToken,
       );
       setReversalResult(result);
       setAlert({
@@ -482,8 +445,7 @@ export function useCustomerBanking() {
     cursor = "",
     append = false,
   ) {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("거래내역 조회", async () => {
@@ -502,8 +464,8 @@ export function useCustomerBanking() {
       };
       const result =
         mode === "archive"
-          ? await api.getArchivedTransactions(params, currentSession.accessToken)
-          : await api.getTransactions(params, currentSession.accessToken);
+          ? await api.getArchivedTransactions(params)
+          : await api.getTransactions(params);
       setTransactionMode(mode);
       setTransactionSlice(result);
       setTransactions((items) => (append ? [...items, ...result.items] : result.items));
@@ -516,8 +478,7 @@ export function useCustomerBanking() {
   }
 
   async function handleLoadTransactionDetail(transactionReference: string) {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     const accountId = Number(transactionFilters.accountId || selectedAccount?.accountId);
@@ -529,7 +490,6 @@ export function useCustomerBanking() {
       const result = await api.getTransactionDetail(
         transactionReference,
         accountId,
-        currentSession.accessToken,
       );
       setTransactionDetail(result);
       setAlert({ type: "success", text: "거래 상세를 불러왔습니다." });
@@ -541,8 +501,7 @@ export function useCustomerBanking() {
     cursor = "",
     append = false,
   ) {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("알림 조회", async () => {
@@ -560,9 +519,8 @@ export function useCustomerBanking() {
                 from: toIsoDateTime(notificationFilters.from),
                 to: toIsoDateTime(notificationFilters.to),
               },
-              currentSession.accessToken,
             )
-          : await api.getNotifications(commonParams, currentSession.accessToken);
+          : await api.getNotifications(commonParams);
       setNotificationMode(mode);
       setNotificationSlice(result);
       setNotifications((items) => (append ? [...items, ...result.items] : result.items));
@@ -576,36 +534,33 @@ export function useCustomerBanking() {
   }
 
   async function handleLoadUnreadCount() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("미확인 알림 조회", async () => {
-      const result = await api.getUnreadCount(currentSession.accessToken);
+      const result = await api.getUnreadCount();
       setUnreadCount(result.unreadCount);
       setAlert({ type: "success", text: "미확인 알림 수를 불러왔습니다." });
     });
   }
 
   async function handleLoadPreferences() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("알림 설정 조회", async () => {
-      const result = await api.getNotificationPreferences(currentSession.accessToken);
+      const result = await api.getNotificationPreferences();
       setPreferences(result.items);
       setAlert({ type: "success", text: "알림 설정을 불러왔습니다." });
     });
   }
 
   async function handleUpdatePreferences() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     await runAction("알림 설정 저장", async () => {
-      await api.updateNotificationPreferences({ items: preferences }, currentSession.accessToken);
+      await api.updateNotificationPreferences({ items: preferences });
       setAlert({ type: "success", text: "알림 설정을 저장했습니다." });
     });
   }
@@ -622,8 +577,7 @@ export function useCustomerBanking() {
     action: "read" | "archive" | "delete",
     notificationId?: number,
   ) {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     const notificationIds =
@@ -634,13 +588,13 @@ export function useCustomerBanking() {
     }
     await runAction("알림 처리", async () => {
       if (action === "read" && notificationId !== undefined) {
-        await api.markNotificationAsRead(notificationId, currentSession.accessToken);
+        await api.markNotificationAsRead(notificationId);
       } else if (action === "read") {
-        await api.markNotificationsAsRead({ notificationIds }, currentSession.accessToken);
+        await api.markNotificationsAsRead({ notificationIds });
       } else if (action === "archive") {
-        await api.archiveNotifications({ notificationIds }, currentSession.accessToken);
+        await api.archiveNotifications({ notificationIds });
       } else {
-        await api.deleteNotifications({ notificationIds }, currentSession.accessToken);
+        await api.deleteNotifications({ notificationIds });
       }
       setNotifications((items) =>
         action === "delete" || action === "archive"
@@ -657,15 +611,12 @@ export function useCustomerBanking() {
   }
 
   function handleConnectNotifications() {
-    const currentSession = requireSession();
-    if (!currentSession) {
+    if (!requireSession()) {
       return;
     }
     try {
       eventSourceRef.current?.close();
-      const eventSource = new EventSource(
-        api.streamUrl("/api/v1/notifications/stream", currentSession.accessToken),
-      );
+      const eventSource = new EventSource(api.streamUrl("/api/v1/notifications/stream"));
       eventSourceRef.current = eventSource;
       setSseStatus({
         state: "connecting",

--- a/front/src/lib/api/client.ts
+++ b/front/src/lib/api/client.ts
@@ -6,7 +6,6 @@ import type {
   BackupCodeIssueResponse,
   LoginRequest,
   LoginResponse,
-  LogoutRequest,
   NotificationBulkActionRequest,
   NotificationPreferenceResponse,
   NotificationPreferenceUpdateRequest,
@@ -19,7 +18,6 @@ import type {
   PasswordRecoveryRequest,
   PasswordRecoveryRequestResult,
   PasswordResetRequest,
-  RefreshRequest,
   TotpChallengeVerifyRequest,
   TotpCodeRequest,
   TotpEnrollmentStartResponse,
@@ -36,7 +34,6 @@ import type {
 type RequestOptions = {
   method?: "GET" | "POST" | "DELETE";
   body?: unknown;
-  accessToken?: string;
   headers?: Record<string, string>;
 };
 
@@ -91,10 +88,6 @@ function defaultHeaders(options: RequestOptions): HeadersInit {
     headers["Content-Type"] = "application/json";
   }
 
-  if (options.accessToken) {
-    headers.Authorization = `Bearer ${options.accessToken}`;
-  }
-
   return headers;
 }
 
@@ -119,16 +112,12 @@ export function createIdempotencyKey(prefix = "web"): string {
 export class AquilaBankApiClient {
   constructor(private readonly baseUrl = resolveApiBaseUrl()) {}
 
-  streamUrl(path: string, accessToken?: string): string {
+  streamUrl(path: string): string {
     if (!this.baseUrl) {
       throw new ApiConfigurationError();
     }
 
     const url = new URL(`${this.baseUrl}${path}`);
-    if (accessToken) {
-      // EventSource는 custom header를 지원하지 않아 MVP에서는 query fallback으로 제한합니다.
-      url.searchParams.set("accessToken", accessToken);
-    }
     return url.toString();
   }
 
@@ -187,83 +176,71 @@ export class AquilaBankApiClient {
     });
   }
 
-  startTotpEnrollment(accessToken: string): Promise<TotpEnrollmentStartResponse> {
+  startTotpEnrollment(): Promise<TotpEnrollmentStartResponse> {
     return this.request("/api/v1/auth/mfa/totp/enroll", {
       method: "POST",
-      accessToken,
     });
   }
 
   verifyTotpEnrollment(
     request: TotpCodeRequest,
-    accessToken: string,
   ): Promise<TotpEnrollmentVerifyResponse> {
     return this.request("/api/v1/auth/mfa/totp/enroll/verify", {
       method: "POST",
       body: request,
-      accessToken,
     });
   }
 
-  disableTotp(request: TotpCodeRequest, accessToken: string): Promise<void> {
+  disableTotp(request: TotpCodeRequest): Promise<void> {
     return this.request("/api/v1/auth/mfa/totp/disable", {
       method: "POST",
       body: request,
-      accessToken,
     });
   }
 
   issueBackupCodes(
     request: TotpCodeRequest,
-    accessToken: string,
   ): Promise<BackupCodeIssueResponse> {
     return this.request("/api/v1/auth/mfa/backup-codes", {
       method: "POST",
       body: request,
-      accessToken,
     });
   }
 
-  getSessions(accessToken: string, size = 20): Promise<AuthSessionListResponse> {
-    return this.request(appendSearchParams("/api/v1/auth/sessions", { size }), {
-      accessToken,
-    });
+  getSessions(size = 20): Promise<AuthSessionListResponse> {
+    return this.request(appendSearchParams("/api/v1/auth/sessions", { size }));
   }
 
-  revokeSession(sessionId: number, accessToken: string): Promise<void> {
+  revokeSession(sessionId: number): Promise<void> {
     return this.request(`/api/v1/auth/sessions/${sessionId}`, {
       method: "DELETE",
-      accessToken,
     });
   }
 
-  revokeAllSessions(accessToken: string): Promise<void> {
+  revokeAllSessions(): Promise<void> {
     return this.request("/api/v1/auth/sessions", {
       method: "DELETE",
-      accessToken,
     });
   }
 
-  refresh(request: RefreshRequest): Promise<LoginResponse> {
+  refresh(): Promise<LoginResponse> {
     return this.request("/api/v1/auth/refresh", {
       method: "POST",
-      body: request,
+      body: {},
     });
   }
 
-  logout(request: LogoutRequest, accessToken: string): Promise<void> {
+  logout(): Promise<void> {
     return this.request("/api/v1/auth/logout", {
       method: "POST",
-      body: request,
-      accessToken,
+      body: {},
     });
   }
 
-  resetPassword(request: PasswordResetRequest, accessToken: string): Promise<void> {
+  resetPassword(request: PasswordResetRequest): Promise<void> {
     return this.request("/api/v1/auth/password-reset", {
       method: "POST",
       body: request,
-      accessToken,
     });
   }
 
@@ -290,27 +267,22 @@ export class AquilaBankApiClient {
   }
 
   getAccounts(
-    accessToken: string,
     params: { limit?: number; cursor?: string } = {},
   ): Promise<AccountListResponse> {
-    return this.request(appendSearchParams("/api/v1/accounts", params), {
-      accessToken,
-    });
+    return this.request(appendSearchParams("/api/v1/accounts", params));
   }
 
-  getAccount(accountId: number, accessToken: string): Promise<AccountSummaryResponse> {
-    return this.request(`/api/v1/accounts/${accountId}`, { accessToken });
+  getAccount(accountId: number): Promise<AccountSummaryResponse> {
+    return this.request(`/api/v1/accounts/${accountId}`);
   }
 
   transfer(
     request: TransferRequest,
-    accessToken: string,
     idempotencyKey = createIdempotencyKey("transfer"),
   ): Promise<TransferResponse> {
     return this.request("/api/v1/transfers", {
       method: "POST",
       body: request,
-      accessToken,
       headers: { "Idempotency-Key": idempotencyKey },
     });
   }
@@ -318,122 +290,85 @@ export class AquilaBankApiClient {
   reverseTransfer(
     transactionReference: string,
     request: TransferReversalRequest,
-    accessToken: string,
     idempotencyKey = createIdempotencyKey("reversal"),
   ): Promise<TransferReversalResponse> {
     return this.request(`/api/v1/transfers/${transactionReference}/reversal`, {
       method: "POST",
       body: request,
-      accessToken,
       headers: { "Idempotency-Key": idempotencyKey },
     });
   }
 
-  getTransactions(
-    params: TransactionQueryParams,
-    accessToken: string,
-  ): Promise<TransactionQueryResponse> {
-    return this.request(appendSearchParams("/api/v1/transactions", params), {
-      accessToken,
-    });
+  getTransactions(params: TransactionQueryParams): Promise<TransactionQueryResponse> {
+    return this.request(appendSearchParams("/api/v1/transactions", params));
   }
 
   getArchivedTransactions(
     params: TransactionQueryParams,
-    accessToken: string,
   ): Promise<TransactionQueryResponse> {
-    return this.request(appendSearchParams("/api/v1/transactions/archive", params), {
-      accessToken,
-    });
+    return this.request(appendSearchParams("/api/v1/transactions/archive", params));
   }
 
   getTransactionDetail(
     transactionReference: string,
     accountId: number,
-    accessToken: string,
   ): Promise<TransactionDetailResponse> {
     return this.request(
       appendSearchParams(`/api/v1/transactions/${transactionReference}`, { accountId }),
-      { accessToken },
     );
   }
 
-  getNotifications(
-    params: NotificationQueryParams,
-    accessToken: string,
-  ): Promise<NotificationQueryResponse> {
-    return this.request(appendSearchParams("/api/v1/notifications", params), {
-      accessToken,
-    });
+  getNotifications(params: NotificationQueryParams): Promise<NotificationQueryResponse> {
+    return this.request(appendSearchParams("/api/v1/notifications", params));
   }
 
   searchNotifications(
     params: NotificationSearchParams,
-    accessToken: string,
   ): Promise<NotificationSearchResponse> {
-    return this.request(appendSearchParams("/api/v1/notifications/search", params), {
-      accessToken,
-    });
+    return this.request(appendSearchParams("/api/v1/notifications/search", params));
   }
 
-  getUnreadCount(accessToken: string): Promise<NotificationUnreadCountResponse> {
-    return this.request("/api/v1/notifications/unread-count", { accessToken });
+  getUnreadCount(): Promise<NotificationUnreadCountResponse> {
+    return this.request("/api/v1/notifications/unread-count");
   }
 
-  getNotificationPreferences(
-    accessToken: string,
-  ): Promise<NotificationPreferenceResponse> {
-    return this.request("/api/v1/notifications/preferences", { accessToken });
+  getNotificationPreferences(): Promise<NotificationPreferenceResponse> {
+    return this.request("/api/v1/notifications/preferences");
   }
 
   updateNotificationPreferences(
     request: NotificationPreferenceUpdateRequest,
-    accessToken: string,
   ): Promise<void> {
     return this.request("/api/v1/notifications/preferences", {
       method: "POST",
       body: request,
-      accessToken,
     });
   }
 
-  markNotificationAsRead(notificationId: number, accessToken: string): Promise<void> {
+  markNotificationAsRead(notificationId: number): Promise<void> {
     return this.request(`/api/v1/notifications/${notificationId}/read`, {
       method: "POST",
-      accessToken,
     });
   }
 
-  markNotificationsAsRead(
-    request: NotificationBulkActionRequest,
-    accessToken: string,
-  ): Promise<void> {
+  markNotificationsAsRead(request: NotificationBulkActionRequest): Promise<void> {
     return this.request("/api/v1/notifications/read", {
       method: "POST",
       body: request,
-      accessToken,
     });
   }
 
-  archiveNotifications(
-    request: NotificationBulkActionRequest,
-    accessToken: string,
-  ): Promise<void> {
+  archiveNotifications(request: NotificationBulkActionRequest): Promise<void> {
     return this.request("/api/v1/notifications/archive", {
       method: "POST",
       body: request,
-      accessToken,
     });
   }
 
-  deleteNotifications(
-    request: NotificationBulkActionRequest,
-    accessToken: string,
-  ): Promise<void> {
+  deleteNotifications(request: NotificationBulkActionRequest): Promise<void> {
     return this.request("/api/v1/notifications/delete", {
       method: "POST",
       body: request,
-      accessToken,
     });
   }
 }

--- a/front/src/lib/api/session.ts
+++ b/front/src/lib/api/session.ts
@@ -1,19 +1,11 @@
 import type { CustomerSession, LoginResponse } from "./types";
 
-const STORAGE_KEY = "aquila-bank.customer-session";
-
-function canUseStorage(): boolean {
-  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
-}
-
 export function toCustomerSession(result: LoginResponse): CustomerSession | null {
-  if (!result.accessToken || !result.refreshToken) {
+  if (result.status !== "SUCCESS") {
     return null;
   }
 
   return {
-    accessToken: result.accessToken,
-    refreshToken: result.refreshToken,
     tokenType: result.tokenType ?? "Bearer",
     userId: result.userId,
     expiresAt: result.expiresAt,
@@ -22,35 +14,11 @@ export function toCustomerSession(result: LoginResponse): CustomerSession | null
 }
 
 export function loadCustomerSession(): CustomerSession | null {
-  if (!canUseStorage()) {
-    return null;
-  }
-
-  const rawValue = window.localStorage.getItem(STORAGE_KEY);
-  if (!rawValue) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(rawValue) as CustomerSession;
-  } catch {
-    window.localStorage.removeItem(STORAGE_KEY);
-    return null;
-  }
+  return null;
 }
 
 export function saveCustomerSession(session: CustomerSession): void {
-  if (!canUseStorage()) {
-    return;
-  }
-
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+  void session;
 }
 
-export function clearCustomerSession(): void {
-  if (!canUseStorage()) {
-    return;
-  }
-
-  window.localStorage.removeItem(STORAGE_KEY);
-}
+export function clearCustomerSession(): void {}

--- a/front/src/lib/api/types.ts
+++ b/front/src/lib/api/types.ts
@@ -84,11 +84,11 @@ export type AuthSessionListResponse = {
 };
 
 export type RefreshRequest = {
-  refreshToken: string;
+  refreshToken?: string;
 };
 
 export type LogoutRequest = {
-  refreshToken: string;
+  refreshToken?: string;
 };
 
 export type PasswordResetRequest = {
@@ -299,8 +299,6 @@ export type NotificationPreferenceUpdateRequest = {
 };
 
 export type CustomerSession = {
-  accessToken: string;
-  refreshToken: string;
   tokenType: string;
   userId: Nullable<number>;
   expiresAt: Nullable<string>;

--- a/ops/deploy/oci/bluegreen-deploy.sh
+++ b/ops/deploy/oci/bluegreen-deploy.sh
@@ -807,6 +807,10 @@ events {
 
 http {
   limit_req_status 429;
+  server_tokens off;
+  client_header_timeout 10s;
+  client_body_timeout 10s;
+  send_timeout 30s;
   # upstream latency와 edge limit 결과를 같은 JSON line에 남겨 429 원인을 분리합니다.
   log_format aquila_bank_upstream escape=json
     '{'
@@ -839,6 +843,8 @@ ${real_ip_trusted_proxy_lines}
   limit_req_zone \$binary_remote_addr zone=aquila_bank_api_per_ip:10m rate=30r/s;
   # 공개 auth 진입점은 token/bcrypt 비용 전에 더 보수적으로 edge 차단합니다.
   limit_req_zone \$binary_remote_addr zone=aquila_bank_auth_per_ip:10m rate=5r/s;
+  # 페이지/정적 리소스 경로도 저비용 edge queue로 bot burst를 먼저 흡수합니다.
+  limit_req_zone \$binary_remote_addr zone=aquila_bank_frontend_per_ip:10m rate=10r/s;
   # active/archive read는 arrival-16 정상 구간을 delay queue 없이 통과시키도록 headroom을 둡니다.
   limit_req_zone \$binary_remote_addr zone=aquila_bank_transaction_hot_per_ip:10m rate=${transaction_read_hot_rate_rps}r/s;
   limit_req_zone \$binary_remote_addr zone=aquila_bank_transaction_archive_per_ip:10m rate=${transaction_read_archive_rate_rps}r/s;
@@ -861,11 +867,22 @@ ${real_ip_trusted_proxy_lines}
   server {
     listen 80 default_server;
     server_name ${SERVER_NAME};
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header Referrer-Policy no-referrer always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+    add_header X-Robots-Tag "noindex, nofollow, noarchive" always;
 
     proxy_http_version 1.1;
     proxy_connect_timeout 3s;
     proxy_socket_keepalive on;
     error_page 429 = @aquila_edge_rate_limited;
+
+    location ~* ^/(?:\\.env(?:\\..*)?|\\.git(?:/|\$)|wp-login\\.php|xmlrpc\\.php|phpmyadmin(?:/|\$)|adminer(?:/|\$)|vendor/phpunit(?:/|\$)|cgi-bin(?:/|\$)) {
+      add_header X-Aquila-Reject-Source nginx-bot-guard always;
+      add_header X-Aquila-Reject-Reason scanner-path always;
+      return 404;
+    }
 
     location @aquila_edge_rate_limited {
       internal;
@@ -1072,6 +1089,7 @@ ${real_ip_trusted_proxy_lines}
       proxy_set_header X-Forwarded-Host \$host;
       proxy_set_header X-Forwarded-Port \$server_port;
       proxy_set_header Connection "";
+      limit_req zone=aquila_bank_frontend_per_ip burst=60 delay=20;
       proxy_read_timeout 60s;
       proxy_send_timeout 60s;
     }

--- a/ops/nginx/nginx.conf
+++ b/ops/nginx/nginx.conf
@@ -13,6 +13,10 @@ http {
   keepalive_timeout 65;
   client_max_body_size 1m;
   limit_req_status 429;
+  server_tokens off;
+  client_header_timeout 10s;
+  client_body_timeout 10s;
+  send_timeout 30s;
   # upstream latency와 edge limit 결과를 같은 JSON line에 남겨 429 원인을 분리합니다.
   log_format aquila_bank_upstream escape=json
     '{'
@@ -46,6 +50,8 @@ ${NGINX_REAL_IP_TRUSTED_PROXY_LINES}
   limit_req_zone $binary_remote_addr zone=aquila_bank_api_per_ip:10m rate=30r/s;
   # 공개 auth 진입점은 token/bcrypt 비용 전에 더 보수적으로 edge 차단합니다.
   limit_req_zone $binary_remote_addr zone=aquila_bank_auth_per_ip:10m rate=5r/s;
+  # 페이지/정적 리소스 경로도 저비용 edge queue로 bot burst를 먼저 흡수합니다.
+  limit_req_zone $binary_remote_addr zone=aquila_bank_frontend_per_ip:10m rate=10r/s;
   # active/archive read는 arrival-16 정상 구간을 delay queue 없이 통과시키도록 headroom을 둡니다.
   limit_req_zone $binary_remote_addr zone=aquila_bank_transaction_hot_per_ip:10m rate=${NGINX_TRANSACTION_READ_HOT_RATE_RPS}r/s;
   limit_req_zone $binary_remote_addr zone=aquila_bank_transaction_archive_per_ip:10m rate=${NGINX_TRANSACTION_READ_ARCHIVE_RATE_RPS}r/s;
@@ -74,6 +80,11 @@ ${NGINX_BACKEND_SSE_SERVER_LINES}
   server {
     listen 80 default_server;
     server_name ${NGINX_SERVER_NAME};
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header Referrer-Policy no-referrer always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+    add_header X-Robots-Tag "noindex, nofollow, noarchive" always;
 
     proxy_http_version 1.1;
     proxy_connect_timeout 3s;
@@ -83,6 +94,12 @@ ${NGINX_BACKEND_SSE_SERVER_LINES}
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $host;
+
+    location ~* ^/(?:\.env(?:\..*)?|\.git(?:/|$)|wp-login\.php|xmlrpc\.php|phpmyadmin(?:/|$)|adminer(?:/|$)|vendor/phpunit(?:/|$)|cgi-bin(?:/|$)) {
+      add_header X-Aquila-Reject-Source nginx-bot-guard always;
+      add_header X-Aquila-Reject-Reason scanner-path always;
+      return 404;
+    }
 
     # ACME challenge는 HTTP 경로가 필요해 redirect 예외로 둡니다.
     location ^~ /.well-known/acme-challenge/ {
@@ -110,6 +127,11 @@ ${NGINX_BACKEND_SSE_SERVER_LINES}
   server {
     listen 443 ssl http2;
     server_name ${NGINX_SERVER_NAME};
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header Referrer-Policy no-referrer always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+    add_header X-Robots-Tag "noindex, nofollow, noarchive" always;
 
     ssl_certificate ${NGINX_SSL_CERTIFICATE_PATH};
     ssl_certificate_key ${NGINX_SSL_CERTIFICATE_KEY_PATH};
@@ -127,6 +149,12 @@ ${NGINX_BACKEND_SSE_SERVER_LINES}
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $host;
+
+    location ~* ^/(?:\.env(?:\..*)?|\.git(?:/|$)|wp-login\.php|xmlrpc\.php|phpmyadmin(?:/|$)|adminer(?:/|$)|vendor/phpunit(?:/|$)|cgi-bin(?:/|$)) {
+      add_header X-Aquila-Reject-Source nginx-bot-guard always;
+      add_header X-Aquila-Reject-Reason scanner-path always;
+      return 404;
+    }
 
     location @aquila_edge_rate_limited {
       internal;
@@ -276,6 +304,7 @@ ${NGINX_BACKEND_SSE_SERVER_LINES}
     location / {
       proxy_pass http://aquila_bank_frontend;
       proxy_set_header Connection "";
+      limit_req zone=aquila_bank_frontend_per_ip burst=60 delay=20;
       proxy_read_timeout 60s;
       proxy_send_timeout 60s;
     }

--- a/tools/test/check-frontend-auth-cookie-contract.sh
+++ b/tools/test/check-frontend-auth-cookie-contract.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_if_found() {
+  local pattern="$1"
+  local path="$2"
+  local message="$3"
+
+  if rg -n "$pattern" "$ROOT_DIR/$path" >/tmp/aquila_front_auth_contract_match.txt; then
+    echo "[FAIL] $message" >&2
+    cat /tmp/aquila_front_auth_contract_match.txt >&2
+    exit 1
+  fi
+}
+
+fail_if_found "localStorage|sessionStorage" "front/src/lib/api/session.ts" \
+  "customer session module must not use browser storage"
+fail_if_found "accessToken\\?:" "front/src/lib/api/client.ts" \
+  "API client request options must not accept browser-readable access token"
+fail_if_found "headers\\.Authorization|Authorization =" "front/src/lib/api/client.ts" \
+  "API client must not attach Authorization from browser state"
+fail_if_found "searchParams\\.set\\(\"accessToken\"" "front/src/lib/api/client.ts" \
+  "SSE stream URL must not append accessToken query parameter"
+fail_if_found "currentSession\\.(accessToken|refreshToken)|session\\.accessToken" "front/src" \
+  "customer frontend must not read token fields from CustomerSession"
+fail_if_found "accessToken: string;|refreshToken: string;" "front/src/lib/api/types.ts" \
+  "CustomerSession must not expose token fields"
+
+echo "[OK] frontend auth cookie contract"

--- a/tools/test/check-nginx-sse-proxy.sh
+++ b/tools/test/check-nginx-sse-proxy.sh
@@ -23,8 +23,17 @@ if [[ ! -f "$runtime_gate_path" ]]; then
   exit 1
 fi
 
+deploy_path="ops/deploy/oci/bluegreen-deploy.sh"
+if [[ ! -f "$deploy_path" ]]; then
+  echo "[nginx-sse-check] missing deploy renderer: $deploy_path" >&2
+  exit 1
+fi
+
 required_patterns=(
   "limit_req_status 429;"
+  "server_tokens off;"
+  "client_header_timeout 10s;"
+  "client_body_timeout 10s;"
   "log_format aquila_bank_upstream escape=json"
   '"status":$status'
   '"realip_remote_addr":"$realip_remote_addr"'
@@ -46,6 +55,7 @@ required_patterns=(
   "real_ip_recursive on;"
   "limit_req_zone \$binary_remote_addr zone=aquila_bank_api_per_ip:10m rate=30r/s;"
   "limit_req_zone \$binary_remote_addr zone=aquila_bank_auth_per_ip:10m rate=5r/s;"
+  "limit_req_zone \$binary_remote_addr zone=aquila_bank_frontend_per_ip:10m rate=10r/s;"
   "limit_req_zone \$binary_remote_addr zone=aquila_bank_transaction_hot_per_ip:10m rate=\${NGINX_TRANSACTION_READ_HOT_RATE_RPS}r/s;"
   "limit_req_zone \$binary_remote_addr zone=aquila_bank_transaction_archive_per_ip:10m rate=\${NGINX_TRANSACTION_READ_ARCHIVE_RATE_RPS}r/s;"
   "limit_req_zone \$binary_remote_addr zone=aquila_bank_transfer_per_ip:10m rate=8r/s;"
@@ -59,6 +69,14 @@ required_patterns=(
   "keepalive_requests 1000;"
   "keepalive_timeout \${NGINX_BACKEND_API_KEEPALIVE_TIMEOUT_SECONDS}s;"
   "server_name \${NGINX_SERVER_NAME};"
+  "add_header X-Content-Type-Options nosniff always;"
+  "add_header X-Frame-Options DENY always;"
+  "add_header Referrer-Policy no-referrer always;"
+  "add_header Permissions-Policy \"geolocation=(), microphone=(), camera=()\" always;"
+  "add_header X-Robots-Tag \"noindex, nofollow, noarchive\" always;"
+  "location ~* ^/(?:\\.env(?:\\..*)?|\\.git(?:/|\$)|wp-login\\.php|xmlrpc\\.php|phpmyadmin(?:/|\$)|adminer(?:/|\$)|vendor/phpunit(?:/|\$)|cgi-bin(?:/|\$))"
+  "add_header X-Aquila-Reject-Source nginx-bot-guard always;"
+  "add_header X-Aquila-Reject-Reason scanner-path always;"
   "location ^~ /.well-known/acme-challenge/"
   "return 308 https://\$server_name\$request_uri;"
   "listen 443 ssl http2;"
@@ -105,11 +123,32 @@ required_patterns=(
   "limit_req zone=aquila_bank_api_per_ip burst=20 delay=5;"
   "location ^~ /actuator/health"
   "location / {"
+  "limit_req zone=aquila_bank_frontend_per_ip burst=60 delay=20;"
 )
 
 for pattern in "${required_patterns[@]}"; do
   if ! contains_pattern "$pattern"; then
     echo "[nginx-sse-check] missing directive: $pattern" >&2
+    exit 1
+  fi
+done
+
+deploy_required_patterns=(
+  "server_tokens off;"
+  'limit_req_zone \$binary_remote_addr zone=aquila_bank_frontend_per_ip:10m rate=10r/s;'
+  "add_header X-Aquila-Reject-Source nginx-bot-guard always;"
+  "add_header X-Aquila-Reject-Reason scanner-path always;"
+  "add_header X-Content-Type-Options nosniff always;"
+  "add_header X-Frame-Options DENY always;"
+  "add_header Referrer-Policy no-referrer always;"
+  "add_header Permissions-Policy \"geolocation=(), microphone=(), camera=()\" always;"
+  "add_header X-Robots-Tag \"noindex, nofollow, noarchive\" always;"
+  "limit_req zone=aquila_bank_frontend_per_ip burst=60 delay=20;"
+)
+
+for pattern in "${deploy_required_patterns[@]}"; do
+  if ! grep -Fq -- "$pattern" "$deploy_path"; then
+    echo "[nginx-sse-check] deploy renderer missing directive: $pattern" >&2
     exit 1
   fi
 done

--- a/tools/test/run-nginx-runtime-template-gate.sh
+++ b/tools/test/run-nginx-runtime-template-gate.sh
@@ -123,9 +123,24 @@ fi
 
 if ! contains_pattern "limit_req_zone \$binary_remote_addr zone=aquila_bank_transaction_hot_per_ip:10m rate=256r/s;" ||
   ! contains_pattern "limit_req_zone \$binary_remote_addr zone=aquila_bank_transaction_archive_per_ip:10m rate=256r/s;" ||
+  ! contains_pattern "limit_req_zone \$binary_remote_addr zone=aquila_bank_frontend_per_ip:10m rate=10r/s;" ||
   ! contains_pattern "limit_req zone=aquila_bank_transaction_hot_per_ip burst=256 nodelay;" ||
-  ! contains_pattern "limit_req zone=aquila_bank_transaction_archive_per_ip burst=256 nodelay;"; then
+  ! contains_pattern "limit_req zone=aquila_bank_transaction_archive_per_ip burst=256 nodelay;" ||
+  ! contains_pattern "limit_req zone=aquila_bank_frontend_per_ip burst=60 delay=20;"; then
   echo "[nginx-runtime-gate] rendered config must use transaction-read burst80 nodelay defaults" >&2
+  exit 1
+fi
+
+if ! contains_pattern "server_tokens off;" ||
+  ! contains_pattern "location ~* ^/(?:\\.env(?:\\..*)?|\\.git(?:/|\$)|wp-login\\.php|xmlrpc\\.php|phpmyadmin(?:/|\$)|adminer(?:/|\$)|vendor/phpunit(?:/|\$)|cgi-bin(?:/|\$))" ||
+  ! contains_pattern "add_header X-Aquila-Reject-Source nginx-bot-guard always;" ||
+  ! contains_pattern "add_header X-Aquila-Reject-Reason scanner-path always;" ||
+  ! contains_pattern "add_header X-Content-Type-Options nosniff always;" ||
+  ! contains_pattern "add_header X-Frame-Options DENY always;" ||
+  ! contains_pattern "add_header Referrer-Policy no-referrer always;" ||
+  ! contains_pattern "add_header Permissions-Policy \"geolocation=(), microphone=(), camera=()\" always;" ||
+  ! contains_pattern "add_header X-Robots-Tag \"noindex, nofollow, noarchive\" always;"; then
+  echo "[nginx-runtime-gate] rendered config must include bot guard and browser security headers" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #882

## 🌿 Base Branch
- `main`

## 📝 Summary
- 고객 웹뱅킹의 browser storage token/SSE query token fallback을 제거하고, public API는 httpOnly cookie session으로 인증됩니다.
- 백엔드는 기존 Authorization header 계약은 유지하면서 access cookie fallback과 refresh/logout cookie fallback을 추가했습니다.
- 외부 노출 Nginx에는 scanner path 차단, 프론트 rate limit, 기본 보안 헤더를 추가했습니다.

## 🛠 Changes
- `ab_access_token`, `ab_refresh_token` httpOnly cookie 발급/삭제 및 refresh cookie fallback 추가
- public API bearer resolver를 Authorization header 우선, access cookie fallback 구조로 변경
- 프론트 API client에서 Authorization header 조립, localStorage session 저장, SSE accessToken query 생성을 제거
- Nginx 템플릿/OCI blue-green renderer에 bot scanner 404, frontend rate limit, `server_tokens off`, security headers 추가
- 프론트 auth cookie contract smoke test 추가

## 🎯 Scope
- [x] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-auth-cookie-green ./back/gradlew -p back test --tests com.aquilabank.global.security.CookieBearerTokenResolverTest --tests com.aquilabank.global.web.auth.AuthSessionCookieManagerTest --tests com.aquilabank.global.web.auth.LoginControllerRememberDeviceTest --tests com.aquilabank.global.web.auth.LoginControllerRefreshDeviceBindingTest --tests com.aquilabank.global.web.auth.OidcLoginAuthenticationSuccessHandlerTest`
- `./back/gradlew -p back check` (pre-commit)
- `tools/test/check-frontend-auth-cookie-contract.sh`
- `yarn --cwd front lint`
- `yarn --cwd front build`
- `bash tools/test/check-nginx-sse-proxy.sh`
- `bash tools/test/run-nginx-runtime-template-gate.sh`
- `bash -n ops/deploy/oci/bluegreen-deploy.sh`
- 외부 확인: `http://140.238.12.73/` 200 + 보안 헤더, `http://140.238.12.73/.env` 404 + `X-Aquila-Reject-Source: nginx-bot-guard`, `http://140.238.12.73/actuator/health` UP

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: httpOnly cookie 기반으로 전환되므로 다른 origin에서 호출하면 CORS/credential 설정이 맞아야 합니다. direct HTTP staging에서는 cookie secure 설정을 환경값으로 낮춰야 smoke가 가능합니다.
- 롤백 방법: 이 PR revert 후 기존 bearer token frontend 계약으로 되돌립니다. 운영 Nginx hot patch는 이전 `/opt/aquila-bank/nginx/nginx.conf.pre-bot-hardening.*` 백업본으로 복구 후 `docker exec aquila-bank-nginx nginx -s reload` 합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
