### PR TITLE
[Fix] HTTP 모드 ACME challenge bootstrap 경로 추가

### DIFF
--- a/ops/deploy/oci/bluegreen-deploy.sh
+++ b/ops/deploy/oci/bluegreen-deploy.sh
@@ -83,9 +83,7 @@ install_runtime() {
 prepare_layout() {
   mkdir -p "${APP_DIR}/env" "${APP_DIR}/nginx" "${APP_DIR}/state" "${APP_DIR}/logs"
   chmod 750 "${APP_DIR}" "${APP_DIR}/env" "${APP_DIR}/nginx" "${APP_DIR}/state" "${APP_DIR}/logs"
-  if nginx_https_enabled; then
-    mkdir -p "${NGINX_ACME_CHALLENGE_ROOT}"
-  fi
+  mkdir -p "${NGINX_ACME_CHALLENGE_ROOT}"
   docker network create "${NETWORK}" >/dev/null 2>&1 || true
 }
 
@@ -741,8 +739,11 @@ nginx_https_port_flags() {
 nginx_tls_mount_flags() {
   if nginx_https_enabled; then
     printf '%s\n' "-v" "${NGINX_SSL_MOUNT_PATH}:${NGINX_SSL_MOUNT_PATH}:ro"
-    printf '%s\n' "-v" "${NGINX_ACME_CHALLENGE_ROOT}:${NGINX_ACME_CHALLENGE_ROOT}:ro"
   fi
+}
+
+nginx_acme_mount_flags() {
+  printf '%s\n' "-v" "${NGINX_ACME_CHALLENGE_ROOT}:${NGINX_ACME_CHALLENGE_ROOT}:ro"
 }
 
 render_nginx_real_ip_trusted_proxy_lines() {
@@ -1017,6 +1018,11 @@ ${proxy_server_tls_directives}
     proxy_socket_keepalive on;
     error_page 429 = @aquila_edge_rate_limited;
 
+    location ^~ /.well-known/acme-challenge/ {
+      root ${NGINX_ACME_CHALLENGE_ROOT};
+      default_type text/plain;
+    }
+
     location ~* ^/(?:\\.env(?:\\..*)?|\\.git(?:/|\$)|wp-login\\.php|xmlrpc\\.php|phpmyadmin(?:/|\$)|adminer(?:/|\$)|vendor/phpunit(?:/|\$)|cgi-bin(?:/|\$)) {
       add_header X-Aquila-Reject-Source nginx-bot-guard always;
       add_header X-Aquila-Reject-Reason scanner-path always;
@@ -1266,6 +1272,7 @@ ensure_nginx_container() {
     -p 80:80 \
     $(nginx_https_port_flags) \
     $(nginx_tls_mount_flags) \
+    $(nginx_acme_mount_flags) \
     -v "${APP_DIR}/nginx/nginx.conf:/etc/nginx/nginx.conf:ro" \
     nginx:1.27-alpine >/dev/null
 }
@@ -1300,6 +1307,7 @@ switch_nginx() {
   # Nginx reload 전 동일 Docker network에서 config를 검증해 기존 blue 슬롯을 보존한다.
   docker run --rm --network "${NETWORK}" \
     $(nginx_tls_mount_flags) \
+    $(nginx_acme_mount_flags) \
     -v "${next_config}:/etc/nginx/nginx.conf:ro" \
     nginx:1.27-alpine nginx -t
 

--- a/ops/nginx/README.md
+++ b/ops/nginx/README.md
@@ -58,6 +58,7 @@ bash tools/ops/render-nginx-runtime-config.sh /tmp/aquila-bank-nginx.conf ops/ng
 - `return 308 https://$server_name$request_uri;`를 써서 요청 `Host` 헤더를 그대로 반사하지 않고 설정한 host 기준으로 redirect 합니다.
 - OCI blue/green 배포는 `NGINX_ENABLE_HTTPS=auto`일 때 `NGINX_SERVER_NAME`이 `_`가 아니고 cert/key 파일이 존재하면 443을 publish 합니다. 강제하려면 `NGINX_ENABLE_HTTPS=true`로 두고, 파일이 없으면 배포 전에 fail-fast 합니다.
 - raw IP는 공인 인증서 발급 대상이 아니므로 상용 HTTPS 전환은 FQDN DNS가 OCI public IP를 가리킨 뒤 진행합니다.
+- 인증서 최초 발급을 위해 OCI blue/green HTTP-only 모드에서도 `/.well-known/acme-challenge/`는 `NGINX_ACME_CHALLENGE_ROOT` webroot로 제공합니다. 이 경로를 통해 certbot webroot 발급을 먼저 끝낸 뒤 `NGINX_ENABLE_HTTPS=true`로 재배포합니다.
 
 ## Rate Limit 기준
 

--- a/tools/test/check-nginx-sse-proxy.sh
+++ b/tools/test/check-nginx-sse-proxy.sh
@@ -155,8 +155,11 @@ deploy_required_patterns=(
   '"ssl_protocol":"\$ssl_protocol"'
   '"body_bytes_sent":\$body_bytes_sent'
   "nginx_https_port_flags"
+  "nginx_acme_mount_flags"
   "443:443"
   "nginx_tls_mount_flags"
+  'mkdir -p "${NGINX_ACME_CHALLENGE_ROOT}"'
+  '${NGINX_ACME_CHALLENGE_ROOT}:${NGINX_ACME_CHALLENGE_ROOT}:ro'
   "server_tokens off;"
   "listen 443 ssl http2;"
   'return 308 https://${SERVER_NAME}\$request_uri;'
@@ -170,6 +173,7 @@ deploy_required_patterns=(
   "add_header X-Robots-Tag \"noindex, nofollow, noarchive\" always;"
   'add_header Strict-Transport-Security \"max-age=${hsts_max_age_seconds}; includeSubDomains\" always;'
   "location ^~ /.well-known/acme-challenge/"
+  "root \${NGINX_ACME_CHALLENGE_ROOT};"
   "limit_req zone=aquila_bank_frontend_per_ip burst=60 delay=20;"
 )
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #888

## 🌿 Base Branch
- `main`

## 📝 Summary
- HTTP-only Nginx 모드에서도 `/.well-known/acme-challenge/`를 webroot로 제공하게 했습니다.
- HTTPS 비활성 상태에서도 Nginx container가 ACME challenge root를 read-only mount합니다.
- 인증서 최초 발급 시 Nginx를 내리는 standalone 방식 대신 certbot webroot 방식을 사용할 수 있습니다.

## 🛠 Changes
- `NGINX_ACME_CHALLENGE_ROOT`를 배포 layout에서 항상 생성
- HTTP proxy server block에 ACME challenge location 추가
- ACME webroot mount를 HTTPS 활성 여부와 분리
- directive smoke에 ACME bootstrap 계약 추가

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `bash tools/test/check-nginx-sse-proxy.sh`
- `bash -n ops/deploy/oci/bluegreen-deploy.sh tools/test/check-nginx-sse-proxy.sh`
- HTTP mode render smoke: `listen 80`, ACME route, webroot root 포함 및 443 미포함 확인
- `git diff --check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: ACME challenge path가 별도 webroot로 처리되므로 해당 경로 아래 파일만 외부에 노출됩니다. certbot challenge 파일 외 민감 파일을 이 디렉터리에 두면 안 됩니다.
- 롤백 방법: PR revert. 기존 HTTP proxy 동작으로 돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?