### PR TITLE
[Fix] always-free A1 HTTPS ingress 운영화

### DIFF
--- a/infra/terraform/oci/always-free-a1-flex/README.md
+++ b/infra/terraform/oci/always-free-a1-flex/README.md
@@ -10,7 +10,7 @@ OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만�
 - Boot Volume: `50GB`
 - Data Block Volume: `150GB`, Lower Cost `0` VPU/GB
 - Network: 새 VCN, public subnet, Internet Gateway, Route Table
-- Ingress: SSH `22/tcp`, staging HTTP `80/tcp`
+- Ingress: SSH `22/tcp`, staging HTTP `80/tcp`, staging HTTPS `443/tcp`
 - 제외: NAT Gateway, Load Balancer, Managed Database
 
 ## 무료 한도 조건
@@ -22,7 +22,8 @@ OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만�
 - 기존 200GB boot volume 단일 구성에서 이 구조로 바꾸면 boot volume shrink가 아니라 instance 재생성으로 처리될 수 있다. `terraform plan`에서 destroy/create 범위를 먼저 확인한다.
 - `region`은 tenancy 홈 리전으로 설정한다. 홈 리전 밖 volume은 무료 한도 적용에서 벗어날 수 있다.
 - 기본 경로는 Terraform `oci_core_images` data source로 `VM.Standard.A1.Flex` 호환 최신 Ubuntu 이미지를 조회한다.
-- 최신 이미지 자동 조회는 다음 `terraform apply` 시점에 더 새 이미지가 잡힐 수 있다. 재현성이 필요하면 `source_image_ocid_override`에 특정 image OCID를 고정한다.
+- 최신 이미지 자동 조회는 신규 생성에만 사용한다. 기존 instance는 `source_id` drift를 무시해 보안목록 같은 운영 변경에 이미지 변경이 섞이지 않게 한다.
+- 재현성이 필요하면 `source_image_ocid_override`에 특정 image OCID를 고정한다.
 - cloud-init은 data volume을 `/var/lib/aquila-data`에 mount하고 Docker data-root를 `/var/lib/aquila-data/docker`로 고정한다. staging deploy의 Docker named volume과 image layer는 이 data volume을 사용한다.
 
 ## 준비 값
@@ -37,6 +38,7 @@ OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만�
 - `ssh_public_key`
 - `ssh_ingress_cidr`
 - `http_ingress_cidr`
+- `https_ingress_cidr`
 
 선택 값:
 
@@ -48,6 +50,7 @@ OCI Always Free 한도 안에서 `VM.Standard.A1.Flex` 인스턴스 1대를 만�
 
 `ssh_ingress_cidr`는 운영자 현재 공인 IP의 `/32`를 우선 사용한다. `0.0.0.0/0`은 임시 테스트가 아니면 사용하지 않는다.
 `http_ingress_cidr`는 GitHub Actions smoke와 브라우저 접근을 받는 staging HTTP 포트다. public staging이면 `0.0.0.0/0`, 사설 접근만 허용할 수 있으면 제한 CIDR을 사용한다.
+`https_ingress_cidr`는 공인 인증서 기반 HTTPS 포트다. public staging이면 `0.0.0.0/0`, Cloudflare Tunnel/사설 접근만 사용할 수 있으면 제한 CIDR을 사용한다.
 
 ## 실행
 

--- a/infra/terraform/oci/always-free-a1-flex/compute.tf
+++ b/infra/terraform/oci/always-free-a1-flex/compute.tf
@@ -35,4 +35,9 @@ resource "oci_core_instance" "this" {
     source_id               = local.selected_image_id
     source_type             = "image"
   }
+
+  lifecycle {
+    # 최신 이미지 조회는 신규 생성 전용. 운영 중 네트워크 변경에 image drift가 섞이지 않게 고정한다.
+    ignore_changes = [source_details[0].source_id]
+  }
 }

--- a/infra/terraform/oci/always-free-a1-flex/network.tf
+++ b/infra/terraform/oci/always-free-a1-flex/network.tf
@@ -64,6 +64,18 @@ resource "oci_core_security_list" "public_ssh" {
       min = 80
     }
   }
+
+  ingress_security_rules {
+    description = "HTTPS ingress for OCI A1 staging"
+    protocol    = "6"
+    source      = var.https_ingress_cidr
+    source_type = "CIDR_BLOCK"
+
+    tcp_options {
+      max = 443
+      min = 443
+    }
+  }
 }
 
 resource "oci_core_subnet" "public" {

--- a/infra/terraform/oci/always-free-a1-flex/terraform.tfvars.example
+++ b/infra/terraform/oci/always-free-a1-flex/terraform.tfvars.example
@@ -11,9 +11,10 @@ image_operating_system         = "Canonical Ubuntu"
 image_operating_system_version = null
 source_image_ocid_override     = null
 
-ssh_public_key   = "ssh-ed25519 example-public-key"
-ssh_ingress_cidr = "203.0.113.10/32"
+ssh_public_key    = "ssh-ed25519 example-public-key"
+ssh_ingress_cidr  = "203.0.113.10/32"
 http_ingress_cidr = "0.0.0.0/0"
+https_ingress_cidr = "0.0.0.0/0"
 
 name_prefix    = "aquila-free-a1"
 hostname_label = "aquilafreea1"

--- a/infra/terraform/oci/always-free-a1-flex/variables.tf
+++ b/infra/terraform/oci/always-free-a1-flex/variables.tf
@@ -148,6 +148,18 @@ variable "http_ingress_cidr" {
   }
 }
 
+variable "https_ingress_cidr" {
+  description = "CIDR allowed to connect to the staging Nginx HTTPS port 443. Public staging uses 0.0.0.0/0."
+  type        = string
+  default     = "0.0.0.0/0"
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.https_ingress_cidr))
+    error_message = "https_ingress_cidr must be a valid IPv4 CIDR."
+  }
+}
+
 variable "name_prefix" {
   description = "Name prefix for OCI resources."
   type        = string


### PR DESCRIPTION
## 🔗 Related Issue
- close #890

## 🌿 Base Branch
- `main`

## 📝 Summary
- OCI Always Free A1 security list에 staging HTTPS `443/tcp` ingress를 Terraform 관리 대상으로 추가했습니다.
- 기존 instance의 Ubuntu latest image data source drift가 보안목록 변경에 섞이지 않도록 `source_details[0].source_id`를 ignore 처리했습니다.
- `bank.aquilaxk.site` 인증서 발급, 443 개방, Nginx HTTPS 재배포, certbot renewal dry-run까지 live로 확인했습니다.

## 🛠 Changes
- `https_ingress_cidr` 변수와 example 값을 추가했습니다.
- public security list에 `HTTPS ingress for OCI A1 staging` 443/tcp rule을 추가했습니다.
- 기존 VM source image drift guard와 운영 문서 설명을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex fmt -check`
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex validate`
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex plan -target=oci_core_security_list.public_ssh -var-file=terraform.tfvars` -> 0 add, 1 change, 0 destroy
- `terraform -chdir=infra/terraform/oci/always-free-a1-flex apply -target=oci_core_security_list.public_ssh -var-file=terraform.tfvars -auto-approve` -> 0 added, 1 changed, 0 destroyed
- post-apply `terraform -chdir=infra/terraform/oci/always-free-a1-flex plan -var-file=terraform.tfvars` -> resource change 없음, selected image output-only drift만 표시
- `curl -I http://bank.aquilaxk.site/` -> 308, `Location: https://bank.aquilaxk.site/`
- `curl -I https://bank.aquilaxk.site/` -> HTTP/2 200, HSTS header 확인
- `PUBLIC_EDGE_BASE_URL=https://bank.aquilaxk.site PUBLIC_EDGE_EXPECT_HSTS=true PUBLIC_EDGE_CURL_RETRY_COUNT=5 bash tools/test/check-public-edge-bot-guard-live.sh` -> live smoke passed
- `sudo certbot renew --dry-run --cert-name bank.aquilaxk.site --no-random-sleep-on-renew` -> simulated renewal success

## 📸 Screenshot / API Example
- UI 변경 없음
- HTTPS live endpoint: `https://bank.aquilaxk.site/`
- 인증서 만료: 2026-08-09 03:49:16+00:00

## ⚠️ Risk & Rollback
- 예상 리스크: public 443 노출 범위가 `https_ingress_cidr` 기본값 `0.0.0.0/0`이다. staging 공개 HTTPS 요구사항에 맞춘 값이며, Cloudflare Tunnel 전용 전환 시 CIDR 제한이 필요하다.
- 롤백 방법: Terraform에서 `https_ingress_cidr` rule 제거 후 apply, 서버 Nginx는 `/opt/aquila-bank/nginx/nginx.conf.pre-https-*` 백업으로 복구하고 443 publish 없이 재기동한다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?