### PR TITLE
[Fix] 웹뱅킹 인증 세션 보안 강화

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start -p ${PORT:-3000}",
     "lint": "next lint",
-    "test:ui-contract": "node scripts/check-customer-banking-ui-contract.mjs"
+    "test:ui-contract": "node scripts/check-customer-banking-ui-contract.mjs",
+    "test:auth-session": "node scripts/check-auth-session-hardening-contract.mjs"
   },
   "dependencies": {
     "next": "^14.2.5",

--- a/front/scripts/check-auth-session-hardening-contract.mjs
+++ b/front/scripts/check-auth-session-hardening-contract.mjs
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+
+function read(path) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+const files = {
+  client: read("src/lib/api/client.ts"),
+  session: read("src/lib/api/session.ts"),
+  hook: read("src/hooks/use-customer-banking.ts"),
+};
+
+const required = [
+  ["fetch cookie credentials", files.client, 'credentials: "include"'],
+  ["session load stays memory only", files.session, "return null;"],
+  ["session save does not persist", files.session, "void session;"],
+  ["SSE uses cookie credentials", files.hook, "withCredentials: true"],
+  ["SSE stream path", files.hook, 'api.streamUrl("/api/v1/notifications/stream")'],
+];
+
+const forbidden = [
+  ["client localStorage", files.client, "localStorage"],
+  ["client sessionStorage", files.client, "sessionStorage"],
+  ["session localStorage", files.session, "localStorage"],
+  ["session sessionStorage", files.session, "sessionStorage"],
+  ["hook localStorage", files.hook, "localStorage"],
+  ["hook sessionStorage", files.hook, "sessionStorage"],
+  ["client Authorization fallback", files.client, "Authorization"],
+  ["client bearer fallback", files.client, "Bearer "],
+  ["client refreshToken body field", files.client, "refreshToken:"],
+  ["client accessToken body field", files.client, "accessToken:"],
+  ["SSE token query", files.hook, "token="],
+  ["SSE access token query", files.hook, "accessToken"],
+  ["SSE refresh token query", files.hook, "refreshToken"],
+];
+
+const missing = required.filter(([, content, expected]) => !content.includes(expected));
+const present = forbidden.filter(([, content, value]) => content.includes(value));
+
+if (missing.length > 0 || present.length > 0) {
+  console.error("[auth-session-hardening-contract] contract violations:");
+  for (const [name, , expected] of missing) {
+    console.error(`- missing ${name}: ${expected}`);
+  }
+  for (const [name, , value] of present) {
+    console.error(`- forbidden ${name}: ${value}`);
+  }
+  process.exit(1);
+}
+
+console.log("[auth-session-hardening-contract] passed");

--- a/front/src/hooks/use-customer-banking.ts
+++ b/front/src/hooks/use-customer-banking.ts
@@ -618,7 +618,10 @@ export function useCustomerBanking() {
     }
     try {
       eventSourceRef.current?.close();
-      const eventSource = new EventSource(api.streamUrl("/api/v1/notifications/stream"));
+      const eventSource = new EventSource(
+        api.streamUrl("/api/v1/notifications/stream"),
+        { withCredentials: true },
+      );
       eventSourceRef.current = eventSource;
       setSseStatus({
         state: "connecting",


### PR DESCRIPTION
## 🔗 Related Issue
- close #896

## 🌿 Base Branch
- `main`

## 📝 Summary
- 고객 웹뱅킹 프론트의 인증 세션 계약을 httpOnly cookie 기반으로 고정하는 contract test를 추가했습니다.
- SSE 연결은 query token 없이 cookie credential을 명시하도록 `EventSource` 옵션을 보강했습니다.

## 🛠 Changes
- `front/scripts/check-auth-session-hardening-contract.mjs` 추가
- `yarn --cwd front test:auth-session` script 추가
- notification SSE `EventSource`에 `{ withCredentials: true }` 명시

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front test:auth-session`
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front lint`
- pre-commit: `yarn --cwd front lint`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: cross-origin API 배치에서 SSE cookie 전달이 브라우저 정책에 따라 CORS credentials 설정과 함께 맞아야 합니다. 현재 staging은 동일 public origin 계약을 우선합니다.
- 롤백 방법: 이 PR revert. 기존 cookie 기반 fetch 요청은 유지됩니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?