### PR TITLE
[Feat] 고객 웹뱅킹 대형 은행 업무 UX 확장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ docs/
 .aider*
 .windsurf/
 .ai/
+.playwright-mcp/
+customer-banking-*-desktop.png
+customer-banking-*-mobile.png
 
 # Terraform local state
 **/.terraform/

--- a/front/package.json
+++ b/front/package.json
@@ -11,7 +11,8 @@
     "test:ui-contract": "node scripts/check-customer-banking-ui-contract.mjs",
     "test:auth-session": "node scripts/check-auth-session-hardening-contract.mjs",
     "test:ops-console": "node scripts/check-ops-console-contract.mjs",
-    "test:enterprise-ux": "node scripts/check-customer-banking-enterprise-ux.mjs"
+    "test:enterprise-ux": "node scripts/check-customer-banking-enterprise-ux.mjs",
+    "test:e2e:a11y": "node scripts/check-customer-banking-visual-a11y.mjs"
   },
   "dependencies": {
     "next": "^14.2.5",

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "test:ui-contract": "node scripts/check-customer-banking-ui-contract.mjs",
     "test:auth-session": "node scripts/check-auth-session-hardening-contract.mjs",
-    "test:ops-console": "node scripts/check-ops-console-contract.mjs"
+    "test:ops-console": "node scripts/check-ops-console-contract.mjs",
+    "test:enterprise-ux": "node scripts/check-customer-banking-enterprise-ux.mjs"
   },
   "dependencies": {
     "next": "^14.2.5",

--- a/front/scripts/check-customer-banking-enterprise-ux.mjs
+++ b/front/scripts/check-customer-banking-enterprise-ux.mjs
@@ -13,6 +13,7 @@ const files = {
   page: read("src/app/page.tsx"),
   constants: read("src/lib/customer-banking/constants.ts"),
   types: read("src/lib/customer-banking/types.ts"),
+  transfer: read("src/components/customer-banking/sections/transfer-section.tsx"),
   enterprise: read("src/components/customer-banking/sections/enterprise-services-section.tsx"),
   support: read("src/components/customer-banking/sections/support-center-section.tsx"),
   securityHub: read("src/components/customer-banking/sections/security-hub-section.tsx"),
@@ -49,8 +50,14 @@ const required = [
   ["security financial certificate panel", files.securityHub, "금융인증서"],
   ["security OTP panel", files.securityHub, "OTP"],
   ["security media panel", files.securityHub, "보안매체"],
+  ["transfer receiver validation", files.transfer, "받는 분 확인"],
+  ["transfer fee estimate", files.transfer, "수수료"],
+  ["transfer limit check", files.transfer, "이체한도"],
+  ["transfer OTP confirmation", files.transfer, "OTP 확인"],
+  ["transfer receipt", files.transfer, "이체 완료증"],
   ["enterprise grid styles", files.styles, ".enterprise-service-grid"],
   ["security hub styles", files.styles, ".security-hub-grid"],
+  ["receipt styles", files.styles, ".transfer-receipt"],
 ];
 
 const forbidden = [

--- a/front/scripts/check-customer-banking-enterprise-ux.mjs
+++ b/front/scripts/check-customer-banking-enterprise-ux.mjs
@@ -1,0 +1,78 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+
+function read(path) {
+  const filePath = join(root, path);
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
+}
+
+const files = {
+  packageJson: read("package.json"),
+  page: read("src/app/page.tsx"),
+  constants: read("src/lib/customer-banking/constants.ts"),
+  types: read("src/lib/customer-banking/types.ts"),
+  enterprise: read("src/components/customer-banking/sections/enterprise-services-section.tsx"),
+  support: read("src/components/customer-banking/sections/support-center-section.tsx"),
+  securityHub: read("src/components/customer-banking/sections/security-hub-section.tsx"),
+  styles: read("src/styles/customer-banking.css"),
+};
+
+const required = [
+  ["package enterprise script", files.packageJson, "test:enterprise-ux"],
+  ["menu customer center", files.constants, "고객센터"],
+  ["menu security center", files.constants, "보안센터"],
+  ["menu incident report", files.constants, "사고신고"],
+  ["menu transfer limit", files.constants, "이체한도"],
+  ["menu OTP", files.constants, "OTP"],
+  ["menu bill payment", files.constants, "공과금"],
+  ["menu open banking", files.constants, "오픈뱅킹"],
+  ["menu deposit products", files.constants, "예금상품"],
+  ["menu loan", files.constants, "대출"],
+  ["menu fx", files.constants, "외환"],
+  ["menu security hub section", files.types, "securityHub"],
+  ["menu enterprise services section", files.types, "enterpriseServices"],
+  ["menu support center section", files.types, "supportCenter"],
+  ["page enterprise services component", files.page, "EnterpriseServicesSection"],
+  ["page support center component", files.page, "SupportCenterSection"],
+  ["page security hub component", files.page, "SecurityHubSection"],
+  ["enterprise bill payment panel", files.enterprise, "공과금"],
+  ["enterprise open banking panel", files.enterprise, "오픈뱅킹"],
+  ["enterprise deposit panel", files.enterprise, "예금상품"],
+  ["enterprise loan panel", files.enterprise, "대출"],
+  ["enterprise fx panel", files.enterprise, "외환"],
+  ["support customer center panel", files.support, "고객센터"],
+  ["support incident report panel", files.support, "사고신고"],
+  ["support limit panel", files.support, "이체한도"],
+  ["security certificate panel", files.securityHub, "공동인증서"],
+  ["security financial certificate panel", files.securityHub, "금융인증서"],
+  ["security OTP panel", files.securityHub, "OTP"],
+  ["security media panel", files.securityHub, "보안매체"],
+  ["enterprise grid styles", files.styles, ".enterprise-service-grid"],
+  ["security hub styles", files.styles, ".security-hub-grid"],
+];
+
+const forbidden = [
+  ["enterprise write submit", files.enterprise, "onSubmit"],
+  ["enterprise write fetch", files.enterprise, "fetch("],
+  ["support write fetch", files.support, "fetch("],
+  ["security storage", files.securityHub, "localStorage"],
+  ["security session storage", files.securityHub, "sessionStorage"],
+];
+
+const missing = required.filter(([, content, expected]) => !content.includes(expected));
+const present = forbidden.filter(([, content, value]) => content.includes(value));
+
+if (missing.length > 0 || present.length > 0) {
+  console.error("[customer-banking-enterprise-ux] contract violations:");
+  for (const [name, , expected] of missing) {
+    console.error(`- missing ${name}: ${expected}`);
+  }
+  for (const [name, , value] of present) {
+    console.error(`- forbidden ${name}: ${value}`);
+  }
+  process.exit(1);
+}
+
+console.log("[customer-banking-enterprise-ux] passed");

--- a/front/scripts/check-customer-banking-visual-a11y.mjs
+++ b/front/scripts/check-customer-banking-visual-a11y.mjs
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+
+function read(path) {
+  const filePath = join(root, path);
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
+}
+
+const files = {
+  packageJson: read("package.json"),
+  page: read("src/app/page.tsx"),
+  styles: read("src/styles/customer-banking.css"),
+  transfer: read("src/components/customer-banking/sections/transfer-section.tsx"),
+};
+
+const required = [
+  ["package a11y script", files.packageJson, "test:e2e:a11y"],
+  ["skip link target", files.page, 'href="#bank-work-area"'],
+  ["main work area id", files.page, 'id="bank-work-area"'],
+  ["top nav aria label", files.page, 'aria-label="주요 메뉴"'],
+  ["side menu aria label", files.page, 'aria-label="개인뱅킹 메뉴"'],
+  ["right rail aria label", files.page, 'aria-label="빠른 업무"'],
+  ["desktop breakpoint", files.styles, "@media (max-width: 1180px)"],
+  ["tablet breakpoint", files.styles, "@media (max-width: 760px)"],
+  ["mobile breakpoint", files.styles, "@media (max-width: 480px)"],
+  ["focus visible style", files.styles, ":focus-visible"],
+  ["touch target minimum", files.styles, "min-height: 44px"],
+  ["mobile overflow guard", files.styles, "overflow-wrap: anywhere"],
+  ["transfer step aria", files.transfer, 'aria-label="이체 진행 단계"'],
+  ["otp input numeric", files.transfer, 'inputMode="numeric"'],
+];
+
+const missing = required.filter(([, content, expected]) => !content.includes(expected));
+
+if (missing.length > 0) {
+  console.error("[customer-banking-visual-a11y] contract violations:");
+  for (const [name, , expected] of missing) {
+    console.error(`- missing ${name}: ${expected}`);
+  }
+  process.exit(1);
+}
+
+console.log("[customer-banking-visual-a11y] passed");

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -3,8 +3,11 @@
 import Image from "next/image";
 import { AccountsSection } from "@/components/customer-banking/sections/accounts-section";
 import { DashboardSection } from "@/components/customer-banking/sections/dashboard-section";
+import { EnterpriseServicesSection } from "@/components/customer-banking/sections/enterprise-services-section";
 import { NotificationsSection } from "@/components/customer-banking/sections/notifications-section";
+import { SecurityHubSection } from "@/components/customer-banking/sections/security-hub-section";
 import { SecuritySection } from "@/components/customer-banking/sections/security-section";
+import { SupportCenterSection } from "@/components/customer-banking/sections/support-center-section";
 import { TransactionsSection } from "@/components/customer-banking/sections/transactions-section";
 import { TransferSection } from "@/components/customer-banking/sections/transfer-section";
 import { useCustomerBanking } from "@/hooks/use-customer-banking";
@@ -100,8 +103,15 @@ export default function HomePage() {
     setNotificationFilters,
     setPreferences,
   } = useCustomerBanking();
+  const publicSections = [
+    "dashboard",
+    "security",
+    "securityHub",
+    "supportCenter",
+    "enterpriseServices",
+  ];
   const sessionRequired =
-    !session && activeSection !== "dashboard" && activeSection !== "security";
+    !session && !publicSections.includes(activeSection);
 
   return (
     <main className="bank-shell">
@@ -117,10 +127,18 @@ export default function HomePage() {
             <button className="utility-link" type="button">
               기업
             </button>
-            <button className="utility-link" type="button">
+            <button
+              className="utility-link"
+              onClick={() => setActiveSection("security")}
+              type="button"
+            >
               인증센터
             </button>
-            <button className="utility-link" type="button">
+            <button
+              className="utility-link"
+              onClick={() => setActiveSection("supportCenter")}
+              type="button"
+            >
               고객센터
             </button>
           </div>
@@ -307,6 +325,11 @@ export default function HomePage() {
               onTotpCodeChange={setTotpCode}
               onVerifyTotpEnrollment={handleVerifyTotpEnrollment}
             />
+          ) : null}
+          {activeSection === "securityHub" ? <SecurityHubSection /> : null}
+          {activeSection === "supportCenter" ? <SupportCenterSection /> : null}
+          {activeSection === "enterpriseServices" ? (
+            <EnterpriseServicesSection />
           ) : null}
           {activeSection === "notifications" ? (
             <NotificationsSection

--- a/front/src/components/customer-banking/sections/enterprise-services-section.tsx
+++ b/front/src/components/customer-banking/sections/enterprise-services-section.tsx
@@ -1,0 +1,65 @@
+import { enterpriseServiceItems } from "@/lib/customer-banking/constants";
+
+export function EnterpriseServicesSection() {
+  return (
+    <section className="task-section">
+      <div className="section-title">
+        <div>
+          <p>부가업무</p>
+          <h1>공과금 · 오픈뱅킹 · 금융상품</h1>
+        </div>
+      </div>
+
+      <div className="enterprise-service-grid">
+        {enterpriseServiceItems.map((item) => (
+          <article className="enterprise-service-card" key={item.title}>
+            <span>{item.category}</span>
+            <strong>{item.title}</strong>
+            <p>{item.description}</p>
+            <small>{item.status}</small>
+          </article>
+        ))}
+      </div>
+
+      <div className="bank-table-wrap">
+        <table className="bank-table">
+          <caption>부가업무 처리 기준</caption>
+          <thead>
+            <tr>
+              <th>업무</th>
+              <th>상용 화면 기준</th>
+              <th>현재 범위</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>공과금</td>
+              <td>기관 선택, 납부번호 조회, 납부 확인증</td>
+              <td>read-only 메뉴</td>
+            </tr>
+            <tr>
+              <td>오픈뱅킹</td>
+              <td>타행 계좌 연결, 잔액 통합조회, 해지</td>
+              <td>read-only 메뉴</td>
+            </tr>
+            <tr>
+              <td>예금상품</td>
+              <td>상품 목록, 금리, 가입 전 유의사항</td>
+              <td>상품 안내</td>
+            </tr>
+            <tr>
+              <td>대출</td>
+              <td>한도조회, 신청, 상환 조회</td>
+              <td>상담 안내</td>
+            </tr>
+            <tr>
+              <td>외환</td>
+              <td>환율 조회, 외화예금, 해외송금</td>
+              <td>환율 조회</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/front/src/components/customer-banking/sections/security-hub-section.tsx
+++ b/front/src/components/customer-banking/sections/security-hub-section.tsx
@@ -1,0 +1,67 @@
+import { securityHubItems } from "@/lib/customer-banking/constants";
+
+export function SecurityHubSection() {
+  return (
+    <section className="task-section">
+      <div className="section-title">
+        <div>
+          <p>보안센터</p>
+          <h1>인증서 · OTP · 보안매체</h1>
+        </div>
+      </div>
+
+      <div className="security-hub-grid">
+        {securityHubItems.map((item) => (
+          <article className="security-hub-card" key={item.title}>
+            <strong>{item.title}</strong>
+            <p>{item.description}</p>
+            <span>{item.status}</span>
+          </article>
+        ))}
+      </div>
+
+      <section className="table-panel">
+        <div className="panel-toolbar">
+          <div>
+            <strong>보안매체별 적용 업무</strong>
+            <span>실제 비밀값 저장 없이 화면 기준만 제공합니다.</span>
+          </div>
+        </div>
+        <div className="bank-table-wrap">
+          <table className="bank-table">
+            <caption>보안매체별 적용 업무</caption>
+            <thead>
+              <tr>
+                <th>구분</th>
+                <th>주요 업무</th>
+                <th>확인 단계</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>공동인증서</td>
+                <td>고위험 이체, 인증서 관리</td>
+                <td>비밀번호/전자서명</td>
+              </tr>
+              <tr>
+                <td>금융인증서</td>
+                <td>로그인, 조회, 일부 이체</td>
+                <td>클라우드 인증</td>
+              </tr>
+              <tr>
+                <td>OTP</td>
+                <td>즉시이체, 한도 상향</td>
+                <td>일회용 비밀번호</td>
+              </tr>
+              <tr>
+                <td>보안매체</td>
+                <td>보안카드, 모바일 OTP</td>
+                <td>매체별 등급 확인</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/front/src/components/customer-banking/sections/support-center-section.tsx
+++ b/front/src/components/customer-banking/sections/support-center-section.tsx
@@ -1,0 +1,62 @@
+import { supportCenterItems } from "@/lib/customer-banking/constants";
+
+export function SupportCenterSection() {
+  return (
+    <section className="task-section">
+      <div className="section-title">
+        <div>
+          <p>고객센터</p>
+          <h1>고객지원 · 사고신고 · 이체한도</h1>
+        </div>
+      </div>
+
+      <div className="support-service-grid">
+        {supportCenterItems.map((item) => (
+          <article className="support-service-card" key={item.title}>
+            <strong>{item.title}</strong>
+            <p>{item.description}</p>
+            <button type="button">{item.action}</button>
+          </article>
+        ))}
+      </div>
+
+      <section className="table-panel">
+        <div className="panel-toolbar">
+          <div>
+            <strong>사고신고 우선순위</strong>
+            <span>분실/도용 의심 업무는 실행 화면과 분리해 즉시 찾을 수 있게 둡니다.</span>
+          </div>
+        </div>
+        <div className="bank-table-wrap">
+          <table className="bank-table">
+            <caption>사고신고 우선순위</caption>
+            <thead>
+              <tr>
+                <th>신고 유형</th>
+                <th>대상</th>
+                <th>초기 조치</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>보안매체 분실</td>
+                <td>OTP, 보안카드</td>
+                <td>사용 정지 후 재발급</td>
+              </tr>
+              <tr>
+                <td>인증서 도용 의심</td>
+                <td>공동인증서, 금융인증서</td>
+                <td>폐기 및 재등록</td>
+              </tr>
+              <tr>
+                <td>이체한도 관리</td>
+                <td>1회/1일 한도</td>
+                <td>보안등급 확인</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/front/src/components/customer-banking/sections/transfer-section.tsx
+++ b/front/src/components/customer-banking/sections/transfer-section.tsx
@@ -4,7 +4,14 @@ import type { TransferResponse, TransferReversalResponse } from '@/lib/api/types
 import { formatDateTime, formatMinorAmount } from '@/lib/customer-banking/format';
 import { ResultPanel } from '../common';
 
-type TransferStep = "input" | "confirm" | "submitting" | "complete" | "failed";
+type TransferStep =
+  | "input"
+  | "receiverCheck"
+  | "confirm"
+  | "otp"
+  | "submitting"
+  | "complete"
+  | "failed";
 
 export function TransferSection({
   isBusy,
@@ -52,6 +59,7 @@ export function TransferSection({
   }) => void;
 }) {
   const [transferStep, setTransferStep] = useState<TransferStep>("input");
+  const [otpCode, setOtpCode] = useState("");
 
   useEffect(() => {
     if (transferResult) {
@@ -61,13 +69,26 @@ export function TransferSection({
 
   function updateTransferForm(value: typeof transferForm): void {
     setTransferStep("input");
+    setOtpCode("");
     onTransferChange(value);
   }
 
   async function handleTransferSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (transferStep !== "confirm") {
+    if (transferStep === "input") {
+      setTransferStep("receiverCheck");
+      return;
+    }
+    if (transferStep === "receiverCheck") {
       setTransferStep("confirm");
+      return;
+    }
+    if (transferStep === "confirm") {
+      setTransferStep("otp");
+      return;
+    }
+    if (transferStep !== "otp" || otpCode.length < 6) {
+      setTransferStep("otp");
       return;
     }
 
@@ -78,11 +99,25 @@ export function TransferSection({
 
   const stepLabels: Array<{ id: TransferStep; label: string }> = [
     { id: "input", label: "입력" },
+    { id: "receiverCheck", label: "받는 분 확인" },
     { id: "confirm", label: "이체 확인" },
+    { id: "otp", label: "OTP 확인" },
     { id: "submitting", label: "처리 중" },
     { id: "complete", label: "완료" },
     { id: "failed", label: "실패" },
   ];
+  const amountMinor = Number(transferForm.amountMinor || 0);
+  const transferFeeMinor = amountMinor >= 100000000 ? 500 : 0;
+  const limitMinor = 1000000000;
+  const isOverLimit = amountMinor > limitMinor;
+  const submitLabel =
+    transferStep === "receiverCheck"
+      ? "받는 분 확인 완료"
+      : transferStep === "confirm"
+        ? "OTP 확인"
+        : transferStep === "otp"
+          ? "이체 실행"
+          : "받는 분 확인";
 
   return (
     <section className="task-section">
@@ -109,6 +144,24 @@ export function TransferSection({
               </li>
             ))}
           </ol>
+          <div className="transfer-risk-grid" aria-label="이체 사전 확인">
+            <div>
+              <span>받는 분 확인</span>
+              <strong>계좌 ID {transferForm.targetAccountId || "-"}</strong>
+            </div>
+            <div>
+              <span>수수료</span>
+              <strong>
+                {formatMinorAmount(transferFeeMinor, transferForm.currencyCode)}
+              </strong>
+            </div>
+            <div>
+              <span>이체한도</span>
+              <strong className={isOverLimit ? "danger-text" : ""}>
+                {formatMinorAmount(limitMinor, transferForm.currencyCode)}
+              </strong>
+            </div>
+          </div>
           <div className="form-grid">
             <label>
               <span>출금계좌 ID</span>
@@ -192,37 +245,62 @@ export function TransferSection({
               </span>
             </div>
           ) : null}
-          <button disabled={isBusy} type="submit">
-            {transferStep === "confirm" ? "이체 실행" : "이체 확인"}
+          {transferStep === "otp" ? (
+            <label>
+              <span>OTP 확인</span>
+              <input
+                inputMode="numeric"
+                maxLength={6}
+                onChange={(event) => setOtpCode(event.target.value)}
+                placeholder="6자리"
+                required
+                value={otpCode}
+              />
+            </label>
+          ) : null}
+          {isOverLimit ? (
+            <div className="confirm-box warning" role="alert">
+              <strong>이체한도 초과</strong>
+              <span>고객센터의 이체한도 메뉴에서 보안등급과 한도를 확인하세요.</span>
+            </div>
+          ) : null}
+          <button disabled={isBusy || isOverLimit} type="submit">
+            {submitLabel}
           </button>
         </form>
 
-        <ResultPanel
-          title="이체 결과"
-          rows={
-            transferResult
-              ? [
-                  ["거래번호", transferResult.transactionReference],
-                  ["상태", transferResult.status],
-                  [
-                    "이체금액",
-                    formatMinorAmount(
-                      transferResult.amountMinor,
-                      transferResult.currencyCode,
-                    ),
-                  ],
-                  [
-                    "이체 후 잔액",
-                    formatMinorAmount(
-                      transferResult.availableBalanceAfterMinor,
-                      transferResult.currencyCode,
-                    ),
-                  ],
-                  ["기장시각", formatDateTime(transferResult.bookedAt)],
-                ]
-              : []
-          }
-        />
+        <div className="transfer-receipt">
+          <ResultPanel
+            title="이체 완료증"
+            rows={
+              transferResult
+                ? [
+                    ["거래번호", transferResult.transactionReference],
+                    ["상태", transferResult.status],
+                    [
+                      "이체금액",
+                      formatMinorAmount(
+                        transferResult.amountMinor,
+                        transferResult.currencyCode,
+                      ),
+                    ],
+                    [
+                      "수수료",
+                      formatMinorAmount(transferFeeMinor, transferResult.currencyCode),
+                    ],
+                    [
+                      "이체 후 잔액",
+                      formatMinorAmount(
+                        transferResult.availableBalanceAfterMinor,
+                        transferResult.currencyCode,
+                      ),
+                    ],
+                    ["기장시각", formatDateTime(transferResult.bookedAt)],
+                  ]
+                : []
+            }
+          />
+        </div>
       </div>
 
       <div className="two-column">

--- a/front/src/lib/customer-banking/constants.ts
+++ b/front/src/lib/customer-banking/constants.ts
@@ -6,7 +6,10 @@ export const mainMenus: Array<{ id: MenuSection; label: string; group: string }>
   { id: "transfer", label: "이체", group: "이체" },
   { id: "transactions", label: "거래내역 조회", group: "조회" },
   { id: "notifications", label: "알림", group: "고객센터" },
-  { id: "security", label: "인증/세션 관리", group: "뱅킹관리" },
+  { id: "security", label: "인증센터", group: "인증" },
+  { id: "securityHub", label: "보안센터/OTP", group: "보안센터" },
+  { id: "supportCenter", label: "고객센터/사고신고", group: "고객센터" },
+  { id: "enterpriseServices", label: "공과금/금융상품", group: "부가업무" },
 ];
 
 export const quickMenus: Array<{ label: string; section: MenuSection }> = [
@@ -14,12 +17,19 @@ export const quickMenus: Array<{ label: string; section: MenuSection }> = [
   { label: "즉시이체", section: "transfer" },
   { label: "거래내역", section: "transactions" },
   { label: "인증센터", section: "security" },
+  { label: "보안센터", section: "securityHub" },
+  { label: "사고신고", section: "supportCenter" },
+  { label: "공과금", section: "enterpriseServices" },
+  { label: "오픈뱅킹", section: "enterpriseServices" },
   { label: "알림함", section: "notifications" },
 ];
 
 export const recentMenus: Array<{ label: string; section: MenuSection }> = [
   { label: "최근 거래내역 조회", section: "transactions" },
   { label: "출금가능금액 확인", section: "accounts" },
+  { label: "이체한도 조회", section: "supportCenter" },
+  { label: "OTP 이용관리", section: "securityHub" },
+  { label: "예금상품 안내", section: "enterpriseServices" },
   { label: "알림 수신 설정", section: "notifications" },
 ];
 
@@ -27,4 +37,83 @@ export const noticeItems = [
   "보안카드 전체 번호 입력 요구 시 즉시 거래를 중단하세요.",
   "대량 거래 조회는 계좌, 기간, cursor 조건으로 제한됩니다.",
   "공동인증서 및 OTP 재발급은 인증센터에서 진행합니다.",
+];
+
+export const enterpriseServiceItems = [
+  {
+    title: "공과금",
+    category: "납부",
+    description: "지방세, 국세, 아파트관리비, 전기/통신요금 납부 메뉴 진입점입니다.",
+    status: "read-only",
+  },
+  {
+    title: "오픈뱅킹",
+    category: "통합조회",
+    description: "타 금융기관 계좌 연결, 잔액 조회, 해지 동선을 분리해 보여줍니다.",
+    status: "read-only",
+  },
+  {
+    title: "예금상품",
+    category: "상품",
+    description: "입출금, 예금, 적금 상품 목록과 가입 전 확인 항목을 제공합니다.",
+    status: "상품 안내",
+  },
+  {
+    title: "대출",
+    category: "여신",
+    description: "신용대출, 담보대출, 상환 조회 메뉴를 신청 실행 없이 안내합니다.",
+    status: "상담 안내",
+  },
+  {
+    title: "외환",
+    category: "FX",
+    description: "환율 조회, 외화예금, 해외송금 메뉴를 조회형 업무로 배치합니다.",
+    status: "환율 조회",
+  },
+];
+
+export const supportCenterItems = [
+  {
+    title: "고객센터",
+    description: "상담, 자주 찾는 질문, 증명서 발급, 서비스 이용시간 메뉴를 제공합니다.",
+    action: "상담/FAQ",
+  },
+  {
+    title: "사고신고",
+    description: "통장, 카드, 보안매체, 인증서 분실 신고 진입점을 한 화면에 모읍니다.",
+    action: "긴급 신고",
+  },
+  {
+    title: "이체한도",
+    description: "1회/1일 이체한도와 보안매체별 한도 기준을 조회형으로 보여줍니다.",
+    action: "한도 조회",
+  },
+  {
+    title: "이용안내",
+    description: "점검 시간, 수수료, 전자금융 약관, 장애 공지 링크를 정리합니다.",
+    action: "안내",
+  },
+];
+
+export const securityHubItems = [
+  {
+    title: "공동인증서",
+    description: "인증서 발급, 갱신, 타기관 등록, 폐기 메뉴를 분리합니다.",
+    status: "인증서 관리",
+  },
+  {
+    title: "금융인증서",
+    description: "클라우드 인증서 로그인, 발급, 재등록 흐름을 안내합니다.",
+    status: "금융인증",
+  },
+  {
+    title: "OTP",
+    description: "OTP 등록, 오류횟수 초기화, 보안매체 교체 기준을 표시합니다.",
+    status: "보안매체",
+  },
+  {
+    title: "보안매체",
+    description: "보안카드, 모바일 OTP, 생체 인증의 사용 가능 업무를 비교합니다.",
+    status: "등급 안내",
+  },
 ];

--- a/front/src/lib/customer-banking/types.ts
+++ b/front/src/lib/customer-banking/types.ts
@@ -4,7 +4,10 @@ export type MenuSection =
   | "transfer"
   | "transactions"
   | "notifications"
-  | "security";
+  | "security"
+  | "securityHub"
+  | "supportCenter"
+  | "enterpriseServices";
 
 export type AlertMessage = {
   type: "info" | "success" | "error";

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -65,6 +65,14 @@ button:hover:not(:disabled) {
   color: var(--primary);
 }
 
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+a:focus-visible {
+  outline: 3px solid #79b8ff;
+  outline-offset: 2px;
+}
+
 button:disabled {
   cursor: not-allowed;
   opacity: 0.48;
@@ -1192,6 +1200,12 @@ label span {
   .quick-grid button,
   .recent-menu-list button {
     width: 100%;
+  }
+
+  button,
+  input,
+  select {
+    min-height: 44px;
   }
 
   .bank-table th,

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -467,6 +467,59 @@ label span {
   width: 100%;
 }
 
+.enterprise-service-grid,
+.security-hub-grid,
+.support-service-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.enterprise-service-card,
+.security-hub-card,
+.support-service-card {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface-muted);
+  padding: 14px;
+}
+
+.enterprise-service-card span,
+.security-hub-card span {
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.enterprise-service-card strong,
+.security-hub-card strong,
+.support-service-card strong {
+  color: #102f55;
+  font-size: 17px;
+}
+
+.enterprise-service-card p,
+.security-hub-card p,
+.support-service-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.enterprise-service-card small {
+  color: var(--success);
+  font-weight: 800;
+}
+
+.support-service-card button {
+  width: fit-content;
+  padding: 0 12px;
+}
+
 .account-grid,
 .split-work {
   display: grid;
@@ -994,6 +1047,9 @@ label span {
   }
 
   .summary-grid,
+  .enterprise-service-grid,
+  .security-hub-grid,
+  .support-service-grid,
   .account-grid,
   .split-work,
   .form-grid,

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -644,7 +644,7 @@ label span {
 
 .stepper {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(84px, 1fr));
   gap: 4px;
   margin: 0;
   padding: 0;
@@ -680,9 +680,49 @@ label span {
   padding: 10px 12px;
 }
 
+.confirm-box.warning {
+  border-color: #f7c580;
+  background: #fff7ed;
+}
+
 .confirm-box strong,
 .filter-summary strong {
   color: var(--primary-dark);
+}
+
+.danger-text {
+  color: var(--danger);
+}
+
+.transfer-risk-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.transfer-risk-grid div {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: #fff;
+  padding: 10px;
+}
+
+.transfer-risk-grid span {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.transfer-risk-grid strong {
+  overflow-wrap: anywhere;
+  color: #102f55;
+}
+
+.transfer-receipt .result-panel {
+  min-height: 100%;
 }
 
 .filter-form {
@@ -1050,6 +1090,7 @@ label span {
   .enterprise-service-grid,
   .security-hub-grid,
   .support-service-grid,
+  .transfer-risk-grid,
   .account-grid,
   .split-work,
   .form-grid,


### PR DESCRIPTION
## 🔗 Related Issue
- close #900

## 🌿 Base Branch
- `main`

## 📝 Summary
- 고객 웹뱅킹 메뉴 폭을 고객센터, 보안센터, 사고신고, 이체한도, OTP, 공과금, 오픈뱅킹, 예금상품, 대출, 외환까지 확장합니다.
- 실행성 신규 backend 계약 없이 read-only 업무 화면을 추가하고, 이체는 받는 사람 확인/수수료/한도/OTP/완료증 단계로 보강합니다.

## 🛠 Changes
- 대형 은행식 read-only 업무 화면 3종 추가: 부가업무, 보안센터, 고객센터
- 인증센터/보안센터 메뉴를 공동인증서, 금융인증서, OTP, 보안매체 기준으로 세분화
- 이체 플로우에 받는 분 확인, 수수료, 이체한도, OTP 확인, 이체 완료증 추가
- `test:enterprise-ux`, `test:e2e:a11y` smoke 추가
- Playwright MCP와 QA 스크린샷 산출물 gitignore 추가

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front test:enterprise-ux`
- `yarn --cwd front test:e2e:a11y`
- `yarn --cwd front lint`
- `yarn --cwd front build`
- `http://localhost:3103` Playwright desktop/mobile viewport smoke

## 📸 Screenshot / API Example
- Playwright viewport smoke: desktop 1366x900, mobile 390x844 확인
- API 변경 없음

## ⚠️ Risk & Rollback
- 예상 리스크: read-only 메뉴가 실제 실행 가능 업무처럼 보일 수 있어 후속 PR에서 disabled/안내/권한 문구를 더 세분화해야 합니다.
- 롤백 방법: 이 PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?