### PR TITLE
[Feat] 고객 웹뱅킹 실거래 상세 UX 확장

### DIFF
--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
@@ -1,12 +1,16 @@
 package com.aquilabank.global.web.ledger;
 
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
 import com.aquilabank.domain.ledger.model.TransferCommand;
 import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.model.TransferReversalCommand;
 import com.aquilabank.domain.ledger.model.TransferReversalReason;
 import com.aquilabank.domain.ledger.model.TransferReversalResult;
+import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
 import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
+import com.aquilabank.global.config.TransferLimitPolicyProperties;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
 import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
@@ -16,13 +20,19 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** 송금 명령 use case를 노출하는 HTTP adapter */
@@ -34,14 +44,92 @@ public class TransferCommandController {
   private final TransferCommandUseCase transferCommandUseCase;
   private final TransferReversalUseCase transferReversalUseCase;
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
+  private final AccountSummaryQueryUseCase accountSummaryQueryUseCase;
+  private final TransferLimitUsageReadPort transferLimitUsageReadPort;
+  private final TransferLimitPolicyProperties transferLimitPolicyProperties;
+  private final Clock clock;
 
+  @Autowired
   public TransferCommandController(
       TransferCommandUseCase transferCommandUseCase,
       TransferReversalUseCase transferReversalUseCase,
-      RequestAccountAuthorizationService requestAccountAuthorizationService) {
+      RequestAccountAuthorizationService requestAccountAuthorizationService,
+      AccountSummaryQueryUseCase accountSummaryQueryUseCase,
+      TransferLimitUsageReadPort transferLimitUsageReadPort,
+      TransferLimitPolicyProperties transferLimitPolicyProperties) {
+    this(
+        transferCommandUseCase,
+        transferReversalUseCase,
+        requestAccountAuthorizationService,
+        accountSummaryQueryUseCase,
+        transferLimitUsageReadPort,
+        transferLimitPolicyProperties,
+        Clock.systemUTC());
+  }
+
+  TransferCommandController(
+      TransferCommandUseCase transferCommandUseCase,
+      TransferReversalUseCase transferReversalUseCase,
+      RequestAccountAuthorizationService requestAccountAuthorizationService,
+      AccountSummaryQueryUseCase accountSummaryQueryUseCase,
+      TransferLimitUsageReadPort transferLimitUsageReadPort,
+      TransferLimitPolicyProperties transferLimitPolicyProperties,
+      Clock clock) {
     this.transferCommandUseCase = transferCommandUseCase;
     this.transferReversalUseCase = transferReversalUseCase;
     this.requestAccountAuthorizationService = requestAccountAuthorizationService;
+    this.accountSummaryQueryUseCase = accountSummaryQueryUseCase;
+    this.transferLimitUsageReadPort = transferLimitUsageReadPort;
+    this.transferLimitPolicyProperties = transferLimitPolicyProperties;
+    this.clock = clock;
+  }
+
+  @GetMapping("/preview")
+  public TransferPreviewResponse preview(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @RequestParam @Positive(message = "sourceAccountId must be positive") long sourceAccountId,
+      @RequestParam @Positive(message = "targetAccountId must be positive") long targetAccountId,
+      @RequestParam @Positive(message = "amountMinor must be positive") long amountMinor,
+      @RequestParam
+          @NotBlank(message = "currencyCode is required") @Pattern(
+              regexp = "^[A-Z]{3}$",
+              message = "currencyCode must be a 3-letter uppercase code")
+          String currencyCode) {
+    long resolvedSourceAccountId =
+        requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            principal, sourceAccountId);
+    AccountSummary source = accountSummaryQueryUseCase.getByAccountId(resolvedSourceAccountId);
+    AccountSummary target = accountSummaryQueryUseCase.getByAccountId(targetAccountId);
+    ZoneId businessZoneId = ZoneId.of(transferLimitPolicyProperties.businessZoneId());
+    Instant now = clock.instant();
+    LocalDate businessDate = LocalDate.ofInstant(now, businessZoneId);
+    Instant fromInclusive = businessDate.atStartOfDay(businessZoneId).toInstant();
+    Instant toExclusive = businessDate.plusDays(1).atStartOfDay(businessZoneId).toInstant();
+    long dailyUsedMinor =
+        transferLimitUsageReadPort.sumBookedDebitAmountMinor(
+            resolvedSourceAccountId, currencyCode, fromInclusive, toExclusive);
+    long feeMinor = 0L;
+    long totalDebitMinor = amountMinor + feeMinor;
+    long dailyRemainingMinor =
+        Math.max(0L, transferLimitPolicyProperties.dailyTransferLimitMinor() - dailyUsedMinor);
+    String blockedReason =
+        resolvePreviewBlockedReason(
+            source, target, amountMinor, totalDebitMinor, dailyUsedMinor, currencyCode);
+    return new TransferPreviewResponse(
+        resolvedSourceAccountId,
+        TransferPreviewAccountResponse.from(target),
+        amountMinor,
+        currencyCode,
+        feeMinor,
+        "INTERNAL_TRANSFER_WAIVED",
+        totalDebitMinor,
+        transferLimitPolicyProperties.singleTransferLimitMinor(),
+        transferLimitPolicyProperties.dailyTransferLimitMinor(),
+        dailyUsedMinor,
+        dailyRemainingMinor,
+        "OK".equals(blockedReason),
+        blockedReason,
+        true);
   }
 
   @PostMapping
@@ -84,6 +172,74 @@ public class TransferCommandController {
                 idempotencyKey));
     return TransferReversalResponse.from(result);
   }
+
+  private String resolvePreviewBlockedReason(
+      AccountSummary source,
+      AccountSummary target,
+      long amountMinor,
+      long totalDebitMinor,
+      long dailyUsedMinor,
+      String currencyCode) {
+    if (!source.currencyCode().equals(currencyCode)
+        || !target.currencyCode().equals(currencyCode)) {
+      return "CURRENCY_MISMATCH";
+    }
+    if (!"ACTIVE".equals(target.accountStatus())) {
+      return "TARGET_ACCOUNT_NOT_ACTIVE";
+    }
+    if (amountMinor > transferLimitPolicyProperties.singleTransferLimitMinor()) {
+      return "SINGLE_LIMIT_EXCEEDED";
+    }
+    if (dailyUsedMinor + amountMinor > transferLimitPolicyProperties.dailyTransferLimitMinor()) {
+      return "DAILY_LIMIT_EXCEEDED";
+    }
+    if (totalDebitMinor > source.availableBalanceMinor()) {
+      return "INSUFFICIENT_BALANCE";
+    }
+    return "OK";
+  }
+
+  /** 송금 preview target 계좌 요약. 계좌번호는 확인용 마지막 4자리만 노출합니다. */
+  public record TransferPreviewAccountResponse(
+      long accountId,
+      String maskedAccountNumber,
+      String displayName,
+      String accountStatus,
+      String currencyCode) {
+
+    static TransferPreviewAccountResponse from(AccountSummary summary) {
+      return new TransferPreviewAccountResponse(
+          summary.accountId(),
+          maskAccountNumber(summary.accountNumber()),
+          summary.displayName(),
+          summary.accountStatus(),
+          summary.currencyCode());
+    }
+
+    private static String maskAccountNumber(String accountNumber) {
+      if (accountNumber.length() <= 4) {
+        return "****";
+      }
+      return "********" + accountNumber.substring(accountNumber.length() - 4);
+    }
+  }
+
+  /** 송금 실행 전 수취인/수수료/한도 확인 응답 */
+  public record TransferPreviewResponse(
+      long sourceAccountId,
+      TransferPreviewAccountResponse targetAccount,
+      long amountMinor,
+      String currencyCode,
+      long feeMinor,
+      String feePolicy,
+      long totalDebitMinor,
+      long singleTransferLimitMinor,
+      long dailyTransferLimitMinor,
+      long dailyUsedMinor,
+      long dailyRemainingMinor,
+      boolean allowed,
+      String blockedReason,
+      boolean otpRequired) {}
 
   /** 송금 요청 body */
   public record TransferRequest(

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -4,18 +4,26 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
 import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.model.TransferReversalResult;
+import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
 import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
+import com.aquilabank.global.config.TransferLimitPolicyProperties;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
 import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -27,6 +35,8 @@ class TransferCommandControllerTest {
   private TransferCommandUseCase transferCommandUseCase;
   private TransferReversalUseCase transferReversalUseCase;
   private RequestAccountAuthorizationService requestAccountAuthorizationService;
+  private AccountSummaryQueryUseCase accountSummaryQueryUseCase;
+  private TransferLimitUsageReadPort transferLimitUsageReadPort;
   private MockMvc mockMvc;
 
   @BeforeEach
@@ -34,16 +44,57 @@ class TransferCommandControllerTest {
     transferCommandUseCase = mock(TransferCommandUseCase.class);
     transferReversalUseCase = mock(TransferReversalUseCase.class);
     requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
+    accountSummaryQueryUseCase = mock(AccountSummaryQueryUseCase.class);
+    transferLimitUsageReadPort = mock(TransferLimitUsageReadPort.class);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new TransferCommandController(
                     transferCommandUseCase,
                     transferReversalUseCase,
-                    requestAccountAuthorizationService))
+                    requestAccountAuthorizationService,
+                    accountSummaryQueryUseCase,
+                    transferLimitUsageReadPort,
+                    new TransferLimitPolicyProperties(2_000L, 3_000L, "Asia/Seoul"),
+                    Clock.fixed(Instant.parse("2026-05-11T01:00:00Z"), ZoneOffset.UTC)))
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .setControllerAdvice(new ApiExceptionHandler())
             .build();
+  }
+
+  @Test
+  void previewsTransferRecipientFeeAndLimitWithoutWritingLedger() throws Exception {
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+    when(accountSummaryQueryUseCase.getByAccountId(101L))
+        .thenReturn(account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L));
+    when(accountSummaryQueryUseCase.getByAccountId(202L))
+        .thenReturn(account(202L, "999900001234", "홍길동", "ACTIVE", 0L));
+    when(transferLimitUsageReadPort.sumBookedDebitAmountMinor(
+            org.mockito.ArgumentMatchers.eq(101L),
+            org.mockito.ArgumentMatchers.eq("KRW"),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(1_000L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transfers/preview")
+                .header("X-Account-Id", "101")
+                .queryParam("sourceAccountId", "101")
+                .queryParam("targetAccountId", "202")
+                .queryParam("amountMinor", "1500")
+                .queryParam("currencyCode", "KRW"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sourceAccountId").value(101))
+        .andExpect(jsonPath("$.targetAccount.accountId").value(202))
+        .andExpect(jsonPath("$.feeMinor").value(0))
+        .andExpect(jsonPath("$.singleTransferLimitMinor").value(2000))
+        .andExpect(jsonPath("$.dailyTransferLimitMinor").value(3000))
+        .andExpect(jsonPath("$.dailyUsedMinor").value(1000))
+        .andExpect(jsonPath("$.allowed").value(true))
+        .andExpect(jsonPath("$.otpRequired").value(true));
   }
 
   @Test
@@ -174,5 +225,23 @@ class TransferCommandControllerTest {
                     }
                     """))
         .andExpect(status().isBadRequest());
+  }
+
+  private static AccountSummary account(
+      long accountId,
+      String accountNumber,
+      String displayName,
+      String status,
+      long availableBalanceMinor) {
+    return new AccountSummary(
+        accountId,
+        accountNumber,
+        displayName,
+        status,
+        "KRW",
+        availableBalanceMinor,
+        0L,
+        Instant.parse("2026-05-11T00:00:00Z"),
+        Instant.parse("2026-05-11T00:00:00Z"));
   }
 }

--- a/front/e2e/customer-banking-click-flow.spec.ts
+++ b/front/e2e/customer-banking-click-flow.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+test("고객 웹뱅킹 주요 공개 업무와 미로그인 이체 가드를 실제 클릭으로 확인한다", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "뱅킹 업무" })).toBeVisible();
+  await page.getByRole("navigation", { name: "주요 메뉴" }).getByRole("button", { name: "이체" }).click();
+  await expect(page.getByText("권한 만료 또는 미로그인")).toBeVisible();
+
+  await page.getByRole("button", { name: "인증센터로 이동" }).click();
+  await expect(page.getByRole("heading", { name: "로그인 및 보안관리" })).toBeVisible();
+
+  await page
+    .getByRole("navigation", { name: "주요 메뉴" })
+    .getByRole("button", { name: "보안센터/OTP" })
+    .click();
+  await expect(page.getByText("공동인증서 등록")).toBeVisible();
+  await expect(page.getByText("금융인증서 등록")).toBeVisible();
+  await expect(page.getByText("보안매체 등록")).toBeVisible();
+
+  await page
+    .getByRole("navigation", { name: "주요 메뉴" })
+    .getByRole("button", { name: "공과금/금융상품" })
+    .click();
+  await expect(page.getByText("공과금 상세")).toBeVisible();
+  await expect(page.getByText("오픈뱅킹 상세")).toBeVisible();
+  await expect(page.getByText("외환 상세")).toBeVisible();
+
+  await page
+    .getByRole("navigation", { name: "주요 메뉴" })
+    .getByRole("button", { name: "고객센터/사고신고" })
+    .click();
+  await expect(page.getByText("사고신고 접수", { exact: true })).toBeVisible();
+  await expect(page.getByText("이체확인증", { exact: true })).toBeVisible();
+  await page.getByText("FAQ 이체확인증은 어디서 발급하나요?").click();
+  await expect(page.getByText("이체 완료 후 완료증 영역")).toBeVisible();
+
+  await page.getByLabel("통합검색").fill("OTP");
+  await expect(page.getByLabel("통합검색")).toHaveValue("OTP");
+});

--- a/front/package.json
+++ b/front/package.json
@@ -12,6 +12,7 @@
     "test:auth-session": "node scripts/check-auth-session-hardening-contract.mjs",
     "test:ops-console": "node scripts/check-ops-console-contract.mjs",
     "test:enterprise-ux": "node scripts/check-customer-banking-enterprise-ux.mjs",
+    "test:fulfillment-ux": "node scripts/check-customer-banking-fulfillment-ux.mjs",
     "test:e2e:a11y": "node scripts/check-customer-banking-visual-a11y.mjs"
   },
   "dependencies": {

--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,7 @@
     "test:ops-console": "node scripts/check-ops-console-contract.mjs",
     "test:enterprise-ux": "node scripts/check-customer-banking-enterprise-ux.mjs",
     "test:fulfillment-ux": "node scripts/check-customer-banking-fulfillment-ux.mjs",
+    "test:e2e:click-flow": "playwright test --config=playwright.config.ts e2e/customer-banking-click-flow.spec.ts",
     "test:e2e:a11y": "node scripts/check-customer-banking-visual-a11y.mjs"
   },
   "dependencies": {
@@ -21,6 +22,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "^20.17.10",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 3113);
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 980 },
+      },
+    },
+    {
+      name: "mobile-chromium",
+      use: {
+        ...devices["Pixel 5"],
+      },
+    },
+  ],
+  webServer: {
+    command: `NEXT_TELEMETRY_DISABLED=1 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:18080 ./node_modules/.bin/next dev -H 127.0.0.1 -p ${port}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/front/scripts/check-customer-banking-fulfillment-ux.mjs
+++ b/front/scripts/check-customer-banking-fulfillment-ux.mjs
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+
+function read(path) {
+  const filePath = join(root, path);
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
+}
+
+const files = {
+  packageJson: read("package.json"),
+  apiTypes: read("src/lib/api/types.ts"),
+  apiClient: read("src/lib/api/client.ts"),
+  hook: read("src/hooks/use-customer-banking.ts"),
+  page: read("src/app/page.tsx"),
+  transfer: read("src/components/customer-banking/sections/transfer-section.tsx"),
+};
+
+const required = [
+  ["package script", files.packageJson, "test:fulfillment-ux"],
+  ["preview request type", files.apiTypes, "TransferPreviewRequest"],
+  ["preview response type", files.apiTypes, "TransferPreviewResponse"],
+  ["preview blocked reason", files.apiTypes, "blockedReason"],
+  ["preview api method", files.apiClient, "previewTransfer"],
+  ["preview api path", files.apiClient, "/api/v1/transfers/preview"],
+  ["preview hook state", files.hook, "transferPreview"],
+  ["preview hook handler", files.hook, "handlePreviewTransfer"],
+  ["preview page binding", files.page, "onPreviewTransfer"],
+  ["preview section prop", files.transfer, "onPreviewTransfer"],
+  ["backend preview label", files.transfer, "backend preview"],
+  ["receiver validation display", files.transfer, "받는 분 검증"],
+  ["fee policy display", files.transfer, "feePolicy"],
+  ["limit remaining display", files.transfer, "dailyRemainingMinor"],
+  ["otp required display", files.transfer, "otpRequired"],
+];
+
+const missing = required.filter(([, content, expected]) => !content.includes(expected));
+
+if (missing.length > 0) {
+  console.error("[customer-banking-fulfillment-ux] contract violations:");
+  for (const [name, , expected] of missing) {
+    console.error(`- missing ${name}: ${expected}`);
+  }
+  process.exit(1);
+}
+
+console.log("[customer-banking-fulfillment-ux] passed");

--- a/front/scripts/check-customer-banking-fulfillment-ux.mjs
+++ b/front/scripts/check-customer-banking-fulfillment-ux.mjs
@@ -15,6 +15,10 @@ const files = {
   hook: read("src/hooks/use-customer-banking.ts"),
   page: read("src/app/page.tsx"),
   transfer: read("src/components/customer-banking/sections/transfer-section.tsx"),
+  enterprise: read("src/components/customer-banking/sections/enterprise-services-section.tsx"),
+  securityHub: read("src/components/customer-banking/sections/security-hub-section.tsx"),
+  support: read("src/components/customer-banking/sections/support-center-section.tsx"),
+  styles: read("src/styles/customer-banking.css"),
 };
 
 const required = [
@@ -33,6 +37,24 @@ const required = [
   ["fee policy display", files.transfer, "feePolicy"],
   ["limit remaining display", files.transfer, "dailyRemainingMinor"],
   ["otp required display", files.transfer, "otpRequired"],
+  ["bill payment detail", files.enterprise, "공과금 상세"],
+  ["open banking detail", files.enterprise, "오픈뱅킹 상세"],
+  ["deposit product detail", files.enterprise, "예금상품 상세"],
+  ["loan detail", files.enterprise, "대출 상세"],
+  ["fx detail", files.enterprise, "외환 상세"],
+  ["common certificate registration", files.securityHub, "공동인증서 등록"],
+  ["financial certificate registration", files.securityHub, "금융인증서 등록"],
+  ["security media registration", files.securityHub, "보안매체 등록"],
+  ["otp registration", files.securityHub, "OTP 등록"],
+  ["transfer receipt certificate", files.support, "이체확인증"],
+  ["balance certificate", files.support, "잔액증명서"],
+  ["transaction certificate", files.support, "거래내역확인서"],
+  ["support FAQ", files.support, "FAQ"],
+  ["incident intake", files.support, "사고신고 접수"],
+  ["fulfillment detail styles", files.styles, ".fulfillment-detail-grid"],
+  ["registration flow styles", files.styles, ".registration-flow-grid"],
+  ["incident form styles", files.styles, ".incident-form"],
+  ["certificate list styles", files.styles, ".certificate-list"],
 ];
 
 const missing = required.filter(([, content, expected]) => !content.includes(expected));

--- a/front/scripts/check-customer-banking-fulfillment-ux.mjs
+++ b/front/scripts/check-customer-banking-fulfillment-ux.mjs
@@ -18,11 +18,14 @@ const files = {
   enterprise: read("src/components/customer-banking/sections/enterprise-services-section.tsx"),
   securityHub: read("src/components/customer-banking/sections/security-hub-section.tsx"),
   support: read("src/components/customer-banking/sections/support-center-section.tsx"),
+  playwrightConfig: read("playwright.config.ts"),
+  clickFlow: read("e2e/customer-banking-click-flow.spec.ts"),
   styles: read("src/styles/customer-banking.css"),
 };
 
 const required = [
   ["package script", files.packageJson, "test:fulfillment-ux"],
+  ["package click flow script", files.packageJson, "test:e2e:click-flow"],
   ["preview request type", files.apiTypes, "TransferPreviewRequest"],
   ["preview response type", files.apiTypes, "TransferPreviewResponse"],
   ["preview blocked reason", files.apiTypes, "blockedReason"],
@@ -55,6 +58,10 @@ const required = [
   ["registration flow styles", files.styles, ".registration-flow-grid"],
   ["incident form styles", files.styles, ".incident-form"],
   ["certificate list styles", files.styles, ".certificate-list"],
+  ["playwright config", files.playwrightConfig, "defineConfig"],
+  ["click flow playwright test", files.clickFlow, "@playwright/test"],
+  ["click flow transfer guard", files.clickFlow, "권한 만료 또는 미로그인"],
+  ["click flow public service", files.clickFlow, "공과금 상세"],
 ];
 
 const missing = required.filter(([, content, expected]) => !content.includes(expected));

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -43,6 +43,7 @@ export default function HomePage() {
     selectedAccount,
     transferForm,
     transferResult,
+    transferPreview,
     reversalForm,
     reversalResult,
     transactionMode,
@@ -76,6 +77,7 @@ export default function HomePage() {
     handleLoadAccounts,
     handleLoadAccountDetail,
     handleTransfer,
+    handlePreviewTransfer,
     handleReversal,
     handleSearchTransactions,
     handleLoadTransactionDetail,
@@ -255,7 +257,9 @@ export default function HomePage() {
               reversalForm={reversalForm}
               reversalResult={reversalResult}
               transferForm={transferForm}
+              transferPreview={transferPreview}
               transferResult={transferResult}
+              onPreviewTransfer={handlePreviewTransfer}
               onReversal={handleReversal}
               onReversalChange={setReversalForm}
               onTransfer={handleTransfer}

--- a/front/src/components/customer-banking/sections/enterprise-services-section.tsx
+++ b/front/src/components/customer-banking/sections/enterprise-services-section.tsx
@@ -1,5 +1,48 @@
 import { enterpriseServiceItems } from "@/lib/customer-banking/constants";
 
+const fulfillmentDetails = [
+  {
+    title: "공과금 상세",
+    headline: "지로/지방세/아파트관리비 납부",
+    description: "기관 선택, 납부번호 조회, 납부 예정금액 확인, 납부확인증 발급 흐름을 한 화면에 배치합니다.",
+    fields: ["납부기관", "전자납부번호", "출금계좌", "납부예정일"],
+    steps: ["기관 선택", "납부번호 조회", "금액 확인", "확인증 발급"],
+    status: "조회/확인증 화면 준비",
+  },
+  {
+    title: "오픈뱅킹 상세",
+    headline: "타행 계좌 연결 및 통합조회",
+    description: "동의 상태, 연결 은행, 대표 계좌, 잔액 갱신 시각을 고객이 반복 조회하기 쉬운 표 형태로 제공합니다.",
+    fields: ["은행", "계좌 별칭", "동의 만료일", "최근 동기화"],
+    steps: ["은행 선택", "약관 동의", "계좌 확인", "통합조회"],
+    status: "연결 상태 read-only",
+  },
+  {
+    title: "예금상품 상세",
+    headline: "정기예금/입출금 상품 비교",
+    description: "금리, 가입 기간, 우대 조건, 중도해지 기준을 실제 상품몰처럼 비교 가능한 정보 구조로 확장합니다.",
+    fields: ["상품명", "기본금리", "우대조건", "가입기간"],
+    steps: ["상품 비교", "유의사항 확인", "예상 이자 계산", "상담 연결"],
+    status: "상품 상세 안내",
+  },
+  {
+    title: "대출 상세",
+    headline: "한도조회/상환조회/서류 안내",
+    description: "한도조회 준비 정보와 상환 스케줄, 필요 서류, 금리 변동 안내를 분리해 보여줍니다.",
+    fields: ["대출 유형", "예상 한도", "상환 방식", "필요 서류"],
+    steps: ["기본정보 확인", "한도 사전조회", "서류 안내", "상담 예약"],
+    status: "조회형 상세",
+  },
+  {
+    title: "외환 상세",
+    headline: "환율/외화예금/해외송금 준비",
+    description: "통화별 환율, 우대율, 외화예금 가능 여부, 해외송금 준비 정보를 은행권 외환 메뉴처럼 묶습니다.",
+    fields: ["통화", "고시환율", "우대율", "송금 목적"],
+    steps: ["환율 조회", "우대 조건 확인", "외화계좌 선택", "송금 준비"],
+    status: "환율/준비 정보",
+  },
+];
+
 export function EnterpriseServicesSection() {
   return (
     <section className="task-section">
@@ -60,6 +103,33 @@ export function EnterpriseServicesSection() {
           </tbody>
         </table>
       </div>
+
+      <section className="fulfillment-detail-grid" aria-label="부가업무 상세 화면">
+        {fulfillmentDetails.map((item) => (
+          <article className="fulfillment-detail-card" key={item.title}>
+            <div className="fulfillment-detail-head">
+              <span>{item.title}</span>
+              <strong>{item.headline}</strong>
+              <p>{item.description}</p>
+            </div>
+            <dl className="detail-list">
+              <div>
+                <dt>필수 입력</dt>
+                <dd>{item.fields.join(" / ")}</dd>
+              </div>
+              <div>
+                <dt>현재 상태</dt>
+                <dd>{item.status}</dd>
+              </div>
+            </dl>
+            <ol className="process-strip" aria-label={`${item.title} 처리 단계`}>
+              {item.steps.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ol>
+          </article>
+        ))}
+      </section>
     </section>
   );
 }

--- a/front/src/components/customer-banking/sections/security-hub-section.tsx
+++ b/front/src/components/customer-banking/sections/security-hub-section.tsx
@@ -1,5 +1,32 @@
 import { securityHubItems } from "@/lib/customer-banking/constants";
 
+const registrationFlows = [
+  {
+    title: "공동인증서 등록",
+    description: "인증서 선택, 비밀번호 확인, 타기관 인증서 등록 여부, 만료일 확인을 실제 인증센터 흐름처럼 분리합니다.",
+    steps: ["인증서 선택", "비밀번호 확인", "타기관 등록 확인", "등록 완료"],
+    checks: ["브라우저 저장소 저장 금지", "서명 원문 미보관", "만료일/발급기관 표시"],
+  },
+  {
+    title: "금융인증서 등록",
+    description: "클라우드 인증 요청, 휴대폰 본인확인, 간편 비밀번호 확인, 기기 등록 상태를 보여줍니다.",
+    steps: ["본인확인", "클라우드 인증", "기기 확인", "사용 등록"],
+    checks: ["세션 내 요청번호만 유지", "인증 완료 시각 표시", "재등록 경로 제공"],
+  },
+  {
+    title: "OTP 등록",
+    description: "실물 OTP와 모바일 OTP를 나눠 일련번호, 제조사, 보안등급, 이체한도 반영 상태를 확인합니다.",
+    steps: ["매체 선택", "일련번호 확인", "OTP 검증", "한도 반영"],
+    checks: ["OTP 원문 저장 금지", "오류 횟수 안내", "분실 신고 연결"],
+  },
+  {
+    title: "보안매체 등록",
+    description: "보안카드, 모바일 OTP, 대체 인증수단을 은행권 보안매체 관리 화면 기준으로 정리합니다.",
+    steps: ["매체 종류 선택", "본인확인", "매체 상태 확인", "업무별 적용"],
+    checks: ["등급별 한도 표시", "해지/재발급 분리", "고위험 업무 안내"],
+  },
+];
+
 export function SecurityHubSection() {
   return (
     <section className="task-section">
@@ -61,6 +88,28 @@ export function SecurityHubSection() {
             </tbody>
           </table>
         </div>
+      </section>
+
+      <section className="registration-flow-grid" aria-label="인증센터 등록 흐름">
+        {registrationFlows.map((flow) => (
+          <article className="registration-flow-card" key={flow.title}>
+            <div>
+              <span>인증센터</span>
+              <strong>{flow.title}</strong>
+              <p>{flow.description}</p>
+            </div>
+            <ol className="process-strip" aria-label={`${flow.title} 단계`}>
+              {flow.steps.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ol>
+            <ul className="check-list">
+              {flow.checks.map((check) => (
+                <li key={check}>{check}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
       </section>
     </section>
   );

--- a/front/src/components/customer-banking/sections/support-center-section.tsx
+++ b/front/src/components/customer-banking/sections/support-center-section.tsx
@@ -1,5 +1,38 @@
 import { supportCenterItems } from "@/lib/customer-banking/constants";
 
+const faqItems = [
+  {
+    question: "FAQ 이체확인증은 어디서 발급하나요?",
+    answer: "이체 완료 후 완료증 영역에서 거래번호를 확인하고 증명서 메뉴의 이체확인증 발급으로 이동합니다.",
+  },
+  {
+    question: "OTP 오류 횟수가 초과되면 어떻게 하나요?",
+    answer: "사고신고 접수에서 보안매체 오류 초기화를 선택하고 본인확인 후 재등록 흐름을 진행합니다.",
+  },
+  {
+    question: "오픈뱅킹 연결 계좌가 보이지 않습니다.",
+    answer: "동의 만료일과 은행별 점검 시간을 확인한 뒤 오픈뱅킹 상세의 통합조회 갱신을 다시 실행합니다.",
+  },
+];
+
+const certificateItems = [
+  {
+    title: "이체확인증",
+    description: "거래번호, 출금계좌, 입금계좌, 이체금액, 수수료, 처리시각을 확인증 형태로 제공합니다.",
+    scope: "즉시이체 완료 거래",
+  },
+  {
+    title: "잔액증명서",
+    description: "기준일, 계좌, 통화, 잔액, 발급 목적을 확인한 뒤 증명서 발급 화면으로 이어집니다.",
+    scope: "예금/입출금 계좌",
+  },
+  {
+    title: "거래내역확인서",
+    description: "조회 기간, 거래 상태, 입출금 구분, 증명 대상 거래를 선택하는 화면 구조를 제공합니다.",
+    scope: "거래내역 조회 결과",
+  },
+];
+
 export function SupportCenterSection() {
   return (
     <section className="task-section">
@@ -56,6 +89,73 @@ export function SupportCenterSection() {
             </tbody>
           </table>
         </div>
+      </section>
+
+      <section className="support-detail-grid" aria-label="고객센터 상세 업무">
+        <article className="faq-list">
+          <div className="panel-toolbar">
+            <div>
+              <strong>FAQ</strong>
+              <span>반복 문의는 업무 화면 바로 옆에서 확인합니다.</span>
+            </div>
+          </div>
+          {faqItems.map((item) => (
+            <details key={item.question}>
+              <summary>{item.question}</summary>
+              <p>{item.answer}</p>
+            </details>
+          ))}
+        </article>
+
+        <article className="incident-form">
+          <div className="panel-toolbar">
+            <div>
+              <strong>사고신고 접수</strong>
+              <span>분실/도용/오류 신고를 한 화면에서 접수 준비합니다.</span>
+            </div>
+          </div>
+          <div className="form-grid">
+            <label>
+              <span>신고 유형</span>
+              <select defaultValue="security-media">
+                <option value="security-media">보안매체 분실</option>
+                <option value="certificate">인증서 도용 의심</option>
+                <option value="transfer">미확인 이체</option>
+                <option value="otp-error">OTP 오류 초과</option>
+              </select>
+            </label>
+            <label>
+              <span>대상 계좌/매체</span>
+              <input defaultValue="선택 대기" readOnly />
+            </label>
+            <label>
+              <span>긴급 연락처</span>
+              <input defaultValue="본인 인증 후 표시" readOnly />
+            </label>
+            <label>
+              <span>처리 상태</span>
+              <input defaultValue="접수 전 확인" readOnly />
+            </label>
+          </div>
+          <button type="button">신고 접수 준비</button>
+        </article>
+
+        <article className="certificate-list">
+          <div className="panel-toolbar">
+            <div>
+              <strong>증명서 발급</strong>
+              <span>완료증, 잔액, 거래내역 증명서를 업무별로 분리합니다.</span>
+            </div>
+          </div>
+          {certificateItems.map((item) => (
+            <div className="certificate-item" key={item.title}>
+              <strong>{item.title}</strong>
+              <p>{item.description}</p>
+              <span>{item.scope}</span>
+              <button type="button">발급 화면 보기</button>
+            </div>
+          ))}
+        </article>
       </section>
     </section>
   );

--- a/front/src/components/customer-banking/sections/transfer-section.tsx
+++ b/front/src/components/customer-banking/sections/transfer-section.tsx
@@ -1,6 +1,6 @@
 import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
-import type { TransferResponse, TransferReversalResponse } from '@/lib/api/types';
+import type { TransferPreviewResponse, TransferResponse, TransferReversalResponse } from '@/lib/api/types';
 import { formatDateTime, formatMinorAmount } from '@/lib/customer-banking/format';
 import { ResultPanel } from '../common';
 
@@ -18,7 +18,9 @@ export function TransferSection({
   reversalForm,
   reversalResult,
   transferForm,
+  transferPreview,
   transferResult,
+  onPreviewTransfer,
   onReversal,
   onReversalChange,
   onTransfer,
@@ -40,7 +42,9 @@ export function TransferSection({
     currencyCode: string;
     summary: string;
   };
+  transferPreview: TransferPreviewResponse | null;
   transferResult: TransferResponse | null;
+  onPreviewTransfer: () => Promise<boolean>;
   onReversal: (event: FormEvent<HTMLFormElement>) => void;
   onReversalChange: (value: {
     transactionReference: string;
@@ -76,7 +80,13 @@ export function TransferSection({
   async function handleTransferSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (transferStep === "input") {
-      setTransferStep("receiverCheck");
+      setTransferStep("submitting");
+      const ok = await onPreviewTransfer();
+      setTransferStep(ok ? "receiverCheck" : "failed");
+      return;
+    }
+    if (transferStep === "failed") {
+      setTransferStep("input");
       return;
     }
     if (transferStep === "receiverCheck") {
@@ -107,9 +117,14 @@ export function TransferSection({
     { id: "failed", label: "실패" },
   ];
   const amountMinor = Number(transferForm.amountMinor || 0);
-  const transferFeeMinor = amountMinor >= 100000000 ? 500 : 0;
-  const limitMinor = 1000000000;
-  const isOverLimit = amountMinor > limitMinor;
+  const transferFeeMinor = transferPreview?.feeMinor ?? 0;
+  const limitMinor = transferPreview?.singleTransferLimitMinor ?? 1000000000;
+  const dailyRemainingMinor = transferPreview?.dailyRemainingMinor ?? limitMinor;
+  const blockedReason = transferPreview?.blockedReason ?? "PREVIEW_REQUIRED";
+  const otpRequired = transferPreview?.otpRequired ?? true;
+  const isOverLimit = transferPreview
+    ? !transferPreview.allowed
+    : amountMinor > limitMinor;
   const submitLabel =
     transferStep === "receiverCheck"
       ? "받는 분 확인 완료"
@@ -117,6 +132,8 @@ export function TransferSection({
         ? "OTP 확인"
         : transferStep === "otp"
           ? "이체 실행"
+          : transferStep === "failed"
+            ? "입력 다시 확인"
           : "받는 분 확인";
 
   return (
@@ -146,20 +163,32 @@ export function TransferSection({
           </ol>
           <div className="transfer-risk-grid" aria-label="이체 사전 확인">
             <div>
-              <span>받는 분 확인</span>
-              <strong>계좌 ID {transferForm.targetAccountId || "-"}</strong>
+              <span>받는 분 검증</span>
+              <strong>
+                {transferPreview
+                  ? `${transferPreview.targetAccount.displayName} ${transferPreview.targetAccount.maskedAccountNumber}`
+                  : `계좌 ID ${transferForm.targetAccountId || "-"}`}
+              </strong>
+              <small>backend preview: {blockedReason}</small>
             </div>
             <div>
               <span>수수료</span>
               <strong>
                 {formatMinorAmount(transferFeeMinor, transferForm.currencyCode)}
               </strong>
+              <small>feePolicy {transferPreview?.feePolicy ?? "-"}</small>
             </div>
             <div>
-              <span>이체한도</span>
+              <span>잔여 이체한도</span>
               <strong className={isOverLimit ? "danger-text" : ""}>
-                {formatMinorAmount(limitMinor, transferForm.currencyCode)}
+                {formatMinorAmount(dailyRemainingMinor, transferForm.currencyCode)}
               </strong>
+              <small>dailyRemainingMinor / 단건 {formatMinorAmount(limitMinor, transferForm.currencyCode)}</small>
+            </div>
+            <div>
+              <span>OTP 확인</span>
+              <strong>{otpRequired ? "필요" : "미필요"}</strong>
+              <small>otpRequired {String(otpRequired)}</small>
             </div>
           </div>
           <div className="form-grid">
@@ -242,6 +271,12 @@ export function TransferSection({
                   transferForm.currencyCode,
                 )}
                 을 이체합니다.
+                {transferPreview
+                  ? ` 총 출금액은 ${formatMinorAmount(
+                      transferPreview.totalDebitMinor,
+                      transferPreview.currencyCode,
+                    )}입니다.`
+                  : ""}
               </span>
             </div>
           ) : null}
@@ -260,8 +295,8 @@ export function TransferSection({
           ) : null}
           {isOverLimit ? (
             <div className="confirm-box warning" role="alert">
-              <strong>이체한도 초과</strong>
-              <span>고객센터의 이체한도 메뉴에서 보안등급과 한도를 확인하세요.</span>
+              <strong>이체 사전 검증 실패</strong>
+              <span>사유 {blockedReason}. 고객센터의 이체한도 메뉴에서 보안등급과 한도를 확인하세요.</span>
             </div>
           ) : null}
           <button disabled={isBusy || isOverLimit} type="submit">
@@ -287,6 +322,13 @@ export function TransferSection({
                     [
                       "수수료",
                       formatMinorAmount(transferFeeMinor, transferResult.currencyCode),
+                    ],
+                    [
+                      "총 출금액",
+                      formatMinorAmount(
+                        transferPreview?.totalDebitMinor ?? transferResult.amountMinor,
+                        transferResult.currencyCode,
+                      ),
                     ],
                     [
                       "이체 후 잔액",

--- a/front/src/hooks/use-customer-banking.ts
+++ b/front/src/hooks/use-customer-banking.ts
@@ -2,7 +2,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AquilaBankApiClient } from '@/lib/api/client';
 import { clearCustomerSession, toCustomerSession } from '@/lib/api/session';
-import type { AccountItem, AccountSummaryResponse, AuthSessionItem, BackupCodeIssueResponse, CustomerSession, LoginResponse, NotificationItem, NotificationPreferenceItem, NotificationQueryResponse, PasswordRecoveryRequestResult, TransactionDetailResponse, TransactionItem, TransactionQueryResponse, TotpEnrollmentStartResponse, TransferResponse, TransferReversalResponse } from '@/lib/api/types';
+import type { AccountItem, AccountSummaryResponse, AuthSessionItem, BackupCodeIssueResponse, CustomerSession, LoginResponse, NotificationItem, NotificationPreferenceItem, NotificationQueryResponse, PasswordRecoveryRequestResult, TransactionDetailResponse, TransactionItem, TransactionQueryResponse, TotpEnrollmentStartResponse, TransferPreviewResponse, TransferResponse, TransferReversalResponse } from '@/lib/api/types';
 import { formatMinorAmount, toErrorMessage, toIsoDateTime, toLocalInputValue, toOptionalNumber } from '@/lib/customer-banking/format';
 import type { AlertMessage, MenuSection } from '@/lib/customer-banking/types';
 
@@ -58,6 +58,8 @@ export function useCustomerBanking() {
   const [transferResult, setTransferResult] = useState<TransferResponse | null>(
     null,
   );
+  const [transferPreview, setTransferPreview] =
+    useState<TransferPreviewResponse | null>(null);
   const [reversalForm, setReversalForm] = useState({
     transactionReference: "",
     sourceAccountId: "",
@@ -419,6 +421,34 @@ export function useCustomerBanking() {
     });
   }
 
+  function handleTransferFormChange(value: typeof transferForm): void {
+    setTransferPreview(null);
+    setTransferResult(null);
+    setTransferForm(value);
+  }
+
+  async function handlePreviewTransfer(): Promise<boolean> {
+    if (!requireSession()) {
+      return false;
+    }
+    return runAction("받는 사람 검증", async () => {
+      const result = await api.previewTransfer({
+        sourceAccountId: Number(transferForm.sourceAccountId),
+        targetAccountId: Number(transferForm.targetAccountId),
+        amountMinor: Number(transferForm.amountMinor),
+        currencyCode: transferForm.currencyCode,
+      });
+      setTransferPreview(result);
+      if (!result.allowed) {
+        throw new Error(`이체 사전 검증 실패: ${result.blockedReason}`);
+      }
+      setAlert({
+        type: "success",
+        text: `받는 사람 검증 완료: ${result.targetAccount.displayName}`,
+      });
+    });
+  }
+
   async function handleReversal(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!requireSession()) {
@@ -679,6 +709,7 @@ export function useCustomerBanking() {
     selectedAccount,
     transferForm,
     transferResult,
+    transferPreview,
     reversalForm,
     reversalResult,
     transactionMode,
@@ -712,6 +743,7 @@ export function useCustomerBanking() {
     handleLoadAccounts,
     handleLoadAccountDetail,
     handleTransfer,
+    handlePreviewTransfer,
     handleReversal,
     handleSearchTransactions,
     handleLoadTransactionDetail,
@@ -731,7 +763,7 @@ export function useCustomerBanking() {
     setPasswordResetForm,
     setTotpCode,
     setAccountLimit,
-    setTransferForm,
+    setTransferForm: handleTransferFormChange,
     setReversalForm,
     setTransactionMode,
     setTransactionFilters,

--- a/front/src/lib/api/client.ts
+++ b/front/src/lib/api/client.ts
@@ -25,6 +25,8 @@ import type {
   TransactionDetailResponse,
   TransactionQueryParams,
   TransactionQueryResponse,
+  TransferPreviewRequest,
+  TransferPreviewResponse,
   TransferRequest,
   TransferResponse,
   TransferReversalRequest,
@@ -274,6 +276,12 @@ export class AquilaBankApiClient {
 
   getAccount(accountId: number): Promise<AccountSummaryResponse> {
     return this.request(`/api/v1/accounts/${accountId}`);
+  }
+
+  previewTransfer(
+    params: TransferPreviewRequest,
+  ): Promise<TransferPreviewResponse> {
+    return this.request(appendSearchParams("/api/v1/transfers/preview", params));
   }
 
   transfer(

--- a/front/src/lib/api/types.ts
+++ b/front/src/lib/api/types.ts
@@ -136,6 +136,38 @@ export type TransferRequest = {
   summary: string;
 };
 
+export type TransferPreviewRequest = {
+  sourceAccountId: number;
+  targetAccountId: number;
+  amountMinor: number;
+  currencyCode: string;
+};
+
+export type TransferPreviewAccount = {
+  accountId: number;
+  maskedAccountNumber: string;
+  displayName: string;
+  accountStatus: string;
+  currencyCode: string;
+};
+
+export type TransferPreviewResponse = {
+  sourceAccountId: number;
+  targetAccount: TransferPreviewAccount;
+  amountMinor: number;
+  currencyCode: string;
+  feeMinor: number;
+  feePolicy: string;
+  totalDebitMinor: number;
+  singleTransferLimitMinor: number;
+  dailyTransferLimitMinor: number;
+  dailyUsedMinor: number;
+  dailyRemainingMinor: number;
+  allowed: boolean;
+  blockedReason: string;
+  otpRequired: boolean;
+};
+
 export type TransferResponse = {
   transactionReference: string;
   sourceAccountId: number;

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -528,6 +528,159 @@ label span {
   padding: 0 12px;
 }
 
+.fulfillment-detail-grid,
+.registration-flow-grid,
+.support-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.fulfillment-detail-card,
+.registration-flow-card,
+.faq-list,
+.incident-form,
+.certificate-list {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  padding: 14px;
+}
+
+.fulfillment-detail-head {
+  display: grid;
+  gap: 6px;
+}
+
+.fulfillment-detail-head span,
+.registration-flow-card span {
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.fulfillment-detail-head strong,
+.registration-flow-card strong {
+  color: #102f55;
+  font-size: 17px;
+}
+
+.fulfillment-detail-head p,
+.registration-flow-card p,
+.faq-list p,
+.certificate-item p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.detail-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.detail-list div {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 10px;
+  border-top: 1px solid var(--line);
+  padding-top: 8px;
+}
+
+.detail-list dt {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.detail-list dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.process-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.process-strip li {
+  border: 1px solid #bcd3ef;
+  border-radius: 6px;
+  background: var(--primary-soft);
+  color: #184069;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.35;
+  min-height: 36px;
+  padding: 8px;
+  text-align: center;
+}
+
+.check-list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.support-detail-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.faq-list details {
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+}
+
+.faq-list summary {
+  cursor: pointer;
+  color: #102f55;
+  font-weight: 800;
+}
+
+.incident-form button {
+  width: fit-content;
+}
+
+.certificate-list {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.certificate-list .panel-toolbar {
+  grid-column: 1 / -1;
+}
+
+.certificate-item {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface-muted);
+  padding: 12px;
+}
+
+.certificate-item span {
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.certificate-item button {
+  width: fit-content;
+}
+
 .account-grid,
 .split-work {
   display: grid;
@@ -1098,6 +1251,10 @@ label span {
   .enterprise-service-grid,
   .security-hub-grid,
   .support-service-grid,
+  .fulfillment-detail-grid,
+  .registration-flow-grid,
+  .support-detail-grid,
+  .certificate-list,
   .transfer-risk-grid,
   .account-grid,
   .split-work,
@@ -1169,7 +1326,8 @@ label span {
   }
 
   .session-required,
-  .stepper {
+  .stepper,
+  .process-strip {
     grid-template-columns: 1fr;
   }
 

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -184,6 +184,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.59.1":
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
+  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
+  dependencies:
+    playwright "1.59.1"
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
@@ -1259,6 +1266,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
@@ -2036,6 +2048,20 @@ picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
+playwright-core@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
+  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
+
+playwright@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
+  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
+  dependencies:
+    playwright-core "1.59.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## 🔗 Related Issue
- close #902

## 🌿 Base Branch
- `main`

## 📝 Summary
- 고객 웹뱅킹의 read-only 부가업무를 공과금/오픈뱅킹/예금/대출/외환 상세 화면으로 확장했습니다.
- 이체 사전 검증을 백엔드 preview 계약과 연결하고, 인증센터/고객센터/증명서/사고신고 UX와 Playwright 클릭 E2E를 추가했습니다.

## 🛠 Changes
- `GET /api/v1/transfers/preview` 추가: 받는 사람 계좌, 통화/상태, 수수료 정책, 단건/일일 한도, OTP 필요 여부를 ledger write 없이 반환.
- 프론트 API/types/hook/이체 화면을 preview 계약에 연결해 받는 사람 검증, 수수료, 잔여한도, OTP 필요 여부를 서버 기준으로 표시.
- 공과금/오픈뱅킹/예금상품/대출/외환 상세 업무, 공동인증서/금융인증서/OTP/보안매체 등록 흐름, FAQ/사고신고/증명서 UX 확장.
- `@playwright/test` 기반 desktop/mobile 클릭 플로우 smoke 추가.

## 🎯 Scope
- [x] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back test --tests '*TransferCommandControllerTest.previewsTransferRecipientFeeAndLimitWithoutWritingLedger'`
- `yarn --cwd front test:fulfillment-ux`
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front test:enterprise-ux`
- `yarn --cwd front lint`
- `yarn --cwd front build`
- `yarn --cwd front test:e2e:click-flow`
- 참고: 전체 `./back/gradlew -p back check`는 pre-commit에서 `apache/kafka-native:3.8.0` Testcontainers가 exit 139로 종료되어 실패했습니다. 변경 대상 컨트롤러 테스트는 통과했고, 해당 실패는 로컬 Docker/Kafka 컨테이너 기동 차단으로 분리했습니다.

## 📸 Screenshot / API Example
- API 예시: `GET /api/v1/transfers/preview?sourceAccountId=1&targetAccountId=2&amountMinor=1000&currencyCode=KRW`
- UI 스크린샷: 없음

## ⚠️ Risk & Rollback
- 예상 리스크: preview 응답의 수수료 정책은 현재 write 경로와 맞추기 위해 내부이체 수수료 0원 기준입니다. 실제 수수료 과금 정책이 추가되면 write 경로와 함께 계약을 확장해야 합니다.
- 롤백 방법: 이 PR revert 후 프론트는 기존 이체 입력/확인 플로우로 복귀합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
