### PR TITLE
[Test] transfer preview coverage 보강

### DIFF
--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class TransferCommandControllerTest {
@@ -64,28 +65,12 @@ class TransferCommandControllerTest {
 
   @Test
   void previewsTransferRecipientFeeAndLimitWithoutWritingLedger() throws Exception {
-    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
-            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
-        .thenReturn(101L);
-    when(accountSummaryQueryUseCase.getByAccountId(101L))
-        .thenReturn(account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L));
-    when(accountSummaryQueryUseCase.getByAccountId(202L))
-        .thenReturn(account(202L, "999900001234", "홍길동", "ACTIVE", 0L));
-    when(transferLimitUsageReadPort.sumBookedDebitAmountMinor(
-            org.mockito.ArgumentMatchers.eq(101L),
-            org.mockito.ArgumentMatchers.eq("KRW"),
-            org.mockito.ArgumentMatchers.any(),
-            org.mockito.ArgumentMatchers.any()))
-        .thenReturn(1_000L);
+    stubPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L),
+        account(202L, "999900001234", "홍길동", "ACTIVE", 0L),
+        1_000L);
 
-    mockMvc
-        .perform(
-            get("/api/v1/transfers/preview")
-                .header("X-Account-Id", "101")
-                .queryParam("sourceAccountId", "101")
-                .queryParam("targetAccountId", "202")
-                .queryParam("amountMinor", "1500")
-                .queryParam("currencyCode", "KRW"))
+    performPreview(1_500L, "KRW")
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.sourceAccountId").value(101))
         .andExpect(jsonPath("$.targetAccount.accountId").value(202))
@@ -95,6 +80,73 @@ class TransferCommandControllerTest {
         .andExpect(jsonPath("$.dailyUsedMinor").value(1000))
         .andExpect(jsonPath("$.allowed").value(true))
         .andExpect(jsonPath("$.otpRequired").value(true));
+  }
+
+  @Test
+  void previewsCurrencyMismatchAsBlocked() throws Exception {
+    stubPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", "KRW", 10_000L),
+        account(202L, "999900001234", "외화 계좌", "ACTIVE", "USD", 0L),
+        0L);
+
+    performPreview(1_000L, "KRW")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.allowed").value(false))
+        .andExpect(jsonPath("$.blockedReason").value("CURRENCY_MISMATCH"));
+  }
+
+  @Test
+  void previewsInactiveRecipientAsBlockedAndMasksShortAccountNumber() throws Exception {
+    stubPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L),
+        account(202L, "123", "휴면 계좌", "SUSPENDED", 0L),
+        0L);
+
+    performPreview(1_000L, "KRW")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.targetAccount.maskedAccountNumber").value("****"))
+        .andExpect(jsonPath("$.allowed").value(false))
+        .andExpect(jsonPath("$.blockedReason").value("TARGET_ACCOUNT_NOT_ACTIVE"));
+  }
+
+  @Test
+  void previewsSingleTransferLimitExceededAsBlocked() throws Exception {
+    stubPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L),
+        account(202L, "999900001234", "홍길동", "ACTIVE", 0L),
+        0L);
+
+    performPreview(2_001L, "KRW")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.allowed").value(false))
+        .andExpect(jsonPath("$.blockedReason").value("SINGLE_LIMIT_EXCEEDED"));
+  }
+
+  @Test
+  void previewsDailyTransferLimitExceededAsBlocked() throws Exception {
+    stubPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L),
+        account(202L, "999900001234", "홍길동", "ACTIVE", 0L),
+        2_000L);
+
+    performPreview(1_500L, "KRW")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.dailyRemainingMinor").value(1_000))
+        .andExpect(jsonPath("$.allowed").value(false))
+        .andExpect(jsonPath("$.blockedReason").value("DAILY_LIMIT_EXCEEDED"));
+  }
+
+  @Test
+  void previewsInsufficientBalanceAsBlocked() throws Exception {
+    stubPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", 1_000L),
+        account(202L, "999900001234", "홍길동", "ACTIVE", 0L),
+        0L);
+
+    performPreview(1_500L, "KRW")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.allowed").value(false))
+        .andExpect(jsonPath("$.blockedReason").value("INSUFFICIENT_BALANCE"));
   }
 
   @Test
@@ -233,15 +285,50 @@ class TransferCommandControllerTest {
       String displayName,
       String status,
       long availableBalanceMinor) {
+    return account(accountId, accountNumber, displayName, status, "KRW", availableBalanceMinor);
+  }
+
+  private static AccountSummary account(
+      long accountId,
+      String accountNumber,
+      String displayName,
+      String status,
+      String currencyCode,
+      long availableBalanceMinor) {
     return new AccountSummary(
         accountId,
         accountNumber,
         displayName,
         status,
-        "KRW",
+        currencyCode,
         availableBalanceMinor,
         0L,
         Instant.parse("2026-05-11T00:00:00Z"),
         Instant.parse("2026-05-11T00:00:00Z"));
+  }
+
+  private void stubPreview(
+      AccountSummary sourceAccount, AccountSummary targetAccount, long dailyUsedMinor) {
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+    when(accountSummaryQueryUseCase.getByAccountId(101L)).thenReturn(sourceAccount);
+    when(accountSummaryQueryUseCase.getByAccountId(202L)).thenReturn(targetAccount);
+    when(transferLimitUsageReadPort.sumBookedDebitAmountMinor(
+            org.mockito.ArgumentMatchers.eq(101L),
+            org.mockito.ArgumentMatchers.eq("KRW"),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(dailyUsedMinor);
+  }
+
+  private ResultActions performPreview(long amountMinor, String currencyCode) throws Exception {
+    return mockMvc.perform(
+        get("/api/v1/transfers/preview")
+            .header("X-Account-Id", "101")
+            .queryParam("sourceAccountId", "101")
+            .queryParam("targetAccountId", "202")
+            .queryParam("amountMinor", String.valueOf(amountMinor))
+            .queryParam("currencyCode", currencyCode));
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #904

## 🌿 Base Branch
- `main`

## 📝 Summary
- Backend Check 실패 원인인 `ciFastCoverageVerification` line coverage 1.00 미달을 해결합니다.
- transfer preview 신규 계약의 blockedReason/마스킹 분기 테스트를 보강해 신규 컨트롤러 라인 미커버를 제거했습니다.

## 🛠 Changes
- `TransferCommandControllerTest`에 currency mismatch, inactive recipient, single limit, daily limit, insufficient balance 분기 테스트 추가.
- 짧은 계좌번호가 `****`로 마스킹되는 preview 응답도 검증.
- 중복 preview setup을 helper로 정리.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back test --tests '*TransferCommandControllerTest' --rerun-tasks`
- `./back/gradlew -p back test jacocoTestReport -x integrationTest -x queryPlanTest`
- `./back/gradlew -p back spotlessCheck`
- `git diff --check origin/main..HEAD`
- JaCoCo XML 확인: `TransferCommandController has no missed lines in current JaCoCo report`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 테스트만 보강하므로 런타임 동작 리스크는 낮습니다.
- 롤백 방법: 이 PR revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
