### PR TITLE
[Feat] 고객 웹뱅킹 은행권 UX 고도화

### DIFF
--- a/front/e2e/customer-banking-click-flow.spec.ts
+++ b/front/e2e/customer-banking-click-flow.spec.ts
@@ -6,6 +6,8 @@ test("고객 웹뱅킹 주요 공개 업무와 미로그인 이체 가드를 실
   await page.goto("/");
 
   await expect(page.getByRole("heading", { name: "뱅킹 업무" })).toBeVisible();
+  await expect(page.getByText("보안등급").first()).toBeVisible();
+  await expect(page.getByText("이용시간")).toBeVisible();
   await page.getByRole("navigation", { name: "주요 메뉴" }).getByRole("button", { name: "이체" }).click();
   await expect(page.getByText("권한 만료 또는 미로그인")).toBeVisible();
 
@@ -25,9 +27,10 @@ test("고객 웹뱅킹 주요 공개 업무와 미로그인 이체 가드를 실
     .getByRole("navigation", { name: "주요 메뉴" })
     .getByRole("button", { name: "공과금/금융상품" })
     .click();
-  await expect(page.getByText("공과금 상세")).toBeVisible();
-  await expect(page.getByText("오픈뱅킹 상세")).toBeVisible();
-  await expect(page.getByText("외환 상세")).toBeVisible();
+  const enterpriseDetails = page.getByLabel("부가업무 상세 화면");
+  await expect(enterpriseDetails.getByText("공과금 납부", { exact: true })).toBeVisible();
+  await expect(enterpriseDetails.getByText("오픈뱅킹 연결", { exact: true })).toBeVisible();
+  await expect(enterpriseDetails.getByText("외환 신청", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "신청 접수" }).first()).toBeVisible();
 
   await page

--- a/front/scripts/check-customer-banking-fulfillment-ux.mjs
+++ b/front/scripts/check-customer-banking-fulfillment-ux.mjs
@@ -18,6 +18,7 @@ const files = {
   enterprise: read("src/components/customer-banking/sections/enterprise-services-section.tsx"),
   securityHub: read("src/components/customer-banking/sections/security-hub-section.tsx"),
   support: read("src/components/customer-banking/sections/support-center-section.tsx"),
+  security: read("src/components/customer-banking/sections/security-section.tsx"),
   playwrightConfig: read("playwright.config.ts"),
   clickFlow: read("e2e/customer-banking-click-flow.spec.ts"),
   styles: read("src/styles/customer-banking.css"),
@@ -49,20 +50,19 @@ const required = [
   ["preview page binding", files.page, "onPreviewTransfer"],
   ["customer application page binding", files.page, "onSubmitCustomerApplication"],
   ["preview section prop", files.transfer, "onPreviewTransfer"],
-  ["backend preview label", files.transfer, "backend preview"],
-  ["receiver validation display", files.transfer, "받는 분 검증"],
-  ["fee policy display", files.transfer, "feePolicy"],
-  ["limit remaining display", files.transfer, "dailyRemainingMinor"],
-  ["otp required display", files.transfer, "otpRequired"],
-  ["bill payment detail", files.enterprise, "공과금 상세"],
+  ["transfer security verification label", files.transfer, "보안 확인"],
+  ["receiver validation display", files.transfer, "받는 분"],
+  ["fee display", files.transfer, "수수료"],
+  ["limit remaining display", files.transfer, "잔여한도"],
+  ["bill payment detail", files.enterprise, "공과금 납부"],
   ["bill payment write type", files.enterprise, "BILL_PAYMENT"],
-  ["open banking detail", files.enterprise, "오픈뱅킹 상세"],
+  ["open banking detail", files.enterprise, "오픈뱅킹 연결"],
   ["open banking write type", files.enterprise, "OPEN_BANKING_CONNECTION"],
-  ["deposit product detail", files.enterprise, "예금상품 상세"],
+  ["deposit product detail", files.enterprise, "예금 가입"],
   ["deposit product write type", files.enterprise, "DEPOSIT_PRODUCT_APPLICATION"],
-  ["loan detail", files.enterprise, "대출 상세"],
+  ["loan detail", files.enterprise, "대출 신청"],
   ["loan write type", files.enterprise, "LOAN_APPLICATION"],
-  ["fx detail", files.enterprise, "외환 상세"],
+  ["fx detail", files.enterprise, "외환 신청"],
   ["fx write type", files.enterprise, "FOREIGN_EXCHANGE_APPLICATION"],
   ["enterprise application submit panel", files.enterprise, "application-submit-panel"],
   ["common certificate registration", files.securityHub, "공동인증서 등록"],
@@ -87,7 +87,7 @@ const required = [
   ["playwright config", files.playwrightConfig, "defineConfig"],
   ["click flow playwright test", files.clickFlow, "@playwright/test"],
   ["click flow transfer guard", files.clickFlow, "권한 만료 또는 미로그인"],
-  ["click flow public service", files.clickFlow, "공과금 상세"],
+  ["click flow public service", files.clickFlow, "신청 접수"],
   ["click flow application submit buttons", files.clickFlow, "신청 접수"],
   ["backend customer application controller", files.backendController, "/api/v1/customer-service/applications"],
   ["backend idempotency header", files.backendController, "Idempotency-Key"],
@@ -98,12 +98,31 @@ const required = [
   ["backend TOTP coverage", files.backendTotpTest, "TotpOperationVerifyServiceTest"],
 ];
 
-const missing = required.filter(([, content, expected]) => !content.includes(expected));
+const customerSections = [
+  files.transfer,
+  files.enterprise,
+  files.security,
+  files.securityHub,
+  files.support,
+].join("\n");
 
-if (missing.length > 0) {
+const forbidden = [
+  ["no-op work tabs", customerSections, "onClick: () => undefined"],
+  ["raw challenge type fallback", files.security, 'props.challenge.challengeType ?? "TOTP"'],
+  ["raw blocked reason render", files.transfer, "{blockedReason}"],
+  ["raw transfer status render", files.transfer, '["상태", transferResult.status]'],
+];
+
+const missing = required.filter(([, content, expected]) => !content.includes(expected));
+const present = forbidden.filter(([, content, value]) => content.includes(value));
+
+if (missing.length > 0 || present.length > 0) {
   console.error("[customer-banking-fulfillment-ux] contract violations:");
   for (const [name, , expected] of missing) {
     console.error(`- missing ${name}: ${expected}`);
+  }
+  for (const [name, , value] of present) {
+    console.error(`- forbidden ${name}: ${value}`);
   }
   process.exit(1);
 }

--- a/front/scripts/check-customer-banking-ui-contract.mjs
+++ b/front/scripts/check-customer-banking-ui-contract.mjs
@@ -17,11 +17,31 @@ const files = {
   layout: read("src/app/layout.tsx"),
   manifest: readOptional("src/app/manifest.ts"),
   constants: read("src/lib/customer-banking/constants.ts"),
+  dashboard: read("src/components/customer-banking/sections/dashboard-section.tsx"),
+  accounts: read("src/components/customer-banking/sections/accounts-section.tsx"),
   transfer: read("src/components/customer-banking/sections/transfer-section.tsx"),
   transactions: read("src/components/customer-banking/sections/transactions-section.tsx"),
   notifications: read("src/components/customer-banking/sections/notifications-section.tsx"),
+  security: read("src/components/customer-banking/sections/security-section.tsx"),
+  securityHub: read("src/components/customer-banking/sections/security-hub-section.tsx"),
+  support: read("src/components/customer-banking/sections/support-center-section.tsx"),
+  enterprise: read("src/components/customer-banking/sections/enterprise-services-section.tsx"),
   styles: read("src/styles/customer-banking.css"),
 };
+
+const customerVisibleContent = [
+  files.page,
+  files.constants,
+  files.dashboard,
+  files.accounts,
+  files.transfer,
+  files.transactions,
+  files.notifications,
+  files.security,
+  files.securityHub,
+  files.support,
+  files.enterprise,
+].join("\n");
 
 const checks = [
   ["top personal tab", files.page, "개인"],
@@ -48,7 +68,7 @@ const checks = [
   ["transfer failed state", files.transfer, "실패"],
   ["transfer stepper style", files.styles, ".stepper"],
   ["transaction current filters", files.transactions, "현재 조건"],
-  ["transaction cursor pagination", files.transactions, "cursor pagination"],
+  ["transaction next lookup label", files.transactions, "다음 조회"],
   ["transaction next page label", files.transactions, "다음 페이지"],
   ["notification live connection label", files.notifications, "실시간 연결 상태"],
   ["notification bulk action label", files.notifications, "선택 일괄 처리"],
@@ -62,14 +82,48 @@ const checks = [
   ["manifest public url", files.manifest, "https://bank.aquilaxk.site"],
   ["mobile small breakpoint", files.styles, "@media (max-width: 480px)"],
   ["button overflow guard", files.styles, "overflow-wrap: anywhere"],
+  ["bank shell status class", files.styles, ".bank-service-strip"],
+  ["bank work tabs class", files.styles, ".work-tabs"],
+  ["bank notice strip class", files.styles, ".bank-notice-strip"],
+  ["bank dense table class", files.styles, ".bank-table"],
+  ["bank right rail security notice", files.page, "보안알림"],
+  ["dashboard operating hours", files.dashboard, "이용시간"],
+  ["dashboard security level", files.dashboard, "보안등급"],
+  ["account available amount label", files.accounts, "출금가능금액"],
+  ["transfer receiver label", files.transfer, "받는 분"],
+  ["transfer security verification label", files.transfer, "보안 확인"],
+  ["security center login status", files.security, "로그인 상태"],
+  ["security hub certificate tab", files.securityHub, "공동인증서"],
+  ["support certificate issue label", files.support, "증명서 발급"],
+  ["enterprise bill payment application label", files.enterprise, "공과금 납부"],
+];
+
+const forbidden = [
+  ["customer visible read-only", customerVisibleContent, "read-only"],
+  ["customer visible backend preview", customerVisibleContent, "backend preview"],
+  ["customer visible bounded query", customerVisibleContent, "bounded query"],
+  ["customer visible idempotency key", customerVisibleContent, "Idempotency-Key"],
+  ["customer visible cursor pagination", customerVisibleContent, "cursor pagination"],
+  ["customer visible response shape", customerVisibleContent, "응답형태"],
+  ["customer visible transfer minor label", customerVisibleContent, "금액 minor"],
+  ["customer visible reversal minor label", customerVisibleContent, "취소금액 minor"],
+  ["customer visible min minor label", customerVisibleContent, "최소금액 minor"],
+  ["customer visible max minor label", customerVisibleContent, "최대금액 minor"],
+  ["customer visible daily remaining field", customerVisibleContent, "dailyRemainingMinor /"],
 ];
 
 const missing = checks.filter(([, content, expected]) => !content.includes(expected));
+const present = forbidden.filter(([, content, expected]) =>
+  content.toLowerCase().includes(expected.toLowerCase()),
+);
 
-if (missing.length > 0) {
-  console.error("[customer-banking-ui-contract] missing required UI contract:");
+if (missing.length > 0 || present.length > 0) {
+  console.error("[customer-banking-ui-contract] bank UX contract violations:");
   for (const [name, , expected] of missing) {
-    console.error(`- ${name}: ${expected}`);
+    console.error(`- missing ${name}: ${expected}`);
+  }
+  for (const [name, , expected] of present) {
+    console.error(`- forbidden ${name}: ${expected}`);
   }
   process.exit(1);
 }

--- a/front/scripts/check-customer-banking-ui-contract.mjs
+++ b/front/scripts/check-customer-banking-ui-contract.mjs
@@ -92,15 +92,22 @@ const checks = [
   ["account available amount label", files.accounts, "출금가능금액"],
   ["transfer receiver label", files.transfer, "받는 분"],
   ["transfer security verification label", files.transfer, "보안 확인"],
+  ["auth center eyebrow", files.security, "인증센터"],
+  ["auth center heading", files.security, "로그인 및 보안관리"],
   ["security center login status", files.security, "로그인 상태"],
   ["security hub certificate tab", files.securityHub, "공동인증서"],
+  ["support incident report label", files.support, "사고신고 접수"],
   ["support certificate issue label", files.support, "증명서 발급"],
+  ["support transfer confirmation label", files.support, "이체확인증"],
   ["enterprise bill payment application label", files.enterprise, "공과금 납부"],
+  ["enterprise open banking application label", files.enterprise, "오픈뱅킹 연결"],
+  ["enterprise foreign exchange application label", files.enterprise, "외환 신청"],
 ];
 
 const forbidden = [
   ["customer visible read-only", customerVisibleContent, "read-only"],
   ["customer visible backend preview", customerVisibleContent, "backend preview"],
+  ["customer visible backend", customerVisibleContent, "backend"],
   ["customer visible bounded query", customerVisibleContent, "bounded query"],
   ["customer visible idempotency key", customerVisibleContent, "Idempotency-Key"],
   ["customer visible cursor pagination", customerVisibleContent, "cursor pagination"],

--- a/front/scripts/check-customer-banking-visual-a11y.mjs
+++ b/front/scripts/check-customer-banking-visual-a11y.mjs
@@ -12,6 +12,7 @@ const files = {
   packageJson: read("package.json"),
   page: read("src/app/page.tsx"),
   styles: read("src/styles/customer-banking.css"),
+  dashboard: read("src/components/customer-banking/sections/dashboard-section.tsx"),
   transfer: read("src/components/customer-banking/sections/transfer-section.tsx"),
 };
 
@@ -35,6 +36,8 @@ const required = [
   ["bank work tabs", files.styles, ".work-tabs"],
   ["bank page title compact", files.styles, ".section-title h1"],
   ["right rail security notice", files.page, "보안알림"],
+  ["bank shell security level", files.page, "보안등급"],
+  ["bank work operating hours", files.dashboard, "이용시간"],
 ];
 
 const missing = required.filter(([, content, expected]) => !content.includes(expected));

--- a/front/scripts/check-customer-banking-visual-a11y.mjs
+++ b/front/scripts/check-customer-banking-visual-a11y.mjs
@@ -30,6 +30,11 @@ const required = [
   ["mobile overflow guard", files.styles, "overflow-wrap: anywhere"],
   ["transfer step aria", files.transfer, 'aria-label="이체 진행 단계"'],
   ["otp input numeric", files.transfer, 'inputMode="numeric"'],
+  ["bank service strip", files.styles, ".bank-service-strip"],
+  ["bank notice strip", files.styles, ".bank-notice-strip"],
+  ["bank work tabs", files.styles, ".work-tabs"],
+  ["bank page title compact", files.styles, ".section-title h1"],
+  ["right rail security notice", files.page, "보안알림"],
 ];
 
 const missing = required.filter(([, content, expected]) => !content.includes(expected));

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { AccountsSection } from "@/components/customer-banking/sections/accounts-section";
+import { BankNoticeStrip } from "@/components/customer-banking/common";
 import { DashboardSection } from "@/components/customer-banking/sections/dashboard-section";
 import { EnterpriseServicesSection } from "@/components/customer-banking/sections/enterprise-services-section";
 import { NotificationsSection } from "@/components/customer-banking/sections/notifications-section";
@@ -186,7 +187,7 @@ export default function HomePage() {
             ))}
           </nav>
         </div>
-        <div className="banking-status-bar" aria-label="뱅킹 이용 상태">
+        <div className="bank-service-strip" aria-label="뱅킹 이용 상태">
           <span>
             보안등급 <strong>정상</strong>
           </span>
@@ -413,7 +414,7 @@ export default function HomePage() {
                 </div>
               </dl>
             ) : (
-              <p className="rail-copy">인증 후 조회, 이체, 거래내역 업무를 이용할 수 있습니다.</p>
+              <p className="rail-copy">로그인 후 조회, 이체, 거래내역 이용 가능</p>
             )}
             <div className="button-row compact">
               <button onClick={() => setActiveSection("security")} type="button">
@@ -457,6 +458,22 @@ export default function HomePage() {
                 </button>
               ))}
             </div>
+          </section>
+
+          <section className="rail-panel security-notice">
+            <div className="rail-heading">
+              <span>보안알림</span>
+            </div>
+            <BankNoticeStrip
+              items={[
+                { label: "보안등급", value: "정상" },
+                { label: "접속상태", value: "HTTPS" },
+                {
+                  label: "인증수단",
+                  value: session ? "세션 활성" : "로그인 필요",
+                },
+              ]}
+            />
           </section>
 
           <section className="rail-panel notice-list">

--- a/front/src/components/customer-banking/common.tsx
+++ b/front/src/components/customer-banking/common.tsx
@@ -6,7 +6,7 @@ export function ResultPanel({ title, rows }: { title: string; rows: string[][] }
         <span>{rows.length > 0 ? "완료" : "대기"}</span>
       </div>
       {rows.length === 0 ? (
-        <p className="rail-copy">처리 결과가 여기에 표시됩니다.</p>
+        <p className="rail-copy">처리 결과 없음</p>
       ) : (
         <dl className="detail-list">
           {rows.map(([key, value]) => (
@@ -18,5 +18,52 @@ export function ResultPanel({ title, rows }: { title: string; rows: string[][] }
         </dl>
       )}
     </div>
+  );
+}
+
+export function WorkTabs({
+  active,
+  items,
+}: {
+  active: string;
+  items: Array<{
+    id: string;
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+  }>;
+}) {
+  return (
+    <div className="work-tabs">
+      {items.map((item) => (
+        <button
+          aria-current={active === item.id ? "page" : undefined}
+          className={active === item.id ? "active" : undefined}
+          disabled={item.disabled}
+          key={item.id}
+          onClick={item.onClick}
+          type="button"
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function BankNoticeStrip({
+  items,
+}: {
+  items: Array<{ label: string; value: string }>;
+}) {
+  return (
+    <dl className="bank-notice-strip">
+      {items.map((item) => (
+        <div key={item.label}>
+          <dt>{item.label}</dt>
+          <dd>{item.value}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }

--- a/front/src/components/customer-banking/sections/accounts-section.tsx
+++ b/front/src/components/customer-banking/sections/accounts-section.tsx
@@ -1,5 +1,6 @@
 import type { AccountItem, AccountSummaryResponse } from '@/lib/api/types';
 import { formatDateTime, formatMinorAmount } from '@/lib/customer-banking/format';
+import { BankNoticeStrip, WorkTabs } from '../common';
 
 export function AccountsSection({
   accountCursor,
@@ -24,6 +25,34 @@ export function AccountsSection({
 }) {
   return (
     <section className="task-section">
+      <WorkTabs
+        active="전계좌조회"
+        items={[
+          { id: "전계좌조회", label: "전계좌조회", onClick: onLoadAccounts },
+          {
+            id: "계좌상세",
+            label: "계좌상세",
+            onClick: () => {
+              if (selectedAccount) {
+                onLoadAccountDetail(selectedAccount.accountId);
+              }
+            },
+            disabled: !selectedAccount,
+          },
+          {
+            id: "거래내역",
+            label: "거래내역",
+            onClick: () => undefined,
+            disabled: true,
+          },
+          {
+            id: "이체",
+            label: "이체",
+            onClick: () => undefined,
+            disabled: true,
+          },
+        ]}
+      />
       <div className="section-title">
         <div>
           <p>조회</p>
@@ -49,13 +78,21 @@ export function AccountsSection({
           </button>
         </div>
       </div>
+      <BankNoticeStrip
+        items={[
+          { label: "조회구분", value: "전계좌조회" },
+          { label: "표시건수", value: `${accountLimit}건` },
+          { label: "상태", value: "정상/제한 계좌 포함" },
+          { label: "통화", value: "계좌별 통화 표시" },
+        ]}
+      />
 
       <div className="account-grid">
         <section className="table-panel embedded">
           <div className="panel-toolbar">
             <div>
               <strong>보유계좌</strong>
-              <span>계좌별 잔액과 상태</span>
+              <span>계좌별 잔액과 상태 · {accounts.length}건</span>
             </div>
           </div>
           <div className="bank-table-wrap">
@@ -73,7 +110,7 @@ export function AccountsSection({
               <tbody>
                 {accounts.length === 0 ? (
                   <tr>
-                    <td colSpan={5}>조회된 계좌가 없습니다.</td>
+                    <td colSpan={5}>조회 내역 없음</td>
                   </tr>
                 ) : (
                   accounts.map((account) => (
@@ -125,7 +162,7 @@ export function AccountsSection({
               </div>
               <dl className="detail-list">
                 <div>
-                  <dt>Account ID</dt>
+                  <dt>고객계좌번호</dt>
                   <dd>{selectedAccount.accountId}</dd>
                 </div>
                 <div>
@@ -148,7 +185,7 @@ export function AccountsSection({
               </dl>
             </>
           ) : (
-            <p className="rail-copy">계좌 목록에서 상세 버튼을 선택하세요.</p>
+            <p className="rail-copy">계좌 선택 필요</p>
           )}
         </aside>
       </div>

--- a/front/src/components/customer-banking/sections/dashboard-section.tsx
+++ b/front/src/components/customer-banking/sections/dashboard-section.tsx
@@ -1,4 +1,5 @@
 import type { MenuSection } from '@/lib/customer-banking/types';
+import { BankNoticeStrip, WorkTabs } from '../common';
 
 export function DashboardSection({
   hasSession,
@@ -13,6 +14,30 @@ export function DashboardSection({
 }) {
   return (
     <section className="task-section">
+      <WorkTabs
+        active="개인뱅킹"
+        items={["개인뱅킹", "조회", "이체", "인증센터", "고객센터"].map((label) => ({
+          id: label,
+          label,
+          onClick: () => {
+            if (label === "개인뱅킹") {
+              onMove("dashboard");
+            }
+            if (label === "조회") {
+              onMove("accounts");
+            }
+            if (label === "이체") {
+              onMove("transfer");
+            }
+            if (label === "인증센터") {
+              onMove("security");
+            }
+            if (label === "고객센터") {
+              onMove("supportCenter");
+            }
+          },
+        }))}
+      />
       <div className="section-title">
         <div>
           <p>개인뱅킹</p>
@@ -30,32 +55,40 @@ export function DashboardSection({
           </button>
         </div>
       </div>
+      <BankNoticeStrip
+        items={[
+          { label: "이용시간", value: "00:30~23:30" },
+          { label: "보안등급", value: "개인 인증 완료 후 이체 가능" },
+          { label: "상담", value: "평일 09:00~18:00" },
+          { label: "서비스", value: "조회/이체/인증 업무 제공" },
+        ]}
+      />
       <div className="summary-grid">
         <article className="summary-box">
-          <span>조회</span>
+          <span>전계좌조회</span>
           <strong>계좌 목록/잔액</strong>
           <button onClick={() => onMove("accounts")} type="button">
             바로가기
           </button>
         </article>
         <article className="summary-box">
-          <span>이체</span>
+          <span>즉시이체</span>
           <strong>즉시이체/취소</strong>
           <button onClick={() => onMove("transfer")} type="button">
             바로가기
           </button>
         </article>
         <article className="summary-box">
-          <span>조회</span>
+          <span>거래내역조회</span>
           <strong>거래내역</strong>
           <button onClick={() => onMove("transactions")} type="button">
             바로가기
           </button>
         </article>
         <article className="summary-box">
-          <span>알림</span>
-          <strong>알림함/설정</strong>
-          <button onClick={() => onMove("notifications")} type="button">
+          <span>인증센터</span>
+          <strong>인증서/보안업무</strong>
+          <button onClick={() => onMove("security")} type="button">
             바로가기
           </button>
         </article>
@@ -73,18 +106,18 @@ export function DashboardSection({
           <tbody>
             <tr>
               <td>거래내역 조회</td>
-              <td>계좌, 기간, limit, cursor 기반</td>
-              <td>bounded query</td>
+              <td>계좌와 기간 조건 조회</td>
+              <td>다음 조회 가능</td>
             </tr>
             <tr>
               <td>이체</td>
-              <td>요청 단위 Idempotency-Key 발급</td>
+              <td>요청 단위 중복 방지</td>
               <td>중복 방지</td>
             </tr>
             <tr>
               <td>알림</td>
-              <td>SSE 연결 상태와 inbox 동시 제공</td>
-              <td>실시간</td>
+              <td>실시간 알림과 알림함 동시 제공</td>
+              <td>실시간 알림</td>
             </tr>
           </tbody>
         </table>

--- a/front/src/components/customer-banking/sections/enterprise-services-section.tsx
+++ b/front/src/components/customer-banking/sections/enterprise-services-section.tsx
@@ -7,10 +7,13 @@ import type {
   CustomerApplicationLatestResult,
   CustomerApplicationSubmitHandler,
 } from "@/lib/customer-banking/types";
+import { BankNoticeStrip, WorkTabs } from "../common";
+
+function stayOnCurrentWorkTab(): void {}
 
 const fulfillmentDetails = [
   {
-    title: "공과금 상세",
+    title: "공과금 납부",
     applicationType: "BILL_PAYMENT",
     headline: "지로/지방세/아파트관리비 납부",
     description: "기관 선택, 납부번호 조회, 납부 예정금액 확인, 납부확인증 발급 흐름을 한 화면에 배치합니다.",
@@ -24,7 +27,7 @@ const fulfillmentDetails = [
     status: "OTP 확인 후 접수",
   },
   {
-    title: "오픈뱅킹 상세",
+    title: "오픈뱅킹 연결",
     applicationType: "OPEN_BANKING_CONNECTION",
     headline: "타행 계좌 연결 및 통합조회",
     description: "동의 상태, 연결 은행, 대표 계좌, 잔액 갱신 시각을 고객이 반복 조회하기 쉬운 표 형태로 제공합니다.",
@@ -38,7 +41,7 @@ const fulfillmentDetails = [
     status: "OTP 확인 후 연결 신청",
   },
   {
-    title: "예금상품 상세",
+    title: "예금 가입",
     applicationType: "DEPOSIT_PRODUCT_APPLICATION",
     headline: "정기예금/입출금 상품 비교",
     description: "금리, 가입 기간, 우대 조건, 중도해지 기준을 실제 상품몰처럼 비교 가능한 정보 구조로 확장합니다.",
@@ -52,7 +55,7 @@ const fulfillmentDetails = [
     status: "OTP 확인 후 가입 신청",
   },
   {
-    title: "대출 상세",
+    title: "대출 신청",
     applicationType: "LOAN_APPLICATION",
     headline: "한도조회/상환조회/서류 안내",
     description: "한도조회 준비 정보와 상환 스케줄, 필요 서류, 금리 변동 안내를 분리해 보여줍니다.",
@@ -66,7 +69,7 @@ const fulfillmentDetails = [
     status: "OTP 확인 후 한도 신청",
   },
   {
-    title: "외환 상세",
+    title: "외환 신청",
     applicationType: "FOREIGN_EXCHANGE_APPLICATION",
     headline: "환율/외화예금/해외송금 준비",
     description: "통화별 환율, 우대율, 외화예금 가능 여부, 해외송금 준비 정보를 은행권 외환 메뉴처럼 묶습니다.",
@@ -138,6 +141,23 @@ export function EnterpriseServicesSection({
           <h1>공과금 · 오픈뱅킹 · 금융상품</h1>
         </div>
       </div>
+      <WorkTabs
+        active="bill"
+        items={[
+          { id: "bill", label: "공과금", onClick: stayOnCurrentWorkTab, disabled: true },
+          { id: "open-banking", label: "오픈뱅킹", onClick: stayOnCurrentWorkTab, disabled: true },
+          { id: "products", label: "금융상품", onClick: stayOnCurrentWorkTab, disabled: true },
+        ]}
+      />
+      <BankNoticeStrip
+        items={[
+          { label: "공과금", value: "납부 접수" },
+          { label: "오픈뱅킹", value: "연결 신청" },
+          { label: "예금상품", value: "가입 신청" },
+          { label: "대출", value: "한도 신청" },
+          { label: "외환", value: "외환 신청" },
+        ]}
+      />
 
       <div className="enterprise-service-grid">
         {enterpriseServiceItems.map((item) => (
@@ -164,27 +184,27 @@ export function EnterpriseServicesSection({
             <tr>
               <td>공과금</td>
               <td>기관 선택, 납부번호 조회, 납부 확인증</td>
-              <td>read-only 메뉴</td>
+              <td>접수 가능</td>
             </tr>
             <tr>
               <td>오픈뱅킹</td>
               <td>타행 계좌 연결, 잔액 통합조회, 해지</td>
-              <td>read-only 메뉴</td>
+              <td>연결 신청</td>
             </tr>
             <tr>
               <td>예금상품</td>
               <td>상품 목록, 금리, 가입 전 유의사항</td>
-              <td>상품 안내</td>
+              <td>가입 신청</td>
             </tr>
             <tr>
               <td>대출</td>
               <td>한도조회, 신청, 상환 조회</td>
-              <td>상담 안내</td>
+              <td>한도 신청</td>
             </tr>
             <tr>
               <td>외환</td>
               <td>환율 조회, 외화예금, 해외송금</td>
-              <td>환율 조회</td>
+              <td>외환 신청</td>
             </tr>
           </tbody>
         </table>
@@ -225,7 +245,7 @@ export function EnterpriseServicesSection({
                   payload: Object.fromEntries(
                     item.formFields.map((field) => [field.key, form[field.key]]),
                   ),
-                  successMessage: `${item.title} 신청이 접수되었습니다.`,
+                  successMessage: `${item.title} 접수가 완료되었습니다.`,
                 });
               }}
             >

--- a/front/src/components/customer-banking/sections/notifications-section.tsx
+++ b/front/src/components/customer-banking/sections/notifications-section.tsx
@@ -1,6 +1,7 @@
 import type { FormEvent } from 'react';
 import type { NotificationItem, NotificationPreferenceItem, NotificationQueryResponse } from '@/lib/api/types';
 import { formatDateTime } from '@/lib/customer-banking/format';
+import { BankNoticeStrip, WorkTabs } from '../common';
 
 export function NotificationsSection({
   filters,
@@ -70,6 +71,14 @@ export function NotificationsSection({
 }) {
   return (
     <section className="task-section">
+      <WorkTabs
+        active={mode === "inbox" ? "알림함" : "조건검색"}
+        items={[
+          { id: "알림함", label: "알림함", onClick: () => onModeChange("inbox") },
+          { id: "조건검색", label: "조건검색", onClick: () => onModeChange("search") },
+          { id: "수신설정", label: "수신설정", onClick: onLoadPreferences },
+        ]}
+      />
       <div className="section-title">
         <div>
           <p>고객센터</p>
@@ -80,7 +89,7 @@ export function NotificationsSection({
             미확인 조회
           </button>
           <button disabled={isBusy} onClick={onConnect} type="button">
-            SSE 연결
+            실시간 연결
           </button>
           <button onClick={onDisconnect} type="button">
             연결 해제
@@ -94,11 +103,11 @@ export function NotificationsSection({
           <strong>{sseStatus.state}</strong>
         </div>
         <div>
-          <span>Unread</span>
+          <span>미확인</span>
           <strong>{unreadCount ?? "-"}</strong>
         </div>
         <div>
-          <span>Last Event</span>
+          <span>최근 알림</span>
           <strong>{sseStatus.lastEventId || "-"}</strong>
         </div>
         <div>
@@ -106,6 +115,14 @@ export function NotificationsSection({
           <strong>{formatDateTime(sseStatus.lastEventAt)}</strong>
         </div>
       </div>
+      <BankNoticeStrip
+        items={[
+          { label: "알림함", value: `${notifications.length}건` },
+          { label: "조건검색", value: mode === "search" ? "사용 중" : "대기" },
+          { label: "미확인", value: unreadCount == null ? "조회 전" : `${unreadCount}건` },
+          { label: "다음 조회", value: slice?.hasNext ? "가능" : "없음" },
+        ]}
+      />
 
       <form className="bank-form filter-form" onSubmit={onSearch}>
         <div className="panel-toolbar inline-toolbar">
@@ -117,7 +134,7 @@ export function NotificationsSection({
               role="tab"
               type="button"
             >
-              Inbox
+              알림함
             </button>
             <button
               aria-selected={mode === "search"}
@@ -126,7 +143,7 @@ export function NotificationsSection({
               role="tab"
               type="button"
             >
-              Search
+              조건검색
             </button>
           </div>
           <div className="button-row compact">
@@ -134,7 +151,7 @@ export function NotificationsSection({
               조회
             </button>
             <button disabled={!slice?.nextCursor || isBusy} onClick={onNext} type="button">
-              다음
+              다음 조회
             </button>
           </div>
         </div>
@@ -161,9 +178,9 @@ export function NotificationsSection({
               }
               value={filters.readStatus}
             >
-              <option value="ALL">ALL</option>
-              <option value="READ">READ</option>
-              <option value="UNREAD">UNREAD</option>
+              <option value="ALL">전체</option>
+              <option value="READ">확인</option>
+              <option value="UNREAD">미확인</option>
             </select>
           </label>
           <label>
@@ -208,7 +225,7 @@ export function NotificationsSection({
               <strong>알림함</strong>
               <span>
                 {slice
-                  ? `${notifications.length}건 표시 / next ${slice.hasNext ? "있음" : "없음"}`
+                  ? `${notifications.length}건 / 다음 조회 ${slice.hasNext ? "가능" : "없음"}`
                   : "조회 전"}
               </span>
             </div>
@@ -268,7 +285,7 @@ export function NotificationsSection({
                       </td>
                       <td>
                         <span className={item.read ? "status-badge" : "status-badge unread"}>
-                          {item.read ? "READ" : "UNREAD"}
+                          {item.read ? "확인" : "미확인"}
                         </span>
                       </td>
                       <td>{item.eventType}</td>

--- a/front/src/components/customer-banking/sections/security-hub-section.tsx
+++ b/front/src/components/customer-banking/sections/security-hub-section.tsx
@@ -7,6 +7,9 @@ import type {
   CustomerApplicationLatestResult,
   CustomerApplicationSubmitHandler,
 } from "@/lib/customer-banking/types";
+import { BankNoticeStrip, WorkTabs } from "../common";
+
+function stayOnCurrentWorkTab(): void {}
 
 const registrationFlows = [
   {
@@ -82,6 +85,22 @@ export function SecurityHubSection({
           <h1>인증서 · OTP · 보안매체</h1>
         </div>
       </div>
+      <WorkTabs
+        active="certificate"
+        items={[
+          { id: "certificate", label: "인증서", onClick: stayOnCurrentWorkTab, disabled: true },
+          { id: "otp", label: "OTP", onClick: stayOnCurrentWorkTab, disabled: true },
+          { id: "media", label: "보안매체", onClick: stayOnCurrentWorkTab, disabled: true },
+        ]}
+      />
+      <BankNoticeStrip
+        items={[
+          { label: "공동인증서", value: "고위험 이체" },
+          { label: "금융인증서", value: "로그인/조회" },
+          { label: "OTP", value: "이체 승인" },
+          { label: "보안매체", value: "업무별 한도" },
+        ]}
+      />
 
       <div className="security-hub-grid">
         {securityHubItems.map((item) => (
@@ -97,7 +116,7 @@ export function SecurityHubSection({
         <div className="panel-toolbar">
           <div>
             <strong>보안매체별 적용 업무</strong>
-            <span>실제 비밀값 저장 없이 화면 기준만 제공합니다.</span>
+            <span>이체/인증 업무 적용 기준</span>
           </div>
         </div>
         <div className="bank-table-wrap">

--- a/front/src/components/customer-banking/sections/security-section.tsx
+++ b/front/src/components/customer-banking/sections/security-section.tsx
@@ -1,6 +1,20 @@
 import type { FormEvent } from 'react';
 import type { AuthSessionItem, BackupCodeIssueResponse, CustomerSession, LoginResponse, PasswordRecoveryRequestResult, TotpEnrollmentStartResponse } from '@/lib/api/types';
 import { formatDateTime } from '@/lib/customer-banking/format';
+import { BankNoticeStrip, WorkTabs } from '../common';
+
+function stayOnCurrentWorkTab(): void {}
+
+function getChallengeLabel(challengeType: string | null | undefined): string {
+  switch (challengeType) {
+    case "TOTP":
+      return "OTP 인증";
+    case "BACKUP_CODE":
+      return "복구코드 인증";
+    default:
+      return "추가 인증";
+  }
+}
 
 export function SecuritySection(props: {
   backupChallengeForm: {
@@ -80,6 +94,22 @@ export function SecuritySection(props: {
           </button>
         </div>
       </div>
+      <WorkTabs
+        active="login"
+        items={[
+          { id: "login", label: "로그인", onClick: stayOnCurrentWorkTab, disabled: true },
+          { id: "mfa", label: "추가 인증", onClick: stayOnCurrentWorkTab, disabled: true },
+          { id: "session", label: "세션", onClick: stayOnCurrentWorkTab, disabled: true },
+        ]}
+      />
+      <BankNoticeStrip
+        items={[
+          { label: "로그인 상태", value: props.session ? "로그인됨" : "로그인 필요" },
+          { label: "추가 인증", value: props.challenge ? "확인 필요" : "대기" },
+          { label: "세션", value: formatDateTime(props.session?.refreshExpiresAt) },
+          { label: "보안수단", value: "OTP / 복구코드" },
+        ]}
+      />
 
       <div className="two-column">
         <form className="bank-form" onSubmit={props.onLogin}>
@@ -88,7 +118,7 @@ export function SecuritySection(props: {
             <span>아이디와 비밀번호</span>
           </div>
           <label>
-            <span>이용자 ID</span>
+            <span>고객 ID</span>
             <input
               autoComplete="username"
               onChange={(event) =>
@@ -128,7 +158,7 @@ export function SecuritySection(props: {
           </div>
           <dl className="detail-list">
             <div>
-              <dt>User ID</dt>
+              <dt>고객번호</dt>
               <dd>{props.session?.userId ?? "-"}</dd>
             </div>
             <div>
@@ -136,7 +166,7 @@ export function SecuritySection(props: {
               <dd>{props.session?.tokenType ?? "-"}</dd>
             </div>
             <div>
-              <dt>Refresh 만료</dt>
+              <dt>세션 만료</dt>
               <dd>{formatDateTime(props.session?.refreshExpiresAt)}</dd>
             </div>
           </dl>
@@ -147,8 +177,8 @@ export function SecuritySection(props: {
         <div className="two-column">
           <form className="bank-form" onSubmit={props.onTotpChallenge}>
             <div className="form-heading">
-              <strong>TOTP 추가 인증</strong>
-              <span>{props.challenge.challengeType ?? "TOTP"}</span>
+              <strong>OTP 추가 인증</strong>
+              <span>{getChallengeLabel(props.challenge.challengeType)}</span>
             </div>
             <label>
               <span>인증번호 6자리</span>
@@ -185,11 +215,11 @@ export function SecuritySection(props: {
 
           <form className="bank-form" onSubmit={props.onBackupChallenge}>
             <div className="form-heading">
-              <strong>Backup Code 인증</strong>
+              <strong>복구코드 인증</strong>
               <span>대체 인증수단</span>
             </div>
             <label>
-              <span>Backup Code</span>
+              <span>복구코드</span>
               <input
                 onChange={(event) =>
                   props.onBackupChallengeChange({
@@ -228,7 +258,7 @@ export function SecuritySection(props: {
             <span>복구 요청</span>
           </div>
           <label>
-            <span>이용자 ID</span>
+            <span>고객 ID</span>
             <input
               onChange={(event) =>
                 props.onPasswordRecoveryChange({
@@ -245,7 +275,7 @@ export function SecuritySection(props: {
           </button>
           {props.passwordRecoveryResult?.handoffRequestId ? (
             <p className="field-note">
-              Request ID: {props.passwordRecoveryResult.handoffRequestId}
+              요청번호: {props.passwordRecoveryResult.handoffRequestId}
             </p>
           ) : null}
         </form>
@@ -253,7 +283,7 @@ export function SecuritySection(props: {
         <form className="bank-form" onSubmit={props.onPasswordRecoveryConfirm}>
           <div className="form-heading">
             <strong>복구 확정</strong>
-            <span>토큰 기반 변경</span>
+            <span>본인확인 후 변경</span>
           </div>
           <label>
             <span>복구 토큰</span>
@@ -329,11 +359,11 @@ export function SecuritySection(props: {
 
         <div className="bank-form passive">
           <div className="form-heading">
-            <strong>MFA 관리</strong>
-            <span>TOTP / Backup Code</span>
+            <strong>추가 인증 관리</strong>
+            <span>OTP / 복구코드</span>
           </div>
           <label>
-            <span>TOTP 인증번호</span>
+            <span>OTP 인증번호</span>
             <input
               inputMode="numeric"
               maxLength={6}
@@ -374,7 +404,7 @@ export function SecuritySection(props: {
           {props.totpEnrollment ? (
             <dl className="detail-list compact-list">
               <div>
-                <dt>Secret</dt>
+                <dt>등록키</dt>
                 <dd>{props.totpEnrollment.secretKey}</dd>
               </div>
               <div>
@@ -397,7 +427,7 @@ export function SecuritySection(props: {
         <div className="panel-toolbar">
           <div>
             <strong>접속 세션</strong>
-            <span>현재 사용자 refresh token session</span>
+            <span>현재 로그인 기기와 세션 상태</span>
           </div>
           <div className="button-row compact">
             <button
@@ -421,7 +451,7 @@ export function SecuritySection(props: {
             <caption>인증 세션 목록</caption>
             <thead>
               <tr>
-                <th>Session ID</th>
+                <th>세션번호</th>
                 <th>상태</th>
                 <th>기기</th>
                 <th>IP</th>

--- a/front/src/components/customer-banking/sections/support-center-section.tsx
+++ b/front/src/components/customer-banking/sections/support-center-section.tsx
@@ -6,6 +6,9 @@ import type {
   CustomerApplicationLatestResult,
   CustomerApplicationSubmitHandler,
 } from "@/lib/customer-banking/types";
+import { BankNoticeStrip, WorkTabs } from "../common";
+
+function stayOnCurrentWorkTab(): void {}
 
 const faqItems = [
   {
@@ -18,7 +21,7 @@ const faqItems = [
   },
   {
     question: "오픈뱅킹 연결 계좌가 보이지 않습니다.",
-    answer: "동의 만료일과 은행별 점검 시간을 확인한 뒤 오픈뱅킹 상세의 통합조회 갱신을 다시 실행합니다.",
+    answer: "동의 만료일과 은행 점검 시간을 확인한 뒤 통합조회를 다시 실행합니다.",
   },
 ];
 
@@ -89,6 +92,22 @@ export function SupportCenterSection({
           <h1>고객지원 · 사고신고 · 이체한도</h1>
         </div>
       </div>
+      <WorkTabs
+        active="support"
+        items={[
+          { id: "support", label: "고객센터", onClick: stayOnCurrentWorkTab, disabled: true },
+          { id: "incident", label: "사고신고", onClick: stayOnCurrentWorkTab, disabled: true },
+          { id: "certificate", label: "증명서", onClick: stayOnCurrentWorkTab, disabled: true },
+        ]}
+      />
+      <BankNoticeStrip
+        items={[
+          { label: "FAQ", value: "자주 찾는 문의" },
+          { label: "사고신고", value: "분실/도용 접수" },
+          { label: "이체한도", value: "보안등급 확인" },
+          { label: "증명서 발급", value: "확인증/잔액/거래내역" },
+        ]}
+      />
 
       <div className="support-service-grid">
         {supportCenterItems.map((item) => (
@@ -104,7 +123,7 @@ export function SupportCenterSection({
         <div className="panel-toolbar">
           <div>
             <strong>사고신고 우선순위</strong>
-            <span>분실/도용 의심 업무는 실행 화면과 분리해 즉시 찾을 수 있게 둡니다.</span>
+            <span>분실/도용 의심 업무 우선 접수</span>
           </div>
         </div>
         <div className="bank-table-wrap">
@@ -143,7 +162,7 @@ export function SupportCenterSection({
           <div className="panel-toolbar">
             <div>
               <strong>FAQ</strong>
-              <span>반복 문의는 업무 화면 바로 옆에서 확인합니다.</span>
+              <span>자주 찾는 문의</span>
             </div>
           </div>
           {faqItems.map((item) => (
@@ -158,7 +177,7 @@ export function SupportCenterSection({
           <div className="panel-toolbar">
             <div>
               <strong>사고신고 접수</strong>
-              <span>분실/도용/오류 신고를 한 화면에서 접수 준비합니다.</span>
+              <span>분실/도용/오류 신고</span>
             </div>
           </div>
           <div className="form-grid">
@@ -240,7 +259,7 @@ export function SupportCenterSection({
           <div className="panel-toolbar">
             <div>
               <strong>증명서 발급</strong>
-              <span>완료증, 잔액, 거래내역 증명서를 업무별로 분리합니다.</span>
+              <span>확인증, 잔액, 거래내역</span>
             </div>
           </div>
           {certificateItems.map((item) => (

--- a/front/src/components/customer-banking/sections/transactions-section.tsx
+++ b/front/src/components/customer-banking/sections/transactions-section.tsx
@@ -1,6 +1,27 @@
 import type { FormEvent } from 'react';
 import type { TransactionDetailResponse, TransactionItem, TransactionQueryResponse } from '@/lib/api/types';
 import { formatDateTime, formatMinorAmount } from '@/lib/customer-banking/format';
+import { BankNoticeStrip, WorkTabs } from '../common';
+
+const transactionStatusLabels: Record<string, string> = {
+  PENDING: "처리중",
+  BOOKED: "처리완료",
+  REVERSED: "취소완료",
+  FAILED: "실패",
+};
+
+const transactionDirectionLabels: Record<string, string> = {
+  DEBIT: "출금",
+  CREDIT: "입금",
+};
+
+function getTransactionStatusLabel(status: string) {
+  return transactionStatusLabels[status] ?? status;
+}
+
+function getTransactionDirectionLabel(direction: string) {
+  return transactionDirectionLabels[direction] ?? direction;
+}
 
 export function TransactionsSection({
   filters,
@@ -53,6 +74,28 @@ export function TransactionsSection({
 }) {
   return (
     <section className="task-section">
+      <WorkTabs
+        active="거래내역조회"
+        items={[
+          {
+            id: "거래내역조회",
+            label: "거래내역조회",
+            onClick: () => onModeChange("active"),
+          },
+          {
+            id: "상세조회",
+            label: "상세조회",
+            onClick: () => undefined,
+            disabled: true,
+          },
+          {
+            id: "증명서 발급",
+            label: "증명서 발급",
+            onClick: () => undefined,
+            disabled: true,
+          },
+        ]}
+      />
       <div className="section-title">
         <div>
           <p>조회</p>
@@ -79,6 +122,14 @@ export function TransactionsSection({
           </button>
         </div>
       </div>
+      <BankNoticeStrip
+        items={[
+          { label: "조회기간", value: `${filters.from || "-"} ~ ${filters.to || "-"}` },
+          { label: "계좌", value: filters.accountId || "미입력" },
+          { label: "표시건수", value: `${filters.limit}건` },
+          { label: "다음 조회", value: slice?.hasNext ? "가능" : "대기" },
+        ]}
+      />
 
       <form className="bank-form filter-form" onSubmit={onSearch}>
         <div className="filter-summary" aria-label="현재 조건">
@@ -89,7 +140,7 @@ export function TransactionsSection({
           </span>
           <span>건수 {filters.limit}</span>
           <span>
-            cursor pagination {slice?.nextCursor ? "다음 페이지 준비" : "첫 페이지"}
+            다음 조회 {slice?.nextCursor ? "준비됨" : "첫 조회"}
           </span>
         </div>
         <div className="filter-grid">
@@ -148,10 +199,10 @@ export function TransactionsSection({
               value={filters.status}
             >
               <option value="">전체</option>
-              <option value="PENDING">PENDING</option>
-              <option value="BOOKED">BOOKED</option>
-              <option value="REVERSED">REVERSED</option>
-              <option value="FAILED">FAILED</option>
+              <option value="PENDING">처리중</option>
+              <option value="BOOKED">처리완료</option>
+              <option value="REVERSED">취소완료</option>
+              <option value="FAILED">실패</option>
             </select>
           </label>
           <label>
@@ -168,7 +219,7 @@ export function TransactionsSection({
             </select>
           </label>
           <label>
-            <span>최소금액 minor</span>
+            <span>최소금액</span>
             <input
               inputMode="numeric"
               onChange={(event) =>
@@ -181,7 +232,7 @@ export function TransactionsSection({
             />
           </label>
           <label>
-            <span>최대금액 minor</span>
+            <span>최대금액</span>
             <input
               inputMode="numeric"
               onChange={(event) =>
@@ -206,7 +257,7 @@ export function TransactionsSection({
             />
           </label>
           <label>
-            <span>응답형태</span>
+            <span>조회방식</span>
             <select
               onChange={(event) =>
                 onFilterChange({
@@ -216,8 +267,8 @@ export function TransactionsSection({
               }
               value={filters.responseShape}
             >
-              <option value="full">full</option>
-              <option value="slim">slim</option>
+              <option value="full">상세</option>
+              <option value="slim">요약</option>
             </select>
           </label>
         </div>
@@ -238,7 +289,7 @@ export function TransactionsSection({
               <strong>거래내역</strong>
               <span>
                 {slice
-                  ? `${transactions.length}건 표시 / next ${slice.hasNext ? "있음" : "없음"}`
+                  ? `${transactions.length}건 / 다음 조회 ${slice.hasNext ? "가능" : "없음"}`
                   : "조회 전"}
               </span>
             </div>
@@ -267,9 +318,11 @@ export function TransactionsSection({
                     <tr key={`${item.id}-${item.transactionReference}`}>
                       <td>{formatDateTime(item.bookedAt)}</td>
                       <td>{item.transactionReference}</td>
-                      <td>{item.direction}</td>
+                      <td>{getTransactionDirectionLabel(item.direction)}</td>
                       <td>
-                        <span className="status-badge">{item.status}</span>
+                        <span className="status-badge">
+                          {getTransactionStatusLabel(item.status)}
+                        </span>
                       </td>
                       <td className={item.direction === "DEBIT" ? "amount debit" : "amount credit"}>
                         {formatMinorAmount(item.amountMinor, item.currencyCode)}
@@ -302,7 +355,11 @@ export function TransactionsSection({
         <aside className="detail-panel">
           <div className="form-heading">
             <strong>거래상세</strong>
-            <span>{transactionDetail?.transactionStatus ?? "미선택"}</span>
+            <span>
+              {transactionDetail
+                ? getTransactionStatusLabel(transactionDetail.transactionStatus)
+                : "미선택"}
+            </span>
           </div>
           {transactionDetail ? (
             <dl className="detail-list">
@@ -312,7 +369,7 @@ export function TransactionsSection({
               </div>
               <div>
                 <dt>입출금</dt>
-                <dd>{transactionDetail.direction}</dd>
+                <dd>{getTransactionDirectionLabel(transactionDetail.direction)}</dd>
               </div>
               <div>
                 <dt>금액</dt>
@@ -337,7 +394,7 @@ export function TransactionsSection({
                 <dd>{transactionDetail.counterpartyMaskedName ?? "-"}</dd>
               </div>
               <div>
-                <dt>Ledger</dt>
+                <dt>처리번호</dt>
                 <dd>{transactionDetail.entryReference}</dd>
               </div>
               <div>

--- a/front/src/components/customer-banking/sections/transfer-section.tsx
+++ b/front/src/components/customer-banking/sections/transfer-section.tsx
@@ -2,7 +2,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import type { TransferPreviewResponse, TransferResponse, TransferReversalResponse } from '@/lib/api/types';
 import { formatDateTime, formatMinorAmount } from '@/lib/customer-banking/format';
-import { ResultPanel } from '../common';
+import { BankNoticeStrip, ResultPanel, WorkTabs } from '../common';
 
 type TransferStep =
   | "input"
@@ -12,6 +12,44 @@ type TransferStep =
   | "submitting"
   | "complete"
   | "failed";
+
+function stayOnCurrentWorkTab(): void {}
+
+function getTransferBlockedReasonLabel(reason: string | undefined, allowed: boolean | undefined): string {
+  if (allowed) {
+    return "이체 가능";
+  }
+  switch (reason) {
+    case "LIMIT_EXCEEDED":
+    case "DAILY_LIMIT_EXCEEDED":
+    case "SINGLE_LIMIT_EXCEEDED":
+      return "한도 확인 필요";
+    case "OTP_REQUIRED":
+      return "보안 확인 필요";
+    case "TARGET_ACCOUNT_NOT_FOUND":
+    case "INVALID_TARGET_ACCOUNT":
+      return "받는 계좌 확인 필요";
+    case "INSUFFICIENT_FUNDS":
+      return "출금가능금액 확인 필요";
+    case "PREVIEW_REQUIRED":
+    default:
+      return "받는 계좌 확인 필요";
+  }
+}
+
+function getTransferStatusLabel(status: string | undefined): string {
+  switch (status) {
+    case "BOOKED":
+    case "REVERSED":
+      return "처리 완료";
+    case "FAILED":
+      return "처리 실패";
+    case "PENDING":
+      return "처리 중";
+    default:
+      return status ? "처리 확인 필요" : "-";
+  }
+}
 
 export function TransferSection({
   isBusy,
@@ -119,8 +157,11 @@ export function TransferSection({
   const amountMinor = Number(transferForm.amountMinor || 0);
   const transferFeeMinor = transferPreview?.feeMinor ?? 0;
   const limitMinor = transferPreview?.singleTransferLimitMinor ?? 1000000000;
-  const dailyRemainingMinor = transferPreview?.dailyRemainingMinor ?? limitMinor;
-  const blockedReason = transferPreview?.blockedReason ?? "PREVIEW_REQUIRED";
+  const remainingLimitMinor = transferPreview?.dailyRemainingMinor ?? limitMinor;
+  const blockedReasonLabel = getTransferBlockedReasonLabel(
+    transferPreview?.blockedReason,
+    transferPreview?.allowed,
+  );
   const otpRequired = transferPreview?.otpRequired ?? true;
   const isOverLimit = transferPreview
     ? !transferPreview.allowed
@@ -144,6 +185,21 @@ export function TransferSection({
           <h1>즉시이체</h1>
         </div>
       </div>
+      <WorkTabs
+        active="transfer"
+        items={[
+          { id: "transfer", label: "즉시이체", onClick: stayOnCurrentWorkTab, disabled: true },
+          { id: "reversal", label: "이체 취소", onClick: stayOnCurrentWorkTab, disabled: true },
+        ]}
+      />
+      <BankNoticeStrip
+        items={[
+          { label: "이용시간", value: "00:05-23:50" },
+          { label: "수수료", value: formatMinorAmount(transferFeeMinor, transferForm.currencyCode) },
+          { label: "잔여한도", value: formatMinorAmount(remainingLimitMinor, transferForm.currencyCode) },
+          { label: "보안 확인", value: otpRequired ? "OTP 필요" : "추가 확인 없음" },
+        ]}
+      />
 
       <div className="two-column">
         <form className="bank-form" onSubmit={handleTransferSubmit}>
@@ -163,32 +219,32 @@ export function TransferSection({
           </ol>
           <div className="transfer-risk-grid" aria-label="이체 사전 확인">
             <div>
-              <span>받는 분 검증</span>
+              <span>받는 분</span>
               <strong>
                 {transferPreview
                   ? `${transferPreview.targetAccount.displayName} ${transferPreview.targetAccount.maskedAccountNumber}`
                   : `계좌 ID ${transferForm.targetAccountId || "-"}`}
               </strong>
-              <small>backend preview: {blockedReason}</small>
+              <small>{blockedReasonLabel}</small>
             </div>
             <div>
               <span>수수료</span>
               <strong>
                 {formatMinorAmount(transferFeeMinor, transferForm.currencyCode)}
               </strong>
-              <small>feePolicy {transferPreview?.feePolicy ?? "-"}</small>
+              <small>이체 실행 전 최종 확인</small>
             </div>
             <div>
-              <span>잔여 이체한도</span>
+              <span>잔여한도</span>
               <strong className={isOverLimit ? "danger-text" : ""}>
-                {formatMinorAmount(dailyRemainingMinor, transferForm.currencyCode)}
+                {formatMinorAmount(remainingLimitMinor, transferForm.currencyCode)}
               </strong>
-              <small>dailyRemainingMinor / 단건 {formatMinorAmount(limitMinor, transferForm.currencyCode)}</small>
+              <small>1회 한도 {formatMinorAmount(limitMinor, transferForm.currencyCode)}</small>
             </div>
             <div>
-              <span>OTP 확인</span>
+              <span>보안 확인</span>
               <strong>{otpRequired ? "필요" : "미필요"}</strong>
-              <small>otpRequired {String(otpRequired)}</small>
+              <small>OTP 또는 보안매체 확인</small>
             </div>
           </div>
           <div className="form-grid">
@@ -221,7 +277,7 @@ export function TransferSection({
               />
             </label>
             <label>
-              <span>금액 minor</span>
+              <span>이체금액</span>
               <input
                 inputMode="numeric"
                 onChange={(event) =>
@@ -296,7 +352,7 @@ export function TransferSection({
           {isOverLimit ? (
             <div className="confirm-box warning" role="alert">
               <strong>이체 사전 검증 실패</strong>
-              <span>사유 {blockedReason}. 고객센터의 이체한도 메뉴에서 보안등급과 한도를 확인하세요.</span>
+              <span>{blockedReasonLabel}. 고객센터의 이체한도 메뉴에서 보안등급과 한도를 확인하세요.</span>
             </div>
           ) : null}
           <button disabled={isBusy || isOverLimit} type="submit">
@@ -311,7 +367,7 @@ export function TransferSection({
               transferResult
                 ? [
                     ["거래번호", transferResult.transactionReference],
-                    ["상태", transferResult.status],
+                    ["상태", getTransferStatusLabel(transferResult.status)],
                     [
                       "이체금액",
                       formatMinorAmount(
@@ -349,7 +405,7 @@ export function TransferSection({
         <form className="bank-form" onSubmit={onReversal}>
           <div className="form-heading">
             <strong>이체 취소</strong>
-            <span>원거래 reference 기준</span>
+            <span>원거래번호 기준</span>
           </div>
           <label>
             <span>원거래번호</span>
@@ -380,7 +436,7 @@ export function TransferSection({
               />
             </label>
             <label>
-              <span>취소금액 minor</span>
+              <span>취소금액</span>
               <input
                 inputMode="numeric"
                 onChange={(event) =>
@@ -405,11 +461,11 @@ export function TransferSection({
               }
               value={reversalForm.reversalReason}
             >
-              <option value="CUSTOMER_REQUEST">CUSTOMER_REQUEST</option>
-              <option value="DUPLICATE">DUPLICATE</option>
-              <option value="WRONG_AMOUNT">WRONG_AMOUNT</option>
-              <option value="WRONG_TARGET">WRONG_TARGET</option>
-              <option value="FRAUD_REPORTED">FRAUD_REPORTED</option>
+              <option value="CUSTOMER_REQUEST">고객 요청</option>
+              <option value="DUPLICATE">중복 이체</option>
+              <option value="WRONG_AMOUNT">금액 오류</option>
+              <option value="WRONG_TARGET">받는 분 오류</option>
+              <option value="FRAUD_REPORTED">사기 의심 신고</option>
             </select>
           </label>
           <label>
@@ -435,7 +491,7 @@ export function TransferSection({
               ? [
                   ["원거래", reversalResult.originalTransactionReference],
                   ["취소거래", reversalResult.reversalTransactionReference],
-                  ["상태", reversalResult.status],
+                  ["상태", getTransferStatusLabel(reversalResult.status)],
                   [
                     "취소금액",
                     formatMinorAmount(

--- a/front/src/lib/customer-banking/constants.ts
+++ b/front/src/lib/customer-banking/constants.ts
@@ -34,41 +34,41 @@ export const recentMenus: Array<{ label: string; section: MenuSection }> = [
 ];
 
 export const noticeItems = [
-  "보안카드 전체 번호 입력 요구 시 즉시 거래를 중단하세요.",
-  "대량 거래 조회는 계좌, 기간, cursor 조건으로 제한됩니다.",
-  "공동인증서 및 OTP 재발급은 인증센터에서 진행합니다.",
+  "OTP/보안카드 전체 번호 입력 요구 시 거래를 중단하세요.",
+  "거래내역은 계좌와 기간 조건으로 조회합니다.",
+  "공동인증서와 OTP 재발급은 인증센터에서 처리합니다.",
 ];
 
 export const enterpriseServiceItems = [
   {
     title: "공과금",
     category: "납부",
-    description: "지방세, 국세, 아파트관리비, 전기/통신요금 납부 메뉴 진입점입니다.",
-    status: "read-only",
+    description: "지로, 지방세, 아파트관리비, 전기/통신요금",
+    status: "접수 가능",
   },
   {
     title: "오픈뱅킹",
     category: "통합조회",
-    description: "타 금융기관 계좌 연결, 잔액 조회, 해지 동선을 분리해 보여줍니다.",
-    status: "read-only",
+    description: "타행 계좌 연결, 통합조회, 연결 해지",
+    status: "접수 가능",
   },
   {
     title: "예금상품",
     category: "상품",
-    description: "입출금, 예금, 적금 상품 목록과 가입 전 확인 항목을 제공합니다.",
-    status: "상품 안내",
+    description: "입출금, 예금, 적금 상품 신청",
+    status: "접수 가능",
   },
   {
     title: "대출",
     category: "여신",
-    description: "신용대출, 담보대출, 상환 조회 메뉴를 신청 실행 없이 안내합니다.",
-    status: "상담 안내",
+    description: "한도조회, 상담 신청, 상환 조회",
+    status: "접수 가능",
   },
   {
     title: "외환",
     category: "FX",
-    description: "환율 조회, 외화예금, 해외송금 메뉴를 조회형 업무로 배치합니다.",
-    status: "환율 조회",
+    description: "환율 조회, 외화예금, 해외송금 신청",
+    status: "접수 가능",
   },
 ];
 

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -99,6 +99,7 @@ label span {
 
 .bank-shell {
   min-width: 1180px;
+  background: var(--page);
 }
 
 .skip-link {
@@ -242,8 +243,10 @@ label span {
   color: var(--primary);
 }
 
+.bank-service-strip,
 .banking-status-bar {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: 8px 18px;
   width: min(1440px, calc(100% - 48px));
@@ -256,6 +259,7 @@ label span {
   font-weight: 700;
 }
 
+.bank-service-strip strong,
 .banking-status-bar strong {
   color: var(--success);
 }
@@ -323,7 +327,7 @@ label span {
 .rail-panel,
 .table-panel {
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: 3px;
   background: var(--surface);
 }
 
@@ -341,7 +345,7 @@ label span {
 }
 
 .section-title {
-  padding-bottom: 14px;
+  padding-bottom: 10px;
   border-bottom: 2px solid #263b56;
 }
 
@@ -354,7 +358,7 @@ label span {
 
 .section-title h1 {
   margin: 0;
-  font-size: 24px;
+  font-size: 22px;
   letter-spacing: 0;
 }
 
@@ -717,7 +721,7 @@ label span {
 .detail-panel,
 .result-panel {
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: 3px;
   background: #fff;
   padding: 14px;
 }
@@ -814,7 +818,7 @@ label span {
   display: grid;
   gap: 12px;
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: 3px;
   background: var(--surface-muted);
   padding: 14px;
 }
@@ -1177,6 +1181,39 @@ label span {
   color: #fff;
 }
 
+.work-tabs {
+  display: flex;
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 3px;
+  background: #fff;
+  scrollbar-width: thin;
+}
+
+.work-tabs button {
+  flex: 0 0 auto;
+  min-width: 96px;
+  min-height: 34px;
+  border: 0;
+  border-radius: 0;
+  border-right: 1px solid var(--line-strong);
+  background: #fff;
+  color: var(--muted);
+  padding: 0 12px;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.work-tabs button:last-child {
+  border-right: 0;
+}
+
+.work-tabs button.active {
+  background: var(--primary);
+  color: #fff;
+}
+
 .right-rail {
   display: flex;
   flex-direction: column;
@@ -1212,6 +1249,39 @@ label span {
   gap: 8px;
   margin: 12px 0;
   font-size: 12px;
+}
+
+.bank-notice-strip {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0 0;
+  font-size: 12px;
+}
+
+.bank-notice-strip div {
+  display: grid;
+  grid-template-columns: 82px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  border-top: 1px solid var(--line);
+  padding-top: 8px;
+}
+
+.bank-notice-strip dt {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.bank-notice-strip dd {
+  min-width: 0;
+  margin: 0;
+  color: #102f55;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.security-notice dd {
+  color: var(--success);
 }
 
 .quick-grid {
@@ -1255,6 +1325,8 @@ label span {
 
   .utility-bar,
   .brand-row,
+  .bank-service-strip,
+  .banking-status-bar,
   .bank-layout {
     width: min(100% - 24px, 960px);
   }
@@ -1300,6 +1372,7 @@ label span {
 @media (max-width: 760px) {
   .utility-bar,
   .brand-row,
+  .bank-service-strip,
   .banking-status-bar,
   .bank-layout {
     width: calc(100% - 20px);
@@ -1363,6 +1436,7 @@ label span {
 }
 
 @media (max-width: 480px) {
+  .bank-service-strip,
   .banking-status-bar {
     gap: 6px 10px;
   }

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -1214,6 +1214,11 @@ label span {
   color: #fff;
 }
 
+.work-tabs button.active:disabled {
+  cursor: default;
+  opacity: 1;
+}
+
 .right-rail {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 🔗 Related Issue
- close #908

## 🌿 Base Branch
- `main`

## 📝 Summary
- 고객 웹뱅킹 MVP의 화면 문구와 레이아웃을 은행권 인터넷뱅킹 문법에 맞춰 고도화했습니다.
- 상단/좌측/중앙/우측 구조, 조회/이체/인증/고객센터/부가업무 화면, smoke 계약을 함께 정리했습니다.

## 🛠 Changes
- 고객 웹뱅킹 shell에 업무 탭, 보안알림, 업무 안내 strip, 고밀도 table/form 스타일을 추가했습니다.
- 계좌/거래/알림 조회 화면의 backend 노출 문구를 고객용 은행 업무 문구로 교체했습니다.
- 이체, 인증센터, 보안센터, 고객센터, 공과금/오픈뱅킹/상품 신청 화면을 은행권 업무 흐름에 맞춰 정리했습니다.
- UI contract, fulfillment contract, visual/a11y, click-flow smoke를 최신 문구 기준으로 강화했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front lint`
- `yarn --cwd front build`
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front test:enterprise-ux`
- `yarn --cwd front test:fulfillment-ux`
- `yarn --cwd front test:e2e:a11y`
- `yarn --cwd front test:e2e:click-flow`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 은행권 UX 문구 변경으로 기존 smoke 기대 문구와 화면 텍스트가 달라질 수 있습니다.
- 롤백 방법: 이 PR을 revert하면 고객 웹뱅킹 UX와 smoke 계약 변경이 함께 되돌아갑니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
