### PR TITLE
[Feat] 로그인 후 웹뱅킹 업무 UI 고도화

### DIFF
--- a/front/e2e/customer-banking-authenticated-workflow.spec.ts
+++ b/front/e2e/customer-banking-authenticated-workflow.spec.ts
@@ -1,0 +1,200 @@
+import { expect, test } from "@playwright/test";
+
+test("로그인 후 계좌, 이체, 거래내역, 세션 관리 업무 화면을 실제 클릭 흐름으로 확인한다", async ({
+  page,
+}) => {
+  await page.route("**/api/v1/auth/login", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        status: "SUCCESS",
+        accessToken: "browser-cookie-session",
+        refreshToken: null,
+        tokenType: "Cookie",
+        expiresAt: "2026-05-12T03:30:00Z",
+        refreshExpiresAt: "2026-05-12T04:30:00Z",
+        userId: 1001,
+        challengeId: null,
+        challengeType: null,
+        challengeExpiresAt: null,
+      },
+    });
+  });
+
+  await page.route("**/api/v1/auth/sessions**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        items: [
+          {
+            sessionId: 77,
+            sessionStatus: "ACTIVE",
+            expiresAt: "2026-05-12T04:30:00Z",
+            lastUsedAt: "2026-05-12T02:20:00Z",
+            createdAt: "2026-05-12T01:30:00Z",
+            deviceName: "Chrome Desktop",
+            ipAddress: "203.0.113.10",
+            currentSession: true,
+          },
+        ],
+      },
+    });
+  });
+
+  await page.route("**/api/v1/accounts?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        items: [
+          {
+            accountId: 101,
+            accountNumber: "110-123-456789",
+            displayName: "Aquila 주거래통장",
+            accountStatus: "ACTIVE",
+            currencyCode: "KRW",
+            availableBalanceMinor: 350000000,
+            pendingBalanceMinor: 0,
+            createdAt: "2026-05-01T00:00:00Z",
+            balanceUpdatedAt: "2026-05-12T02:20:00Z",
+          },
+        ],
+        nextCursor: null,
+      },
+    });
+  });
+
+  await page.route("**/api/v1/accounts/101", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        accountId: 101,
+        accountNumber: "110-123-456789",
+        displayName: "Aquila 주거래통장",
+        accountStatus: "ACTIVE",
+        currencyCode: "KRW",
+        availableBalanceMinor: 350000000,
+        pendingBalanceMinor: 0,
+        createdAt: "2026-05-01T00:00:00Z",
+        balanceUpdatedAt: "2026-05-12T02:20:00Z",
+      },
+    });
+  });
+
+  await page.route("**/api/v1/transfers/preview**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        sourceAccountId: 101,
+        targetAccount: {
+          accountId: 202,
+          maskedAccountNumber: "220-***-445566",
+          displayName: "홍길동",
+          accountStatus: "ACTIVE",
+          currencyCode: "KRW",
+        },
+        amountMinor: 1200000,
+        currencyCode: "KRW",
+        feeMinor: 0,
+        feePolicy: "WAIVED",
+        totalDebitMinor: 1200000,
+        singleTransferLimitMinor: 500000000,
+        dailyTransferLimitMinor: 1000000000,
+        dailyUsedMinor: 0,
+        dailyRemainingMinor: 998800000,
+        allowed: true,
+        blockedReason: "",
+        otpRequired: true,
+      },
+    });
+  });
+
+  await page.route("**/api/v1/transfers", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        transactionReference: "TRX-20260512-0001",
+        sourceAccountId: 101,
+        targetAccountId: 202,
+        amountMinor: 1200000,
+        currencyCode: "KRW",
+        availableBalanceAfterMinor: 348800000,
+        bookedAt: "2026-05-12T02:25:00Z",
+        status: "BOOKED",
+      },
+    });
+  });
+
+  await page.route("**/api/v1/transactions?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        items: [
+          {
+            id: 901,
+            transactionReference: "TRX-20260512-0001",
+            direction: "DEBIT",
+            status: "BOOKED",
+            amountMinor: 1200000,
+            currencyCode: "KRW",
+            balanceAfterMinor: 348800000,
+            bookedAt: "2026-05-12T02:25:00Z",
+          },
+        ],
+        nextCursor: null,
+        hasNext: false,
+      },
+    });
+  });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "인증센터" }).first().click();
+  const loginForm = page.locator("form").filter({ hasText: "아이디와 비밀번호" });
+  await loginForm.getByLabel("고객 ID").fill("customer01");
+  await loginForm.getByLabel("비밀번호").fill("Password1!");
+  await loginForm.getByRole("button", { exact: true, name: "로그인" }).click();
+  await expect(page.locator(".bank-layout")).toHaveAttribute("data-auth-state", "member");
+
+  await page
+    .getByRole("navigation", { name: "주요 메뉴" })
+    .getByRole("button", { exact: true, name: "조회" })
+    .click();
+  await page.locator("#bank-work-area").getByRole("button", { exact: true, name: "조회" }).click();
+  await expect(page.getByRole("cell", { name: "Aquila 주거래통장" })).toBeVisible();
+  await expect(page.getByLabel("조회 업무 상태")).toContainText("1건");
+
+  await page
+    .getByRole("navigation", { name: "주요 메뉴" })
+    .getByRole("button", { exact: true, name: "이체" })
+    .click();
+  const transferForm = page.locator("form").filter({ hasText: "이체정보 입력" });
+  await transferForm.getByLabel("출금계좌 ID").fill("101");
+  await transferForm.getByLabel("입금계좌 ID").fill("202");
+  await transferForm.getByLabel("이체금액").fill("1200000");
+  await transferForm.getByLabel("받는 분 통장 표시").fill("생활비");
+  await transferForm.getByRole("button", { name: "받는 분 확인" }).click();
+  await expect(page.getByLabel("이체 진행 상태")).toContainText("확인");
+  await transferForm.getByRole("button", { name: "받는 분 확인 완료" }).click();
+  await transferForm.getByRole("button", { name: "OTP 확인" }).click();
+  await transferForm.getByLabel("OTP 확인").fill("123456");
+  await transferForm.getByRole("button", { name: "이체 실행" }).click();
+  await expect(page.getByLabel("이체 완료증 인쇄")).toContainText("TRX-20260512-0001");
+  await expect(page.locator(".print-receipt-button")).toBeVisible();
+
+  await page
+    .getByRole("navigation", { name: "주요 메뉴" })
+    .getByRole("button", { exact: true, name: "거래내역 조회" })
+    .click();
+  await expect(page.getByRole("button", { name: "상세조건 접기" })).toBeVisible();
+  await page.getByRole("button", { name: "1개월" }).click();
+  await page.locator("#bank-work-area").getByRole("button", { exact: true, name: "조회" }).click();
+  await expect(page.getByText("TRX-20260512-0001")).toBeVisible();
+  await page.getByRole("button", { name: "초기화" }).click();
+  await expect(page.getByLabel("거래 조회 상태")).toContainText("조회 전");
+
+  await page
+    .getByRole("navigation", { name: "주요 메뉴" })
+    .getByRole("button", { exact: true, name: "인증센터" })
+    .click();
+  await page.locator("#bank-work-area").getByRole("button", { exact: true, name: "조회" }).click();
+  await expect(page.getByText("Chrome Desktop")).toBeVisible();
+});

--- a/front/e2e/customer-banking-click-flow.spec.ts
+++ b/front/e2e/customer-banking-click-flow.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test("고객 웹뱅킹 주요 공개 업무와 미로그인 이체 가드를 실제 클릭으로 확인한다", async ({
   page,
-}) => {
+}, testInfo) => {
   await page.goto("/");
 
   await expect(page.getByRole("heading", { name: "뱅킹 업무" })).toBeVisible();
@@ -10,6 +10,10 @@ test("고객 웹뱅킹 주요 공개 업무와 미로그인 이체 가드를 실
   await expect(page.getByText("이용시간", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("업무현황")).toBeVisible();
   await expect(page.getByText("알림 수신 설정")).toBeVisible();
+  if (testInfo.project.name.includes("mobile")) {
+    await expect(page.getByText("추천검색어")).toBeHidden();
+    await page.getByRole("button", { exact: true, name: "검색" }).click();
+  }
   await expect(page.getByText("추천검색어")).toBeVisible();
   await expect(page.getByText("자주찾는서비스")).toBeVisible();
   await expect(page.getByText("새소식")).toBeVisible();

--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,8 @@
     "test:ops-console": "node scripts/check-ops-console-contract.mjs",
     "test:enterprise-ux": "node scripts/check-customer-banking-enterprise-ux.mjs",
     "test:fulfillment-ux": "node scripts/check-customer-banking-fulfillment-ux.mjs",
+    "test:authenticated-ux": "node scripts/check-customer-banking-authenticated-ux.mjs",
+    "test:e2e:authenticated": "playwright test --config=playwright.config.ts e2e/customer-banking-authenticated-workflow.spec.ts",
     "test:e2e:click-flow": "playwright test --config=playwright.config.ts e2e/customer-banking-click-flow.spec.ts",
     "test:e2e:visual": "playwright test --config=playwright.config.ts e2e/customer-banking-visual-layout.spec.ts",
     "test:e2e:a11y": "node scripts/check-customer-banking-visual-a11y.mjs"

--- a/front/scripts/check-customer-banking-authenticated-ux.mjs
+++ b/front/scripts/check-customer-banking-authenticated-ux.mjs
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+
+function read(path) {
+  const filePath = join(root, path);
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
+}
+
+const files = {
+  packageJson: read("package.json"),
+  page: read("src/app/page.tsx"),
+  layout: read("src/components/customer-banking/layout.tsx"),
+  common: read("src/components/customer-banking/common.tsx"),
+  transfer: read("src/components/customer-banking/sections/transfer-section.tsx"),
+  transactions: read("src/components/customer-banking/sections/transactions-section.tsx"),
+  styles: read("src/styles/customer-banking.css"),
+  e2e: read("e2e/customer-banking-authenticated-workflow.spec.ts"),
+};
+
+const required = [
+  ["package authenticated ux script", files.packageJson, "test:e2e:authenticated"],
+  ["layout file", files.layout, "BankHeader"],
+  ["header component", files.layout, "export function BankHeader"],
+  ["side menu component", files.layout, "export function SideMenu"],
+  ["right rail component", files.layout, "export function RightRail"],
+  ["page uses bank header", files.page, "<BankHeader"],
+  ["page uses side menu", files.page, "<SideMenu"],
+  ["page uses right rail", files.page, "<RightRail"],
+  ["work panel component", files.common, "export function WorkPanel"],
+  ["bank table component", files.common, "export function BankTable"],
+  ["form field component", files.common, "export function FormField"],
+  ["transfer print receipt aria", files.transfer, 'aria-label="이체 완료증 인쇄"'],
+  ["transfer print receipt class", files.transfer, "transfer-print-receipt"],
+  ["transfer print button", files.transfer, "print-receipt-button"],
+  ["transaction quick range toolbar", files.transactions, "quick-range-toolbar"],
+  ["transaction quick today", files.transactions, "오늘"],
+  ["transaction quick one month", files.transactions, "1개월"],
+  ["transaction quick reset", files.transactions, "초기화"],
+  ["transaction detail toggle", files.transactions, "상세조건 접기"],
+  ["mobile search collapse", files.layout, "mobile-search-toggle"],
+  ["mobile nav scroll style", files.styles, ".mobile-search-toggle"],
+  ["touch action strip style", files.styles, ".touch-action-strip"],
+  ["print media receipt style", files.styles, "@media print"],
+  ["authenticated e2e login route", files.e2e, "/api/v1/auth/login"],
+  ["authenticated e2e transfer route", files.e2e, "/api/v1/transfers"],
+  ["authenticated e2e transaction route", files.e2e, "/api/v1/transactions"],
+];
+
+const missing = required.filter(([, content, expected]) => !content.includes(expected));
+
+if (missing.length > 0) {
+  console.error("[customer-banking-authenticated-ux] contract violations:");
+  for (const [name, , expected] of missing) {
+    console.error(`- missing ${name}: ${expected}`);
+  }
+  process.exit(1);
+}
+
+console.log("[customer-banking-authenticated-ux] passed");

--- a/front/scripts/check-customer-banking-ui-contract.mjs
+++ b/front/scripts/check-customer-banking-ui-contract.mjs
@@ -13,7 +13,10 @@ function readOptional(path) {
 }
 
 const files = {
-  page: read("src/app/page.tsx"),
+  page: [
+    read("src/app/page.tsx"),
+    read("src/components/customer-banking/layout.tsx"),
+  ].join("\n"),
   layout: read("src/app/layout.tsx"),
   manifest: readOptional("src/app/manifest.ts"),
   constants: read("src/lib/customer-banking/constants.ts"),

--- a/front/scripts/check-customer-banking-visual-a11y.mjs
+++ b/front/scripts/check-customer-banking-visual-a11y.mjs
@@ -11,7 +11,10 @@ function read(path) {
 const files = {
   packageJson: read("package.json"),
   common: read("src/components/customer-banking/common.tsx"),
-  page: read("src/app/page.tsx"),
+  page: [
+    read("src/app/page.tsx"),
+    read("src/components/customer-banking/layout.tsx"),
+  ].join("\n"),
   playwright: read("playwright.config.ts"),
   styles: read("src/styles/customer-banking.css"),
   accounts: read("src/components/customer-banking/sections/accounts-section.tsx"),

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import Image from "next/image";
 import { AccountsSection } from "@/components/customer-banking/sections/accounts-section";
-import { BankNoticeStrip } from "@/components/customer-banking/common";
+import { BankHeader, RightRail, SideMenu } from "@/components/customer-banking/layout";
 import { DashboardSection } from "@/components/customer-banking/sections/dashboard-section";
 import { EnterpriseServicesSection } from "@/components/customer-banking/sections/enterprise-services-section";
 import { NotificationsSection } from "@/components/customer-banking/sections/notifications-section";
@@ -13,15 +12,6 @@ import { SupportCenterSection } from "@/components/customer-banking/sections/sup
 import { TransactionsSection } from "@/components/customer-banking/sections/transactions-section";
 import { TransferSection } from "@/components/customer-banking/sections/transfer-section";
 import { useCustomerBanking } from "@/hooks/use-customer-banking";
-import {
-  mainMenus,
-  noticeItems,
-  quickMenus,
-  recentMenus,
-  recommendedKeywords,
-  serviceMapGroups,
-} from "@/lib/customer-banking/constants";
-import { formatDateTime } from "@/lib/customer-banking/format";
 import type { MenuSection } from "@/lib/customer-banking/types";
 
 const publicSections: MenuSection[] = ["dashboard", "security"];
@@ -89,6 +79,7 @@ export default function HomePage() {
     handleReversal,
     handleSubmitCustomerApplication,
     handleSearchTransactions,
+    handleResetTransactionFilters,
     handleLoadTransactionDetail,
     handleLoadNotifications,
     handleLoadUnreadCount,
@@ -119,14 +110,10 @@ export default function HomePage() {
   const canRenderWorkSection = !sessionRequired;
   const [searchQuery, setSearchQuery] = useState("");
   const [serviceMapOpen, setServiceMapOpen] = useState(false);
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
 
   function moveToSection(section: MenuSection) {
     setActiveSection(section);
-  }
-
-  function moveFromServiceMap(section: MenuSection) {
-    setServiceMapOpen(false);
-    moveToSection(section);
   }
 
   function renderLoginRequiredWork() {
@@ -172,158 +159,25 @@ export default function HomePage() {
       <a className="skip-link" href="#bank-work-area">
         본문 바로가기
       </a>
-      <header className="bank-header">
-        <div className="utility-bar" aria-label="상단 유틸리티">
-          <div className="utility-left">
-            <button className="utility-link active" type="button">
-              개인
-            </button>
-            <button className="utility-link" type="button">
-              기업
-            </button>
-            <button
-              className="utility-link"
-              onClick={() => moveToSection("security")}
-              type="button"
-            >
-              인증센터
-            </button>
-            <button
-              className="utility-link"
-              onClick={() => moveToSection("supportCenter")}
-              type="button"
-            >
-              고객센터
-            </button>
-          </div>
-          <div className="utility-right">
-            <button
-              aria-controls="service-map-panel"
-              aria-expanded={serviceMapOpen}
-              className="utility-link service-map"
-              onClick={() => setServiceMapOpen((value) => !value)}
-              type="button"
-            >
-              전체서비스
-            </button>
-            <div className="utility-search">
-              <label className="search-field">
-                <span>통합검색</span>
-                <input
-                  aria-label="통합검색"
-                  onChange={(event) => setSearchQuery(event.target.value)}
-                  placeholder="업무명 또는 메뉴 검색"
-                  value={searchQuery}
-                />
-              </label>
-              <div className="keyword-list" aria-label="추천검색어">
-                <span>추천검색어</span>
-                {recommendedKeywords.map((keyword) => (
-                  <button
-                    key={keyword}
-                    onClick={() => setSearchQuery(keyword)}
-                    type="button"
-                  >
-                    {keyword}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="brand-row">
-          <div className="brand-mark" aria-label="Aquila Bank">
-            <span className="brand-symbol" aria-hidden="true">
-              <Image
-                alt=""
-                height={34}
-                priority
-                src="/brand-mascot.png"
-                width={34}
-              />
-            </span>
-            <div>
-              <strong>Aquila Bank</strong>
-              <small>Personal Internet Banking</small>
-            </div>
-          </div>
-          <nav className="primary-nav" aria-label="주요 메뉴">
-            {mainMenus.map((item) => (
-              <button
-                aria-current={activeSection === item.id ? "page" : undefined}
-                className={activeSection === item.id ? "nav-tab active" : "nav-tab"}
-                key={item.id}
-                onClick={() => moveToSection(item.id)}
-                type="button"
-              >
-                {item.label}
-              </button>
-            ))}
-          </nav>
-        </div>
-        <div className="bank-service-strip" aria-label="뱅킹 이용 상태">
-          <span>
-            보안등급 <strong>정상</strong>
-          </span>
-          <span>HTTPS 보안접속</span>
-          <span>평일 09:00-18:00 상담</span>
-          <span>서비스 상태 정상</span>
-        </div>
-        <div className="layout-health-strip" aria-label="화면 이용 상태">
-          <span>개인뱅킹</span>
-          <span>{session ? "로그인 정상" : "미로그인"}</span>
-          <span>{sessionRequired ? "로그인 필요" : "업무 가능"}</span>
-        </div>
-        {serviceMapOpen ? (
-          <section
-            aria-label="전체서비스 메뉴"
-            className="service-map-panel"
-            id="service-map-panel"
-          >
-            <div className="service-map-title">
-              <strong>전체서비스 메뉴</strong>
-              <span>개인뱅킹</span>
-            </div>
-            <div className="service-map-grid">
-              {serviceMapGroups.map((group) => (
-                <div className="service-map-group" key={group.title}>
-                  <strong>{group.title}</strong>
-                  {group.items.map((item) => (
-                    <button
-                      key={`${group.title}-${item.label}`}
-                      onClick={() => moveFromServiceMap(item.section)}
-                      type="button"
-                    >
-                      {item.label}
-                    </button>
-                  ))}
-                </div>
-              ))}
-            </div>
-          </section>
-        ) : null}
-      </header>
+      <BankHeader
+        activeSection={activeSection}
+        mobileSearchOpen={mobileSearchOpen}
+        searchQuery={searchQuery}
+        serviceMapOpen={serviceMapOpen}
+        session={session}
+        sessionRequired={sessionRequired}
+        onMobileSearchToggle={() => setMobileSearchOpen((value) => !value)}
+        onMove={moveToSection}
+        onSearchChange={setSearchQuery}
+        onServiceMapToggle={() => setServiceMapOpen((value) => !value)}
+      />
 
       <div
         className="bank-layout"
         data-active-section={activeSection}
         data-auth-state={session ? "member" : "guest"}
       >
-        <aside className="side-menu" aria-label="개인뱅킹 메뉴">
-          <div className="side-title">개인뱅킹</div>
-          {mainMenus.map((item) => (
-            <button
-              aria-current={activeSection === item.id ? "page" : undefined}
-              className={activeSection === item.id ? "side-item active" : "side-item"}
-              key={item.id}
-              onClick={() => moveToSection(item.id)}
-              type="button"
-            >
-              <span>{item.group}</span>
-              <strong>{item.label}</strong>
-            </button>
-          ))}
-        </aside>
+        <SideMenu activeSection={activeSection} onMove={moveToSection} />
 
         <section
           aria-live="polite"
@@ -401,6 +255,7 @@ export default function HomePage() {
                 event.preventDefault();
                 handleSearchTransactions(transactionMode);
               }}
+              onReset={handleResetTransactionFilters}
             />
           ) : null}
           {activeSection === "security" ? (
@@ -500,101 +355,12 @@ export default function HomePage() {
           ) : null}
         </section>
 
-        <aside className="right-rail" aria-label="빠른 업무">
-          <section className="rail-panel login-panel">
-            <div className="rail-heading">
-              <span>로그인 상태</span>
-              <strong>{session ? "정상" : "미로그인"}</strong>
-            </div>
-            {session ? (
-              <dl className="session-summary">
-                <div>
-                  <dt>User ID</dt>
-                  <dd>{session.userId ?? "-"}</dd>
-                </div>
-                <div>
-                  <dt>세션 방식</dt>
-                  <dd>{session.tokenType}</dd>
-                </div>
-                <div>
-                  <dt>만료</dt>
-                  <dd>{formatDateTime(session.expiresAt)}</dd>
-                </div>
-              </dl>
-            ) : (
-              <p className="rail-copy">로그인 후 조회, 이체, 거래내역 이용 가능</p>
-            )}
-            <div className="button-row compact rail-auth-actions">
-              <button onClick={() => moveToSection("security")} type="button">
-                인증센터
-              </button>
-              <button disabled={!session || isBusy} onClick={handleRefresh} type="button">
-                재발급
-              </button>
-            </div>
-          </section>
-
-          <section className="rail-panel">
-            <div className="rail-heading">
-              <span>빠른메뉴</span>
-            </div>
-            <div className="quick-grid">
-              {quickMenus.map((item) => (
-                <button
-                  key={item.label}
-                  onClick={() => moveToSection(item.section)}
-                  type="button"
-                >
-                  {item.label}
-                </button>
-              ))}
-            </div>
-          </section>
-
-          <section className="rail-panel recent-list">
-            <div className="rail-heading">
-              <span>최근 이용 메뉴</span>
-            </div>
-            <div className="recent-menu-list">
-              {recentMenus.map((item) => (
-                <button
-                  key={item.label}
-                  onClick={() => moveToSection(item.section)}
-                  type="button"
-                >
-                  {item.label}
-                </button>
-              ))}
-            </div>
-          </section>
-
-          <section className="rail-panel security-notice">
-            <div className="rail-heading">
-              <span>보안알림</span>
-            </div>
-            <BankNoticeStrip
-              items={[
-                { label: "보안등급", value: "정상" },
-                { label: "접속상태", value: "HTTPS" },
-                {
-                  label: "인증수단",
-                  value: session ? "세션 활성" : "로그인 필요",
-                },
-              ]}
-            />
-          </section>
-
-          <section className="rail-panel notice-list">
-            <div className="rail-heading">
-              <span>공지사항</span>
-            </div>
-            <ul>
-              {noticeItems.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
-          </section>
-        </aside>
+        <RightRail
+          isBusy={isBusy}
+          session={session}
+          onMove={moveToSection}
+          onRefresh={handleRefresh}
+        />
       </div>
     </main>
   );

--- a/front/src/components/customer-banking/common.tsx
+++ b/front/src/components/customer-banking/common.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 export function ResultPanel({ title, rows }: { title: string; rows: string[][] }) {
   return (
     <div className="result-panel">
@@ -18,6 +20,65 @@ export function ResultPanel({ title, rows }: { title: string; rows: string[][] }
         </dl>
       )}
     </div>
+  );
+}
+
+export function WorkPanel({
+  children,
+  className = "",
+  title,
+  meta,
+}: {
+  children: ReactNode;
+  className?: string;
+  title: string;
+  meta?: string;
+}) {
+  return (
+    <section className={`table-panel bank-work-panel ${className}`.trim()}>
+      <div className="panel-toolbar">
+        <div>
+          <strong>{title}</strong>
+          {meta ? <span>{meta}</span> : null}
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function BankTable({
+  caption,
+  children,
+}: {
+  caption: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="bank-table-wrap">
+      <table className="bank-table">
+        <caption>{caption}</caption>
+        {children}
+      </table>
+    </div>
+  );
+}
+
+export function FormField({
+  children,
+  label,
+  note,
+}: {
+  children: ReactNode;
+  label: string;
+  note?: string;
+}) {
+  return (
+    <label className="form-field">
+      <span>{label}</span>
+      {children}
+      {note ? <small className="field-note">{note}</small> : null}
+    </label>
   );
 }
 

--- a/front/src/components/customer-banking/layout.tsx
+++ b/front/src/components/customer-banking/layout.tsx
@@ -1,0 +1,326 @@
+import Image from "next/image";
+import type { CustomerSession } from "@/lib/api/types";
+import {
+  mainMenus,
+  noticeItems,
+  quickMenus,
+  recentMenus,
+  recommendedKeywords,
+  serviceMapGroups,
+} from "@/lib/customer-banking/constants";
+import { formatDateTime } from "@/lib/customer-banking/format";
+import type { MenuSection } from "@/lib/customer-banking/types";
+import { BankNoticeStrip } from "./common";
+
+type MoveHandler = (section: MenuSection) => void;
+
+export function BankHeader({
+  activeSection,
+  mobileSearchOpen,
+  searchQuery,
+  serviceMapOpen,
+  session,
+  sessionRequired,
+  onMobileSearchToggle,
+  onMove,
+  onSearchChange,
+  onServiceMapToggle,
+}: {
+  activeSection: MenuSection;
+  mobileSearchOpen: boolean;
+  searchQuery: string;
+  serviceMapOpen: boolean;
+  session: CustomerSession | null;
+  sessionRequired: boolean;
+  onMobileSearchToggle: () => void;
+  onMove: MoveHandler;
+  onSearchChange: (value: string) => void;
+  onServiceMapToggle: () => void;
+}) {
+  function moveFromServiceMap(section: MenuSection) {
+    onServiceMapToggle();
+    onMove(section);
+  }
+
+  return (
+    <header className="bank-header">
+      <div className="utility-bar" aria-label="상단 유틸리티">
+        <div className="utility-left">
+          <button className="utility-link active" type="button">
+            개인
+          </button>
+          <button className="utility-link" type="button">
+            기업
+          </button>
+          <button
+            className="utility-link"
+            onClick={() => onMove("security")}
+            type="button"
+          >
+            인증센터
+          </button>
+          <button
+            className="utility-link"
+            onClick={() => onMove("supportCenter")}
+            type="button"
+          >
+            고객센터
+          </button>
+        </div>
+        <div className="utility-right">
+          <button
+            aria-controls="service-map-panel"
+            aria-expanded={serviceMapOpen}
+            className="utility-link service-map"
+            onClick={onServiceMapToggle}
+            type="button"
+          >
+            전체서비스
+          </button>
+          <button
+            aria-controls="utility-search-panel"
+            aria-expanded={mobileSearchOpen}
+            className="mobile-search-toggle"
+            onClick={onMobileSearchToggle}
+            type="button"
+          >
+            검색
+          </button>
+          <div
+            className={mobileSearchOpen ? "utility-search open" : "utility-search"}
+            id="utility-search-panel"
+          >
+            <label className="search-field">
+              <span>통합검색</span>
+              <input
+                aria-label="통합검색"
+                onChange={(event) => onSearchChange(event.target.value)}
+                placeholder="업무명 또는 메뉴 검색"
+                value={searchQuery}
+              />
+            </label>
+            <div className="keyword-list" aria-label="추천검색어">
+              <span>추천검색어</span>
+              {recommendedKeywords.map((keyword) => (
+                <button
+                  key={keyword}
+                  onClick={() => onSearchChange(keyword)}
+                  type="button"
+                >
+                  {keyword}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="brand-row">
+        <div className="brand-mark" aria-label="Aquila Bank">
+          <span className="brand-symbol" aria-hidden="true">
+            <Image
+              alt=""
+              height={34}
+              priority
+              src="/brand-mascot.png"
+              width={34}
+            />
+          </span>
+          <div>
+            <strong>Aquila Bank</strong>
+            <small>Personal Internet Banking</small>
+          </div>
+        </div>
+        <nav className="primary-nav" aria-label="주요 메뉴">
+          {mainMenus.map((item) => (
+            <button
+              aria-current={activeSection === item.id ? "page" : undefined}
+              className={activeSection === item.id ? "nav-tab active" : "nav-tab"}
+              key={item.id}
+              onClick={() => onMove(item.id)}
+              type="button"
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+      <div className="bank-service-strip" aria-label="뱅킹 이용 상태">
+        <span>
+          보안등급 <strong>정상</strong>
+        </span>
+        <span>HTTPS 보안접속</span>
+        <span>평일 09:00-18:00 상담</span>
+        <span>서비스 상태 정상</span>
+      </div>
+      <div className="layout-health-strip" aria-label="화면 이용 상태">
+        <span>개인뱅킹</span>
+        <span>{session ? "로그인 정상" : "미로그인"}</span>
+        <span>{sessionRequired ? "로그인 필요" : "업무 가능"}</span>
+      </div>
+      {serviceMapOpen ? (
+        <section
+          aria-label="전체서비스 메뉴"
+          className="service-map-panel"
+          id="service-map-panel"
+        >
+          <div className="service-map-title">
+            <strong>전체서비스 메뉴</strong>
+            <span>개인뱅킹</span>
+          </div>
+          <div className="service-map-grid">
+            {serviceMapGroups.map((group) => (
+              <div className="service-map-group" key={group.title}>
+                <strong>{group.title}</strong>
+                {group.items.map((item) => (
+                  <button
+                    key={`${group.title}-${item.label}`}
+                    onClick={() => moveFromServiceMap(item.section)}
+                    type="button"
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </header>
+  );
+}
+
+export function SideMenu({
+  activeSection,
+  onMove,
+}: {
+  activeSection: MenuSection;
+  onMove: MoveHandler;
+}) {
+  return (
+    <aside className="side-menu" aria-label="개인뱅킹 메뉴">
+      <div className="side-title">개인뱅킹</div>
+      {mainMenus.map((item) => (
+        <button
+          aria-current={activeSection === item.id ? "page" : undefined}
+          className={activeSection === item.id ? "side-item active" : "side-item"}
+          key={item.id}
+          onClick={() => onMove(item.id)}
+          type="button"
+        >
+          <span>{item.group}</span>
+          <strong>{item.label}</strong>
+        </button>
+      ))}
+    </aside>
+  );
+}
+
+export function RightRail({
+  isBusy,
+  session,
+  onMove,
+  onRefresh,
+}: {
+  isBusy: boolean;
+  session: CustomerSession | null;
+  onMove: MoveHandler;
+  onRefresh: () => void;
+}) {
+  return (
+    <aside className="right-rail" aria-label="빠른 업무">
+      <section className="rail-panel login-panel">
+        <div className="rail-heading">
+          <span>로그인 상태</span>
+          <strong>{session ? "정상" : "미로그인"}</strong>
+        </div>
+        {session ? (
+          <dl className="session-summary">
+            <div>
+              <dt>User ID</dt>
+              <dd>{session.userId ?? "-"}</dd>
+            </div>
+            <div>
+              <dt>세션 방식</dt>
+              <dd>{session.tokenType}</dd>
+            </div>
+            <div>
+              <dt>만료</dt>
+              <dd>{formatDateTime(session.expiresAt)}</dd>
+            </div>
+          </dl>
+        ) : (
+          <p className="rail-copy">로그인 후 조회, 이체, 거래내역 이용 가능</p>
+        )}
+        <div className="button-row compact rail-auth-actions">
+          <button onClick={() => onMove("security")} type="button">
+            인증센터
+          </button>
+          <button disabled={!session || isBusy} onClick={onRefresh} type="button">
+            재발급
+          </button>
+        </div>
+      </section>
+
+      <section className="rail-panel">
+        <div className="rail-heading">
+          <span>빠른메뉴</span>
+        </div>
+        <div className="quick-grid">
+          {quickMenus.map((item) => (
+            <button
+              key={item.label}
+              onClick={() => onMove(item.section)}
+              type="button"
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="rail-panel recent-list">
+        <div className="rail-heading">
+          <span>최근 이용 메뉴</span>
+        </div>
+        <div className="recent-menu-list">
+          {recentMenus.map((item) => (
+            <button
+              key={item.label}
+              onClick={() => onMove(item.section)}
+              type="button"
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="rail-panel security-notice">
+        <div className="rail-heading">
+          <span>보안알림</span>
+        </div>
+        <BankNoticeStrip
+          items={[
+            { label: "보안등급", value: "정상" },
+            { label: "접속상태", value: "HTTPS" },
+            {
+              label: "인증수단",
+              value: session ? "세션 활성" : "로그인 필요",
+            },
+          ]}
+        />
+      </section>
+
+      <section className="rail-panel notice-list">
+        <div className="rail-heading">
+          <span>공지사항</span>
+        </div>
+        <ul>
+          {noticeItems.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+    </aside>
+  );
+}

--- a/front/src/components/customer-banking/sections/transactions-section.tsx
+++ b/front/src/components/customer-banking/sections/transactions-section.tsx
@@ -1,7 +1,22 @@
 import type { FormEvent } from 'react';
+import { useState } from 'react';
 import type { TransactionDetailResponse, TransactionItem, TransactionQueryResponse } from '@/lib/api/types';
-import { formatDateTime, formatMinorAmount } from '@/lib/customer-banking/format';
+import { formatDateTime, formatMinorAmount, toLocalInputValue } from '@/lib/customer-banking/format';
 import { BankNoticeStrip, EmptyState, WorkStateGrid, WorkTabs } from '../common';
+
+type TransactionFilters = {
+  accountId: string;
+  from: string;
+  to: string;
+  limit: string;
+  cursor: string;
+  status: string;
+  direction: string;
+  minAmountMinor: string;
+  maxAmountMinor: string;
+  transactionReference: string;
+  responseShape: "full" | "slim";
+};
 
 const transactionStatusLabels: Record<string, string> = {
   PENDING: "처리중",
@@ -34,44 +49,40 @@ export function TransactionsSection({
   onFilterChange,
   onModeChange,
   onNext,
+  onReset,
   onSearch,
 }: {
-  filters: {
-    accountId: string;
-    from: string;
-    to: string;
-    limit: string;
-    cursor: string;
-    status: string;
-    direction: string;
-    minAmountMinor: string;
-    maxAmountMinor: string;
-    transactionReference: string;
-    responseShape: "full" | "slim";
-  };
+  filters: TransactionFilters;
   isBusy: boolean;
   mode: "active" | "archive";
   slice: TransactionQueryResponse | null;
   transactionDetail: TransactionDetailResponse | null;
   transactions: TransactionItem[];
   onDetail: (transactionReference: string) => void;
-  onFilterChange: (value: {
-    accountId: string;
-    from: string;
-    to: string;
-    limit: string;
-    cursor: string;
-    status: string;
-    direction: string;
-    minAmountMinor: string;
-    maxAmountMinor: string;
-    transactionReference: string;
-    responseShape: "full" | "slim";
-  }) => void;
+  onFilterChange: (value: TransactionFilters) => void;
   onModeChange: (mode: "active" | "archive") => void;
   onNext: () => void;
+  onReset: () => void;
   onSearch: (event: FormEvent<HTMLFormElement>) => void;
 }) {
+  const [filterOpen, setFilterOpen] = useState(true);
+
+  function setQuickRange(days: number): void {
+    const to = new Date();
+    const from = new Date(to);
+    if (days === 0) {
+      from.setHours(0, 0, 0, 0);
+    } else {
+      from.setDate(from.getDate() - days);
+    }
+    onFilterChange({
+      ...filters,
+      cursor: "",
+      from: toLocalInputValue(from),
+      to: toLocalInputValue(to),
+    });
+  }
+
   return (
     <section className="task-section">
       <WorkTabs
@@ -159,7 +170,30 @@ export function TransactionsSection({
               다음 조회 {slice?.nextCursor ? "준비됨" : "첫 조회"}
             </span>
           </div>
-        <div className="filter-grid">
+          <div className="quick-range-toolbar touch-action-strip" aria-label="기간 빠른 선택">
+            <button onClick={() => setQuickRange(0)} type="button">
+              오늘
+            </button>
+            <button onClick={() => setQuickRange(30)} type="button">
+              1개월
+            </button>
+            <button onClick={() => setQuickRange(90)} type="button">
+              3개월
+            </button>
+            <button onClick={onReset} type="button">
+              초기화
+            </button>
+            <button
+              aria-controls="transaction-detail-filter"
+              aria-expanded={filterOpen}
+              onClick={() => setFilterOpen((value) => !value)}
+              type="button"
+            >
+              {filterOpen ? "상세조건 접기" : "상세조건 펼치기"}
+            </button>
+          </div>
+        {filterOpen ? (
+        <div className="filter-grid" id="transaction-detail-filter">
           <label>
             <span>계좌 ID</span>
             <input
@@ -288,6 +322,11 @@ export function TransactionsSection({
             </select>
           </label>
         </div>
+        ) : (
+          <div className="filter-collapsed-line" id="transaction-detail-filter" role="status">
+            상세조건 접힘 · 계좌, 기간, 금액 조건은 현재 값으로 유지됩니다.
+          </div>
+        )}
         <div className="button-row">
           <button disabled={isBusy} type="submit">
             조회

--- a/front/src/components/customer-banking/sections/transfer-section.tsx
+++ b/front/src/components/customer-banking/sections/transfer-section.tsx
@@ -15,6 +15,10 @@ type TransferStep =
 
 function stayOnCurrentWorkTab(): void {}
 
+function printTransferReceipt(): void {
+  window.print();
+}
+
 function getTransferBlockedReasonLabel(reason: string | undefined, allowed: boolean | undefined): string {
   if (allowed) {
     return "이체 가능";
@@ -387,7 +391,21 @@ export function TransferSection({
           </button>
         </form>
 
-        <div className="transfer-receipt transfer-receipt-panel">
+        <div
+          aria-label="이체 완료증 인쇄"
+          className="transfer-receipt transfer-receipt-panel transfer-print-receipt"
+        >
+          <div className="receipt-action-row">
+            <span>완료증 출력</span>
+            <button
+              className="print-receipt-button"
+              disabled={!transferResult}
+              onClick={printTransferReceipt}
+              type="button"
+            >
+              인쇄
+            </button>
+          </div>
           <ResultPanel
             title="이체 완료증"
             rows={

--- a/front/src/hooks/use-customer-banking.ts
+++ b/front/src/hooks/use-customer-banking.ts
@@ -74,7 +74,7 @@ export function useCustomerBanking() {
   const [transactionMode, setTransactionMode] = useState<"active" | "archive">(
     "active",
   );
-  const [transactionFilters, setTransactionFilters] = useState({
+  const initialTransactionFilters = useMemo(() => ({
     accountId: "",
     from: toLocalInputValue(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)),
     to: toLocalInputValue(new Date()),
@@ -86,6 +86,9 @@ export function useCustomerBanking() {
     maxAmountMinor: "",
     transactionReference: "",
     responseShape: "full" as "full" | "slim",
+  }), []);
+  const [transactionFilters, setTransactionFilters] = useState({
+    ...initialTransactionFilters,
   });
   const [transactionSlice, setTransactionSlice] =
     useState<TransactionQueryResponse | null>(null);
@@ -532,6 +535,17 @@ export function useCustomerBanking() {
     });
   }
 
+  function handleResetTransactionFilters() {
+    setTransactionFilters({
+      ...initialTransactionFilters,
+      accountId: selectedAccount ? String(selectedAccount.accountId) : "",
+    });
+    setTransactionSlice(null);
+    setTransactions([]);
+    setTransactionDetail(null);
+    setAlert({ type: "info", text: "거래내역 조회 조건을 초기화했습니다." });
+  }
+
   async function handleLoadTransactionDetail(transactionReference: string) {
     if (!requireSession()) {
       return;
@@ -771,6 +785,7 @@ export function useCustomerBanking() {
     handleReversal,
     handleSubmitCustomerApplication,
     handleSearchTransactions,
+    handleResetTransactionFilters,
     handleLoadTransactionDetail,
     handleLoadNotifications,
     handleLoadUnreadCount,

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -171,6 +171,12 @@ label span {
   color: #344054;
 }
 
+.mobile-search-toggle {
+  display: none;
+  min-height: 30px;
+  padding: 0 10px;
+}
+
 .search-field {
   display: grid;
   grid-template-columns: auto 220px;
@@ -1212,6 +1218,28 @@ label span {
   margin-top: 12px;
 }
 
+.quick-range-toolbar,
+.touch-action-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.quick-range-toolbar button {
+  min-width: 72px;
+}
+
+.filter-collapsed-line {
+  border: 1px dashed var(--line-strong);
+  border-radius: 4px;
+  background: #fff;
+  color: var(--muted);
+  padding: 10px 12px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
 .transfer-process-grid {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
@@ -1221,6 +1249,31 @@ label span {
   align-content: start;
   border-top: 3px solid var(--primary);
   background: #fff;
+}
+
+.transfer-print-receipt {
+  min-width: 0;
+}
+
+.receipt-action-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid var(--line);
+  border-bottom: 0;
+  background: #f8fafc;
+  padding: 10px 12px;
+}
+
+.receipt-action-row span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.print-receipt-button {
+  min-width: 72px;
 }
 
 .auth-method-grid,
@@ -1883,6 +1936,21 @@ label span {
     width: 100%;
   }
 
+  .mobile-search-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .utility-search {
+    display: none;
+    width: 100%;
+  }
+
+  .utility-search.open {
+    display: grid;
+  }
+
   .utility-right,
   .search-field {
     grid-template-columns: 1fr;
@@ -1964,8 +2032,50 @@ label span {
     min-height: 44px;
   }
 
+  .quick-range-toolbar button,
+  .touch-action-strip button {
+    flex: 1 1 calc(50% - 6px);
+  }
+
   .bank-table th,
   .bank-table td {
     padding: 9px 10px;
+  }
+}
+
+@media print {
+  body {
+    background: #fff;
+  }
+
+  .bank-header,
+  .side-menu,
+  .right-rail,
+  .alert,
+  .busy-strip,
+  .bank-form,
+  .work-tabs,
+  .work-summary-strip,
+  .work-state-grid,
+  .receipt-action-row,
+  .two-column + .two-column {
+    display: none !important;
+  }
+
+  .bank-shell,
+  .bank-layout,
+  .work-area,
+  .task-section,
+  .transfer-print-receipt {
+    display: block;
+    min-width: 0;
+    width: 100%;
+    border: 0;
+    box-shadow: none;
+    background: #fff;
+  }
+
+  .transfer-print-receipt .result-panel {
+    border: 1px solid #222;
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #922

## 🌿 Base Branch
- `main`

## 📝 Summary
- 로그인 후 계좌조회, 즉시이체, 거래내역, 인증/세션 관리 화면의 업무 상태와 클릭 검증을 보강합니다.
- `page.tsx`에 몰려 있던 헤더/좌측 메뉴/우측 레일을 공통 layout 컴포넌트로 분리하고, 모바일 검색 접힘과 완료증 인쇄 UX를 추가합니다.
- #921 merge SHA `f3cdcd3906380523ece988e74b6b44876d071416`의 staging 배포와 live visual QA 결과를 확인했습니다.

## 🛠 Changes
- `BankHeader`, `SideMenu`, `RightRail`, `WorkPanel`, `BankTable`, `FormField` 공통 구조 추가
- 로그인 후 E2E 추가: 계좌조회, 이체 preview/OTP/완료증, 거래내역 필터/초기화, 세션 조회
- 거래내역 빠른 기간, 상세조건 접힘/펼침, 초기화 UX 추가
- 이체 완료증 인쇄 영역과 print media 스타일 추가
- 모바일 검색 접힘 기준에 맞춰 click-flow/contract 검사 갱신

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front test:authenticated-ux`
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front test:e2e:a11y`
- `yarn --cwd front lint`
- `yarn --cwd front build`
- `yarn --cwd front test:e2e:authenticated`
- `yarn --cwd front test:e2e:click-flow`
- `yarn --cwd front test:e2e:visual`
- `PLAYWRIGHT_BASE_URL=https://bank.aquilaxk.site yarn --cwd front test:e2e:visual`
- `curl -I https://bank.aquilaxk.site`
- GitHub Actions Staging Deploy `25709243500`: success, head SHA `f3cdcd3906380523ece988e74b6b44876d071416`

## 📸 Screenshot / API Example
- live visual QA 자동화로 desktop/mobile 레이아웃 확인 완료

## ⚠️ Risk & Rollback
- 예상 리스크: 로그인 후 업무 화면의 DOM 구조가 바뀌어 기존 E2E selector에 영향이 있을 수 있음. 이번 PR에 selector 계약과 실제 클릭 E2E를 같이 보강함.
- 롤백 방법: 이 PR revert 후 main staging 자동 배포 상태 확인.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
