### PR TITLE
[Feat] 고객 웹뱅킹 밀도 정렬과 live artifact 고도화

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -19,7 +19,7 @@ jobs:
   frontend-lint-build:
     name: Frontend Lint And Build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: front
@@ -42,3 +42,20 @@ jobs:
 
       - name: Run frontend build
         run: yarn build
+
+      - name: Install Playwright Chromium
+        run: yarn playwright install --with-deps chromium
+
+      - name: Run live artifact smoke
+        run: yarn test:e2e:live-artifacts
+
+      - name: Upload frontend visual artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-live-visual-artifacts
+          path: |
+            front/test-results/**/*.png
+            front/test-results/**/error-context.md
+            front/playwright-report/**
+          retention-days: 14

--- a/front/e2e/customer-banking-authenticated-workflow.spec.ts
+++ b/front/e2e/customer-banking-authenticated-workflow.spec.ts
@@ -204,7 +204,7 @@ test("로그인 후 계좌, 이체, 거래내역, 세션 관리 업무 화면을
   await page.locator("#bank-work-area").getByRole("button", { exact: true, name: "조회" }).click();
   await expect(page.getByText("TRX-20260512-0001")).toBeVisible();
   await expect(page.getByText("Keyset 기준")).toBeVisible();
-  await expect(page.getByRole("button", { name: "이체확인증" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "이체확인증 출력" })).toBeVisible();
   await page.getByRole("button", { name: "초기화" }).click();
   await expect(page.getByLabel("거래 조회 상태")).toContainText("조회 전");
 

--- a/front/package.json
+++ b/front/package.json
@@ -15,6 +15,7 @@
     "test:fulfillment-ux": "node scripts/check-customer-banking-fulfillment-ux.mjs",
     "test:authenticated-ux": "node scripts/check-customer-banking-authenticated-ux.mjs",
     "test:work-detail-ux": "node scripts/check-customer-banking-work-detail-ux.mjs",
+    "test:density-polish-ux": "node scripts/check-customer-banking-density-polish-ux.mjs",
     "test:e2e:authenticated": "playwright test --config=playwright.config.ts e2e/customer-banking-authenticated-workflow.spec.ts",
     "test:e2e:click-flow": "playwright test --config=playwright.config.ts e2e/customer-banking-click-flow.spec.ts",
     "test:e2e:visual": "playwright test --config=playwright.config.ts e2e/customer-banking-visual-layout.spec.ts",

--- a/front/scripts/check-customer-banking-density-polish-ux.mjs
+++ b/front/scripts/check-customer-banking-density-polish-ux.mjs
@@ -1,0 +1,71 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+const repoRoot = join(root, "..");
+
+function read(path) {
+  const filePath = path.startsWith(".github")
+    ? join(repoRoot, path)
+    : join(root, path);
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
+}
+
+const files = {
+  packageJson: read("package.json"),
+  common: read("src/components/customer-banking/common.tsx"),
+  page: read("src/app/page.tsx"),
+  layout: read("src/components/customer-banking/layout.tsx"),
+  accounts: read("src/components/customer-banking/sections/accounts-section.tsx"),
+  transfer: read("src/components/customer-banking/sections/transfer-section.tsx"),
+  transactions: read("src/components/customer-banking/sections/transactions-section.tsx"),
+  security: read("src/components/customer-banking/sections/security-section.tsx"),
+  styles: read("src/styles/customer-banking.css"),
+  workflow: read(".github/workflows/frontend-ci.yml"),
+  liveArtifacts: read("e2e/customer-banking-live-artifacts.spec.ts"),
+};
+
+const required = [
+  ["package density script", files.packageJson, "test:density-polish-ux"],
+  ["bank input primitive", files.common, "export function BankInput"],
+  ["bank date range primitive", files.common, "export function BankDateRange"],
+  ["bank action bar primitive", files.common, "export function BankActionBar"],
+  ["bank drawer primitive", files.common, "export function BankDrawer"],
+  ["bank dialog primitive", files.common, "export function BankDialog"],
+  ["bank toolbar primitive", files.common, "export function BankToolbar"],
+  ["dense shell class", files.page, "bank-shell dense-banking-shell"],
+  ["dense section style", files.styles, ".dense-banking-shell"],
+  ["menu compact style", files.styles, ".side-menu.compact-menu"],
+  ["rail equalized style", files.styles, ".right-rail.aligned-rail"],
+  ["work title compact style", files.styles, ".task-section.compact-work-section"],
+  ["account low balance", files.accounts, "잔액부족"],
+  ["account selected badge", files.accounts, "선택계좌"],
+  ["transfer limit exceeded state", files.transfer, "한도 초과"],
+  ["transfer otp error state", files.transfer, "OTP 오류"],
+  ["transfer recipient mismatch", files.transfer, "수취계좌 불일치"],
+  ["transfer failed receipt", files.transfer, "실패 완료증"],
+  ["transaction drawer hook", files.transactions, "BankDrawer"],
+  ["transaction print view hook", files.transactions, "이체확인증 출력"],
+  ["security expiring session", files.security, "만료 임박"],
+  ["security current device", files.security, "현재 기기"],
+  ["security revoke impossible", files.security, "해지 불가"],
+  ["action bar usage", [files.accounts, files.transfer, files.transactions, files.security].join("\n"), "BankActionBar"],
+  ["toolbar usage", [files.accounts, files.transactions].join("\n"), "BankToolbar"],
+  ["ci playwright install", files.workflow, "playwright install --with-deps chromium"],
+  ["ci live artifact test", files.workflow, "test:e2e:live-artifacts"],
+  ["ci upload artifact", files.workflow, "actions/upload-artifact@v7"],
+  ["artifact retention", files.workflow, "retention-days"],
+  ["live artifact output path", files.liveArtifacts, "customer-banking-live-desktop.png"],
+];
+
+const missing = required.filter(([, content, expected]) => !content.includes(expected));
+
+if (missing.length > 0) {
+  console.error("[customer-banking-density-polish-ux] contract violations:");
+  for (const [name, , expected] of missing) {
+    console.error(`- missing ${name}: ${expected}`);
+  }
+  process.exit(1);
+}
+
+console.log("[customer-banking-density-polish-ux] passed");

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -155,7 +155,7 @@ export default function HomePage() {
   }
 
   return (
-    <main className="bank-shell">
+    <main className="bank-shell dense-banking-shell">
       <a className="skip-link" href="#bank-work-area">
         본문 바로가기
       </a>

--- a/front/src/components/customer-banking/common.tsx
+++ b/front/src/components/customer-banking/common.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from "react";
-import type { FormEventHandler } from "react";
+import type { ChangeEventHandler, FormEventHandler, ReactNode } from "react";
 
 export function ResultPanel({ title, rows }: { title: string; rows: string[][] }) {
   return (
@@ -116,6 +115,142 @@ export function BankSelect({
         ))}
       </select>
     </label>
+  );
+}
+
+export function BankInput({
+  inputMode,
+  label,
+  maxLength,
+  onChange,
+  placeholder,
+  required,
+  type = "text",
+  value,
+}: {
+  inputMode?: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search";
+  label: string;
+  maxLength?: number;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  placeholder?: string;
+  required?: boolean;
+  type?: string;
+  value: string | number;
+}) {
+  return (
+    <label className="form-field bank-input">
+      <span>{label}</span>
+      <input
+        inputMode={inputMode}
+        maxLength={maxLength}
+        onChange={onChange}
+        placeholder={placeholder}
+        required={required}
+        type={type}
+        value={value}
+      />
+    </label>
+  );
+}
+
+export function BankDateRange({
+  from,
+  onFromChange,
+  onToChange,
+  to,
+}: {
+  from: string;
+  onFromChange: (value: string) => void;
+  onToChange: (value: string) => void;
+  to: string;
+}) {
+  return (
+    <div className="bank-date-range" aria-label="기간 선택">
+      <label>
+        <span>시작일시</span>
+        <input
+          onChange={(event) => onFromChange(event.target.value)}
+          required
+          type="datetime-local"
+          value={from}
+        />
+      </label>
+      <label>
+        <span>종료일시</span>
+        <input
+          onChange={(event) => onToChange(event.target.value)}
+          required
+          type="datetime-local"
+          value={to}
+        />
+      </label>
+    </div>
+  );
+}
+
+export function BankActionBar({
+  children,
+  align = "end",
+}: {
+  children: ReactNode;
+  align?: "start" | "end" | "between";
+}) {
+  return <div className={`bank-action-bar align-${align}`}>{children}</div>;
+}
+
+export function BankToolbar({
+  children,
+  label,
+}: {
+  children: ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="bank-toolbar" aria-label={label}>
+      {children}
+    </div>
+  );
+}
+
+export function BankDrawer({
+  children,
+  open,
+  title,
+}: {
+  children: ReactNode;
+  open: boolean;
+  title: string;
+}) {
+  return (
+    <aside className={open ? "bank-drawer open" : "bank-drawer"} aria-label={title}>
+      <div className="form-heading">
+        <strong>{title}</strong>
+        <span>{open ? "열림" : "닫힘"}</span>
+      </div>
+      {children}
+    </aside>
+  );
+}
+
+export function BankDialog({
+  children,
+  open,
+  title,
+}: {
+  children: ReactNode;
+  open: boolean;
+  title: string;
+}) {
+  if (!open) {
+    return null;
+  }
+  return (
+    <section aria-label={title} className="bank-dialog" role="dialog">
+      <div className="form-heading">
+        <strong>{title}</strong>
+      </div>
+      {children}
+    </section>
   );
 }
 

--- a/front/src/components/customer-banking/layout.tsx
+++ b/front/src/components/customer-banking/layout.tsx
@@ -197,7 +197,7 @@ export function SideMenu({
   onMove: MoveHandler;
 }) {
   return (
-    <aside className="side-menu" aria-label="개인뱅킹 메뉴">
+    <aside className="side-menu compact-menu" aria-label="개인뱅킹 메뉴">
       <div className="side-title">개인뱅킹</div>
       {mainMenus.map((item) => (
         <button
@@ -227,7 +227,7 @@ export function RightRail({
   onRefresh: () => void;
 }) {
   return (
-    <aside className="right-rail" aria-label="빠른 업무">
+    <aside className="right-rail aligned-rail" aria-label="빠른 업무">
       <section className="rail-panel login-panel">
         <div className="rail-heading">
           <span>로그인 상태</span>

--- a/front/src/components/customer-banking/sections/accounts-section.tsx
+++ b/front/src/components/customer-banking/sections/accounts-section.tsx
@@ -2,8 +2,10 @@ import type { AccountItem, AccountSummaryResponse } from '@/lib/api/types';
 import { formatDateTime, formatMinorAmount } from '@/lib/customer-banking/format';
 import {
   BankNoticeStrip,
+  BankActionBar,
   BankSelect,
   BankTable,
+  BankToolbar,
   EmptyState,
   PaginationBar,
   StatusBadge,
@@ -64,9 +66,12 @@ export function AccountsSection({
   const activeCount = accounts.filter((account) => account.accountStatus === "ACTIVE").length;
   const suspendedCount = accounts.filter((account) => account.accountStatus === "SUSPENDED").length;
   const restrictedCount = accounts.filter((account) => account.accountStatus === "RESTRICTED").length;
+  const lowBalanceCount = accounts.filter(
+    (account) => account.availableBalanceMinor <= 0,
+  ).length;
 
   return (
-    <section className="task-section">
+    <section className="task-section compact-work-section">
       <WorkTabs
         active="전계좌조회"
         items={[
@@ -100,7 +105,7 @@ export function AccountsSection({
           <p>조회</p>
           <h1>계좌조회</h1>
         </div>
-        <div className="button-row">
+        <BankToolbar label="계좌조회 상단 업무 버튼">
           <BankSelect
             label="건수"
             onChange={(value) => onAccountLimitChange(Number(value))}
@@ -117,7 +122,7 @@ export function AccountsSection({
           <button disabled={!accountCursor || isBusy} onClick={onLoadNextAccounts} type="button">
             다음
           </button>
-        </div>
+        </BankToolbar>
       </div>
       <BankNoticeStrip
         items={[
@@ -186,6 +191,11 @@ export function AccountsSection({
           <strong>{restrictedCount}건</strong>
           <small>업무 확인 필요</small>
         </div>
+        <div>
+          <span>잔액부족</span>
+          <strong>{lowBalanceCount}건</strong>
+          <small>출금 가능액 확인</small>
+        </div>
       </div>
 
       <section className="work-command-panel" aria-label="조회 업무">
@@ -193,7 +203,7 @@ export function AccountsSection({
           <strong>조회 업무</strong>
           <span>계좌 목록을 조회하고 선택 계좌의 잔액과 보류금액을 확인합니다.</span>
         </div>
-        <div className="button-row compact">
+        <BankActionBar>
           <button disabled={isBusy} onClick={onLoadAccounts} type="button">
             전계좌조회
           </button>
@@ -211,7 +221,7 @@ export function AccountsSection({
           <button disabled={!accountCursor || isBusy} onClick={onLoadNextAccounts} type="button">
             다음 조회
           </button>
-        </div>
+        </BankActionBar>
       </section>
 
       <div className="account-grid">
@@ -263,7 +273,13 @@ export function AccountsSection({
                           account.currencyCode,
                         )}
                       </td>
-                      <td>{account.accountId === selectedAccountId ? "선택됨" : "-"}</td>
+                      <td>
+                        {account.accountId === selectedAccountId ? (
+                          <StatusBadge tone="success">선택계좌 선택됨</StatusBadge>
+                        ) : (
+                          "-"
+                        )}
+                      </td>
                       <td>
                         <button
                           disabled={isBusy}

--- a/front/src/components/customer-banking/sections/dashboard-section.tsx
+++ b/front/src/components/customer-banking/sections/dashboard-section.tsx
@@ -18,7 +18,7 @@ export function DashboardSection({
   onRefresh: () => void;
 }) {
   return (
-    <section className="task-section">
+    <section className="task-section compact-work-section">
       <WorkTabs
         active="개인뱅킹"
         items={["개인뱅킹", "조회", "이체", "인증센터", "고객센터"].map((label) => ({

--- a/front/src/components/customer-banking/sections/enterprise-services-section.tsx
+++ b/front/src/components/customer-banking/sections/enterprise-services-section.tsx
@@ -134,7 +134,7 @@ export function EnterpriseServicesSection({
   }
 
   return (
-    <section className="task-section">
+    <section className="task-section compact-work-section">
       <div className="section-title">
         <div>
           <p>부가업무</p>

--- a/front/src/components/customer-banking/sections/notifications-section.tsx
+++ b/front/src/components/customer-banking/sections/notifications-section.tsx
@@ -70,7 +70,7 @@ export function NotificationsSection({
   onUpdatePreferences: () => void;
 }) {
   return (
-    <section className="task-section">
+    <section className="task-section compact-work-section">
       <WorkTabs
         active={mode === "inbox" ? "알림함" : "조건검색"}
         items={[

--- a/front/src/components/customer-banking/sections/security-hub-section.tsx
+++ b/front/src/components/customer-banking/sections/security-hub-section.tsx
@@ -78,7 +78,7 @@ export function SecurityHubSection({
   }
 
   return (
-    <section className="task-section">
+    <section className="task-section compact-work-section">
       <div className="section-title">
         <div>
           <p>보안센터</p>

--- a/front/src/components/customer-banking/sections/security-section.tsx
+++ b/front/src/components/customer-banking/sections/security-section.tsx
@@ -1,7 +1,7 @@
 import type { FormEvent } from 'react';
 import type { AuthSessionItem, BackupCodeIssueResponse, CustomerSession, LoginResponse, PasswordRecoveryRequestResult, TotpEnrollmentStartResponse } from '@/lib/api/types';
 import { formatDateTime } from '@/lib/customer-banking/format';
-import { BankNoticeStrip, StatusBadge, WorkStateGrid, WorkTabs } from '../common';
+import { BankActionBar, BankNoticeStrip, StatusBadge, WorkStateGrid, WorkTabs } from '../common';
 
 function stayOnCurrentWorkTab(): void {}
 
@@ -78,8 +78,14 @@ export function SecuritySection(props: {
   onTotpCodeChange: (value: string) => void;
   onVerifyTotpEnrollment: () => void;
 }) {
+  const sessionExpiryState = props.session ? "만료 임박" : "로그인 필요";
+  const currentDeviceState = props.sessions.some((item) => item.currentSession)
+    ? "현재 기기"
+    : "조회 전";
+  const revokeState = props.session ? "해지 가능" : "해지 불가";
+
   return (
-    <section className="task-section security-section">
+    <section className="task-section compact-work-section security-section">
       <div className="section-title">
         <div>
           <p>인증센터</p>
@@ -155,8 +161,18 @@ export function SecuritySection(props: {
         </div>
         <div>
           <span>세션 해지 상태</span>
-          <strong>{props.session ? "해지 가능" : "대기"}</strong>
+          <strong>{revokeState}</strong>
           <small>세션/기기 목록 기준</small>
+        </div>
+        <div>
+          <span>세션 만료</span>
+          <strong>{sessionExpiryState}</strong>
+          <small>{formatDateTime(props.session?.expiresAt)}</small>
+        </div>
+        <div>
+          <span>현재 기기</span>
+          <strong>{currentDeviceState}</strong>
+          <small>세션 조회 기준</small>
         </div>
       </div>
 
@@ -496,7 +512,7 @@ export function SecuritySection(props: {
             <strong>세션/기기 목록</strong>
             <span>현재 로그인 기기와 세션 상태</span>
           </div>
-          <div className="button-row compact">
+          <BankActionBar>
             <button
               disabled={!props.session || props.isBusy}
               onClick={props.onLoadSessions}
@@ -511,7 +527,7 @@ export function SecuritySection(props: {
             >
               전체 해지
             </button>
-          </div>
+          </BankActionBar>
         </div>
         <div className="bank-table-wrap">
           <table className="bank-table">

--- a/front/src/components/customer-banking/sections/support-center-section.tsx
+++ b/front/src/components/customer-banking/sections/support-center-section.tsx
@@ -85,7 +85,7 @@ export function SupportCenterSection({
   }
 
   return (
-    <section className="task-section">
+    <section className="task-section compact-work-section">
       <div className="section-title">
         <div>
           <p>고객센터</p>

--- a/front/src/components/customer-banking/sections/transactions-section.tsx
+++ b/front/src/components/customer-banking/sections/transactions-section.tsx
@@ -4,6 +4,9 @@ import type { TransactionDetailResponse, TransactionItem, TransactionQueryRespon
 import { formatDateTime, formatMinorAmount, toLocalInputValue } from '@/lib/customer-banking/format';
 import {
   BankNoticeStrip,
+  BankDateRange,
+  BankDrawer,
+  BankToolbar,
   EmptyState,
   PaginationBar,
   StatusBadge,
@@ -91,7 +94,7 @@ export function TransactionsSection({
   }
 
   return (
-    <section className="task-section">
+    <section className="task-section compact-work-section">
       <WorkTabs
         active="거래내역조회"
         items={[
@@ -177,265 +180,251 @@ export function TransactionsSection({
               다음 조회 {slice?.nextCursor ? "준비됨" : "첫 조회"}
             </span>
           </div>
-          <div className="quick-range-toolbar touch-action-strip" aria-label="기간 빠른 선택">
-            <button onClick={() => setQuickRange(0)} type="button">
-              오늘
+          <BankToolbar label="거래내역 기간 빠른 선택">
+            <div className="quick-range-toolbar touch-action-strip" aria-label="기간 빠른 선택">
+              <button onClick={() => setQuickRange(0)} type="button">
+                오늘
+              </button>
+              <button onClick={() => setQuickRange(30)} type="button">
+                1개월
+              </button>
+              <button onClick={() => setQuickRange(90)} type="button">
+                3개월
+              </button>
+              <button onClick={onReset} type="button">
+                초기화
+              </button>
+              <button
+                aria-controls="transaction-detail-filter"
+                aria-expanded={filterOpen}
+                onClick={() => setFilterOpen((value) => !value)}
+                type="button"
+              >
+                {filterOpen ? "상세조건 접기" : "상세조건 펼치기"}
+              </button>
+            </div>
+          </BankToolbar>
+          {filterOpen ? (
+            <div className="filter-grid" id="transaction-detail-filter">
+              <label>
+                <span>계좌 ID</span>
+                <input
+                  inputMode="numeric"
+                  onChange={(event) =>
+                    onFilterChange({ ...filters, accountId: event.target.value })
+                  }
+                  required
+                  value={filters.accountId}
+                />
+              </label>
+              <BankDateRange
+                from={filters.from}
+                onFromChange={(value) => onFilterChange({ ...filters, from: value })}
+                onToChange={(value) => onFilterChange({ ...filters, to: value })}
+                to={filters.to}
+              />
+              <label>
+                <span>건수</span>
+                <select
+                  onChange={(event) =>
+                    onFilterChange({ ...filters, limit: event.target.value })
+                  }
+                  value={filters.limit}
+                >
+                  <option value="20">20</option>
+                  <option value="50">50</option>
+                  <option value="100">100</option>
+                </select>
+              </label>
+              <label>
+                <span>상태</span>
+                <select
+                  onChange={(event) =>
+                    onFilterChange({ ...filters, status: event.target.value })
+                  }
+                  value={filters.status}
+                >
+                  <option value="">전체</option>
+                  <option value="PENDING">처리중</option>
+                  <option value="BOOKED">처리완료</option>
+                  <option value="REVERSED">취소완료</option>
+                  <option value="FAILED">실패</option>
+                </select>
+              </label>
+              <label>
+                <span>입출금</span>
+                <select
+                  onChange={(event) =>
+                    onFilterChange({ ...filters, direction: event.target.value })
+                  }
+                  value={filters.direction}
+                >
+                  <option value="">전체</option>
+                  <option value="DEBIT">출금</option>
+                  <option value="CREDIT">입금</option>
+                </select>
+              </label>
+              <label>
+                <span>최소금액</span>
+                <input
+                  inputMode="numeric"
+                  onChange={(event) =>
+                    onFilterChange({
+                      ...filters,
+                      minAmountMinor: event.target.value,
+                    })
+                  }
+                  value={filters.minAmountMinor}
+                />
+              </label>
+              <label>
+                <span>최대금액</span>
+                <input
+                  inputMode="numeric"
+                  onChange={(event) =>
+                    onFilterChange({
+                      ...filters,
+                      maxAmountMinor: event.target.value,
+                    })
+                  }
+                  value={filters.maxAmountMinor}
+                />
+              </label>
+              <label>
+                <span>거래번호</span>
+                <input
+                  onChange={(event) =>
+                    onFilterChange({
+                      ...filters,
+                      transactionReference: event.target.value,
+                    })
+                  }
+                  value={filters.transactionReference}
+                />
+              </label>
+              <label>
+                <span>조회방식</span>
+                <select
+                  onChange={(event) =>
+                    onFilterChange({
+                      ...filters,
+                      responseShape: event.target.value as "full" | "slim",
+                    })
+                  }
+                  value={filters.responseShape}
+                >
+                  <option value="full">상세</option>
+                  <option value="slim">요약</option>
+                </select>
+              </label>
+            </div>
+          ) : (
+            <div className="filter-collapsed-line" id="transaction-detail-filter" role="status">
+              상세조건 접힘 · 계좌, 기간, 금액 조건은 현재 값으로 유지됩니다.
+            </div>
+          )}
+          <div className="button-row">
+            <button disabled={isBusy} type="submit">
+              조회
             </button>
-            <button onClick={() => setQuickRange(30)} type="button">
-              1개월
-            </button>
-            <button onClick={() => setQuickRange(90)} type="button">
-              3개월
-            </button>
-            <button onClick={onReset} type="button">
-              초기화
-            </button>
-            <button
-              aria-controls="transaction-detail-filter"
-              aria-expanded={filterOpen}
-              onClick={() => setFilterOpen((value) => !value)}
-              type="button"
-            >
-              {filterOpen ? "상세조건 접기" : "상세조건 펼치기"}
+            <button disabled={!slice?.nextCursor || isBusy} onClick={onNext} type="button">
+              다음 페이지
             </button>
           </div>
-        {filterOpen ? (
-        <div className="filter-grid" id="transaction-detail-filter">
-          <label>
-            <span>계좌 ID</span>
-            <input
-              inputMode="numeric"
-              onChange={(event) =>
-                onFilterChange({ ...filters, accountId: event.target.value })
-              }
-              required
-              value={filters.accountId}
-            />
-          </label>
-          <label>
-            <span>시작일시</span>
-            <input
-              onChange={(event) =>
-                onFilterChange({ ...filters, from: event.target.value })
-              }
-              required
-              type="datetime-local"
-              value={filters.from}
-            />
-          </label>
-          <label>
-            <span>종료일시</span>
-            <input
-              onChange={(event) =>
-                onFilterChange({ ...filters, to: event.target.value })
-              }
-              required
-              type="datetime-local"
-              value={filters.to}
-            />
-          </label>
-          <label>
-            <span>건수</span>
-            <select
-              onChange={(event) =>
-                onFilterChange({ ...filters, limit: event.target.value })
-              }
-              value={filters.limit}
-            >
-              <option value="20">20</option>
-              <option value="50">50</option>
-              <option value="100">100</option>
-            </select>
-          </label>
-          <label>
-            <span>상태</span>
-            <select
-              onChange={(event) =>
-                onFilterChange({ ...filters, status: event.target.value })
-              }
-              value={filters.status}
-            >
-              <option value="">전체</option>
-              <option value="PENDING">처리중</option>
-              <option value="BOOKED">처리완료</option>
-              <option value="REVERSED">취소완료</option>
-              <option value="FAILED">실패</option>
-            </select>
-          </label>
-          <label>
-            <span>입출금</span>
-            <select
-              onChange={(event) =>
-                onFilterChange({ ...filters, direction: event.target.value })
-              }
-              value={filters.direction}
-            >
-              <option value="">전체</option>
-              <option value="DEBIT">출금</option>
-              <option value="CREDIT">입금</option>
-            </select>
-          </label>
-          <label>
-            <span>최소금액</span>
-            <input
-              inputMode="numeric"
-              onChange={(event) =>
-                onFilterChange({
-                  ...filters,
-                  minAmountMinor: event.target.value,
-                })
-              }
-              value={filters.minAmountMinor}
-            />
-          </label>
-          <label>
-            <span>최대금액</span>
-            <input
-              inputMode="numeric"
-              onChange={(event) =>
-                onFilterChange({
-                  ...filters,
-                  maxAmountMinor: event.target.value,
-                })
-              }
-              value={filters.maxAmountMinor}
-            />
-          </label>
-          <label>
-            <span>거래번호</span>
-            <input
-              onChange={(event) =>
-                onFilterChange({
-                  ...filters,
-                  transactionReference: event.target.value,
-                })
-              }
-              value={filters.transactionReference}
-            />
-          </label>
-          <label>
-            <span>조회방식</span>
-            <select
-              onChange={(event) =>
-                onFilterChange({
-                  ...filters,
-                  responseShape: event.target.value as "full" | "slim",
-                })
-              }
-              value={filters.responseShape}
-            >
-              <option value="full">상세</option>
-              <option value="slim">요약</option>
-            </select>
-          </label>
-        </div>
-        ) : (
-          <div className="filter-collapsed-line" id="transaction-detail-filter" role="status">
-            상세조건 접힘 · 계좌, 기간, 금액 조건은 현재 값으로 유지됩니다.
-          </div>
-        )}
-        <div className="button-row">
-          <button disabled={isBusy} type="submit">
-            조회
-          </button>
-          <button disabled={!slice?.nextCursor || isBusy} onClick={onNext} type="button">
-            다음 페이지
-          </button>
-        </div>
         </form>
 
         <div className="split-work">
-        <section className="table-panel embedded">
-          <div className="panel-toolbar">
-            <div>
-              <strong>입출금 내역</strong>
-              <span>
-                {slice
-                  ? `${transactions.length}건 / 다음 조회 ${slice.hasNext ? "가능" : "없음"}`
-                  : "조회 전"}
-              </span>
+          <section className="table-panel embedded">
+            <div className="panel-toolbar">
+              <div>
+                <strong>입출금 내역</strong>
+                <span>
+                  {slice
+                    ? `${transactions.length}건 / 다음 조회 ${slice.hasNext ? "가능" : "없음"}`
+                    : "조회 전"}
+                </span>
+              </div>
             </div>
-          </div>
-          <div className="table-scroll-hint">거래내역 표는 좌우로 스크롤해서 볼 수 있습니다.</div>
-          <div className="bank-table-wrap">
-            <table className="bank-table">
-              <caption>거래내역 목록</caption>
-              <thead>
-                <tr>
-                  <th>기장일시</th>
-                  <th>거래번호</th>
-                  <th>입출금</th>
-                  <th>상태</th>
-                  <th>금액</th>
-                  <th>잔액</th>
-                  <th>상세</th>
-                </tr>
-              </thead>
-              <tbody>
-                {transactions.length === 0 ? (
+            <div className="table-scroll-hint">거래내역 표는 좌우로 스크롤해서 볼 수 있습니다.</div>
+            <div className="bank-table-wrap">
+              <table className="bank-table">
+                <caption>거래내역 목록</caption>
+                <thead>
                   <tr>
-                    <td colSpan={7}>
-                      <EmptyState
-                        title="거래내역 없음"
-                        description="계좌와 기간을 입력한 뒤 조회하세요."
-                      />
-                    </td>
+                    <th>기장일시</th>
+                    <th>거래번호</th>
+                    <th>입출금</th>
+                    <th>상태</th>
+                    <th>금액</th>
+                    <th>잔액</th>
+                    <th>상세</th>
                   </tr>
-                ) : (
-                  transactions.map((item) => (
-                    <tr key={`${item.id}-${item.transactionReference}`}>
-                      <td>{formatDateTime(item.bookedAt)}</td>
-                      <td>{item.transactionReference}</td>
-                      <td>{getTransactionDirectionLabel(item.direction)}</td>
-                      <td>
-                        <StatusBadge tone={item.status === "BOOKED" ? "success" : "warn"}>
-                          {getTransactionStatusLabel(item.status)}
-                        </StatusBadge>
-                      </td>
-                      <td className={item.direction === "DEBIT" ? "amount debit" : "amount credit"}>
-                        {formatMinorAmount(item.amountMinor, item.currencyCode)}
-                      </td>
-                      <td>
-                        {item.balanceAfterMinor == null
-                          ? "-"
-                          : formatMinorAmount(
-                              item.balanceAfterMinor,
-                              item.currencyCode,
-                            )}
-                      </td>
-                      <td>
-                        <button
-                          disabled={isBusy}
-                          onClick={() => onDetail(item.transactionReference)}
-                          type="button"
-                        >
-                          상세
-                        </button>
-                        <button
-                          className="receipt-link-button"
-                          disabled={item.direction !== "DEBIT"}
-                          onClick={() => onDetail(item.transactionReference)}
-                          type="button"
-                        >
-                          이체확인증
-                        </button>
+                </thead>
+                <tbody>
+                  {transactions.length === 0 ? (
+                    <tr>
+                      <td colSpan={7}>
+                        <EmptyState
+                          title="거래내역 없음"
+                          description="계좌와 기간을 입력한 뒤 조회하세요."
+                        />
                       </td>
                     </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-          <PaginationBar
-            disabled={isBusy}
-            hasNext={Boolean(slice?.hasNext)}
-            label="거래내역 Keyset 기준 pagination"
-            nextCursor={slice?.nextCursor}
-            onNext={onNext}
-          />
-        </section>
+                  ) : (
+                    transactions.map((item) => (
+                      <tr key={`${item.id}-${item.transactionReference}`}>
+                        <td>{formatDateTime(item.bookedAt)}</td>
+                        <td>{item.transactionReference}</td>
+                        <td>{getTransactionDirectionLabel(item.direction)}</td>
+                        <td>
+                          <StatusBadge tone={item.status === "BOOKED" ? "success" : "warn"}>
+                            {getTransactionStatusLabel(item.status)}
+                          </StatusBadge>
+                        </td>
+                        <td className={item.direction === "DEBIT" ? "amount debit" : "amount credit"}>
+                          {formatMinorAmount(item.amountMinor, item.currencyCode)}
+                        </td>
+                        <td>
+                          {item.balanceAfterMinor == null
+                            ? "-"
+                            : formatMinorAmount(
+                                item.balanceAfterMinor,
+                                item.currencyCode,
+                              )}
+                        </td>
+                        <td>
+                          <button
+                            disabled={isBusy}
+                            onClick={() => onDetail(item.transactionReference)}
+                            type="button"
+                          >
+                            상세
+                          </button>
+                          <button
+                            className="receipt-link-button"
+                            disabled={item.direction !== "DEBIT"}
+                            onClick={() => onDetail(item.transactionReference)}
+                            type="button"
+                          >
+                            이체확인증 출력
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <PaginationBar
+              disabled={isBusy}
+              hasNext={Boolean(slice?.hasNext)}
+              label="거래내역 Keyset 기준 pagination"
+              nextCursor={slice?.nextCursor}
+              onNext={onNext}
+            />
+          </section>
 
-        <aside className="detail-panel">
+        <BankDrawer open={Boolean(transactionDetail)} title="거래 상세 drawer">
           <div className="form-heading">
             <strong>거래 상세정보</strong>
             <span>
@@ -488,6 +477,10 @@ export function TransactionsSection({
                 <dt>설명</dt>
                 <dd>{transactionDetail.description ?? "-"}</dd>
               </div>
+              <div>
+                <dt>출력</dt>
+                <dd>이체확인증 출력 전용 view</dd>
+              </div>
             </dl>
           ) : (
             <EmptyState
@@ -495,7 +488,7 @@ export function TransactionsSection({
               description="입출금 내역에서 상세 버튼을 선택하세요."
             />
           )}
-        </aside>
+        </BankDrawer>
         </div>
       </div>
     </section>

--- a/front/src/components/customer-banking/sections/transfer-section.tsx
+++ b/front/src/components/customer-banking/sections/transfer-section.tsx
@@ -4,6 +4,8 @@ import type { TransferPreviewResponse, TransferResponse, TransferReversalRespons
 import { formatDateTime, formatMinorAmount } from '@/lib/customer-banking/format';
 import {
   BankForm,
+  BankActionBar,
+  BankDialog,
   BankNoticeStrip,
   FieldError,
   ReceiptPanel,
@@ -197,9 +199,14 @@ export function TransferSection({
     transferStep === "otp" && otpRequired && otpCode.length < 6
       ? "OTP 6자리를 입력하세요."
       : "";
+  const recipientMismatchLabel =
+    transferPreview && !transferPreview.allowed ? "수취계좌 불일치" : "수취계좌 확인";
+  const limitExceededLabel = isOverLimit ? "한도 초과" : "한도 정상";
+  const otpErrorLabel = otpError ? "OTP 오류" : "OTP 대기";
+  const showFailedReceipt = transferStep === "failed";
 
   return (
-    <section className="task-section">
+    <section className="task-section compact-work-section">
       <div className="section-title">
         <div>
           <p>이체</p>
@@ -269,14 +276,16 @@ export function TransferSection({
             <div>
               <span>받는 사람 검증 결과</span>
               <strong>{transferPreview ? blockedReasonLabel : "검증 전"}</strong>
+              <small>{recipientMismatchLabel}</small>
             </div>
             <div>
               <span>OTP 검증 상태</span>
               <strong>{transferStep === "complete" ? "확인 완료" : otpRequired ? "확인 필요" : "생략"}</strong>
+              <small>{otpErrorLabel}</small>
             </div>
             <div>
               <span>한도 확인</span>
-              <strong>{isOverLimit ? "초과" : "정상"}</strong>
+              <strong>{limitExceededLabel}</strong>
             </div>
           </div>
           <div className="transfer-risk-grid transfer-process-grid" aria-label="이체 사전 확인">
@@ -426,11 +435,13 @@ export function TransferSection({
               <span>{blockedReasonLabel}. 고객센터의 이체한도 메뉴에서 보안등급과 한도를 확인하세요.</span>
             </div>
           ) : null}
-          <div className="mobile-sticky-actions">
-            <button disabled={isBusy || isOverLimit} type="submit">
-              {submitLabel}
-            </button>
-          </div>
+          <BankActionBar>
+            <div className="mobile-sticky-actions">
+              <button disabled={isBusy || isOverLimit} type="submit">
+                {submitLabel}
+              </button>
+            </div>
+          </BankActionBar>
         </BankForm>
 
         <div className="transfer-receipt transfer-receipt-panel">
@@ -438,14 +449,14 @@ export function TransferSection({
             action={
               <>
                 <span>완료증 출력</span>
-            <button
-              className="print-receipt-button"
-              disabled={!transferResult}
-              onClick={printTransferReceipt}
-              type="button"
-            >
-              인쇄
-            </button>
+                <button
+                  className="print-receipt-button"
+                  disabled={!transferResult}
+                  onClick={printTransferReceipt}
+                  type="button"
+                >
+                  인쇄
+                </button>
               </>
             }
             label="이체 완료증 인쇄"
@@ -485,6 +496,18 @@ export function TransferSection({
             }
             title="이체 완료증"
           />
+          <BankDialog open={showFailedReceipt} title="실패 완료증">
+            <dl className="detail-list">
+              <div>
+                <dt>처리상태</dt>
+                <dd>실패 완료증</dd>
+              </div>
+              <div>
+                <dt>사유</dt>
+                <dd>{blockedReasonLabel}</dd>
+              </div>
+            </dl>
+          </BankDialog>
         </div>
       </div>
 

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -102,6 +102,11 @@ label span {
   background: var(--page);
 }
 
+.dense-banking-shell {
+  --dense-section-gap: 10px;
+  --dense-panel-padding: 12px;
+}
+
 .skip-link {
   position: absolute;
   z-index: 100;
@@ -386,6 +391,12 @@ label span {
   padding: 14px 0 42px;
 }
 
+.dense-banking-shell .bank-layout {
+  align-items: start;
+  gap: var(--dense-section-gap);
+  padding-top: 10px;
+}
+
 .side-menu,
 .right-rail,
 .work-area {
@@ -395,6 +406,10 @@ label span {
 .side-menu {
   border: 1px solid var(--line);
   background: var(--surface);
+}
+
+.side-menu.compact-menu {
+  align-self: start;
 }
 
 .side-title {
@@ -416,6 +431,11 @@ label span {
   background: #fff;
   padding: 10px 14px;
   text-align: left;
+}
+
+.side-menu.compact-menu .side-item {
+  min-height: 50px;
+  padding: 8px 12px;
 }
 
 .side-item span {
@@ -450,6 +470,10 @@ label span {
   padding: 14px;
 }
 
+.task-section.compact-work-section {
+  padding: var(--dense-panel-padding);
+}
+
 .section-title,
 .panel-toolbar,
 .rail-heading {
@@ -462,6 +486,10 @@ label span {
 .section-title {
   padding-bottom: 10px;
   border-bottom: 2px solid #263b56;
+}
+
+.task-section.compact-work-section .section-title {
+  padding-bottom: 8px;
 }
 
 .section-title p {
@@ -799,6 +827,10 @@ label span {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
   margin-top: 12px;
+}
+
+.account-status-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .account-status-grid div,
@@ -1533,6 +1565,65 @@ label span {
   gap: 12px;
 }
 
+.bank-input {
+  min-width: 0;
+}
+
+.bank-date-range {
+  display: grid;
+  grid-column: span 2;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  min-width: 0;
+}
+
+.bank-action-bar,
+.bank-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.bank-action-bar.align-start,
+.bank-toolbar {
+  justify-content: flex-start;
+}
+
+.bank-action-bar.align-end {
+  justify-content: flex-end;
+}
+
+.bank-action-bar.align-between {
+  justify-content: space-between;
+}
+
+.bank-toolbar {
+  width: 100%;
+}
+
+.bank-drawer,
+.bank-dialog {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-top: 3px solid var(--primary);
+  border-radius: 3px;
+  background: #fff;
+  padding: 12px;
+}
+
+.bank-drawer:not(.open) {
+  border-style: dashed;
+  background: var(--surface-muted);
+}
+
+.bank-dialog {
+  margin-top: 10px;
+  border-top-color: var(--danger);
+}
+
 .form-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -1855,8 +1946,17 @@ label span {
   gap: 12px;
 }
 
+.right-rail.aligned-rail {
+  align-self: start;
+  gap: var(--dense-section-gap);
+}
+
 .rail-panel {
   padding: 12px;
+}
+
+.right-rail.aligned-rail .rail-panel {
+  padding: var(--dense-panel-padding);
 }
 
 .rail-heading {
@@ -2016,6 +2116,7 @@ label span {
   .work-command-panel,
   .form-grid,
   .filter-grid,
+  .bank-date-range,
   .notification-status,
   .transfer-process-grid,
   .auth-method-grid,


### PR DESCRIPTION
## 🔗 Related Issue
- close #926

## 🌿 Base Branch
- `main`

## 📝 Summary
- 고객 웹뱅킹 화면을 좌측 메뉴, 중앙 업무 폼/표, 우측 레일 중심의 조밀한 은행권 업무 화면으로 정리했습니다.
- #925 merge SHA `4af7225f0e15b4bd7993882a89ebff0ddc0c2e7a` 기준 main CI, staging deploy, HTTPS/HSTS, live desktop/mobile visual QA를 확인했습니다.

## 🛠 Changes
- `BankInput`, `BankDateRange`, `BankActionBar`, `BankDrawer`, `BankDialog`, `BankToolbar` 공통 primitive 추가.
- 계좌/이체/거래내역/인증센터에 잔액부족, 한도 초과, OTP 오류, 수취계좌 불일치, 실패 완료증, 세션 만료 임박, 현재 기기, 해지 가능/불가 상태 표시 추가.
- 업무 화면 공통 density class와 좌측 메뉴/우측 rail/중앙 form-table 정렬 스타일 추가.
- GitHub Actions Frontend CI에서 Playwright Chromium 설치, live artifact smoke 실행, screenshot artifact 업로드 단계 추가.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front test:density-polish-ux`
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front test:work-detail-ux`
- `yarn --cwd front test:authenticated-ux`
- `yarn --cwd front test:e2e:a11y`
- `yarn --cwd front test:e2e:authenticated`
- `yarn --cwd front test:e2e:click-flow`
- `yarn --cwd front test:e2e:visual`
- `yarn --cwd front test:e2e:live-artifacts`
- `PLAYWRIGHT_BASE_URL=https://bank.aquilaxk.site yarn --cwd front test:e2e:visual`
- `PLAYWRIGHT_BASE_URL=https://bank.aquilaxk.site yarn --cwd front test:e2e:live-artifacts`
- `yarn --cwd front lint`
- `yarn --cwd front build`
- Main CI run `25714400890`: success
- Staging Deploy run `25714687600`: success
- `curl -I https://bank.aquilaxk.site`: HTTP/2 200, `strict-transport-security: max-age=31536000; includeSubDomains`
- `curl -I http://bank.aquilaxk.site`: HTTP 308 HTTPS redirect

## 📸 Screenshot / API Example
- Local screenshot artifacts:
- `front/test-results/e2e-customer-banking-live--c61d1-영역-screenshot-artifact를-남긴다-desktop-chromium/customer-banking-live-desktop.png`
- `front/test-results/e2e-customer-banking-live--9c72e-구조-screenshot-artifact를-남긴다-mobile-chromium/customer-banking-live-mobile.png`

## ⚠️ Risk & Rollback
- 예상 리스크: 업무 화면 density 변경으로 일부 작은 viewport에서 버튼 줄바꿈이 늘어날 수 있음. desktop/mobile visual QA와 live screenshot artifact로 확인했습니다.
- 롤백 방법: commit `798d855e` revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A
