### PR TITLE
[Fix] 비로그인 웹뱅킹 민감정보 노출 차단

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint",
     "test:api-parity": "node scripts/check-front-backend-api-parity.mjs",
     "test:ui-contract": "node scripts/check-customer-banking-ui-contract.mjs",
+    "test:unauth-security": "node scripts/check-customer-banking-unauth-security.mjs",
     "test:auth-session": "node scripts/check-auth-session-hardening-contract.mjs",
     "test:ops-console": "node scripts/check-ops-console-contract.mjs",
     "test:enterprise-ux": "node scripts/check-customer-banking-enterprise-ux.mjs",

--- a/front/scripts/check-customer-banking-unauth-security.mjs
+++ b/front/scripts/check-customer-banking-unauth-security.mjs
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+
+function read(path) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+const files = {
+  page: read("src/app/page.tsx"),
+  layout: read("src/components/customer-banking/layout.tsx"),
+  dashboard: read("src/components/customer-banking/sections/dashboard-section.tsx"),
+  security: read("src/components/customer-banking/sections/security-section.tsx"),
+  styles: read("src/styles/customer-banking.css"),
+};
+
+const combined = Object.values(files).join("\n");
+
+const required = [
+  ["guest auth state marker", files.page, "data-auth-state"],
+  ["guest protected rail class", files.layout, "guest-protected"],
+  ["guest lock state class", files.styles, ".guest-protected"],
+  ["sensitive placeholder class", files.styles, ".sensitive-placeholder"],
+  ["bank header guest protection", files.layout, "민감정보 보호"],
+  ["guest service strip", files.layout, "보호모드"],
+  ["guest work locked copy", files.layout, "로그인 후 업무 가능"],
+  ["guest recent menu lock", files.layout, "최근 이용 메뉴 잠김"],
+  ["guest dashboard locked summary", files.dashboard, "로그인 후 조회"],
+  ["guest dashboard transfer lock", files.dashboard, "인증 후 이체"],
+  ["guest dashboard notification lock", files.dashboard, "로그인 후 알림 확인"],
+  ["guest dashboard protected table state", files.dashboard, "인증 후 가능"],
+  ["guest security auth marker", files.security, "const isAuthenticated"],
+  ["guest security masked value", files.security, "로그인 후 확인"],
+  ["guest otp masked value", files.security, "OTP 상태 로그인 후 확인"],
+  ["guest session table locked state", files.security, "로그인 후 세션 조회 가능"],
+  ["guest session detail placeholder", files.security, "인증 후 표시"],
+  ["guest recovery public scope", files.security, "비로그인 복구 가능"],
+  ["authenticated-only form class", files.security, "authenticated-only-form"],
+  ["masked form class", files.styles, ".authenticated-only-form"],
+];
+
+const forbiddenUnauthSignals = [
+  ["layout guest work available", files.layout, "sessionRequired ? \"로그인 필요\" : \"업무 가능\""],
+  ["dashboard unauth normal work", files.dashboard, "조회/이체/인증 정상"],
+  ["dashboard unauth next lookup", files.dashboard, "다음 조회 가능"],
+  ["dashboard unauth duplicate guard state", files.dashboard, "중복 방지</td>"],
+  ["dashboard unauth realtime state", files.dashboard, "실시간 알림</td>"],
+  ["security guest otp unregistered", files.security, "props.totpEnrollment ? props.totpEnrollment.status : \"미등록\""],
+  ["security guest raw session count", files.security, "<strong>{props.sessions.length}건</strong>"],
+  ["security guest empty session row", files.security, "조회된 세션이 없습니다."],
+];
+
+const missing = required.filter(([, content, expected]) => !content.includes(expected));
+const present = forbiddenUnauthSignals.filter(([, content, expected]) =>
+  content.includes(expected),
+);
+
+if (missing.length > 0 || present.length > 0) {
+  console.error("[customer-banking-unauth-security] contract violations:");
+  for (const [name, , expected] of missing) {
+    console.error(`- missing ${name}: ${expected}`);
+  }
+  for (const [name, , expected] of present) {
+    console.error(`- forbidden ${name}: ${expected}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `[customer-banking-unauth-security] passed: ${combined.length} checked bytes`,
+);

--- a/front/scripts/check-customer-banking-unauth-security.mjs
+++ b/front/scripts/check-customer-banking-unauth-security.mjs
@@ -31,6 +31,8 @@ const required = [
   ["guest dashboard notification lock", files.dashboard, "로그인 후 알림 확인"],
   ["guest dashboard protected table state", files.dashboard, "인증 후 가능"],
   ["guest security auth marker", files.security, "const isAuthenticated"],
+  ["guest totp state gate", files.security, "activeTotpEnrollment"],
+  ["guest backup code state gate", files.security, "activeBackupCodes"],
   ["guest security masked value", files.security, "로그인 후 확인"],
   ["guest otp masked value", files.security, "OTP 상태 로그인 후 확인"],
   ["guest session table locked state", files.security, "로그인 후 세션 조회 가능"],
@@ -42,10 +44,9 @@ const required = [
 
 const forbiddenUnauthSignals = [
   ["layout guest work available", files.layout, "sessionRequired ? \"로그인 필요\" : \"업무 가능\""],
-  ["dashboard unauth normal work", files.dashboard, "조회/이체/인증 정상"],
-  ["dashboard unauth next lookup", files.dashboard, "다음 조회 가능"],
-  ["dashboard unauth duplicate guard state", files.dashboard, "중복 방지</td>"],
-  ["dashboard unauth realtime state", files.dashboard, "실시간 알림</td>"],
+  ["dashboard unauth next lookup", files.dashboard, "<td>다음 조회 가능</td>"],
+  ["dashboard unauth duplicate guard state", files.dashboard, "<td>중복 방지</td>"],
+  ["dashboard unauth realtime state", files.dashboard, "<td>실시간 알림</td>"],
   ["security guest otp unregistered", files.security, "props.totpEnrollment ? props.totpEnrollment.status : \"미등록\""],
   ["security guest raw session count", files.security, "<strong>{props.sessions.length}건</strong>"],
   ["security guest empty session row", files.security, "조회된 세션이 없습니다."],

--- a/front/src/components/customer-banking/layout.tsx
+++ b/front/src/components/customer-banking/layout.tsx
@@ -37,6 +37,8 @@ export function BankHeader({
   onSearchChange: (value: string) => void;
   onServiceMapToggle: () => void;
 }) {
+  const isAuthenticated = Boolean(session);
+
   function moveFromServiceMap(section: MenuSection) {
     onServiceMapToggle();
     onMove(section);
@@ -146,16 +148,22 @@ export function BankHeader({
       </div>
       <div className="bank-service-strip gothic-state-strip" aria-label="뱅킹 이용 상태">
         <span>
-          보안등급 <strong>정상</strong>
+          보안등급 <strong>{isAuthenticated ? "정상" : "보호모드"}</strong>
         </span>
-        <span>HTTPS 보안접속</span>
+        <span>{isAuthenticated ? "HTTPS 보안접속" : "민감정보 보호"}</span>
         <span>평일 09:00-18:00 상담</span>
-        <span>서비스 상태 정상</span>
+        <span>{isAuthenticated ? "서비스 상태 정상" : "인증센터 로그인"}</span>
       </div>
       <div className="layout-health-strip" aria-label="화면 이용 상태">
         <span>개인뱅킹</span>
-        <span>{session ? "로그인 정상" : "미로그인"}</span>
-        <span>{sessionRequired ? "로그인 필요" : "업무 가능"}</span>
+        <span>{isAuthenticated ? "로그인 정상" : "보호모드"}</span>
+        <span>
+          {isAuthenticated
+            ? sessionRequired
+              ? "로그인 필요"
+              : "업무 가능"
+            : "로그인 후 업무 가능"}
+        </span>
       </div>
       {serviceMapOpen ? (
         <section
@@ -229,14 +237,19 @@ export function RightRail({
   onMove: MoveHandler;
   onRefresh: () => void;
 }) {
+  const isAuthenticated = Boolean(session);
+
   return (
-    <aside className="right-rail aligned-rail" aria-label="빠른 업무">
+    <aside
+      className={`right-rail aligned-rail ${isAuthenticated ? "" : "guest-protected"}`.trim()}
+      aria-label="빠른 업무"
+    >
       <section className="rail-panel login-panel">
         <div className="rail-heading">
           <span>로그인 상태</span>
-          <strong>{session ? "정상" : "미로그인"}</strong>
+          <strong>{isAuthenticated ? "정상" : "보호모드"}</strong>
         </div>
-        {session ? (
+        {isAuthenticated && session ? (
           <dl className="session-summary">
             <div>
               <dt>User ID</dt>
@@ -252,7 +265,9 @@ export function RightRail({
             </div>
           </dl>
         ) : (
-          <p className="rail-copy">로그인 후 조회, 이체, 거래내역 이용 가능</p>
+          <p className="rail-copy sensitive-placeholder">
+            로그인 후 업무 가능. 고객별 조회, 이체, 거래내역은 인증 후 표시됩니다.
+          </p>
         )}
         <div className="button-row compact rail-auth-actions">
           <button onClick={() => onMove("security")} type="button">
@@ -283,19 +298,25 @@ export function RightRail({
 
       <section className="rail-panel recent-list">
         <div className="rail-heading">
-          <span>최근 이용 메뉴</span>
+          <span>{isAuthenticated ? "최근 이용 메뉴" : "최근 이용 메뉴 잠김"}</span>
         </div>
-        <div className="recent-menu-list">
-          {recentMenus.map((item) => (
-            <button
-              key={item.label}
-              onClick={() => onMove(item.section)}
-              type="button"
-            >
-              {item.label}
-            </button>
-          ))}
-        </div>
+        {isAuthenticated ? (
+          <div className="recent-menu-list">
+            {recentMenus.map((item) => (
+              <button
+                key={item.label}
+                onClick={() => onMove(item.section)}
+                type="button"
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <p className="rail-copy sensitive-placeholder">
+            최근 이용 내역은 로그인 후 확인할 수 있습니다.
+          </p>
+        )}
       </section>
 
       <section className="rail-panel security-notice">
@@ -304,12 +325,13 @@ export function RightRail({
         </div>
         <BankNoticeStrip
           items={[
-            { label: "보안등급", value: "정상" },
+            { label: "보안등급", value: isAuthenticated ? "정상" : "로그인 후 확인" },
             { label: "접속상태", value: "HTTPS" },
             {
               label: "인증수단",
-              value: session ? "세션 활성" : "로그인 필요",
+              value: isAuthenticated ? "세션 활성" : "인증센터 로그인",
             },
+            { label: "민감정보", value: isAuthenticated ? "표시 가능" : "보호모드" },
           ]}
         />
       </section>

--- a/front/src/components/customer-banking/sections/dashboard-section.tsx
+++ b/front/src/components/customer-banking/sections/dashboard-section.tsx
@@ -17,6 +17,26 @@ export function DashboardSection({
   onMove: (section: MenuSection) => void;
   onRefresh: () => void;
 }) {
+  const workStatus = hasSession
+    ? {
+        notice: "조회/이체/인증 정상",
+        lookup: "조회 결과 대기",
+        transfer: "이체 처리 대기",
+        notification: "알림 수신 대기",
+        transactionState: "다음 조회 가능",
+        transferState: "중복 방지",
+        notificationState: "실시간 알림",
+      }
+    : {
+        notice: "로그인 후 업무 가능",
+        lookup: "로그인 후 조회",
+        transfer: "인증 후 이체",
+        notification: "로그인 후 알림 확인",
+        transactionState: "인증 후 가능",
+        transferState: "인증 후 가능",
+        notificationState: "로그인 후 알림 확인",
+      };
+
   return (
     <section className="task-section compact-work-section">
       <WorkTabs
@@ -63,15 +83,15 @@ export function DashboardSection({
       <BankNoticeStrip
         items={[
           { label: "이용시간", value: "00:30~23:30" },
-          { label: "보안등급", value: "개인 인증 완료 후 이체 가능" },
+          { label: "보안등급", value: hasSession ? "개인 인증 완료 후 이체 가능" : "로그인 후 확인" },
           { label: "상담", value: "평일 09:00~18:00" },
-          { label: "업무현황", value: "조회/이체/인증 정상" },
+          { label: "업무현황", value: workStatus.notice },
         ]}
       />
       <div className="work-summary-strip" aria-label="개인뱅킹 업무현황">
-        <span>조회 결과 대기</span>
-        <span>이체 처리 대기</span>
-        <span>알림 수신 대기</span>
+        <span>{workStatus.lookup}</span>
+        <span>{workStatus.transfer}</span>
+        <span>{workStatus.notification}</span>
         <span>인증서 관리</span>
       </div>
       <div className="bank-home-grid">
@@ -146,17 +166,17 @@ export function DashboardSection({
             <tr>
               <td>거래내역 조회</td>
               <td>계좌와 기간 조건 조회</td>
-              <td>다음 조회 가능</td>
+              <td>{workStatus.transactionState}</td>
             </tr>
             <tr>
               <td>이체</td>
               <td>요청 단위 중복 방지</td>
-              <td>중복 방지</td>
+              <td>{workStatus.transferState}</td>
             </tr>
             <tr>
               <td>알림</td>
               <td>실시간 알림과 알림함</td>
-              <td>실시간 알림</td>
+              <td>{workStatus.notificationState}</td>
             </tr>
           </tbody>
         </table>

--- a/front/src/components/customer-banking/sections/security-section.tsx
+++ b/front/src/components/customer-banking/sections/security-section.tsx
@@ -78,11 +78,17 @@ export function SecuritySection(props: {
   onTotpCodeChange: (value: string) => void;
   onVerifyTotpEnrollment: () => void;
 }) {
-  const sessionExpiryState = props.session ? "만료 임박" : "로그인 필요";
-  const currentDeviceState = props.sessions.some((item) => item.currentSession)
-    ? "현재 기기"
-    : "조회 전";
-  const revokeState = props.session ? "해지 가능" : "해지 불가";
+  const isAuthenticated = Boolean(props.session);
+  const activeBackupCodes = isAuthenticated ? props.backupCodes : null;
+  const activeTotpEnrollment = isAuthenticated ? props.totpEnrollment : null;
+  const sensitiveValue = isAuthenticated ? undefined : "로그인 후 확인";
+  const sessionExpiryState = isAuthenticated ? "만료 임박" : "로그인 후 확인";
+  const currentDeviceState = !isAuthenticated
+    ? "로그인 후 확인"
+    : props.sessions.some((item) => item.currentSession)
+      ? "현재 기기"
+      : "조회 전";
+  const revokeState = isAuthenticated ? "해지 가능" : "로그인 후 확인";
 
   return (
     <section className="task-section compact-work-section security-section">
@@ -110,22 +116,37 @@ export function SecuritySection(props: {
       />
       <BankNoticeStrip
         items={[
-          { label: "로그인 상태", value: props.session ? "로그인됨" : "로그인 필요" },
+          { label: "로그인 상태", value: isAuthenticated ? "로그인됨" : "로그인 필요" },
           { label: "추가 인증", value: props.challenge ? "확인 필요" : "대기" },
-          { label: "세션", value: formatDateTime(props.session?.refreshExpiresAt) },
+          {
+            label: "세션",
+            value: isAuthenticated
+              ? formatDateTime(props.session?.refreshExpiresAt)
+              : "로그인 후 확인",
+          },
           { label: "보안수단", value: "OTP / 복구코드" },
-          { label: "세션 해지 상태", value: props.session ? "개별/전체 해지 가능" : "로그인 필요" },
+          {
+            label: "세션 해지 상태",
+            value: isAuthenticated ? "개별/전체 해지 가능" : "로그인 후 확인",
+          },
         ]}
       />
       <WorkStateGrid
         label="인증 업무 상태"
         items={[
-          { label: "로그인", value: props.session ? "정상" : "필요" },
+          { label: "로그인", value: isAuthenticated ? "정상" : "필요" },
           {
             label: "추가인증",
             value: props.challenge ? getChallengeLabel(props.challenge.challengeType) : "대기",
           },
-          { label: "세션", value: props.sessions.length > 0 ? `${props.sessions.length}건` : "조회 전" },
+          {
+            label: "세션",
+            value: isAuthenticated
+              ? props.sessions.length > 0
+                ? `${props.sessions.length}건`
+                : "조회 전"
+              : "로그인 후 확인",
+          },
           { label: "보안수단", value: "OTP/복구코드" },
         ]}
       />
@@ -133,7 +154,7 @@ export function SecuritySection(props: {
       <div className="security-dashboard" aria-label="보안관리">
         <div>
           <span>보안관리</span>
-          <strong>{props.session ? "정상" : "로그인 필요"}</strong>
+          <strong>{isAuthenticated ? "정상" : "로그인 필요"}</strong>
           <small>인증센터</small>
         </div>
         <div>
@@ -143,21 +164,29 @@ export function SecuritySection(props: {
         </div>
         <div>
           <span>접속관리</span>
-          <strong>{props.sessions.length}건</strong>
-          <small>활성 세션</small>
+          <strong>{isAuthenticated ? `${props.sessions.length}건` : "로그인 후 확인"}</strong>
+          <small>{isAuthenticated ? "활성 세션" : "로그인 후 세션 조회 가능"}</small>
         </div>
       </div>
 
       <div className="security-media-grid" aria-label="보안매체 등록 상태">
         <div>
           <span>보안매체 등록</span>
-          <strong>{props.totpEnrollment ? "등록 진행" : props.session ? "대기" : "로그인 필요"}</strong>
+          <strong>
+            {activeTotpEnrollment ? "등록 진행" : isAuthenticated ? "대기" : "로그인 후 확인"}
+          </strong>
           <small>OTP / 보안매체</small>
         </div>
         <div>
           <span>OTP 등록 상태</span>
-          <strong>{props.totpEnrollment ? props.totpEnrollment.status : "미등록"}</strong>
-          <small>등록 시작 후 인증번호 확인</small>
+          <strong>
+            {activeTotpEnrollment
+              ? activeTotpEnrollment.status
+              : isAuthenticated
+                ? "대기"
+                : "로그인 후 확인"}
+          </strong>
+          <small>{isAuthenticated ? "등록 시작 후 인증번호 확인" : "OTP 상태 로그인 후 확인"}</small>
         </div>
         <div>
           <span>세션 해지 상태</span>
@@ -167,7 +196,7 @@ export function SecuritySection(props: {
         <div>
           <span>세션 만료</span>
           <strong>{sessionExpiryState}</strong>
-          <small>{formatDateTime(props.session?.expiresAt)}</small>
+          <small>{isAuthenticated ? formatDateTime(props.session?.expiresAt) : "인증 후 표시"}</small>
         </div>
         <div>
           <span>현재 기기</span>
@@ -235,20 +264,26 @@ export function SecuritySection(props: {
         <div className="bank-form passive">
           <div className="form-heading">
             <strong>현재 세션</strong>
-            <span>{props.session ? "로그인됨" : "로그인 필요"}</span>
+            <span>{isAuthenticated ? "로그인됨" : "로그인 필요"}</span>
           </div>
           <dl className="detail-list">
             <div>
               <dt>고객번호</dt>
-              <dd>{props.session?.userId ?? "-"}</dd>
+              <dd className={isAuthenticated ? undefined : "sensitive-placeholder"}>
+                {props.session?.userId ?? sensitiveValue ?? "인증 후 표시"}
+              </dd>
             </div>
             <div>
               <dt>세션 방식</dt>
-              <dd>{props.session?.tokenType ?? "-"}</dd>
+              <dd className={isAuthenticated ? undefined : "sensitive-placeholder"}>
+                {props.session?.tokenType ?? sensitiveValue ?? "인증 후 표시"}
+              </dd>
             </div>
             <div>
               <dt>세션 만료</dt>
-              <dd>{formatDateTime(props.session?.refreshExpiresAt)}</dd>
+              <dd className={isAuthenticated ? undefined : "sensitive-placeholder"}>
+                {isAuthenticated ? formatDateTime(props.session?.refreshExpiresAt) : "인증 후 표시"}
+              </dd>
             </div>
           </dl>
         </div>
@@ -336,7 +371,7 @@ export function SecuritySection(props: {
         <form className="bank-form" onSubmit={props.onPasswordRecoveryRequest}>
           <div className="form-heading">
             <strong>비밀번호 찾기</strong>
-            <span>복구 요청</span>
+            <span>비로그인 복구 가능</span>
           </div>
           <label>
             <span>고객 ID</span>
@@ -400,7 +435,11 @@ export function SecuritySection(props: {
       </div>
 
       <div className="two-column">
-        <form className="bank-form" onSubmit={props.onPasswordReset}>
+        <form
+          className="bank-form authenticated-only-form"
+          data-locked={!isAuthenticated}
+          onSubmit={props.onPasswordReset}
+        >
           <div className="form-heading">
             <strong>비밀번호 변경</strong>
             <span>로그인 세션 필요</span>
@@ -415,6 +454,7 @@ export function SecuritySection(props: {
                 })
               }
               required
+              disabled={!isAuthenticated || props.isBusy}
               type="password"
               value={props.passwordResetForm.currentPassword}
             />
@@ -429,16 +469,20 @@ export function SecuritySection(props: {
                 })
               }
               required
+              disabled={!isAuthenticated || props.isBusy}
               type="password"
               value={props.passwordResetForm.newPassword}
             />
           </label>
-          <button disabled={!props.session || props.isBusy} type="submit">
+          <button disabled={!isAuthenticated || props.isBusy} type="submit">
             변경
           </button>
         </form>
 
-        <div className="bank-form passive">
+        <div
+          className="bank-form passive authenticated-only-form"
+          data-locked={!isAuthenticated}
+        >
           <div className="form-heading">
             <strong>추가 인증 관리</strong>
             <span>OTP / 복구코드</span>
@@ -448,55 +492,56 @@ export function SecuritySection(props: {
             <input
               inputMode="numeric"
               maxLength={6}
+              disabled={!isAuthenticated || props.isBusy}
               onChange={(event) => props.onTotpCodeChange(event.target.value)}
               value={props.totpCode}
             />
           </label>
           <div className="button-row compact">
             <button
-              disabled={!props.session || props.isBusy}
+              disabled={!isAuthenticated || props.isBusy}
               onClick={props.onStartTotpEnrollment}
               type="button"
             >
               등록 시작
             </button>
             <button
-              disabled={!props.session || props.isBusy}
+              disabled={!isAuthenticated || props.isBusy}
               onClick={props.onVerifyTotpEnrollment}
               type="button"
             >
               등록 확인
             </button>
             <button
-              disabled={!props.session || props.isBusy}
+              disabled={!isAuthenticated || props.isBusy}
               onClick={props.onIssueBackupCodes}
               type="button"
             >
               코드 발급
             </button>
             <button
-              disabled={!props.session || props.isBusy}
+              disabled={!isAuthenticated || props.isBusy}
               onClick={props.onDisableTotp}
               type="button"
             >
               해지
             </button>
           </div>
-          {props.totpEnrollment ? (
+          {activeTotpEnrollment ? (
             <dl className="detail-list compact-list">
               <div>
                 <dt>등록키</dt>
-                <dd>{props.totpEnrollment.secretKey}</dd>
+                <dd>{activeTotpEnrollment.secretKey}</dd>
               </div>
               <div>
                 <dt>만료</dt>
-                <dd>{formatDateTime(props.totpEnrollment.expiresAt)}</dd>
+                <dd>{formatDateTime(activeTotpEnrollment.expiresAt)}</dd>
               </div>
             </dl>
           ) : null}
-          {props.backupCodes ? (
+          {activeBackupCodes ? (
             <div className="code-list">
-              {props.backupCodes.backupCodes.map((code) => (
+              {activeBackupCodes.backupCodes.map((code) => (
                 <code key={code}>{code}</code>
               ))}
             </div>
@@ -512,14 +557,14 @@ export function SecuritySection(props: {
           </div>
           <BankActionBar>
             <button
-              disabled={!props.session || props.isBusy}
+              disabled={!isAuthenticated || props.isBusy}
               onClick={props.onLoadSessions}
               type="button"
             >
               조회
             </button>
             <button
-              disabled={!props.session || props.isBusy}
+              disabled={!isAuthenticated || props.isBusy}
               onClick={props.onRevokeAllSessions}
               type="button"
             >
@@ -541,9 +586,15 @@ export function SecuritySection(props: {
               </tr>
             </thead>
             <tbody>
-              {props.sessions.length === 0 ? (
+              {!isAuthenticated ? (
                 <tr>
-                  <td colSpan={6}>조회된 세션이 없습니다.</td>
+                  <td className="sensitive-placeholder" colSpan={6}>
+                    로그인 후 세션 조회 가능
+                  </td>
+                </tr>
+              ) : props.sessions.length === 0 ? (
+                <tr>
+                  <td colSpan={6}>세션 조회 결과가 없습니다.</td>
                 </tr>
               ) : (
                 props.sessions.map((item) => (

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -367,6 +367,17 @@ label span {
   border-top: 3px solid var(--primary);
 }
 
+.guest-protected .rail-panel,
+.bank-layout[data-auth-state="guest"] .security-section .security-dashboard > div,
+.bank-layout[data-auth-state="guest"] .security-section .security-media-grid > div {
+  border-color: var(--line-strong);
+}
+
+.sensitive-placeholder {
+  color: var(--muted);
+  font-weight: 800;
+}
+
 .service-map-panel {
   display: grid;
   grid-template-columns: 150px minmax(0, 1fr);
@@ -1399,6 +1410,15 @@ label span {
 
 .bank-form.passive {
   background: var(--surface-muted);
+}
+
+.authenticated-only-form[data-locked="true"] {
+  border-style: dashed;
+  background: linear-gradient(180deg, var(--surface-muted), var(--page));
+}
+
+.authenticated-only-form[data-locked="true"] input {
+  opacity: 0.56;
 }
 
 .bank-form > button {


### PR DESCRIPTION
## 🔗 Related Issue
- close #936

## 🌿 Base Branch
- `main`

## 📝 Summary
- 비로그인 공개 화면에서 고객별 세션, OTP, 최근 이용, 업무 가능 상태처럼 보이는 값을 보호모드 문구로 대체했습니다.
- 은행권 웹뱅킹 공개 화면처럼 로그인/인증 전에는 조회·이체·세션·보안매체 상태를 확인 불가 상태로 표시합니다.

## 🛠 Changes
- 비로그인 보안 계약 스크립트 `test:unauth-security` 추가
- 헤더/우측 레일의 게스트 상태를 `보호모드`, `민감정보 보호`, `로그인 후 업무 가능`으로 정리
- 대시보드 업무현황의 조회/이체/알림 상태를 로그인 전 잠금 문구로 대체
- 인증센터의 세션, OTP, backup code, 현재 기기 표시를 로그인 상태 기준으로 게이트
- 비밀번호 변경/OTP 관리/세션 조회 영역에 인증 전 잠금 UI 적용

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front test:unauth-security`
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front test:api-parity`
- `yarn --cwd front lint`
- `yarn --cwd front build`
- 브라우저 수동 확인: `http://localhost:3100` 비로그인 뱅킹홈/인증센터에서 보호모드 문구와 잠금 상태 확인

## 📸 Screenshot / API Example
- 수동 확인: 비로그인 뱅킹홈에 `보호모드`, `민감정보 보호`, `최근 이용 메뉴 잠김` 표시
- 수동 확인: 인증센터에 `로그인 후 확인`, `OTP 상태 로그인 후 확인`, `로그인 후 세션 조회 가능` 표시

## ⚠️ Risk & Rollback
- 예상 리스크: 로그인 전 안내 문구가 바뀌므로 기존 게스트 화면 문안에 익숙한 사용자의 탐색 동선이 일부 달라질 수 있습니다.
- 롤백 방법: 이 PR revert. 백엔드/API/DB 변경 없음.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A