### PR TITLE
[Fix] 로그인 요청 Failed to fetch 원인 수정

### DIFF
--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -19,7 +19,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -36,6 +35,9 @@ import org.springframework.security.oauth2.server.resource.web.BearerTokenResolv
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 /** bootstrap auth와 JWT resource server를 함께 조립하는 security 설정 */
 @Configuration
@@ -44,6 +46,7 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
   SecurityAuthCookieProperties.class,
   SecurityTotpProperties.class,
   SecurityRememberDeviceProperties.class,
+  SecurityCorsProperties.class,
   LoginProtectionProperties.class,
   LoginThrottlingProperties.class,
   PasswordRecoveryProperties.class,
@@ -64,11 +67,12 @@ public class SecurityConfiguration {
       ObjectProvider<ClientRegistrationRepository> clientRegistrationRepository,
       ObjectProvider<OidcLoginAuthenticationSuccessHandler> oidcLoginAuthenticationSuccessHandler,
       JwtDecoder jwtDecoder,
-      BearerTokenResolver publicApiBearerTokenResolver)
+      BearerTokenResolver publicApiBearerTokenResolver,
+      CorsConfigurationSource corsConfigurationSource)
       throws Exception {
     // stateless API 기본선
     http.csrf(AbstractHttpConfigurer::disable)
-        .cors(Customizer.withDefaults())
+        .cors(cors -> cors.configurationSource(corsConfigurationSource))
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
         .logout(AbstractHttpConfigurer::disable)
@@ -197,6 +201,25 @@ public class SecurityConfiguration {
   @Bean
   PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  CorsConfigurationSource corsConfigurationSource(SecurityCorsProperties securityCorsProperties) {
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    if (!securityCorsProperties.enabled()) {
+      return source;
+    }
+
+    // credential cookie 사용 API라 명시된 origin에서만 cross-origin 호출을 허용합니다.
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOriginPatterns(securityCorsProperties.allowedOriginPatterns());
+    configuration.setAllowedMethods(securityCorsProperties.allowedMethods());
+    configuration.setAllowedHeaders(securityCorsProperties.allowedHeaders());
+    configuration.setExposedHeaders(securityCorsProperties.exposedHeaders());
+    configuration.setAllowCredentials(securityCorsProperties.allowCredentials());
+    configuration.setMaxAge(securityCorsProperties.maxAgeSeconds());
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/security/SecurityCorsProperties.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityCorsProperties.java
@@ -1,0 +1,58 @@
+package com.aquilabank.global.security;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** credential cookie 기반 CORS 허용 origin 설정 */
+@ConfigurationProperties(prefix = "security.cors")
+public record SecurityCorsProperties(
+    List<String> allowedOriginPatterns,
+    List<String> allowedMethods,
+    List<String> allowedHeaders,
+    List<String> exposedHeaders,
+    Boolean allowCredentials,
+    Long maxAgeSeconds) {
+
+  public SecurityCorsProperties {
+    allowedOriginPatterns = normalize(allowedOriginPatterns);
+    allowedMethods =
+        allowedMethods == null || allowedMethods.isEmpty()
+            ? List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            : normalize(allowedMethods);
+    allowedHeaders =
+        allowedHeaders == null || allowedHeaders.isEmpty()
+            ? List.of(
+                "Authorization",
+                "Content-Type",
+                "Idempotency-Key",
+                "X-Request-Id",
+                "X-Bootstrap-Token",
+                "X-Auth-Bootstrap-Token",
+                "X-Outbox-Ops-Token")
+            : normalize(allowedHeaders);
+    exposedHeaders =
+        exposedHeaders == null || exposedHeaders.isEmpty()
+            ? List.of(
+                "Retry-After",
+                "X-Aquila-429-Source",
+                "X-Aquila-Reject-Reason",
+                "X-Aquila-Reject-Source",
+                "X-Password-Recovery-Request-Id",
+                "X-RateLimit-Scope",
+                "X-Request-Id")
+            : normalize(exposedHeaders);
+    allowCredentials = allowCredentials == null ? Boolean.TRUE : allowCredentials;
+    maxAgeSeconds = maxAgeSeconds == null ? 3600L : maxAgeSeconds;
+  }
+
+  boolean enabled() {
+    return !allowedOriginPatterns.isEmpty();
+  }
+
+  private static List<String> normalize(List<String> items) {
+    if (items == null) {
+      return List.of();
+    }
+    return items.stream().map(String::trim).filter(item -> !item.isEmpty()).toList();
+  }
+}

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -30,6 +30,8 @@ security:
   auth-bootstrap-api:
     enabled: ${SECURITY_AUTH_BOOTSTRAP_API_ENABLED:true}
     token: ${SECURITY_AUTH_BOOTSTRAP_API_TOKEN:dev-auth-bootstrap-api-token}
+  cors:
+    allowed-origin-patterns: ${SECURITY_CORS_ALLOWED_ORIGIN_PATTERNS:http://localhost:3000,http://127.0.0.1:3000}
 
 outbox:
   kafka:

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -397,6 +397,8 @@ security:
     refresh-token-cookie-name: ${SECURITY_AUTH_COOKIE_REFRESH_TOKEN_NAME:ab_refresh_token}
     # TLS 종단 환경은 true를 유지하고, direct HTTP staging smoke만 env에서 false로 낮춥니다.
     secure: ${SECURITY_AUTH_COOKIE_SECURE:true}
+  cors:
+    allowed-origin-patterns: ${SECURITY_CORS_ALLOWED_ORIGIN_PATTERNS:}
   totp:
     issuer: ${SECURITY_TOTP_ISSUER:Aquila Bank}
     secret-encryption-key: ${SECURITY_TOTP_SECRET_ENCRYPTION_KEY:${SECURITY_JWT_SECRET:}}

--- a/back/src/test/java/com/aquilabank/global/security/SecurityCorsIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/SecurityCorsIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.aquilabank.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = "security.cors.allowed-origin-patterns=http://localhost:3000")
+class SecurityCorsIntegrationTest {
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private SecurityCorsProperties securityCorsProperties;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUpMockMvc() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void permitsConfiguredFrontendOriginForLoginPreflight() throws Exception {
+    assertThat(securityCorsProperties.allowedOriginPatterns())
+        .containsExactly("http://localhost:3000");
+
+    mockMvc
+        .perform(
+            options("/api/v1/auth/login")
+                .header("Origin", "http://localhost:3000")
+                .header("Access-Control-Request-Method", "POST")
+                .header("Access-Control-Request-Headers", "content-type"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:3000"))
+        .andExpect(header().string("Access-Control-Allow-Credentials", "true"))
+        .andExpect(header().string("Access-Control-Allow-Methods", containsString("POST")))
+        .andExpect(header().string("Access-Control-Allow-Headers", containsString("content-type")));
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #942

## 🌿 Base Branch
- `main`

## 📝 Summary
- 로그인 요청이 브라우저 preflight 단계에서 CORS 응답 없이 처리되어 `Failed to fetch`로 보이는 경로를 수정합니다.
- credential cookie 기반 인증 흐름을 유지하면서 명시된 origin pattern이 있을 때만 cross-origin API 호출을 허용합니다.

## 🛠 Changes
- `security.cors.allowed-origin-patterns` 설정과 CORS configuration source를 추가했습니다.
- dev profile에서 `http://localhost:3000`, `http://127.0.0.1:3000`을 기본 허용 origin으로 지정했습니다.
- 로그인 preflight가 `Access-Control-Allow-*` 헤더를 반환하는 integration test를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-security-cors ./back/gradlew -p back integrationTest --tests '*SecurityCorsIntegrationTest'` RED: `Access-Control-Allow-Origin` header null 확인
- `tools/test/with-resource-lock.sh back-security-cors ./back/gradlew -p back integrationTest --tests '*SecurityCorsIntegrationTest'` GREEN: BUILD SUCCESSFUL
- `tools/test/with-resource-lock.sh back-check ./back/gradlew -p back check` BUILD SUCCESSFUL in 6m 30s
- commit hook `./back/gradlew -p back check` BUILD SUCCESSFUL

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 허용 origin 오설정 시 cross-origin 인증 쿠키 호출이 계속 차단될 수 있습니다. 운영에서는 `SECURITY_CORS_ALLOWED_ORIGIN_PATTERNS`를 실제 프론트 origin으로 명시해야 합니다.
- 롤백 방법: 이 PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
