### PR TITLE
[Fix] 웹뱅킹 민감 mutation 보안 보강

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/account/port/AccountSummaryReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/account/port/AccountSummaryReadPort.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 public interface AccountSummaryReadPort {
 
   Optional<AccountSummary> findByAccountId(long accountId);
+
+  Optional<AccountSummary> findByAccountNumber(String accountNumber);
 }

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryService.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryService.java
@@ -22,4 +22,14 @@ public final class AccountSummaryQueryService implements AccountSummaryQueryUseC
         .findByAccountId(accountId)
         .orElseThrow(() -> new AccountSummaryNotFoundException("account summary is not found"));
   }
+
+  @Override
+  public AccountSummary getByAccountNumber(String accountNumber) {
+    if (accountNumber == null || accountNumber.isBlank()) {
+      throw new IllegalArgumentException("accountNumber is required");
+    }
+    return accountSummaryReadPort
+        .findByAccountNumber(accountNumber.trim())
+        .orElseThrow(() -> new AccountSummaryNotFoundException("account summary is not found"));
+  }
 }

--- a/back/src/main/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryUseCase.java
@@ -6,4 +6,6 @@ import com.aquilabank.domain.account.model.AccountSummary;
 public interface AccountSummaryQueryUseCase {
 
   AccountSummary getByAccountId(long accountId);
+
+  AccountSummary getByAccountNumber(String accountNumber);
 }

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpOperationRequirementService.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpOperationRequirementService.java
@@ -1,0 +1,26 @@
+package com.aquilabank.domain.auth.usecase;
+
+import com.aquilabank.domain.auth.model.TotpCredentialStatus;
+import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
+import java.util.Objects;
+
+/** active TOTP credential이 있는 사용자에게만 업무별 재검증을 요구합니다. */
+public final class TotpOperationRequirementService implements TotpOperationRequirementUseCase {
+
+  private final TotpCredentialLoadPort totpCredentialLoadPort;
+
+  public TotpOperationRequirementService(TotpCredentialLoadPort totpCredentialLoadPort) {
+    this.totpCredentialLoadPort = Objects.requireNonNull(totpCredentialLoadPort);
+  }
+
+  @Override
+  public boolean requiresVerification(long userId) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    return totpCredentialLoadPort
+        .findCredentialByUserId(userId)
+        .filter(credential -> credential.credentialStatus() == TotpCredentialStatus.ACTIVE)
+        .isPresent();
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpOperationRequirementUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/auth/usecase/TotpOperationRequirementUseCase.java
@@ -1,0 +1,7 @@
+package com.aquilabank.domain.auth.usecase;
+
+/** 고위험 업무 실행 전 TOTP 재검증이 필요한지 판단하는 진입점입니다. */
+public interface TotpOperationRequirementUseCase {
+
+  boolean requiresVerification(long userId);
+}

--- a/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/AuthConfiguration.java
@@ -90,6 +90,8 @@ import com.aquilabank.domain.auth.usecase.TotpDisableService;
 import com.aquilabank.domain.auth.usecase.TotpDisableUseCase;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentService;
 import com.aquilabank.domain.auth.usecase.TotpEnrollmentUseCase;
+import com.aquilabank.domain.auth.usecase.TotpOperationRequirementService;
+import com.aquilabank.domain.auth.usecase.TotpOperationRequirementUseCase;
 import com.aquilabank.domain.auth.usecase.TotpOperationVerifyService;
 import com.aquilabank.domain.auth.usecase.TotpOperationVerifyUseCase;
 import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryService;
@@ -447,6 +449,12 @@ public class AuthConfiguration {
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
     return command ->
         transactionTemplate.executeWithoutResult(status -> totpDisableService.disable(command));
+  }
+
+  @Bean
+  TotpOperationRequirementUseCase totpOperationRequirementUseCase(
+      TotpCredentialLoadPort totpCredentialLoadPort) {
+    return new TotpOperationRequirementService(totpCredentialLoadPort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountSummaryRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/account/JdbcAccountSummaryRepository.java
@@ -16,6 +16,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public class JdbcAccountSummaryRepository implements AccountSummaryReadPort {
 
+  private static final String ACCOUNT_SUMMARY_SELECT =
+      """
+      SELECT account.id,
+             account.account_number,
+             account.display_name,
+             account.account_status,
+             account.currency_code AS account_currency_code,
+             snapshot.available_balance_minor,
+             snapshot.pending_balance_minor,
+             snapshot.currency_code AS snapshot_currency_code,
+             account.created_at,
+             snapshot.updated_at
+      FROM bank_account account
+      JOIN account_balance_snapshot snapshot
+        ON snapshot.account_id = account.id
+      """;
+
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   public JdbcAccountSummaryRepository(NamedParameterJdbcTemplate jdbcTemplate) {
@@ -26,27 +43,22 @@ public class JdbcAccountSummaryRepository implements AccountSummaryReadPort {
   @Transactional(readOnly = true)
   public Optional<AccountSummary> findByAccountId(long accountId) {
     // account_id PK exact lookup이라 account 원본과 snapshot을 한 번만 join 합니다.
-    return jdbcTemplate
-        .query(
-            """
-            SELECT account.id,
-                   account.account_number,
-                   account.display_name,
-                   account.account_status,
-                   account.currency_code AS account_currency_code,
-                   snapshot.available_balance_minor,
-                   snapshot.pending_balance_minor,
-                   snapshot.currency_code AS snapshot_currency_code,
-                   account.created_at,
-                   snapshot.updated_at
-            FROM bank_account account
-            JOIN account_balance_snapshot snapshot
-              ON snapshot.account_id = account.id
-            WHERE account.id = :accountId
-            """,
-            new MapSqlParameterSource().addValue("accountId", accountId),
-            (rs, rowNum) -> mapAccountSummary(rs))
-        .stream()
+    return queryOne(
+        ACCOUNT_SUMMARY_SELECT + "WHERE account.id = :accountId",
+        new MapSqlParameterSource().addValue("accountId", accountId));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<AccountSummary> findByAccountNumber(String accountNumber) {
+    // account_number unique index exact lookup으로 수취인 탐색 비용과 노출 범위를 낮춥니다.
+    return queryOne(
+        ACCOUNT_SUMMARY_SELECT + "WHERE account.account_number = :accountNumber",
+        new MapSqlParameterSource().addValue("accountNumber", accountNumber));
+  }
+
+  private Optional<AccountSummary> queryOne(String sql, MapSqlParameterSource parameters) {
+    return jdbcTemplate.query(sql, parameters, (rs, rowNum) -> mapAccountSummary(rs)).stream()
         .findFirst();
   }
 

--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
@@ -2,6 +2,9 @@ package com.aquilabank.global.web.ledger;
 
 import com.aquilabank.domain.account.model.AccountSummary;
 import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.domain.auth.model.TotpOperationVerifyCommand;
+import com.aquilabank.domain.auth.usecase.TotpOperationRequirementUseCase;
+import com.aquilabank.domain.auth.usecase.TotpOperationVerifyUseCase;
 import com.aquilabank.domain.ledger.model.TransferCommand;
 import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.model.TransferReversalCommand;
@@ -12,6 +15,7 @@ import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
 import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
 import com.aquilabank.global.config.TransferLimitPolicyProperties;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
 import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import jakarta.validation.Valid;
@@ -46,6 +50,8 @@ public class TransferCommandController {
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
   private final AccountSummaryQueryUseCase accountSummaryQueryUseCase;
   private final TransferLimitUsageReadPort transferLimitUsageReadPort;
+  private final TotpOperationRequirementUseCase totpOperationRequirementUseCase;
+  private final TotpOperationVerifyUseCase totpOperationVerifyUseCase;
   private final TransferLimitPolicyProperties transferLimitPolicyProperties;
   private final Clock clock;
 
@@ -56,6 +62,8 @@ public class TransferCommandController {
       RequestAccountAuthorizationService requestAccountAuthorizationService,
       AccountSummaryQueryUseCase accountSummaryQueryUseCase,
       TransferLimitUsageReadPort transferLimitUsageReadPort,
+      TotpOperationRequirementUseCase totpOperationRequirementUseCase,
+      TotpOperationVerifyUseCase totpOperationVerifyUseCase,
       TransferLimitPolicyProperties transferLimitPolicyProperties) {
     this(
         transferCommandUseCase,
@@ -63,6 +71,8 @@ public class TransferCommandController {
         requestAccountAuthorizationService,
         accountSummaryQueryUseCase,
         transferLimitUsageReadPort,
+        totpOperationRequirementUseCase,
+        totpOperationVerifyUseCase,
         transferLimitPolicyProperties,
         Clock.systemUTC());
   }
@@ -73,6 +83,8 @@ public class TransferCommandController {
       RequestAccountAuthorizationService requestAccountAuthorizationService,
       AccountSummaryQueryUseCase accountSummaryQueryUseCase,
       TransferLimitUsageReadPort transferLimitUsageReadPort,
+      TotpOperationRequirementUseCase totpOperationRequirementUseCase,
+      TotpOperationVerifyUseCase totpOperationVerifyUseCase,
       TransferLimitPolicyProperties transferLimitPolicyProperties,
       Clock clock) {
     this.transferCommandUseCase = transferCommandUseCase;
@@ -80,6 +92,8 @@ public class TransferCommandController {
     this.requestAccountAuthorizationService = requestAccountAuthorizationService;
     this.accountSummaryQueryUseCase = accountSummaryQueryUseCase;
     this.transferLimitUsageReadPort = transferLimitUsageReadPort;
+    this.totpOperationRequirementUseCase = totpOperationRequirementUseCase;
+    this.totpOperationVerifyUseCase = totpOperationVerifyUseCase;
     this.transferLimitPolicyProperties = transferLimitPolicyProperties;
     this.clock = clock;
   }
@@ -129,7 +143,7 @@ public class TransferCommandController {
         dailyRemainingMinor,
         "OK".equals(blockedReason),
         blockedReason,
-        true);
+        resolveOtpRequired(principal));
   }
 
   @PostMapping
@@ -137,6 +151,7 @@ public class TransferCommandController {
       @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
       @RequestHeader("Idempotency-Key") String idempotencyKey,
       @Valid @RequestBody TransferRequest request) {
+    verifyOperationTotpIfRequired(principal, request.totpCode());
     long sourceAccountId =
         requestAccountAuthorizationService.resolveTransferSourceAccountId(
             principal, request.sourceAccountId());
@@ -158,6 +173,7 @@ public class TransferCommandController {
       @PathVariable String transactionReference,
       @RequestHeader("Idempotency-Key") String idempotencyKey,
       @Valid @RequestBody TransferReversalRequest request) {
+    verifyOperationTotpIfRequired(principal, request.totpCode());
     long sourceAccountId =
         requestAccountAuthorizationService.resolveTransferSourceAccountId(
             principal, request.sourceAccountId());
@@ -171,6 +187,25 @@ public class TransferCommandController {
                 request.summary(),
                 idempotencyKey));
     return TransferReversalResponse.from(result);
+  }
+
+  private boolean resolveOtpRequired(AuthenticatedRequestPrincipal principal) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      return totpOperationRequirementUseCase.requiresVerification(userPrincipal.userId());
+    }
+    return true;
+  }
+
+  private void verifyOperationTotpIfRequired(
+      AuthenticatedRequestPrincipal principal, String totpCode) {
+    if (!(principal instanceof AuthenticatedUserPrincipal userPrincipal)) {
+      return;
+    }
+    if (!totpOperationRequirementUseCase.requiresVerification(userPrincipal.userId())) {
+      return;
+    }
+    totpOperationVerifyUseCase.verify(
+        new TotpOperationVerifyCommand(userPrincipal.userId(), totpCode));
   }
 
   private String resolvePreviewBlockedReason(
@@ -250,14 +285,16 @@ public class TransferCommandController {
               regexp = "^[A-Z]{3}$",
               message = "currencyCode must be a 3-letter uppercase code")
           String currencyCode,
-      @NotBlank(message = "summary is required") @Size(max = 120, message = "summary must be 120 characters or less") String summary) {}
+      @NotBlank(message = "summary is required") @Size(max = 120, message = "summary must be 120 characters or less") String summary,
+      @Size(max = 12, message = "totpCode must be 12 characters or less") String totpCode) {}
 
   /** 송금 reversal 요청 body */
   public record TransferReversalRequest(
       @Positive(message = "sourceAccountId must be positive") long sourceAccountId,
       @Positive(message = "amountMinor must be positive") Long amountMinor,
       @NotNull(message = "reversalReason is required") TransferReversalReason reversalReason,
-      @NotBlank(message = "summary is required") @Size(max = 120, message = "summary must be 120 characters or less") String summary) {}
+      @NotBlank(message = "summary is required") @Size(max = 120, message = "summary must be 120 characters or less") String summary,
+      @Size(max = 12, message = "totpCode must be 12 characters or less") String totpCode) {}
 
   /** 송금 완료 응답 */
   public record TransferResponse(

--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
@@ -18,6 +18,7 @@ import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
 import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -102,7 +103,9 @@ public class TransferCommandController {
   public TransferPreviewResponse preview(
       @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
       @RequestParam @Positive(message = "sourceAccountId must be positive") long sourceAccountId,
-      @RequestParam @Positive(message = "targetAccountId must be positive") long targetAccountId,
+      @RequestParam(required = false) @Positive(message = "targetAccountId must be positive") Long targetAccountId,
+      @RequestParam(required = false)
+          @Size(max = 20, message = "targetAccountNumber must be 20 characters or less") String targetAccountNumber,
       @RequestParam @Positive(message = "amountMinor must be positive") long amountMinor,
       @RequestParam
           @NotBlank(message = "currencyCode is required") @Pattern(
@@ -113,7 +116,8 @@ public class TransferCommandController {
         requestAccountAuthorizationService.resolveTransferSourceAccountId(
             principal, sourceAccountId);
     AccountSummary source = accountSummaryQueryUseCase.getByAccountId(resolvedSourceAccountId);
-    AccountSummary target = accountSummaryQueryUseCase.getByAccountId(targetAccountId);
+    AccountSummary target =
+        resolveTransferTargetAccount(principal, targetAccountId, targetAccountNumber);
     ZoneId businessZoneId = ZoneId.of(transferLimitPolicyProperties.businessZoneId());
     Instant now = clock.instant();
     LocalDate businessDate = LocalDate.ofInstant(now, businessZoneId);
@@ -131,7 +135,7 @@ public class TransferCommandController {
             source, target, amountMinor, totalDebitMinor, dailyUsedMinor, currencyCode);
     return new TransferPreviewResponse(
         resolvedSourceAccountId,
-        TransferPreviewAccountResponse.from(target),
+        TransferPreviewAccountResponse.from(target, shouldExposeInternalTarget(principal)),
         amountMinor,
         currencyCode,
         feeMinor,
@@ -155,11 +159,14 @@ public class TransferCommandController {
     long sourceAccountId =
         requestAccountAuthorizationService.resolveTransferSourceAccountId(
             principal, request.sourceAccountId());
+    long targetAccountId =
+        resolveTransferTargetAccountId(
+            principal, request.targetAccountId(), request.targetAccountNumber());
     TransferResult result =
         transferCommandUseCase.transfer(
             new TransferCommand(
                 sourceAccountId,
-                request.targetAccountId(),
+                targetAccountId,
                 request.amountMinor(),
                 request.currencyCode(),
                 request.summary(),
@@ -194,6 +201,36 @@ public class TransferCommandController {
       return totpOperationRequirementUseCase.requiresVerification(userPrincipal.userId());
     }
     return true;
+  }
+
+  private AccountSummary resolveTransferTargetAccount(
+      AuthenticatedRequestPrincipal principal, Long targetAccountId, String targetAccountNumber) {
+    if (principal instanceof AuthenticatedUserPrincipal) {
+      if (targetAccountNumber == null || targetAccountNumber.isBlank()) {
+        throw new IllegalArgumentException("targetAccountNumber is required");
+      }
+      return accountSummaryQueryUseCase.getByAccountNumber(targetAccountNumber.trim());
+    }
+    if (targetAccountId == null) {
+      throw new IllegalArgumentException("targetAccountId is required");
+    }
+    return accountSummaryQueryUseCase.getByAccountId(targetAccountId);
+  }
+
+  private long resolveTransferTargetAccountId(
+      AuthenticatedRequestPrincipal principal, Long targetAccountId, String targetAccountNumber) {
+    if (principal instanceof AuthenticatedUserPrincipal) {
+      return resolveTransferTargetAccount(principal, targetAccountId, targetAccountNumber)
+          .accountId();
+    }
+    if (targetAccountId == null) {
+      throw new IllegalArgumentException("targetAccountId is required");
+    }
+    return targetAccountId;
+  }
+
+  private boolean shouldExposeInternalTarget(AuthenticatedRequestPrincipal principal) {
+    return !(principal instanceof AuthenticatedUserPrincipal);
   }
 
   private void verifyOperationTotpIfRequired(
@@ -235,20 +272,21 @@ public class TransferCommandController {
   }
 
   /** 송금 preview target 계좌 요약. 계좌번호는 확인용 마지막 4자리만 노출합니다. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public record TransferPreviewAccountResponse(
-      long accountId,
+      Long accountId,
       String maskedAccountNumber,
       String displayName,
       String accountStatus,
       String currencyCode) {
 
-    static TransferPreviewAccountResponse from(AccountSummary summary) {
+    static TransferPreviewAccountResponse from(AccountSummary summary, boolean exposeInternal) {
       return new TransferPreviewAccountResponse(
-          summary.accountId(),
+          exposeInternal ? summary.accountId() : null,
           maskAccountNumber(summary.accountNumber()),
           summary.displayName(),
-          summary.accountStatus(),
-          summary.currencyCode());
+          exposeInternal ? summary.accountStatus() : null,
+          exposeInternal ? summary.currencyCode() : null);
     }
 
     private static String maskAccountNumber(String accountNumber) {
@@ -279,7 +317,8 @@ public class TransferCommandController {
   /** 송금 요청 body */
   public record TransferRequest(
       @Positive(message = "sourceAccountId must be positive") long sourceAccountId,
-      @Positive(message = "targetAccountId must be positive") long targetAccountId,
+      @Positive(message = "targetAccountId must be positive") Long targetAccountId,
+      @Size(max = 20, message = "targetAccountNumber must be 20 characters or less") String targetAccountNumber,
       @Positive(message = "amountMinor must be positive") long amountMinor,
       @NotBlank(message = "currencyCode is required") @Pattern(
               regexp = "^[A-Z]{3}$",

--- a/back/src/main/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptor.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptor.java
@@ -34,7 +34,14 @@ public class CurrentSessionActiveInterceptor implements HandlerInterceptor {
           new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/auth/mfa/totp/disable$")),
           new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/auth/mfa/backup-codes$")),
           new SensitiveMutationPath("DELETE", Pattern.compile("^/api/v1/auth/sessions$")),
-          new SensitiveMutationPath("DELETE", Pattern.compile("^/api/v1/auth/sessions/[^/]+$")));
+          new SensitiveMutationPath("DELETE", Pattern.compile("^/api/v1/auth/sessions/[^/]+$")),
+          new SensitiveMutationPath(
+              "POST", Pattern.compile("^/api/v1/customer-service/applications$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/notifications/preferences$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/notifications/[^/]+/read$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/notifications/read$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/notifications/archive$")),
+          new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/notifications/delete$")));
 
   private final CurrentSessionActiveUseCase currentSessionActiveUseCase;
   private final CurrentSessionActiveAuditPort currentSessionActiveAuditPort;

--- a/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
@@ -46,7 +46,13 @@ public class WebMvcSecurityConfiguration implements WebMvcConfigurer {
             "/api/v1/auth/mfa/totp/disable",
             "/api/v1/auth/mfa/backup-codes",
             "/api/v1/auth/sessions",
-            "/api/v1/auth/sessions/*");
+            "/api/v1/auth/sessions/*",
+            "/api/v1/customer-service/applications",
+            "/api/v1/notifications/preferences",
+            "/api/v1/notifications/*/read",
+            "/api/v1/notifications/read",
+            "/api/v1/notifications/archive",
+            "/api/v1/notifications/delete");
 
     registry
         .addInterceptor(internalServiceTokenAuthenticationInterceptor)

--- a/back/src/test/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/account/usecase/AccountSummaryQueryServiceTest.java
@@ -1,0 +1,66 @@
+package com.aquilabank.domain.account.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.port.AccountSummaryReadPort;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AccountSummaryQueryServiceTest {
+
+  private AccountSummaryReadPort accountSummaryReadPort;
+  private AccountSummaryQueryService service;
+
+  @BeforeEach
+  void setUp() {
+    accountSummaryReadPort = mock(AccountSummaryReadPort.class);
+    service = new AccountSummaryQueryService(accountSummaryReadPort);
+  }
+
+  @Test
+  void returnsAccountSummaryByAccountNumberExactLookup() {
+    AccountSummary summary = account(202L, "999900001234");
+    when(accountSummaryReadPort.findByAccountNumber("999900001234"))
+        .thenReturn(Optional.of(summary));
+
+    AccountSummary result = service.getByAccountNumber("999900001234");
+
+    assertThat(result).isSameAs(summary);
+  }
+
+  @Test
+  void rejectsBlankAccountNumber() {
+    assertThatThrownBy(() -> service.getByAccountNumber(" "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("accountNumber is required");
+  }
+
+  @Test
+  void throwsNotFoundWhenAccountNumberDoesNotExist() {
+    when(accountSummaryReadPort.findByAccountNumber("999900009999")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getByAccountNumber("999900009999"))
+        .isInstanceOf(AccountSummaryNotFoundException.class)
+        .hasMessage("account summary is not found");
+  }
+
+  private static AccountSummary account(long accountId, String accountNumber) {
+    return new AccountSummary(
+        accountId,
+        accountNumber,
+        "홍길동",
+        "ACTIVE",
+        "KRW",
+        0L,
+        0L,
+        Instant.parse("2026-05-11T00:00:00Z"),
+        Instant.parse("2026-05-11T00:00:00Z"));
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/auth/usecase/TotpOperationRequirementServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/auth/usecase/TotpOperationRequirementServiceTest.java
@@ -1,0 +1,49 @@
+package com.aquilabank.domain.auth.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.auth.model.TotpCredential;
+import com.aquilabank.domain.auth.model.TotpCredentialStatus;
+import com.aquilabank.domain.auth.port.TotpCredentialLoadPort;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class TotpOperationRequirementServiceTest {
+
+  private final TotpCredentialLoadPort totpCredentialLoadPort = mock(TotpCredentialLoadPort.class);
+  private final TotpOperationRequirementService service =
+      new TotpOperationRequirementService(totpCredentialLoadPort);
+
+  @Test
+  void requiresVerificationForActiveCredential() {
+    when(totpCredentialLoadPort.findCredentialByUserId(7L))
+        .thenReturn(Optional.of(credential(TotpCredentialStatus.ACTIVE)));
+
+    assertTrue(service.requiresVerification(7L));
+  }
+
+  @Test
+  void doesNotRequireVerificationWhenCredentialIsMissingOrPending() {
+    when(totpCredentialLoadPort.findCredentialByUserId(7L)).thenReturn(Optional.empty());
+    when(totpCredentialLoadPort.findCredentialByUserId(8L))
+        .thenReturn(Optional.of(credential(TotpCredentialStatus.PENDING)));
+
+    assertFalse(service.requiresVerification(7L));
+    assertFalse(service.requiresVerification(8L));
+  }
+
+  @Test
+  void rejectsInvalidUserId() {
+    assertThrows(IllegalArgumentException.class, () -> service.requiresVerification(0L));
+  }
+
+  private static TotpCredential credential(TotpCredentialStatus status) {
+    return new TotpCredential(
+        7L, status, "ciphertext", "nonce", null, Instant.parse("2026-05-11T02:00:00Z"), null);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/account/JdbcAccountSummaryRepositoryIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/account/JdbcAccountSummaryRepositoryIntegrationTest.java
@@ -1,0 +1,94 @@
+package com.aquilabank.global.persistence.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.support.PostgresContainerTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {"spring.flyway.enabled=true", "management.health.db.enabled=true"})
+class JdbcAccountSummaryRepositoryIntegrationTest extends PostgresContainerTestSupport {
+
+  @Autowired private JdbcAccountSummaryRepository repository;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUp() {
+    resetBankingTables(jdbcTemplate);
+  }
+
+  @Test
+  void findsAccountSummaryByAccountNumberExactLookup() {
+    long[] accountId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          accountId[0] = insertAccount("999900001234", "홍길동");
+          insertSnapshot(accountId[0]);
+        });
+
+    AccountSummary result = repository.findByAccountNumber("999900001234").orElseThrow();
+
+    assertThat(result.accountId()).isEqualTo(accountId[0]);
+    assertThat(result.accountNumber()).isEqualTo("999900001234");
+    assertThat(result.displayName()).isEqualTo("홍길동");
+  }
+
+  private long insertAccount(String accountNumber, String displayName) {
+    Long accountId =
+        jdbcTemplate.queryForObject(
+            """
+            INSERT INTO bank_account (
+                account_number,
+                display_name,
+                account_status,
+                currency_code,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                :accountNumber,
+                :displayName,
+                'ACTIVE',
+                'KRW',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            RETURNING id
+            """,
+            new MapSqlParameterSource()
+                .addValue("accountNumber", accountNumber)
+                .addValue("displayName", displayName),
+            Long.class);
+    if (accountId == null) {
+      throw new IllegalStateException("bank_account insert did not return id");
+    }
+    return accountId;
+  }
+
+  private void insertSnapshot(long accountId) {
+    jdbcTemplate.update(
+        """
+        INSERT INTO account_balance_snapshot (
+            account_id,
+            available_balance_minor,
+            pending_balance_minor,
+            currency_code,
+            updated_at
+        )
+        VALUES (:accountId, 0, 0, 'KRW', CURRENT_TIMESTAMP)
+        """,
+        new MapSqlParameterSource().addValue("accountId", accountId));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/auth/LoginAndAccountAccessApiIntegrationTest.java
@@ -117,6 +117,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
   private long userId;
   private long allowedSourceAccountId;
   private long targetAccountId;
+  private String targetAccountNumber;
   private long deniedAccountId;
   private final Map<String, String> refreshDeviceBindingTokenByRefreshToken = new HashMap<>();
 
@@ -129,6 +130,7 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
 
     allowedSourceAccountId = bootstrapAccount("allowed source", 10_000L);
     targetAccountId = bootstrapAccount("allowed target", 0L);
+    targetAccountNumber = loadAccountNumber(targetAccountId);
     deniedAccountId = bootstrapAccount("denied source", 5_000L);
 
     userId = bootstrapUser("alice", "Alice", "password123!");
@@ -152,13 +154,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                         """
                         {
                           "sourceAccountId": %d,
-                          "targetAccountId": %d,
+                          "targetAccountNumber": "%s",
                           "amountMinor": 1500,
                           "currencyCode": "KRW",
                           "summary": "rent"
                         }
                         """
-                            .formatted(allowedSourceAccountId, targetAccountId)))
+                            .formatted(allowedSourceAccountId, targetAccountNumber)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.sourceAccountId").value(allowedSourceAccountId))
             .andReturn();
@@ -254,13 +256,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                         """
                         {
                           "sourceAccountId": %d,
-                          "targetAccountId": %d,
+                          "targetAccountNumber": "%s",
                           "amountMinor": 1500,
                           "currencyCode": "KRW",
                           "summary": "rent"
                         }
                         """
-                            .formatted(allowedSourceAccountId, targetAccountId)))
+                            .formatted(allowedSourceAccountId, targetAccountNumber)))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -304,13 +306,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """
                     {
                       "sourceAccountId": %d,
-                      "targetAccountId": %d,
+                      "targetAccountNumber": "%s",
                       "amountMinor": 500,
                       "currencyCode": "KRW",
                       "summary": "locked-blocked"
                     }
                     """
-                        .formatted(allowedSourceAccountId, targetAccountId)))
+                        .formatted(allowedSourceAccountId, targetAccountNumber)))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
 
@@ -350,13 +352,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                         """
                         {
                           "sourceAccountId": %d,
-                          "targetAccountId": %d,
+                          "targetAccountNumber": "%s",
                           "amountMinor": 1500,
                           "currencyCode": "KRW",
                           "summary": "rent"
                         }
                         """
-                            .formatted(allowedSourceAccountId, targetAccountId)))
+                            .formatted(allowedSourceAccountId, targetAccountNumber)))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -399,13 +401,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """
                     {
                       "sourceAccountId": %d,
-                      "targetAccountId": %d,
+                      "targetAccountNumber": "%s",
                       "amountMinor": 500,
                       "currencyCode": "KRW",
                       "summary": "closed-blocked"
                     }
                     """
-                        .formatted(allowedSourceAccountId, targetAccountId)))
+                        .formatted(allowedSourceAccountId, targetAccountNumber)))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
 
@@ -509,13 +511,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                         """
                         {
                           "sourceAccountId": %d,
-                          "targetAccountId": %d,
+                          "targetAccountNumber": "%s",
                           "amountMinor": 1500,
                           "currencyCode": "KRW",
                           "summary": "rent"
                         }
                         """
-                            .formatted(allowedSourceAccountId, targetAccountId)))
+                            .formatted(allowedSourceAccountId, targetAccountNumber)))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -575,13 +577,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """
                     {
                       "sourceAccountId": %d,
-                      "targetAccountId": %d,
+                      "targetAccountNumber": "%s",
                       "amountMinor": 500,
                       "currencyCode": "KRW",
                       "summary": "blocked"
                     }
                     """
-                        .formatted(deniedAccountId, targetAccountId)))
+                        .formatted(deniedAccountId, targetAccountNumber)))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
   }
@@ -633,13 +635,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """
                     {
                       "sourceAccountId": %d,
-                      "targetAccountId": %d,
+                      "targetAccountNumber": "%s",
                       "amountMinor": 500,
                       "currencyCode": "KRW",
                       "summary": "viewer-blocked"
                     }
                     """
-                        .formatted(allowedSourceAccountId, targetAccountId)))
+                        .formatted(allowedSourceAccountId, targetAccountNumber)))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
   }
@@ -1067,13 +1069,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """
                     {
                       "sourceAccountId": %d,
-                      "targetAccountId": %d,
+                      "targetAccountNumber": "%s",
                       "amountMinor": 500,
                       "currencyCode": "KRW",
                       "summary": "revoked-session-blocked"
                     }
                     """
-                        .formatted(allowedSourceAccountId, targetAccountId)))
+                        .formatted(allowedSourceAccountId, targetAccountNumber)))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.message").value("current session is not active"));
 
@@ -1109,13 +1111,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """
                     {
                       "sourceAccountId": %d,
-                      "targetAccountId": %d,
+                      "targetAccountNumber": "%s",
                       "amountMinor": 500,
                       "currencyCode": "KRW",
                       "summary": "legacy-session-blocked"
                     }
                     """
-                        .formatted(allowedSourceAccountId, targetAccountId)))
+                        .formatted(allowedSourceAccountId, targetAccountNumber)))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.message").value("current session is not active"));
 
@@ -1445,13 +1447,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """
                     {
                       "sourceAccountId": %d,
-                      "targetAccountId": %d,
+                      "targetAccountNumber": "%s",
                       "amountMinor": 500,
                       "currencyCode": "KRW",
                       "summary": "disabled-blocked"
                     }
                     """
-                        .formatted(allowedSourceAccountId, targetAccountId)))
+                        .formatted(allowedSourceAccountId, targetAccountNumber)))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.message").value("current session is not active"));
   }
@@ -1547,13 +1549,13 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
                     """
                     {
                       "sourceAccountId": %d,
-                      "targetAccountId": %d,
+                      "targetAccountNumber": "%s",
                       "amountMinor": 500,
                       "currencyCode": "KRW",
                       "summary": "revoked-blocked"
                     }
                     """
-                        .formatted(allowedSourceAccountId, targetAccountId)))
+                        .formatted(allowedSourceAccountId, targetAccountNumber)))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("account access is denied"));
 
@@ -2893,6 +2895,22 @@ class LoginAndAccountAccessApiIntegrationTest extends PostgresContainerTestSuppo
         .stream()
         .findFirst()
         .orElseThrow(() -> new AssertionError("refresh token session id is not found"));
+  }
+
+  private String loadAccountNumber(long accountId) {
+    return jdbcTemplate
+        .query(
+            """
+            SELECT account_number
+            FROM bank_account
+            WHERE id = :accountId
+            """,
+            new org.springframework.jdbc.core.namedparam.MapSqlParameterSource()
+                .addValue("accountId", accountId),
+            (rs, rowNum) -> rs.getString("account_number"))
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("account number is not found"));
   }
 
   private TotpCredentialView loadTotpCredential(long userId) {

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -108,14 +108,45 @@ class TransferCommandControllerTest {
   void previewsOperationOtpRequirementForJwtUser() throws Exception {
     authenticateUser(7L);
     when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(true);
-    stubPreview(
+    stubUserPreview(
         account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L),
         account(202L, "999900001234", "홍길동", "ACTIVE", 0L),
         1_000L);
 
     performUserPreview(1_500L, "KRW")
         .andExpect(status().isOk())
+        .andExpect(jsonPath("$.targetAccount.accountId").doesNotExist())
+        .andExpect(jsonPath("$.targetAccount.accountStatus").doesNotExist())
+        .andExpect(jsonPath("$.targetAccount.currencyCode").doesNotExist())
         .andExpect(jsonPath("$.otpRequired").value(true));
+  }
+
+  @Test
+  void rejectsUserPreviewWithoutTargetAccountNumber() throws Exception {
+    authenticateUser(7L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/transfers/preview")
+                .queryParam("sourceAccountId", "101")
+                .queryParam("targetAccountId", "202")
+                .queryParam("amountMinor", "1500")
+                .queryParam("currencyCode", "KRW"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("targetAccountNumber is required"));
+  }
+
+  @Test
+  void rejectsBootstrapPreviewWithoutTargetAccountId() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/transfers/preview")
+                .header("X-Account-Id", "101")
+                .queryParam("sourceAccountId", "101")
+                .queryParam("amountMinor", "1500")
+                .queryParam("currencyCode", "KRW"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("targetAccountId is required"));
   }
 
   @Test
@@ -258,6 +289,8 @@ class TransferCommandControllerTest {
   void verifiesUserTransferOperationTotpBeforeCommandExecution() throws Exception {
     authenticateUser(7L);
     when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(true);
+    when(accountSummaryQueryUseCase.getByAccountNumber("999900001234"))
+        .thenReturn(account(202L, "999900001234", "홍길동", "ACTIVE", 0L));
     when(transferCommandUseCase.transfer(argThat(command -> command.sourceAccountId() == 101L)))
         .thenReturn(
             new TransferResult(
@@ -282,7 +315,7 @@ class TransferCommandControllerTest {
                     """
                     {
                       "sourceAccountId": 101,
-                      "targetAccountId": 202,
+                      "targetAccountNumber": "999900001234",
                       "amountMinor": 1500,
                       "currencyCode": "KRW",
                       "summary": "rent",
@@ -294,7 +327,60 @@ class TransferCommandControllerTest {
 
     verify(totpOperationVerifyUseCase).verify(eq(new TotpOperationVerifyCommand(7L, "123456")));
     verify(transferCommandUseCase)
-        .transfer(argThat(command -> "transfer-user-002".equals(command.idempotencyKey())));
+        .transfer(
+            argThat(
+                command ->
+                    "transfer-user-002".equals(command.idempotencyKey())
+                        && command.targetAccountId() == 202L));
+  }
+
+  @Test
+  void rejectsUserTransferWithoutTargetAccountNumber() throws Exception {
+    authenticateUser(7L);
+    when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(false);
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Idempotency-Key", "transfer-user-003")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": 101,
+                      "targetAccountId": 202,
+                      "amountMinor": 1500,
+                      "currencyCode": "KRW",
+                      "summary": "rent"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("targetAccountNumber is required"));
+
+    verifyNoInteractions(transferCommandUseCase);
+  }
+
+  @Test
+  void rejectsBootstrapTransferWithoutTargetAccountId() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("X-Account-Id", "101")
+                .header("Idempotency-Key", "transfer-bootstrap-missing-target")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": 101,
+                      "amountMinor": 1500,
+                      "currencyCode": "KRW",
+                      "summary": "rent"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("targetAccountId is required"));
+
+    verifyNoInteractions(transferCommandUseCase);
   }
 
   @Test
@@ -472,6 +558,22 @@ class TransferCommandControllerTest {
         .thenReturn(dailyUsedMinor);
   }
 
+  private void stubUserPreview(
+      AccountSummary sourceAccount, AccountSummary targetAccount, long dailyUsedMinor) {
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(101L)))
+        .thenReturn(101L);
+    when(accountSummaryQueryUseCase.getByAccountId(101L)).thenReturn(sourceAccount);
+    when(accountSummaryQueryUseCase.getByAccountNumber(targetAccount.accountNumber()))
+        .thenReturn(targetAccount);
+    when(transferLimitUsageReadPort.sumBookedDebitAmountMinor(
+            org.mockito.ArgumentMatchers.eq(101L),
+            org.mockito.ArgumentMatchers.eq("KRW"),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(dailyUsedMinor);
+  }
+
   private ResultActions performPreview(long amountMinor, String currencyCode) throws Exception {
     return mockMvc.perform(
         get("/api/v1/transfers/preview")
@@ -486,7 +588,7 @@ class TransferCommandControllerTest {
     return mockMvc.perform(
         get("/api/v1/transfers/preview")
             .queryParam("sourceAccountId", "101")
-            .queryParam("targetAccountId", "202")
+            .queryParam("targetAccountNumber", "999900001234")
             .queryParam("amountMinor", String.valueOf(amountMinor))
             .queryParam("currencyCode", currencyCode));
   }

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -1,8 +1,10 @@
 package com.aquilabank.global.web.ledger;
 
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,12 +13,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.aquilabank.domain.account.model.AccountSummary;
 import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.domain.auth.model.TotpOperationVerifyCommand;
+import com.aquilabank.domain.auth.usecase.TotpOperationRequirementUseCase;
+import com.aquilabank.domain.auth.usecase.TotpOperationVerifyUseCase;
 import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.model.TransferReversalResult;
 import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
 import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
 import com.aquilabank.global.config.TransferLimitPolicyProperties;
+import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
@@ -24,9 +30,13 @@ import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -38,6 +48,8 @@ class TransferCommandControllerTest {
   private RequestAccountAuthorizationService requestAccountAuthorizationService;
   private AccountSummaryQueryUseCase accountSummaryQueryUseCase;
   private TransferLimitUsageReadPort transferLimitUsageReadPort;
+  private TotpOperationRequirementUseCase totpOperationRequirementUseCase;
+  private TotpOperationVerifyUseCase totpOperationVerifyUseCase;
   private MockMvc mockMvc;
 
   @BeforeEach
@@ -47,6 +59,8 @@ class TransferCommandControllerTest {
     requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
     accountSummaryQueryUseCase = mock(AccountSummaryQueryUseCase.class);
     transferLimitUsageReadPort = mock(TransferLimitUsageReadPort.class);
+    totpOperationRequirementUseCase = mock(TotpOperationRequirementUseCase.class);
+    totpOperationVerifyUseCase = mock(TotpOperationVerifyUseCase.class);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new TransferCommandController(
@@ -55,12 +69,20 @@ class TransferCommandControllerTest {
                     requestAccountAuthorizationService,
                     accountSummaryQueryUseCase,
                     transferLimitUsageReadPort,
+                    totpOperationRequirementUseCase,
+                    totpOperationVerifyUseCase,
                     new TransferLimitPolicyProperties(2_000L, 3_000L, "Asia/Seoul"),
                     Clock.fixed(Instant.parse("2026-05-11T01:00:00Z"), ZoneOffset.UTC)))
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .setControllerAdvice(new ApiExceptionHandler())
             .build();
+    SecurityContextHolder.clearContext();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
   }
 
   @Test
@@ -79,6 +101,20 @@ class TransferCommandControllerTest {
         .andExpect(jsonPath("$.dailyTransferLimitMinor").value(3000))
         .andExpect(jsonPath("$.dailyUsedMinor").value(1000))
         .andExpect(jsonPath("$.allowed").value(true))
+        .andExpect(jsonPath("$.otpRequired").value(true));
+  }
+
+  @Test
+  void previewsOperationOtpRequirementForJwtUser() throws Exception {
+    authenticateUser(7L);
+    when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(true);
+    stubPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L),
+        account(202L, "999900001234", "홍길동", "ACTIVE", 0L),
+        1_000L);
+
+    performUserPreview(1_500L, "KRW")
+        .andExpect(status().isOk())
         .andExpect(jsonPath("$.otpRequired").value(true));
   }
 
@@ -192,6 +228,76 @@ class TransferCommandControllerTest {
   }
 
   @Test
+  void rejectsUserTransferWhenOperationTotpIsRequiredAndMissing() throws Exception {
+    authenticateUser(7L);
+    when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(true);
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Idempotency-Key", "transfer-user-001")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": 101,
+                      "targetAccountId": 202,
+                      "amountMinor": 1500,
+                      "currencyCode": "KRW",
+                      "summary": "rent"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("totpCode is required"));
+
+    verifyNoInteractions(totpOperationVerifyUseCase);
+    verifyNoInteractions(transferCommandUseCase);
+  }
+
+  @Test
+  void verifiesUserTransferOperationTotpBeforeCommandExecution() throws Exception {
+    authenticateUser(7L);
+    when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(true);
+    when(transferCommandUseCase.transfer(argThat(command -> command.sourceAccountId() == 101L)))
+        .thenReturn(
+            new TransferResult(
+                "TRX-USER-1",
+                101L,
+                202L,
+                1500L,
+                "KRW",
+                8500L,
+                java.time.Instant.parse("2026-04-16T10:00:00Z"),
+                "BOOKED"));
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Idempotency-Key", "transfer-user-002")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": 101,
+                      "targetAccountId": 202,
+                      "amountMinor": 1500,
+                      "currencyCode": "KRW",
+                      "summary": "rent",
+                      "totpCode": "123456"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.transactionReference").value("TRX-USER-1"));
+
+    verify(totpOperationVerifyUseCase).verify(eq(new TotpOperationVerifyCommand(7L, "123456")));
+    verify(transferCommandUseCase)
+        .transfer(argThat(command -> "transfer-user-002".equals(command.idempotencyKey())));
+  }
+
+  @Test
   void reversesTransferUsingAuthenticatedAccountAndIdempotencyKey() throws Exception {
     when(transferReversalUseCase.reverse(
             argThat(command -> "TRX-1".equals(command.originalTransactionReference()))))
@@ -236,6 +342,50 @@ class TransferCommandControllerTest {
                 command ->
                     "reversal-001".equals(command.idempotencyKey())
                         && Long.valueOf(700L).equals(command.amountMinor())));
+  }
+
+  @Test
+  void verifiesUserReversalOperationTotpBeforeCommandExecution() throws Exception {
+    authenticateUser(7L);
+    when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(true);
+    when(transferReversalUseCase.reverse(
+            argThat(command -> "TRX-1".equals(command.originalTransactionReference()))))
+        .thenReturn(
+            new TransferReversalResult(
+                "TRX-1",
+                "TRX-2",
+                101L,
+                202L,
+                1500L,
+                "KRW",
+                10_000L,
+                java.time.Instant.parse("2026-04-16T10:10:00Z"),
+                "REVERSED"));
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), eq(101L)))
+        .thenReturn(101L);
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers/TRX-1/reversal")
+                .header("Idempotency-Key", "reversal-user-001")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": 101,
+                      "amountMinor": 700,
+                      "reversalReason": "CANCEL",
+                      "summary": "cancel transfer",
+                      "totpCode": "123456"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.reversalTransactionReference").value("TRX-2"));
+
+    verify(totpOperationVerifyUseCase).verify(eq(new TotpOperationVerifyCommand(7L, "123456")));
+    verify(transferReversalUseCase)
+        .reverse(argThat(command -> "reversal-user-001".equals(command.idempotencyKey())));
   }
 
   @Test
@@ -330,5 +480,21 @@ class TransferCommandControllerTest {
             .queryParam("targetAccountId", "202")
             .queryParam("amountMinor", String.valueOf(amountMinor))
             .queryParam("currencyCode", currencyCode));
+  }
+
+  private ResultActions performUserPreview(long amountMinor, String currencyCode) throws Exception {
+    return mockMvc.perform(
+        get("/api/v1/transfers/preview")
+            .queryParam("sourceAccountId", "101")
+            .queryParam("targetAccountId", "202")
+            .queryParam("amountMinor", String.valueOf(amountMinor))
+            .queryParam("currencyCode", currencyCode));
+  }
+
+  private void authenticateUser(long userId) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            UsernamePasswordAuthenticationToken.authenticated(
+                new AuthenticatedUserPrincipal(userId, "tester"), null, List.of()));
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/notification/NotificationApiIntegrationTest.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Date;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1318,12 +1319,14 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
 
   private String issueToken(String subject, long userId) throws JOSEException {
     Instant now = Instant.now();
+    long sessionId = insertActiveRefreshTokenSession(userId, now);
     JWTClaimsSet claimsSet =
         new JWTClaimsSet.Builder()
             .subject(subject)
             .issueTime(Date.from(now))
             .expirationTime(Date.from(now.plusSeconds(300)))
             .claim("user_id", userId)
+            .claim("session_id", sessionId)
             .build();
 
     SignedJWT signedJwt =
@@ -1331,5 +1334,48 @@ class NotificationApiIntegrationTest extends PostgresContainerTestSupport {
             new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JWT).build(), claimsSet);
     signedJwt.sign(new MACSigner(TEST_SECRET.getBytes(StandardCharsets.UTF_8)));
     return signedJwt.serialize();
+  }
+
+  private long insertActiveRefreshTokenSession(long userId, Instant now) {
+    long[] sessionId = new long[1];
+    commit(
+        transactionManager,
+        () -> {
+          Long insertedId =
+              jdbcTemplate.queryForObject(
+                  """
+                  INSERT INTO auth_refresh_token_session (
+                      user_id,
+                      token_hash,
+                      session_status,
+                      expires_at,
+                      created_at,
+                      updated_at
+                  )
+                  VALUES (
+                      :userId,
+                      :tokenHash,
+                      'ACTIVE',
+                      :expiresAt,
+                      :now,
+                      :now
+                  )
+                  RETURNING id
+                  """,
+                  new MapSqlParameterSource()
+                      .addValue("userId", userId)
+                      .addValue("tokenHash", UUID.randomUUID().toString().replace("-", ""))
+                      .addValue("expiresAt", Timestamp.from(now.plusSeconds(600)))
+                      .addValue("now", Timestamp.from(now)),
+                  Long.class);
+          if (insertedId == null) {
+            throw new IllegalStateException("auth_refresh_token_session insert did not return id");
+          }
+          sessionId[0] = insertedId;
+        });
+    if (sessionId[0] <= 0) {
+      throw new IllegalStateException("auth_refresh_token_session insert did not return id");
+    }
+    return sessionId[0];
   }
 }

--- a/back/src/test/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptorTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptorTest.java
@@ -63,7 +63,13 @@ class CurrentSessionActiveInterceptorTest {
             new RequestPath("POST", "/api/v1/auth/mfa/totp/disable"),
             new RequestPath("POST", "/api/v1/auth/mfa/backup-codes"),
             new RequestPath("DELETE", "/api/v1/auth/sessions"),
-            new RequestPath("DELETE", "/api/v1/auth/sessions/11"));
+            new RequestPath("DELETE", "/api/v1/auth/sessions/11"),
+            new RequestPath("POST", "/api/v1/customer-service/applications"),
+            new RequestPath("POST", "/api/v1/notifications/preferences"),
+            new RequestPath("POST", "/api/v1/notifications/10/read"),
+            new RequestPath("POST", "/api/v1/notifications/read"),
+            new RequestPath("POST", "/api/v1/notifications/archive"),
+            new RequestPath("POST", "/api/v1/notifications/delete"));
 
     for (RequestPath item : items) {
       assertTrue(interceptor.preHandle(request(item.method(), item.path()), response(), null));

--- a/front/src/components/customer-banking/sections/transfer-section.tsx
+++ b/front/src/components/customer-banking/sections/transfer-section.tsx
@@ -91,7 +91,7 @@ export function TransferSection({
   reversalResult: TransferReversalResponse | null;
   transferForm: {
     sourceAccountId: string;
-    targetAccountId: string;
+    targetAccountNumber: string;
     amountMinor: string;
     currencyCode: string;
     summary: string;
@@ -107,10 +107,10 @@ export function TransferSection({
     reversalReason: string;
     summary: string;
   }) => void;
-  onTransfer: (event: FormEvent<HTMLFormElement>) => Promise<boolean>;
+  onTransfer: (event: FormEvent<HTMLFormElement>, totpCode?: string) => Promise<boolean>;
   onTransferChange: (value: {
     sourceAccountId: string;
-    targetAccountId: string;
+    targetAccountNumber: string;
     amountMinor: string;
     currencyCode: string;
     summary: string;
@@ -157,7 +157,7 @@ export function TransferSection({
     }
 
     setTransferStep("submitting");
-    const ok = await onTransfer(event);
+    const ok = await onTransfer(event, otpRequired ? otpCode : undefined);
     setTransferStep(ok ? "complete" : "failed");
   }
 
@@ -193,7 +193,7 @@ export function TransferSection({
             ? "입력 다시 확인"
           : "받는 분 확인";
   const sourceAccountError = transferForm.sourceAccountId ? "" : "출금계좌를 입력하세요.";
-  const targetAccountError = transferForm.targetAccountId ? "" : "입금계좌를 입력하세요.";
+  const targetAccountError = transferForm.targetAccountNumber ? "" : "입금계좌를 입력하세요.";
   const amountError = amountMinor > 0 ? "" : "이체금액을 입력하세요.";
   const summaryError = transferForm.summary ? "" : "받는 분 통장 표시를 입력하세요.";
   const otpError =
@@ -296,7 +296,7 @@ export function TransferSection({
               <strong>
                 {transferPreview
                   ? `${transferPreview.targetAccount.displayName} ${transferPreview.targetAccount.maskedAccountNumber}`
-                  : `계좌 ID ${transferForm.targetAccountId || "-"}`}
+                  : `계좌번호 ${transferForm.targetAccountNumber || "-"}`}
               </strong>
               <small>{blockedReasonLabel}</small>
             </div>
@@ -341,15 +341,15 @@ export function TransferSection({
             <BankInput
               error={targetAccountError}
               inputMode="numeric"
-              label="입금계좌 ID"
+              label="입금계좌번호"
               onChange={(event) =>
                 updateTransferForm({
                   ...transferForm,
-                  targetAccountId: event.target.value,
+                  targetAccountNumber: event.target.value,
                 })
               }
               required
-              value={transferForm.targetAccountId}
+              value={transferForm.targetAccountNumber}
             />
             <BankInput
               error={amountError}
@@ -392,7 +392,7 @@ export function TransferSection({
               <strong>이체정보 확인</strong>
               <span>
                 출금계좌 {transferForm.sourceAccountId}에서 입금계좌{" "}
-                {transferForm.targetAccountId}로{" "}
+                {transferForm.targetAccountNumber}로{" "}
                 {formatMinorAmount(
                   Number(transferForm.amountMinor || 0),
                   transferForm.currencyCode,

--- a/front/src/hooks/use-customer-banking.ts
+++ b/front/src/hooks/use-customer-banking.ts
@@ -50,7 +50,7 @@ export function useCustomerBanking() {
     useState<AccountSummaryResponse | null>(null);
   const [transferForm, setTransferForm] = useState({
     sourceAccountId: "",
-    targetAccountId: "",
+    targetAccountNumber: "",
     amountMinor: "",
     currencyCode: "KRW",
     summary: "",
@@ -403,7 +403,7 @@ export function useCustomerBanking() {
     });
   }
 
-  async function handleTransfer(event: FormEvent<HTMLFormElement>) {
+  async function handleTransfer(event: FormEvent<HTMLFormElement>, totpCode = "") {
     event.preventDefault();
     if (!requireSession()) {
       return false;
@@ -412,10 +412,11 @@ export function useCustomerBanking() {
       const result = await api.transfer(
         {
           sourceAccountId: Number(transferForm.sourceAccountId),
-          targetAccountId: Number(transferForm.targetAccountId),
+          targetAccountNumber: transferForm.targetAccountNumber,
           amountMinor: Number(transferForm.amountMinor),
           currencyCode: transferForm.currencyCode,
           summary: transferForm.summary,
+          totpCode: totpCode || undefined,
         },
       );
       setTransferResult(result);
@@ -439,7 +440,7 @@ export function useCustomerBanking() {
     return runAction("받는 사람 검증", async () => {
       const result = await api.previewTransfer({
         sourceAccountId: Number(transferForm.sourceAccountId),
-        targetAccountId: Number(transferForm.targetAccountId),
+        targetAccountNumber: transferForm.targetAccountNumber,
         amountMinor: Number(transferForm.amountMinor),
         currencyCode: transferForm.currencyCode,
       });

--- a/front/src/lib/api/types.ts
+++ b/front/src/lib/api/types.ts
@@ -130,25 +130,26 @@ export type AccountSummaryResponse = AccountItem;
 
 export type TransferRequest = {
   sourceAccountId: number;
-  targetAccountId: number;
+  targetAccountNumber: string;
   amountMinor: number;
   currencyCode: string;
   summary: string;
+  totpCode?: string;
 };
 
 export type TransferPreviewRequest = {
   sourceAccountId: number;
-  targetAccountId: number;
+  targetAccountNumber: string;
   amountMinor: number;
   currencyCode: string;
 };
 
 export type TransferPreviewAccount = {
-  accountId: number;
+  accountId?: number;
   maskedAccountNumber: string;
   displayName: string;
-  accountStatus: string;
-  currencyCode: string;
+  accountStatus?: string;
+  currencyCode?: string;
 };
 
 export type TransferPreviewResponse = {


### PR DESCRIPTION
## 🔗 Related Issue
- close #944

## 🌿 Base Branch
- `main`

## 📝 Summary
- 이체 실행/reversal에 operation TOTP 검증을 연결해 preview의 `otpRequired`와 실제 실행 보안 흐름을 맞췄다.
- 고객센터/보안센터 신청과 알림 상태 변경 mutation을 current-session-active gate에 포함했다.
- JWT 사용자 이체 수취인 입력을 내부 `targetAccountId`에서 `targetAccountNumber` 기반 exact lookup으로 전환하고 preview 노출을 줄였다.

## 🛠 Changes
- `TransferCommandController`에서 활성 TOTP credential 보유 사용자는 `totpCode` 검증 후 이체/취소 use case로 진입한다.
- `POST /api/v1/customer-service/applications`, 알림 preference/read/archive/delete mutation을 현재 세션 ACTIVE 재확인 대상에 추가했다.
- 계좌 요약 조회에 account number exact lookup 포트/서비스/저장소를 추가하고, 공개 JWT 사용자 이체 preview/execute는 `targetAccountNumber`를 요구한다.
- 프런트 이체 요청 타입/화면도 `targetAccountNumber`와 `totpCode` 전송 계약에 맞췄다.
- 신청 접수 이후 심사/승인/실행 엔진은 이번 보안 보강 범위 밖으로 유지했다.

## 🎯 Scope
- [x] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*TotpOperationRequirementServiceTest' --tests '*TransferCommandControllerTest'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back spotlessApply integrationTest --tests '*NotificationApiIntegrationTest' test --tests '*CurrentSessionActiveInterceptorTest'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*AccountSummaryQueryServiceTest' --tests '*TransferCommandControllerTest' integrationTest --tests '*JdbcAccountSummaryRepositoryIntegrationTest'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back test --tests '*TransferCommandControllerTest' integrationTest --tests '*LoginAndAccountAccessApiIntegrationTest'`
- `tools/test/with-resource-lock.sh backend ./back/gradlew -p back integrationTest --tests '*PrometheusMetricsIntegrationTest'`
- `./back/gradlew -p back check` via pre-commit hook
- `yarn --cwd front lint`
- `git rev-list --count main..HEAD` = `3`

## 📸 Screenshot / API Example
- API 계약 변경: JWT 사용자 이체 요청은 `targetAccountNumber`를 사용하고, operation MFA 필요 시 `totpCode`를 함께 보낸다.

```json
{
  "sourceAccountId": 101,
  "targetAccountNumber": "999900001234",
  "amountMinor": 1500,
  "currencyCode": "KRW",
  "summary": "rent",
  "totpCode": "123456"
}
```

## ⚠️ Risk & Rollback
- 예상 리스크: JWT 사용자 이체 API 요청 계약이 `targetAccountNumber` 기반으로 바뀌어 기존 내부 ID 기반 호출은 400을 받는다. 활성 세션이 아닌 access token의 민감 mutation은 401로 차단된다.
- 롤백 방법: 이 PR revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
