### PR TITLE
[Feat] 웹뱅킹 신청 실행 경계와 민감 보안 보강

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/customerapplication/exception/CustomerApplicationInvalidTransitionException.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/exception/CustomerApplicationInvalidTransitionException.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.customerapplication.exception;
+
+public class CustomerApplicationInvalidTransitionException extends RuntimeException {
+
+  public CustomerApplicationInvalidTransitionException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/exception/CustomerApplicationNotFoundException.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/exception/CustomerApplicationNotFoundException.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.customerapplication.exception;
+
+public class CustomerApplicationNotFoundException extends RuntimeException {
+
+  public CustomerApplicationNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationAction.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationAction.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.customerapplication.model;
+
+public enum CustomerApplicationAction {
+  START_REVIEW,
+  APPROVE,
+  REJECT,
+  CANCEL,
+  EXECUTE
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationDecisionCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationDecisionCommand.java
@@ -1,0 +1,28 @@
+package com.aquilabank.domain.customerapplication.model;
+
+/** 운영자 검토/승인/실행 요청은 내부 service token subject와 request id를 감사 기준으로 저장합니다. */
+public record CustomerApplicationDecisionCommand(
+    String applicationReference,
+    CustomerApplicationAction action,
+    String actorSubject,
+    String reason,
+    String requestId) {
+
+  public CustomerApplicationDecisionCommand {
+    if (applicationReference == null || applicationReference.isBlank()) {
+      throw new IllegalArgumentException("applicationReference is required");
+    }
+    if (action == null) {
+      throw new IllegalArgumentException("action is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (reason != null && reason.length() > 300) {
+      throw new IllegalArgumentException("reason must be 300 characters or less");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationDetails.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationDetails.java
@@ -1,0 +1,57 @@
+package com.aquilabank.domain.customerapplication.model;
+
+import java.time.Instant;
+import java.util.Map;
+
+/** 운영/실행 경로에서 payload와 마지막 처리 결과까지 함께 보는 신청 상세 모델입니다. */
+public record CustomerApplicationDetails(
+    String applicationReference,
+    long userId,
+    Long accountId,
+    CustomerApplicationType applicationType,
+    CustomerApplicationStatus status,
+    boolean mfaVerified,
+    Instant mfaVerifiedAt,
+    Map<String, Object> payload,
+    Instant submittedAt,
+    Instant updatedAt,
+    String reason,
+    String processedBy,
+    Instant processedAt,
+    Map<String, Object> executionResult) {
+
+  public CustomerApplicationDetails {
+    if (applicationReference == null || applicationReference.isBlank()) {
+      throw new IllegalArgumentException("applicationReference is required");
+    }
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId != null && accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (applicationType == null) {
+      throw new IllegalArgumentException("applicationType is required");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+    if (mfaVerified && mfaVerifiedAt == null) {
+      throw new IllegalArgumentException("mfaVerifiedAt is required");
+    }
+    if (payload == null) {
+      throw new IllegalArgumentException("payload is required");
+    }
+    if (submittedAt == null) {
+      throw new IllegalArgumentException("submittedAt is required");
+    }
+    if (updatedAt == null) {
+      throw new IllegalArgumentException("updatedAt is required");
+    }
+    if (executionResult == null) {
+      throw new IllegalArgumentException("executionResult is required");
+    }
+    payload = Map.copyOf(payload);
+    executionResult = Map.copyOf(executionResult);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationExecutionResult.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationExecutionResult.java
@@ -1,0 +1,37 @@
+package com.aquilabank.domain.customerapplication.model;
+
+import java.util.Map;
+
+/** 실행 adapter가 원장 변경 없이 신청 처리 결과만 도메인에 돌려주는 값입니다. */
+public record CustomerApplicationExecutionResult(
+    CustomerApplicationStatus status, String reason, Map<String, Object> payload) {
+
+  public CustomerApplicationExecutionResult {
+    if (status != CustomerApplicationStatus.EXECUTED
+        && status != CustomerApplicationStatus.FAILED) {
+      throw new IllegalArgumentException("execution status must be EXECUTED or FAILED");
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new IllegalArgumentException("reason is required");
+    }
+    if (reason.length() > 300) {
+      throw new IllegalArgumentException("reason must be 300 characters or less");
+    }
+    if (payload == null) {
+      throw new IllegalArgumentException("payload is required");
+    }
+    payload = Map.copyOf(payload);
+  }
+
+  public static CustomerApplicationExecutionResult executed(
+      String reason, Map<String, Object> payload) {
+    return new CustomerApplicationExecutionResult(
+        CustomerApplicationStatus.EXECUTED, reason, payload);
+  }
+
+  public static CustomerApplicationExecutionResult failed(
+      String reason, Map<String, Object> payload) {
+    return new CustomerApplicationExecutionResult(
+        CustomerApplicationStatus.FAILED, reason, payload);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationStateUpdateCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationStateUpdateCommand.java
@@ -1,0 +1,36 @@
+package com.aquilabank.domain.customerapplication.model;
+
+import java.time.Instant;
+import java.util.Map;
+
+/** 상태전이는 단일 row lock 안에서 최종 상태와 처리자 정보를 함께 갱신합니다. */
+public record CustomerApplicationStateUpdateCommand(
+    String applicationReference,
+    CustomerApplicationStatus status,
+    String reason,
+    String actorSubject,
+    Instant processedAt,
+    Map<String, Object> executionResult) {
+
+  public CustomerApplicationStateUpdateCommand {
+    if (applicationReference == null || applicationReference.isBlank()) {
+      throw new IllegalArgumentException("applicationReference is required");
+    }
+    if (status == null) {
+      throw new IllegalArgumentException("status is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (processedAt == null) {
+      throw new IllegalArgumentException("processedAt is required");
+    }
+    if (reason != null && reason.length() > 300) {
+      throw new IllegalArgumentException("reason must be 300 characters or less");
+    }
+    if (executionResult == null) {
+      throw new IllegalArgumentException("executionResult is required");
+    }
+    executionResult = Map.copyOf(executionResult);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationStatus.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationStatus.java
@@ -2,8 +2,24 @@ package com.aquilabank.domain.customerapplication.model;
 
 public enum CustomerApplicationStatus {
   SUBMITTED,
-  IN_REVIEW,
-  COMPLETED,
+  REVIEWING,
+  APPROVED,
+  EXECUTED,
+  FAILED,
   REJECTED,
-  CANCELLED
+  CANCELLED,
+  // 기존 row 호환용 legacy 상태입니다. 신규 상태전이는 REVIEWING/EXECUTED를 사용합니다.
+  IN_REVIEW,
+  COMPLETED;
+
+  public boolean isTerminal() {
+    return switch (this) {
+      case EXECUTED, FAILED, REJECTED, CANCELLED, COMPLETED -> true;
+      default -> false;
+    };
+  }
+
+  public boolean isReviewingState() {
+    return this == REVIEWING || this == IN_REVIEW;
+  }
 }

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerTransferLimitPolicyCommand.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerTransferLimitPolicyCommand.java
@@ -1,0 +1,43 @@
+package com.aquilabank.domain.customerapplication.model;
+
+import java.time.Instant;
+
+/** 한도 변경 신청 실행 결과를 실제 계좌별 송금 한도로 반영하는 command입니다. */
+public record CustomerTransferLimitPolicyCommand(
+    long userId,
+    long accountId,
+    long singleTransferLimitMinor,
+    long dailyTransferLimitMinor,
+    String applicationReference,
+    String actorSubject,
+    String requestId,
+    Instant approvedAt) {
+
+  public CustomerTransferLimitPolicyCommand {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+    if (accountId <= 0) {
+      throw new IllegalArgumentException("accountId must be positive");
+    }
+    if (singleTransferLimitMinor <= 0) {
+      throw new IllegalArgumentException("singleTransferLimitMinor must be positive");
+    }
+    if (dailyTransferLimitMinor < singleTransferLimitMinor) {
+      throw new IllegalArgumentException(
+          "dailyTransferLimitMinor must be greater than or equal to singleTransferLimitMinor");
+    }
+    if (applicationReference == null || applicationReference.isBlank()) {
+      throw new IllegalArgumentException("applicationReference is required");
+    }
+    if (actorSubject == null || actorSubject.isBlank()) {
+      throw new IllegalArgumentException("actorSubject is required");
+    }
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    if (approvedAt == null) {
+      throw new IllegalArgumentException("approvedAt is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerApplicationExecutorPort.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerApplicationExecutorPort.java
@@ -1,0 +1,10 @@
+package com.aquilabank.domain.customerapplication.port;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
+
+public interface CustomerApplicationExecutorPort {
+
+  CustomerApplicationExecutionResult execute(
+      CustomerApplicationDetails application, String actorSubject, String requestId);
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerApplicationOperationPort.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerApplicationOperationPort.java
@@ -1,0 +1,12 @@
+package com.aquilabank.domain.customerapplication.port;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStateUpdateCommand;
+import java.util.Optional;
+
+public interface CustomerApplicationOperationPort {
+
+  Optional<CustomerApplicationDetails> findByReferenceForUpdate(String applicationReference);
+
+  CustomerApplicationDetails updateStatus(CustomerApplicationStateUpdateCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerTransferLimitPolicyPort.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerTransferLimitPolicyPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.customerapplication.port;
+
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitPolicyCommand;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+
+public interface CustomerTransferLimitPolicyPort {
+
+  TransferLimitPolicy applyTransferLimitChange(CustomerTransferLimitPolicyCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorService.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorService.java
@@ -1,0 +1,93 @@
+package com.aquilabank.domain.customerapplication.usecase;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitPolicyCommand;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationExecutorPort;
+import com.aquilabank.domain.customerapplication.port.CustomerTransferLimitPolicyPort;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+/** 외부 기관 연동 없는 신청은 실패로 남기고, 내부 실행 가능한 신청만 실제 policy로 반영합니다. */
+public final class CustomerApplicationExecutorService implements CustomerApplicationExecutorPort {
+
+  private static final String SINGLE_LIMIT_KEY = "singleTransferLimitMinor";
+  private static final String DAILY_LIMIT_KEY = "dailyTransferLimitMinor";
+  private static final String REQUESTED_SINGLE_LIMIT_KEY = "requestedSingleTransferLimitMinor";
+  private static final String REQUESTED_DAILY_LIMIT_KEY = "requestedDailyTransferLimitMinor";
+
+  private final CustomerTransferLimitPolicyPort transferLimitPolicyPort;
+
+  public CustomerApplicationExecutorService(
+      CustomerTransferLimitPolicyPort transferLimitPolicyPort) {
+    this.transferLimitPolicyPort = Objects.requireNonNull(transferLimitPolicyPort);
+  }
+
+  @Override
+  public CustomerApplicationExecutionResult execute(
+      CustomerApplicationDetails application, String actorSubject, String requestId) {
+    if (application.applicationType() == CustomerApplicationType.TRANSFER_LIMIT_CHANGE) {
+      return executeTransferLimitChange(application, actorSubject, requestId);
+    }
+    return CustomerApplicationExecutionResult.failed(
+        "EXTERNAL_EXECUTION_NOT_CONFIGURED",
+        Map.of("applicationType", application.applicationType().name()));
+  }
+
+  private CustomerApplicationExecutionResult executeTransferLimitChange(
+      CustomerApplicationDetails application, String actorSubject, String requestId) {
+    if (application.accountId() == null) {
+      return CustomerApplicationExecutionResult.failed(
+          "TRANSFER_LIMIT_ACCOUNT_REQUIRED",
+          Map.of("applicationType", application.applicationType().name()));
+    }
+    Long singleLimit =
+        longPayloadValue(application.payload(), SINGLE_LIMIT_KEY, REQUESTED_SINGLE_LIMIT_KEY);
+    Long dailyLimit =
+        longPayloadValue(application.payload(), DAILY_LIMIT_KEY, REQUESTED_DAILY_LIMIT_KEY);
+    if (singleLimit == null || dailyLimit == null || dailyLimit < singleLimit) {
+      return CustomerApplicationExecutionResult.failed(
+          "TRANSFER_LIMIT_PAYLOAD_INVALID",
+          Map.of("applicationType", application.applicationType().name()));
+    }
+
+    TransferLimitPolicy policy =
+        transferLimitPolicyPort.applyTransferLimitChange(
+            new CustomerTransferLimitPolicyCommand(
+                application.userId(),
+                application.accountId(),
+                singleLimit,
+                dailyLimit,
+                application.applicationReference(),
+                actorSubject,
+                requestId,
+                Instant.now()));
+    return CustomerApplicationExecutionResult.executed(
+        "TRANSFER_LIMIT_UPDATED",
+        Map.of(
+            "accountId",
+            application.accountId(),
+            "singleTransferLimitMinor",
+            policy.singleTransferLimitMinor(),
+            "dailyTransferLimitMinor",
+            policy.dailyTransferLimitMinor()));
+  }
+
+  private Long longPayloadValue(Map<String, Object> payload, String key, String fallbackKey) {
+    Object value = payload.containsKey(key) ? payload.get(key) : payload.get(fallbackKey);
+    if (value instanceof Number number) {
+      return number.longValue();
+    }
+    if (value instanceof String stringValue && !stringValue.isBlank()) {
+      try {
+        return Long.parseLong(stringValue);
+      } catch (NumberFormatException ex) {
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationService.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationService.java
@@ -1,0 +1,123 @@
+package com.aquilabank.domain.customerapplication.usecase;
+
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationInvalidTransitionException;
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationNotFoundException;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationAction;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDecisionCommand;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStateUpdateCommand;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationExecutorPort;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+/** 고객 업무 상태전이는 row lock 안에서 검증해 중복 승인/실행을 차단합니다. */
+public final class CustomerApplicationOperationService
+    implements CustomerApplicationOperationUseCase {
+
+  private static final Map<CustomerApplicationAction, CustomerApplicationStatus> TARGET_STATUSES =
+      Map.of(
+          CustomerApplicationAction.START_REVIEW, CustomerApplicationStatus.REVIEWING,
+          CustomerApplicationAction.APPROVE, CustomerApplicationStatus.APPROVED,
+          CustomerApplicationAction.REJECT, CustomerApplicationStatus.REJECTED,
+          CustomerApplicationAction.CANCEL, CustomerApplicationStatus.CANCELLED);
+
+  private final CustomerApplicationOperationPort operationPort;
+  private final CustomerApplicationExecutorPort executorPort;
+  private final Clock clock;
+
+  public CustomerApplicationOperationService(
+      CustomerApplicationOperationPort operationPort,
+      CustomerApplicationExecutorPort executorPort,
+      Clock clock) {
+    this.operationPort = Objects.requireNonNull(operationPort);
+    this.executorPort = Objects.requireNonNull(executorPort);
+    this.clock = Objects.requireNonNull(clock);
+  }
+
+  @Override
+  public CustomerApplicationDetails apply(CustomerApplicationDecisionCommand command) {
+    CustomerApplicationDetails application =
+        operationPort
+            .findByReferenceForUpdate(command.applicationReference())
+            .orElseThrow(
+                () ->
+                    new CustomerApplicationNotFoundException("customer application was not found"));
+    Instant now = Instant.now(clock);
+    if (command.action() == CustomerApplicationAction.EXECUTE) {
+      validateTransition(application.status(), command.action());
+      CustomerApplicationExecutionResult result =
+          executorPort.execute(application, command.actorSubject(), command.requestId());
+      return operationPort.updateStatus(
+          new CustomerApplicationStateUpdateCommand(
+              command.applicationReference(),
+              result.status(),
+              result.reason(),
+              command.actorSubject(),
+              now,
+              result.payload()));
+    }
+
+    CustomerApplicationStatus status = targetStatus(application.status(), command.action());
+    return operationPort.updateStatus(
+        new CustomerApplicationStateUpdateCommand(
+            command.applicationReference(),
+            status,
+            normalizeReason(command.reason()),
+            command.actorSubject(),
+            now,
+            application.executionResult()));
+  }
+
+  private CustomerApplicationStatus targetStatus(
+      CustomerApplicationStatus currentStatus, CustomerApplicationAction action) {
+    validateTransition(currentStatus, action);
+    return TARGET_STATUSES.get(action);
+  }
+
+  private void validateTransition(
+      CustomerApplicationStatus currentStatus, CustomerApplicationAction action) {
+    if (currentStatus.isTerminal()) {
+      throw invalidTransition(currentStatus, action);
+    }
+    boolean allowed =
+        switch (action) {
+          case START_REVIEW -> currentStatus == CustomerApplicationStatus.SUBMITTED;
+          case APPROVE ->
+              currentStatus == CustomerApplicationStatus.SUBMITTED
+                  || currentStatus.isReviewingState();
+          case REJECT ->
+              currentStatus == CustomerApplicationStatus.SUBMITTED
+                  || currentStatus.isReviewingState()
+                  || currentStatus == CustomerApplicationStatus.APPROVED;
+          case CANCEL ->
+              currentStatus == CustomerApplicationStatus.SUBMITTED
+                  || currentStatus.isReviewingState();
+          case EXECUTE -> currentStatus == CustomerApplicationStatus.APPROVED;
+        };
+    if (!allowed) {
+      throw invalidTransition(currentStatus, action);
+    }
+  }
+
+  private CustomerApplicationInvalidTransitionException invalidTransition(
+      CustomerApplicationStatus currentStatus, CustomerApplicationAction action) {
+    return new CustomerApplicationInvalidTransitionException(
+        "cannot %s customer application from %s".formatted(action.name(), currentStatus.name()));
+  }
+
+  private String normalizeReason(String reason) {
+    return reason == null || reason.isBlank() ? null : reason;
+  }
+
+  public static CustomerApplicationExecutorPort unsupportedExecutor() {
+    return (application, actorSubject, requestId) ->
+        CustomerApplicationExecutionResult.failed(
+            "EXTERNAL_EXECUTION_NOT_CONFIGURED",
+            Map.of("applicationType", application.applicationType().name()));
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationUseCase.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.customerapplication.usecase;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDecisionCommand;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+
+public interface CustomerApplicationOperationUseCase {
+
+  CustomerApplicationDetails apply(CustomerApplicationDecisionCommand command);
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/port/TransferLimitPolicyOverrideReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/port/TransferLimitPolicyOverrideReadPort.java
@@ -1,0 +1,9 @@
+package com.aquilabank.domain.ledger.port;
+
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import java.util.Optional;
+
+public interface TransferLimitPolicyOverrideReadPort {
+
+  Optional<TransferLimitPolicy> findByAccountId(long accountId);
+}

--- a/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyService.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyService.java
@@ -3,27 +3,32 @@ package com.aquilabank.domain.ledger.usecase;
 import com.aquilabank.domain.ledger.exception.TransferLimitExceededException;
 import com.aquilabank.domain.ledger.model.TransferCommand;
 import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import com.aquilabank.domain.ledger.port.TransferLimitPolicyOverrideReadPort;
 import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Objects;
+import java.util.Optional;
 
 /** source 계좌 기준 risk limit을 command write 전에 검증합니다. */
 public final class TransferLimitPolicyService implements TransferLimitPolicyUseCase {
 
   private final TransferLimitUsageReadPort usageReadPort;
+  private final TransferLimitPolicyOverrideReadPort overrideReadPort;
   private final Clock clock;
   private final ZoneId businessZoneId;
   private final TransferLimitPolicy policy;
 
   public TransferLimitPolicyService(
       TransferLimitUsageReadPort usageReadPort,
+      TransferLimitPolicyOverrideReadPort overrideReadPort,
       Clock clock,
       ZoneId businessZoneId,
       TransferLimitPolicy policy) {
     this.usageReadPort = Objects.requireNonNull(usageReadPort, "usageReadPort");
+    this.overrideReadPort = Objects.requireNonNull(overrideReadPort, "overrideReadPort");
     this.clock = Objects.requireNonNull(clock, "clock");
     this.businessZoneId = Objects.requireNonNull(businessZoneId, "businessZoneId");
     this.policy = Objects.requireNonNull(policy, "policy");
@@ -31,7 +36,8 @@ public final class TransferLimitPolicyService implements TransferLimitPolicyUseC
 
   @Override
   public void validate(TransferCommand command) {
-    if (command.amountMinor() > policy.singleTransferLimitMinor()) {
+    TransferLimitPolicy effectivePolicy = resolvePolicy(command.sourceAccountId());
+    if (command.amountMinor() > effectivePolicy.singleTransferLimitMinor()) {
       throw new TransferLimitExceededException("single transfer limit exceeded");
     }
     Instant now = clock.instant();
@@ -41,8 +47,14 @@ public final class TransferLimitPolicyService implements TransferLimitPolicyUseC
     long dailyUsed =
         usageReadPort.sumBookedDebitAmountMinor(
             command.sourceAccountId(), command.currencyCode(), fromInclusive, toExclusive);
-    if (dailyUsed + command.amountMinor() > policy.dailyTransferLimitMinor()) {
+    if (dailyUsed + command.amountMinor() > effectivePolicy.dailyTransferLimitMinor()) {
       throw new TransferLimitExceededException("daily transfer limit exceeded");
     }
+  }
+
+  @Override
+  public TransferLimitPolicy resolvePolicy(long sourceAccountId) {
+    Optional<TransferLimitPolicy> override = overrideReadPort.findByAccountId(sourceAccountId);
+    return override == null ? policy : override.orElse(policy);
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyUseCase.java
@@ -1,8 +1,11 @@
 package com.aquilabank.domain.ledger.usecase;
 
 import com.aquilabank.domain.ledger.model.TransferCommand;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
 
 public interface TransferLimitPolicyUseCase {
 
   void validate(TransferCommand command);
+
+  TransferLimitPolicy resolvePolicy(long sourceAccountId);
 }

--- a/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliverySkipReason.java
+++ b/back/src/main/java/com/aquilabank/domain/notification/model/NotificationChannelDeliverySkipReason.java
@@ -3,5 +3,6 @@ package com.aquilabank.domain.notification.model;
 /** provider 미호출 완료 사유를 SENT 상태와 분리해 운영자가 바로 구분합니다. */
 public enum NotificationChannelDeliverySkipReason {
   VERIFIED_CONTACT_MISSING,
-  PROVIDER_URL_MISSING
+  PROVIDER_URL_MISSING,
+  PROVIDER_DISABLED
 }

--- a/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
@@ -7,6 +7,8 @@ import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperati
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationReferencePort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationSecurityVerificationPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationWritePort;
+import com.aquilabank.domain.customerapplication.port.CustomerTransferLimitPolicyPort;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationExecutorService;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationOperationService;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationOperationUseCase;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationService;
@@ -55,8 +57,9 @@ public class CustomerApplicationConfiguration {
   }
 
   @Bean
-  CustomerApplicationExecutorPort customerApplicationExecutorPort() {
-    return CustomerApplicationOperationService.unsupportedExecutor();
+  CustomerApplicationExecutorPort customerApplicationExecutorPort(
+      CustomerTransferLimitPolicyPort transferLimitPolicyPort) {
+    return new CustomerApplicationExecutorService(transferLimitPolicyPort);
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
@@ -2,9 +2,13 @@ package com.aquilabank.global.config;
 
 import com.aquilabank.domain.auth.model.TotpOperationVerifyCommand;
 import com.aquilabank.domain.auth.usecase.TotpOperationVerifyUseCase;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationExecutorPort;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationReferencePort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationSecurityVerificationPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationWritePort;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationOperationService;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationOperationUseCase;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationService;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSubmitUseCase;
 import java.time.Clock;
@@ -45,6 +49,30 @@ public class CustomerApplicationConfiguration {
       var result = transactionTemplate.execute(status -> service.submit(command));
       if (result == null) {
         throw new IllegalStateException("customer application transaction returned null result");
+      }
+      return result;
+    };
+  }
+
+  @Bean
+  CustomerApplicationExecutorPort customerApplicationExecutorPort() {
+    return CustomerApplicationOperationService.unsupportedExecutor();
+  }
+
+  @Bean
+  CustomerApplicationOperationUseCase customerApplicationOperationUseCase(
+      CustomerApplicationOperationPort operationPort,
+      CustomerApplicationExecutorPort executorPort,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    CustomerApplicationOperationService service =
+        new CustomerApplicationOperationService(operationPort, executorPort, authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return command -> {
+      var result = transactionTemplate.execute(status -> service.apply(command));
+      if (result == null) {
+        throw new IllegalStateException(
+            "customer application operation transaction returned null result");
       }
       return result;
     };

--- a/back/src/main/java/com/aquilabank/global/config/TransferLimitPolicyConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/TransferLimitPolicyConfiguration.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.config;
 
 import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import com.aquilabank.domain.ledger.port.TransferLimitPolicyOverrideReadPort;
 import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
 import com.aquilabank.domain.ledger.usecase.TransferLimitPolicyService;
 import com.aquilabank.domain.ledger.usecase.TransferLimitPolicyUseCase;
@@ -17,9 +18,12 @@ public class TransferLimitPolicyConfiguration {
 
   @Bean
   TransferLimitPolicyUseCase transferLimitPolicyUseCase(
-      TransferLimitUsageReadPort usageReadPort, TransferLimitPolicyProperties properties) {
+      TransferLimitUsageReadPort usageReadPort,
+      TransferLimitPolicyOverrideReadPort overrideReadPort,
+      TransferLimitPolicyProperties properties) {
     return new TransferLimitPolicyService(
         usageReadPort,
+        overrideReadPort,
         Clock.systemUTC(),
         ZoneId.of(properties.businessZoneId()),
         new TransferLimitPolicy(

--- a/back/src/main/java/com/aquilabank/global/notification/LoggingNotificationChannelProvider.java
+++ b/back/src/main/java/com/aquilabank/global/notification/LoggingNotificationChannelProvider.java
@@ -1,6 +1,7 @@
 package com.aquilabank.global.notification;
 
 import com.aquilabank.domain.notification.model.NotificationChannelDeliveryResult;
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
 import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
 import com.aquilabank.domain.notification.port.NotificationChannelProviderPort;
 import org.slf4j.Logger;
@@ -14,13 +15,14 @@ public class LoggingNotificationChannelProvider implements NotificationChannelPr
 
   @Override
   public NotificationChannelDeliveryResult send(NotificationChannelOutboxItem item) {
-    // 외부 secret 없이 worker 상태 전이와 idempotency key 로그 형태를 먼저 검증합니다.
+    // 실제 provider가 없으면 SENT로 위장하지 않고 SKIPPED로 남겨 운영 지표 왜곡을 막습니다.
     log.info(
-        "sending notification channel delivery. id={}, channel={}, key={}, eventType={}",
+        "skipping notification channel delivery because provider is disabled. id={}, channel={}, key={}, eventType={}",
         item.id(),
         item.channel(),
         item.eventKey(),
         item.eventType());
-    return NotificationChannelDeliveryResult.delivered();
+    return NotificationChannelDeliveryResult.skipped(
+        NotificationChannelDeliverySkipReason.PROVIDER_DISABLED);
   }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/customerapplication/JdbcCustomerApplicationRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/customerapplication/JdbcCustomerApplicationRepository.java
@@ -1,23 +1,33 @@
 package com.aquilabank.global.persistence.customerapplication;
 
 import com.aquilabank.domain.customerapplication.exception.CustomerApplicationConflictException;
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationNotFoundException;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStateUpdateCommand;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmission;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationWriteCommand;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationWritePort;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 /** 고객 신청 접수 write 모델을 idempotency key 기준으로 한 번만 저장합니다. */
 @Repository
-public class JdbcCustomerApplicationRepository implements CustomerApplicationWritePort {
+public class JdbcCustomerApplicationRepository
+    implements CustomerApplicationWritePort, CustomerApplicationOperationPort {
+
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
   private final ObjectMapper objectMapper;
@@ -101,6 +111,83 @@ public class JdbcCustomerApplicationRepository implements CustomerApplicationWri
                     "idempotency key is already used by a different application request"));
   }
 
+  @Override
+  public Optional<CustomerApplicationDetails> findByReferenceForUpdate(
+      String applicationReference) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("applicationReference", applicationReference);
+    return jdbcTemplate
+        .query(
+            """
+            SELECT application_reference,
+                   user_id,
+                   account_id,
+                   application_type,
+                   application_status,
+                   mfa_verified,
+                   mfa_verified_at,
+                   payload,
+                   submitted_at,
+                   updated_at,
+                   status_reason,
+                   processed_by,
+                   processed_at,
+                   execution_result
+            FROM customer_service_application
+            WHERE application_reference = :applicationReference
+            FOR UPDATE
+            """,
+            params,
+            (rs, rowNum) -> mapDetails(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public CustomerApplicationDetails updateStatus(CustomerApplicationStateUpdateCommand command) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("applicationReference", command.applicationReference())
+            .addValue("applicationStatus", command.status().name())
+            .addValue("statusReason", command.reason())
+            .addValue("processedBy", command.actorSubject())
+            .addValue("processedAt", Timestamp.from(command.processedAt()))
+            .addValue("executionResult", toJson(command.executionResult()));
+
+    return jdbcTemplate
+        .query(
+            """
+            UPDATE customer_service_application
+            SET application_status = :applicationStatus,
+                status_reason = :statusReason,
+                processed_by = :processedBy,
+                processed_at = :processedAt,
+                execution_result = CAST(:executionResult AS jsonb),
+                updated_at = :processedAt
+            WHERE application_reference = :applicationReference
+            RETURNING application_reference,
+                      user_id,
+                      account_id,
+                      application_type,
+                      application_status,
+                      mfa_verified,
+                      mfa_verified_at,
+                      payload,
+                      submitted_at,
+                      updated_at,
+                      status_reason,
+                      processed_by,
+                      processed_at,
+                      execution_result
+            """,
+            params,
+            (rs, rowNum) -> mapDetails(rs))
+        .stream()
+        .findFirst()
+        .orElseThrow(
+            () -> new CustomerApplicationNotFoundException("customer application was not found"));
+  }
+
   private CustomerApplicationSubmission mapSubmission(ResultSet rs, int rowNum)
       throws SQLException {
     long accountId = rs.getLong("account_id");
@@ -118,11 +205,44 @@ public class JdbcCustomerApplicationRepository implements CustomerApplicationWri
         rs.getTimestamp("updated_at").toInstant());
   }
 
+  private CustomerApplicationDetails mapDetails(ResultSet rs) throws SQLException {
+    long accountId = rs.getLong("account_id");
+    Long nullableAccountId = rs.wasNull() ? null : accountId;
+    Timestamp mfaVerifiedAt = rs.getTimestamp("mfa_verified_at");
+    Timestamp processedAt = rs.getTimestamp("processed_at");
+    return new CustomerApplicationDetails(
+        rs.getString("application_reference"),
+        rs.getLong("user_id"),
+        nullableAccountId,
+        CustomerApplicationType.valueOf(rs.getString("application_type")),
+        CustomerApplicationStatus.valueOf(rs.getString("application_status")),
+        rs.getBoolean("mfa_verified"),
+        mfaVerifiedAt == null ? null : mfaVerifiedAt.toInstant(),
+        fromJson(rs.getString("payload")),
+        rs.getTimestamp("submitted_at").toInstant(),
+        rs.getTimestamp("updated_at").toInstant(),
+        rs.getString("status_reason"),
+        rs.getString("processed_by"),
+        processedAt == null ? null : processedAt.toInstant(),
+        fromJson(rs.getString("execution_result")));
+  }
+
   private String toJson(Object value) {
     try {
       return objectMapper.writeValueAsString(value);
     } catch (JsonProcessingException ex) {
       throw new IllegalStateException("json serialization failed", ex);
+    }
+  }
+
+  private Map<String, Object> fromJson(String value) {
+    if (value == null || value.isBlank()) {
+      return Map.of();
+    }
+    try {
+      return objectMapper.readValue(value, MAP_TYPE);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException("json deserialization failed", ex);
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferLimitPolicyOverrideRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/ledger/JdbcTransferLimitPolicyOverrideRepository.java
@@ -1,0 +1,106 @@
+package com.aquilabank.global.persistence.ledger;
+
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitPolicyCommand;
+import com.aquilabank.domain.customerapplication.port.CustomerTransferLimitPolicyPort;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import com.aquilabank.domain.ledger.port.TransferLimitPolicyOverrideReadPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Optional;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** 승인된 고객 신청이 만든 계좌별 송금 한도 override를 읽고 갱신합니다. */
+@Repository
+public class JdbcTransferLimitPolicyOverrideRepository
+    implements TransferLimitPolicyOverrideReadPort, CustomerTransferLimitPolicyPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcTransferLimitPolicyOverrideRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public Optional<TransferLimitPolicy> findByAccountId(long accountId) {
+    MapSqlParameterSource params = new MapSqlParameterSource().addValue("accountId", accountId);
+    return jdbcTemplate
+        .query(
+            """
+            SELECT single_transfer_limit_minor,
+                   daily_transfer_limit_minor
+            FROM account_transfer_limit_policy
+            WHERE account_id = :accountId
+            """,
+            params,
+            (rs, rowNum) -> mapPolicy(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public TransferLimitPolicy applyTransferLimitChange(CustomerTransferLimitPolicyCommand command) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("accountId", command.accountId())
+            .addValue("userId", command.userId())
+            .addValue("singleTransferLimitMinor", command.singleTransferLimitMinor())
+            .addValue("dailyTransferLimitMinor", command.dailyTransferLimitMinor())
+            .addValue("applicationReference", command.applicationReference())
+            .addValue("approvedBy", command.actorSubject())
+            .addValue("approvedAt", Timestamp.from(command.approvedAt()))
+            .addValue("requestId", command.requestId());
+
+    return jdbcTemplate
+        .query(
+            """
+            INSERT INTO account_transfer_limit_policy (
+                account_id,
+                user_id,
+                single_transfer_limit_minor,
+                daily_transfer_limit_minor,
+                source_application_reference,
+                approved_by,
+                approved_at,
+                request_id,
+                updated_at
+            )
+            VALUES (
+                :accountId,
+                :userId,
+                :singleTransferLimitMinor,
+                :dailyTransferLimitMinor,
+                :applicationReference,
+                :approvedBy,
+                :approvedAt,
+                :requestId,
+                :approvedAt
+            )
+            ON CONFLICT (account_id)
+            DO UPDATE
+            SET user_id = EXCLUDED.user_id,
+                single_transfer_limit_minor = EXCLUDED.single_transfer_limit_minor,
+                daily_transfer_limit_minor = EXCLUDED.daily_transfer_limit_minor,
+                source_application_reference = EXCLUDED.source_application_reference,
+                approved_by = EXCLUDED.approved_by,
+                approved_at = EXCLUDED.approved_at,
+                request_id = EXCLUDED.request_id,
+                updated_at = EXCLUDED.updated_at
+            RETURNING single_transfer_limit_minor,
+                      daily_transfer_limit_minor
+            """,
+            params,
+            (rs, rowNum) -> mapPolicy(rs))
+        .stream()
+        .findFirst()
+        .orElseThrow(
+            () -> new IllegalStateException("transfer limit policy upsert returned no row"));
+  }
+
+  private TransferLimitPolicy mapPolicy(ResultSet rs) throws SQLException {
+    return new TransferLimitPolicy(
+        rs.getLong("single_transfer_limit_minor"), rs.getLong("daily_transfer_limit_minor"));
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/InternalServiceScope.java
+++ b/back/src/main/java/com/aquilabank/global/security/InternalServiceScope.java
@@ -6,6 +6,7 @@ public enum InternalServiceScope {
   ACCOUNT_ADMIN("internal:account-admin"),
   AUTH_BOOTSTRAP("internal:auth-bootstrap"),
   AUTH_ADMIN("internal:auth-admin"),
+  CUSTOMER_APPLICATION_OPS("internal:customer-application-ops"),
   OUTBOX_OPS("internal:outbox-ops"),
   LEDGER_OPS("internal:ledger-ops");
 

--- a/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/security/SecurityConfiguration.java
@@ -106,6 +106,8 @@ public class SecurityConfiguration {
                     .permitAll()
                     .requestMatchers("/internal/api/v1/bootstrap/bulk-import")
                     .permitAll()
+                    .requestMatchers("/internal/api/v1/customer-service/applications/**")
+                    .permitAll()
                     .requestMatchers("/internal/api/v1/outbox/**")
                     .permitAll()
                     .requestMatchers("/internal/api/v1/ledger/**")

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -15,6 +15,8 @@ import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundExcepti
 import com.aquilabank.domain.auth.model.AuthStatusChangeReasonCode;
 import com.aquilabank.domain.auth.model.InternalAuthConflictReasonCode;
 import com.aquilabank.domain.customerapplication.exception.CustomerApplicationConflictException;
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationInvalidTransitionException;
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationNotFoundException;
 import com.aquilabank.domain.ledger.exception.CommandConflictException;
 import com.aquilabank.domain.ledger.exception.CurrencyMismatchException;
 import com.aquilabank.domain.ledger.exception.InsufficientBalanceException;
@@ -299,6 +301,7 @@ public class ApiExceptionHandler {
     LedgerAuditEntryNotFoundException.class,
     PasswordRecoveryTokenNotFoundException.class,
     UserAccountMembershipNotFoundException.class,
+    CustomerApplicationNotFoundException.class,
     NotificationNotFoundException.class,
     TransactionDetailNotFoundException.class
   })
@@ -310,6 +313,7 @@ public class ApiExceptionHandler {
     DuplicateExternalIdentityMappingException.class,
     DuplicateLoginIdException.class,
     CustomerApplicationConflictException.class,
+    CustomerApplicationInvalidTransitionException.class,
     CommandConflictException.class,
     CurrencyMismatchException.class,
     InsufficientBalanceException.class,

--- a/back/src/main/java/com/aquilabank/global/web/customerapplication/InternalCustomerApplicationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/customerapplication/InternalCustomerApplicationController.java
@@ -1,0 +1,151 @@
+package com.aquilabank.global.web.customerapplication;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationAction;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDecisionCommand;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationOperationUseCase;
+import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenClaims;
+import com.aquilabank.global.web.RequestTraceContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 내부 운영 도구가 고객 신청을 검토/승인/실행하는 adapter입니다. */
+@Validated
+@RestController
+@RequestMapping("/internal/api/v1/customer-service/applications")
+public class InternalCustomerApplicationController {
+
+  private final CustomerApplicationOperationUseCase operationUseCase;
+  private final InternalServiceRequestAuthorizer internalServiceRequestAuthorizer;
+
+  public InternalCustomerApplicationController(
+      CustomerApplicationOperationUseCase operationUseCase,
+      InternalServiceRequestAuthorizer internalServiceRequestAuthorizer) {
+    this.operationUseCase = operationUseCase;
+    this.internalServiceRequestAuthorizer = internalServiceRequestAuthorizer;
+  }
+
+  @PostMapping("/{applicationReference}/review")
+  public CustomerApplicationOperationResponse startReview(
+      HttpServletRequest httpServletRequest,
+      @PathVariable String applicationReference,
+      @Valid @RequestBody(required = false) CustomerApplicationOperationRequest request) {
+    return apply(
+        httpServletRequest, applicationReference, CustomerApplicationAction.START_REVIEW, request);
+  }
+
+  @PostMapping("/{applicationReference}/approve")
+  public CustomerApplicationOperationResponse approve(
+      HttpServletRequest httpServletRequest,
+      @PathVariable String applicationReference,
+      @Valid @RequestBody(required = false) CustomerApplicationOperationRequest request) {
+    return apply(
+        httpServletRequest, applicationReference, CustomerApplicationAction.APPROVE, request);
+  }
+
+  @PostMapping("/{applicationReference}/reject")
+  public CustomerApplicationOperationResponse reject(
+      HttpServletRequest httpServletRequest,
+      @PathVariable String applicationReference,
+      @Valid @RequestBody(required = false) CustomerApplicationOperationRequest request) {
+    return apply(
+        httpServletRequest, applicationReference, CustomerApplicationAction.REJECT, request);
+  }
+
+  @PostMapping("/{applicationReference}/cancel")
+  public CustomerApplicationOperationResponse cancel(
+      HttpServletRequest httpServletRequest,
+      @PathVariable String applicationReference,
+      @Valid @RequestBody(required = false) CustomerApplicationOperationRequest request) {
+    return apply(
+        httpServletRequest, applicationReference, CustomerApplicationAction.CANCEL, request);
+  }
+
+  @PostMapping("/{applicationReference}/execute")
+  public CustomerApplicationOperationResponse execute(
+      HttpServletRequest httpServletRequest,
+      @PathVariable String applicationReference,
+      @Valid @RequestBody(required = false) CustomerApplicationOperationRequest request) {
+    return apply(
+        httpServletRequest, applicationReference, CustomerApplicationAction.EXECUTE, request);
+  }
+
+  private CustomerApplicationOperationResponse apply(
+      HttpServletRequest httpServletRequest,
+      String applicationReference,
+      CustomerApplicationAction action,
+      CustomerApplicationOperationRequest request) {
+    InternalServiceTokenClaims claims =
+        internalServiceRequestAuthorizer.requireScope(
+            httpServletRequest, InternalServiceScope.CUSTOMER_APPLICATION_OPS);
+    CustomerApplicationDetails result =
+        operationUseCase.apply(
+            new CustomerApplicationDecisionCommand(
+                applicationReference,
+                action,
+                claims.subject(),
+                request == null ? null : request.reason(),
+                resolveRequestId(httpServletRequest)));
+    return CustomerApplicationOperationResponse.from(result);
+  }
+
+  private String resolveRequestId(HttpServletRequest httpServletRequest) {
+    return RequestTraceContext.currentRequestId()
+        .orElseGet(
+            () -> {
+              String requestId =
+                  httpServletRequest.getHeader(RequestTraceContext.REQUEST_ID_HEADER);
+              if (requestId == null || requestId.isBlank()) {
+                throw new IllegalStateException("requestId is not initialized");
+              }
+              return requestId;
+            });
+  }
+
+  public record CustomerApplicationOperationRequest(
+      @Size(max = 300, message = "reason must be 300 characters or less") String reason) {}
+
+  public record CustomerApplicationOperationResponse(
+      String applicationReference,
+      long userId,
+      Long accountId,
+      String applicationType,
+      String status,
+      boolean mfaVerified,
+      Instant mfaVerifiedAt,
+      Instant submittedAt,
+      Instant updatedAt,
+      String reason,
+      String processedBy,
+      Instant processedAt,
+      Map<String, Object> executionResult) {
+
+    static CustomerApplicationOperationResponse from(CustomerApplicationDetails result) {
+      return new CustomerApplicationOperationResponse(
+          result.applicationReference(),
+          result.userId(),
+          result.accountId(),
+          result.applicationType().name(),
+          result.status().name(),
+          result.mfaVerified(),
+          result.mfaVerifiedAt(),
+          result.submittedAt(),
+          result.updatedAt(),
+          result.reason(),
+          result.processedBy(),
+          result.processedAt(),
+          result.executionResult());
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
@@ -6,12 +6,14 @@ import com.aquilabank.domain.auth.model.TotpOperationVerifyCommand;
 import com.aquilabank.domain.auth.usecase.TotpOperationRequirementUseCase;
 import com.aquilabank.domain.auth.usecase.TotpOperationVerifyUseCase;
 import com.aquilabank.domain.ledger.model.TransferCommand;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
 import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.model.TransferReversalCommand;
 import com.aquilabank.domain.ledger.model.TransferReversalReason;
 import com.aquilabank.domain.ledger.model.TransferReversalResult;
 import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
+import com.aquilabank.domain.ledger.usecase.TransferLimitPolicyUseCase;
 import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
 import com.aquilabank.global.config.TransferLimitPolicyProperties;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
@@ -51,6 +53,7 @@ public class TransferCommandController {
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
   private final AccountSummaryQueryUseCase accountSummaryQueryUseCase;
   private final TransferLimitUsageReadPort transferLimitUsageReadPort;
+  private final TransferLimitPolicyUseCase transferLimitPolicyUseCase;
   private final TotpOperationRequirementUseCase totpOperationRequirementUseCase;
   private final TotpOperationVerifyUseCase totpOperationVerifyUseCase;
   private final TransferLimitPolicyProperties transferLimitPolicyProperties;
@@ -63,6 +66,7 @@ public class TransferCommandController {
       RequestAccountAuthorizationService requestAccountAuthorizationService,
       AccountSummaryQueryUseCase accountSummaryQueryUseCase,
       TransferLimitUsageReadPort transferLimitUsageReadPort,
+      TransferLimitPolicyUseCase transferLimitPolicyUseCase,
       TotpOperationRequirementUseCase totpOperationRequirementUseCase,
       TotpOperationVerifyUseCase totpOperationVerifyUseCase,
       TransferLimitPolicyProperties transferLimitPolicyProperties) {
@@ -72,6 +76,7 @@ public class TransferCommandController {
         requestAccountAuthorizationService,
         accountSummaryQueryUseCase,
         transferLimitUsageReadPort,
+        transferLimitPolicyUseCase,
         totpOperationRequirementUseCase,
         totpOperationVerifyUseCase,
         transferLimitPolicyProperties,
@@ -84,6 +89,7 @@ public class TransferCommandController {
       RequestAccountAuthorizationService requestAccountAuthorizationService,
       AccountSummaryQueryUseCase accountSummaryQueryUseCase,
       TransferLimitUsageReadPort transferLimitUsageReadPort,
+      TransferLimitPolicyUseCase transferLimitPolicyUseCase,
       TotpOperationRequirementUseCase totpOperationRequirementUseCase,
       TotpOperationVerifyUseCase totpOperationVerifyUseCase,
       TransferLimitPolicyProperties transferLimitPolicyProperties,
@@ -93,6 +99,7 @@ public class TransferCommandController {
     this.requestAccountAuthorizationService = requestAccountAuthorizationService;
     this.accountSummaryQueryUseCase = accountSummaryQueryUseCase;
     this.transferLimitUsageReadPort = transferLimitUsageReadPort;
+    this.transferLimitPolicyUseCase = transferLimitPolicyUseCase;
     this.totpOperationRequirementUseCase = totpOperationRequirementUseCase;
     this.totpOperationVerifyUseCase = totpOperationVerifyUseCase;
     this.transferLimitPolicyProperties = transferLimitPolicyProperties;
@@ -126,13 +133,13 @@ public class TransferCommandController {
     long dailyUsedMinor =
         transferLimitUsageReadPort.sumBookedDebitAmountMinor(
             resolvedSourceAccountId, currencyCode, fromInclusive, toExclusive);
+    TransferLimitPolicy policy = transferLimitPolicyUseCase.resolvePolicy(resolvedSourceAccountId);
     long feeMinor = 0L;
     long totalDebitMinor = amountMinor + feeMinor;
-    long dailyRemainingMinor =
-        Math.max(0L, transferLimitPolicyProperties.dailyTransferLimitMinor() - dailyUsedMinor);
+    long dailyRemainingMinor = Math.max(0L, policy.dailyTransferLimitMinor() - dailyUsedMinor);
     String blockedReason =
         resolvePreviewBlockedReason(
-            source, target, amountMinor, totalDebitMinor, dailyUsedMinor, currencyCode);
+            source, target, amountMinor, totalDebitMinor, dailyUsedMinor, currencyCode, policy);
     return new TransferPreviewResponse(
         resolvedSourceAccountId,
         TransferPreviewAccountResponse.from(target, shouldExposeInternalTarget(principal)),
@@ -141,8 +148,8 @@ public class TransferCommandController {
         feeMinor,
         "INTERNAL_TRANSFER_WAIVED",
         totalDebitMinor,
-        transferLimitPolicyProperties.singleTransferLimitMinor(),
-        transferLimitPolicyProperties.dailyTransferLimitMinor(),
+        policy.singleTransferLimitMinor(),
+        policy.dailyTransferLimitMinor(),
         dailyUsedMinor,
         dailyRemainingMinor,
         "OK".equals(blockedReason),
@@ -251,7 +258,8 @@ public class TransferCommandController {
       long amountMinor,
       long totalDebitMinor,
       long dailyUsedMinor,
-      String currencyCode) {
+      String currencyCode,
+      TransferLimitPolicy policy) {
     if (!source.currencyCode().equals(currencyCode)
         || !target.currencyCode().equals(currencyCode)) {
       return "CURRENCY_MISMATCH";
@@ -259,10 +267,10 @@ public class TransferCommandController {
     if (!"ACTIVE".equals(target.accountStatus())) {
       return "TARGET_ACCOUNT_NOT_ACTIVE";
     }
-    if (amountMinor > transferLimitPolicyProperties.singleTransferLimitMinor()) {
+    if (amountMinor > policy.singleTransferLimitMinor()) {
       return "SINGLE_LIMIT_EXCEEDED";
     }
-    if (dailyUsedMinor + amountMinor > transferLimitPolicyProperties.dailyTransferLimitMinor()) {
+    if (dailyUsedMinor + amountMinor > policy.dailyTransferLimitMinor()) {
       return "DAILY_LIMIT_EXCEEDED";
     }
     if (totalDebitMinor > source.availableBalanceMinor()) {

--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
@@ -162,13 +162,13 @@ public class TransferCommandController {
       @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
       @RequestHeader("Idempotency-Key") String idempotencyKey,
       @Valid @RequestBody TransferRequest request) {
-    verifyOperationTotpIfRequired(principal, request.totpCode());
     long sourceAccountId =
         requestAccountAuthorizationService.resolveTransferSourceAccountId(
             principal, request.sourceAccountId());
     long targetAccountId =
         resolveTransferTargetAccountId(
             principal, request.targetAccountId(), request.targetAccountNumber());
+    verifyOperationTotpIfRequired(principal, request.totpCode());
     TransferResult result =
         transferCommandUseCase.transfer(
             new TransferCommand(
@@ -187,10 +187,10 @@ public class TransferCommandController {
       @PathVariable String transactionReference,
       @RequestHeader("Idempotency-Key") String idempotencyKey,
       @Valid @RequestBody TransferReversalRequest request) {
-    verifyOperationTotpIfRequired(principal, request.totpCode());
     long sourceAccountId =
         requestAccountAuthorizationService.resolveTransferSourceAccountId(
             principal, request.sourceAccountId());
+    verifyOperationTotpIfRequired(principal, request.totpCode());
     TransferReversalResult result =
         transferReversalUseCase.reverse(
             new TransferReversalCommand(
@@ -279,7 +279,7 @@ public class TransferCommandController {
     return "OK";
   }
 
-  /** 송금 preview target 계좌 요약. 계좌번호는 확인용 마지막 4자리만 노출합니다. */
+  /** 송금 preview target 계좌 요약. 공개 사용자 응답은 계좌번호 확인값만 노출합니다. */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public record TransferPreviewAccountResponse(
       Long accountId,
@@ -292,7 +292,7 @@ public class TransferCommandController {
       return new TransferPreviewAccountResponse(
           exposeInternal ? summary.accountId() : null,
           maskAccountNumber(summary.accountNumber()),
-          summary.displayName(),
+          exposeInternal ? summary.displayName() : null,
           exposeInternal ? summary.accountStatus() : null,
           exposeInternal ? summary.currencyCode() : null);
     }

--- a/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
@@ -61,6 +61,7 @@ public class WebMvcSecurityConfiguration implements WebMvcConfigurer {
             "/internal/api/v1/accounts/status-change-audits/**",
             "/internal/api/v1/accounts/*/status",
             "/internal/api/v1/bootstrap/bulk-import",
+            "/internal/api/v1/customer-service/applications/**",
             "/internal/api/v1/auth/**",
             "/internal/api/v1/ledger/**",
             "/internal/api/v1/outbox/**");

--- a/back/src/main/resources/db/migration/V55__add_customer_application_lifecycle.sql
+++ b/back/src/main/resources/db/migration/V55__add_customer_application_lifecycle.sql
@@ -1,0 +1,30 @@
+ALTER TABLE customer_service_application
+    DROP CONSTRAINT IF EXISTS customer_service_application_application_status_check;
+
+ALTER TABLE customer_service_application
+    ADD CONSTRAINT customer_service_application_application_status_check
+    CHECK (
+        application_status IN (
+            'SUBMITTED',
+            'REVIEWING',
+            'APPROVED',
+            'EXECUTED',
+            'FAILED',
+            'REJECTED',
+            'CANCELLED',
+            'IN_REVIEW',
+            'COMPLETED'
+        )
+    );
+
+ALTER TABLE customer_service_application
+    ADD COLUMN status_reason VARCHAR(300),
+    ADD COLUMN processed_by VARCHAR(120),
+    ADD COLUMN processed_at TIMESTAMPTZ,
+    ADD COLUMN execution_result JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN customer_service_application.status_reason IS
+    '운영 검토/실행/실패 사유. 외부 실행 adapter 미구성 같은 미처리 사유를 명확히 남긴다.';
+
+COMMENT ON COLUMN customer_service_application.execution_result IS
+    '신청 실행 결과 payload. 외부 기관 연동이 없는 경우 실패 사유와 타입만 저장한다.';

--- a/back/src/main/resources/db/migration/V55__add_customer_application_lifecycle.sql
+++ b/back/src/main/resources/db/migration/V55__add_customer_application_lifecycle.sql
@@ -1,3 +1,4 @@
+-- flyway:allow-breaking-change application_status CHECK constraint is widened for additive lifecycle states.
 ALTER TABLE customer_service_application
     DROP CONSTRAINT IF EXISTS customer_service_application_application_status_check;
 

--- a/back/src/main/resources/db/migration/V56__add_account_transfer_limit_policy.sql
+++ b/back/src/main/resources/db/migration/V56__add_account_transfer_limit_policy.sql
@@ -1,0 +1,24 @@
+CREATE TABLE account_transfer_limit_policy (
+    account_id BIGINT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    single_transfer_limit_minor BIGINT NOT NULL CHECK (single_transfer_limit_minor > 0),
+    daily_transfer_limit_minor BIGINT NOT NULL CHECK (daily_transfer_limit_minor >= single_transfer_limit_minor),
+    source_application_reference VARCHAR(64) NOT NULL,
+    approved_by VARCHAR(120) NOT NULL,
+    approved_at TIMESTAMPTZ NOT NULL,
+    request_id VARCHAR(120) NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT fk_account_transfer_limit_policy_account
+        FOREIGN KEY (account_id) REFERENCES bank_account (id),
+    CONSTRAINT fk_account_transfer_limit_policy_user
+        FOREIGN KEY (user_id) REFERENCES bank_user (id),
+    CONSTRAINT fk_account_transfer_limit_policy_application
+        FOREIGN KEY (source_application_reference)
+        REFERENCES customer_service_application (application_reference)
+);
+
+CREATE INDEX idx_account_transfer_limit_policy_user_account
+    ON account_transfer_limit_policy (user_id, account_id);
+
+COMMENT ON TABLE account_transfer_limit_policy IS
+    '승인/실행된 이체한도 변경 신청을 실제 송금 정책에서 조회하는 계좌별 override';

--- a/back/src/test/java/com/aquilabank/domain/DomainModelCoverageTest.java
+++ b/back/src/test/java/com/aquilabank/domain/DomainModelCoverageTest.java
@@ -16,6 +16,8 @@ import com.aquilabank.domain.auth.model.LoginResultStatus;
 import com.aquilabank.domain.auth.model.MembershipRole;
 import com.aquilabank.domain.auth.model.MembershipStatus;
 import com.aquilabank.domain.bootstrap.model.BootstrapBulkImportCommand;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
 import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
 import com.aquilabank.domain.notification.model.NotificationBulkActionCommand;
 import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
@@ -891,6 +893,13 @@ class DomainModelCoverageTest {
           new BootstrapBulkImportCommand.MembershipItem(
               user.clientRef(), account.clientRef(), MembershipRole.OWNER, MembershipStatus.ACTIVE);
       return new Object[] {List.of(account), List.of(user), List.of(membership)};
+    }
+    if (type == CustomerApplicationExecutionResult.class) {
+      return new Object[] {
+        variant == 0 ? CustomerApplicationStatus.EXECUTED : CustomerApplicationStatus.FAILED,
+        "execution-result-" + variant,
+        Map.of("variant", variant)
+      };
     }
     return null;
   }

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationModelTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationModelTest.java
@@ -2,7 +2,9 @@ package com.aquilabank.domain.customerapplication.model;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Instant;
 import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class CustomerApplicationModelTest {
@@ -17,5 +19,34 @@ class CustomerApplicationModelTest {
         () ->
             new CustomerApplicationSubmitCommand(
                 7L, 101L, CustomerApplicationType.BILL_PAYMENT, "bill-001", "123456", payload));
+  }
+
+  @Test
+  void rejectsInvalidOperationModelValues() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new CustomerApplicationExecutionResult(
+                CustomerApplicationStatus.SUBMITTED, "not terminal", Map.of()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new CustomerApplicationExecutionResult(
+                CustomerApplicationStatus.FAILED, "x".repeat(301), Map.of()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new CustomerApplicationDecisionCommand(
+                "CSA-001", CustomerApplicationAction.APPROVE, "ops", "x".repeat(301), "req-1"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new CustomerApplicationStateUpdateCommand(
+                "CSA-001",
+                CustomerApplicationStatus.APPROVED,
+                "x".repeat(301),
+                "ops",
+                Instant.parse("2026-05-13T03:00:00Z"),
+                Map.of()));
   }
 }

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorServiceTest.java
@@ -1,0 +1,150 @@
+package com.aquilabank.domain.customerapplication.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.port.CustomerTransferLimitPolicyPort;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CustomerApplicationExecutorServiceTest {
+
+  private final CustomerTransferLimitPolicyPort transferLimitPolicyPort =
+      mock(CustomerTransferLimitPolicyPort.class);
+  private final CustomerApplicationExecutorService service =
+      new CustomerApplicationExecutorService(transferLimitPolicyPort);
+
+  @Test
+  void executesTransferLimitChangeApplication() {
+    when(transferLimitPolicyPort.applyTransferLimitChange(
+            argThat(command -> command != null && command.accountId() == 101L)))
+        .thenReturn(new TransferLimitPolicy(500_000L, 2_000_000L));
+
+    CustomerApplicationExecutionResult result =
+        service.execute(
+            details(
+                CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                101L,
+                Map.of(
+                    "requestedSingleTransferLimitMinor", 500_000L,
+                    "requestedDailyTransferLimitMinor", 2_000_000L)),
+            "ops-executor",
+            "req-transfer-limit");
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.EXECUTED);
+    assertThat(result.reason()).isEqualTo("TRANSFER_LIMIT_UPDATED");
+    assertThat(result.payload()).containsEntry("dailyTransferLimitMinor", 2_000_000L);
+    verify(transferLimitPolicyPort)
+        .applyTransferLimitChange(
+            argThat(
+                command ->
+                    command != null
+                        && command.userId() == 7L
+                        && command.accountId() == 101L
+                        && command.singleTransferLimitMinor() == 500_000L
+                        && command.dailyTransferLimitMinor() == 2_000_000L
+                        && command.applicationReference().equals("CSA-001")
+                        && command.actorSubject().equals("ops-executor")
+                        && command.requestId().equals("req-transfer-limit")));
+  }
+
+  @Test
+  void failsTransferLimitChangeWithoutAccountOrValidPayload() {
+    assertThat(
+            service
+                .execute(
+                    details(CustomerApplicationType.TRANSFER_LIMIT_CHANGE, null, Map.of()),
+                    "ops-executor",
+                    "req-no-account")
+                .reason())
+        .isEqualTo("TRANSFER_LIMIT_ACCOUNT_REQUIRED");
+
+    assertThat(
+            service
+                .execute(
+                    details(
+                        CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                        101L,
+                        Map.of("requestedSingleTransferLimitMinor", 10_000L)),
+                    "ops-executor",
+                    "req-invalid-payload")
+                .reason())
+        .isEqualTo("TRANSFER_LIMIT_PAYLOAD_INVALID");
+
+    assertThat(
+            service
+                .execute(
+                    details(
+                        CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                        101L,
+                        Map.of(
+                            "requestedSingleTransferLimitMinor",
+                            "bad-number",
+                            "requestedDailyTransferLimitMinor",
+                            "20_000")),
+                    "ops-executor",
+                    "req-invalid-string-payload")
+                .reason())
+        .isEqualTo("TRANSFER_LIMIT_PAYLOAD_INVALID");
+  }
+
+  @Test
+  void acceptsStringTransferLimitPayloadValues() {
+    when(transferLimitPolicyPort.applyTransferLimitChange(
+            argThat(command -> command != null && command.singleTransferLimitMinor() == 50_000L)))
+        .thenReturn(new TransferLimitPolicy(50_000L, 200_000L));
+
+    CustomerApplicationExecutionResult result =
+        service.execute(
+            details(
+                CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                101L,
+                Map.of("singleTransferLimitMinor", "50000", "dailyTransferLimitMinor", "200000")),
+            "ops-executor",
+            "req-string-payload");
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.EXECUTED);
+  }
+
+  @Test
+  void failsUnsupportedExternalApplicationExplicitly() {
+    CustomerApplicationExecutionResult result =
+        service.execute(
+            details(CustomerApplicationType.LOAN_APPLICATION, 101L, Map.of()),
+            "ops-executor",
+            "req-loan");
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.FAILED);
+    assertThat(result.reason()).isEqualTo("EXTERNAL_EXECUTION_NOT_CONFIGURED");
+    assertThat(result.payload()).containsEntry("applicationType", "LOAN_APPLICATION");
+  }
+
+  private static CustomerApplicationDetails details(
+      CustomerApplicationType type, Long accountId, Map<String, Object> payload) {
+    Instant now = Instant.parse("2026-05-13T03:00:00Z");
+    return new CustomerApplicationDetails(
+        "CSA-001",
+        7L,
+        accountId,
+        type,
+        CustomerApplicationStatus.APPROVED,
+        true,
+        now,
+        payload,
+        now,
+        now,
+        null,
+        null,
+        null,
+        Map.of());
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationServiceTest.java
@@ -1,0 +1,234 @@
+package com.aquilabank.domain.customerapplication.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationInvalidTransitionException;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationAction;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDecisionCommand;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationExecutorPort;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CustomerApplicationOperationServiceTest {
+
+  private final CustomerApplicationOperationPort operationPort =
+      mock(CustomerApplicationOperationPort.class);
+  private final CustomerApplicationExecutorPort executorPort =
+      mock(CustomerApplicationExecutorPort.class);
+  private final Clock clock = Clock.fixed(Instant.parse("2026-05-13T03:00:00Z"), ZoneOffset.UTC);
+  private final CustomerApplicationOperationService service =
+      new CustomerApplicationOperationService(operationPort, executorPort, clock);
+
+  @Test
+  void approvesApplicationFromReviewingState() {
+    CustomerApplicationDetails reviewing =
+        details(CustomerApplicationType.BILL_PAYMENT, CustomerApplicationStatus.REVIEWING);
+    CustomerApplicationDetails approved =
+        details(CustomerApplicationType.BILL_PAYMENT, CustomerApplicationStatus.APPROVED);
+    when(operationPort.findByReferenceForUpdate("CSA-001")).thenReturn(Optional.of(reviewing));
+    when(operationPort.updateStatus(
+            argThat(
+                command ->
+                    command != null && command.status() == CustomerApplicationStatus.APPROVED)))
+        .thenReturn(approved);
+
+    CustomerApplicationDetails result =
+        service.apply(
+            new CustomerApplicationDecisionCommand(
+                "CSA-001",
+                CustomerApplicationAction.APPROVE,
+                "ops-reviewer",
+                "limit document checked",
+                "req-approve-001"));
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.APPROVED);
+    verify(operationPort)
+        .updateStatus(
+            argThat(
+                command ->
+                    command.status() == CustomerApplicationStatus.APPROVED
+                        && command.reason().equals("limit document checked")
+                        && command.actorSubject().equals("ops-reviewer")
+                        && command.processedAt().equals(Instant.parse("2026-05-13T03:00:00Z"))));
+  }
+
+  @Test
+  void startsReviewRejectsAndCancelsAllowedStates() {
+    assertStatusTransition(
+        CustomerApplicationStatus.SUBMITTED,
+        CustomerApplicationAction.START_REVIEW,
+        CustomerApplicationStatus.REVIEWING);
+    assertStatusTransition(
+        CustomerApplicationStatus.APPROVED,
+        CustomerApplicationAction.REJECT,
+        CustomerApplicationStatus.REJECTED);
+    assertStatusTransition(
+        CustomerApplicationStatus.REVIEWING,
+        CustomerApplicationAction.CANCEL,
+        CustomerApplicationStatus.CANCELLED);
+  }
+
+  @Test
+  void executesUnsupportedApplicationAsFailedWithReason() {
+    CustomerApplicationDetails approved =
+        details(CustomerApplicationType.LOAN_APPLICATION, CustomerApplicationStatus.APPROVED);
+    CustomerApplicationDetails failed =
+        details(CustomerApplicationType.LOAN_APPLICATION, CustomerApplicationStatus.FAILED);
+    when(operationPort.findByReferenceForUpdate("CSA-002")).thenReturn(Optional.of(approved));
+    when(executorPort.execute(approved, "ops-executor", "req-execute-002"))
+        .thenReturn(
+            CustomerApplicationExecutionResult.failed(
+                "EXTERNAL_EXECUTION_NOT_CONFIGURED",
+                Map.of("applicationType", "LOAN_APPLICATION")));
+    when(operationPort.updateStatus(
+            argThat(
+                command ->
+                    command != null && command.status() == CustomerApplicationStatus.FAILED)))
+        .thenReturn(failed);
+
+    CustomerApplicationDetails result =
+        service.apply(
+            new CustomerApplicationDecisionCommand(
+                "CSA-002",
+                CustomerApplicationAction.EXECUTE,
+                "ops-executor",
+                "run approved application",
+                "req-execute-002"));
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.FAILED);
+    verify(operationPort)
+        .updateStatus(
+            argThat(
+                command ->
+                    command.status() == CustomerApplicationStatus.FAILED
+                        && command.reason().equals("EXTERNAL_EXECUTION_NOT_CONFIGURED")
+                        && "LOAN_APPLICATION"
+                            .equals(command.executionResult().get("applicationType"))));
+  }
+
+  @Test
+  void rejectsTransitionAfterTerminalState() {
+    when(operationPort.findByReferenceForUpdate("CSA-003"))
+        .thenReturn(
+            Optional.of(
+                details(CustomerApplicationType.BILL_PAYMENT, CustomerApplicationStatus.EXECUTED)));
+
+    assertThrows(
+        CustomerApplicationInvalidTransitionException.class,
+        () ->
+            service.apply(
+                new CustomerApplicationDecisionCommand(
+                    "CSA-003",
+                    CustomerApplicationAction.APPROVE,
+                    "ops-reviewer",
+                    "already done",
+                    "req-invalid-003")));
+  }
+
+  @Test
+  void rejectsTransitionThatIsNotAllowedBeforeTerminalState() {
+    when(operationPort.findByReferenceForUpdate("CSA-004"))
+        .thenReturn(
+            Optional.of(
+                details(CustomerApplicationType.BILL_PAYMENT, CustomerApplicationStatus.APPROVED)));
+
+    assertThrows(
+        CustomerApplicationInvalidTransitionException.class,
+        () ->
+            service.apply(
+                new CustomerApplicationDecisionCommand(
+                    "CSA-004",
+                    CustomerApplicationAction.START_REVIEW,
+                    "ops-reviewer",
+                    "already approved",
+                    "req-invalid-004")));
+  }
+
+  @Test
+  void rejectsMissingApplicationReference() {
+    when(operationPort.findByReferenceForUpdate("CSA-missing")).thenReturn(Optional.empty());
+
+    assertThrows(
+        com.aquilabank.domain.customerapplication.exception.CustomerApplicationNotFoundException
+            .class,
+        () ->
+            service.apply(
+                new CustomerApplicationDecisionCommand(
+                    "CSA-missing",
+                    CustomerApplicationAction.APPROVE,
+                    "ops-reviewer",
+                    "not found",
+                    "req-missing")));
+  }
+
+  @Test
+  void unsupportedExecutorFailsWithApplicationTypePayload() {
+    CustomerApplicationExecutionResult result =
+        CustomerApplicationOperationService.unsupportedExecutor()
+            .execute(
+                details(
+                    CustomerApplicationType.FOREIGN_EXCHANGE_APPLICATION,
+                    CustomerApplicationStatus.APPROVED),
+                "ops-executor",
+                "req-unsupported");
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.FAILED);
+    assertThat(result.reason()).isEqualTo("EXTERNAL_EXECUTION_NOT_CONFIGURED");
+    assertThat(result.payload()).containsEntry("applicationType", "FOREIGN_EXCHANGE_APPLICATION");
+  }
+
+  private void assertStatusTransition(
+      CustomerApplicationStatus currentStatus,
+      CustomerApplicationAction action,
+      CustomerApplicationStatus targetStatus) {
+    CustomerApplicationDetails current =
+        details(CustomerApplicationType.BILL_PAYMENT, currentStatus);
+    CustomerApplicationDetails updated =
+        details(CustomerApplicationType.BILL_PAYMENT, targetStatus);
+    when(operationPort.findByReferenceForUpdate("CSA-001")).thenReturn(Optional.of(current));
+    when(operationPort.updateStatus(
+            argThat(command -> command != null && command.status() == targetStatus)))
+        .thenReturn(updated);
+
+    CustomerApplicationDetails result =
+        service.apply(
+            new CustomerApplicationDecisionCommand(
+                "CSA-001", action, "ops-reviewer", " ", "req-transition"));
+
+    assertThat(result.status()).isEqualTo(targetStatus);
+  }
+
+  private static CustomerApplicationDetails details(
+      CustomerApplicationType type, CustomerApplicationStatus status) {
+    Instant now = Instant.parse("2026-05-13T02:00:00Z");
+    return new CustomerApplicationDetails(
+        "CSA-001",
+        7L,
+        101L,
+        type,
+        status,
+        true,
+        now,
+        Map.of("requestedSingleTransferLimitMinor", 100_000L),
+        now,
+        now,
+        null,
+        null,
+        null,
+        Map.of());
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/ledger/usecase/TransferLimitPolicyServiceTest.java
@@ -9,11 +9,13 @@ import static org.mockito.Mockito.when;
 import com.aquilabank.domain.ledger.exception.TransferLimitExceededException;
 import com.aquilabank.domain.ledger.model.TransferCommand;
 import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import com.aquilabank.domain.ledger.port.TransferLimitPolicyOverrideReadPort;
 import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -24,12 +26,15 @@ class TransferLimitPolicyServiceTest {
 
   private final TransferLimitUsageReadPort usageReadPort =
       Mockito.mock(TransferLimitUsageReadPort.class);
+  private final TransferLimitPolicyOverrideReadPort overrideReadPort =
+      Mockito.mock(TransferLimitPolicyOverrideReadPort.class);
 
   @Test
   void rejectsWhenSingleTransferLimitIsExceededWithoutUsageLookup() {
     TransferLimitPolicyService service =
         new TransferLimitPolicyService(
             usageReadPort,
+            overrideReadPort,
             Clock.fixed(NOW, ZoneOffset.UTC),
             SEOUL,
             new TransferLimitPolicy(1_000L, 10_000L));
@@ -45,6 +50,7 @@ class TransferLimitPolicyServiceTest {
     TransferLimitPolicyService service =
         new TransferLimitPolicyService(
             usageReadPort,
+            overrideReadPort,
             Clock.fixed(NOW, ZoneOffset.UTC),
             SEOUL,
             new TransferLimitPolicy(1_000L, 5_000L));
@@ -64,6 +70,7 @@ class TransferLimitPolicyServiceTest {
     TransferLimitPolicyService service =
         new TransferLimitPolicyService(
             usageReadPort,
+            overrideReadPort,
             Clock.fixed(NOW, ZoneOffset.UTC),
             SEOUL,
             new TransferLimitPolicy(1_000L, 5_000L));
@@ -73,6 +80,27 @@ class TransferLimitPolicyServiceTest {
         .thenReturn(4_400L);
 
     assertThatCode(() -> service.validate(command(600L))).doesNotThrowAnyException();
+    verify(usageReadPort).sumBookedDebitAmountMinor(101L, "KRW", expectedFrom, expectedTo);
+  }
+
+  @Test
+  void usesAccountOverridePolicyBeforeDefaultPolicy() {
+    TransferLimitPolicyService service =
+        new TransferLimitPolicyService(
+            usageReadPort,
+            overrideReadPort,
+            Clock.fixed(NOW, ZoneOffset.UTC),
+            SEOUL,
+            new TransferLimitPolicy(1_000L, 5_000L));
+    Instant expectedFrom = Instant.parse("2026-04-20T15:00:00Z");
+    Instant expectedTo = Instant.parse("2026-04-21T15:00:00Z");
+    when(overrideReadPort.findByAccountId(101L))
+        .thenReturn(Optional.of(new TransferLimitPolicy(5_000L, 10_000L)));
+    when(usageReadPort.sumBookedDebitAmountMinor(101L, "KRW", expectedFrom, expectedTo))
+        .thenReturn(4_000L);
+
+    assertThatCode(() -> service.validate(command(3_000L))).doesNotThrowAnyException();
+    verify(overrideReadPort).findByAccountId(101L);
     verify(usageReadPort).sumBookedDebitAmountMinor(101L, "KRW", expectedFrom, expectedTo);
   }
 

--- a/back/src/test/java/com/aquilabank/global/config/TransferLimitPolicyConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/TransferLimitPolicyConfigurationTest.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import com.aquilabank.domain.ledger.port.TransferLimitPolicyOverrideReadPort;
 import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
 import com.aquilabank.domain.ledger.usecase.TransferLimitPolicyUseCase;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,9 @@ class TransferLimitPolicyConfigurationTest {
       new ApplicationContextRunner()
           .withUserConfiguration(TransferLimitPolicyConfiguration.class)
           .withBean(TransferLimitUsageReadPort.class, () -> mock(TransferLimitUsageReadPort.class))
+          .withBean(
+              TransferLimitPolicyOverrideReadPort.class,
+              () -> mock(TransferLimitPolicyOverrideReadPort.class))
           .withPropertyValues(
               "ledger.transfer-limit.single-transfer-limit-minor=1000000",
               "ledger.transfer-limit.daily-transfer-limit-minor=5000000",

--- a/back/src/test/java/com/aquilabank/global/notification/LoggingNotificationChannelProviderTest.java
+++ b/back/src/test/java/com/aquilabank/global/notification/LoggingNotificationChannelProviderTest.java
@@ -1,0 +1,46 @@
+package com.aquilabank.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aquilabank.domain.notification.model.NotificationChannelDeliverySkipReason;
+import com.aquilabank.domain.notification.model.NotificationChannelDeliveryStatus;
+import com.aquilabank.domain.notification.model.NotificationChannelOutboxItem;
+import com.aquilabank.domain.notification.model.NotificationPreferenceCategory;
+import com.aquilabank.domain.notification.model.NotificationPreferenceChannel;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class LoggingNotificationChannelProviderTest {
+
+  @Test
+  void skipsDeliveryBecauseFallbackProviderDoesNotSendExternally() {
+    LoggingNotificationChannelProvider provider = new LoggingNotificationChannelProvider();
+
+    var result = provider.send(item());
+
+    assertThat(result.sent()).isFalse();
+    assertThat(result.skipReason())
+        .isEqualTo(NotificationChannelDeliverySkipReason.PROVIDER_DISABLED);
+  }
+
+  private NotificationChannelOutboxItem item() {
+    Instant now = Instant.parse("2026-05-13T03:00:00Z");
+    return new NotificationChannelOutboxItem(
+        1L,
+        10L,
+        20L,
+        30L,
+        NotificationPreferenceCategory.TRANSACTIONAL,
+        NotificationPreferenceChannel.EMAIL,
+        "TransferBooked",
+        "evt-logging-provider",
+        "{\"kind\":\"transfer\"}",
+        NotificationChannelDeliveryStatus.SENDING,
+        now.minusSeconds(1),
+        null,
+        0,
+        null,
+        now.minusSeconds(10),
+        now);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/persistence/customerapplication/JdbcCustomerApplicationRepositoryTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/customerapplication/JdbcCustomerApplicationRepositoryTest.java
@@ -8,6 +8,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.aquilabank.domain.customerapplication.exception.CustomerApplicationConflictException;
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationNotFoundException;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStateUpdateCommand;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmission;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
@@ -66,6 +69,122 @@ class JdbcCustomerApplicationRepositoryTest {
   }
 
   @Test
+  void findsApplicationByReferenceForUpdateAndMapsPayload() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcCustomerApplicationRepository repository =
+        new JdbcCustomerApplicationRepository(jdbcTemplate, new ObjectMapper());
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<CustomerApplicationDetails>>any()))
+        .thenAnswer(
+            invocation -> {
+              RowMapper<CustomerApplicationDetails> mapper = invocation.getArgument(2);
+              return List.of(mapper.mapRow(detailsResultSet("{}", false), 0));
+            });
+
+    CustomerApplicationDetails result =
+        repository.findByReferenceForUpdate("CSA-20260511-001").orElseThrow();
+
+    assertEquals(CustomerApplicationStatus.APPROVED, result.status());
+    assertEquals("GIRO", result.payload().get("billerCode"));
+    assertEquals(Map.of(), result.executionResult());
+  }
+
+  @Test
+  void mapsBlankExecutionResultAsEmptyPayload() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcCustomerApplicationRepository repository =
+        new JdbcCustomerApplicationRepository(jdbcTemplate, new ObjectMapper());
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<CustomerApplicationDetails>>any()))
+        .thenAnswer(
+            invocation -> {
+              RowMapper<CustomerApplicationDetails> mapper = invocation.getArgument(2);
+              return List.of(mapper.mapRow(detailsResultSet("", false), 0));
+            });
+
+    CustomerApplicationDetails result =
+        repository.findByReferenceForUpdate("CSA-20260511-001").orElseThrow();
+
+    assertEquals(Map.of(), result.executionResult());
+  }
+
+  @Test
+  void updatesApplicationStatusAndMapsExecutionResult() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcCustomerApplicationRepository repository =
+        new JdbcCustomerApplicationRepository(jdbcTemplate, new ObjectMapper());
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<CustomerApplicationDetails>>any()))
+        .thenAnswer(
+            invocation -> {
+              RowMapper<CustomerApplicationDetails> mapper = invocation.getArgument(2);
+              return List.of(mapper.mapRow(detailsResultSet("{\"executed\":true}", false), 0));
+            });
+
+    CustomerApplicationDetails result =
+        repository.updateStatus(
+            new CustomerApplicationStateUpdateCommand(
+                "CSA-20260511-001",
+                CustomerApplicationStatus.EXECUTED,
+                "done",
+                "ops",
+                Instant.parse("2026-05-11T03:10:00Z"),
+                Map.of("executed", true)));
+
+    assertEquals(CustomerApplicationStatus.APPROVED, result.status());
+    assertEquals(true, result.executionResult().get("executed"));
+  }
+
+  @Test
+  void updateStatusReturnsNotFoundWhenReferenceIsMissing() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcCustomerApplicationRepository repository =
+        new JdbcCustomerApplicationRepository(jdbcTemplate, new ObjectMapper());
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<CustomerApplicationDetails>>any()))
+        .thenReturn(List.of());
+
+    assertThrows(
+        CustomerApplicationNotFoundException.class,
+        () ->
+            repository.updateStatus(
+                new CustomerApplicationStateUpdateCommand(
+                    "CSA-missing",
+                    CustomerApplicationStatus.REJECTED,
+                    "missing",
+                    "ops",
+                    Instant.parse("2026-05-11T03:10:00Z"),
+                    Map.of())));
+  }
+
+  @Test
+  void wrapsJsonDeserializationFailure() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcCustomerApplicationRepository repository =
+        new JdbcCustomerApplicationRepository(jdbcTemplate, new ObjectMapper());
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<CustomerApplicationDetails>>any()))
+        .thenAnswer(
+            invocation -> {
+              RowMapper<CustomerApplicationDetails> mapper = invocation.getArgument(2);
+              return List.of(mapper.mapRow(detailsResultSet("{", false), 0));
+            });
+
+    assertThrows(
+        IllegalStateException.class, () -> repository.findByReferenceForUpdate("CSA-20260511-001"));
+  }
+
+  @Test
   void wrapsJsonSerializationFailure() throws Exception {
     NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
     ObjectMapper objectMapper = mock(ObjectMapper.class);
@@ -105,6 +224,28 @@ class JdbcCustomerApplicationRepositoryTest {
     when(rs.getTimestamp("mfa_verified_at")).thenReturn(Timestamp.from(now));
     when(rs.getTimestamp("submitted_at")).thenReturn(Timestamp.from(now));
     when(rs.getTimestamp("updated_at")).thenReturn(Timestamp.from(now));
+    return rs;
+  }
+
+  private static ResultSet detailsResultSet(String executionResult, boolean accountWasNull)
+      throws Exception {
+    Instant now = Instant.parse("2026-05-11T03:00:00Z");
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("application_reference")).thenReturn("CSA-20260511-001");
+    when(rs.getLong("user_id")).thenReturn(7L);
+    when(rs.getLong("account_id")).thenReturn(101L);
+    when(rs.wasNull()).thenReturn(accountWasNull);
+    when(rs.getString("application_type")).thenReturn("BILL_PAYMENT");
+    when(rs.getString("application_status")).thenReturn("APPROVED");
+    when(rs.getBoolean("mfa_verified")).thenReturn(true);
+    when(rs.getTimestamp("mfa_verified_at")).thenReturn(Timestamp.from(now));
+    when(rs.getString("payload")).thenReturn("{\"billerCode\":\"GIRO\"}");
+    when(rs.getTimestamp("submitted_at")).thenReturn(Timestamp.from(now));
+    when(rs.getTimestamp("updated_at")).thenReturn(Timestamp.from(now));
+    when(rs.getString("status_reason")).thenReturn("done");
+    when(rs.getString("processed_by")).thenReturn("ops");
+    when(rs.getTimestamp("processed_at")).thenReturn(Timestamp.from(now));
+    when(rs.getString("execution_result")).thenReturn(executionResult);
     return rs;
   }
 }

--- a/back/src/test/java/com/aquilabank/global/persistence/ledger/JdbcTransferLimitPolicyOverrideRepositoryTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/ledger/JdbcTransferLimitPolicyOverrideRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.aquilabank.global.persistence.ledger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitPolicyCommand;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
+import java.sql.ResultSet;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+class JdbcTransferLimitPolicyOverrideRepositoryTest {
+
+  @Test
+  void findsOverridePolicyByAccountId() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcTransferLimitPolicyOverrideRepository repository =
+        new JdbcTransferLimitPolicyOverrideRepository(jdbcTemplate);
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<TransferLimitPolicy>>any()))
+        .thenAnswer(
+            invocation -> {
+              RowMapper<TransferLimitPolicy> mapper = invocation.getArgument(2);
+              return List.of(mapper.mapRow(resultSet(), 0));
+            });
+
+    assertThat(repository.findByAccountId(101L))
+        .contains(new TransferLimitPolicy(500_000L, 2_000_000L));
+  }
+
+  @Test
+  void appliesTransferLimitChangeWithUpsert() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcTransferLimitPolicyOverrideRepository repository =
+        new JdbcTransferLimitPolicyOverrideRepository(jdbcTemplate);
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<TransferLimitPolicy>>any()))
+        .thenAnswer(
+            invocation -> {
+              RowMapper<TransferLimitPolicy> mapper = invocation.getArgument(2);
+              return List.of(mapper.mapRow(resultSet(), 0));
+            });
+
+    TransferLimitPolicy result =
+        repository.applyTransferLimitChange(
+            new CustomerTransferLimitPolicyCommand(
+                7L,
+                101L,
+                500_000L,
+                2_000_000L,
+                "CSA-001",
+                "ops-executor",
+                "req-transfer-limit",
+                Instant.parse("2026-05-13T03:00:00Z")));
+
+    assertThat(result).isEqualTo(new TransferLimitPolicy(500_000L, 2_000_000L));
+  }
+
+  @Test
+  void failsWhenTransferLimitChangeUpsertReturnsNoRow() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcTransferLimitPolicyOverrideRepository repository =
+        new JdbcTransferLimitPolicyOverrideRepository(jdbcTemplate);
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<TransferLimitPolicy>>any()))
+        .thenReturn(List.of());
+
+    assertThatThrownBy(
+            () ->
+                repository.applyTransferLimitChange(
+                    new CustomerTransferLimitPolicyCommand(
+                        7L,
+                        101L,
+                        500_000L,
+                        2_000_000L,
+                        "CSA-001",
+                        "ops-executor",
+                        "req-transfer-limit",
+                        Instant.parse("2026-05-13T03:00:00Z"))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("transfer limit policy upsert returned no row");
+  }
+
+  private static ResultSet resultSet() throws Exception {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getLong("single_transfer_limit_minor")).thenReturn(500_000L);
+    when(rs.getLong("daily_transfer_limit_minor")).thenReturn(2_000_000L);
+    return rs;
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/customerapplication/InternalCustomerApplicationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/customerapplication/InternalCustomerApplicationControllerTest.java
@@ -1,0 +1,214 @@
+package com.aquilabank.global.web.customerapplication;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationAction;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationOperationUseCase;
+import com.aquilabank.global.security.InternalServiceScope;
+import com.aquilabank.global.security.InternalServiceTokenTestSupport;
+import com.aquilabank.global.web.ApiExceptionHandler;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class InternalCustomerApplicationControllerTest {
+
+  private static final String SUBJECT = "customer-ops-test";
+  private static final String REQUEST_ID_HEADER = "X-Request-Id";
+
+  private CustomerApplicationOperationUseCase operationUseCase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    operationUseCase = mock(CustomerApplicationOperationUseCase.class);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new InternalCustomerApplicationController(
+                    operationUseCase, InternalServiceTokenTestSupport.authorizer()))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void approvesApplicationWithInternalCustomerOpsScope() throws Exception {
+    when(operationUseCase.apply(
+            argThat(
+                command ->
+                    command != null && command.action() == CustomerApplicationAction.APPROVE)))
+        .thenReturn(details(CustomerApplicationStatus.APPROVED));
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/customer-service/applications/CSA-001/approve")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_OPS))
+                .header(REQUEST_ID_HEADER, "customer-application-approve-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "reason": "documents checked"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.applicationReference").value("CSA-001"))
+        .andExpect(jsonPath("$.status").value("APPROVED"))
+        .andExpect(jsonPath("$.processedBy").value(SUBJECT));
+
+    verify(operationUseCase)
+        .apply(
+            argThat(
+                command ->
+                    command.applicationReference().equals("CSA-001")
+                        && command.action() == CustomerApplicationAction.APPROVE
+                        && command.actorSubject().equals(SUBJECT)
+                        && command.reason().equals("documents checked")
+                        && command.requestId().equals("customer-application-approve-request")));
+  }
+
+  @Test
+  void handlesReviewRejectCancelAndExecuteActions() throws Exception {
+    when(operationUseCase.apply(any()))
+        .thenAnswer(
+            invocation -> {
+              var command =
+                  (com.aquilabank.domain.customerapplication.model
+                          .CustomerApplicationDecisionCommand)
+                      invocation.getArgument(0);
+              CustomerApplicationStatus status =
+                  switch (command.action()) {
+                    case START_REVIEW -> CustomerApplicationStatus.REVIEWING;
+                    case REJECT -> CustomerApplicationStatus.REJECTED;
+                    case CANCEL -> CustomerApplicationStatus.CANCELLED;
+                    case EXECUTE -> CustomerApplicationStatus.FAILED;
+                    case APPROVE -> CustomerApplicationStatus.APPROVED;
+                  };
+              return details(status);
+            });
+
+    performOperation("review").andExpect(jsonPath("$.status").value("REVIEWING"));
+    performOperation("reject").andExpect(jsonPath("$.status").value("REJECTED"));
+    performOperation("cancel").andExpect(jsonPath("$.status").value("CANCELLED"));
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/customer-service/applications/CSA-001/execute")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_OPS))
+                .header(REQUEST_ID_HEADER, "customer-application-execute-request")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("FAILED"));
+  }
+
+  @Test
+  void rejectsMissingRequestId() throws Exception {
+    mockMvc
+        .perform(
+            post("/internal/api/v1/customer-service/applications/CSA-001/approve")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_OPS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "reason": "documents checked"
+                    }
+                    """))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.message").value("requestId is not initialized"));
+  }
+
+  @Test
+  void rejectsMissingOrWrongInternalServiceToken() throws Exception {
+    mockMvc
+        .perform(
+            post("/internal/api/v1/customer-service/applications/CSA-001/approve")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "reason": "documents checked"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+
+    mockMvc
+        .perform(
+            post("/internal/api/v1/customer-service/applications/CSA-001/approve")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.ACCOUNT_ADMIN))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "reason": "documents checked"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+
+  private static CustomerApplicationDetails details(CustomerApplicationStatus status) {
+    Instant now = Instant.parse("2026-05-13T03:00:00Z");
+    return new CustomerApplicationDetails(
+        "CSA-001",
+        7L,
+        101L,
+        CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+        status,
+        true,
+        now,
+        Map.of("requestedSingleTransferLimitMinor", 100_000L),
+        now,
+        now,
+        "documents checked",
+        SUBJECT,
+        now,
+        Map.of());
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performOperation(String action)
+      throws Exception {
+    return mockMvc
+        .perform(
+            post("/internal/api/v1/customer-service/applications/CSA-001/" + action)
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_OPS))
+                .header(REQUEST_ID_HEADER, "customer-application-" + action + "-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "reason": "documents checked"
+                    }
+                    """))
+        .andExpect(status().isOk());
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -16,10 +16,12 @@ import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
 import com.aquilabank.domain.auth.model.TotpOperationVerifyCommand;
 import com.aquilabank.domain.auth.usecase.TotpOperationRequirementUseCase;
 import com.aquilabank.domain.auth.usecase.TotpOperationVerifyUseCase;
+import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
 import com.aquilabank.domain.ledger.model.TransferResult;
 import com.aquilabank.domain.ledger.model.TransferReversalResult;
 import com.aquilabank.domain.ledger.port.TransferLimitUsageReadPort;
 import com.aquilabank.domain.ledger.usecase.TransferCommandUseCase;
+import com.aquilabank.domain.ledger.usecase.TransferLimitPolicyUseCase;
 import com.aquilabank.domain.ledger.usecase.TransferReversalUseCase;
 import com.aquilabank.global.config.TransferLimitPolicyProperties;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
@@ -48,6 +50,7 @@ class TransferCommandControllerTest {
   private RequestAccountAuthorizationService requestAccountAuthorizationService;
   private AccountSummaryQueryUseCase accountSummaryQueryUseCase;
   private TransferLimitUsageReadPort transferLimitUsageReadPort;
+  private TransferLimitPolicyUseCase transferLimitPolicyUseCase;
   private TotpOperationRequirementUseCase totpOperationRequirementUseCase;
   private TotpOperationVerifyUseCase totpOperationVerifyUseCase;
   private MockMvc mockMvc;
@@ -59,8 +62,11 @@ class TransferCommandControllerTest {
     requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
     accountSummaryQueryUseCase = mock(AccountSummaryQueryUseCase.class);
     transferLimitUsageReadPort = mock(TransferLimitUsageReadPort.class);
+    transferLimitPolicyUseCase = mock(TransferLimitPolicyUseCase.class);
     totpOperationRequirementUseCase = mock(TotpOperationRequirementUseCase.class);
     totpOperationVerifyUseCase = mock(TotpOperationVerifyUseCase.class);
+    when(transferLimitPolicyUseCase.resolvePolicy(101L))
+        .thenReturn(new TransferLimitPolicy(2_000L, 3_000L));
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new TransferCommandController(
@@ -69,6 +75,7 @@ class TransferCommandControllerTest {
                     requestAccountAuthorizationService,
                     accountSummaryQueryUseCase,
                     transferLimitUsageReadPort,
+                    transferLimitPolicyUseCase,
                     totpOperationRequirementUseCase,
                     totpOperationVerifyUseCase,
                     new TransferLimitPolicyProperties(2_000L, 3_000L, "Asia/Seoul"),
@@ -201,6 +208,23 @@ class TransferCommandControllerTest {
         .andExpect(jsonPath("$.dailyRemainingMinor").value(1_000))
         .andExpect(jsonPath("$.allowed").value(false))
         .andExpect(jsonPath("$.blockedReason").value("DAILY_LIMIT_EXCEEDED"));
+  }
+
+  @Test
+  void previewsEffectiveAccountTransferLimitOverride() throws Exception {
+    when(transferLimitPolicyUseCase.resolvePolicy(101L))
+        .thenReturn(new TransferLimitPolicy(5_000L, 10_000L));
+    stubPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L),
+        account(202L, "999900001234", "홍길동", "ACTIVE", 0L),
+        4_000L);
+
+    performPreview(3_000L, "KRW")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.singleTransferLimitMinor").value(5000))
+        .andExpect(jsonPath("$.dailyTransferLimitMinor").value(10000))
+        .andExpect(jsonPath("$.dailyRemainingMinor").value(6000))
+        .andExpect(jsonPath("$.allowed").value(true));
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -2,6 +2,7 @@ package com.aquilabank.global.web.ledger;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -13,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.aquilabank.domain.account.model.AccountSummary;
 import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.domain.auth.exception.AccountAccessDeniedException;
 import com.aquilabank.domain.auth.model.TotpOperationVerifyCommand;
 import com.aquilabank.domain.auth.usecase.TotpOperationRequirementUseCase;
 import com.aquilabank.domain.auth.usecase.TotpOperationVerifyUseCase;
@@ -36,6 +38,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -123,6 +126,7 @@ class TransferCommandControllerTest {
     performUserPreview(1_500L, "KRW")
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.targetAccount.accountId").doesNotExist())
+        .andExpect(jsonPath("$.targetAccount.displayName").doesNotExist())
         .andExpect(jsonPath("$.targetAccount.accountStatus").doesNotExist())
         .andExpect(jsonPath("$.targetAccount.currencyCode").doesNotExist())
         .andExpect(jsonPath("$.otpRequired").value(true));
@@ -286,6 +290,11 @@ class TransferCommandControllerTest {
   void rejectsUserTransferWhenOperationTotpIsRequiredAndMissing() throws Exception {
     authenticateUser(7L);
     when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(true);
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), eq(101L)))
+        .thenReturn(101L);
+    when(accountSummaryQueryUseCase.getByAccountNumber("999900001234"))
+        .thenReturn(account(202L, "999900001234", "홍길동", "ACTIVE", 0L));
 
     mockMvc
         .perform(
@@ -296,7 +305,7 @@ class TransferCommandControllerTest {
                     """
                     {
                       "sourceAccountId": 101,
-                      "targetAccountId": 202,
+                      "targetAccountNumber": "999900001234",
                       "amountMinor": 1500,
                       "currencyCode": "KRW",
                       "summary": "rent"
@@ -310,7 +319,8 @@ class TransferCommandControllerTest {
   }
 
   @Test
-  void verifiesUserTransferOperationTotpBeforeCommandExecution() throws Exception {
+  void verifiesUserTransferOperationTotpAfterAccountResolutionBeforeCommandExecution()
+      throws Exception {
     authenticateUser(7L);
     when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(true);
     when(accountSummaryQueryUseCase.getByAccountNumber("999900001234"))
@@ -349,13 +359,56 @@ class TransferCommandControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.transactionReference").value("TRX-USER-1"));
 
-    verify(totpOperationVerifyUseCase).verify(eq(new TotpOperationVerifyCommand(7L, "123456")));
-    verify(transferCommandUseCase)
+    InOrder inOrder =
+        inOrder(
+            requestAccountAuthorizationService,
+            accountSummaryQueryUseCase,
+            totpOperationVerifyUseCase,
+            transferCommandUseCase);
+    inOrder
+        .verify(requestAccountAuthorizationService)
+        .resolveTransferSourceAccountId(org.mockito.ArgumentMatchers.any(), eq(101L));
+    inOrder.verify(accountSummaryQueryUseCase).getByAccountNumber("999900001234");
+    inOrder
+        .verify(totpOperationVerifyUseCase)
+        .verify(eq(new TotpOperationVerifyCommand(7L, "123456")));
+    inOrder
+        .verify(transferCommandUseCase)
         .transfer(
             argThat(
                 command ->
                     "transfer-user-002".equals(command.idempotencyKey())
                         && command.targetAccountId() == 202L));
+  }
+
+  @Test
+  void rejectsUserTransferWithoutConsumingTotpWhenSourceAccountIsDenied() throws Exception {
+    authenticateUser(7L);
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), eq(101L)))
+        .thenThrow(new AccountAccessDeniedException("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers")
+                .header("Idempotency-Key", "transfer-user-denied")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": 101,
+                      "targetAccountNumber": "999900001234",
+                      "amountMinor": 1500,
+                      "currencyCode": "KRW",
+                      "summary": "rent",
+                      "totpCode": "123456"
+                    }
+                    """))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    verifyNoInteractions(totpOperationVerifyUseCase);
+    verifyNoInteractions(transferCommandUseCase);
   }
 
   @Test
@@ -455,7 +508,8 @@ class TransferCommandControllerTest {
   }
 
   @Test
-  void verifiesUserReversalOperationTotpBeforeCommandExecution() throws Exception {
+  void verifiesUserReversalOperationTotpAfterAccountAuthorizationBeforeCommandExecution()
+      throws Exception {
     authenticateUser(7L);
     when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(true);
     when(transferReversalUseCase.reverse(
@@ -493,9 +547,49 @@ class TransferCommandControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.reversalTransactionReference").value("TRX-2"));
 
-    verify(totpOperationVerifyUseCase).verify(eq(new TotpOperationVerifyCommand(7L, "123456")));
-    verify(transferReversalUseCase)
+    InOrder inOrder =
+        inOrder(
+            requestAccountAuthorizationService,
+            totpOperationVerifyUseCase,
+            transferReversalUseCase);
+    inOrder
+        .verify(requestAccountAuthorizationService)
+        .resolveTransferSourceAccountId(org.mockito.ArgumentMatchers.any(), eq(101L));
+    inOrder
+        .verify(totpOperationVerifyUseCase)
+        .verify(eq(new TotpOperationVerifyCommand(7L, "123456")));
+    inOrder
+        .verify(transferReversalUseCase)
         .reverse(argThat(command -> "reversal-user-001".equals(command.idempotencyKey())));
+  }
+
+  @Test
+  void rejectsUserReversalWithoutConsumingTotpWhenSourceAccountIsDenied() throws Exception {
+    authenticateUser(7L);
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(
+            org.mockito.ArgumentMatchers.any(), eq(101L)))
+        .thenThrow(new AccountAccessDeniedException("account access is denied"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/transfers/TRX-1/reversal")
+                .header("Idempotency-Key", "reversal-user-denied")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "sourceAccountId": 101,
+                      "amountMinor": 700,
+                      "reversalReason": "CANCEL",
+                      "summary": "cancel transfer",
+                      "totpCode": "123456"
+                    }
+                    """))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("account access is denied"));
+
+    verifyNoInteractions(totpOperationVerifyUseCase);
+    verifyNoInteractions(transferReversalUseCase);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 Related Issue
close #946

## 🌿 Base Branch
- `main`

## 📝 Summary
- 웹뱅킹 신청 업무에 내부 검토/승인/실행 상태 전이와 실행 경계를 추가했습니다.
- 이체 한도 변경 신청이 실제 계좌별 이체 한도 정책에 반영되도록 연결하고, 수취인 preview/TOTP/알림 fallback 보안 공백을 줄였습니다.

## 🛠 Changes
- 고객 신청 상태 전이, 내부 실행 API, 실행 결과/실패 사유 저장을 추가했습니다.
- `TRANSFER_LIMIT_CHANGE` 승인 실행 결과를 계좌별 한도 read model에 저장하고 이체 preview/검증에서 우선 적용합니다.
- 알림 logging fallback이 실제 발송 없이 `DELIVERED` 처리하지 않고 `PROVIDER_DISABLED` skip으로 남기도록 변경했습니다.
- JWT 사용자 수취인 preview에서 displayName 등 내부 상세를 제거하고, 이체/취소 TOTP 소비 순서를 source/target 검증 뒤로 이동했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back test --tests '*CustomerApplication*'`
- `./back/gradlew -p back test --tests '*DomainModelCoverageTest' --tests '*CustomerApplication*'`
- `./back/gradlew -p back test --tests '*TransferCommandControllerTest'`
- `./back/gradlew -p back test --tests '*TransferCommandControllerTest' --tests '*TransferCommandApiIntegrationTest' --tests '*TransferLimitPolicyServiceTest'`
- `tools/test/with-resource-lock.sh back-gradlew ./back/gradlew -p back test --rerun-tasks`
- `tools/test/with-resource-lock.sh back-gradlew ./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 고객 신청 실행 API/상태 전이가 새로 추가되어 운영 권한 토큰 설정과 실행 호출 순서를 맞춰야 합니다. 외부 bill/open banking/loan/FX/certificate/security media provider 연동은 이번 범위 밖이며, 미지원 타입 실행은 실패 사유로 명시됩니다.
- 롤백 방법: 이 PR revert 후 DB migration은 운영 정책에 따라 추가된 상태/한도 테이블 사용 중단 또는 후속 rollback migration으로 정리합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [ ] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
