### PR TITLE
[Feat] 웹뱅킹 신청 거버넌스와 고객 상태 API 보강

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationProcessingMode.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationProcessingMode.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.customerapplication.model;
+
+/** 신청 타입별 처리 책임: 자동 실행과 외부/수동 처리 경계를 분리합니다. */
+public enum CustomerApplicationProcessingMode {
+  INTERNAL_EXECUTION,
+  EXTERNAL_PROVIDER_REQUIRED,
+  MANUAL_REVIEW_REQUIRED
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationType.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationType.java
@@ -1,16 +1,30 @@
 package com.aquilabank.domain.customerapplication.model;
 
 public enum CustomerApplicationType {
-  BILL_PAYMENT,
-  OPEN_BANKING_CONNECTION,
-  DEPOSIT_PRODUCT_APPLICATION,
-  LOAN_APPLICATION,
-  FOREIGN_EXCHANGE_APPLICATION,
-  CERTIFICATE_ISSUANCE,
-  CERTIFICATE_REGISTRATION,
-  SECURITY_MEDIA_APPLICATION,
-  TRANSFER_LIMIT_CHANGE,
-  INCIDENT_REPORT;
+  BILL_PAYMENT(CustomerApplicationProcessingMode.EXTERNAL_PROVIDER_REQUIRED),
+  OPEN_BANKING_CONNECTION(CustomerApplicationProcessingMode.EXTERNAL_PROVIDER_REQUIRED),
+  DEPOSIT_PRODUCT_APPLICATION(CustomerApplicationProcessingMode.EXTERNAL_PROVIDER_REQUIRED),
+  LOAN_APPLICATION(CustomerApplicationProcessingMode.EXTERNAL_PROVIDER_REQUIRED),
+  FOREIGN_EXCHANGE_APPLICATION(CustomerApplicationProcessingMode.EXTERNAL_PROVIDER_REQUIRED),
+  CERTIFICATE_ISSUANCE(CustomerApplicationProcessingMode.EXTERNAL_PROVIDER_REQUIRED),
+  CERTIFICATE_REGISTRATION(CustomerApplicationProcessingMode.EXTERNAL_PROVIDER_REQUIRED),
+  SECURITY_MEDIA_APPLICATION(CustomerApplicationProcessingMode.EXTERNAL_PROVIDER_REQUIRED),
+  TRANSFER_LIMIT_CHANGE(CustomerApplicationProcessingMode.INTERNAL_EXECUTION),
+  INCIDENT_REPORT(CustomerApplicationProcessingMode.MANUAL_REVIEW_REQUIRED);
+
+  private final CustomerApplicationProcessingMode processingMode;
+
+  CustomerApplicationType(CustomerApplicationProcessingMode processingMode) {
+    this.processingMode = processingMode;
+  }
+
+  public CustomerApplicationProcessingMode processingMode() {
+    return processingMode;
+  }
+
+  public boolean supportsAutomatedExecution() {
+    return processingMode == CustomerApplicationProcessingMode.INTERNAL_EXECUTION;
+  }
 
   public boolean requiresTotp() {
     return true;

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerTransferLimitChangePolicy.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerTransferLimitChangePolicy.java
@@ -1,0 +1,42 @@
+package com.aquilabank.domain.customerapplication.model;
+
+/** 승인 payload가 은행 risk cap을 우회하지 못하도록 신청/실행 양쪽에서 공유하는 한도 상한입니다. */
+public record CustomerTransferLimitChangePolicy(
+    long maxSingleTransferLimitMinor, long maxDailyTransferLimitMinor) {
+
+  public CustomerTransferLimitChangePolicy {
+    if (maxSingleTransferLimitMinor <= 0) {
+      throw new IllegalArgumentException("maxSingleTransferLimitMinor must be positive");
+    }
+    if (maxDailyTransferLimitMinor <= 0) {
+      throw new IllegalArgumentException("maxDailyTransferLimitMinor must be positive");
+    }
+    if (maxDailyTransferLimitMinor < maxSingleTransferLimitMinor) {
+      throw new IllegalArgumentException(
+          "maxDailyTransferLimitMinor must be greater than or equal to maxSingleTransferLimitMinor");
+    }
+  }
+
+  public void validate(long singleTransferLimitMinor, long dailyTransferLimitMinor) {
+    if (singleTransferLimitMinor <= 0 || dailyTransferLimitMinor <= 0) {
+      throw new IllegalArgumentException("transfer limits must be positive");
+    }
+    if (dailyTransferLimitMinor < singleTransferLimitMinor) {
+      throw new IllegalArgumentException(
+          "dailyTransferLimitMinor must be greater than or equal to singleTransferLimitMinor");
+    }
+    if (singleTransferLimitMinor > maxSingleTransferLimitMinor
+        || dailyTransferLimitMinor > maxDailyTransferLimitMinor) {
+      throw new IllegalArgumentException("transfer limit change exceeds configured policy");
+    }
+  }
+
+  public boolean allows(long singleTransferLimitMinor, long dailyTransferLimitMinor) {
+    try {
+      validate(singleTransferLimitMinor, dailyTransferLimitMinor);
+      return true;
+    } catch (IllegalArgumentException ex) {
+      return false;
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerTransferLimitChangeRequest.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerTransferLimitChangeRequest.java
@@ -1,0 +1,53 @@
+package com.aquilabank.domain.customerapplication.model;
+
+import java.util.Map;
+import java.util.Optional;
+
+/** 이체한도 변경 payload는 신청 접수와 실행 단계에서 같은 parser를 사용합니다. */
+public record CustomerTransferLimitChangeRequest(
+    long singleTransferLimitMinor, long dailyTransferLimitMinor) {
+
+  private static final String SINGLE_LIMIT_KEY = "singleTransferLimitMinor";
+  private static final String DAILY_LIMIT_KEY = "dailyTransferLimitMinor";
+  private static final String REQUESTED_SINGLE_LIMIT_KEY = "requestedSingleTransferLimitMinor";
+  private static final String REQUESTED_DAILY_LIMIT_KEY = "requestedDailyTransferLimitMinor";
+
+  public CustomerTransferLimitChangeRequest {
+    if (singleTransferLimitMinor <= 0) {
+      throw new IllegalArgumentException("singleTransferLimitMinor must be positive");
+    }
+    if (dailyTransferLimitMinor < singleTransferLimitMinor) {
+      throw new IllegalArgumentException(
+          "dailyTransferLimitMinor must be greater than or equal to singleTransferLimitMinor");
+    }
+  }
+
+  public static Optional<CustomerTransferLimitChangeRequest> fromPayload(
+      Map<String, Object> payload) {
+    if (payload == null) {
+      return Optional.empty();
+    }
+    Long singleLimit = longPayloadValue(payload, SINGLE_LIMIT_KEY, REQUESTED_SINGLE_LIMIT_KEY);
+    Long dailyLimit = longPayloadValue(payload, DAILY_LIMIT_KEY, REQUESTED_DAILY_LIMIT_KEY);
+    if (singleLimit == null || dailyLimit == null || dailyLimit < singleLimit) {
+      return Optional.empty();
+    }
+    return Optional.of(new CustomerTransferLimitChangeRequest(singleLimit, dailyLimit));
+  }
+
+  private static Long longPayloadValue(
+      Map<String, Object> payload, String key, String fallbackKey) {
+    Object value = payload.containsKey(key) ? payload.get(key) : payload.get(fallbackKey);
+    if (value instanceof Number number) {
+      return number.longValue();
+    }
+    if (value instanceof String stringValue && !stringValue.isBlank()) {
+      try {
+        return Long.parseLong(stringValue);
+      } catch (NumberFormatException ex) {
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerApplicationReadPort.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerApplicationReadPort.java
@@ -1,0 +1,14 @@
+package com.aquilabank.domain.customerapplication.port;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import java.util.List;
+import java.util.Optional;
+
+/** 고객 본인 신청 조회는 user_id index를 타는 bounded read path로 분리합니다. */
+public interface CustomerApplicationReadPort {
+
+  List<CustomerApplicationDetails> findByUserId(long userId, int limit);
+
+  Optional<CustomerApplicationDetails> findByUserIdAndReference(
+      long userId, String applicationReference);
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorService.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorService.java
@@ -2,7 +2,10 @@ package com.aquilabank.domain.customerapplication.usecase;
 
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationProcessingMode;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangePolicy;
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangeRequest;
 import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitPolicyCommand;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationExecutorPort;
 import com.aquilabank.domain.customerapplication.port.CustomerTransferLimitPolicyPort;
@@ -14,16 +17,14 @@ import java.util.Objects;
 /** 외부 기관 연동 없는 신청은 실패로 남기고, 내부 실행 가능한 신청만 실제 policy로 반영합니다. */
 public final class CustomerApplicationExecutorService implements CustomerApplicationExecutorPort {
 
-  private static final String SINGLE_LIMIT_KEY = "singleTransferLimitMinor";
-  private static final String DAILY_LIMIT_KEY = "dailyTransferLimitMinor";
-  private static final String REQUESTED_SINGLE_LIMIT_KEY = "requestedSingleTransferLimitMinor";
-  private static final String REQUESTED_DAILY_LIMIT_KEY = "requestedDailyTransferLimitMinor";
-
   private final CustomerTransferLimitPolicyPort transferLimitPolicyPort;
+  private final CustomerTransferLimitChangePolicy transferLimitChangePolicy;
 
   public CustomerApplicationExecutorService(
-      CustomerTransferLimitPolicyPort transferLimitPolicyPort) {
+      CustomerTransferLimitPolicyPort transferLimitPolicyPort,
+      CustomerTransferLimitChangePolicy transferLimitChangePolicy) {
     this.transferLimitPolicyPort = Objects.requireNonNull(transferLimitPolicyPort);
+    this.transferLimitChangePolicy = Objects.requireNonNull(transferLimitChangePolicy);
   }
 
   @Override
@@ -32,9 +33,18 @@ public final class CustomerApplicationExecutorService implements CustomerApplica
     if (application.applicationType() == CustomerApplicationType.TRANSFER_LIMIT_CHANGE) {
       return executeTransferLimitChange(application, actorSubject, requestId);
     }
+    String reason =
+        application.applicationType().processingMode()
+                == CustomerApplicationProcessingMode.MANUAL_REVIEW_REQUIRED
+            ? "MANUAL_REVIEW_REQUIRED"
+            : "EXTERNAL_EXECUTION_NOT_CONFIGURED";
     return CustomerApplicationExecutionResult.failed(
-        "EXTERNAL_EXECUTION_NOT_CONFIGURED",
-        Map.of("applicationType", application.applicationType().name()));
+        reason,
+        Map.of(
+            "applicationType",
+            application.applicationType().name(),
+            "processingMode",
+            application.applicationType().processingMode().name()));
   }
 
   private CustomerApplicationExecutionResult executeTransferLimitChange(
@@ -44,14 +54,24 @@ public final class CustomerApplicationExecutorService implements CustomerApplica
           "TRANSFER_LIMIT_ACCOUNT_REQUIRED",
           Map.of("applicationType", application.applicationType().name()));
     }
-    Long singleLimit =
-        longPayloadValue(application.payload(), SINGLE_LIMIT_KEY, REQUESTED_SINGLE_LIMIT_KEY);
-    Long dailyLimit =
-        longPayloadValue(application.payload(), DAILY_LIMIT_KEY, REQUESTED_DAILY_LIMIT_KEY);
-    if (singleLimit == null || dailyLimit == null || dailyLimit < singleLimit) {
+    CustomerTransferLimitChangeRequest request =
+        CustomerTransferLimitChangeRequest.fromPayload(application.payload()).orElse(null);
+    if (request == null) {
       return CustomerApplicationExecutionResult.failed(
           "TRANSFER_LIMIT_PAYLOAD_INVALID",
           Map.of("applicationType", application.applicationType().name()));
+    }
+    if (!transferLimitChangePolicy.allows(
+        request.singleTransferLimitMinor(), request.dailyTransferLimitMinor())) {
+      return CustomerApplicationExecutionResult.failed(
+          "TRANSFER_LIMIT_POLICY_EXCEEDED",
+          Map.of(
+              "applicationType",
+              application.applicationType().name(),
+              "maxSingleTransferLimitMinor",
+              transferLimitChangePolicy.maxSingleTransferLimitMinor(),
+              "maxDailyTransferLimitMinor",
+              transferLimitChangePolicy.maxDailyTransferLimitMinor()));
     }
 
     TransferLimitPolicy policy =
@@ -59,8 +79,8 @@ public final class CustomerApplicationExecutorService implements CustomerApplica
             new CustomerTransferLimitPolicyCommand(
                 application.userId(),
                 application.accountId(),
-                singleLimit,
-                dailyLimit,
+                request.singleTransferLimitMinor(),
+                request.dailyTransferLimitMinor(),
                 application.applicationReference(),
                 actorSubject,
                 requestId,
@@ -74,20 +94,5 @@ public final class CustomerApplicationExecutorService implements CustomerApplica
             policy.singleTransferLimitMinor(),
             "dailyTransferLimitMinor",
             policy.dailyTransferLimitMinor()));
-  }
-
-  private Long longPayloadValue(Map<String, Object> payload, String key, String fallbackKey) {
-    Object value = payload.containsKey(key) ? payload.get(key) : payload.get(fallbackKey);
-    if (value instanceof Number number) {
-      return number.longValue();
-    }
-    if (value instanceof String stringValue && !stringValue.isBlank()) {
-      try {
-        return Long.parseLong(stringValue);
-      } catch (NumberFormatException ex) {
-        return null;
-      }
-    }
-    return null;
   }
 }

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationService.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationService.java
@@ -49,7 +49,7 @@ public final class CustomerApplicationOperationService
                     new CustomerApplicationNotFoundException("customer application was not found"));
     Instant now = Instant.now(clock);
     if (command.action() == CustomerApplicationAction.EXECUTE) {
-      validateTransition(application.status(), command.action());
+      validateOperationPolicy(application, command);
       CustomerApplicationExecutionResult result =
           executorPort.execute(application, command.actorSubject(), command.requestId());
       return operationPort.updateStatus(
@@ -62,7 +62,7 @@ public final class CustomerApplicationOperationService
               result.payload()));
     }
 
-    CustomerApplicationStatus status = targetStatus(application.status(), command.action());
+    CustomerApplicationStatus status = targetStatus(application, command);
     return operationPort.updateStatus(
         new CustomerApplicationStateUpdateCommand(
             command.applicationReference(),
@@ -74,9 +74,22 @@ public final class CustomerApplicationOperationService
   }
 
   private CustomerApplicationStatus targetStatus(
-      CustomerApplicationStatus currentStatus, CustomerApplicationAction action) {
-    validateTransition(currentStatus, action);
-    return TARGET_STATUSES.get(action);
+      CustomerApplicationDetails application, CustomerApplicationDecisionCommand command) {
+    validateOperationPolicy(application, command);
+    return TARGET_STATUSES.get(command.action());
+  }
+
+  private void validateOperationPolicy(
+      CustomerApplicationDetails application, CustomerApplicationDecisionCommand command) {
+    validateTransition(application.status(), command.action());
+    if (command.action() == CustomerApplicationAction.APPROVE
+        && sameActor(application.processedBy(), command.actorSubject())) {
+      throw makerCheckerViolation(application.status(), command.action());
+    }
+    if (command.action() == CustomerApplicationAction.EXECUTE
+        && sameActor(application.processedBy(), command.actorSubject())) {
+      throw makerCheckerViolation(application.status(), command.action());
+    }
   }
 
   private void validateTransition(
@@ -87,9 +100,7 @@ public final class CustomerApplicationOperationService
     boolean allowed =
         switch (action) {
           case START_REVIEW -> currentStatus == CustomerApplicationStatus.SUBMITTED;
-          case APPROVE ->
-              currentStatus == CustomerApplicationStatus.SUBMITTED
-                  || currentStatus.isReviewingState();
+          case APPROVE -> currentStatus.isReviewingState();
           case REJECT ->
               currentStatus == CustomerApplicationStatus.SUBMITTED
                   || currentStatus.isReviewingState()
@@ -108,6 +119,17 @@ public final class CustomerApplicationOperationService
       CustomerApplicationStatus currentStatus, CustomerApplicationAction action) {
     return new CustomerApplicationInvalidTransitionException(
         "cannot %s customer application from %s".formatted(action.name(), currentStatus.name()));
+  }
+
+  private CustomerApplicationInvalidTransitionException makerCheckerViolation(
+      CustomerApplicationStatus currentStatus, CustomerApplicationAction action) {
+    return new CustomerApplicationInvalidTransitionException(
+        "maker-checker violation: cannot %s customer application from %s with same actor"
+            .formatted(action.name(), currentStatus.name()));
+  }
+
+  private boolean sameActor(String processedBy, String actorSubject) {
+    return processedBy != null && processedBy.equals(actorSubject);
   }
 
   private String normalizeReason(String reason) {

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationSelfService.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationSelfService.java
@@ -1,0 +1,101 @@
+package com.aquilabank.domain.customerapplication.usecase;
+
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationInvalidTransitionException;
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationNotFoundException;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStateUpdateCommand;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationReadPort;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** 고객 self-service는 본인 신청만 조회/취소하고 운영자 승인 단계는 건드리지 않습니다. */
+public final class CustomerApplicationSelfService implements CustomerApplicationSelfServiceUseCase {
+
+  private static final int DEFAULT_LIMIT = 20;
+  private static final int MAX_LIMIT = 50;
+
+  private final CustomerApplicationReadPort readPort;
+  private final CustomerApplicationOperationPort operationPort;
+  private final Clock clock;
+
+  public CustomerApplicationSelfService(
+      CustomerApplicationReadPort readPort,
+      CustomerApplicationOperationPort operationPort,
+      Clock clock) {
+    this.readPort = Objects.requireNonNull(readPort);
+    this.operationPort = Objects.requireNonNull(operationPort);
+    this.clock = Objects.requireNonNull(clock);
+  }
+
+  @Override
+  public List<CustomerApplicationDetails> findByUserId(long userId, int limit) {
+    validateUserId(userId);
+    return readPort.findByUserId(userId, normalizeLimit(limit));
+  }
+
+  @Override
+  public CustomerApplicationDetails getByUserIdAndReference(
+      long userId, String applicationReference) {
+    validateUserId(userId);
+    validateReference(applicationReference);
+    return readPort
+        .findByUserIdAndReference(userId, applicationReference)
+        .orElseThrow(
+            () -> new CustomerApplicationNotFoundException("customer application was not found"));
+  }
+
+  @Override
+  public CustomerApplicationDetails cancel(
+      long userId, String applicationReference, String requestId) {
+    validateUserId(userId);
+    validateReference(applicationReference);
+    if (requestId == null || requestId.isBlank()) {
+      throw new IllegalArgumentException("requestId is required");
+    }
+    CustomerApplicationDetails application =
+        operationPort
+            .findByReferenceForUpdate(applicationReference)
+            .filter(item -> item.userId() == userId)
+            .orElseThrow(
+                () ->
+                    new CustomerApplicationNotFoundException("customer application was not found"));
+    if (application.status().isTerminal()
+        || application.status() == CustomerApplicationStatus.APPROVED) {
+      throw new CustomerApplicationInvalidTransitionException(
+          "cannot CANCEL customer application from " + application.status().name());
+    }
+    Instant now = Instant.now(clock);
+    return operationPort.updateStatus(
+        new CustomerApplicationStateUpdateCommand(
+            applicationReference,
+            CustomerApplicationStatus.CANCELLED,
+            null,
+            "customer:" + userId,
+            now,
+            Map.of("requestId", requestId)));
+  }
+
+  private int normalizeLimit(int limit) {
+    if (limit <= 0) {
+      return DEFAULT_LIMIT;
+    }
+    return Math.min(limit, MAX_LIMIT);
+  }
+
+  private void validateUserId(long userId) {
+    if (userId <= 0) {
+      throw new IllegalArgumentException("userId must be positive");
+    }
+  }
+
+  private void validateReference(String applicationReference) {
+    if (applicationReference == null || applicationReference.isBlank()) {
+      throw new IllegalArgumentException("applicationReference is required");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationSelfServiceUseCase.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationSelfServiceUseCase.java
@@ -1,0 +1,13 @@
+package com.aquilabank.domain.customerapplication.usecase;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import java.util.List;
+
+public interface CustomerApplicationSelfServiceUseCase {
+
+  List<CustomerApplicationDetails> findByUserId(long userId, int limit);
+
+  CustomerApplicationDetails getByUserIdAndReference(long userId, String applicationReference);
+
+  CustomerApplicationDetails cancel(long userId, String applicationReference, String requestId);
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationService.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationService.java
@@ -4,6 +4,8 @@ import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmission;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmitCommand;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationWriteCommand;
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangePolicy;
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangeRequest;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationReferencePort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationSecurityVerificationPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationWritePort;
@@ -22,20 +24,24 @@ public final class CustomerApplicationService implements CustomerApplicationSubm
   private final CustomerApplicationSecurityVerificationPort securityVerificationPort;
   private final CustomerApplicationReferencePort referencePort;
   private final Clock clock;
+  private final CustomerTransferLimitChangePolicy transferLimitChangePolicy;
 
   public CustomerApplicationService(
       CustomerApplicationWritePort writePort,
       CustomerApplicationSecurityVerificationPort securityVerificationPort,
       CustomerApplicationReferencePort referencePort,
-      Clock clock) {
+      Clock clock,
+      CustomerTransferLimitChangePolicy transferLimitChangePolicy) {
     this.writePort = Objects.requireNonNull(writePort);
     this.securityVerificationPort = Objects.requireNonNull(securityVerificationPort);
     this.referencePort = Objects.requireNonNull(referencePort);
     this.clock = Objects.requireNonNull(clock);
+    this.transferLimitChangePolicy = Objects.requireNonNull(transferLimitChangePolicy);
   }
 
   @Override
   public CustomerApplicationSubmission submit(CustomerApplicationSubmitCommand command) {
+    validateCommand(command);
     Instant now = Instant.now(clock);
     boolean mfaVerified = false;
     Instant mfaVerifiedAt = null;
@@ -61,6 +67,24 @@ public final class CustomerApplicationService implements CustomerApplicationSubm
             mfaVerifiedAt,
             command.payload(),
             now));
+  }
+
+  private void validateCommand(CustomerApplicationSubmitCommand command) {
+    if (command.applicationType().supportsAutomatedExecution()) {
+      validateTransferLimitChange(command);
+    }
+  }
+
+  private void validateTransferLimitChange(CustomerApplicationSubmitCommand command) {
+    if (command.accountId() == null) {
+      throw new IllegalArgumentException("accountId is required for transfer limit change");
+    }
+    CustomerTransferLimitChangeRequest request =
+        CustomerTransferLimitChangeRequest.fromPayload(command.payload())
+            .orElseThrow(
+                () -> new IllegalArgumentException("transfer limit change payload is invalid"));
+    transferLimitChangePolicy.validate(
+        request.singleTransferLimitMinor(), request.dailyTransferLimitMinor());
   }
 
   private String fingerprint(CustomerApplicationSubmitCommand command) {

--- a/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
@@ -2,8 +2,10 @@ package com.aquilabank.global.config;
 
 import com.aquilabank.domain.auth.model.TotpOperationVerifyCommand;
 import com.aquilabank.domain.auth.usecase.TotpOperationVerifyUseCase;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationExecutorPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationReadPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationReferencePort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationSecurityVerificationPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationWritePort;
@@ -11,9 +13,12 @@ import com.aquilabank.domain.customerapplication.port.CustomerTransferLimitPolic
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationExecutorService;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationOperationService;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationOperationUseCase;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSelfService;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSelfServiceUseCase;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationService;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSubmitUseCase;
 import java.time.Clock;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -87,6 +92,42 @@ public class CustomerApplicationConfiguration {
             "customer application operation transaction returned null result");
       }
       return result;
+    };
+  }
+
+  @Bean
+  CustomerApplicationSelfServiceUseCase customerApplicationSelfServiceUseCase(
+      CustomerApplicationReadPort readPort,
+      CustomerApplicationOperationPort operationPort,
+      Clock authClock,
+      PlatformTransactionManager platformTransactionManager) {
+    CustomerApplicationSelfService service =
+        new CustomerApplicationSelfService(readPort, operationPort, authClock);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    return new CustomerApplicationSelfServiceUseCase() {
+      @Override
+      public List<CustomerApplicationDetails> findByUserId(long userId, int limit) {
+        return service.findByUserId(userId, limit);
+      }
+
+      @Override
+      public CustomerApplicationDetails getByUserIdAndReference(
+          long userId, String applicationReference) {
+        return service.getByUserIdAndReference(userId, applicationReference);
+      }
+
+      @Override
+      public CustomerApplicationDetails cancel(
+          long userId, String applicationReference, String requestId) {
+        var result =
+            transactionTemplate.execute(
+                status -> service.cancel(userId, applicationReference, requestId));
+        if (result == null) {
+          throw new IllegalStateException(
+              "customer application self-service transaction returned null result");
+        }
+        return result;
+      }
     };
   }
 }

--- a/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
@@ -15,6 +15,7 @@ import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationServ
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSubmitUseCase;
 import java.time.Clock;
 import java.util.UUID;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -22,6 +23,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 /** 고객 업무 신청 접수 use case와 인증 adapter를 조립합니다. */
 @Configuration
+@EnableConfigurationProperties(CustomerApplicationProperties.class)
 public class CustomerApplicationConfiguration {
 
   @Bean
@@ -42,10 +44,15 @@ public class CustomerApplicationConfiguration {
       CustomerApplicationSecurityVerificationPort securityVerificationPort,
       CustomerApplicationReferencePort referencePort,
       Clock authClock,
+      CustomerApplicationProperties properties,
       PlatformTransactionManager platformTransactionManager) {
     CustomerApplicationService service =
         new CustomerApplicationService(
-            writePort, securityVerificationPort, referencePort, authClock);
+            writePort,
+            securityVerificationPort,
+            referencePort,
+            authClock,
+            properties.transferLimitChangePolicy());
     TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
     return command -> {
       var result = transactionTemplate.execute(status -> service.submit(command));
@@ -58,8 +65,10 @@ public class CustomerApplicationConfiguration {
 
   @Bean
   CustomerApplicationExecutorPort customerApplicationExecutorPort(
-      CustomerTransferLimitPolicyPort transferLimitPolicyPort) {
-    return new CustomerApplicationExecutorService(transferLimitPolicyPort);
+      CustomerTransferLimitPolicyPort transferLimitPolicyPort,
+      CustomerApplicationProperties properties) {
+    return new CustomerApplicationExecutorService(
+        transferLimitPolicyPort, properties.transferLimitChangePolicy());
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/config/CustomerApplicationProperties.java
+++ b/back/src/main/java/com/aquilabank/global/config/CustomerApplicationProperties.java
@@ -1,0 +1,41 @@
+package com.aquilabank.global.config;
+
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangePolicy;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** 고객 신청별 운영 정책값. domain에는 검증 policy 값만 전달합니다. */
+@ConfigurationProperties(prefix = "customer-application")
+public record CustomerApplicationProperties(TransferLimitChange transferLimitChange) {
+
+  public CustomerApplicationProperties {
+    transferLimitChange =
+        transferLimitChange == null
+            ? new TransferLimitChange(50_000_000L, 200_000_000L)
+            : transferLimitChange;
+  }
+
+  public CustomerTransferLimitChangePolicy transferLimitChangePolicy() {
+    return new CustomerTransferLimitChangePolicy(
+        transferLimitChange.maxSingleTransferLimitMinor(),
+        transferLimitChange.maxDailyTransferLimitMinor());
+  }
+
+  public record TransferLimitChange(
+      long maxSingleTransferLimitMinor, long maxDailyTransferLimitMinor) {
+
+    public TransferLimitChange {
+      if (maxSingleTransferLimitMinor <= 0) {
+        throw new IllegalArgumentException(
+            "customer-application.transfer-limit-change.max-single-transfer-limit-minor must be positive");
+      }
+      if (maxDailyTransferLimitMinor <= 0) {
+        throw new IllegalArgumentException(
+            "customer-application.transfer-limit-change.max-daily-transfer-limit-minor must be positive");
+      }
+      if (maxDailyTransferLimitMinor < maxSingleTransferLimitMinor) {
+        throw new IllegalArgumentException(
+            "customer-application.transfer-limit-change.max-daily-transfer-limit-minor must be greater than or equal to max-single-transfer-limit-minor");
+      }
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/config/NotificationChannelProviderWorkerConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/NotificationChannelProviderWorkerConfiguration.java
@@ -57,7 +57,9 @@ public class NotificationChannelProviderWorkerConfiguration {
   NotificationChannelProviderWorkerUseCase notificationChannelProviderWorkerUseCase(
       NotificationChannelOutboxDispatchPort dispatchPort,
       NotificationChannelProviderPort providerPort,
-      NotificationChannelProviderWorkerProperties properties) {
+      NotificationChannelProviderWorkerProperties properties,
+      NotificationChannelProviderDeliveryProperties deliveryProperties) {
+    validateProviderWorkerDeliveryBoundary(properties, deliveryProperties);
     return new NotificationChannelProviderWorkerService(
         dispatchPort,
         providerPort,
@@ -66,6 +68,23 @@ public class NotificationChannelProviderWorkerConfiguration {
         Duration.ofSeconds(properties.retryBaseDelaySeconds()),
         Duration.ofSeconds(properties.maxRetryDelaySeconds()),
         properties.maxRetryAttempts());
+  }
+
+  private void validateProviderWorkerDeliveryBoundary(
+      NotificationChannelProviderWorkerProperties workerProperties,
+      NotificationChannelProviderDeliveryProperties deliveryProperties) {
+    if (!workerProperties.enabled()) {
+      return;
+    }
+    // 운영 worker가 logging/skip provider로 도는 misconfiguration을 시작 단계에서 차단합니다.
+    if (!deliveryProperties.enabled()) {
+      throw new IllegalStateException(
+          "notification channel provider worker requires delivery.enabled=true");
+    }
+    if (!deliveryProperties.email().configured() && !deliveryProperties.sms().configured()) {
+      throw new IllegalStateException(
+          "notification channel provider worker requires at least one provider URL");
+    }
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/persistence/customerapplication/JdbcCustomerApplicationRepository.java
+++ b/back/src/main/java/com/aquilabank/global/persistence/customerapplication/JdbcCustomerApplicationRepository.java
@@ -9,6 +9,7 @@ import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmis
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationWriteCommand;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationReadPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationWritePort;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -25,7 +27,9 @@ import org.springframework.stereotype.Repository;
 /** 고객 신청 접수 write 모델을 idempotency key 기준으로 한 번만 저장합니다. */
 @Repository
 public class JdbcCustomerApplicationRepository
-    implements CustomerApplicationWritePort, CustomerApplicationOperationPort {
+    implements CustomerApplicationWritePort,
+        CustomerApplicationOperationPort,
+        CustomerApplicationReadPort {
 
   private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
@@ -136,6 +140,69 @@ public class JdbcCustomerApplicationRepository
             FROM customer_service_application
             WHERE application_reference = :applicationReference
             FOR UPDATE
+            """,
+            params,
+            (rs, rowNum) -> mapDetails(rs))
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public List<CustomerApplicationDetails> findByUserId(long userId, int limit) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("userId", userId).addValue("limit", limit);
+    return jdbcTemplate.query(
+        """
+        SELECT application_reference,
+               user_id,
+               account_id,
+               application_type,
+               application_status,
+               mfa_verified,
+               mfa_verified_at,
+               payload,
+               submitted_at,
+               updated_at,
+               status_reason,
+               processed_by,
+               processed_at,
+               execution_result
+        FROM customer_service_application
+        WHERE user_id = :userId
+        ORDER BY submitted_at DESC, id DESC
+        LIMIT :limit
+        """,
+        params,
+        (rs, rowNum) -> mapDetails(rs));
+  }
+
+  @Override
+  public Optional<CustomerApplicationDetails> findByUserIdAndReference(
+      long userId, String applicationReference) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("applicationReference", applicationReference);
+    return jdbcTemplate
+        .query(
+            """
+            SELECT application_reference,
+                   user_id,
+                   account_id,
+                   application_type,
+                   application_status,
+                   mfa_verified,
+                   mfa_verified_at,
+                   payload,
+                   submitted_at,
+                   updated_at,
+                   status_reason,
+                   processed_by,
+                   processed_at,
+                   execution_result
+            FROM customer_service_application
+            WHERE user_id = :userId
+              AND application_reference = :applicationReference
             """,
             params,
             (rs, rowNum) -> mapDetails(rs))

--- a/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
+++ b/back/src/main/java/com/aquilabank/global/web/ApiExceptionHandler.java
@@ -38,6 +38,7 @@ import com.aquilabank.global.security.InternalServiceRequestAuthorizer;
 import com.aquilabank.global.security.InternalServiceTokenClaims;
 import com.aquilabank.global.security.LoginThrottleScope;
 import com.aquilabank.global.security.LoginThrottledException;
+import com.aquilabank.global.web.ledger.TransferRecipientPreviewThrottledException;
 import com.aquilabank.global.web.transaction.TransactionReadAccountFairnessRejectedException;
 import com.aquilabank.global.web.transaction.TransactionReadUpstream429Metrics;
 import jakarta.servlet.http.HttpServletRequest;
@@ -176,6 +177,27 @@ public class ApiExceptionHandler {
         .header(
             RATE_LIMIT_RETRY_JITTER_MILLIS_HEADER,
             Integer.toString(retryJitterMillis(ex.retryAfterSeconds())))
+        .body(
+            new ApiErrorResponse(
+                Instant.now(),
+                HttpStatus.TOO_MANY_REQUESTS.value(),
+                HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI()));
+  }
+
+  @ExceptionHandler(TransferRecipientPreviewThrottledException.class)
+  ResponseEntity<ApiErrorResponse> handleTransferRecipientPreviewThrottled(
+      TransferRecipientPreviewThrottledException ex, HttpServletRequest request) {
+    logInternalAuthStatusFailure(HttpStatus.TOO_MANY_REQUESTS, request, ex.getMessage());
+    String source = "transfer-recipient-preview";
+    return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+        .header("Retry-After", Long.toString(ex.retryAfterSeconds()))
+        .header(UPSTREAM_429_SOURCE_HEADER, source)
+        .header(REJECT_SOURCE_HEADER, "security")
+        .header(REJECT_REASON_HEADER, source)
+        .header(RATE_LIMIT_SCOPE_HEADER, source)
+        .header(RATE_LIMIT_RETRY_AFTER_HEADER, Long.toString(ex.retryAfterSeconds()))
         .body(
             new ApiErrorResponse(
                 Instant.now(),

--- a/back/src/main/java/com/aquilabank/global/web/customerapplication/CustomerApplicationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/customerapplication/CustomerApplicationController.java
@@ -1,11 +1,14 @@
 package com.aquilabank.global.web.customerapplication;
 
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmission;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmitCommand;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSelfServiceUseCase;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSubmitUseCase;
 import com.aquilabank.global.security.AuthenticatedRequestPrincipal;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
+import com.aquilabank.global.web.RequestTraceContext;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipal;
 import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
 import jakarta.validation.Valid;
@@ -13,13 +16,17 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -32,13 +39,52 @@ public class CustomerApplicationController {
   private static final int MAX_PAYLOAD_FIELDS = 30;
 
   private final CustomerApplicationSubmitUseCase customerApplicationSubmitUseCase;
+  private final CustomerApplicationSelfServiceUseCase customerApplicationSelfServiceUseCase;
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
 
   public CustomerApplicationController(
       CustomerApplicationSubmitUseCase customerApplicationSubmitUseCase,
+      CustomerApplicationSelfServiceUseCase customerApplicationSelfServiceUseCase,
       RequestAccountAuthorizationService requestAccountAuthorizationService) {
     this.customerApplicationSubmitUseCase = customerApplicationSubmitUseCase;
+    this.customerApplicationSelfServiceUseCase = customerApplicationSelfServiceUseCase;
     this.requestAccountAuthorizationService = requestAccountAuthorizationService;
+  }
+
+  @GetMapping
+  public CustomerApplicationListResponse list(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @RequestParam(required = false) @Positive(message = "limit must be positive") Integer limit) {
+    AuthenticatedUserPrincipal userPrincipal = requireUserPrincipal(principal);
+    List<CustomerApplicationDetailsResponse> items =
+        customerApplicationSelfServiceUseCase
+            .findByUserId(userPrincipal.userId(), limit == null ? 20 : limit)
+            .stream()
+            .map(CustomerApplicationDetailsResponse::from)
+            .toList();
+    return new CustomerApplicationListResponse(items);
+  }
+
+  @GetMapping("/{applicationReference}")
+  public CustomerApplicationDetailsResponse get(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @PathVariable String applicationReference) {
+    AuthenticatedUserPrincipal userPrincipal = requireUserPrincipal(principal);
+    return CustomerApplicationDetailsResponse.from(
+        customerApplicationSelfServiceUseCase.getByUserIdAndReference(
+            userPrincipal.userId(), applicationReference));
+  }
+
+  @PostMapping("/{applicationReference}/cancel")
+  public CustomerApplicationDetailsResponse cancel(
+      @CurrentAuthenticatedPrincipal AuthenticatedRequestPrincipal principal,
+      @PathVariable String applicationReference) {
+    AuthenticatedUserPrincipal userPrincipal = requireUserPrincipal(principal);
+    return CustomerApplicationDetailsResponse.from(
+        customerApplicationSelfServiceUseCase.cancel(
+            userPrincipal.userId(),
+            applicationReference,
+            RequestTraceContext.currentRequestId().orElse("request-id-unavailable")));
   }
 
   @PostMapping
@@ -116,6 +162,8 @@ public class CustomerApplicationController {
       String applicationReference,
       Long accountId,
       String applicationType,
+      String processingMode,
+      boolean automatedExecutionSupported,
       String status,
       boolean mfaVerified,
       Instant mfaVerifiedAt,
@@ -127,11 +175,50 @@ public class CustomerApplicationController {
           result.applicationReference(),
           result.accountId(),
           result.applicationType().name(),
+          result.applicationType().processingMode().name(),
+          result.applicationType().supportsAutomatedExecution(),
           result.status().name(),
           result.mfaVerified(),
           result.mfaVerifiedAt(),
           result.submittedAt(),
           result.updatedAt());
+    }
+  }
+
+  public record CustomerApplicationListResponse(List<CustomerApplicationDetailsResponse> items) {}
+
+  public record CustomerApplicationDetailsResponse(
+      String applicationReference,
+      Long accountId,
+      String applicationType,
+      String processingMode,
+      boolean automatedExecutionSupported,
+      String status,
+      boolean mfaVerified,
+      Instant mfaVerifiedAt,
+      Instant submittedAt,
+      Instant updatedAt,
+      String reason,
+      String processedBy,
+      Instant processedAt,
+      Map<String, Object> executionResult) {
+
+    static CustomerApplicationDetailsResponse from(CustomerApplicationDetails result) {
+      return new CustomerApplicationDetailsResponse(
+          result.applicationReference(),
+          result.accountId(),
+          result.applicationType().name(),
+          result.applicationType().processingMode().name(),
+          result.applicationType().supportsAutomatedExecution(),
+          result.status().name(),
+          result.mfaVerified(),
+          result.mfaVerifiedAt(),
+          result.submittedAt(),
+          result.updatedAt(),
+          result.reason(),
+          result.processedBy(),
+          result.processedAt(),
+          result.executionResult());
     }
   }
 }

--- a/back/src/main/java/com/aquilabank/global/web/customerapplication/CustomerApplicationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/customerapplication/CustomerApplicationController.java
@@ -47,7 +47,7 @@ public class CustomerApplicationController {
       @RequestHeader("Idempotency-Key") @Size(max = 120) String idempotencyKey,
       @Valid @RequestBody CustomerApplicationRequest request) {
     AuthenticatedUserPrincipal userPrincipal = requireUserPrincipal(principal);
-    Long accountId = resolveAccountId(principal, request.accountId());
+    Long accountId = resolveAccountId(principal, request.applicationType(), request.accountId());
     validatePayload(request.payload());
     CustomerApplicationSubmission result =
         customerApplicationSubmitUseCase.submit(
@@ -61,9 +61,16 @@ public class CustomerApplicationController {
     return CustomerApplicationResponse.from(result);
   }
 
-  private Long resolveAccountId(AuthenticatedRequestPrincipal principal, Long accountId) {
+  private Long resolveAccountId(
+      AuthenticatedRequestPrincipal principal,
+      CustomerApplicationType applicationType,
+      Long accountId) {
     if (accountId == null) {
       return null;
+    }
+    if (applicationType == CustomerApplicationType.TRANSFER_LIMIT_CHANGE) {
+      return requestAccountAuthorizationService.resolveTransferSourceAccountId(
+          principal, accountId);
     }
     return requestAccountAuthorizationService.resolveReadableAccountId(principal, accountId);
   }

--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferCommandController.java
@@ -31,6 +31,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,6 +50,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/transfers")
 public class TransferCommandController {
 
+  private static final int USER_RECIPIENT_PREVIEW_MAX_ATTEMPTS = 20;
+  private static final long USER_RECIPIENT_PREVIEW_WINDOW_SECONDS = 60L;
+  private static final int USER_RECIPIENT_PREVIEW_MAX_TRACKED_USERS = 10_000;
+
   private final TransferCommandUseCase transferCommandUseCase;
   private final TransferReversalUseCase transferReversalUseCase;
   private final RequestAccountAuthorizationService requestAccountAuthorizationService;
@@ -58,6 +64,8 @@ public class TransferCommandController {
   private final TotpOperationVerifyUseCase totpOperationVerifyUseCase;
   private final TransferLimitPolicyProperties transferLimitPolicyProperties;
   private final Clock clock;
+  private final ConcurrentMap<Long, RecipientPreviewThrottleWindow>
+      recipientPreviewThrottleWindows = new ConcurrentHashMap<>();
 
   @Autowired
   public TransferCommandController(
@@ -124,7 +132,7 @@ public class TransferCommandController {
             principal, sourceAccountId);
     AccountSummary source = accountSummaryQueryUseCase.getByAccountId(resolvedSourceAccountId);
     AccountSummary target =
-        resolveTransferTargetAccount(principal, targetAccountId, targetAccountNumber);
+        resolveTransferPreviewTargetAccount(principal, targetAccountId, targetAccountNumber);
     ZoneId businessZoneId = ZoneId.of(transferLimitPolicyProperties.businessZoneId());
     Instant now = clock.instant();
     LocalDate businessDate = LocalDate.ofInstant(now, businessZoneId);
@@ -224,6 +232,18 @@ public class TransferCommandController {
     return accountSummaryQueryUseCase.getByAccountId(targetAccountId);
   }
 
+  private AccountSummary resolveTransferPreviewTargetAccount(
+      AuthenticatedRequestPrincipal principal, Long targetAccountId, String targetAccountNumber) {
+    if (principal instanceof AuthenticatedUserPrincipal userPrincipal) {
+      if (targetAccountNumber == null || targetAccountNumber.isBlank()) {
+        throw new IllegalArgumentException("targetAccountNumber is required");
+      }
+      checkRecipientPreviewThrottle(userPrincipal);
+      return accountSummaryQueryUseCase.getByAccountNumber(targetAccountNumber.trim());
+    }
+    return resolveTransferTargetAccount(principal, targetAccountId, targetAccountNumber);
+  }
+
   private long resolveTransferTargetAccountId(
       AuthenticatedRequestPrincipal principal, Long targetAccountId, String targetAccountNumber) {
     if (principal instanceof AuthenticatedUserPrincipal) {
@@ -234,6 +254,36 @@ public class TransferCommandController {
       throw new IllegalArgumentException("targetAccountId is required");
     }
     return targetAccountId;
+  }
+
+  private void checkRecipientPreviewThrottle(AuthenticatedUserPrincipal userPrincipal) {
+    long nowEpochSecond = clock.instant().getEpochSecond();
+    RecipientPreviewThrottleWindow window =
+        recipientPreviewThrottleWindows.compute(
+            userPrincipal.userId(),
+            (userId, current) -> {
+              if (current == null || current.expired(nowEpochSecond)) {
+                return new RecipientPreviewThrottleWindow(nowEpochSecond, 1);
+              }
+              int attempts =
+                  Math.min(current.attempts() + 1, USER_RECIPIENT_PREVIEW_MAX_ATTEMPTS + 1);
+              return new RecipientPreviewThrottleWindow(current.windowStartEpochSecond(), attempts);
+            });
+    pruneExpiredRecipientPreviewWindows(nowEpochSecond);
+    if (window.attempts() > USER_RECIPIENT_PREVIEW_MAX_ATTEMPTS) {
+      throw new TransferRecipientPreviewThrottledException(
+          window.retryAfterSeconds(nowEpochSecond));
+    }
+  }
+
+  private void pruneExpiredRecipientPreviewWindows(long nowEpochSecond) {
+    if (recipientPreviewThrottleWindows.size() <= USER_RECIPIENT_PREVIEW_MAX_TRACKED_USERS) {
+      return;
+    }
+    // 사용자별 고정 window만 유지해 sequence 계좌번호 탐색 비용과 메모리 증가를 제한합니다.
+    recipientPreviewThrottleWindows
+        .entrySet()
+        .removeIf(entry -> entry.getValue().expired(nowEpochSecond));
   }
 
   private boolean shouldExposeInternalTarget(AuthenticatedRequestPrincipal principal) {
@@ -277,6 +327,18 @@ public class TransferCommandController {
       return "INSUFFICIENT_BALANCE";
     }
     return "OK";
+  }
+
+  private record RecipientPreviewThrottleWindow(long windowStartEpochSecond, int attempts) {
+
+    boolean expired(long nowEpochSecond) {
+      return nowEpochSecond - windowStartEpochSecond >= USER_RECIPIENT_PREVIEW_WINDOW_SECONDS;
+    }
+
+    long retryAfterSeconds(long nowEpochSecond) {
+      return Math.max(
+          1L, windowStartEpochSecond + USER_RECIPIENT_PREVIEW_WINDOW_SECONDS - nowEpochSecond);
+    }
   }
 
   /** 송금 preview target 계좌 요약. 공개 사용자 응답은 계좌번호 확인값만 노출합니다. */

--- a/back/src/main/java/com/aquilabank/global/web/ledger/TransferRecipientPreviewThrottledException.java
+++ b/back/src/main/java/com/aquilabank/global/web/ledger/TransferRecipientPreviewThrottledException.java
@@ -1,0 +1,19 @@
+package com.aquilabank.global.web.ledger;
+
+/** 공개 송금 preview 수취인 조회가 짧은 window 상한을 넘은 상태 */
+public final class TransferRecipientPreviewThrottledException extends RuntimeException {
+
+  private final long retryAfterSeconds;
+
+  public TransferRecipientPreviewThrottledException(long retryAfterSeconds) {
+    super("too many recipient preview requests");
+    if (retryAfterSeconds <= 0) {
+      throw new IllegalArgumentException("retryAfterSeconds must be positive");
+    }
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+
+  public long retryAfterSeconds() {
+    return retryAfterSeconds;
+  }
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -312,6 +312,11 @@ transaction:
       batch-size: ${TRANSACTION_READ_MODEL_CLEANUP_BATCH_SIZE:500}
       retention-days: ${TRANSACTION_READ_MODEL_CLEANUP_RETENTION_DAYS:365}
 
+customer-application:
+  transfer-limit-change:
+    max-single-transfer-limit-minor: ${CUSTOMER_APPLICATION_TRANSFER_LIMIT_CHANGE_MAX_SINGLE_TRANSFER_LIMIT_MINOR:50000000}
+    max-daily-transfer-limit-minor: ${CUSTOMER_APPLICATION_TRANSFER_LIMIT_CHANGE_MAX_DAILY_TRANSFER_LIMIT_MINOR:200000000}
+
 notification:
   channel-provider:
     delivery:

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationModelTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationModelTest.java
@@ -1,5 +1,6 @@
 package com.aquilabank.domain.customerapplication.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
@@ -8,6 +9,37 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class CustomerApplicationModelTest {
+
+  @Test
+  void exposesApplicationProcessingMode() {
+    assertThat(CustomerApplicationType.TRANSFER_LIMIT_CHANGE.processingMode())
+        .isEqualTo(CustomerApplicationProcessingMode.INTERNAL_EXECUTION);
+    assertThat(CustomerApplicationType.TRANSFER_LIMIT_CHANGE.supportsAutomatedExecution()).isTrue();
+    assertThat(CustomerApplicationType.BILL_PAYMENT.processingMode())
+        .isEqualTo(CustomerApplicationProcessingMode.EXTERNAL_PROVIDER_REQUIRED);
+    assertThat(CustomerApplicationType.INCIDENT_REPORT.processingMode())
+        .isEqualTo(CustomerApplicationProcessingMode.MANUAL_REVIEW_REQUIRED);
+  }
+
+  @Test
+  void rejectsInvalidTransferLimitChangePolicy() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new CustomerTransferLimitChangePolicy(0L, 1_000L));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CustomerTransferLimitChangePolicy(2_000L, 1_000L));
+  }
+
+  @Test
+  void validatesTransferLimitChangePolicyRequestValues() {
+    CustomerTransferLimitChangePolicy policy =
+        new CustomerTransferLimitChangePolicy(1_000L, 5_000L);
+
+    assertThat(policy.allows(1_000L, 5_000L)).isTrue();
+    assertThat(policy.allows(2_000L, 5_000L)).isFalse();
+    assertThrows(IllegalArgumentException.class, () -> policy.validate(0L, 1_000L));
+    assertThrows(IllegalArgumentException.class, () -> policy.validate(2_000L, 1_000L));
+  }
 
   @Test
   void rejectsPayloadNullValues() {

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorServiceTest.java
@@ -10,6 +10,7 @@ import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetail
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangePolicy;
 import com.aquilabank.domain.customerapplication.port.CustomerTransferLimitPolicyPort;
 import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
 import java.time.Instant;
@@ -20,8 +21,10 @@ class CustomerApplicationExecutorServiceTest {
 
   private final CustomerTransferLimitPolicyPort transferLimitPolicyPort =
       mock(CustomerTransferLimitPolicyPort.class);
+  private final CustomerTransferLimitChangePolicy transferLimitChangePolicy =
+      new CustomerTransferLimitChangePolicy(1_000_000L, 5_000_000L);
   private final CustomerApplicationExecutorService service =
-      new CustomerApplicationExecutorService(transferLimitPolicyPort);
+      new CustomerApplicationExecutorService(transferLimitPolicyPort, transferLimitChangePolicy);
 
   @Test
   void executesTransferLimitChangeApplication() {
@@ -116,6 +119,22 @@ class CustomerApplicationExecutorServiceTest {
   }
 
   @Test
+  void failsTransferLimitChangeAbovePolicyOnExecution() {
+    CustomerApplicationExecutionResult result =
+        service.execute(
+            details(
+                CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                101L,
+                Map.of(
+                    "singleTransferLimitMinor", 1_500_000L, "dailyTransferLimitMinor", 6_000_000L)),
+            "ops-executor",
+            "req-policy-exceeded");
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.FAILED);
+    assertThat(result.reason()).isEqualTo("TRANSFER_LIMIT_POLICY_EXCEEDED");
+  }
+
+  @Test
   void failsUnsupportedExternalApplicationExplicitly() {
     CustomerApplicationExecutionResult result =
         service.execute(
@@ -126,6 +145,20 @@ class CustomerApplicationExecutorServiceTest {
     assertThat(result.status()).isEqualTo(CustomerApplicationStatus.FAILED);
     assertThat(result.reason()).isEqualTo("EXTERNAL_EXECUTION_NOT_CONFIGURED");
     assertThat(result.payload()).containsEntry("applicationType", "LOAN_APPLICATION");
+    assertThat(result.payload()).containsEntry("processingMode", "EXTERNAL_PROVIDER_REQUIRED");
+  }
+
+  @Test
+  void failsManualReviewApplicationWithoutAutomatedExecution() {
+    CustomerApplicationExecutionResult result =
+        service.execute(
+            details(CustomerApplicationType.INCIDENT_REPORT, 101L, Map.of()),
+            "ops-executor",
+            "req-incident");
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.FAILED);
+    assertThat(result.reason()).isEqualTo("MANUAL_REVIEW_REQUIRED");
+    assertThat(result.payload()).containsEntry("processingMode", "MANUAL_REVIEW_REQUIRED");
   }
 
   private static CustomerApplicationDetails details(

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationOperationServiceTest.java
@@ -36,7 +36,10 @@ class CustomerApplicationOperationServiceTest {
   @Test
   void approvesApplicationFromReviewingState() {
     CustomerApplicationDetails reviewing =
-        details(CustomerApplicationType.BILL_PAYMENT, CustomerApplicationStatus.REVIEWING);
+        details(
+            CustomerApplicationType.BILL_PAYMENT,
+            CustomerApplicationStatus.REVIEWING,
+            "ops-reviewer");
     CustomerApplicationDetails approved =
         details(CustomerApplicationType.BILL_PAYMENT, CustomerApplicationStatus.APPROVED);
     when(operationPort.findByReferenceForUpdate("CSA-001")).thenReturn(Optional.of(reviewing));
@@ -51,7 +54,7 @@ class CustomerApplicationOperationServiceTest {
             new CustomerApplicationDecisionCommand(
                 "CSA-001",
                 CustomerApplicationAction.APPROVE,
-                "ops-reviewer",
+                "ops-approver",
                 "limit document checked",
                 "req-approve-001"));
 
@@ -62,8 +65,52 @@ class CustomerApplicationOperationServiceTest {
                 command ->
                     command.status() == CustomerApplicationStatus.APPROVED
                         && command.reason().equals("limit document checked")
-                        && command.actorSubject().equals("ops-reviewer")
+                        && command.actorSubject().equals("ops-approver")
                         && command.processedAt().equals(Instant.parse("2026-05-13T03:00:00Z"))));
+  }
+
+  @Test
+  void rejectsApproveBySameActorThatStartedReview() {
+    when(operationPort.findByReferenceForUpdate("CSA-005"))
+        .thenReturn(
+            Optional.of(
+                details(
+                    CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                    CustomerApplicationStatus.REVIEWING,
+                    "ops-reviewer")));
+
+    assertThrows(
+        CustomerApplicationInvalidTransitionException.class,
+        () ->
+            service.apply(
+                new CustomerApplicationDecisionCommand(
+                    "CSA-005",
+                    CustomerApplicationAction.APPROVE,
+                    "ops-reviewer",
+                    "same actor",
+                    "req-maker-checker-approve")));
+  }
+
+  @Test
+  void rejectsExecuteBySameActorThatApprovedApplication() {
+    when(operationPort.findByReferenceForUpdate("CSA-006"))
+        .thenReturn(
+            Optional.of(
+                details(
+                    CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                    CustomerApplicationStatus.APPROVED,
+                    "ops-approver")));
+
+    assertThrows(
+        CustomerApplicationInvalidTransitionException.class,
+        () ->
+            service.apply(
+                new CustomerApplicationDecisionCommand(
+                    "CSA-006",
+                    CustomerApplicationAction.EXECUTE,
+                    "ops-approver",
+                    "same actor",
+                    "req-maker-checker-execute")));
   }
 
   @Test
@@ -76,6 +123,14 @@ class CustomerApplicationOperationServiceTest {
         CustomerApplicationStatus.APPROVED,
         CustomerApplicationAction.REJECT,
         CustomerApplicationStatus.REJECTED);
+    assertStatusTransition(
+        CustomerApplicationStatus.REVIEWING,
+        CustomerApplicationAction.REJECT,
+        CustomerApplicationStatus.REJECTED);
+    assertStatusTransition(
+        CustomerApplicationStatus.SUBMITTED,
+        CustomerApplicationAction.CANCEL,
+        CustomerApplicationStatus.CANCELLED);
     assertStatusTransition(
         CustomerApplicationStatus.REVIEWING,
         CustomerApplicationAction.CANCEL,
@@ -159,6 +214,27 @@ class CustomerApplicationOperationServiceTest {
   }
 
   @Test
+  void rejectsApproveBeforeReviewStarts() {
+    when(operationPort.findByReferenceForUpdate("CSA-007"))
+        .thenReturn(
+            Optional.of(
+                details(
+                    CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                    CustomerApplicationStatus.SUBMITTED)));
+
+    assertThrows(
+        CustomerApplicationInvalidTransitionException.class,
+        () ->
+            service.apply(
+                new CustomerApplicationDecisionCommand(
+                    "CSA-007",
+                    CustomerApplicationAction.APPROVE,
+                    "ops-approver",
+                    "review missing",
+                    "req-review-required")));
+  }
+
+  @Test
   void rejectsMissingApplicationReference() {
     when(operationPort.findByReferenceForUpdate("CSA-missing")).thenReturn(Optional.empty());
 
@@ -214,6 +290,11 @@ class CustomerApplicationOperationServiceTest {
 
   private static CustomerApplicationDetails details(
       CustomerApplicationType type, CustomerApplicationStatus status) {
+    return details(type, status, null);
+  }
+
+  private static CustomerApplicationDetails details(
+      CustomerApplicationType type, CustomerApplicationStatus status, String processedBy) {
     Instant now = Instant.parse("2026-05-13T02:00:00Z");
     return new CustomerApplicationDetails(
         "CSA-001",
@@ -227,7 +308,7 @@ class CustomerApplicationOperationServiceTest {
         now,
         now,
         null,
-        null,
+        processedBy,
         null,
         Map.of());
   }

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationSelfServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationSelfServiceTest.java
@@ -1,0 +1,136 @@
+package com.aquilabank.domain.customerapplication.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationInvalidTransitionException;
+import com.aquilabank.domain.customerapplication.exception.CustomerApplicationNotFoundException;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationReadPort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CustomerApplicationSelfServiceTest {
+
+  private final CustomerApplicationReadPort readPort = mock(CustomerApplicationReadPort.class);
+  private final CustomerApplicationOperationPort operationPort =
+      mock(CustomerApplicationOperationPort.class);
+  private final Clock clock = Clock.fixed(Instant.parse("2026-05-13T03:00:00Z"), ZoneOffset.UTC);
+  private final CustomerApplicationSelfService service =
+      new CustomerApplicationSelfService(readPort, operationPort, clock);
+
+  @Test
+  void listsOwnApplicationsWithBoundedLimit() {
+    when(readPort.findByUserId(7L, 50)).thenReturn(List.of(details("CSA-001", 7L)));
+
+    List<CustomerApplicationDetails> result = service.findByUserId(7L, 99);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().applicationReference()).isEqualTo("CSA-001");
+  }
+
+  @Test
+  void usesDefaultLimitWhenLimitIsNotPositive() {
+    when(readPort.findByUserId(7L, 20)).thenReturn(List.of());
+
+    service.findByUserId(7L, 0);
+
+    verify(readPort).findByUserId(7L, 20);
+  }
+
+  @Test
+  void getsOwnApplicationByReference() {
+    when(readPort.findByUserIdAndReference(7L, "CSA-001"))
+        .thenReturn(Optional.of(details("CSA-001", 7L)));
+
+    CustomerApplicationDetails result = service.getByUserIdAndReference(7L, "CSA-001");
+
+    assertThat(result.userId()).isEqualTo(7L);
+  }
+
+  @Test
+  void hidesOtherUsersApplicationAsNotFound() {
+    when(readPort.findByUserIdAndReference(7L, "CSA-missing")).thenReturn(Optional.empty());
+
+    assertThrows(
+        CustomerApplicationNotFoundException.class,
+        () -> service.getByUserIdAndReference(7L, "CSA-missing"));
+  }
+
+  @Test
+  void cancelsOwnSubmittedApplication() {
+    CustomerApplicationDetails submitted = details("CSA-001", 7L);
+    CustomerApplicationDetails cancelled =
+        details("CSA-001", 7L, CustomerApplicationStatus.CANCELLED, "customer:7");
+    when(operationPort.findByReferenceForUpdate("CSA-001")).thenReturn(Optional.of(submitted));
+    when(operationPort.updateStatus(
+            argThat(
+                command ->
+                    command != null
+                        && command.status() == CustomerApplicationStatus.CANCELLED
+                        && command.actorSubject().equals("customer:7"))))
+        .thenReturn(cancelled);
+
+    CustomerApplicationDetails result = service.cancel(7L, "CSA-001", "req-cancel");
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.CANCELLED);
+  }
+
+  @Test
+  void rejectsCancelForOtherUserOrTerminalStatus() {
+    when(operationPort.findByReferenceForUpdate("CSA-other"))
+        .thenReturn(Optional.of(details("CSA-other", 8L)));
+    when(operationPort.findByReferenceForUpdate("CSA-done"))
+        .thenReturn(
+            Optional.of(details("CSA-done", 7L, CustomerApplicationStatus.EXECUTED, "ops")));
+
+    assertThrows(
+        CustomerApplicationNotFoundException.class, () -> service.cancel(7L, "CSA-other", "req"));
+    assertThrows(
+        CustomerApplicationInvalidTransitionException.class,
+        () -> service.cancel(7L, "CSA-done", "req"));
+  }
+
+  @Test
+  void rejectsInvalidSelfServiceInputs() {
+    assertThrows(IllegalArgumentException.class, () -> service.findByUserId(0L, 20));
+    assertThrows(IllegalArgumentException.class, () -> service.getByUserIdAndReference(7L, " "));
+    assertThrows(IllegalArgumentException.class, () -> service.cancel(7L, "CSA-001", " "));
+  }
+
+  private static CustomerApplicationDetails details(String reference, long userId) {
+    return details(reference, userId, CustomerApplicationStatus.SUBMITTED, null);
+  }
+
+  private static CustomerApplicationDetails details(
+      String reference, long userId, CustomerApplicationStatus status, String processedBy) {
+    Instant now = Instant.parse("2026-05-13T02:00:00Z");
+    return new CustomerApplicationDetails(
+        reference,
+        userId,
+        101L,
+        CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+        status,
+        true,
+        now,
+        Map.of("requestedSingleTransferLimitMinor", 100_000L),
+        now,
+        now,
+        null,
+        processedBy,
+        null,
+        Map.of());
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationServiceTest.java
@@ -4,12 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmission;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmitCommand;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangePolicy;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationReferencePort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationSecurityVerificationPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationWritePort;
@@ -28,8 +30,11 @@ class CustomerApplicationServiceTest {
   private final CustomerApplicationReferencePort referencePort =
       mock(CustomerApplicationReferencePort.class);
   private final Clock clock = Clock.fixed(Instant.parse("2026-05-11T03:00:00Z"), ZoneOffset.UTC);
+  private final CustomerTransferLimitChangePolicy transferLimitChangePolicy =
+      new CustomerTransferLimitChangePolicy(1_000_000L, 5_000_000L);
   private final CustomerApplicationService service =
-      new CustomerApplicationService(writePort, securityVerificationPort, referencePort, clock);
+      new CustomerApplicationService(
+          writePort, securityVerificationPort, referencePort, clock, transferLimitChangePolicy);
 
   @Test
   void verifiesTotpAndSubmitsCustomerApplication() {
@@ -77,6 +82,94 @@ class CustomerApplicationServiceTest {
   }
 
   @Test
+  void rejectsTransferLimitChangeWithoutAccountBeforeTotp() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            service.submit(
+                new CustomerApplicationSubmitCommand(
+                    7L,
+                    null,
+                    CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                    "limit-001",
+                    "123456",
+                    Map.of(
+                        "requestedSingleTransferLimitMinor",
+                        500_000L,
+                        "requestedDailyTransferLimitMinor",
+                        2_000_000L))));
+
+    verifyNoInteractions(securityVerificationPort, writePort);
+  }
+
+  @Test
+  void rejectsTransferLimitChangeAbovePolicyBeforeTotp() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            service.submit(
+                new CustomerApplicationSubmitCommand(
+                    7L,
+                    101L,
+                    CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                    "limit-002",
+                    "123456",
+                    Map.of(
+                        "requestedSingleTransferLimitMinor",
+                        1_500_000L,
+                        "requestedDailyTransferLimitMinor",
+                        6_000_000L))));
+
+    verifyNoInteractions(securityVerificationPort, writePort);
+  }
+
+  @Test
+  void rejectsTransferLimitChangeInvalidPayloadBeforeTotp() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            service.submit(
+                new CustomerApplicationSubmitCommand(
+                    7L,
+                    101L,
+                    CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                    "limit-003",
+                    "123456",
+                    Map.of("requestedSingleTransferLimitMinor", 500_000L))));
+
+    verifyNoInteractions(securityVerificationPort, writePort);
+  }
+
+  @Test
+  void submitsTransferLimitChangeWhenWithinPolicy() {
+    when(referencePort.issueReference(CustomerApplicationType.TRANSFER_LIMIT_CHANGE))
+        .thenReturn("CSA-20260511-003");
+    when(writePort.submit(argThat(command -> "CSA-20260511-003".equals(command.reference()))))
+        .thenReturn(transferLimitSubmission());
+
+    service.submit(
+        new CustomerApplicationSubmitCommand(
+            7L,
+            101L,
+            CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+            "limit-004",
+            "123456",
+            Map.of(
+                "requestedSingleTransferLimitMinor",
+                500_000L,
+                "requestedDailyTransferLimitMinor",
+                2_000_000L)));
+
+    verify(securityVerificationPort).verifyTotp(7L, "123456");
+    verify(writePort)
+        .submit(
+            argThat(
+                command ->
+                    command.applicationType() == CustomerApplicationType.TRANSFER_LIMIT_CHANGE
+                        && Long.valueOf(101L).equals(command.accountId())));
+  }
+
+  @Test
   void fingerprintsNestedListPayloadDeterministically() {
     when(referencePort.issueReference(CustomerApplicationType.OPEN_BANKING_CONNECTION))
         .thenReturn("CSA-20260511-002");
@@ -117,6 +210,20 @@ class CustomerApplicationServiceTest {
         7L,
         101L,
         CustomerApplicationType.BILL_PAYMENT,
+        CustomerApplicationStatus.SUBMITTED,
+        true,
+        now,
+        now,
+        now);
+  }
+
+  private static CustomerApplicationSubmission transferLimitSubmission() {
+    Instant now = Instant.parse("2026-05-11T03:00:00Z");
+    return new CustomerApplicationSubmission(
+        "CSA-20260511-003",
+        7L,
+        101L,
+        CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
         CustomerApplicationStatus.SUBMITTED,
         true,
         now,

--- a/back/src/test/java/com/aquilabank/global/config/CustomerApplicationConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/CustomerApplicationConfigurationTest.java
@@ -1,0 +1,100 @@
+package com.aquilabank.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationReadPort;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSelfServiceUseCase;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class CustomerApplicationConfigurationTest {
+
+  private final CustomerApplicationConfiguration configuration =
+      new CustomerApplicationConfiguration();
+  private final CustomerApplicationReadPort readPort = mock(CustomerApplicationReadPort.class);
+  private final CustomerApplicationOperationPort operationPort =
+      mock(CustomerApplicationOperationPort.class);
+  private final Clock clock = Clock.fixed(Instant.parse("2026-05-13T03:00:00Z"), ZoneOffset.UTC);
+
+  @Test
+  void createsSelfServiceUseCaseForReadAndCancel() {
+    CustomerApplicationSelfServiceUseCase useCase =
+        configuration.customerApplicationSelfServiceUseCase(
+            readPort, operationPort, clock, new NoopTransactionManager());
+    when(readPort.findByUserId(7L, 20))
+        .thenReturn(List.of(details(CustomerApplicationStatus.SUBMITTED)));
+    when(readPort.findByUserIdAndReference(7L, "CSA-001"))
+        .thenReturn(java.util.Optional.of(details(CustomerApplicationStatus.SUBMITTED)));
+    when(operationPort.findByReferenceForUpdate("CSA-001"))
+        .thenReturn(java.util.Optional.of(details(CustomerApplicationStatus.SUBMITTED)));
+    when(operationPort.updateStatus(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(details(CustomerApplicationStatus.CANCELLED));
+
+    assertThat(useCase.findByUserId(7L, 20)).hasSize(1);
+    assertThat(useCase.getByUserIdAndReference(7L, "CSA-001").applicationReference())
+        .isEqualTo("CSA-001");
+    assertThat(useCase.cancel(7L, "CSA-001", "req").status())
+        .isEqualTo(CustomerApplicationStatus.CANCELLED);
+  }
+
+  @Test
+  void rejectsNullSelfServiceTransactionResult() {
+    CustomerApplicationSelfServiceUseCase useCase =
+        configuration.customerApplicationSelfServiceUseCase(
+            readPort, operationPort, clock, new NoopTransactionManager());
+    when(operationPort.findByReferenceForUpdate("CSA-001"))
+        .thenReturn(java.util.Optional.of(details(CustomerApplicationStatus.SUBMITTED)));
+
+    assertThrows(IllegalStateException.class, () -> useCase.cancel(7L, "CSA-001", "req"));
+  }
+
+  private static CustomerApplicationDetails details(CustomerApplicationStatus status) {
+    Instant now = Instant.parse("2026-05-13T02:00:00Z");
+    return new CustomerApplicationDetails(
+        "CSA-001",
+        7L,
+        101L,
+        CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+        status,
+        true,
+        now,
+        Map.of("requestedSingleTransferLimitMinor", 100_000L),
+        now,
+        now,
+        null,
+        null,
+        null,
+        Map.of());
+  }
+
+  private static final class NoopTransactionManager implements PlatformTransactionManager {
+
+    @Override
+    public TransactionStatus getTransaction(TransactionDefinition definition)
+        throws TransactionException {
+      return new SimpleTransactionStatus();
+    }
+
+    @Override
+    public void commit(TransactionStatus status) throws TransactionException {}
+
+    @Override
+    public void rollback(TransactionStatus status) throws TransactionException {}
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/CustomerApplicationPropertiesTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/CustomerApplicationPropertiesTest.java
@@ -1,0 +1,32 @@
+package com.aquilabank.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangePolicy;
+import org.junit.jupiter.api.Test;
+
+class CustomerApplicationPropertiesTest {
+
+  @Test
+  void createsTransferLimitChangePolicyWithDefaults() {
+    CustomerTransferLimitChangePolicy policy =
+        new CustomerApplicationProperties(null).transferLimitChangePolicy();
+
+    assertThat(policy.maxSingleTransferLimitMinor()).isEqualTo(50_000_000L);
+    assertThat(policy.maxDailyTransferLimitMinor()).isEqualTo(200_000_000L);
+  }
+
+  @Test
+  void rejectsInvalidTransferLimitChangeProperties() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CustomerApplicationProperties.TransferLimitChange(0L, 1_000L));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CustomerApplicationProperties.TransferLimitChange(1_000L, 0L));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CustomerApplicationProperties.TransferLimitChange(2_000L, 1_000L));
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/config/NotificationChannelProviderWorkerConfigurationTest.java
+++ b/back/src/test/java/com/aquilabank/global/config/NotificationChannelProviderWorkerConfigurationTest.java
@@ -76,10 +76,49 @@ class NotificationChannelProviderWorkerConfigurationTest {
   @Test
   void registersPollerWhenWorkerIsEnabled() {
     contextRunner
-        .withPropertyValues("notification.channel-provider.worker.enabled=true")
+        .withBean(
+            NotificationChannelRecipientLookupPort.class,
+            () -> (userId, channel) -> java.util.Optional.of("alice@example.com"))
+        .withBean(ObjectMapper.class, () -> new ObjectMapper().findAndRegisterModules())
+        .withPropertyValues(
+            "notification.channel-provider.worker.enabled=true",
+            "notification.channel-provider.delivery.enabled=true",
+            "notification.channel-provider.delivery.email.url=https://email-provider.example/notifications")
         .run(
             context ->
                 assertThat(context).hasSingleBean(NotificationChannelProviderWorkerPoller.class));
+  }
+
+  @Test
+  void rejectsWorkerEnabledWithoutDeliveryProvider() {
+    contextRunner
+        .withPropertyValues("notification.channel-provider.worker.enabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .hasRootCauseMessage(
+                      "notification channel provider worker requires delivery.enabled=true");
+            });
+  }
+
+  @Test
+  void rejectsWorkerEnabledWithoutAnyProviderUrl() {
+    contextRunner
+        .withBean(
+            NotificationChannelRecipientLookupPort.class,
+            () -> (userId, channel) -> java.util.Optional.of("alice@example.com"))
+        .withBean(ObjectMapper.class, () -> new ObjectMapper().findAndRegisterModules())
+        .withPropertyValues(
+            "notification.channel-provider.worker.enabled=true",
+            "notification.channel-provider.delivery.enabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .hasRootCauseMessage(
+                      "notification channel provider worker requires at least one provider URL");
+            });
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/global/persistence/customerapplication/JdbcCustomerApplicationRepositoryTest.java
+++ b/back/src/test/java/com/aquilabank/global/persistence/customerapplication/JdbcCustomerApplicationRepositoryTest.java
@@ -113,6 +113,48 @@ class JdbcCustomerApplicationRepositoryTest {
   }
 
   @Test
+  void findsApplicationsByUserIdWithLimit() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcCustomerApplicationRepository repository =
+        new JdbcCustomerApplicationRepository(jdbcTemplate, new ObjectMapper());
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<CustomerApplicationDetails>>any()))
+        .thenAnswer(
+            invocation -> {
+              RowMapper<CustomerApplicationDetails> mapper = invocation.getArgument(2);
+              return List.of(mapper.mapRow(detailsResultSet("{}", false), 0));
+            });
+
+    List<CustomerApplicationDetails> result = repository.findByUserId(7L, 20);
+
+    assertEquals(1, result.size());
+    assertEquals("CSA-20260511-001", result.getFirst().applicationReference());
+  }
+
+  @Test
+  void findsApplicationByUserIdAndReference() {
+    NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    JdbcCustomerApplicationRepository repository =
+        new JdbcCustomerApplicationRepository(jdbcTemplate, new ObjectMapper());
+    when(jdbcTemplate.query(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            ArgumentMatchers.<RowMapper<CustomerApplicationDetails>>any()))
+        .thenAnswer(
+            invocation -> {
+              RowMapper<CustomerApplicationDetails> mapper = invocation.getArgument(2);
+              return List.of(mapper.mapRow(detailsResultSet("{}", false), 0));
+            });
+
+    CustomerApplicationDetails result =
+        repository.findByUserIdAndReference(7L, "CSA-20260511-001").orElseThrow();
+
+    assertEquals(7L, result.userId());
+  }
+
+  @Test
   void updatesApplicationStatusAndMapsExecutionResult() {
     NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
     JdbcCustomerApplicationRepository repository =

--- a/back/src/test/java/com/aquilabank/global/web/customerapplication/CustomerApplicationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/customerapplication/CustomerApplicationControllerTest.java
@@ -103,6 +103,40 @@ class CustomerApplicationControllerTest {
   }
 
   @Test
+  void submitsTransferLimitChangeWithTransferAccountAuthorization() throws Exception {
+    authenticateUser(7L);
+    when(requestAccountAuthorizationService.resolveTransferSourceAccountId(any(), eq(101L)))
+        .thenReturn(101L);
+    when(customerApplicationSubmitUseCase.submit(
+            argThat(
+                command ->
+                    command.applicationType() == CustomerApplicationType.TRANSFER_LIMIT_CHANGE)))
+        .thenReturn(transferLimitSubmission());
+
+    mockMvc
+        .perform(
+            post("/api/v1/customer-service/applications")
+                .header("Idempotency-Key", "limit-001")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "applicationType": "TRANSFER_LIMIT_CHANGE",
+                      "accountId": 101,
+                      "totpCode": "123456",
+                      "payload": {
+                        "requestedSingleTransferLimitMinor": 500000,
+                        "requestedDailyTransferLimitMinor": 2000000
+                      }
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.applicationType").value("TRANSFER_LIMIT_CHANGE"));
+
+    verify(requestAccountAuthorizationService).resolveTransferSourceAccountId(any(), eq(101L));
+  }
+
+  @Test
   void rejectsSensitivePayloadKeysBeforeSubmit() throws Exception {
     authenticateUser(7L);
 
@@ -216,6 +250,20 @@ class CustomerApplicationControllerTest {
         7L,
         101L,
         CustomerApplicationType.BILL_PAYMENT,
+        CustomerApplicationStatus.SUBMITTED,
+        true,
+        now,
+        now,
+        now);
+  }
+
+  private static CustomerApplicationSubmission transferLimitSubmission() {
+    Instant now = Instant.parse("2026-05-11T03:00:00Z");
+    return new CustomerApplicationSubmission(
+        "CSA-20260511-002",
+        7L,
+        101L,
+        CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
         CustomerApplicationStatus.SUBMITTED,
         true,
         now,

--- a/back/src/test/java/com/aquilabank/global/web/customerapplication/CustomerApplicationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/customerapplication/CustomerApplicationControllerTest.java
@@ -8,13 +8,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmission;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
+import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSelfServiceUseCase;
 import com.aquilabank.domain.customerapplication.usecase.CustomerApplicationSubmitUseCase;
 import com.aquilabank.global.security.AuthenticatedUserPrincipal;
 import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
@@ -37,17 +40,21 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class CustomerApplicationControllerTest {
 
   private CustomerApplicationSubmitUseCase customerApplicationSubmitUseCase;
+  private CustomerApplicationSelfServiceUseCase customerApplicationSelfServiceUseCase;
   private RequestAccountAuthorizationService requestAccountAuthorizationService;
   private MockMvc mockMvc;
 
   @BeforeEach
   void setUp() {
     customerApplicationSubmitUseCase = mock(CustomerApplicationSubmitUseCase.class);
+    customerApplicationSelfServiceUseCase = mock(CustomerApplicationSelfServiceUseCase.class);
     requestAccountAuthorizationService = mock(RequestAccountAuthorizationService.class);
     mockMvc =
         MockMvcBuilders.standaloneSetup(
                 new CustomerApplicationController(
-                    customerApplicationSubmitUseCase, requestAccountAuthorizationService))
+                    customerApplicationSubmitUseCase,
+                    customerApplicationSelfServiceUseCase,
+                    requestAccountAuthorizationService))
             .setControllerAdvice(new ApiExceptionHandler())
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
@@ -137,6 +144,59 @@ class CustomerApplicationControllerTest {
   }
 
   @Test
+  void listsOwnApplications() throws Exception {
+    authenticateUser(7L);
+    when(customerApplicationSelfServiceUseCase.findByUserId(7L, 20))
+        .thenReturn(List.of(details("CSA-20260511-001", CustomerApplicationStatus.SUBMITTED)));
+
+    mockMvc
+        .perform(get("/api/v1/customer-service/applications"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].applicationReference").value("CSA-20260511-001"))
+        .andExpect(jsonPath("$.items[0].processingMode").value("EXTERNAL_PROVIDER_REQUIRED"))
+        .andExpect(jsonPath("$.items[0].automatedExecutionSupported").value(false));
+  }
+
+  @Test
+  void listsOwnApplicationsWithExplicitLimit() throws Exception {
+    authenticateUser(7L);
+    when(customerApplicationSelfServiceUseCase.findByUserId(7L, 10)).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/v1/customer-service/applications").param("limit", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items").isArray());
+
+    verify(customerApplicationSelfServiceUseCase).findByUserId(7L, 10);
+  }
+
+  @Test
+  void getsOwnApplicationDetail() throws Exception {
+    authenticateUser(7L);
+    when(customerApplicationSelfServiceUseCase.getByUserIdAndReference(7L, "CSA-20260511-001"))
+        .thenReturn(details("CSA-20260511-001", CustomerApplicationStatus.FAILED));
+
+    mockMvc
+        .perform(get("/api/v1/customer-service/applications/CSA-20260511-001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.applicationReference").value("CSA-20260511-001"))
+        .andExpect(jsonPath("$.status").value("FAILED"));
+  }
+
+  @Test
+  void cancelsOwnApplication() throws Exception {
+    authenticateUser(7L);
+    when(customerApplicationSelfServiceUseCase.cancel(
+            eq(7L), eq("CSA-20260511-001"), org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(details("CSA-20260511-001", CustomerApplicationStatus.CANCELLED));
+
+    mockMvc
+        .perform(post("/api/v1/customer-service/applications/CSA-20260511-001/cancel"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("CANCELLED"));
+  }
+
+  @Test
   void rejectsSensitivePayloadKeysBeforeSubmit() throws Exception {
     authenticateUser(7L);
 
@@ -201,7 +261,9 @@ class CustomerApplicationControllerTest {
   void rejectsInvalidPayloadShapeDirectly() {
     CustomerApplicationController controller =
         new CustomerApplicationController(
-            customerApplicationSubmitUseCase, requestAccountAuthorizationService);
+            customerApplicationSubmitUseCase,
+            customerApplicationSelfServiceUseCase,
+            requestAccountAuthorizationService);
     AuthenticatedUserPrincipal principal = new AuthenticatedUserPrincipal(7L, "tester");
 
     assertThrows(
@@ -255,6 +317,28 @@ class CustomerApplicationControllerTest {
         now,
         now,
         now);
+  }
+
+  private static CustomerApplicationDetails details(
+      String applicationReference, CustomerApplicationStatus status) {
+    Instant now = Instant.parse("2026-05-11T03:00:00Z");
+    return new CustomerApplicationDetails(
+        applicationReference,
+        7L,
+        101L,
+        CustomerApplicationType.BILL_PAYMENT,
+        status,
+        true,
+        now,
+        Map.of("billerCode", "GIRO"),
+        now,
+        now,
+        status == CustomerApplicationStatus.FAILED ? "EXTERNAL_EXECUTION_NOT_CONFIGURED" : null,
+        status == CustomerApplicationStatus.FAILED ? "ops-executor" : null,
+        status == CustomerApplicationStatus.FAILED ? now : null,
+        status == CustomerApplicationStatus.FAILED
+            ? Map.of("applicationType", "BILL_PAYMENT")
+            : Map.of());
   }
 
   private static CustomerApplicationSubmission transferLimitSubmission() {

--- a/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/ledger/TransferCommandControllerTest.java
@@ -1,9 +1,11 @@
 package com.aquilabank.global.web.ledger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -31,10 +33,13 @@ import com.aquilabank.global.security.BootstrapHeaderAuthenticationFilter;
 import com.aquilabank.global.web.ApiExceptionHandler;
 import com.aquilabank.global.web.security.CurrentAuthenticatedPrincipalArgumentResolver;
 import com.aquilabank.global.web.security.RequestAccountAuthorizationService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.concurrent.ConcurrentMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,6 +61,7 @@ class TransferCommandControllerTest {
   private TransferLimitPolicyUseCase transferLimitPolicyUseCase;
   private TotpOperationRequirementUseCase totpOperationRequirementUseCase;
   private TotpOperationVerifyUseCase totpOperationVerifyUseCase;
+  private TransferCommandController controller;
   private MockMvc mockMvc;
 
   @BeforeEach
@@ -70,19 +76,20 @@ class TransferCommandControllerTest {
     totpOperationVerifyUseCase = mock(TotpOperationVerifyUseCase.class);
     when(transferLimitPolicyUseCase.resolvePolicy(101L))
         .thenReturn(new TransferLimitPolicy(2_000L, 3_000L));
+    controller =
+        new TransferCommandController(
+            transferCommandUseCase,
+            transferReversalUseCase,
+            requestAccountAuthorizationService,
+            accountSummaryQueryUseCase,
+            transferLimitUsageReadPort,
+            transferLimitPolicyUseCase,
+            totpOperationRequirementUseCase,
+            totpOperationVerifyUseCase,
+            new TransferLimitPolicyProperties(2_000L, 3_000L, "Asia/Seoul"),
+            Clock.fixed(Instant.parse("2026-05-11T01:00:00Z"), ZoneOffset.UTC));
     mockMvc =
-        MockMvcBuilders.standaloneSetup(
-                new TransferCommandController(
-                    transferCommandUseCase,
-                    transferReversalUseCase,
-                    requestAccountAuthorizationService,
-                    accountSummaryQueryUseCase,
-                    transferLimitUsageReadPort,
-                    transferLimitPolicyUseCase,
-                    totpOperationRequirementUseCase,
-                    totpOperationVerifyUseCase,
-                    new TransferLimitPolicyProperties(2_000L, 3_000L, "Asia/Seoul"),
-                    Clock.fixed(Instant.parse("2026-05-11T01:00:00Z"), ZoneOffset.UTC)))
+        MockMvcBuilders.standaloneSetup(controller)
             .addFilters(new BootstrapHeaderAuthenticationFilter("X-Account-Id", "X-Subject"))
             .setCustomArgumentResolvers(new CurrentAuthenticatedPrincipalArgumentResolver())
             .setControllerAdvice(new ApiExceptionHandler())
@@ -145,6 +152,41 @@ class TransferCommandControllerTest {
                 .queryParam("currencyCode", "KRW"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("targetAccountNumber is required"));
+  }
+
+  @Test
+  void throttlesUserRecipientPreviewBeforeRepeatedAccountNumberLookup() throws Exception {
+    authenticateUser(7L);
+    when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(false);
+    stubUserPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L),
+        account(202L, "999900001234", "홍길동", "ACTIVE", 0L),
+        0L);
+
+    for (int i = 0; i < 20; i++) {
+      performUserPreview(1_000L, "KRW").andExpect(status().isOk());
+    }
+
+    performUserPreview(1_000L, "KRW")
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.message").value("too many recipient preview requests"));
+
+    verify(accountSummaryQueryUseCase, times(20)).getByAccountNumber("999900001234");
+  }
+
+  @Test
+  void prunesExpiredRecipientPreviewThrottleWindowsWhenTrackedUsersExceedCap() throws Exception {
+    authenticateUser(7L);
+    when(totpOperationRequirementUseCase.requiresVerification(7L)).thenReturn(false);
+    stubUserPreview(
+        account(101L, "111122223333", "생활비 계좌", "ACTIVE", 10_000L),
+        account(202L, "999900001234", "홍길동", "ACTIVE", 0L),
+        0L);
+    ConcurrentMap<Long, Object> windows = seedExpiredRecipientPreviewThrottleWindows(10_001);
+
+    performUserPreview(1_000L, "KRW").andExpect(status().isOk());
+
+    assertThat(windows).containsOnlyKeys(7L);
   }
 
   @Test
@@ -709,6 +751,27 @@ class TransferCommandControllerTest {
             .queryParam("targetAccountNumber", "999900001234")
             .queryParam("amountMinor", String.valueOf(amountMinor))
             .queryParam("currencyCode", currencyCode));
+  }
+
+  @SuppressWarnings("unchecked")
+  private ConcurrentMap<Long, Object> seedExpiredRecipientPreviewThrottleWindows(int count)
+      throws Exception {
+    Field windowsField =
+        TransferCommandController.class.getDeclaredField("recipientPreviewThrottleWindows");
+    windowsField.setAccessible(true);
+    ConcurrentMap<Long, Object> windows =
+        (ConcurrentMap<Long, Object>) windowsField.get(controller);
+    Class<?> windowType =
+        Class.forName(
+            "com.aquilabank.global.web.ledger.TransferCommandController$RecipientPreviewThrottleWindow");
+    Constructor<?> constructor = windowType.getDeclaredConstructor(long.class, int.class);
+    constructor.setAccessible(true);
+    Object expiredWindow =
+        constructor.newInstance(Instant.parse("2026-05-11T00:58:59Z").getEpochSecond(), 1);
+    for (long userId = 10_000L; userId < 10_000L + count; userId++) {
+      windows.put(userId, expiredWindow);
+    }
+    return windows;
   }
 
   private void authenticateUser(long userId) {


### PR DESCRIPTION
## 🔗 Related Issue
- close #948

## 🌿 Base Branch
- `main`

## 📝 Summary
- 고객 신청 타입별 처리 모드를 명확히 분리하고, 자동 실행 가능한 범위를 `TRANSFER_LIMIT_CHANGE`로 제한했습니다.
- 이체한도 변경 검증, 내부 maker-checker, 고객용 신청 상태 조회/취소 API, 수취인 preview 탐색 방어, notification delivery 운영 경계를 보강했습니다.

## 🛠 Changes
- Customer application processing mode, 이체한도 변경 payload/계좌/상한 검증, unsupported external execution reason 추가
- 내부 신청 review/approve/execute 동일 actor 연속 처리 차단 및 고객 목록/상세/취소 API 추가
- JWT 사용자 수취인 preview 60초/20회 throttle 추가, notification provider worker misconfiguration startup guard 추가

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [x] Transaction / Ledger
- [x] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/with-resource-lock.sh back-gradle ./back/gradlew -p back test jacocoTestCoverageVerification`
- pre-commit: `./back/gradlew -p back check`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 고객 신청 응답 필드/조회 API가 추가되고, JWT 사용자 수취인 preview는 60초 20회 초과 시 429를 반환합니다. notification worker는 delivery provider URL 없이 켜면 startup fail로 바뀝니다.
- 롤백 방법: 이 PR의 커밋을 revert합니다. 운영 긴급 회피는 `notification.channel-provider.worker.enabled=false`로 worker를 끄거나 preview throttle 상수를 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (N/A: 미완성 기능 없음)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (N/A: 문서/모니터링 변경 없음)
