### PR TITLE
[Fix] 고객 신청 보안 정책 보강

### DIFF
--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationAccountPolicyCheck.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationAccountPolicyCheck.java
@@ -1,0 +1,21 @@
+package com.aquilabank.domain.customerapplication.model;
+
+/** 신청 실행 직전 계좌/권한 상태를 다시 확인한 결과입니다. */
+public record CustomerApplicationAccountPolicyCheck(boolean permitted, String rejectionReason) {
+
+  public CustomerApplicationAccountPolicyCheck {
+    if (permitted) {
+      rejectionReason = null;
+    } else if (rejectionReason == null || rejectionReason.isBlank()) {
+      throw new IllegalArgumentException("rejectionReason is required when rejected");
+    }
+  }
+
+  public static CustomerApplicationAccountPolicyCheck allowed() {
+    return new CustomerApplicationAccountPolicyCheck(true, null);
+  }
+
+  public static CustomerApplicationAccountPolicyCheck rejected(String rejectionReason) {
+    return new CustomerApplicationAccountPolicyCheck(false, rejectionReason);
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationPayloadSchema.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationPayloadSchema.java
@@ -1,0 +1,121 @@
+package com.aquilabank.domain.customerapplication.model;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/** 신청 타입별 최소 payload 계약입니다. 외부 실행 전 단계에서도 잘못된 신청 접수를 줄입니다. */
+public final class CustomerApplicationPayloadSchema {
+
+  private static final Pattern CURRENCY_CODE = Pattern.compile("^[A-Z]{3}$");
+  private static final Pattern POSITIVE_INTEGER = Pattern.compile("^[1-9][0-9]*$");
+
+  private CustomerApplicationPayloadSchema() {}
+
+  public static void validate(CustomerApplicationType type, Map<String, Object> payload) {
+    Objects.requireNonNull(type, "applicationType is required");
+    if (payload == null) {
+      throw new IllegalArgumentException("payload is required");
+    }
+    switch (type) {
+      case BILL_PAYMENT -> validateBillPayment(payload);
+      case OPEN_BANKING_CONNECTION -> validateOpenBankingConnection(payload);
+      case DEPOSIT_PRODUCT_APPLICATION -> validateDepositProductApplication(payload);
+      case LOAN_APPLICATION -> validateLoanApplication(payload);
+      case FOREIGN_EXCHANGE_APPLICATION -> validateForeignExchangeApplication(payload);
+      case CERTIFICATE_ISSUANCE -> validateCertificateIssuance(payload);
+      case CERTIFICATE_REGISTRATION -> validateCertificateRegistration(payload);
+      case SECURITY_MEDIA_APPLICATION -> validateSecurityMediaApplication(payload);
+      case INCIDENT_REPORT -> validateIncidentReport(payload);
+      case TRANSFER_LIMIT_CHANGE -> {
+        // 한도 변경은 금액 상한 정책까지 포함한 전용 parser가 use case에서 검증합니다.
+      }
+    }
+  }
+
+  private static void validateBillPayment(Map<String, Object> payload) {
+    requireText(payload, "billerCode", 40);
+    requireText(payload, "paymentNumber", 80);
+    requirePositiveMinor(payload, "amountMinor");
+    requireCurrencyCode(payload, "currencyCode");
+  }
+
+  private static void validateOpenBankingConnection(Map<String, Object> payload) {
+    requireText(payload, "institutionCode", 20);
+    requireText(payload, "externalAccountNumber", 40);
+    requireText(payload, "consentId", 80);
+  }
+
+  private static void validateDepositProductApplication(Map<String, Object> payload) {
+    requireText(payload, "productCode", 40);
+    requirePositiveMinor(payload, "amountMinor");
+    requireCurrencyCode(payload, "currencyCode");
+  }
+
+  private static void validateLoanApplication(Map<String, Object> payload) {
+    requireText(payload, "productCode", 40);
+    requirePositiveMinor(payload, "requestedAmountMinor");
+    requireCurrencyCode(payload, "currencyCode");
+    requireText(payload, "purpose", 120);
+  }
+
+  private static void validateForeignExchangeApplication(Map<String, Object> payload) {
+    String sourceCurrencyCode = requireCurrencyCode(payload, "sourceCurrencyCode");
+    String targetCurrencyCode = requireCurrencyCode(payload, "targetCurrencyCode");
+    if (sourceCurrencyCode.equals(targetCurrencyCode)) {
+      throw new IllegalArgumentException("targetCurrencyCode must differ from sourceCurrencyCode");
+    }
+    requirePositiveMinor(payload, "amountMinor");
+  }
+
+  private static void validateCertificateIssuance(Map<String, Object> payload) {
+    requireText(payload, "certificateType", 40);
+    requireText(payload, "subjectDn", 200);
+  }
+
+  private static void validateCertificateRegistration(Map<String, Object> payload) {
+    requireText(payload, "certificateSerialNumber", 80);
+    requireText(payload, "issuerDn", 200);
+  }
+
+  private static void validateSecurityMediaApplication(Map<String, Object> payload) {
+    requireText(payload, "mediaType", 40);
+    requireText(payload, "deliveryMethod", 40);
+  }
+
+  private static void validateIncidentReport(Map<String, Object> payload) {
+    requireText(payload, "incidentType", 40);
+    requireText(payload, "description", 500);
+  }
+
+  private static String requireCurrencyCode(Map<String, Object> payload, String key) {
+    String value = requireText(payload, key, 3);
+    if (!CURRENCY_CODE.matcher(value).matches()) {
+      throw new IllegalArgumentException(key + " must be a 3-letter uppercase code");
+    }
+    return value;
+  }
+
+  private static long requirePositiveMinor(Map<String, Object> payload, String key) {
+    Object value = payload.get(key);
+    if (value instanceof Number number) {
+      long result = number.longValue();
+      if (result <= 0 || Double.compare(number.doubleValue(), (double) result) != 0) {
+        throw new IllegalArgumentException(key + " must be a positive integer minor amount");
+      }
+      return result;
+    }
+    if (value instanceof String text && POSITIVE_INTEGER.matcher(text).matches()) {
+      return Long.parseLong(text);
+    }
+    throw new IllegalArgumentException(key + " must be a positive integer minor amount");
+  }
+
+  private static String requireText(Map<String, Object> payload, String key, int maxLength) {
+    Object value = payload.get(key);
+    if (!(value instanceof String text) || text.isBlank() || text.length() > maxLength) {
+      throw new IllegalArgumentException(key + " is required");
+    }
+    return text;
+  }
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerApplicationAccountPolicyPort.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/port/CustomerApplicationAccountPolicyPort.java
@@ -1,0 +1,8 @@
+package com.aquilabank.domain.customerapplication.port;
+
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationAccountPolicyCheck;
+
+public interface CustomerApplicationAccountPolicyPort {
+
+  CustomerApplicationAccountPolicyCheck checkTransferLimitChange(long userId, long accountId);
+}

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorService.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorService.java
@@ -1,5 +1,6 @@
 package com.aquilabank.domain.customerapplication.usecase;
 
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationAccountPolicyCheck;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationProcessingMode;
@@ -7,6 +8,7 @@ import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
 import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangePolicy;
 import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangeRequest;
 import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitPolicyCommand;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationAccountPolicyPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationExecutorPort;
 import com.aquilabank.domain.customerapplication.port.CustomerTransferLimitPolicyPort;
 import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
@@ -18,12 +20,15 @@ import java.util.Objects;
 public final class CustomerApplicationExecutorService implements CustomerApplicationExecutorPort {
 
   private final CustomerTransferLimitPolicyPort transferLimitPolicyPort;
+  private final CustomerApplicationAccountPolicyPort accountPolicyPort;
   private final CustomerTransferLimitChangePolicy transferLimitChangePolicy;
 
   public CustomerApplicationExecutorService(
       CustomerTransferLimitPolicyPort transferLimitPolicyPort,
+      CustomerApplicationAccountPolicyPort accountPolicyPort,
       CustomerTransferLimitChangePolicy transferLimitChangePolicy) {
     this.transferLimitPolicyPort = Objects.requireNonNull(transferLimitPolicyPort);
+    this.accountPolicyPort = Objects.requireNonNull(accountPolicyPort);
     this.transferLimitChangePolicy = Objects.requireNonNull(transferLimitChangePolicy);
   }
 
@@ -72,6 +77,19 @@ public final class CustomerApplicationExecutorService implements CustomerApplica
               transferLimitChangePolicy.maxSingleTransferLimitMinor(),
               "maxDailyTransferLimitMinor",
               transferLimitChangePolicy.maxDailyTransferLimitMinor()));
+    }
+    CustomerApplicationAccountPolicyCheck accountPolicyCheck =
+        Objects.requireNonNull(
+            accountPolicyPort.checkTransferLimitChange(
+                application.userId(), application.accountId()));
+    if (!accountPolicyCheck.permitted()) {
+      return CustomerApplicationExecutionResult.failed(
+          accountPolicyCheck.rejectionReason(),
+          Map.of(
+              "applicationType",
+              application.applicationType().name(),
+              "accountId",
+              application.accountId()));
     }
 
     TransferLimitPolicy policy =

--- a/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationService.java
+++ b/back/src/main/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationService.java
@@ -1,5 +1,6 @@
 package com.aquilabank.domain.customerapplication.usecase;
 
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationPayloadSchema;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmission;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationSubmitCommand;
@@ -72,7 +73,9 @@ public final class CustomerApplicationService implements CustomerApplicationSubm
   private void validateCommand(CustomerApplicationSubmitCommand command) {
     if (command.applicationType().supportsAutomatedExecution()) {
       validateTransferLimitChange(command);
+      return;
     }
+    CustomerApplicationPayloadSchema.validate(command.applicationType(), command.payload());
   }
 
   private void validateTransferLimitChange(CustomerApplicationSubmitCommand command) {

--- a/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/config/CustomerApplicationConfiguration.java
@@ -3,6 +3,7 @@ package com.aquilabank.global.config;
 import com.aquilabank.domain.auth.model.TotpOperationVerifyCommand;
 import com.aquilabank.domain.auth.usecase.TotpOperationVerifyUseCase;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationAccountPolicyPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationExecutorPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationOperationPort;
 import com.aquilabank.domain.customerapplication.port.CustomerApplicationReadPort;
@@ -71,9 +72,10 @@ public class CustomerApplicationConfiguration {
   @Bean
   CustomerApplicationExecutorPort customerApplicationExecutorPort(
       CustomerTransferLimitPolicyPort transferLimitPolicyPort,
+      CustomerApplicationAccountPolicyPort accountPolicyPort,
       CustomerApplicationProperties properties) {
     return new CustomerApplicationExecutorService(
-        transferLimitPolicyPort, properties.transferLimitChangePolicy());
+        transferLimitPolicyPort, accountPolicyPort, properties.transferLimitChangePolicy());
   }
 
   @Bean

--- a/back/src/main/java/com/aquilabank/global/customerapplication/CustomerApplicationAccountPolicyAdapter.java
+++ b/back/src/main/java/com/aquilabank/global/customerapplication/CustomerApplicationAccountPolicyAdapter.java
@@ -1,0 +1,54 @@
+package com.aquilabank.global.customerapplication;
+
+import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
+import com.aquilabank.domain.account.model.AccountStatus;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationAccountPolicyCheck;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationAccountPolicyPort;
+import org.springframework.stereotype.Component;
+
+/** 신청 승인 이후 실행 직전에도 계좌/멤버십 상태를 다시 확인하는 adapter입니다. */
+@Component
+public class CustomerApplicationAccountPolicyAdapter
+    implements CustomerApplicationAccountPolicyPort {
+
+  private final AccountSummaryQueryUseCase accountSummaryQueryUseCase;
+  private final UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase;
+
+  public CustomerApplicationAccountPolicyAdapter(
+      AccountSummaryQueryUseCase accountSummaryQueryUseCase,
+      UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase) {
+    this.accountSummaryQueryUseCase = accountSummaryQueryUseCase;
+    this.userAccountMembershipQueryUseCase = userAccountMembershipQueryUseCase;
+  }
+
+  @Override
+  public CustomerApplicationAccountPolicyCheck checkTransferLimitChange(
+      long userId, long accountId) {
+    try {
+      var membership = userAccountMembershipQueryUseCase.getByUserIdAndAccountId(userId, accountId);
+      if (membership.status() != MembershipStatus.ACTIVE) {
+        return CustomerApplicationAccountPolicyCheck.rejected("TRANSFER_LIMIT_MEMBERSHIP_INACTIVE");
+      }
+    } catch (UserAccountMembershipNotFoundException exception) {
+      return CustomerApplicationAccountPolicyCheck.rejected("TRANSFER_LIMIT_MEMBERSHIP_NOT_FOUND");
+    }
+
+    try {
+      var account = accountSummaryQueryUseCase.getByAccountId(accountId);
+      AccountStatus status = AccountStatus.valueOf(account.accountStatus());
+      if (status != AccountStatus.ACTIVE) {
+        return CustomerApplicationAccountPolicyCheck.rejected("TRANSFER_LIMIT_ACCOUNT_NOT_ACTIVE");
+      }
+      return CustomerApplicationAccountPolicyCheck.allowed();
+    } catch (AccountSummaryNotFoundException exception) {
+      return CustomerApplicationAccountPolicyCheck.rejected("TRANSFER_LIMIT_ACCOUNT_NOT_FOUND");
+    } catch (IllegalArgumentException exception) {
+      return CustomerApplicationAccountPolicyCheck.rejected(
+          "TRANSFER_LIMIT_ACCOUNT_STATUS_INVALID");
+    }
+  }
+}

--- a/back/src/main/java/com/aquilabank/global/security/InternalServiceScope.java
+++ b/back/src/main/java/com/aquilabank/global/security/InternalServiceScope.java
@@ -7,6 +7,9 @@ public enum InternalServiceScope {
   AUTH_BOOTSTRAP("internal:auth-bootstrap"),
   AUTH_ADMIN("internal:auth-admin"),
   CUSTOMER_APPLICATION_OPS("internal:customer-application-ops"),
+  CUSTOMER_APPLICATION_REVIEWER("internal:customer-application-reviewer"),
+  CUSTOMER_APPLICATION_APPROVER("internal:customer-application-approver"),
+  CUSTOMER_APPLICATION_EXECUTOR("internal:customer-application-executor"),
   OUTBOX_OPS("internal:outbox-ops"),
   LEDGER_OPS("internal:ledger-ops");
 

--- a/back/src/main/java/com/aquilabank/global/web/customerapplication/InternalCustomerApplicationController.java
+++ b/back/src/main/java/com/aquilabank/global/web/customerapplication/InternalCustomerApplicationController.java
@@ -87,8 +87,7 @@ public class InternalCustomerApplicationController {
       CustomerApplicationAction action,
       CustomerApplicationOperationRequest request) {
     InternalServiceTokenClaims claims =
-        internalServiceRequestAuthorizer.requireScope(
-            httpServletRequest, InternalServiceScope.CUSTOMER_APPLICATION_OPS);
+        internalServiceRequestAuthorizer.requireScope(httpServletRequest, requiredScope(action));
     CustomerApplicationDetails result =
         operationUseCase.apply(
             new CustomerApplicationDecisionCommand(
@@ -98,6 +97,15 @@ public class InternalCustomerApplicationController {
                 request == null ? null : request.reason(),
                 resolveRequestId(httpServletRequest)));
     return CustomerApplicationOperationResponse.from(result);
+  }
+
+  private InternalServiceScope requiredScope(CustomerApplicationAction action) {
+    // 민감 신청은 검토/승인/실행 JWT scope를 분리해 단일 운영 토큰 오남용 범위를 줄입니다.
+    return switch (action) {
+      case START_REVIEW -> InternalServiceScope.CUSTOMER_APPLICATION_REVIEWER;
+      case APPROVE, REJECT, CANCEL -> InternalServiceScope.CUSTOMER_APPLICATION_APPROVER;
+      case EXECUTE -> InternalServiceScope.CUSTOMER_APPLICATION_EXECUTOR;
+    };
   }
 
   private String resolveRequestId(HttpServletRequest httpServletRequest) {

--- a/back/src/main/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptor.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptor.java
@@ -37,6 +37,8 @@ public class CurrentSessionActiveInterceptor implements HandlerInterceptor {
           new SensitiveMutationPath("DELETE", Pattern.compile("^/api/v1/auth/sessions/[^/]+$")),
           new SensitiveMutationPath(
               "POST", Pattern.compile("^/api/v1/customer-service/applications$")),
+          new SensitiveMutationPath(
+              "POST", Pattern.compile("^/api/v1/customer-service/applications/[^/]+/cancel$")),
           new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/notifications/preferences$")),
           new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/notifications/[^/]+/read$")),
           new SensitiveMutationPath("POST", Pattern.compile("^/api/v1/notifications/read$")),

--- a/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
+++ b/back/src/main/java/com/aquilabank/global/web/security/WebMvcSecurityConfiguration.java
@@ -48,6 +48,7 @@ public class WebMvcSecurityConfiguration implements WebMvcConfigurer {
             "/api/v1/auth/sessions",
             "/api/v1/auth/sessions/*",
             "/api/v1/customer-service/applications",
+            "/api/v1/customer-service/applications/*/cancel",
             "/api/v1/notifications/preferences",
             "/api/v1/notifications/*/read",
             "/api/v1/notifications/read",

--- a/back/src/main/resources/application-prod.yml
+++ b/back/src/main/resources/application-prod.yml
@@ -13,3 +13,8 @@ spring:
 logging:
   level:
     com.aquilabank: INFO
+
+security:
+  cors:
+    # production은 환경에서 명시한 origin만 허용합니다.
+    allowed-origin-patterns: ${SECURITY_CORS_ALLOWED_ORIGIN_PATTERNS:}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -403,7 +403,8 @@ security:
     # TLS 종단 환경은 true를 유지하고, direct HTTP staging smoke만 env에서 false로 낮춥니다.
     secure: ${SECURITY_AUTH_COOKIE_SECURE:true}
   cors:
-    allowed-origin-patterns: ${SECURITY_CORS_ALLOWED_ORIGIN_PATTERNS:}
+    # 로컬 기본 실행(`bootRun`)에서 프론트 로그인 fetch가 CORS에 막히지 않도록 개발 origin만 허용합니다.
+    allowed-origin-patterns: ${SECURITY_CORS_ALLOWED_ORIGIN_PATTERNS:http://localhost:3000,http://127.0.0.1:3000}
   totp:
     issuer: ${SECURITY_TOTP_ISSUER:Aquila Bank}
     secret-encryption-key: ${SECURITY_TOTP_SECRET_ENCRYPTION_KEY:${SECURITY_JWT_SECRET:}}

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationPayloadSchemaTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/model/CustomerApplicationPayloadSchemaTest.java
@@ -1,0 +1,144 @@
+package com.aquilabank.domain.customerapplication.model;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CustomerApplicationPayloadSchemaTest {
+
+  @Test
+  void acceptsMinimumPayloadForTypedApplications() {
+    validPayloads()
+        .forEach(
+            (type, payload) ->
+                assertDoesNotThrow(() -> CustomerApplicationPayloadSchema.validate(type, payload)));
+  }
+
+  @Test
+  void rejectsMissingRequiredPayloadFields() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CustomerApplicationPayloadSchema.validate(
+                CustomerApplicationType.SECURITY_MEDIA_APPLICATION, Map.of("mediaType", "OTP")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CustomerApplicationPayloadSchema.validate(CustomerApplicationType.BILL_PAYMENT, null));
+  }
+
+  @Test
+  void rejectsInvalidAmountAndCurrencyValues() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CustomerApplicationPayloadSchema.validate(
+                CustomerApplicationType.BILL_PAYMENT,
+                Map.of(
+                    "billerCode",
+                    "GIRO",
+                    "paymentNumber",
+                    "1234567890",
+                    "amountMinor",
+                    0L,
+                    "currencyCode",
+                    "krw")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CustomerApplicationPayloadSchema.validate(
+                CustomerApplicationType.BILL_PAYMENT,
+                Map.of(
+                    "billerCode",
+                    "GIRO",
+                    "paymentNumber",
+                    "1234567890",
+                    "amountMinor",
+                    50_000L,
+                    "currencyCode",
+                    "krw")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CustomerApplicationPayloadSchema.validate(
+                CustomerApplicationType.DEPOSIT_PRODUCT_APPLICATION,
+                Map.of("productCode", "DEP-001", "amountMinor", "10_000", "currencyCode", "KRW")));
+  }
+
+  @Test
+  void acceptsStringAmountAndRejectsSameFxCurrency() {
+    assertDoesNotThrow(
+        () ->
+            CustomerApplicationPayloadSchema.validate(
+                CustomerApplicationType.DEPOSIT_PRODUCT_APPLICATION,
+                Map.of("productCode", "DEP-001", "amountMinor", "1000", "currencyCode", "KRW")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CustomerApplicationPayloadSchema.validate(
+                CustomerApplicationType.FOREIGN_EXCHANGE_APPLICATION,
+                Map.of(
+                    "sourceCurrencyCode",
+                    "KRW",
+                    "targetCurrencyCode",
+                    "KRW",
+                    "amountMinor",
+                    300_000L)));
+  }
+
+  private static Map<CustomerApplicationType, Map<String, Object>> validPayloads() {
+    return Map.ofEntries(
+        Map.entry(
+            CustomerApplicationType.BILL_PAYMENT,
+            Map.of(
+                "billerCode",
+                "GIRO",
+                "paymentNumber",
+                "1234567890",
+                "amountMinor",
+                50_000L,
+                "currencyCode",
+                "KRW")),
+        Map.entry(
+            CustomerApplicationType.OPEN_BANKING_CONNECTION,
+            Map.of(
+                "institutionCode",
+                "088",
+                "externalAccountNumber",
+                "1234567890",
+                "consentId",
+                "CONSENT-001")),
+        Map.entry(
+            CustomerApplicationType.DEPOSIT_PRODUCT_APPLICATION,
+            Map.of("productCode", "DEP-001", "amountMinor", 1_000_000L, "currencyCode", "KRW")),
+        Map.entry(
+            CustomerApplicationType.LOAN_APPLICATION,
+            Map.of(
+                "productCode",
+                "LOAN-001",
+                "requestedAmountMinor",
+                10_000_000L,
+                "currencyCode",
+                "KRW",
+                "purpose",
+                "housing")),
+        Map.entry(
+            CustomerApplicationType.FOREIGN_EXCHANGE_APPLICATION,
+            Map.of(
+                "sourceCurrencyCode", "KRW", "targetCurrencyCode", "USD", "amountMinor", 300_000L)),
+        Map.entry(
+            CustomerApplicationType.CERTIFICATE_ISSUANCE,
+            Map.of("certificateType", "BANKING", "subjectDn", "CN=alice")),
+        Map.entry(
+            CustomerApplicationType.CERTIFICATE_REGISTRATION,
+            Map.of("certificateSerialNumber", "SERIAL-001", "issuerDn", "CN=issuer")),
+        Map.entry(
+            CustomerApplicationType.SECURITY_MEDIA_APPLICATION,
+            Map.of("mediaType", "OTP", "deliveryMethod", "BRANCH")),
+        Map.entry(
+            CustomerApplicationType.INCIDENT_REPORT,
+            Map.of("incidentType", "CARD_LOSS", "description", "lost card")));
+  }
+}

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationExecutorServiceTest.java
@@ -4,13 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.aquilabank.domain.customerapplication.model.CustomerApplicationAccountPolicyCheck;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationDetails;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationExecutionResult;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationStatus;
 import com.aquilabank.domain.customerapplication.model.CustomerApplicationType;
 import com.aquilabank.domain.customerapplication.model.CustomerTransferLimitChangePolicy;
+import com.aquilabank.domain.customerapplication.port.CustomerApplicationAccountPolicyPort;
 import com.aquilabank.domain.customerapplication.port.CustomerTransferLimitPolicyPort;
 import com.aquilabank.domain.ledger.model.TransferLimitPolicy;
 import java.time.Instant;
@@ -21,16 +24,21 @@ class CustomerApplicationExecutorServiceTest {
 
   private final CustomerTransferLimitPolicyPort transferLimitPolicyPort =
       mock(CustomerTransferLimitPolicyPort.class);
+  private final CustomerApplicationAccountPolicyPort accountPolicyPort =
+      mock(CustomerApplicationAccountPolicyPort.class);
   private final CustomerTransferLimitChangePolicy transferLimitChangePolicy =
       new CustomerTransferLimitChangePolicy(1_000_000L, 5_000_000L);
   private final CustomerApplicationExecutorService service =
-      new CustomerApplicationExecutorService(transferLimitPolicyPort, transferLimitChangePolicy);
+      new CustomerApplicationExecutorService(
+          transferLimitPolicyPort, accountPolicyPort, transferLimitChangePolicy);
 
   @Test
   void executesTransferLimitChangeApplication() {
     when(transferLimitPolicyPort.applyTransferLimitChange(
             argThat(command -> command != null && command.accountId() == 101L)))
         .thenReturn(new TransferLimitPolicy(500_000L, 2_000_000L));
+    when(accountPolicyPort.checkTransferLimitChange(7L, 101L))
+        .thenReturn(CustomerApplicationAccountPolicyCheck.allowed());
 
     CustomerApplicationExecutionResult result =
         service.execute(
@@ -105,6 +113,8 @@ class CustomerApplicationExecutorServiceTest {
     when(transferLimitPolicyPort.applyTransferLimitChange(
             argThat(command -> command != null && command.singleTransferLimitMinor() == 50_000L)))
         .thenReturn(new TransferLimitPolicy(50_000L, 200_000L));
+    when(accountPolicyPort.checkTransferLimitChange(7L, 101L))
+        .thenReturn(CustomerApplicationAccountPolicyCheck.allowed());
 
     CustomerApplicationExecutionResult result =
         service.execute(
@@ -132,6 +142,27 @@ class CustomerApplicationExecutorServiceTest {
 
     assertThat(result.status()).isEqualTo(CustomerApplicationStatus.FAILED);
     assertThat(result.reason()).isEqualTo("TRANSFER_LIMIT_POLICY_EXCEEDED");
+  }
+
+  @Test
+  void failsTransferLimitChangeWhenAccountPolicyRejectsAtExecution() {
+    when(accountPolicyPort.checkTransferLimitChange(7L, 101L))
+        .thenReturn(
+            CustomerApplicationAccountPolicyCheck.rejected("TRANSFER_LIMIT_ACCOUNT_NOT_ACTIVE"));
+
+    CustomerApplicationExecutionResult result =
+        service.execute(
+            details(
+                CustomerApplicationType.TRANSFER_LIMIT_CHANGE,
+                101L,
+                Map.of(
+                    "singleTransferLimitMinor", 500_000L, "dailyTransferLimitMinor", 2_000_000L)),
+            "ops-executor",
+            "req-account-inactive");
+
+    assertThat(result.status()).isEqualTo(CustomerApplicationStatus.FAILED);
+    assertThat(result.reason()).isEqualTo("TRANSFER_LIMIT_ACCOUNT_NOT_ACTIVE");
+    verifyNoInteractions(transferLimitPolicyPort);
   }
 
   @Test

--- a/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationServiceTest.java
+++ b/back/src/test/java/com/aquilabank/domain/customerapplication/usecase/CustomerApplicationServiceTest.java
@@ -50,7 +50,15 @@ class CustomerApplicationServiceTest {
             CustomerApplicationType.BILL_PAYMENT,
             "bill-001",
             "123456",
-            Map.of("billerCode", "GIRO", "paymentNumber", "1234567890")));
+            Map.of(
+                "billerCode",
+                "GIRO",
+                "paymentNumber",
+                "1234567890",
+                "amountMinor",
+                50_000L,
+                "currencyCode",
+                "KRW")));
 
     verify(securityVerificationPort).verifyTotp(7L, "123456");
     verify(writePort)
@@ -78,7 +86,32 @@ class CustomerApplicationServiceTest {
                     CustomerApplicationType.BILL_PAYMENT,
                     "bill-001",
                     "",
-                    Map.of("billerCode", "GIRO"))));
+                    Map.of(
+                        "billerCode",
+                        "GIRO",
+                        "paymentNumber",
+                        "1234567890",
+                        "amountMinor",
+                        50_000L,
+                        "currencyCode",
+                        "KRW"))));
+  }
+
+  @Test
+  void rejectsTypedApplicationPayloadBeforeTotp() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            service.submit(
+                new CustomerApplicationSubmitCommand(
+                    7L,
+                    101L,
+                    CustomerApplicationType.BILL_PAYMENT,
+                    "bill-invalid",
+                    "123456",
+                    Map.of("billerCode", "GIRO", "paymentNumber", "1234567890"))));
+
+    verifyNoInteractions(securityVerificationPort, writePort);
   }
 
   @Test
@@ -193,7 +226,15 @@ class CustomerApplicationServiceTest {
             CustomerApplicationType.OPEN_BANKING_CONNECTION,
             "open-001",
             "123456",
-            Map.of("banks", List.of("088", "020"))));
+            Map.of(
+                "institutionCode",
+                "088",
+                "externalAccountNumber",
+                "1234567890",
+                "consentId",
+                "CONSENT-001",
+                "banks",
+                List.of("088", "020"))));
 
     verify(writePort)
         .submit(

--- a/back/src/test/java/com/aquilabank/global/customerapplication/CustomerApplicationAccountPolicyAdapterTest.java
+++ b/back/src/test/java/com/aquilabank/global/customerapplication/CustomerApplicationAccountPolicyAdapterTest.java
@@ -1,0 +1,104 @@
+package com.aquilabank.global.customerapplication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aquilabank.domain.account.exception.AccountSummaryNotFoundException;
+import com.aquilabank.domain.account.model.AccountSummary;
+import com.aquilabank.domain.account.usecase.AccountSummaryQueryUseCase;
+import com.aquilabank.domain.auth.exception.UserAccountMembershipNotFoundException;
+import com.aquilabank.domain.auth.model.MembershipRole;
+import com.aquilabank.domain.auth.model.MembershipStatus;
+import com.aquilabank.domain.auth.model.UserAccountMembershipSummary;
+import com.aquilabank.domain.auth.usecase.UserAccountMembershipQueryUseCase;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class CustomerApplicationAccountPolicyAdapterTest {
+
+  private final AccountSummaryQueryUseCase accountSummaryQueryUseCase =
+      mock(AccountSummaryQueryUseCase.class);
+  private final UserAccountMembershipQueryUseCase userAccountMembershipQueryUseCase =
+      mock(UserAccountMembershipQueryUseCase.class);
+  private final CustomerApplicationAccountPolicyAdapter adapter =
+      new CustomerApplicationAccountPolicyAdapter(
+          accountSummaryQueryUseCase, userAccountMembershipQueryUseCase);
+
+  @Test
+  void permitsActiveMembershipAndActiveAccount() {
+    when(userAccountMembershipQueryUseCase.getByUserIdAndAccountId(7L, 101L))
+        .thenReturn(membership(MembershipStatus.ACTIVE));
+    when(accountSummaryQueryUseCase.getByAccountId(101L)).thenReturn(account("ACTIVE"));
+
+    var result = adapter.checkTransferLimitChange(7L, 101L);
+
+    assertThat(result.permitted()).isTrue();
+  }
+
+  @Test
+  void rejectsInactiveAccountAtExecutionBoundary() {
+    when(userAccountMembershipQueryUseCase.getByUserIdAndAccountId(7L, 101L))
+        .thenReturn(membership(MembershipStatus.ACTIVE));
+    when(accountSummaryQueryUseCase.getByAccountId(101L)).thenReturn(account("LOCKED"));
+
+    var result = adapter.checkTransferLimitChange(7L, 101L);
+
+    assertThat(result.permitted()).isFalse();
+    assertThat(result.rejectionReason()).isEqualTo("TRANSFER_LIMIT_ACCOUNT_NOT_ACTIVE");
+  }
+
+  @Test
+  void rejectsInactiveMembershipAtExecutionBoundary() {
+    when(userAccountMembershipQueryUseCase.getByUserIdAndAccountId(7L, 101L))
+        .thenReturn(membership(MembershipStatus.REVOKED));
+
+    var result = adapter.checkTransferLimitChange(7L, 101L);
+
+    assertThat(result.permitted()).isFalse();
+    assertThat(result.rejectionReason()).isEqualTo("TRANSFER_LIMIT_MEMBERSHIP_INACTIVE");
+  }
+
+  @Test
+  void rejectsMissingMembershipOrAccountAtExecutionBoundary() {
+    when(userAccountMembershipQueryUseCase.getByUserIdAndAccountId(7L, 101L))
+        .thenThrow(new UserAccountMembershipNotFoundException("membership is not found"));
+
+    var membershipResult = adapter.checkTransferLimitChange(7L, 101L);
+
+    assertThat(membershipResult.permitted()).isFalse();
+    assertThat(membershipResult.rejectionReason()).isEqualTo("TRANSFER_LIMIT_MEMBERSHIP_NOT_FOUND");
+
+    when(userAccountMembershipQueryUseCase.getByUserIdAndAccountId(8L, 102L))
+        .thenReturn(membership(MembershipStatus.ACTIVE));
+    when(accountSummaryQueryUseCase.getByAccountId(102L))
+        .thenThrow(new AccountSummaryNotFoundException("account is not found"));
+
+    var accountResult = adapter.checkTransferLimitChange(8L, 102L);
+
+    assertThat(accountResult.permitted()).isFalse();
+    assertThat(accountResult.rejectionReason()).isEqualTo("TRANSFER_LIMIT_ACCOUNT_NOT_FOUND");
+  }
+
+  @Test
+  void rejectsInvalidAccountStatusAtExecutionBoundary() {
+    when(userAccountMembershipQueryUseCase.getByUserIdAndAccountId(7L, 101L))
+        .thenReturn(membership(MembershipStatus.ACTIVE));
+    when(accountSummaryQueryUseCase.getByAccountId(101L)).thenReturn(account("BROKEN"));
+
+    var result = adapter.checkTransferLimitChange(7L, 101L);
+
+    assertThat(result.permitted()).isFalse();
+    assertThat(result.rejectionReason()).isEqualTo("TRANSFER_LIMIT_ACCOUNT_STATUS_INVALID");
+  }
+
+  private static UserAccountMembershipSummary membership(MembershipStatus status) {
+    Instant now = Instant.parse("2026-05-13T03:00:00Z");
+    return new UserAccountMembershipSummary(7L, 101L, MembershipRole.OWNER, status, now, now);
+  }
+
+  private static AccountSummary account(String status) {
+    Instant now = Instant.parse("2026-05-13T03:00:00Z");
+    return new AccountSummary(101L, "10000000000101", "입출금", status, "KRW", 0L, 0L, now, now);
+  }
+}

--- a/back/src/test/java/com/aquilabank/global/security/SecurityCorsIntegrationTest.java
+++ b/back/src/test/java/com/aquilabank/global/security/SecurityCorsIntegrationTest.java
@@ -17,9 +17,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 @ActiveProfiles("test")
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-    properties = "security.cors.allowed-origin-patterns=http://localhost:3000")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 class SecurityCorsIntegrationTest {
 
   @Autowired private WebApplicationContext context;
@@ -36,7 +34,7 @@ class SecurityCorsIntegrationTest {
   @Test
   void permitsConfiguredFrontendOriginForLoginPreflight() throws Exception {
     assertThat(securityCorsProperties.allowedOriginPatterns())
-        .containsExactly("http://localhost:3000");
+        .containsExactly("http://localhost:3000", "http://127.0.0.1:3000");
 
     mockMvc
         .perform(

--- a/back/src/test/java/com/aquilabank/global/web/customerapplication/InternalCustomerApplicationControllerTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/customerapplication/InternalCustomerApplicationControllerTest.java
@@ -45,7 +45,7 @@ class InternalCustomerApplicationControllerTest {
   }
 
   @Test
-  void approvesApplicationWithInternalCustomerOpsScope() throws Exception {
+  void approvesApplicationWithInternalCustomerApproverScope() throws Exception {
     when(operationUseCase.apply(
             argThat(
                 command ->
@@ -58,7 +58,7 @@ class InternalCustomerApplicationControllerTest {
                 .header(
                     "Authorization",
                     InternalServiceTokenTestSupport.authorization(
-                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_OPS))
+                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_APPROVER))
                 .header(REQUEST_ID_HEADER, "customer-application-approve-request")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
@@ -84,6 +84,27 @@ class InternalCustomerApplicationControllerTest {
   }
 
   @Test
+  void rejectsLegacyCustomerOpsScopeForApproval() throws Exception {
+    mockMvc
+        .perform(
+            post("/internal/api/v1/customer-service/applications/CSA-001/approve")
+                .header(
+                    "Authorization",
+                    InternalServiceTokenTestSupport.authorization(
+                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_OPS))
+                .header(REQUEST_ID_HEADER, "customer-application-approve-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "reason": "documents checked"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("internal service token is invalid"));
+  }
+
+  @Test
   void handlesReviewRejectCancelAndExecuteActions() throws Exception {
     when(operationUseCase.apply(any()))
         .thenAnswer(
@@ -103,9 +124,12 @@ class InternalCustomerApplicationControllerTest {
               return details(status);
             });
 
-    performOperation("review").andExpect(jsonPath("$.status").value("REVIEWING"));
-    performOperation("reject").andExpect(jsonPath("$.status").value("REJECTED"));
-    performOperation("cancel").andExpect(jsonPath("$.status").value("CANCELLED"));
+    performOperation("review", InternalServiceScope.CUSTOMER_APPLICATION_REVIEWER)
+        .andExpect(jsonPath("$.status").value("REVIEWING"));
+    performOperation("reject", InternalServiceScope.CUSTOMER_APPLICATION_APPROVER)
+        .andExpect(jsonPath("$.status").value("REJECTED"));
+    performOperation("cancel", InternalServiceScope.CUSTOMER_APPLICATION_APPROVER)
+        .andExpect(jsonPath("$.status").value("CANCELLED"));
 
     mockMvc
         .perform(
@@ -113,7 +137,7 @@ class InternalCustomerApplicationControllerTest {
                 .header(
                     "Authorization",
                     InternalServiceTokenTestSupport.authorization(
-                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_OPS))
+                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_EXECUTOR))
                 .header(REQUEST_ID_HEADER, "customer-application-execute-request")
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
@@ -128,7 +152,7 @@ class InternalCustomerApplicationControllerTest {
                 .header(
                     "Authorization",
                     InternalServiceTokenTestSupport.authorization(
-                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_OPS))
+                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_APPROVER))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -194,13 +218,16 @@ class InternalCustomerApplicationControllerTest {
 
   private org.springframework.test.web.servlet.ResultActions performOperation(String action)
       throws Exception {
+    return performOperation(action, InternalServiceScope.CUSTOMER_APPLICATION_APPROVER);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions performOperation(
+      String action, InternalServiceScope scope) throws Exception {
     return mockMvc
         .perform(
             post("/internal/api/v1/customer-service/applications/CSA-001/" + action)
                 .header(
-                    "Authorization",
-                    InternalServiceTokenTestSupport.authorization(
-                        SUBJECT, InternalServiceScope.CUSTOMER_APPLICATION_OPS))
+                    "Authorization", InternalServiceTokenTestSupport.authorization(SUBJECT, scope))
                 .header(REQUEST_ID_HEADER, "customer-application-" + action + "-request")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(

--- a/back/src/test/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptorTest.java
+++ b/back/src/test/java/com/aquilabank/global/web/security/CurrentSessionActiveInterceptorTest.java
@@ -65,6 +65,8 @@ class CurrentSessionActiveInterceptorTest {
             new RequestPath("DELETE", "/api/v1/auth/sessions"),
             new RequestPath("DELETE", "/api/v1/auth/sessions/11"),
             new RequestPath("POST", "/api/v1/customer-service/applications"),
+            new RequestPath(
+                "POST", "/api/v1/customer-service/applications/CSA-20260513-001/cancel"),
             new RequestPath("POST", "/api/v1/notifications/preferences"),
             new RequestPath("POST", "/api/v1/notifications/10/read"),
             new RequestPath("POST", "/api/v1/notifications/read"),


### PR DESCRIPTION
## 🔗 Related Issue
- close #950

## 🌿 Base Branch
- `main`

## 📝 Summary
- 고객 신청 취소 mutation을 active session gate에 포함하고, 내부 신청 처리 scope를 review/approve/execute로 분리했습니다.
- 신청 payload schema와 이체한도 실행 시점 계좌 정책 검증을 추가했습니다.
- 기본 local bootRun에서 로그인 CORS preflight가 막혀 `Failed to fetch`로 보이는 문제를 재현 테스트와 함께 수정했습니다.

## 🛠 Changes
- `/api/v1/customer-service/applications/{ref}/cancel` current-session-active 검사 추가
- customer application 내부 operation별 scope 분리 및 동일 actor 제한 유지
- 신청 타입별 payload 필수 필드/값 검증 추가
- TRANSFER_LIMIT_CHANGE 실행 전 membership/account active 상태 재검증 추가
- local 기본 CORS origin을 `localhost:3000`, `127.0.0.1:3000`으로 열고 production profile은 env 명시 origin만 허용

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `./back/gradlew -p back integrationTest --tests '*SecurityCorsIntegrationTest'`
- `./back/gradlew -p back check` via pre-commit hook
- branch commit count: `origin/main..HEAD = 3`, brief commit_plan = 3

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: local 기본 CORS origin이 개발 편의성을 위해 열립니다. production profile은 `SECURITY_CORS_ALLOWED_ORIGIN_PATTERNS` 미설정 시 닫히도록 별도 override했습니다.
- 롤백 방법: 이 PR revert 후 기존 보안/CORS 정책으로 복구합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A