### PR TITLE
[Fix] 로그인 데모 실행 안정화

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,39 @@ docker compose up -d postgres kafka
 
 ```bash
 yarn --cwd front install
-yarn --cwd front dev
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080 yarn --cwd front dev
+```
+
+다른 포트를 쓰려면 `PORT`를 함께 지정합니다.
+
+```bash
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080 PORT=3001 yarn --cwd front dev
 ```
 
 - Front: `http://localhost:3000`
+
+로그인 시 `Failed to fetch` 또는 백엔드 연결 오류가 보이면 다음 순서로 확인합니다.
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+1. `docker compose up -d postgres kafka`가 먼저 실행됐는지 확인합니다.
+2. `./back/gradlew -p back bootRun` 백엔드가 `http://localhost:8080`에서 떠 있는지 확인합니다.
+3. 프런트 실행 shell에 `NEXT_PUBLIC_API_BASE_URL=http://localhost:8080`이 들어갔는지 확인합니다.
+
+프런트만 실행한 상태에서는 로그인, 계좌, 이체, 고객 신청 API 호출이 동작하지 않습니다. 이 경우 화면에는 API 주소 미설정 또는 백엔드 연결 실패 안내가 표시됩니다.
+
+### 4. 프런트 단독 정적 검증
+
+```bash
+yarn --cwd front install
+yarn --cwd front lint
+yarn --cwd front test:login-runtime
+yarn --cwd front test:ui-contract
+```
+
+프런트 contract 검증은 서버가 없어도 실행할 수 있습니다. 실제 로그인 데모는 백엔드가 실행된 상태에서 확인합니다.
 
 ## 품질 게이트
 

--- a/front/README.md
+++ b/front/README.md
@@ -6,10 +6,12 @@ Next.js 기반 개인 프로젝트 웹뱅킹 프런트엔드입니다.
 
 ## Run
 
+백엔드가 먼저 `http://localhost:8080`에서 실행되어야 로그인과 계좌/이체/신청 API가 동작합니다.
+
 ```bash
 cp .env.example .env.local
 yarn install
-yarn dev
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080 yarn dev
 ```
 
 기본 개발 서버는 `http://localhost:3000`에서 실행됩니다.
@@ -29,6 +31,18 @@ PORT=3002 yarn dev
 ## Environment
 
 `NEXT_PUBLIC_API_BASE_URL`로 백엔드 API 주소를 주입합니다.
+
+```bash
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+```
+
+로그인 시 `Failed to fetch` 또는 백엔드 연결 실패 안내가 나오면 다음을 확인합니다.
+
+1. 루트에서 `docker compose up -d postgres kafka`를 실행했는지 확인합니다.
+2. 루트에서 `./back/gradlew -p back bootRun`을 실행했는지 확인합니다.
+3. 프런트 dev shell 또는 `.env.local`에 `NEXT_PUBLIC_API_BASE_URL=http://localhost:8080`을 넣었는지 확인합니다.
+
+프런트만 실행하면 화면 렌더링과 정적 contract 검증은 가능하지만 로그인 API 호출은 실패합니다.
 
 `NEXT_PUBLIC_FEATURE_FLAGS`에는 쉼표 구분 flag key를 넣습니다.
 

--- a/front/package.json
+++ b/front/package.json
@@ -9,6 +9,7 @@
     "start": "next start -p ${PORT:-3000}",
     "lint": "next lint",
     "test:api-parity": "node scripts/check-front-backend-api-parity.mjs",
+    "test:login-runtime": "node scripts/check-customer-banking-login-runtime.mjs",
     "test:ui-contract": "node scripts/check-customer-banking-ui-contract.mjs",
     "test:unauth-security": "node scripts/check-customer-banking-unauth-security.mjs",
     "test:auth-session": "node scripts/check-auth-session-hardening-contract.mjs",

--- a/front/scripts/check-customer-banking-login-runtime.mjs
+++ b/front/scripts/check-customer-banking-login-runtime.mjs
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+
+function read(path) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+const files = {
+  packageJson: read("package.json"),
+  apiClient: read("src/lib/api/client.ts"),
+  format: read("src/lib/customer-banking/format.ts"),
+};
+
+const required = [
+  ["package script", files.packageJson, "test:login-runtime"],
+  ["network error type", files.apiClient, "ApiNetworkError"],
+  ["network fetch cause check", files.apiClient, "Failed to fetch"],
+  ["network fetch cause check", files.apiClient, "fetch failed"],
+  ["network guidance message", files.format, "백엔드 서버에 연결하지 못했습니다."],
+  ["api url guidance", files.format, "NEXT_PUBLIC_API_BASE_URL"],
+  ["backend run guidance", files.format, "백엔드 실행 상태와 API 주소를 확인하세요."],
+  ["auth error keeps status", files.format, "[${error.status}]"],
+];
+
+const missing = required.filter(([, content, expected]) => !content.includes(expected));
+
+if (missing.length > 0) {
+  console.error("[customer-banking-login-runtime] contract violations:");
+  for (const [name, , expected] of missing) {
+    console.error(`- missing ${name}: ${expected}`);
+  }
+  process.exit(1);
+}
+
+console.log("[customer-banking-login-runtime] passed");

--- a/front/src/lib/api/client.ts
+++ b/front/src/lib/api/client.ts
@@ -66,6 +66,13 @@ export class ApiConfigurationError extends Error {
   }
 }
 
+export class ApiNetworkError extends Error {
+  constructor(public readonly cause: unknown) {
+    super("Backend API network request failed.");
+    this.name = "ApiNetworkError";
+  }
+}
+
 export function resolveApiBaseUrl(): string {
   return (process.env.NEXT_PUBLIC_API_BASE_URL ?? "").replace(/\/+$/, "");
 }
@@ -108,6 +115,15 @@ async function parseResponseBody(response: Response): Promise<unknown> {
   return response.text();
 }
 
+function isFetchNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return ["Failed to fetch", "fetch failed", "Load failed"].some((message) =>
+    error.message.includes(message),
+  );
+}
+
 export function createIdempotencyKey(prefix = "web"): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return `${prefix}-${crypto.randomUUID()}`;
@@ -135,12 +151,20 @@ export class AquilaBankApiClient {
       throw new ApiConfigurationError();
     }
 
-    const response = await fetch(`${this.baseUrl}${path}`, {
-      method: options.method ?? "GET",
-      headers: defaultHeaders(options),
-      body: options.body === undefined ? undefined : JSON.stringify(options.body),
-      credentials: "include",
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}${path}`, {
+        method: options.method ?? "GET",
+        headers: defaultHeaders(options),
+        body: options.body === undefined ? undefined : JSON.stringify(options.body),
+        credentials: "include",
+      });
+    } catch (error) {
+      if (isFetchNetworkError(error)) {
+        throw new ApiNetworkError(error);
+      }
+      throw error;
+    }
     const body = await parseResponseBody(response);
 
     if (!response.ok) {

--- a/front/src/lib/customer-banking/format.ts
+++ b/front/src/lib/customer-banking/format.ts
@@ -1,4 +1,4 @@
-import { ApiClientError, ApiConfigurationError } from "@/lib/api/client";
+import { ApiClientError, ApiConfigurationError, ApiNetworkError } from "@/lib/api/client";
 
 export function toLocalInputValue(date: Date): string {
   const offset = date.getTimezoneOffset();
@@ -28,6 +28,9 @@ export function formatMinorAmount(value: number, currencyCode = "KRW"): string {
 export function toErrorMessage(error: unknown): string {
   if (error instanceof ApiConfigurationError) {
     return "백엔드 API 주소가 설정되지 않았습니다. NEXT_PUBLIC_API_BASE_URL을 확인하세요.";
+  }
+  if (error instanceof ApiNetworkError) {
+    return "백엔드 서버에 연결하지 못했습니다. 백엔드 실행 상태와 API 주소를 확인하세요.";
   }
   if (error instanceof ApiClientError) {
     return `[${error.status}] ${error.message}`;


### PR DESCRIPTION
## 🔗 Related Issue
- close #960

## 🌿 Base Branch
- `main`

## 📝 Summary
- 로그인 시 `Failed to fetch`가 그대로 노출되는 데모 실행 문제를 정리합니다.
- API 주소 미설정과 백엔드 연결 실패를 구분하고, 로컬 실행 가이드에 백엔드 선행 실행과 API URL 설정을 명시합니다.

## 🛠 Changes
- `ApiNetworkError`를 추가해 fetch/network failure를 HTTP API error와 분리했습니다.
- 고객 화면 오류 메시지를 API 주소 미설정, 백엔드 연결 실패, HTTP 오류로 구분했습니다.
- `test:login-runtime` contract를 추가하고 README/front README에 데모 실행 순서와 troubleshooting을 보강했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [x] Auth / Security
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트
- [ ] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front lint`
- `yarn --cwd front test:api-parity`
- `yarn --cwd front test:login-runtime`
- `node front/scripts/check-customer-banking-ui-contract.mjs`
- `node front/scripts/check-customer-banking-unauth-security.mjs`

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 네트워크 오류 문구가 변경됩니다. backend auth/session 동작 변경은 없습니다.
- 롤백 방법: 이 PR의 두 커밋을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
