### PR TITLE
[Fix] 고객뱅킹 UI 가독성 깨짐 정리

### DIFF
--- a/front/e2e/customer-banking-visual-layout.spec.ts
+++ b/front/e2e/customer-banking-visual-layout.spec.ts
@@ -8,6 +8,24 @@ async function expectNoHorizontalOverflow(page: import("@playwright/test").Page)
   expect(overflow).toBeLessThanOrEqual(1);
 }
 
+async function expectNoTextClipping(
+  page: import("@playwright/test").Page,
+  selector: string,
+) {
+  const clipped = await page.locator(selector).evaluateAll((items) =>
+    items
+      .filter((item) => {
+        const element = item as HTMLElement;
+        return (
+          element.scrollWidth > element.clientWidth + 1 ||
+          element.scrollHeight > element.clientHeight + 1
+        );
+      })
+      .map((item) => item.textContent?.trim() ?? ""),
+  );
+  expect(clipped).toEqual([]);
+}
+
 test("desktop 공개 화면은 3열 업무형 구조와 미로그인 보호 업무 가드를 유지한다", async ({
   page,
 }, testInfo) => {
@@ -80,5 +98,29 @@ test("mobile 공개 화면은 단일 흐름으로 접히고 키보드 접근 순
   await page.screenshot({
     fullPage: true,
     path: testInfo.outputPath("customer-banking-mobile-home.png"),
+  });
+});
+
+test("tablet compact 폭에서도 검색, 메뉴, 보안알림 텍스트가 컨테이너 안에 머문다", async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "tablet 폭 visual QA");
+
+  await page.setViewportSize({ width: 820, height: 900 });
+  await page.goto("/");
+  await expectNoHorizontalOverflow(page);
+  await expect(page.getByLabel("추천검색어")).toBeVisible();
+  await expect(page.getByLabel("개인뱅킹 메뉴")).toBeVisible();
+  await expect(page.getByText("보안알림")).toBeVisible();
+
+  await expectNoTextClipping(page, ".keyword-list button");
+  await expectNoTextClipping(page, ".side-menu .side-item span");
+  await expectNoTextClipping(page, ".side-menu .side-item strong");
+  await expectNoTextClipping(page, ".security-notice .bank-notice-strip dt");
+  await expectNoTextClipping(page, ".security-notice .bank-notice-strip dd");
+
+  await page.screenshot({
+    fullPage: true,
+    path: testInfo.outputPath("customer-banking-tablet-compact-home.png"),
   });
 });

--- a/front/scripts/check-customer-banking-ui-contract.mjs
+++ b/front/scripts/check-customer-banking-ui-contract.mjs
@@ -165,6 +165,12 @@ const checks = [
   ["gothic work panel class", files.styles, ".gothic-work-panel"],
   ["gothic state strip class", files.styles, ".gothic-state-strip"],
   ["gothic bank table class", files.styles, ".gothic-bank-table"],
+  ["visual polish keep korean words", files.styles, "word-break: keep-all"],
+  ["visual polish utility search min width", files.styles, ".utility-search"],
+  ["visual polish tablet utility wrap", files.styles, ".utility-bar.mobile-compact-utility"],
+  ["visual polish side item stable mobile height", files.styles, ".side-menu.mobile-compact-side-menu .side-item strong"],
+  ["visual polish notice stable columns", files.styles, ".bank-notice-strip div"],
+  ["visual polish notice value line height", files.styles, ".bank-notice-strip dd"],
 ];
 
 const forbidden = [

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -75,6 +75,7 @@ button {
   cursor: pointer;
   font-weight: 700;
   line-height: 1.25;
+  word-break: keep-all;
   overflow-wrap: anywhere;
 }
 
@@ -187,6 +188,12 @@ label span {
   gap: 8px;
 }
 
+.utility-right {
+  min-width: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .utility-link {
   min-height: 28px;
   border: 0;
@@ -216,18 +223,26 @@ label span {
 
 .search-field {
   display: grid;
-  grid-template-columns: auto 220px;
+  grid-template-columns: max-content minmax(220px, 1fr);
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
 .search-field span {
   margin: 0;
 }
 
+.search-field input {
+  min-width: 0;
+}
+
 .utility-search {
   display: grid;
   gap: 5px;
+  flex: 1 1 520px;
+  min-width: min(100%, 520px);
+  max-width: 100%;
 }
 
 .keyword-list {
@@ -238,6 +253,9 @@ label span {
   color: var(--muted);
   font-size: 12px;
   font-weight: 800;
+  min-width: 0;
+  line-height: 1.45;
+  word-break: keep-all;
 }
 
 .keyword-list button {
@@ -247,6 +265,7 @@ label span {
   color: var(--primary-dark);
   padding: 0 4px;
   font-size: 12px;
+  white-space: nowrap;
 }
 
 .brand-row {
@@ -487,6 +506,8 @@ label span {
 
 .side-item {
   display: grid;
+  align-content: center;
+  gap: 2px;
   width: 100%;
   min-height: 58px;
   border: 0;
@@ -505,10 +526,14 @@ label span {
 .side-item span {
   color: var(--muted);
   font-size: 12px;
+  line-height: 1.25;
+  word-break: keep-all;
 }
 
 .side-item strong {
   font-size: 15px;
+  line-height: 1.28;
+  word-break: keep-all;
 }
 
 .side-item.active {
@@ -2231,9 +2256,10 @@ label span {
 
 .bank-notice-strip div {
   display: grid;
-  grid-template-columns: 82px minmax(0, 1fr);
-  gap: 8px;
-  align-items: center;
+  grid-template-columns: minmax(72px, max-content) minmax(0, 1fr);
+  gap: 4px 10px;
+  align-items: start;
+  min-width: 0;
   border-top: 1px solid var(--line);
   padding-top: 8px;
 }
@@ -2241,6 +2267,8 @@ label span {
 .bank-notice-strip dt {
   color: var(--muted);
   font-weight: 800;
+  line-height: 1.35;
+  word-break: keep-all;
 }
 
 .bank-notice-strip dd {
@@ -2248,6 +2276,8 @@ label span {
   margin: 0;
   color: var(--primary-dark);
   font-weight: 800;
+  line-height: 1.35;
+  word-break: keep-all;
   overflow-wrap: anywhere;
 }
 
@@ -2366,6 +2396,20 @@ label span {
   .utility-bar,
   .primary-nav {
     flex-wrap: wrap;
+  }
+
+  .utility-bar.mobile-compact-utility {
+    align-items: flex-start;
+    gap: 8px 12px;
+  }
+
+  .utility-right {
+    flex: 1 1 100%;
+    justify-content: flex-start;
+  }
+
+  .utility-search {
+    flex-basis: min(100%, 640px);
   }
 
   .service-map-panel {
@@ -2493,8 +2537,8 @@ label span {
   .side-menu.mobile-compact-side-menu .side-title,
   .side-menu.mobile-compact-side-menu .mobile-work-jump,
   .side-menu.mobile-compact-side-menu .side-item {
-    flex: 0 0 132px;
-    min-height: 44px;
+    flex: 0 0 152px;
+    min-height: 58px;
   }
 
   .side-menu.mobile-compact-side-menu .side-title {
@@ -2518,7 +2562,18 @@ label span {
   .side-menu.mobile-compact-side-menu .side-item {
     border-bottom: 0;
     border-left: 1px solid var(--line);
-    padding: 7px 10px;
+    gap: 3px;
+    padding: 8px 10px;
+  }
+
+  .side-menu.mobile-compact-side-menu .side-item span,
+  .side-menu.mobile-compact-side-menu .side-item strong {
+    display: block;
+    white-space: normal;
+  }
+
+  .side-menu.mobile-compact-side-menu .side-item strong {
+    font-size: 14px;
   }
 
   .nav-tab {
@@ -2576,6 +2631,13 @@ label span {
   .quick-grid button,
   .recent-menu-list button {
     width: 100%;
+  }
+
+  .side-menu.mobile-compact-side-menu .side-title,
+  .side-menu.mobile-compact-side-menu .mobile-work-jump,
+  .side-menu.mobile-compact-side-menu .side-item {
+    flex-basis: 148px;
+    width: auto;
   }
 
   button,


### PR DESCRIPTION
## 🔗 Related Issue
- close #964

## 🌿 Base Branch
- `main`

## 📝 Summary
- 첨부 화면에서 보인 보안알림, 개인뱅킹 사이드 메뉴, 통합검색/추천검색어의 텍스트 겹침과 잘림을 정리했습니다.
- 색상 테마와 화면 구조는 유지하고, compact/tablet/mobile 폭에서 한글 텍스트가 컨테이너 안에 머물도록 CSS guard와 visual E2E를 보강했습니다.

## 🛠 Changes
- header 검색 영역이 1180px 이하에서도 flex wrapping과 min-width를 안정적으로 쓰도록 조정했습니다.
- 사이드 메뉴 버튼의 줄 높이, 모바일 높이, flex-basis를 보강해 active 상태 텍스트가 버튼 밖으로 밀리지 않게 했습니다.
- 우측 보안알림 label/value grid를 안정화해 값 텍스트가 줄바꿈되어도 겹치지 않게 했습니다.
- 820px tablet compact visual E2E에서 검색/메뉴/보안알림 clipping을 검사하고 screenshot artifact를 남기도록 추가했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front lint`
- `yarn --cwd front test:api-parity`
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front build`
- `yarn --cwd front test:e2e:visual`
- `yarn --cwd front test:e2e:live-artifacts`

## 📸 Screenshot / API Example
- Playwright artifact: `front/test-results/**/customer-banking-tablet-compact-home.png`
- API 변경 없음

## ⚠️ Risk & Rollback
- 예상 리스크: CSS responsive 규칙 변경으로 중간 폭 메뉴 줄바꿈 위치가 달라질 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?