### PR TITLE
[Test] 부하 테스트 실행 전제 안정화

### DIFF
--- a/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
+++ b/.github/workflows/oci-k6-burst-reject-curve-matrix.yml
@@ -96,6 +96,11 @@ on:
       - "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh"
       - "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh"
       - "tools/test/run-k6-transaction-100m-loadtest.sh"
+      - "tools/test/check-k6-transaction-100m-loadtest.sh"
+      - "tools/ops/staging-fixture-principal-bootstrap.sh"
+      - "tools/test/run-staging-fixture-principal-bootstrap-contract.sh"
+      - "tools/ops/issue-staging-replay-token.py"
+      - "tools/test/check-issue-staging-replay-token.py"
 
 permissions:
   contents: read
@@ -112,6 +117,15 @@ jobs:
 
       - name: Validate workflow contract
         run: bash tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
+
+      - name: Validate k6 transaction loadtest contract
+        run: bash tools/test/check-k6-transaction-100m-loadtest.sh
+
+      - name: Validate staging fixture principal bootstrap
+        run: bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+
+      - name: Validate staging replay token issuer
+        run: python3 tools/test/check-issue-staging-replay-token.py
 
   burst-matrix:
     name: Authenticated OCI k6 burst reject curve matrix
@@ -214,7 +228,9 @@ jobs:
           fi
 
           missing=()
-          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
+          if [[ -z "${STAGING_REPLAY_TOKEN:-}" && -z "${OCI_A1_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-}}" ]]; then
+            missing+=("STAGING_REPLAY_TOKEN_OR_OCI_A1_BACKEND_ENV_B64")
+          fi
           [[ -z "${K6_DOCKER_CONTEXT}" ]] && missing+=("K6_DOCKER_CONTEXT")
           [[ -z "${K6_REMOTE_BASE_URL}" ]] && missing+=("K6_REMOTE_BASE_URL")
           [[ -z "${K6_REMOTE_PROMETHEUS_RW_SERVER_URL}" ]] && missing+=("K6_REMOTE_PROMETHEUS_RW_SERVER_URL")
@@ -231,6 +247,17 @@ jobs:
 
           env_names=(
             STAGING_REPLAY_TOKEN
+            STAGING_OCI_A1_DATABASE_URL
+            STAGING_RDS_DATABASE_URL
+            OCI_A1_BACKEND_ENV_B64
+            BACKEND_ENV_B64
+            POSTGRES_CONTAINER_NAME
+            POSTGRES_NETWORK_ALIAS
+            POSTGRES_HOST_BIND
+            STAGING_REPLAY_USER_ID
+            STAGING_REPLAY_LOGIN_ID
+            STAGING_REPLAY_USER_PASSWORD_HASH
+            STAGING_REPLAY_USER_DISPLAY_NAME
             K6_MATRIX_REPORT_NAME
             K6_BURST_RATES
             K6_RUN_PURPOSE
@@ -276,6 +303,54 @@ jobs:
               printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_ENV}"
             fi
           done
+
+      - name: Resolve OCI A1 staging database URL
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "build/reports/k6/${K6_MATRIX_REPORT_NAME}"
+          if ! resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"; then
+            echo "::error::Failed to resolve burst matrix staging database URL."
+            exit 1
+          fi
+          echo "::add-mask::${resolved_database_url}"
+          printf 'STAGING_OCI_A1_DATABASE_URL=%s\n' "${resolved_database_url}" >>"${GITHUB_ENV}"
+
+      - name: Issue burst matrix replay token
+        shell: bash
+        run: |
+          set -euo pipefail
+          replay_token_file="${RUNNER_TEMP}/staging-replay-token.jwt"
+          if [[ -n "${OCI_A1_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-}}" ]]; then
+            STAGING_REPLAY_SESSION_ID="" \
+            STAGING_REPLAY_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-}" \
+            STAGING_REPLAY_TOKEN_OUTPUT_FILE="${replay_token_file}" \
+            STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE=auto \
+            STAGING_REPLAY_TOKEN_TTL_SECONDS="${K6_REPLAY_TOKEN_TTL_SECONDS:-7200}" \
+              python3 tools/ops/issue-staging-replay-token.py
+            replay_token="$(<"${replay_token_file}")"
+            printf '::add-mask::%s\n' "${replay_token}"
+            printf 'STAGING_REPLAY_TOKEN=%s\n' "${replay_token}" >>"${GITHUB_ENV}"
+            printf 'STAGING_REPLAY_TOKEN_FILE=%s\n' "${replay_token_file}" >>"${GITHUB_ENV}"
+            printf 'STAGING_REPLAY_ALLOW_SESSION_REASSIGN=true\n' >>"${GITHUB_ENV}"
+            exit 0
+          fi
+          if [[ -z "${STAGING_REPLAY_TOKEN:-}" ]]; then
+            echo "::error::STAGING_REPLAY_TOKEN or OCI_A1_BACKEND_ENV_B64 is required for authenticated OCI k6."
+            exit 1
+          fi
+          umask 077
+          printf '%s' "${STAGING_REPLAY_TOKEN}" >"${replay_token_file}"
+          printf 'STAGING_REPLAY_TOKEN_FILE=%s\n' "${replay_token_file}" >>"${GITHUB_ENV}"
+
+      - name: Ensure service auth fixture principal
+        shell: bash
+        run: |
+          set -euo pipefail
+          HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
+          COLD_ACCOUNT_ID="${K6_COLD_ACCOUNT_ID}" \
+          STAGING_REPLAY_TOKEN_FILE="${STAGING_REPLAY_TOKEN_FILE}" \
+            tools/ops/staging-fixture-principal-bootstrap.sh
 
       - name: Run authenticated k6 burst matrix
         shell: bash

--- a/.github/workflows/oci-k6-service-auth-token.yml
+++ b/.github/workflows/oci-k6-service-auth-token.yml
@@ -134,10 +134,13 @@ on:
       - "tools/test/check-transaction-read-promotion-pacing-contract.sh"
       - "tools/test/run-transaction-read-promotion-pacing-contract.sh"
       - "tools/test/run-k6-transaction-100m-loadtest.sh"
+      - "tools/test/check-k6-transaction-100m-loadtest.sh"
       - "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh"
       - "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh"
       - "tools/ops/staging-fixture-principal-bootstrap.sh"
       - "tools/test/run-staging-fixture-principal-bootstrap-contract.sh"
+      - "tools/ops/issue-staging-replay-token.py"
+      - "tools/test/check-issue-staging-replay-token.py"
 
 permissions:
   contents: read
@@ -154,6 +157,9 @@ jobs:
       - name: Validate workflow contract
         run: bash tools/test/check-oci-k6-service-auth-token-workflow.sh
 
+      - name: Validate k6 transaction loadtest contract
+        run: bash tools/test/check-k6-transaction-100m-loadtest.sh
+
       - name: Validate promotion pacing contract
         run: bash tools/test/check-transaction-read-promotion-pacing-contract.sh
 
@@ -165,6 +171,9 @@ jobs:
 
       - name: Validate staging fixture principal bootstrap
         run: bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+
+      - name: Validate staging replay token issuer
+        run: python3 tools/test/check-issue-staging-replay-token.py
 
   authenticated-k6:
     name: Authenticated OCI k6 capacity
@@ -321,7 +330,9 @@ jobs:
           fi
 
           missing=()
-          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
+          if [[ -z "${STAGING_REPLAY_TOKEN:-}" && -z "${OCI_A1_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-}}" ]]; then
+            missing+=("STAGING_REPLAY_TOKEN_OR_OCI_A1_BACKEND_ENV_B64")
+          fi
           if [[ -z "${STAGING_OCI_A1_DATABASE_URL:-}" && -z "${STAGING_RDS_DATABASE_URL:-}" ]]; then
             missing+=("STAGING_OCI_A1_DATABASE_URL")
           fi
@@ -341,6 +352,7 @@ jobs:
 
           env_names=(
             OCI_A1_BACKEND_ENV_B64
+            BACKEND_ENV_B64
             POSTGRES_CONTAINER_NAME
             POSTGRES_NETWORK_ALIAS
             POSTGRES_HOST_BIND
@@ -482,6 +494,33 @@ jobs:
           echo "::add-mask::${resolved_database_url}"
           printf 'STAGING_OCI_A1_DATABASE_URL=%s\n' "${resolved_database_url}" >>"${GITHUB_ENV}"
 
+      - name: Issue service auth replay token
+        shell: bash
+        run: |
+          set -euo pipefail
+          replay_token_file="${RUNNER_TEMP}/staging-replay-token.jwt"
+          if [[ -n "${OCI_A1_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-}}" ]]; then
+            STAGING_REPLAY_SESSION_ID="" \
+            STAGING_REPLAY_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-}" \
+            STAGING_REPLAY_TOKEN_OUTPUT_FILE="${replay_token_file}" \
+            STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE=auto \
+            STAGING_REPLAY_TOKEN_TTL_SECONDS="${K6_REPLAY_TOKEN_TTL_SECONDS:-7200}" \
+              python3 tools/ops/issue-staging-replay-token.py
+            replay_token="$(<"${replay_token_file}")"
+            printf '::add-mask::%s\n' "${replay_token}"
+            printf 'STAGING_REPLAY_TOKEN=%s\n' "${replay_token}" >>"${GITHUB_ENV}"
+            printf 'STAGING_REPLAY_TOKEN_FILE=%s\n' "${replay_token_file}" >>"${GITHUB_ENV}"
+            printf 'STAGING_REPLAY_ALLOW_SESSION_REASSIGN=true\n' >>"${GITHUB_ENV}"
+            exit 0
+          fi
+          if [[ -z "${STAGING_REPLAY_TOKEN:-}" ]]; then
+            echo "::error::STAGING_REPLAY_TOKEN or OCI_A1_BACKEND_ENV_B64 is required for authenticated OCI k6."
+            exit 1
+          fi
+          umask 077
+          printf '%s' "${STAGING_REPLAY_TOKEN}" >"${replay_token_file}"
+          printf 'STAGING_REPLAY_TOKEN_FILE=%s\n' "${replay_token_file}" >>"${GITHUB_ENV}"
+
       - name: Ensure service auth fixture principal
         shell: bash
         run: |
@@ -490,6 +529,7 @@ jobs:
           COLD_ACCOUNT_ID="${K6_COLD_ACCOUNT_ID}" \
           HOT_ACCOUNT_IDS="${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" \
           COLD_ACCOUNT_IDS="${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" \
+          STAGING_REPLAY_TOKEN_FILE="${STAGING_REPLAY_TOKEN_FILE}" \
             tools/ops/staging-fixture-principal-bootstrap.sh
 
       - name: Run auth preflight
@@ -511,7 +551,7 @@ jobs:
             local from="$3"
             local to="$4"
             local endpoint="$5"
-            local account_id raw_account_id
+            local account_id canonical_base preflight_base raw_account_id
             IFS="," read -r -a accounts <<<"${account_ids}"
             for raw_account_id in "${accounts[@]}"; do
               account_id="${raw_account_id//[[:space:]]/}"
@@ -525,10 +565,15 @@ jobs:
               echo "[oci-k6-service-auth] auth preflight ${account_group} account=${account_id}" >>"${auth_preflight_log}"
               K6_AUTH_PREFLIGHT_PATH="${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1" \
                 tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >>"${auth_preflight_log}" 2>&1
-              preflight_url="${K6_REMOTE_BASE_URL%/}/${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1"
+              canonical_base="$(
+                awk -F= '/auth preflight canonicalized base url=/{value=$2} END{print value}' "${auth_preflight_log}"
+              )"
+              preflight_base="${canonical_base:-${K6_REMOTE_BASE_URL}}"
+              preflight_url="${preflight_base%/}/${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1"
               preflight_body="${report_dir}/auth-preflight-${account_group}-${account_id}.json"
               status="$(
                 curl -sS -o "${preflight_body}" -w "%{http_code}" \
+                  --location \
                   --max-time 5 \
                   -H "Authorization: Bearer ${STAGING_REPLAY_TOKEN}" \
                   "${preflight_url}" 2>>"${auth_preflight_log}" || true

--- a/.github/workflows/offhost-100m-capacity-prerequisite.yml
+++ b/.github/workflows/offhost-100m-capacity-prerequisite.yml
@@ -63,6 +63,8 @@ on:
     paths:
       - ".github/workflows/offhost-100m-capacity-prerequisite.yml"
       - "tools/test/run-transaction-100m-capacity-gates.sh"
+      - "tools/test/run-k6-transaction-100m-loadtest.sh"
+      - "tools/test/check-k6-transaction-100m-loadtest.sh"
       - "tools/test/run-offhost-capacity-env-doctor.sh"
       - "tools/test/check-offhost-capacity-env-doctor.sh"
       - "tools/test/offhost-capacity.env.example"
@@ -79,6 +81,10 @@ on:
       - "tools/test/check-oci-offhost-host-metrics-snapshot.sh"
       - "tools/test/run-transaction-100m-offhost-capacity-baseline-report.sh"
       - "tools/test/run-t3micro-defensive-gates-aggregate-report.sh"
+      - "tools/ops/staging-fixture-principal-bootstrap.sh"
+      - "tools/test/run-staging-fixture-principal-bootstrap-contract.sh"
+      - "tools/ops/issue-staging-replay-token.py"
+      - "tools/test/check-issue-staging-replay-token.py"
 
 permissions:
   contents: read
@@ -94,6 +100,15 @@ jobs:
 
       - name: Validate workflow contract
         run: tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+
+      - name: Validate k6 transaction loadtest contract
+        run: tools/test/check-k6-transaction-100m-loadtest.sh
+
+      - name: Validate staging fixture principal bootstrap
+        run: tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+
+      - name: Validate staging replay token issuer
+        run: python3 tools/test/check-issue-staging-replay-token.py
 
       - name: Check off-host host metrics timeline
         run: tools/test/check-oci-offhost-host-metrics-timeline.sh
@@ -198,6 +213,36 @@ jobs:
           CAPACITY_K6_COLD_ACCOUNT_ID="${CAPACITY_K6_COLD_ACCOUNT_ID:-${K6_COLD_ACCOUNT_ID:-910000002}}"
           CAPACITY_K6_COLD_FROM="${CAPACITY_K6_COLD_FROM:-${K6_COLD_FROM:-2026-01-01T00:00:00Z}}"
           CAPACITY_K6_COLD_TO="${CAPACITY_K6_COLD_TO:-${K6_COLD_TO:-2026-01-31T00:00:00Z}}"
+          if [[ -z "${STAGING_REPLAY_TOKEN:-}" && -z "${OCI_A1_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-}}" ]]; then
+            echo "::error::STAGING_REPLAY_TOKEN or OCI_A1_BACKEND_ENV_B64 is required for authenticated off-host capacity gates."
+            exit 1
+          fi
+          if ! resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"; then
+            echo "::error::Failed to resolve off-host capacity staging database URL."
+            exit 1
+          fi
+          echo "::add-mask::${resolved_database_url}"
+          export STAGING_OCI_A1_DATABASE_URL="${resolved_database_url}"
+          replay_token_file="${RUNNER_TEMP}/staging-replay-token.jwt"
+          if [[ -n "${OCI_A1_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-}}" ]]; then
+            STAGING_REPLAY_SESSION_ID="" \
+            STAGING_REPLAY_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL}" \
+            STAGING_REPLAY_TOKEN_OUTPUT_FILE="${replay_token_file}" \
+            STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE=auto \
+            STAGING_REPLAY_TOKEN_TTL_SECONDS="${CAPACITY_K6_REPLAY_TOKEN_TTL_SECONDS:-7200}" \
+              python3 tools/ops/issue-staging-replay-token.py
+            STAGING_REPLAY_TOKEN="$(<"${replay_token_file}")"
+            export STAGING_REPLAY_TOKEN
+            export STAGING_REPLAY_ALLOW_SESSION_REASSIGN=true
+            echo "::add-mask::${STAGING_REPLAY_TOKEN}"
+          else
+            umask 077
+            printf '%s' "${STAGING_REPLAY_TOKEN}" >"${replay_token_file}"
+          fi
+          HOT_ACCOUNT_ID="${CAPACITY_K6_HOT_ACCOUNT_ID}" \
+          COLD_ACCOUNT_ID="${CAPACITY_K6_COLD_ACCOUNT_ID}" \
+          STAGING_REPLAY_TOKEN_FILE="${replay_token_file}" \
+            tools/ops/staging-fixture-principal-bootstrap.sh
           host_metrics_snapshot_dir="${report_dir}/offhost-host-metrics-snapshot"
           snapshot_generator_tsv="${host_metrics_snapshot_dir}/${CAPACITY_NAME}-generator-host-metrics.tsv"
           snapshot_target_tsv="${host_metrics_snapshot_dir}/${CAPACITY_NAME}-target-host-metrics.tsv"

--- a/.github/workflows/transaction-read-30m-soak-live-evidence.yml
+++ b/.github/workflows/transaction-read-30m-soak-live-evidence.yml
@@ -29,7 +29,7 @@ on:
       cold_account_id:
         description: "Cold-labeled account id for k6; default must have fixture rows"
         required: false
-        default: "910000001"
+        default: "910000002"
         type: string
       hot_from:
         description: "Hot range start"
@@ -44,12 +44,12 @@ on:
       cold_from:
         description: "Cold-labeled range start for k6; default matches the fixture-backed range"
         required: false
-        default: "2026-04-01T00:00:00Z"
+        default: "2026-01-01T00:00:00Z"
         type: string
       cold_to:
         description: "Cold-labeled range end for k6; default matches the fixture-backed range"
         required: false
-        default: "2026-04-30T00:00:00Z"
+        default: "2026-01-31T00:00:00Z"
         type: string
       nginx_access_log:
         description: "Optional Nginx access log path on the self-hosted runner"
@@ -78,6 +78,12 @@ on:
       - "tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh"
       - "tools/test/run-transaction-read-oci-evidence-execution-gate.sh"
       - "tools/test/check-transaction-read-oci-evidence-execution-gate.sh"
+      - "tools/test/run-k6-transaction-100m-loadtest.sh"
+      - "tools/test/check-k6-transaction-100m-loadtest.sh"
+      - "tools/ops/staging-fixture-principal-bootstrap.sh"
+      - "tools/test/run-staging-fixture-principal-bootstrap-contract.sh"
+      - "tools/ops/issue-staging-replay-token.py"
+      - "tools/test/check-issue-staging-replay-token.py"
 
 permissions:
   contents: read
@@ -104,6 +110,15 @@ jobs:
 
       - name: Check 30m soak live evidence workflow
         run: bash tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
+
+      - name: Validate k6 transaction loadtest contract
+        run: bash tools/test/check-k6-transaction-100m-loadtest.sh
+
+      - name: Validate staging fixture principal bootstrap
+        run: bash tools/test/run-staging-fixture-principal-bootstrap-contract.sh
+
+      - name: Validate staging replay token issuer
+        run: python3 tools/test/check-issue-staging-replay-token.py
 
   live-evidence:
     name: 30m Soak Live Evidence Gate
@@ -236,7 +251,9 @@ jobs:
           K6_NGINX_ACCESS_LOG="${SOAK_30M_NGINX_ACCESS_LOG_INPUT:-${CAPACITY_K6_NGINX_ACCESS_LOG:-/var/log/nginx/access.log}}"
 
           missing=()
-          [[ -z "${STAGING_REPLAY_TOKEN:-}" ]] && missing+=("STAGING_REPLAY_TOKEN")
+          if [[ -z "${STAGING_REPLAY_TOKEN:-}" && -z "${OCI_A1_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-}}" ]]; then
+            missing+=("STAGING_REPLAY_TOKEN_OR_OCI_A1_BACKEND_ENV_B64")
+          fi
           if [[ -z "${STAGING_OCI_A1_DATABASE_URL:-}" && -z "${STAGING_RDS_DATABASE_URL:-}" ]]; then
             missing+=("STAGING_OCI_A1_DATABASE_URL")
           fi
@@ -249,6 +266,7 @@ jobs:
 
           env_names=(
             OCI_A1_BACKEND_ENV_B64
+            BACKEND_ENV_B64
             POSTGRES_CONTAINER_NAME
             POSTGRES_NETWORK_ALIAS
             POSTGRES_HOST_BIND
@@ -364,6 +382,34 @@ jobs:
           echo "::add-mask::${resolved_database_url}"
           printf 'STAGING_OCI_A1_DATABASE_URL=%s\n' "${resolved_database_url}" >>"${GITHUB_ENV}"
 
+      - name: Issue 30m soak replay token
+        if: env.SOAK_30M_USE_EXISTING_MANIFEST != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          replay_token_file="${RUNNER_TEMP}/staging-replay-token.jwt"
+          if [[ -n "${OCI_A1_BACKEND_ENV_B64:-${BACKEND_ENV_B64:-}}" ]]; then
+            STAGING_REPLAY_SESSION_ID="" \
+            STAGING_REPLAY_DATABASE_URL="${STAGING_OCI_A1_DATABASE_URL:-}" \
+            STAGING_REPLAY_TOKEN_OUTPUT_FILE="${replay_token_file}" \
+            STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE=auto \
+            STAGING_REPLAY_TOKEN_TTL_SECONDS="${SOAK_30M_REPLAY_TOKEN_TTL_SECONDS:-7200}" \
+              python3 tools/ops/issue-staging-replay-token.py
+            replay_token="$(<"${replay_token_file}")"
+            printf '::add-mask::%s\n' "${replay_token}"
+            printf 'STAGING_REPLAY_TOKEN=%s\n' "${replay_token}" >>"${GITHUB_ENV}"
+            printf 'STAGING_REPLAY_TOKEN_FILE=%s\n' "${replay_token_file}" >>"${GITHUB_ENV}"
+            printf 'STAGING_REPLAY_ALLOW_SESSION_REASSIGN=true\n' >>"${GITHUB_ENV}"
+            exit 0
+          fi
+          if [[ -z "${STAGING_REPLAY_TOKEN:-}" ]]; then
+            echo "::error::STAGING_REPLAY_TOKEN or OCI_A1_BACKEND_ENV_B64 is required for authenticated OCI k6."
+            exit 1
+          fi
+          umask 077
+          printf '%s' "${STAGING_REPLAY_TOKEN}" >"${replay_token_file}"
+          printf 'STAGING_REPLAY_TOKEN_FILE=%s\n' "${replay_token_file}" >>"${GITHUB_ENV}"
+
       - name: Ensure service auth fixture principal
         if: env.SOAK_30M_USE_EXISTING_MANIFEST != 'true'
         shell: bash
@@ -371,6 +417,7 @@ jobs:
           set -euo pipefail
           HOT_ACCOUNT_ID="${K6_HOT_ACCOUNT_ID}" \
           COLD_ACCOUNT_ID="${K6_COLD_ACCOUNT_ID}" \
+          STAGING_REPLAY_TOKEN_FILE="${STAGING_REPLAY_TOKEN_FILE}" \
             tools/ops/staging-fixture-principal-bootstrap.sh
 
       - name: Capture 30m soak evidence window
@@ -447,18 +494,24 @@ jobs:
           : >"${auth_preflight_log}"
 
           run_account_auth_preflight() {
-            local account_group="$1"
-            local account_id="$2"
-            local from="$3"
-            local to="$4"
-            local endpoint="$5"
+            local account_group account_id from to endpoint canonical_base preflight_base preflight_url preflight_body status item_count
+            account_group="$1"
+            account_id="$2"
+            from="$3"
+            to="$4"
+            endpoint="$5"
             echo "[transaction-read-30m-soak] auth preflight ${account_group} account=${account_id}" >>"${auth_preflight_log}"
             K6_AUTH_PREFLIGHT_PATH="${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1" \
               tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only >>"${auth_preflight_log}" 2>&1
-            preflight_url="${K6_REMOTE_BASE_URL%/}/${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1"
+            canonical_base="$(
+              awk -F= '/auth preflight canonicalized base url=/{value=$2} END{print value}' "${auth_preflight_log}"
+            )"
+            preflight_base="${canonical_base:-${K6_REMOTE_BASE_URL}}"
+            preflight_url="${preflight_base%/}/${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1"
             preflight_body="${report_dir}/auth-preflight-${account_group}-${account_id}.json"
             status="$(
               curl -sS -o "${preflight_body}" -w "%{http_code}" \
+                --location \
                 --max-time 5 \
                 -H "Authorization: Bearer ${STAGING_REPLAY_TOKEN}" \
                 "${preflight_url}" 2>>"${auth_preflight_log}" || true

--- a/tools/ops/issue-staging-replay-token.py
+++ b/tools/ops/issue-staging-replay-token.py
@@ -16,6 +16,12 @@ MIN_RUN_LOCAL_SESSION_ID = 9_000_000_000_000_000_000
 DEFAULT_USER_ID = 55
 DEFAULT_LOGIN_ID = "staging-fixture-user"
 DEFAULT_TTL_SECONDS = 7200
+DEFAULT_BACKEND_CONTAINER_CANDIDATES = (
+    "aquila-bank-backend",
+    "aquila-backend",
+    "aquila-bank-backend-staging",
+    "backend",
+)
 
 
 def fail(message: str) -> None:
@@ -38,7 +44,7 @@ def base64url(value: bytes) -> str:
     return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
 
 
-def decode_backend_env() -> str:
+def decode_backend_env() -> tuple[str, str]:
     encoded = os.environ.get("OCI_A1_BACKEND_ENV_B64") or os.environ.get("BACKEND_ENV_B64")
     if not encoded:
         fail("OCI_A1_BACKEND_ENV_B64 is required")
@@ -50,7 +56,7 @@ def decode_backend_env() -> str:
         base64.urlsafe_b64decode,
     ):
         try:
-            return decoder(padded).decode("utf-8")
+            return decoder(padded).decode("utf-8"), "encoded"
         except Exception:
             continue
     fail("Failed to decode OCI_A1_BACKEND_ENV_B64")
@@ -82,6 +88,75 @@ def require_backend_value(values: dict[str, str], name: str) -> str:
     if not value:
         fail(f"{name} is required in OCI_A1_BACKEND_ENV_B64")
     return value
+
+
+def docker_container_candidates() -> list[str]:
+    candidates: list[str] = []
+    explicit = os.environ.get("STAGING_REPLAY_BACKEND_CONTAINER") or os.environ.get(
+        "BACKEND_CONTAINER_NAME", ""
+    )
+    if explicit:
+        candidates.append(explicit)
+    candidates.extend(DEFAULT_BACKEND_CONTAINER_CANDIDATES)
+
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "--format", "{{.Names}}"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except FileNotFoundError:
+        result = None
+    if result is not None and result.returncode == 0:
+        for line in result.stdout.splitlines():
+            name = line.strip()
+            if name and "backend" in name and name not in candidates:
+                candidates.append(name)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            deduped.append(candidate)
+    return deduped
+
+
+def live_docker_backend_env() -> tuple[str, str] | None:
+    for container in docker_container_candidates():
+        try:
+            result = subprocess.run(
+                ["docker", "exec", container, "env"],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+        except FileNotFoundError:
+            return None
+        if result.returncode != 0:
+            continue
+        values = parse_backend_env(result.stdout)
+        if values.get("SECURITY_JWT_SECRET"):
+            return result.stdout, f"live-docker:{container}"
+    return None
+
+
+def resolve_backend_env() -> tuple[str, str]:
+    source = os.environ.get("STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE", "encoded").strip().lower()
+    if source not in {"encoded", "live-docker", "auto"}:
+        fail("STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE must be encoded, live-docker, or auto")
+
+    if source in {"live-docker", "auto"}:
+        live = live_docker_backend_env()
+        if live is not None:
+            return live
+        if source == "live-docker":
+            fail("Failed to read SECURITY_JWT_SECRET from live backend Docker container")
+
+    return decode_backend_env()
 
 
 def random_session_id() -> int:
@@ -178,7 +253,8 @@ def main() -> None:
     if not output_path.parent.is_dir():
         fail("STAGING_REPLAY_TOKEN_OUTPUT_FILE parent directory must exist")
 
-    backend_values = parse_backend_env(decode_backend_env())
+    backend_env_text, backend_env_source = resolve_backend_env()
+    backend_values = parse_backend_env(backend_env_text)
     secret = require_backend_value(backend_values, "SECURITY_JWT_SECRET")
     issuer = backend_values.get("SECURITY_JWT_ISSUER", "")
     user_id = positive_int("STAGING_REPLAY_USER_ID", DEFAULT_USER_ID)
@@ -194,6 +270,7 @@ def main() -> None:
     print(
         "[issue-staging-replay-token] wrote "
         f"token_file={output_path} user_id={user_id} "
+        f"backend_env_source={backend_env_source} "
         f"session_id_source={session_id_source} ttl_seconds={ttl_seconds}"
     )
 

--- a/tools/test/check-issue-staging-replay-token.py
+++ b/tools/test/check-issue-staging-replay-token.py
@@ -201,6 +201,65 @@ def assert_database_sequence_session_id_is_used_when_available() -> None:
             fail(f"issuer should query auth_refresh_token_session sequence: {psql_args!r}")
 
 
+def assert_auto_backend_env_prefers_live_docker_container() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = pathlib.Path(temp_dir)
+        fake_bin = temp_path / "bin"
+        fake_bin.mkdir()
+        docker = fake_bin / "docker"
+        docker.write_text(
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import sys",
+                    "if sys.argv[1:4] == ['ps', '--format', '{{.Names}}']:",
+                    "    print('aquila-backend')",
+                    "    raise SystemExit(0)",
+                    "if sys.argv[1:4] == ['exec', 'aquila-backend', 'env']:",
+                    "    print('SECURITY_JWT_SECRET=live-container-secret-with-enough-entropy')",
+                    "    print('SECURITY_JWT_ISSUER=https://live.staging.example.test')",
+                    "    raise SystemExit(0)",
+                    "raise SystemExit(1)",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        docker.chmod(0o700)
+
+        output_file = temp_path / "live-docker.jwt"
+        encoded_secret = "encoded-secret-must-not-sign-token"
+        env_b64 = encode_env(f"SECURITY_JWT_SECRET={encoded_secret}\n")
+        result = run_issuer(
+            {
+                "OCI_A1_BACKEND_ENV_B64": env_b64,
+                "STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE": "auto",
+                "STAGING_REPLAY_TOKEN_OUTPUT_FILE": str(output_file),
+                "STAGING_REPLAY_SESSION_ID": "987654321",
+            },
+            path_prefix=fake_bin,
+        )
+
+        if result.returncode != 0:
+            fail(f"issuer should prefer live docker backend env, stderr={result.stderr!r}")
+        if "backend_env_source=live-docker" not in result.stdout:
+            fail(f"issuer should report live docker env source: {result.stdout!r}")
+
+        token = output_file.read_text(encoding="utf-8").strip()
+        parts = token.split(".")
+        payload = decode_segment(parts[1])
+        expected_signature = hmac.new(
+            b"live-container-secret-with-enough-entropy",
+            f"{parts[0]}.{parts[1]}".encode("ascii"),
+            hashlib.sha256,
+        ).digest()
+        actual_signature = base64.urlsafe_b64decode(parts[2] + ("=" * (-len(parts[2]) % 4)))
+        if not hmac.compare_digest(actual_signature, expected_signature):
+            fail("auto source should sign with live backend container secret")
+        if payload.get("iss") != "https://live.staging.example.test":
+            fail(f"auto source should use live backend issuer: {payload!r}")
+
+
 def assert_missing_secret_fails_without_token() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         output_file = pathlib.Path(temp_dir) / "missing-secret.jwt"
@@ -227,6 +286,8 @@ def main() -> None:
     assert_empty_session_id_uses_reserved_generated_range()
     print("[issue-staging-replay-token] database sequence contract")
     assert_database_sequence_session_id_is_used_when_available()
+    print("[issue-staging-replay-token] live docker env source contract")
+    assert_auto_backend_env_prefers_live_docker_container()
     print("[issue-staging-replay-token] missing secret contract")
     assert_missing_secret_fails_without_token()
     print("ok")

--- a/tools/test/check-k6-transaction-100m-loadtest.sh
+++ b/tools/test/check-k6-transaction-100m-loadtest.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runner="tools/test/run-k6-transaction-100m-loadtest.sh"
+
+echo "[k6-transaction-100m-loadtest] shell syntax"
+bash -n "${runner}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+fake_bin="${temp_dir}/bin"
+mkdir -p "${fake_bin}"
+
+cat >"${fake_bin}/curl" <<'SH'
+#!/usr/bin/env bash
+follow_redirects=false
+has_authorization=false
+url=""
+for arg in "$@"; do
+  if [[ "${arg}" == "--location" || "${arg}" == "-L" ]]; then
+    follow_redirects=true
+  fi
+  if [[ "${arg}" == "Authorization: Bearer "* ]]; then
+    has_authorization=true
+  fi
+  if [[ "${arg}" == http://* || "${arg}" == https://* ]]; then
+    url="${arg}"
+  fi
+done
+
+if [[ "${follow_redirects}" == "true" && "${url}" == http://staging.example.com/* ]]; then
+  # curl은 cross-host redirect에서 Authorization을 자동 전달하지 않아 최종 auth endpoint가 401을 낸다.
+  printf "401\thttps://bank.example.com/api/v1/transactions?accountId=910000001&from=2026-04-01T00:00:00Z&to=2026-04-30T00:00:00Z&limit=1"
+elif [[ "${follow_redirects}" == "true" && "${url}" == https://bank.example.com/* && "${has_authorization}" == "true" ]]; then
+  printf "200\thttps://bank.example.com/api/v1/transactions?accountId=910000001&from=2026-04-01T00:00:00Z&to=2026-04-30T00:00:00Z&limit=1"
+elif [[ "${follow_redirects}" == "true" ]]; then
+  printf "200\thttps://staging.example.com/api/v1/transactions?accountId=910000001&from=2026-04-01T00:00:00Z&to=2026-04-30T00:00:00Z&limit=1"
+else
+  printf "308"
+fi
+SH
+chmod +x "${fake_bin}/curl"
+
+echo "[k6-transaction-100m-loadtest] auth preflight follows redirect and canonicalizes remote base"
+output="$(
+  PATH="${fake_bin}:${PATH}" \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=default \
+  K6_REMOTE_BASE_URL=http://staging.example.com \
+  K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://127.0.0.1:9090/api/v1/write \
+  K6_RUN_PURPOSE=capacity \
+  K6_AUTH_TOKEN=fake-token \
+  K6_AUTH_PREFLIGHT=true \
+  K6_AUTH_PREFLIGHT_PATH='api/v1/transactions?accountId=910000001&from=2026-04-01T00:00:00Z&to=2026-04-30T00:00:00Z&limit=1' \
+  K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS=1 \
+    "${runner}" --auth-preflight-only 2>&1
+)"
+grep -F "auth status preflight: expected_status=200 timeout=1 follow_redirects=true" <<<"${output}" >/dev/null
+grep -F "auth preflight canonicalized base url=https://bank.example.com" <<<"${output}" >/dev/null
+
+echo "[k6-transaction-100m-loadtest] auth preflight can keep strict no-redirect mode"
+set +e
+strict_output="$(
+  PATH="${fake_bin}:${PATH}" \
+  K6_GENERATOR_MODE=docker-context \
+  K6_DOCKER_CONTEXT=default \
+  K6_REMOTE_BASE_URL=http://staging.example.com \
+  K6_REMOTE_PROMETHEUS_RW_SERVER_URL=http://127.0.0.1:9090/api/v1/write \
+  K6_RUN_PURPOSE=capacity \
+  K6_AUTH_TOKEN=fake-token \
+  K6_AUTH_PREFLIGHT=true \
+  K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS=false \
+  K6_AUTH_PREFLIGHT_PATH='api/v1/transactions?accountId=910000001&from=2026-04-01T00:00:00Z&to=2026-04-30T00:00:00Z&limit=1' \
+  K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS=1 \
+    "${runner}" --auth-preflight-only 2>&1
+)"
+strict_status=$?
+set -e
+if [[ "${strict_status}" -eq 0 ]]; then
+  echo "strict no-redirect auth preflight unexpectedly passed" >&2
+  exit 1
+fi
+grep -F "auth status preflight failed: expected=200 actual=308" <<<"${strict_output}" >/dev/null

--- a/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
+++ b/tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh
@@ -23,21 +23,42 @@ if [[ "${dispatch_input_count}" -gt 25 ]]; then
 fi
 grep -F "OCI k6 burst reject curve matrix contract" "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-k6-transaction-100m-loadtest.sh" "${workflow}" >/dev/null
+grep -F "Validate k6 transaction loadtest contract" "${workflow}" >/dev/null
 grep -F "tools/test/run-oci-k6-burst-reject-curve-matrix.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-nginx-access-aggregate-artifact.sh" "${workflow}" >/dev/null
+grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-staging-fixture-principal-bootstrap-contract.sh" "${workflow}" >/dev/null
+grep -F "tools/ops/issue-staging-replay-token.py" "${workflow}" >/dev/null
+grep -F "tools/test/check-issue-staging-replay-token.py" "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh" "${workflow}" >/dev/null
+grep -F "Validate staging fixture principal bootstrap" "${workflow}" >/dev/null
+grep -F "Validate staging replay token issuer" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
 grep -F "environment:" "${workflow}" >/dev/null
 grep -F "name: staging" "${workflow}" >/dev/null
 grep -F 'OCI_A1_STAGING_ENV: ${{ secrets.OCI_A1_STAGING_ENV }}' "${workflow}" >/dev/null
 grep -F "Load OCI k6 burst matrix env" "${workflow}" >/dev/null
+grep -F "Resolve OCI A1 staging database URL" "${workflow}" >/dev/null
+grep -F "Issue burst matrix replay token" "${workflow}" >/dev/null
+grep -F "Ensure service auth fixture principal" "${workflow}" >/dev/null
+grep -F 'replay_token_file="${RUNNER_TEMP}/staging-replay-token.jwt"' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_OUTPUT_FILE="${replay_token_file}" \' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE=auto \' "${workflow}" >/dev/null
+grep -F 'python3 tools/ops/issue-staging-replay-token.py' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_FILE="${STAGING_REPLAY_TOKEN_FILE}" \' "${workflow}" >/dev/null
+grep -F "STAGING_REPLAY_TOKEN_OR_OCI_A1_BACKEND_ENV_B64" "${workflow}" >/dev/null
 grep -F 'DEFAULT_K6_DOCKER_CONTEXT="default"' "${workflow}" >/dev/null
 grep -F 'DEFAULT_K6_REMOTE_BASE_URL="${STAGING_BASE_URL:-}"' "${workflow}" >/dev/null
 grep -F 'DEFAULT_K6_REMOTE_PROMETHEUS_RW_SERVER_URL="http://172.17.0.2:9090/api/v1/write"' "${workflow}" >/dev/null
 grep -F 'DEFAULT_K6_NGINX_ACCESS_LOG="/var/log/nginx/access.log"' "${workflow}" >/dev/null
 grep -F "STAGING_REPLAY_TOKEN" "${workflow}" >/dev/null
+grep -F "STAGING_OCI_A1_DATABASE_URL" "${workflow}" >/dev/null
+grep -F "OCI_A1_BACKEND_ENV_B64" "${workflow}" >/dev/null
+grep -F "POSTGRES_CONTAINER_NAME" "${workflow}" >/dev/null
+grep -F "POSTGRES_HOST_BIND" "${workflow}" >/dev/null
 grep -F 'K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"' "${workflow}" >/dev/null
 grep -F 'K6_AUTH_PREFLIGHT="true"' "${workflow}" >/dev/null
 grep -F 'K6_RUN_PURPOSE="capacity"' "${workflow}" >/dev/null
@@ -108,11 +129,16 @@ grep -F 'Authorization: Bearer ${GH_TOKEN}' "${workflow}" >/dev/null
 grep -F 'description "transaction read burst matrix target ${K6_BURST_MATRIX_PROMOTION_TARGET_RATE} passed"' "${workflow}" >/dev/null
 grep -F '"state": "success"' "${workflow}" >/dev/null
 
+resolver_line="$(grep -n "Resolve OCI A1 staging database URL" "${workflow}" | head -1 | cut -d: -f1)"
+issuer_line="$(grep -n "Issue burst matrix replay token" "${workflow}" | head -1 | cut -d: -f1)"
+fixture_principal_line="$(grep -n "Ensure service auth fixture principal" "${workflow}" | head -1 | cut -d: -f1)"
 preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"
 k6_run_line="$(grep -n -- "--no-up --no-deps" "${workflow}" | head -1 | cut -d: -f1)"
 matrix_line="$(grep -n -- "run-oci-k6-burst-reject-curve-matrix.sh" "${workflow}" | tail -1 | cut -d: -f1)"
 admission_deployment_line="$(grep -n -- "Record transaction read admission profile evidence deployment" "${workflow}" | head -1 | cut -d: -f1)"
-if [[ -z "${preflight_line}" || -z "${k6_run_line}" || "${preflight_line}" -ge "${k6_run_line}" ]]; then
+if [[ -z "${resolver_line}" || -z "${issuer_line}" || -z "${fixture_principal_line}" || -z "${preflight_line}" || -z "${k6_run_line}" ||
+  "${resolver_line}" -ge "${issuer_line}" || "${issuer_line}" -ge "${fixture_principal_line}" ||
+  "${fixture_principal_line}" -ge "${preflight_line}" || "${preflight_line}" -ge "${k6_run_line}" ]]; then
   echo "auth preflight must run before authenticated k6 burst run" >&2
   exit 1
 fi

--- a/tools/test/check-oci-k6-service-auth-token-workflow.sh
+++ b/tools/test/check-oci-k6-service-auth-token-workflow.sh
@@ -26,6 +26,8 @@ if [[ "${dispatch_input_count}" -gt 25 ]]; then
 fi
 grep -F "OCI k6 service auth token contract" "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-k6-service-auth-token-workflow.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-k6-transaction-100m-loadtest.sh" "${workflow}" >/dev/null
+grep -F "Validate k6 transaction loadtest contract" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-429-source-gate.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-429-source-gate.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-k6-service-auth-arrival16-evidence-gate.sh" "${workflow}" >/dev/null
@@ -34,9 +36,12 @@ grep -F "tools/test/check-transaction-read-promotion-pacing-contract.sh" "${work
 grep -F "tools/test/run-transaction-read-promotion-pacing-contract.sh" "${workflow}" >/dev/null
 grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-staging-fixture-principal-bootstrap-contract.sh" "${workflow}" >/dev/null
+grep -F "tools/ops/issue-staging-replay-token.py" "${workflow}" >/dev/null
+grep -F "tools/test/check-issue-staging-replay-token.py" "${workflow}" >/dev/null
 grep -F "Validate promotion pacing contract" "${workflow}" >/dev/null
 grep -F "Validate transaction read 429 source gate" "${workflow}" >/dev/null
 grep -F "Validate service auth arrival16 evidence gate" "${workflow}" >/dev/null
+grep -F "Validate staging replay token issuer" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'workflow_dispatch'" "${workflow}" >/dev/null
 grep -F "runs-on: [self-hosted, oci-a1-staging]" "${workflow}" >/dev/null
 grep -F "environment:" "${workflow}" >/dev/null
@@ -56,6 +61,7 @@ grep -F 'if [[ "${K6_DOCKER_CONTEXT}" == "default" ]]; then' "${workflow}" >/dev
 grep -F 'K6_REMOTE_WORKDIR="${GITHUB_WORKSPACE}"' "${workflow}" >/dev/null
 grep -F 'K6_REMOTE_WORKDIR="${CAPACITY_K6_REMOTE_WORKDIR:-${GITHUB_WORKSPACE}}"' "${workflow}" >/dev/null
 grep -F "STAGING_REPLAY_TOKEN" "${workflow}" >/dev/null
+grep -F "STAGING_REPLAY_TOKEN_OR_OCI_A1_BACKEND_ENV_B64" "${workflow}" >/dev/null
 grep -F 'K6_AUTH_TOKEN_ENV_NAME="STAGING_REPLAY_TOKEN"' "${workflow}" >/dev/null
 grep -F 'K6_AUTH_PREFLIGHT="true"' "${workflow}" >/dev/null
 grep -F "OCI_A1_BACKEND_ENV_B64" "${workflow}" >/dev/null
@@ -131,8 +137,15 @@ grep -F 'K6_NGINX_LOG_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' "${workflow}" >/
 grep -F "Resolve OCI A1 staging database URL" "${workflow}" >/dev/null
 grep -F 'resolved_database_url="$(tools/ops/resolve-oci-a1-staging-database-url.sh)"' "${workflow}" >/dev/null
 grep -F 'printf '\''STAGING_OCI_A1_DATABASE_URL=%s\n'\'' "${resolved_database_url}" >>"${GITHUB_ENV}"' "${workflow}" >/dev/null
+grep -F "Issue service auth replay token" "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_OUTPUT_FILE="${replay_token_file}" \' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE=auto \' "${workflow}" >/dev/null
+grep -F 'python3 tools/ops/issue-staging-replay-token.py' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_FILE=%s\n' "${workflow}" >/dev/null
 grep -F "Ensure service auth fixture principal" "${workflow}" >/dev/null
 grep -F 'STAGING_OCI_A1_DATABASE_URL' "${workflow}" >/dev/null
+grep -F 'replay_token_file="${RUNNER_TEMP}/staging-replay-token.jwt"' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_FILE="${STAGING_REPLAY_TOKEN_FILE}" \' "${workflow}" >/dev/null
 grep -F 'HOT_ACCOUNT_IDS="${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" \' "${workflow}" >/dev/null
 grep -F 'COLD_ACCOUNT_IDS="${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" \' "${workflow}" >/dev/null
 grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
@@ -146,9 +159,12 @@ grep -F 'K6_AUTH_PREFLIGHT_PATH="${endpoint}?accountId=${account_id}&from=${from
 grep -F 'run_account_auth_preflight hot "${K6_HOT_ACCOUNT_IDS:-${K6_HOT_ACCOUNT_ID}}" "${K6_HOT_FROM}" "${K6_HOT_TO}" "api/v1/transactions"' "${workflow}" >/dev/null
 grep -F 'run_account_auth_preflight cold "${K6_COLD_ACCOUNT_IDS:-${K6_COLD_ACCOUNT_ID}}" "${K6_COLD_FROM}" "${K6_COLD_TO}" "api/v1/transactions/archive"' "${workflow}" >/dev/null
 grep -F "tools/test/run-k6-transaction-100m-loadtest.sh --auth-preflight-only" "${workflow}" >/dev/null
-grep -F 'preflight_url="${K6_REMOTE_BASE_URL%/}/${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1"' "${workflow}" >/dev/null
+grep -F "auth preflight canonicalized base url=" "${workflow}" >/dev/null
+grep -F 'preflight_base="${canonical_base:-${K6_REMOTE_BASE_URL}}"' "${workflow}" >/dev/null
+grep -F 'preflight_url="${preflight_base%/}/${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1"' "${workflow}" >/dev/null
 grep -F 'preflight_body="${report_dir}/auth-preflight-${account_group}-${account_id}.json"' "${workflow}" >/dev/null
 grep -F 'curl -sS -o "${preflight_body}" -w "%{http_code}"' "${workflow}" >/dev/null
+grep -F -- '--location' "${workflow}" >/dev/null
 grep -F -- '-H "Authorization: Bearer ${STAGING_REPLAY_TOKEN}"' "${workflow}" >/dev/null
 grep -F 'items = data.get("items")' "${workflow}" >/dev/null
 grep -F 'auth item preflight failed' "${workflow}" >/dev/null
@@ -207,12 +223,14 @@ grep -F "tools/test/run-oci-k6-service-auth-arrival16-evidence-gate.sh" "${workf
 grep -F "actions/upload-artifact@" "${workflow}" >/dev/null
 grep -F "oci-k6-service-auth-token" "${workflow}" >/dev/null
 
-fixture_principal_line="$(grep -n "Ensure service auth fixture principal" "${workflow}" | head -1 | cut -d: -f1)"
 resolver_line="$(grep -n "Resolve OCI A1 staging database URL" "${workflow}" | head -1 | cut -d: -f1)"
+issuer_line="$(grep -n "Issue service auth replay token" "${workflow}" | head -1 | cut -d: -f1)"
+fixture_principal_line="$(grep -n "Ensure service auth fixture principal" "${workflow}" | head -1 | cut -d: -f1)"
 auth_preflight_line="$(grep -n -- "--auth-preflight-only" "${workflow}" | head -1 | cut -d: -f1)"
 k6_run_line="$(grep -n -- "--no-up --no-deps" "${workflow}" | head -1 | cut -d: -f1)"
-if [[ -z "${resolver_line}" || -z "${fixture_principal_line}" || -z "${auth_preflight_line}" || -z "${k6_run_line}" ||
-  "${resolver_line}" -ge "${fixture_principal_line}" || "${fixture_principal_line}" -ge "${auth_preflight_line}" || "${auth_preflight_line}" -ge "${k6_run_line}" ]]; then
+if [[ -z "${resolver_line}" || -z "${issuer_line}" || -z "${fixture_principal_line}" || -z "${auth_preflight_line}" || -z "${k6_run_line}" ||
+  "${resolver_line}" -ge "${issuer_line}" || "${issuer_line}" -ge "${fixture_principal_line}" ||
+  "${fixture_principal_line}" -ge "${auth_preflight_line}" || "${auth_preflight_line}" -ge "${k6_run_line}" ]]; then
   echo "auth preflight must run before authenticated k6 capacity" >&2
   exit 1
 fi

--- a/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
+++ b/tools/test/check-offhost-capacity-prerequisite-required-gate.sh
@@ -13,6 +13,22 @@ grep -F "pull_request:" "${workflow}" >/dev/null
 grep -F "off-host capacity prerequisite contract" "${workflow}" >/dev/null
 grep -F "if: github.event_name == 'pull_request'" "${workflow}" >/dev/null
 grep -F "tools/test/check-offhost-capacity-prerequisite-required-gate.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-k6-transaction-100m-loadtest.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-k6-transaction-100m-loadtest.sh" "${workflow}" >/dev/null
+grep -F "Validate k6 transaction loadtest contract" "${workflow}" >/dev/null
+grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-staging-fixture-principal-bootstrap-contract.sh" "${workflow}" >/dev/null
+grep -F "tools/ops/issue-staging-replay-token.py" "${workflow}" >/dev/null
+grep -F "tools/test/check-issue-staging-replay-token.py" "${workflow}" >/dev/null
+grep -F "Validate staging fixture principal bootstrap" "${workflow}" >/dev/null
+grep -F "Validate staging replay token issuer" "${workflow}" >/dev/null
+grep -F "STAGING_REPLAY_TOKEN or OCI_A1_BACKEND_ENV_B64 is required for authenticated off-host capacity gates." "${workflow}" >/dev/null
+grep -F "Failed to resolve off-host capacity staging database URL." "${workflow}" >/dev/null
+grep -F 'replay_token_file="${RUNNER_TEMP}/staging-replay-token.jwt"' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_OUTPUT_FILE="${replay_token_file}" \' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE=auto \' "${workflow}" >/dev/null
+grep -F 'python3 tools/ops/issue-staging-replay-token.py' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_FILE="${replay_token_file}" \' "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-offhost-host-metrics-snapshot.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-oci-offhost-host-metrics-timeline.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-oci-offhost-host-metrics-timeline.sh" "${workflow}" >/dev/null

--- a/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
+++ b/tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh
@@ -29,6 +29,9 @@ grep -F "report_name:" "${workflow}" >/dev/null
 grep -F 'description: "Cold-labeled account id for k6; default must have fixture rows"' "${workflow}" >/dev/null
 grep -F 'description: "Cold-labeled range start for k6; default matches the fixture-backed range"' "${workflow}" >/dev/null
 grep -F 'description: "Cold-labeled range end for k6; default matches the fixture-backed range"' "${workflow}" >/dev/null
+grep -F 'default: "910000002"' "${workflow}" >/dev/null
+grep -F 'default: "2026-01-01T00:00:00Z"' "${workflow}" >/dev/null
+grep -F 'default: "2026-01-31T00:00:00Z"' "${workflow}" >/dev/null
 grep -F "docker_context:" "${workflow}" >/dev/null
 grep -F 'SOAK_30M_DOCKER_CONTEXT_INPUT: ${{ inputs.docker_context }}' "${workflow}" >/dev/null
 grep -F "workload_weights:" "${workflow}" >/dev/null
@@ -38,6 +41,15 @@ grep -F 'SOAK_30M_WORKLOAD_WEIGHTS_INPUT: ${{ inputs.workload_weights }}' "${wor
 grep -F "30m Soak Live Evidence Contract" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-gate.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-k6-transaction-100m-loadtest.sh" "${workflow}" >/dev/null
+grep -F "tools/test/check-k6-transaction-100m-loadtest.sh" "${workflow}" >/dev/null
+grep -F "tools/ops/staging-fixture-principal-bootstrap.sh" "${workflow}" >/dev/null
+grep -F "tools/test/run-staging-fixture-principal-bootstrap-contract.sh" "${workflow}" >/dev/null
+grep -F "tools/ops/issue-staging-replay-token.py" "${workflow}" >/dev/null
+grep -F "tools/test/check-issue-staging-replay-token.py" "${workflow}" >/dev/null
+grep -F "Validate k6 transaction loadtest contract" "${workflow}" >/dev/null
+grep -F "Validate staging fixture principal bootstrap" "${workflow}" >/dev/null
+grep -F "Validate staging replay token issuer" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-30m-soak-live-evidence-manifest.sh" "${workflow}" >/dev/null
 grep -F "tools/test/check-transaction-read-30m-soak-live-evidence-manifest.sh" "${workflow}" >/dev/null
 grep -F "tools/test/run-transaction-read-30m-soak-live-evidence-artifacts.sh" "${workflow}" >/dev/null
@@ -61,6 +73,7 @@ grep -F 'SOAK_30M_DURATION_INPUT: ${{ inputs.duration }}' "${workflow}" >/dev/nu
 grep -F "Prepare 30m soak evidence mode" "${workflow}" >/dev/null
 grep -F 'SOAK_30M_USE_EXISTING_MANIFEST=true' "${workflow}" >/dev/null
 grep -F "Load OCI A1 staging env" "${workflow}" >/dev/null
+grep -F "STAGING_REPLAY_TOKEN_OR_OCI_A1_BACKEND_ENV_B64" "${workflow}" >/dev/null
 grep -F 'K6_RUN_PURPOSE="capacity"' "${workflow}" >/dev/null
 grep -F 'K6_REMOTE_PROMETHEUS_RW_REQUIRED="false"' "${workflow}" >/dev/null
 grep -F 'remote-write optional' "${workflow}" >/dev/null
@@ -81,11 +94,23 @@ grep -F 'falling back to default self-hosted runner Docker context' "${workflow}
 grep -F "K6_DOCKER_CONTEXT=default" "${workflow}" >/dev/null
 grep -F 'printf '\''K6_REMOTE_WORKDIR=%s\n'\'' "${GITHUB_WORKSPACE}"' "${workflow}" >/dev/null
 grep -F "Capture 30m soak evidence window" "${workflow}" >/dev/null
+grep -F "Issue 30m soak replay token" "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_OUTPUT_FILE="${replay_token_file}" \' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_BACKEND_ENV_SOURCE=auto \' "${workflow}" >/dev/null
+grep -F 'python3 tools/ops/issue-staging-replay-token.py' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_FILE=%s\n' "${workflow}" >/dev/null
 grep -F "Capture PostgreSQL baseline counters" "${workflow}" >/dev/null
 grep -F 'SOAK_30M_POSTGRES_CHECKPOINT_START_COUNT=%s' "${workflow}" >/dev/null
 grep -F 'SOAK_30M_POSTGRES_TEMP_FILE_START_COUNT=%s' "${workflow}" >/dev/null
 grep -F "Run 30m authenticated k6 soak" "${workflow}" >/dev/null
-grep -F 'local endpoint="$5"' "${workflow}" >/dev/null
+grep -F 'replay_token_file="${RUNNER_TEMP}/staging-replay-token.jwt"' "${workflow}" >/dev/null
+grep -F 'STAGING_REPLAY_TOKEN_FILE="${STAGING_REPLAY_TOKEN_FILE}" \' "${workflow}" >/dev/null
+grep -F 'endpoint="$5"' "${workflow}" >/dev/null
+grep -F 'local account_group account_id from to endpoint canonical_base preflight_base preflight_url preflight_body status item_count' "${workflow}" >/dev/null
+grep -F "awk -F= '/auth preflight canonicalized base url=/{value=\$2} END{print value}'" "${workflow}" >/dev/null
+grep -F 'preflight_base="${canonical_base:-${K6_REMOTE_BASE_URL}}"' "${workflow}" >/dev/null
+grep -F 'preflight_url="${preflight_base%/}/${endpoint}?accountId=${account_id}&from=${from}&to=${to}&limit=1"' "${workflow}" >/dev/null
+grep -F -- '--location' "${workflow}" >/dev/null
 grep -F 'if [[ "${K6_WORKLOAD_WEIGHTS}" == *cold_* ]]; then' "${workflow}" >/dev/null
 grep -F 'api/v1/transactions/archive' "${workflow}" >/dev/null
 grep -F 'K6_DURATION="${SOAK_30M_DURATION}"' "${workflow}" >/dev/null

--- a/tools/test/run-k6-transaction-100m-loadtest.sh
+++ b/tools/test/run-k6-transaction-100m-loadtest.sh
@@ -61,6 +61,7 @@ Optional environment:
   K6_AUTH_PREFLIGHT_BASE_URL default remote base URL or backend readiness base URL
   K6_AUTH_PREFLIGHT_EXPECTED_STATUS default 200
   K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS default 5
+  K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS follow redirect and canonicalize base URL, default true
   K6_BASE_URL          optional backend base URL for local generator; default k6 script value
   K6_ARCHIVE_RESULTS   copy markdown summary to docs/performance-results, default true
   K6_ARCHIVE_FAILED_SUMMARY archive summary even when hard gate fails, default true
@@ -334,6 +335,82 @@ auth_preflight_url() {
   echo ""
 }
 
+url_origin() {
+  local url="$1"
+  if [[ "${url}" =~ ^([A-Za-z][A-Za-z0-9+.-]*://[^/?#]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+canonicalize_auth_preflight_base_url() {
+  local effective_url="$1"
+  local canonical_origin current_origin
+
+  if [[ "${K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS}" != "true" || -z "${effective_url}" ]]; then
+    return 0
+  fi
+  if ! canonical_origin="$(url_origin "${effective_url}")"; then
+    return 0
+  fi
+
+  # 명시 full URL은 호출자가 범위를 직접 정한 값이므로 k6 base URL 추론에 사용하지 않습니다.
+  if [[ -n "${K6_AUTH_PREFLIGHT_URL}" ]]; then
+    return 0
+  fi
+
+  if [[ -n "${K6_AUTH_PREFLIGHT_BASE_URL}" ]]; then
+    current_origin="$(url_origin "${K6_AUTH_PREFLIGHT_BASE_URL}")" || current_origin=""
+    if [[ "${canonical_origin}" != "${current_origin}" ]]; then
+      K6_AUTH_PREFLIGHT_BASE_URL="${canonical_origin}"
+      export K6_AUTH_PREFLIGHT_BASE_URL
+      echo "[k6-transaction-100m] auth preflight canonicalized base url=${K6_AUTH_PREFLIGHT_BASE_URL}"
+    fi
+    return 0
+  fi
+
+  if [[ "${K6_GENERATOR_MODE}" == "docker-context" ]]; then
+    current_origin="$(url_origin "${K6_REMOTE_BASE_URL}")" || current_origin=""
+    if [[ "${canonical_origin}" != "${current_origin}" ]]; then
+      K6_REMOTE_BASE_URL="${canonical_origin}"
+      export K6_REMOTE_BASE_URL
+      echo "[k6-transaction-100m] auth preflight canonicalized base url=${K6_REMOTE_BASE_URL}"
+    fi
+  fi
+}
+
+canonicalize_auth_preflight_redirect() {
+  local preflight_url curl_output effective_url
+
+  if [[ "${K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS}" != "true" ]]; then
+    return 0
+  fi
+  # 명시 full URL은 호출자가 canonical endpoint를 직접 고른 값으로 둡니다.
+  if [[ -n "${K6_AUTH_PREFLIGHT_URL}" ]]; then
+    return 0
+  fi
+
+  preflight_url="$(auth_preflight_url)"
+  if [[ -z "${preflight_url}" ]]; then
+    return 0
+  fi
+
+  require_command curl
+  # cross-host redirect에서는 curl이 Authorization을 제거하므로, token 없이 origin만 먼저 확정합니다.
+  curl_output="$(
+    curl -sS -o /dev/null -w "%{http_code}\t%{url_effective}" \
+      --location \
+      --max-time "${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}" \
+      "${preflight_url}" 2>/dev/null || true
+  )"
+  effective_url=""
+  if [[ "${curl_output}" == *$'\t'* ]]; then
+    effective_url="${curl_output#*$'\t'}"
+  fi
+  canonicalize_auth_preflight_base_url "${effective_url}"
+}
+
 effective_auth_preflight_enabled() {
   case "${K6_AUTH_PREFLIGHT}" in
     true|false)
@@ -521,6 +598,7 @@ K6_AUTH_PREFLIGHT_PATH="${K6_AUTH_PREFLIGHT_PATH:-}"
 K6_AUTH_PREFLIGHT_BASE_URL="${K6_AUTH_PREFLIGHT_BASE_URL:-}"
 K6_AUTH_PREFLIGHT_EXPECTED_STATUS="${K6_AUTH_PREFLIGHT_EXPECTED_STATUS:-200}"
 K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS="${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS:-5}"
+K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS="${K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS:-true}"
 K6_DOCKER_CONTEXT="${K6_DOCKER_CONTEXT:-}"
 K6_REMOTE_BASE_URL="${K6_REMOTE_BASE_URL:-}"
 K6_REMOTE_PROMETHEUS_RW_SERVER_URL="${K6_REMOTE_PROMETHEUS_RW_SERVER_URL:-}"
@@ -551,7 +629,7 @@ loadtest_postgres_exporter_memory="${LOADTEST_POSTGRES_EXPORTER_MEMORY:-128m}"
 loadtest_postgres_container="${LOADTEST_POSTGRES_CONTAINER_NAME:-aquila-bank-postgres-loadtest}"
 loadtest_backend_container="${LOADTEST_BACKEND_CONTAINER_NAME:-aquila-bank-backend-loadtest}"
 resolve_auth_token
-export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_BURST_HEADROOM_PREFLIGHT K6_BURST_MIN_HEADROOM_VUS K6_WARMUP_DURATION K6_WARMUP_MODE K6_WARMUP_RATE K6_WARMUP_TIME_UNIT K6_WARMUP_PRE_ALLOCATED_VUS K6_WARMUP_MAX_VUS K6_LIMIT K6_HOT_ACCOUNT_IDS K6_COLD_ACCOUNT_IDS K6_HOT_DEEP_CURSOR_BOOKED_AT K6_HOT_DEEP_CURSOR_ID K6_COLD_DEEP_CURSOR_BOOKED_AT K6_COLD_DEEP_CURSOR_ID K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HOT_DEEP_P95_THRESHOLD_MS K6_COLD_DEEP_P95_THRESHOLD_MS K6_HOT_DEEP_P99_THRESHOLD_MS K6_COLD_DEEP_P99_THRESHOLD_MS K6_HOT_DEEP_P999_THRESHOLD_MS K6_COLD_DEEP_P999_THRESHOLD_MS K6_HOT_DEEP_MAX_THRESHOLD_MS K6_COLD_DEEP_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_ARCHIVE_FAILED_SUMMARY K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_BURST_429_RATE_THRESHOLD K6_BACKEND_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_MAX_RETRY_AFTER_SLEEP_MS K6_RETRY_AFTER_ADAPTIVE_PACING K6_RETRY_AFTER_ADAPTIVE_MAX_MULTIPLIER K6_PREEMPTIVE_PACING K6_PREEMPTIVE_PACING_RPS K6_PREEMPTIVE_PACING_MAX_SLEEP_MS K6_PREEMPTIVE_PACING_JITTER_MS K6_CONSTANT_VUS_GATE_ROLE K6_WORKLOAD_SHAPE K6_WORKLOAD_SEED K6_WORKLOAD_WEIGHTS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_BASE_URL K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_AUTH_TOKEN K6_AUTH_TOKEN_REQUIRED K6_AUTH_PREFLIGHT K6_AUTH_PREFLIGHT_URL K6_AUTH_PREFLIGHT_PATH K6_AUTH_PREFLIGHT_BASE_URL K6_AUTH_PREFLIGHT_EXPECTED_STATUS K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_PROMETHEUS_RW_REQUIRED K6_REMOTE_WORKDIR K6_REMOTE_PREFLIGHT K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS K6_REMOTE_PREFLIGHT_IMAGE K6_REMOTE_READINESS_PATH K6_REMOTE_ARTIFACT_IMAGE K6_REMOTE_COLLECT_ARTIFACTS K6_REPORT_NAME K6_RUN_ID
+export K6_VUS K6_SCENARIO_MODE K6_RATE K6_TIME_UNIT K6_PRE_ALLOCATED_VUS K6_MAX_VUS K6_BURST_RATE K6_BURST_DURATION K6_BURST_HEADROOM_PREFLIGHT K6_BURST_MIN_HEADROOM_VUS K6_WARMUP_DURATION K6_WARMUP_MODE K6_WARMUP_RATE K6_WARMUP_TIME_UNIT K6_WARMUP_PRE_ALLOCATED_VUS K6_WARMUP_MAX_VUS K6_LIMIT K6_HOT_ACCOUNT_IDS K6_COLD_ACCOUNT_IDS K6_HOT_DEEP_CURSOR_BOOKED_AT K6_HOT_DEEP_CURSOR_ID K6_COLD_DEEP_CURSOR_BOOKED_AT K6_COLD_DEEP_CURSOR_ID K6_HOT_P95_THRESHOLD_MS K6_COLD_P95_THRESHOLD_MS K6_HOT_P99_THRESHOLD_MS K6_COLD_P99_THRESHOLD_MS K6_HOT_P999_THRESHOLD_MS K6_COLD_P999_THRESHOLD_MS K6_HOT_MAX_THRESHOLD_MS K6_COLD_MAX_THRESHOLD_MS K6_HOT_DEEP_P95_THRESHOLD_MS K6_COLD_DEEP_P95_THRESHOLD_MS K6_HOT_DEEP_P99_THRESHOLD_MS K6_COLD_DEEP_P99_THRESHOLD_MS K6_HOT_DEEP_P999_THRESHOLD_MS K6_COLD_DEEP_P999_THRESHOLD_MS K6_HOT_DEEP_MAX_THRESHOLD_MS K6_COLD_DEEP_MAX_THRESHOLD_MS K6_HTTP_FAILED_RATE K6_ARCHIVE_RESULTS K6_ARCHIVE_FAILED_SUMMARY K6_PREFLIGHT K6_POSTGRES_HEALTH_GATE K6_POSTGRES_RECOVERY_GATE K6_POSTGRES_RECOVERY_STABLE_SECONDS K6_POSTGRES_RECOVERY_NOISE_WINDOW_SECONDS K6_POSTGRES_EXPORTER_STABLE_GATE K6_POSTGRES_EXPORTER_STABLE_TIMEOUT_SECONDS K6_OUTBOX_PREFLIGHT K6_OUTBOX_PREFLIGHT_BASE_URL K6_EXPLAIN_SNAPSHOT K6_OBSERVABILITY_MODE K6_OVERLOAD_MODE K6_OVERLOAD_429_RATE_THRESHOLD K6_BURST_429_RATE_THRESHOLD K6_BACKEND_429_RATE_THRESHOLD K6_OVERLOAD_503_RATE_THRESHOLD K6_MAX_RETRY_AFTER_SLEEP_SECONDS K6_MAX_RETRY_AFTER_SLEEP_MS K6_RETRY_AFTER_ADAPTIVE_PACING K6_RETRY_AFTER_ADAPTIVE_MAX_MULTIPLIER K6_PREEMPTIVE_PACING K6_PREEMPTIVE_PACING_RPS K6_PREEMPTIVE_PACING_MAX_SLEEP_MS K6_PREEMPTIVE_PACING_JITTER_MS K6_CONSTANT_VUS_GATE_ROLE K6_WORKLOAD_SHAPE K6_WORKLOAD_SEED K6_WORKLOAD_WEIGHTS K6_RUN_PURPOSE K6_SUMMARY_GATE K6_BACKEND_READINESS_GATE K6_BACKEND_READINESS_BASE_URL K6_BACKEND_READINESS_PATH K6_BACKEND_READINESS_TIMEOUT_SECONDS K6_AUTH_TOKEN K6_AUTH_TOKEN_REQUIRED K6_AUTH_PREFLIGHT K6_AUTH_PREFLIGHT_URL K6_AUTH_PREFLIGHT_PATH K6_AUTH_PREFLIGHT_BASE_URL K6_AUTH_PREFLIGHT_EXPECTED_STATUS K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS K6_GENERATOR_MODE K6_DOCKER_CONTEXT K6_REMOTE_BASE_URL K6_REMOTE_PROMETHEUS_RW_SERVER_URL K6_REMOTE_PROMETHEUS_RW_REQUIRED K6_REMOTE_WORKDIR K6_REMOTE_PREFLIGHT K6_REMOTE_PREFLIGHT_TIMEOUT_SECONDS K6_REMOTE_PREFLIGHT_IMAGE K6_REMOTE_READINESS_PATH K6_REMOTE_ARTIFACT_IMAGE K6_REMOTE_COLLECT_ARTIFACTS K6_REPORT_NAME K6_RUN_ID
 
 require_positive_integer K6_VUS
 require_positive_integer K6_RATE
@@ -617,6 +695,7 @@ require_bool_value K6_ARCHIVE_FAILED_SUMMARY
 require_bool_value K6_SUMMARY_GATE
 require_bool_value K6_BURST_HEADROOM_PREFLIGHT
 require_bool_value K6_BACKEND_READINESS_GATE
+require_bool_value K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS
 require_auto_bool_value K6_AUTH_TOKEN_REQUIRED
 require_auto_bool_value K6_AUTH_PREFLIGHT
 require_bool_value K6_POSTGRES_HEALTH_GATE
@@ -831,9 +910,9 @@ print_plan() {
   fi
   echo "[k6-transaction-100m] auth token required=$(effective_auth_token_required) token=$(auth_token_presence) source=${auth_token_source}"
   if [[ -n "$(auth_preflight_url)" ]]; then
-    echo "[k6-transaction-100m] auth preflight=$(effective_auth_preflight_enabled) url=configured expected_status=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} timeout=${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}"
+    echo "[k6-transaction-100m] auth preflight=$(effective_auth_preflight_enabled) url=configured expected_status=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} timeout=${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS} follow_redirects=${K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS}"
   else
-    echo "[k6-transaction-100m] auth preflight=$(effective_auth_preflight_enabled) url=not-configured expected_status=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} timeout=${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}"
+    echo "[k6-transaction-100m] auth preflight=$(effective_auth_preflight_enabled) url=not-configured expected_status=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} timeout=${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS} follow_redirects=${K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS}"
   fi
   echo "[k6-transaction-100m] postgres health gate=${K6_POSTGRES_HEALTH_GATE} required_status=healthy"
   echo "[k6-transaction-100m] postgres recovery gate=${K6_POSTGRES_RECOVERY_GATE} stable_seconds=${K6_POSTGRES_RECOVERY_STABLE_SECONDS}"
@@ -883,7 +962,7 @@ print_plan() {
 }
 
 assert_auth_preflight() {
-  local token_required preflight_enabled preflight_url status
+  local token_required preflight_enabled preflight_url status curl_output effective_url
   token_required="$(effective_auth_token_required)"
   if [[ "${token_required}" == "true" && -z "${K6_AUTH_TOKEN}" ]]; then
     echo "K6_AUTH_TOKEN is required before OCI k6 run; set K6_AUTH_TOKEN or K6_AUTH_TOKEN_FILE" >&2
@@ -907,18 +986,36 @@ assert_auth_preflight() {
   fi
 
   require_command curl
-  echo "[k6-transaction-100m] auth status preflight: expected_status=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} timeout=${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}"
-  status="$(
-    curl -sS -o /dev/null -w "%{http_code}" \
-      --max-time "${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}" \
-      -H "Authorization: Bearer ${K6_AUTH_TOKEN}" \
-      "${preflight_url}" 2>/dev/null || true
-  )"
+  canonicalize_auth_preflight_redirect
+  preflight_url="$(auth_preflight_url)"
+  echo "[k6-transaction-100m] auth status preflight: expected_status=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} timeout=${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS} follow_redirects=${K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS}"
+  if [[ "${K6_AUTH_PREFLIGHT_FOLLOW_REDIRECTS}" == "true" ]]; then
+    curl_output="$(
+      curl -sS -o /dev/null -w "%{http_code}\t%{url_effective}" \
+        --location \
+        --max-time "${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}" \
+        -H "Authorization: Bearer ${K6_AUTH_TOKEN}" \
+        "${preflight_url}" 2>/dev/null || true
+    )"
+  else
+    curl_output="$(
+      curl -sS -o /dev/null -w "%{http_code}" \
+        --max-time "${K6_AUTH_PREFLIGHT_TIMEOUT_SECONDS}" \
+        -H "Authorization: Bearer ${K6_AUTH_TOKEN}" \
+        "${preflight_url}" 2>/dev/null || true
+    )"
+  fi
+  status="${curl_output%%$'\t'*}"
+  effective_url=""
+  if [[ "${curl_output}" == *$'\t'* ]]; then
+    effective_url="${curl_output#*$'\t'}"
+  fi
   status="${status:0:3}"
   if [[ "${status}" != "${K6_AUTH_PREFLIGHT_EXPECTED_STATUS}" ]]; then
     echo "auth status preflight failed: expected=${K6_AUTH_PREFLIGHT_EXPECTED_STATUS} actual=${status:-000}" >&2
     exit 1
   fi
+  canonicalize_auth_preflight_base_url "${effective_url}"
 }
 
 print_plan


### PR DESCRIPTION
## 🔗 Related Issue
- close #970

## 🌿 Base Branch
- `main`

## 📝 Summary
- 부하/용량 테스트가 실제 k6 실행 전에 인증 preflight와 fixture 기본값 문제로 중단되던 경로를 안정화했습니다.
- replay token 발급은 실행 중인 backend 컨테이너 env를 우선 사용하고, redirect 이후 canonical HTTPS endpoint를 기준으로 인증 preflight를 수행합니다.

## 🛠 Changes
- k6 transaction loadtest auth preflight가 redirect destination을 canonical base URL로 반영하도록 보강
- staging replay token issuer가 live Docker backend env를 우선 사용하도록 추가
- service auth, burst matrix, off-host prerequisite, 30m soak workflow의 replay token/preflight 계약 보강
- 30m soak 기본 cold fixture 계좌/기간을 실제 archive fixture 범위로 수정

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `tools/test/check-k6-transaction-100m-loadtest.sh`
- `python3 tools/test/check-issue-staging-replay-token.py`
- `tools/test/check-oci-k6-service-auth-token-workflow.sh`
- `tools/test/check-oci-k6-burst-reject-curve-matrix-workflow.sh`
- `tools/test/check-offhost-capacity-prerequisite-required-gate.sh`
- `tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh`
- `bash -n tools/test/run-k6-transaction-100m-loadtest.sh tools/test/check-k6-transaction-100m-loadtest.sh tools/test/check-oci-k6-service-auth-token-workflow.sh tools/test/check-transaction-read-30m-soak-live-evidence-workflow.sh`
- `python3 -m py_compile tools/ops/issue-staging-replay-token.py tools/test/check-issue-staging-replay-token.py`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }; puts "yaml ok"' ...`
- `git diff --check`
- GitHub Actions `OCI k6 service auth token` run 25844323413: success
- GitHub Actions `OCI k6 burst reject curve matrix` run 25844323431: success
- GitHub Actions `off-host 100m capacity prerequisite` run 25844323419: success
- GitHub Actions `Transaction Read 30m Soak Live Evidence` run 25844800640: success

## 📸 Screenshot / API Example
- 없음

## ⚠️ Risk & Rollback
- 예상 리스크: k6/preflight workflow 경로 변경이므로 staging workflow 실행 경로에 영향이 있습니다. 애플리케이션 런타임 코드와 DB 스키마는 변경하지 않았습니다.
- 롤백 방법: 이 PR revert 후 기존 workflow/script 계약으로 되돌립니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
