### PR TITLE
[Fix] 상단 채널 네비 활성 색상 대비 정리

### DIFF
--- a/front/scripts/check-customer-banking-ui-contract.mjs
+++ b/front/scripts/check-customer-banking-ui-contract.mjs
@@ -130,6 +130,8 @@ const checks = [
   ["top channel aria current", files.page, "aria-current"],
   ["top channel active style", files.styles, ".top-channel-link.active"],
   ["top channel active hover style", files.styles, ".top-channel-link.active:hover"],
+  ["top channel active contrast guard", files.styles, ".top-channel-nav .top-channel-link.active"],
+  ["top channel active readable text", files.styles, "color: var(--page)"],
   ["compact brand row wrap gap", files.styles, "gap: 8px 18px"],
   ["spacing safe mobile utility single column", files.styles, "grid-template-columns: 1fr"],
   ["bank dashboard favorite services", files.dashboard, "자주찾는서비스"],

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -672,6 +672,18 @@ label span {
   color: var(--primary-dark);
 }
 
+.top-channel-nav .top-channel-link.active {
+  border-color: var(--primary);
+  background: var(--primary);
+  color: var(--page);
+}
+
+.top-channel-nav .top-channel-link.active:hover:not(:disabled) {
+  border-color: var(--primary-dark);
+  background: var(--primary-dark);
+  color: var(--page);
+}
+
 .work-area {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 🔗 Related Issue
- close #986

## 🌿 Base Branch
- `main`

## 📝 Summary
- 상단 채널 네비 활성 항목의 CSS cascade 충돌을 정리해 선택된 메뉴 텍스트가 배경과 구분되게 수정합니다.
- 공통 active selector가 상단 채널 active 색상을 덮는 회귀를 계약 테스트로 고정했습니다.

## 🛠 Changes
- `check-customer-banking-ui-contract`에 상단 채널 active 대비 guard를 추가했습니다.
- `.top-channel-nav .top-channel-link.active`를 공통 active selector 뒤에 배치해 글자색이 `var(--page)`로 유지되게 했습니다.
- hover 상태도 같은 대비 기준을 유지하도록 상단 채널 전용 selector를 추가했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인 (`N/A`, CSS 표시 수정)

### 실행한 검증
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front lint`
- `yarn --cwd front test:e2e:visual`
- Browser 수동 확인: 활성 상단 채널 computed style `backgroundColor: rgb(194, 163, 91)`, `color: rgb(16, 18, 20)`

## 📸 Screenshot / API Example
- Browser 확인 이미지: `/private/tmp/aquila-top-nav-active-contrast.png`

## ⚠️ Risk & Rollback
- 예상 리스크: 상단 채널 active 스타일만 변경하므로 기능 리스크는 낮고, 다른 active 컴포넌트 색상은 유지됩니다.
- 롤백 방법: 이 PR revert.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? (`N/A`)
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? (`N/A`)
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? (`N/A`)
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? (`N/A`)
