### PR TITLE
[Fix] 통합검색 로그인 필요 배지 제거

### DIFF
--- a/front/e2e/customer-banking-click-flow.spec.ts
+++ b/front/e2e/customer-banking-click-flow.spec.ts
@@ -29,6 +29,8 @@ test("고객 웹뱅킹 주요 공개 업무와 미로그인 이체 가드를 실
     .click();
   const searchInput = page.getByRole("textbox", { name: "통합검색" });
   await expect(searchInput).toHaveValue("이체한도");
+  const searchResults = page.getByLabel("통합검색 결과");
+  await expect(searchResults.getByText("로그인 필요")).toHaveCount(0);
   await page.getByRole("button", { name: "전체서비스" }).click();
   await expect(page.getByText("전체서비스 메뉴")).toHaveCount(0);
   await searchInput.fill("");

--- a/front/scripts/check-customer-banking-ui-contract.mjs
+++ b/front/scripts/check-customer-banking-ui-contract.mjs
@@ -108,7 +108,6 @@ const checks = [
   ["bank search results label", files.page, "통합검색 결과"],
   ["bank search result selection", files.page, "onSearchSelect"],
   ["bank search catalog function", files.search, "searchCustomerBankingServices"],
-  ["bank search login required badge", files.page, "로그인 필요"],
   ["bank search result style", files.styles, ".service-search-panel"],
   ["spacing safe service map hook", files.page, "spacing-safe-service-map"],
   ["spacing safe service map style", files.styles, ".spacing-safe-service-map"],
@@ -203,6 +202,8 @@ const checks = [
 ];
 
 const forbidden = [
+  ["search result login badge markup", files.page, "service-search-badge"],
+  ["search result login badge style", files.styles, ".service-search-badge"],
   ["customer visible read-only", customerVisibleContent, "read-only"],
   ["customer visible backend preview", customerVisibleContent, "backend preview"],
   ["customer visible backend", customerVisibleContent, "backend"],

--- a/front/src/components/customer-banking/layout.tsx
+++ b/front/src/components/customer-banking/layout.tsx
@@ -165,12 +165,7 @@ export function BankHeader({
                       onClick={() => onSearchSelect(item)}
                       type="button"
                     >
-                      <span>
-                        {item.group}
-                        {item.requiresSession ? (
-                          <em className="service-search-badge">로그인 필요</em>
-                        ) : null}
-                      </span>
+                      <span>{item.group}</span>
                       <strong>{item.label}</strong>
                       <small>{item.description}</small>
                     </button>

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -354,19 +354,6 @@ label span {
   line-height: 1.3;
 }
 
-.service-search-badge {
-  display: inline-flex;
-  margin-left: 6px;
-  border: 1px solid var(--line-strong);
-  border-radius: 3px;
-  background: var(--warning-soft);
-  color: var(--primary-dark);
-  padding: 1px 5px;
-  font-size: 11px;
-  font-style: normal;
-  line-height: 1.4;
-}
-
 .service-search-empty {
   min-height: 34px;
   border: 1px dashed var(--line);


### PR DESCRIPTION
## 🔗 Related Issue
- close #988

## 🌿 Base Branch
- `main`

## 📝 Summary
- 통합검색 결과 카드에 반복 노출되던 `로그인 필요` 배지를 제거합니다.
- 검색 결과의 업무 그룹, 제목, 설명은 유지하고 실제 보호 업무 접근 시의 인증/인가 게이트는 그대로 둡니다.
- README에 실제 고객뱅킹 화면 캡처를 추가해 변경된 검색 UX를 바로 확인할 수 있게 합니다.

## 🛠 Changes
- 통합검색 결과 항목에서 세션 필요 배지 렌더링 제거
- 사용하지 않는 `.service-search-badge` 스타일 제거
- UI 계약/클릭 플로우 회귀 검증에 통합검색 배지 미노출 조건 추가
- README 실제 고객뱅킹 화면 섹션과 캡처 이미지 추가

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [ ] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front test:e2e:click-flow`
- `yarn --cwd front test:e2e:visual`
- `yarn --cwd front lint`
- Browser 수동 확인: `이체한도` 검색 결과 패널 badgeCount=0, itemCount=2
- README 이미지 경로 확인: `docs/assets/readme-customer-banking-search.jpg`

## 📸 Screenshot / API Example
- README에 실제 페이지 캡처 추가: `docs/assets/readme-customer-banking-search.jpg`

## ⚠️ Risk & Rollback
- 예상 리스크: 통합검색 결과에서 보호 업무 여부가 덜 강조될 수 있으나 실제 접근 제어와 보호 업무 안내는 유지됨
- 롤백 방법: 이 PR revert

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
