### PR TITLE
[Fix] 프론트 모바일 검색과 비로그인 업무 UX 개선

### DIFF
--- a/front/e2e/customer-banking-click-flow.spec.ts
+++ b/front/e2e/customer-banking-click-flow.spec.ts
@@ -11,7 +11,7 @@ test("고객 웹뱅킹 주요 공개 업무와 미로그인 이체 가드를 실
   await expect(page.getByText("업무현황")).toBeVisible();
   if (testInfo.project.name.includes("mobile")) {
     await expect(page.getByText("추천검색어")).toBeHidden();
-    await page.getByRole("button", { exact: true, name: "검색" }).click();
+    await page.getByRole("button", { exact: true, name: "검색 열기" }).click();
   }
   await expect(page.getByText("추천검색어")).toBeVisible();
   await expect(page.getByText("자주찾는서비스")).toBeVisible();

--- a/front/e2e/customer-banking-live-artifacts.spec.ts
+++ b/front/e2e/customer-banking-live-artifacts.spec.ts
@@ -33,8 +33,8 @@ test("live mobile 화면은 접힌 업무 구조 screenshot artifact를 남긴�
   await page.goto("/");
   await expect(page.locator(".bank-layout")).toHaveAttribute("data-auth-state", "guest");
   await expectVisibleBox(page, ".bank-header");
-  await expect(page.getByRole("button", { exact: true, name: "검색" })).toBeVisible();
-  await page.getByRole("button", { exact: true, name: "검색" }).click();
+  await expect(page.getByRole("button", { exact: true, name: "검색 열기" })).toBeVisible();
+  await page.getByRole("button", { exact: true, name: "검색 열기" }).click();
   await expect(page.getByText("추천검색어")).toBeVisible();
 
   await page.screenshot({

--- a/front/e2e/customer-banking-visual-layout.spec.ts
+++ b/front/e2e/customer-banking-visual-layout.spec.ts
@@ -136,6 +136,44 @@ test("mobile 공개 화면은 단일 흐름으로 접히고 키보드 접근 순
   });
 });
 
+test("mobile 검색과 비로그인 홈 CTA는 첫 화면 업무 흐름을 가리지 않는다", async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "mobile 전용 visual QA");
+
+  await page.goto("/");
+  await expect(page.getByRole("button", { exact: true, name: "로그인 후 계좌조회" })).toBeVisible();
+  await expect(page.getByRole("button", { exact: true, name: "로그인 후 이체" })).toBeVisible();
+
+  await page.getByRole("button", { exact: true, name: "검색 열기" }).click();
+  await page.getByLabel("통합검색").fill("공과금");
+  await expect(page.getByLabel("통합검색 결과")).toBeVisible();
+  await expect(page.getByRole("button", { exact: true, name: "검색어 지우기" })).toBeVisible();
+
+  const metrics = await page.evaluate(() => {
+    const header = document.querySelector(".bank-header");
+    const panel = document.querySelector(".service-search-panel");
+    const workArea = document.querySelector("#bank-work-area");
+
+    return {
+      headerHeight: Math.round(header?.getBoundingClientRect().height ?? 0),
+      panelHeight: Math.round(panel?.getBoundingClientRect().height ?? 0),
+      viewportHeight: window.innerHeight,
+      workTop: Math.round(workArea?.getBoundingClientRect().top ?? 0),
+    };
+  });
+
+  expect(metrics.headerHeight).toBeLessThanOrEqual(Math.round(metrics.viewportHeight * 0.58));
+  expect(metrics.panelHeight).toBeLessThanOrEqual(280);
+  expect(metrics.workTop).toBeLessThan(metrics.viewportHeight);
+  await expectNoHorizontalOverflow(page);
+
+  await page.screenshot({
+    fullPage: true,
+    path: testInfo.outputPath("customer-banking-mobile-search-bounded.png"),
+  });
+});
+
 test("tablet compact 폭에서도 검색, 메뉴, 보안알림 텍스트가 컨테이너 안에 머문다", async ({
   page,
 }, testInfo) => {

--- a/front/src/components/customer-banking/layout.tsx
+++ b/front/src/components/customer-banking/layout.tsx
@@ -120,6 +120,7 @@ export function BankHeader({
           <button
             aria-controls="utility-search-panel"
             aria-expanded={mobileSearchOpen}
+            aria-label={mobileSearchOpen ? "검색 닫기" : "검색 열기"}
             className="mobile-search-toggle"
             onClick={onMobileSearchToggle}
             type="button"
@@ -134,15 +135,28 @@ export function BankHeader({
             }
             id="utility-search-panel"
           >
-            <label className="search-field">
-              <span>통합검색</span>
-              <input
-                aria-label="통합검색"
-                onChange={(event) => onSearchChange(event.target.value)}
-                placeholder="업무명 또는 메뉴 검색"
-                value={searchQuery}
-              />
-            </label>
+            <div className="search-field">
+              <label htmlFor="utility-search-input">통합검색</label>
+              <div className="search-input-row">
+                <input
+                  aria-label="통합검색"
+                  id="utility-search-input"
+                  onChange={(event) => onSearchChange(event.target.value)}
+                  placeholder="업무명 또는 메뉴 검색"
+                  value={searchQuery}
+                />
+                {hasSearchQuery ? (
+                  <button
+                    aria-label="검색어 지우기"
+                    className="search-clear-button"
+                    onClick={() => onSearchChange("")}
+                    type="button"
+                  >
+                    지우기
+                  </button>
+                ) : null}
+              </div>
+            </div>
             <div className="keyword-list" aria-label="추천검색어">
               <span>추천검색어</span>
               {recommendedKeywords.map((keyword) => (

--- a/front/src/components/customer-banking/sections/dashboard-section.tsx
+++ b/front/src/components/customer-banking/sections/dashboard-section.tsx
@@ -70,10 +70,10 @@ export function DashboardSection({
         </div>
         <div className="button-row">
           <button onClick={() => onMove("accounts")} type="button">
-            계좌조회
+            {hasSession ? "계좌조회" : "로그인 후 계좌조회"}
           </button>
           <button onClick={() => onMove("transfer")} type="button">
-            이체
+            {hasSession ? "이체" : "로그인 후 이체"}
           </button>
           <button disabled={!hasSession || isBusy} onClick={onRefresh} type="button">
             토큰 재발급

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -1,16 +1,16 @@
 :root {
   color-scheme: dark;
-  --gothic-page: #101214;
-  --gothic-surface: #171a1d;
-  --gothic-surface-muted: #202328;
-  --gothic-iron: #2d3338;
-  --gothic-line: #3b3a32;
-  --gothic-line-strong: #6d5a35;
-  --gothic-parchment: #efe7d3;
-  --gothic-muted: #a8a195;
-  --gothic-brass: #c2a35b;
-  --gothic-brass-strong: #d2b46d;
-  --gothic-brass-soft: #2b2418;
+  --gothic-page: #121518;
+  --gothic-surface: #1a1f24;
+  --gothic-surface-muted: #222932;
+  --gothic-iron: #303943;
+  --gothic-line: #39434d;
+  --gothic-line-strong: #687480;
+  --gothic-parchment: #f1f4f7;
+  --gothic-muted: #aeb8c2;
+  --gothic-brass: #8eb8a8;
+  --gothic-brass-strong: #c2ddd3;
+  --gothic-brass-soft: #1d312a;
   --gothic-danger: #ef9a91;
   --gothic-danger-soft: #2b1716;
   --gothic-success: #6f9f7b;
@@ -70,7 +70,7 @@ button {
   min-height: 34px;
   border: 1px solid var(--line-strong);
   border-radius: 4px;
-  background: linear-gradient(180deg, #211f1a, #171a1d);
+  background: linear-gradient(180deg, #20262d, #161a1f);
   color: var(--text);
   cursor: pointer;
   font-weight: 700;
@@ -103,14 +103,14 @@ select {
   height: 36px;
   border: 1px solid var(--line-strong);
   border-radius: 3px;
-  background: #0f1113;
+  background: #101418;
   color: var(--text);
   padding: 0 10px;
 }
 
 .gothic-banking-shell input,
 .gothic-banking-shell select {
-  background: #0f1113;
+  background: #101418;
   color: var(--text);
 }
 
@@ -126,7 +126,7 @@ label span {
 .gothic-banking-shell {
   min-width: 1180px;
   background:
-    linear-gradient(180deg, rgba(28, 30, 31, 0.96), rgba(16, 18, 20, 1)),
+    linear-gradient(180deg, rgba(25, 30, 35, 0.96), rgba(18, 21, 24, 1)),
     var(--page);
 }
 
@@ -147,7 +147,7 @@ label span {
   transform: translateY(-140%);
   border: 2px solid var(--primary-dark);
   border-radius: 4px;
-  background: #0f1113;
+  background: #101418;
   color: var(--text);
   padding: 8px 12px;
   font-weight: 800;
@@ -162,7 +162,7 @@ label span {
   display: grid;
   gap: 4px;
   border-bottom: 1px solid var(--line-strong);
-  background: linear-gradient(180deg, #1c1d1c, #121416);
+  background: linear-gradient(180deg, #1d2329, #14181d);
   box-shadow: var(--shadow);
   padding-bottom: 6px;
 }
@@ -262,12 +262,28 @@ label span {
   min-width: 0;
 }
 
-.search-field span {
+.search-field label {
   margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
 }
 
 .search-field input {
   min-width: 0;
+}
+
+.search-input-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px;
+  min-width: 0;
+}
+
+.search-clear-button {
+  min-height: 36px;
+  padding: 0 10px;
+  font-size: 12px;
 }
 
 .utility-search {
@@ -2624,9 +2640,12 @@ label span {
   }
 
   .utility-search.open .service-search-panel {
-    position: static;
-    max-height: none;
-    overflow: visible;
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    left: 0;
+    max-height: min(260px, calc(100vh - 240px));
+    overflow: auto;
   }
 
   .utility-right,
@@ -2636,6 +2655,10 @@ label span {
 
   .search-field {
     width: 100%;
+  }
+
+  .search-input-row {
+    grid-template-columns: minmax(0, 1fr) minmax(76px, auto);
   }
 
   .service-search-item {
@@ -2709,6 +2732,10 @@ label span {
     border-left: 1px solid var(--line);
     gap: 5px;
     padding: 10px 14px;
+  }
+
+  .side-menu.mobile-compact-side-menu .side-item:nth-of-type(n + 5) {
+    display: none;
   }
 
   .side-menu.mobile-compact-side-menu .side-item.active {


### PR DESCRIPTION
## 🔗 Related Issue
- close #994

## 🌿 Base Branch
- `main`

## 📝 Summary
- 모바일 검색 결과를 bounded panel로 제한해 첫 화면 업무 영역이 검색 결과에 밀려 사라지지 않게 조정합니다.
- 비로그인 홈 CTA를 `로그인 후 ...` 문구로 바꾸고 모바일 보조 메뉴/색상 톤을 정리해 고객뱅킹 업무 UX 혼선을 줄입니다.

## 🛠 Changes
- 모바일 검색 토글에 `검색 열기/닫기` 접근성 이름을 부여하고 검색어 지우기 버튼을 추가했습니다.
- 모바일 검색 결과를 absolute bounded panel로 바꿔 header 높이와 panel 높이를 제한했습니다.
- 비로그인 홈의 계좌/이체 CTA를 `로그인 후 계좌조회`, `로그인 후 이체`로 표시합니다.
- 모바일 side menu 반복 노출을 줄이고 dark/brass 중심 색상 토큰을 더 중립적인 업무형 톤으로 조정했습니다.
- visual e2e에 모바일 검색/비로그인 CTA 회귀 검증을 추가하고 click-flow selector를 갱신했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front test:e2e:visual` → 5 passed, 5 skipped
- `yarn --cwd front test:e2e:click-flow` → 2 passed
- `yarn --cwd front test:ui-contract` → passed
- `yarn --cwd front lint` → No ESLint warnings or errors
- Browser QA: `http://localhost:3000`, 1280x720 desktop / 390x844 mobile, console error/warn 없음, framework overlay 없음

## 📸 Screenshot / API Example
- 로컬 Browser QA 스크린샷 확인: `/private/tmp/aquila-ui-pr-desktop.png`, `/private/tmp/aquila-ui-pr-mobile-search.png`
- PR 첨부 파일 없음

## ⚠️ Risk & Rollback
- 예상 리스크: 모바일 검색 결과가 absolute panel로 바뀌어 일부 header 하단 콘텐츠 위에 겹칠 수 있습니다. panel 높이를 260px로 제한하고 clear/close 경로를 둬 완화했습니다.
- 롤백 방법: 이 PR의 단일 commit `9c708d5f`을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가? N/A
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가? N/A
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가? N/A
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가? N/A
