### PR TITLE
[Fix] 고객뱅킹 모바일 메뉴와 터치 타깃 정리

### DIFF
--- a/front/scripts/check-customer-banking-ui-contract.mjs
+++ b/front/scripts/check-customer-banking-ui-contract.mjs
@@ -111,7 +111,7 @@ const checks = [
   ["bank search result style", files.styles, ".service-search-panel"],
   ["spacing safe service map hook", files.page, "spacing-safe-service-map"],
   ["spacing safe service map style", files.styles, ".spacing-safe-service-map"],
-  ["compact service map breathing", files.styles, "padding: 4px 12px"],
+  ["compact service map breathing", files.styles, "padding: 8px 12px"],
   ["spacing safe utility search hook", files.page, "spacing-safe-search"],
   ["compact utility search block padding", files.styles, "padding-block: 0"],
   ["spacing safe side menu hook", files.page, "spacing-safe-side-menu"],
@@ -199,6 +199,18 @@ const checks = [
   ["visual polish side item stable mobile height", files.styles, ".side-menu.mobile-compact-side-menu .side-item strong"],
   ["visual polish notice stable columns", files.styles, ".bank-notice-strip div"],
   ["visual polish notice value line height", files.styles, ".bank-notice-strip dd"],
+  ["customer banking scroll affordance hook", files.page, "scroll-affordance-x"],
+  ["customer banking scroll affordance style", files.styles, ".scroll-affordance-x"],
+  ["customer banking utility touch target", files.styles, ".utility-link {\n  min-height: 44px"],
+  ["customer banking base button touch target", files.styles, "\nbutton {\n  min-height: 44px;\n  min-width: 44px"],
+  ["customer banking base input touch target", files.styles, "\ninput,\nselect {\n  width: 100%;\n  height: 44px"],
+  ["customer banking compact button touch target", files.styles, ".button-row.compact button {\n  min-height: 44px"],
+  ["customer banking work tab touch target", files.styles, ".work-tabs button {\n  flex: 0 0 auto;\n  min-width: 96px;\n  min-height: 44px"],
+  ["customer banking news touch target", files.styles, ".bank-news-list button {\n  width: 100%;\n  min-height: 44px"],
+  ["customer banking quick rail touch target", files.styles, ".quick-grid button {\n  min-height: 44px"],
+  ["customer banking keyword touch target", files.styles, ".keyword-list button {\n  min-height: 44px"],
+  ["customer banking nav touch target", files.styles, ".nav-tab {\n  min-width: 96px;\n  min-height: 44px"],
+  ["customer banking full mobile menu visibility", files.styles, "scroll-snap-type: x proximity"],
 ];
 
 const forbidden = [
@@ -222,6 +234,7 @@ const forbidden = [
   ["customer visible bank-like explanation", customerVisibleContent, "처럼"],
   ["customer visible actual implementation explanation", customerVisibleContent, "실제"],
   ["customer visible customer explanation", customerVisibleContent, "고객이"],
+  ["customer hidden mobile side menu items", files.styles, ".side-menu.mobile-compact-side-menu .side-item:nth-of-type(n + 5) {\n    display: none;"],
 ];
 
 const missing = checks.filter(([, content, expected]) => !content.includes(expected));

--- a/front/src/components/customer-banking/layout.tsx
+++ b/front/src/components/customer-banking/layout.tsx
@@ -86,7 +86,7 @@ export function BankHeader({
   return (
     <header className="bank-header">
       <div className="utility-bar mobile-compact-utility" aria-label="상단 유틸리티">
-        <div className="utility-left top-channel-nav">
+        <div className="utility-left top-channel-nav scroll-affordance-x">
           {topNavItems.map((item) => {
             const isActive = activeTopNavId === item.id;
 
@@ -208,7 +208,10 @@ export function BankHeader({
             <small>Personal Internet Banking</small>
           </div>
         </div>
-        <nav className="primary-nav mobile-compact-primary-nav" aria-label="주요 메뉴">
+        <nav
+          className="primary-nav mobile-compact-primary-nav scroll-affordance-x"
+          aria-label="주요 메뉴"
+        >
           {mainMenus.map((item) => (
             <button
               aria-current={activeSection === item.id ? "page" : undefined}
@@ -282,7 +285,7 @@ export function SideMenu({
 }) {
   return (
     <aside
-      className="side-menu compact-menu mobile-compact-side-menu spacing-safe-side-menu"
+      className="side-menu compact-menu mobile-compact-side-menu spacing-safe-side-menu scroll-affordance-x"
       aria-label="개인뱅킹 메뉴"
     >
       <div className="side-title">개인뱅킹</div>

--- a/front/src/styles/customer-banking.css
+++ b/front/src/styles/customer-banking.css
@@ -67,7 +67,8 @@ select {
 }
 
 button {
-  min-height: 34px;
+  min-height: 44px;
+  min-width: 44px;
   border: 1px solid var(--line-strong);
   border-radius: 4px;
   background: linear-gradient(180deg, #20262d, #161a1f);
@@ -100,7 +101,7 @@ button:disabled {
 input,
 select {
   width: 100%;
-  height: 36px;
+  height: 44px;
   border: 1px solid var(--line-strong);
   border-radius: 3px;
   background: #101418;
@@ -178,9 +179,9 @@ label span {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 38px;
+  min-height: 52px;
   border-bottom: 1px solid var(--line);
-  padding-block: 3px;
+  padding-block: 4px;
 }
 
 .utility-left,
@@ -200,12 +201,12 @@ label span {
 }
 
 .utility-link {
-  min-height: 28px;
+  min-height: 44px;
   border: 1px solid transparent;
   border-radius: 3px;
   background: transparent;
   color: var(--muted);
-  padding: 3px 8px;
+  padding: 8px 10px;
   font-size: 12px;
   line-height: 1.35;
 }
@@ -242,16 +243,16 @@ label span {
 }
 
 .spacing-safe-service-map {
-  min-height: 30px;
+  min-height: 44px;
   margin-block: 0;
-  padding: 4px 12px;
+  padding: 8px 12px;
   line-height: 1.35;
 }
 
 .mobile-search-toggle {
   display: none;
-  min-height: 30px;
-  padding: 0 10px;
+  min-height: 44px;
+  padding: 0 12px;
 }
 
 .search-field {
@@ -281,7 +282,7 @@ label span {
 }
 
 .search-clear-button {
-  min-height: 36px;
+  min-height: 44px;
   padding: 0 10px;
   font-size: 12px;
 }
@@ -316,13 +317,17 @@ label span {
 }
 
 .keyword-list button {
-  min-height: 24px;
+  min-height: 44px;
   border: 0;
   background: transparent;
   color: var(--primary-dark);
-  padding: 0 4px;
+  padding: 0 6px;
   font-size: 12px;
   white-space: nowrap;
+}
+
+.scroll-affordance-x {
+  scroll-padding-inline: 0 32px;
 }
 
 .service-search-panel {
@@ -434,8 +439,8 @@ label span {
 }
 
 .nav-tab {
-  min-width: 88px;
-  min-height: 38px;
+  min-width: 96px;
+  min-height: 44px;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -570,7 +575,7 @@ label span {
 }
 
 .service-map-group button {
-  min-height: 30px;
+  min-height: 44px;
   border: 0;
   background: transparent;
   color: var(--text);
@@ -757,7 +762,7 @@ label span {
 }
 
 .button-row.compact button {
-  min-height: 30px;
+  min-height: 44px;
   padding: 0 9px;
   font-size: 12px;
 }
@@ -966,7 +971,7 @@ label span {
 
 .bank-news-list button {
   width: 100%;
-  min-height: 32px;
+  min-height: 44px;
   border: 0;
   border-bottom: 1px solid var(--line);
   border-radius: 0;
@@ -2322,7 +2327,7 @@ label span {
 .work-tabs button {
   flex: 0 0 auto;
   min-width: 96px;
-  min-height: 40px;
+  min-height: 44px;
   border: 0;
   border-radius: 0;
   border-right: 1px solid var(--line-strong);
@@ -2440,7 +2445,7 @@ label span {
 }
 
 .quick-grid button {
-  min-height: 38px;
+  min-height: 44px;
   font-size: 12px;
 }
 
@@ -2457,7 +2462,7 @@ label span {
 .recent-menu-list button {
   justify-content: flex-start;
   width: 100%;
-  min-height: 34px;
+  min-height: 44px;
   padding: 0 10px;
   text-align: left;
   font-size: 12px;
@@ -2608,6 +2613,7 @@ label span {
     display: flex;
     flex-wrap: nowrap;
     overflow-x: auto;
+    scroll-snap-type: x proximity;
     scrollbar-width: thin;
   }
 
@@ -2673,13 +2679,14 @@ label span {
     min-width: 0;
     max-width: 100%;
     overflow-x: auto;
+    scroll-snap-type: x proximity;
     border-top: 1px solid var(--line);
     scrollbar-width: thin;
   }
 
   .primary-nav.mobile-compact-primary-nav .nav-tab {
     flex: 0 0 auto;
-    min-width: 92px;
+    min-width: 96px;
     min-height: 44px;
   }
 
@@ -2699,6 +2706,7 @@ label span {
     display: flex;
     min-width: 0;
     overflow-x: auto;
+    scroll-snap-type: x proximity;
     scrollbar-width: thin;
   }
 
@@ -2734,12 +2742,17 @@ label span {
     padding: 10px 14px;
   }
 
-  .side-menu.mobile-compact-side-menu .side-item:nth-of-type(n + 5) {
-    display: none;
-  }
-
   .side-menu.mobile-compact-side-menu .side-item.active {
     padding-left: 16px;
+  }
+
+  .scroll-affordance-x {
+    -webkit-mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 30px), transparent);
+    mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 30px), transparent);
+  }
+
+  .scroll-affordance-x > * {
+    scroll-snap-align: start;
   }
 
   .side-menu.mobile-compact-side-menu .side-item span,


### PR DESCRIPTION
## 🔗 Related Issue
- close #1000

## 🌿 Base Branch
- `main`

## 📝 Summary
- 고객뱅킹 상단/업무/우측 rail 조작 요소를 44px 기준으로 정리했습니다.
- 모바일 주요 메뉴와 개인뱅킹 메뉴의 수평 스크롤을 숨기지 않고 scroll affordance와 snap으로 드러냅니다.

## 🛠 Changes
- 상단 채널, 주요 메뉴, 사이드 메뉴에 `scroll-affordance-x` hook을 추가했습니다.
- 기본 `button`, `input`, `select`와 compact button override의 조작 영역을 44px 기준으로 통일했습니다.
- 기존 계약 스크립트에 터치 타깃, 수평 메뉴 affordance, 숨김 메뉴 방지 조건을 추가했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Transaction / Ledger
- [ ] Notification / Async
- [ ] Auth / Security
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트
- [x] 수동 확인
- [x] 로그 / 메트릭 확인

### 실행한 검증
- `yarn --cwd front test:ui-contract`
- `yarn --cwd front test:mobile-work-polish`
- `yarn --cwd front lint`
- Browser `/` 1440x900, 390x844 visual QA

## 📸 Screenshot / API Example
- Browser screenshot evidence:
  - `/private/tmp/aquila-1000-desktop-final.png`
  - `/private/tmp/aquila-1000-mobile-final.png`
  - `/private/tmp/aquila-1000-search-final.png`

## ⚠️ Risk & Rollback
- 예상 리스크: 공통 button/input 높이 증가로 고객뱅킹 일부 섹션의 세로 밀도가 늘어날 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## ☑️ Checklist
- [x] base branch가 `main`인지 확인했는가?
- [x] GitHub issue를 먼저 만들고 번호를 연결했는가?
- [x] 하나의 리뷰 목적을 유지했는가?
- [x] PR 범위 밖 변경은 포함하지 않았는가?
- [x] 커밋을 논리 단위로 정리했는가?
- [x] 필요한 테스트를 수행했는가?
- [x] 미완성 기능이면 feature flag로 기본 비노출 처리했는가?
- [x] 보안/권한/개인정보 영향이 있으면 본문에 적었는가?
- [x] 스키마/API 계약 변경이 있으면 본문에 적었는가?
- [x] 운영 문서 또는 모니터링 반영이 필요하면 처리했는가?
